### PR TITLE
feat(llma): add turn numbers and chronological ordering to session traces

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
@@ -161,9 +161,10 @@ function SessionSceneWrapper(): JSX.Element {
                     <div className="bg-surface-primary border rounded p-4">
                         <h3 className="font-semibold text-sm mb-3">Traces in this session</h3>
                         <div className="space-y-2">
-                            {traces.map((trace) => {
+                            {traces.map((trace, index) => {
                                 const isTraceExpanded = expandedTraceIds.has(trace.id)
                                 const summary: TraceSummary | undefined = traceSummaries[trace.id]
+                                const turnNumber = index + 1
 
                                 return (
                                     <div key={trace.id} className="border rounded">
@@ -180,6 +181,9 @@ function SessionSceneWrapper(): JSX.Element {
                                             </div>
                                             <div className="flex-1">
                                                 <div className="flex items-center gap-2 mb-2 flex-wrap">
+                                                    <span className="text-xs font-semibold text-muted">
+                                                        #{turnNumber}
+                                                    </span>
                                                     <strong className="font-mono text-xs">
                                                         {trace.id.slice(0, 8)}...
                                                     </strong>

--- a/products/llm_analytics/frontend/llmAnalyticsSessionDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSessionDataLogic.ts
@@ -171,7 +171,8 @@ export const llmAnalyticsSessionDataLogic = kea<llmAnalyticsSessionDataLogicType
             (s) => [s.response],
             (response: AnyResponseType | null): LLMTrace[] => {
                 const tracesResponse = response as TracesQueryResponse | null
-                return tracesResponse?.results || []
+                // Reverse to chronological order (oldest first) for session view
+                return [...(tracesResponse?.results || [])].reverse()
             },
         ],
         summariesLoading: [


### PR DESCRIPTION
## Summary
Improves readability of session trace lists by adding turn numbers and reversing the order to chronological (oldest first).

## Changes
- Reversed trace order in `llmAnalyticsSessionDataLogic` selector to show traces chronologically (oldest first)
- Added turn numbers (`#1`, `#2`, etc.) to each trace card in session view

## Context
Previously, traces were displayed newest-first (descending order), which is counterintuitive for conversational sessions where users expect to read chronologically. The lack of turn numbers also made it hard to reference specific traces in the sequence.

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Manual testing: navigate to a session with multiple traces and verify:
  - Traces appear in chronological order (oldest at top)
  - Turn numbers (`#1`, `#2`, etc.) appear before each trace ID
  - Turn numbers correspond to chronological sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)