### PR TITLE
feat(llma): increase request latency bucket granularity

### DIFF
--- a/products/llm_analytics/backend/api/metrics.py
+++ b/products/llm_analytics/backend/api/metrics.py
@@ -25,13 +25,46 @@ from prometheus_client import Counter, Histogram
 F = TypeVar("F", bound=Callable)
 
 
-# Latency histogram for API request duration
-# Buckets are tuned for typical API response times (100ms to 60s)
+# Latency histogram for API request duration.
+# Buckets are denser in the 100ms-60s region for better tail-percentile stability.
+LLMA_REQUEST_LATENCY_BUCKETS = [
+    0.005,
+    0.01,
+    0.015,
+    0.02,
+    0.03,
+    0.05,
+    0.075,
+    0.1,
+    0.15,
+    0.2,
+    0.3,
+    0.5,
+    0.75,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    90.0,
+    120.0,
+    180.0,
+    240.0,
+    300.0,
+]
+
 LLMA_REQUEST_LATENCY = Histogram(
     "llma_request_duration_seconds",
     "LLM Analytics API request latency in seconds",
     labelnames=["endpoint"],
-    buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0],
+    buckets=LLMA_REQUEST_LATENCY_BUCKETS,
 )
 
 
@@ -58,7 +91,7 @@ def llma_track_latency(endpoint: str) -> Callable[[F], F]:
     Decorator to track endpoint latency using Prometheus histograms.
 
     This decorator measures the total time taken by an endpoint and records
-    it in the LLMA_REQUEST_LATENCY histogram. Use this in addition to @monitor
+    it in the LLMA request latency histogram. Use this in addition to @monitor
     for endpoints where latency tracking is important.
 
     Args:

--- a/products/llm_analytics/backend/api/test/test_metrics.py
+++ b/products/llm_analytics/backend/api/test/test_metrics.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.llm_analytics.backend.api.metrics import LLMA_REQUEST_LATENCY_BUCKETS, llma_track_latency
+
+
+class TestLLMAnalyticsMetrics(SimpleTestCase):
+    @parameterized.expand([("single", LLMA_REQUEST_LATENCY_BUCKETS, 30)])
+    def test_request_latency_buckets_are_monotonic(self, _: str, buckets: list[float], expected_count: int):
+        assert len(buckets) == expected_count
+        assert buckets == sorted(buckets)
+        assert buckets[-1] == 300.0
+
+    @patch("products.llm_analytics.backend.api.metrics.LLMA_REQUEST_LATENCY")
+    @patch("products.llm_analytics.backend.api.metrics.time.perf_counter")
+    def test_track_latency_observes_histogram(self, mock_perf_counter, mock_histogram):
+        mock_perf_counter.side_effect = [10.0, 10.2]
+        observer = MagicMock()
+        mock_histogram.labels.return_value = observer
+
+        @llma_track_latency("llma_test_endpoint")
+        def operation():
+            return "ok"
+
+        assert operation() == "ok"
+        mock_histogram.labels.assert_called_once_with(endpoint="llma_test_endpoint")
+        observer.observe.assert_called_once()
+        self.assertAlmostEqual(observer.observe.call_args.args[0], 0.2)
+
+    @patch("products.llm_analytics.backend.api.metrics.LLMA_REQUEST_LATENCY")
+    @patch("products.llm_analytics.backend.api.metrics.time.perf_counter")
+    def test_track_latency_observes_on_exception(self, mock_perf_counter, mock_histogram):
+        mock_perf_counter.side_effect = [10.0, 10.5]
+        observer = MagicMock()
+        mock_histogram.labels.return_value = observer
+
+        @llma_track_latency("llma_test_endpoint")
+        def failing_operation():
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            failing_operation()
+
+        observer.observe.assert_called_once()
+        self.assertAlmostEqual(observer.observe.call_args.args[0], 0.5)


### PR DESCRIPTION
## Problem

LLMA endpoint latency percentiles were often near bucket boundaries, which reduced tail percentile usefulness.

## Changes

- Increased granularity of `llma_request_duration_seconds` buckets for LLMA endpoint latency.

## How did you test this code?

Automated tests.

## Publish to changelog?

do not publish to changelog
