### PR TITLE
fix(experiments): gracefully handle StatisticError instead of propagating to logs

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_stats_config.py
+++ b/posthog/hogql_queries/experiments/test/test_stats_config.py
@@ -15,6 +15,12 @@ from posthog.schema import (
 
 from posthog.hogql_queries.experiments.utils import get_bayesian_experiment_result, get_frequentist_experiment_result
 
+INSUFFICIENT_DATA_CASES = [
+    ("very_small_sample", {"control": (1, 0.5, 0.25), "test": (1, 0.3, 0.09)}),
+    ("zero_baseline_sum", {"control": (100, 0.0, 0.0), "test": (100, 50.0, 2600.0)}),
+    ("zero_variance", {"control": (100, 100.0, 100.0), "test": (100, 100.0, 100.0)}),
+]
+
 
 class TestStatsConfig(APIBaseTest):
     def create_mean_metric(self) -> ExperimentMeanMetric:
@@ -213,3 +219,107 @@ class TestStatsConfig(APIBaseTest):
         assert result.variant_results is not None
         variant = cast(ExperimentVariantResultBayesian, result.variant_results[0])
         assert variant.credible_interval is not None
+
+    @parameterized.expand(INSUFFICIENT_DATA_CASES)
+    def test_frequentist_insufficient_data_returns_raw_values_without_stats(self, _name, data):
+        metric = self.create_mean_metric()
+        control = self.create_variant(
+            "control", sum_val=data["control"][1], sum_squares=data["control"][2], samples=data["control"][0]
+        )
+        test = self.create_variant(
+            "test", sum_val=data["test"][1], sum_squares=data["test"][2], samples=data["test"][0]
+        )
+
+        result = get_frequentist_experiment_result(
+            metric=metric,
+            control_variant=control,
+            test_variants=[test],
+            stats_config=None,
+        )
+
+        assert result.baseline is not None
+        self.assertEqual(result.baseline.key, "control")
+        self.assertEqual(result.baseline.number_of_samples, data["control"][0])
+        self.assertEqual(result.baseline.sum, data["control"][1])
+        self.assertEqual(result.baseline.sum_squares, data["control"][2])
+
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+        variant = cast(ExperimentVariantResultFrequentist, result.variant_results[0])
+        self.assertEqual(variant.key, "test")
+        self.assertEqual(variant.number_of_samples, data["test"][0])
+        self.assertEqual(variant.sum, data["test"][1])
+        self.assertEqual(variant.sum_squares, data["test"][2])
+        self.assertIsNone(variant.p_value)
+        self.assertIsNone(variant.confidence_interval)
+        self.assertIsNone(variant.significant)
+
+    @parameterized.expand(INSUFFICIENT_DATA_CASES)
+    def test_bayesian_insufficient_data_returns_raw_values_without_stats(self, _name, data):
+        metric = self.create_mean_metric()
+        control = self.create_variant(
+            "control", sum_val=data["control"][1], sum_squares=data["control"][2], samples=data["control"][0]
+        )
+        test = self.create_variant(
+            "test", sum_val=data["test"][1], sum_squares=data["test"][2], samples=data["test"][0]
+        )
+
+        result = get_bayesian_experiment_result(
+            metric=metric,
+            control_variant=control,
+            test_variants=[test],
+            stats_config=None,
+        )
+
+        assert result.baseline is not None
+        self.assertEqual(result.baseline.key, "control")
+        self.assertEqual(result.baseline.number_of_samples, data["control"][0])
+        self.assertEqual(result.baseline.sum, data["control"][1])
+        self.assertEqual(result.baseline.sum_squares, data["control"][2])
+
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+        variant = cast(ExperimentVariantResultBayesian, result.variant_results[0])
+        self.assertEqual(variant.key, "test")
+        self.assertEqual(variant.number_of_samples, data["test"][0])
+        self.assertEqual(variant.sum, data["test"][1])
+        self.assertEqual(variant.sum_squares, data["test"][2])
+        self.assertIsNone(variant.chance_to_win)
+        self.assertIsNone(variant.credible_interval)
+        self.assertIsNone(variant.significant)
+
+    def test_frequentist_sufficient_data_returns_stats(self):
+        metric = self.create_mean_metric()
+        control = self.create_variant("control", sum_val=100.0, sum_squares=10500.0, samples=1000)
+        test = self.create_variant("test", sum_val=120.0, sum_squares=14500.0, samples=1000)
+
+        result = get_frequentist_experiment_result(
+            metric=metric,
+            control_variant=control,
+            test_variants=[test],
+            stats_config=None,
+        )
+
+        assert result.variant_results is not None
+        variant = cast(ExperimentVariantResultFrequentist, result.variant_results[0])
+        self.assertIsNotNone(variant.p_value)
+        self.assertIsNotNone(variant.confidence_interval)
+        self.assertIsNotNone(variant.significant)
+
+    def test_bayesian_sufficient_data_returns_stats(self):
+        metric = self.create_mean_metric()
+        control = self.create_variant("control", sum_val=100.0, sum_squares=10500.0, samples=1000)
+        test = self.create_variant("test", sum_val=120.0, sum_squares=14500.0, samples=1000)
+
+        result = get_bayesian_experiment_result(
+            metric=metric,
+            control_variant=control,
+            test_variants=[test],
+            stats_config=None,
+        )
+
+        assert result.variant_results is not None
+        variant = cast(ExperimentVariantResultBayesian, result.variant_results[0])
+        self.assertIsNotNone(variant.chance_to_win)
+        self.assertIsNotNone(variant.credible_interval)
+        self.assertIsNotNone(variant.significant)


### PR DESCRIPTION
## Problem

When experiments have very little data, the stats library throws `StatisticError` exceptions during statistical evaluation (e.g. zero variance, near-zero control mean, invalid `sum_squares` constraints). These bypass the existing `validate_variant_result()` checks and get caught by `@experiment_error_handler`, which:

1. Logs them at `ERROR` level with full stack traces
2. Captures them to Posthog via `capture_exception()`
3. Converts them to a `ValidationError` that kills the entire query response

This creates unnecessary log noise for a normal condition (not enough data yet) and prevents returning partial results.

## Changes

- Wrap `metric_variant_to_statistic()` and `method.run_test()` calls in both `get_frequentist_experiment_result()` and `get_bayesian_experiment_result()` with `try/except StatisticError`
- On catch, log at `info` level with structured context (variant key, sample count, reason) instead of propagating
- Raw values (`number_of_samples`, `sum`, `sum_squares`) always return; statistical fields (`p_value`, `confidence_interval`, `credible_interval`, `chance_to_win`, `significant`) return as `None`
- No schema or frontend changes needed — the frontend already handles `None` gracefully (shows "—" and "Not enough data yet")

## Testing

Added parameterized tests in `test_stats_config.py` covering:
- **Very small sample size** (n=1): raw values returned, statistical fields are `None`
- **Zero baseline sum** (control sum=0): raw values returned, statistical fields are `None`
- **Zero variance** (all identical observations): raw values returned, statistical fields are `None`
- **Sufficient data sanity check** (n=1000): statistical fields are populated

All tested for both frequentist and bayesian methods (8 new tests, 21 total pass).

```
pytest posthog/hogql_queries/experiments/test/test_stats_config.py -v
```