### PR TITLE
fix(phai): Replace exception-based control flow with return value in memory parser

### DIFF
--- a/ee/hogai/chat_agent/memory/parsers.py
+++ b/ee/hogai/chat_agent/memory/parsers.py
@@ -10,15 +10,7 @@ def compressed_memory_parser(memory: str) -> str:
     return memory.replace("\n\n", "\n")
 
 
-class MemoryCollectionCompleted(Exception):
-    """
-    Raised when the agent finishes collecting memory.
-    """
-
-    pass
-
-
-def raise_memory_updated(response: Any):
+def check_memory_collection_completed(response: Any) -> AIMessage | None:
     if isinstance(response, AIMessage) and ("[Done]" in response.content or not response.tool_calls):
-        raise MemoryCollectionCompleted
+        return None
     return response

--- a/ee/hogai/chat_agent/memory/test/test_parsers.py
+++ b/ee/hogai/chat_agent/memory/test/test_parsers.py
@@ -2,7 +2,7 @@ from posthog.test.base import BaseTest
 
 from langchain_core.messages import AIMessage
 
-from ee.hogai.chat_agent.memory.parsers import MemoryCollectionCompleted, compressed_memory_parser, raise_memory_updated
+from ee.hogai.chat_agent.memory.parsers import check_memory_collection_completed, compressed_memory_parser
 
 
 class TestParsers(BaseTest):
@@ -10,14 +10,12 @@ class TestParsers(BaseTest):
         memory = "Hello\n\nWorld "
         self.assertEqual(compressed_memory_parser(memory), "Hello\nWorld ")
 
-    def test_raise_memory_updated(self):
+    def test_check_memory_collection_completed(self):
         message = AIMessage(content="Hello World")
-        with self.assertRaises(MemoryCollectionCompleted):
-            raise_memory_updated(message)
+        self.assertIsNone(check_memory_collection_completed(message))
 
         message = AIMessage(content="[Done]", tool_calls=[{"id": "1", "args": {}, "name": "function"}])
-        with self.assertRaises(MemoryCollectionCompleted):
-            raise_memory_updated(message)
+        self.assertIsNone(check_memory_collection_completed(message))
 
         message = AIMessage(content="Reasoning", tool_calls=[{"id": "1", "args": {}, "name": "function"}])
-        self.assertEqual(raise_memory_updated(message), message)
+        self.assertEqual(check_memory_collection_completed(message), message)


### PR DESCRIPTION
## Problem

The memory collection completion logic uses exception-based control flow, so they're propagated in LLMA. This PR refactors it to use a check.

## Changes

- Renamed `raise_memory_updated` to `check_memory_collection_completed` to better reflect its new behavior
- Changed `check_memory_collection_completed` to return `None` instead of raising `MemoryCollectionCompleted` when collection is complete
- Updated `MemoryCollectorNode.arun()` to check for `None` return value instead of catching an exception
- Removed the `MemoryCollectionCompleted` exception class entirely
- Updated tests to verify the new return value behavior instead of exception handling

## How did you test this code?

Updated unit tests in `test_parsers.py` to verify:
- `check_memory_collection_completed` returns `None` when memory collection is complete (no tool calls or "[Done]" in content)
- `check_memory_collection_completed` returns the message unchanged when collection should continue (has tool calls and no "[Done]")

Existing tests pass with the new implementation.

https://claude.ai/code/session_01T3koQL5DXi29EPV3tL49dz