### PR TITLE
fix(dashboards): re-add experimental dashboard item rendering flag

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -9,7 +9,9 @@ import { useInView } from 'react-intersection-observer'
 
 import { ApiError } from 'lib/api'
 import { Resizeable } from 'lib/components/Cards/CardMeta'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
 import { accessLevelSatisfied, getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { BreakdownColorConfig } from 'scenes/dashboard/DashboardInsightColorsModal'
@@ -137,6 +139,7 @@ function InsightCardInternal(
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
 ): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
     const { ref: inViewRef, inView } = useInView()
     const { isVisible: isPageVisible } = usePageVisibility()
 
@@ -145,7 +148,10 @@ function InsightCardInternal(
      *
      * We add an extra check to make sure all insights are visible in Storybook.
      */
-    const isVisible = (inView && isPageVisible) || inStorybook() || inStorybookTestRunner()
+    const isVisible =
+        featureFlags[FEATURE_FLAGS.EXPERIMENTAL_DASHBOARD_ITEM_RENDERING] === true
+            ? (inView && isPageVisible) || inStorybook() || inStorybookTestRunner()
+            : true
 
     const mergedRefs = useMergeRefs([ref, inViewRef])
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -193,6 +193,9 @@ export const FEATURE_FLAGS = {
     CSP_REPORTING: 'mexicspo', // owner @pauldambra @lricoy @robbiec
     ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking
     EXPERIMENT_INTERVAL_TIMESERIES: 'experiments-interval-timeseries', // owner: @jurajmajerik #team-experiments
+    /* The below flag is used to deactivate unmounting charts outside the viewport, as we're currently investigating frontend performance
+    issues related to this and want to know the impact. */
+    EXPERIMENTAL_DASHBOARD_ITEM_RENDERING: 'experimental-dashboard-item-rendering', // owner: @thmsobrmlr #team-product-analytics
     IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: #team-web-analytics
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: #team-data-stack
     MEMBERS_CAN_USE_PERSONAL_API_KEYS: 'members-can-use-personal-api-keys', // owner: @yasen-posthog #team-platform-features

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -193,8 +193,8 @@ export const FEATURE_FLAGS = {
     CSP_REPORTING: 'mexicspo', // owner @pauldambra @lricoy @robbiec
     ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking
     EXPERIMENT_INTERVAL_TIMESERIES: 'experiments-interval-timeseries', // owner: @jurajmajerik #team-experiments
-    /* The below flag is used to deactivate unmounting charts outside the viewport, as we're currently investigating frontend performance
-    issues related to this and want to know the impact. */
+    /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance
+    issues related to this and want to know the impact of having it on vs. off. */
     EXPERIMENTAL_DASHBOARD_ITEM_RENDERING: 'experimental-dashboard-item-rendering', // owner: @thmsobrmlr #team-product-analytics
     IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: #team-web-analytics
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: #team-data-stack


### PR DESCRIPTION
## Problem

We want to disable experimental dashboard item rendering (i.e. removing the chart from the dom when it's outside the viewport) to investigate its effect on performance for customers, but it got removed here https://github.com/PostHog/posthog/pull/42538.

The thinking here is that removing the elements from the DOM helps reduce memory pressure, but re-rendering the charts is expensive, especially on slower CPUs/GPUs.

## Changes

Re-adds the flag. The flag still exists in PostHog: https://us.posthog.com/project/2/feature_flags/106141

## How did you test this code?

n/a