### PR TITLE
feat(insights): prepare line graph data for chartjs parsing false

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -328,6 +328,7 @@ export const FEATURE_FLAGS = {
     PHAI_WEB_SEARCH: 'phai-web-search', // owner: @Twixes #team-posthog-ai
     PRODUCT_ANALYTICS_AI_INSIGHT_ANALYSIS: 'product-analytics-ai-insight-analysis', // owner: #team-analytics-platform, used to show AI analysis section in insights
     PRODUCT_ANALYTICS_AUTONAME_INSIGHTS_WITH_AI: 'autoname-insights-with-ai', // owner: @gesh #team-product-analytics
+    PRODUCT_ANALYTICS_CHARTJS_PREPARED_DATA: 'product-analytics-chartjs-prepared-data', // owner: #team-product-analytics, enables pre-shaped chart data with parsing: false in LineGraph
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_DATE_PICKER_EXPLICIT_DATE_TOGGLE: 'date-picker-explicit-date-toggle', // owner: @gesh #team-product-analytics
     PRODUCT_ANALYTICS_EVENTS_COMBINATION_IN_TRENDS: 'events-combination-in-trends', // owner: @gesh #team-product-analytics

--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -3,6 +3,34 @@ import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { GraphDataset } from '~/types'
 
+function getTooltipPointValue(dp: TooltipItem<any>, pointDataset: GraphDataset): number {
+    const isHorizontal = dp.chart?.options?.indexAxis === 'y'
+    if (typeof dp.parsed === 'number') {
+        return dp.parsed
+    }
+
+    if (dp.parsed && typeof dp.parsed === 'object') {
+        const parsedValue = (dp.parsed as Record<string, unknown>)[isHorizontal ? 'x' : 'y']
+        if (typeof parsedValue === 'number') {
+            return parsedValue
+        }
+    }
+
+    const rawValue = pointDataset?.data?.[dp.dataIndex]
+    if (typeof rawValue === 'number') {
+        return rawValue
+    }
+
+    if (rawValue && typeof rawValue === 'object') {
+        const pointValue = (rawValue as Record<string, unknown>)[isHorizontal ? 'x' : 'y']
+        if (typeof pointValue === 'number') {
+            return pointValue
+        }
+    }
+
+    return 0
+}
+
 export function createTooltipData(
     tooltipDataPoints: TooltipItem<any>[],
     filterFn?: (s: SeriesDatum) => boolean
@@ -31,7 +59,7 @@ export function createTooltipData(
                 color: Array.isArray(pointDataset.borderColor)
                     ? pointDataset.borderColor?.[dp.dataIndex]
                     : pointDataset.borderColor,
-                count: pointDataset?.data?.[dp.dataIndex] || 0,
+                count: getTooltipPointValue(dp, pointDataset),
                 filter: pointDataset?.filter ?? {},
                 hideTooltip: (pointDataset as any).hideTooltip,
             }


### PR DESCRIPTION
Chart.js doesn't need to do parsing, if we do it ourselves https://www.chartjs.org/docs/latest/general/performance.html#parsing.

This likely just moves the point of data transformation around and isn't a huge performance improvement in itself, but it allows us to enable data decimation with the respective plugin in a follow up PR.

---
<img width="1038" height="435" alt="Screenshot 2026-02-18 at 15 28 50" src="https://github.com/user-attachments/assets/f68c9e5a-6346-411b-a375-4c8bc19a819b" />
