### PR TITLE
fix(settings): apply correct access control rules in surveys settings

### DIFF
--- a/frontend/src/scenes/surveys/SurveySettings.tsx
+++ b/frontend/src/scenes/surveys/SurveySettings.tsx
@@ -5,13 +5,14 @@ import { useState } from 'react'
 import { IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonSwitch, Link } from '@posthog/lemon-ui'
 
-import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { surveysLogic } from 'scenes/surveys/surveysLogic'
 import { sanitizeSurveyAppearance, validateSurveyAppearance } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { AccessControlLevel, AccessControlResourceType, SurveyAppearance } from '~/types'
+import { SurveyAppearance } from '~/types'
 
 import { NEW_SURVEY, defaultSurveyAppearance } from './constants'
 import { Customization } from './survey-appearance/SurveyCustomization'
@@ -20,23 +21,25 @@ import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 export function SurveyEnableToggle(): JSX.Element {
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     return (
-        <AccessControlAction resourceType={AccessControlResourceType.Survey} minAccessLevel={AccessControlLevel.Editor}>
-            <LemonSwitch
-                data-attr="opt-in-surveys-switch"
-                onChange={(checked) => {
-                    updateCurrentTeam({
-                        surveys_opt_in: checked,
-                    })
-                }}
-                label="Enable surveys"
-                bordered
-                checked={!!currentTeam?.surveys_opt_in}
-                disabled={currentTeamLoading}
-                disabledReason={currentTeamLoading ? 'Loading...' : undefined}
-            />
-        </AccessControlAction>
+        <LemonSwitch
+            data-attr="opt-in-surveys-switch"
+            onChange={(checked) => {
+                updateCurrentTeam({
+                    surveys_opt_in: checked,
+                })
+            }}
+            label="Enable surveys"
+            bordered
+            checked={!!currentTeam?.surveys_opt_in}
+            disabled={currentTeamLoading}
+            disabledReason={currentTeamLoading ? 'Loading...' : restrictedReason}
+        />
     )
 }
 
@@ -48,6 +51,11 @@ export function SurveyDefaultAppearance(): JSX.Element {
         SurveyAppearance,
         ValidationErrorType
     > | null>(null)
+
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const [editableSurveyConfig, setEditableSurveyConfig] = useState({
         ...defaultSurveyAppearance,
@@ -86,59 +94,45 @@ export function SurveyDefaultAppearance(): JSX.Element {
     }
 
     return (
-        <AccessControlAction resourceType={AccessControlResourceType.Survey} minAccessLevel={AccessControlLevel.Editor}>
-            {({ disabledReason }) => {
-                if (disabledReason) {
-                    return null
-                }
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                {globalSurveyAppearanceConfigAvailable && (
+                    <LemonButton type="primary" onClick={updateSurveySettings} disabledReason={restrictedReason}>
+                        Save appearance changes
+                    </LemonButton>
+                )}
+            </div>
 
-                return (
-                    <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                            {globalSurveyAppearanceConfigAvailable && (
-                                <LemonButton type="primary" onClick={updateSurveySettings}>
-                                    Save appearance changes
-                                </LemonButton>
-                            )}
-                        </div>
-
-                        <div className="flex gap-8">
-                            <div className="min-w-1/2">
-                                <Customization
-                                    survey={templatedSurvey}
-                                    hasBranchingLogic={false}
-                                    hasRatingButtons={true}
-                                    hasPlaceholderText={true}
-                                    onAppearanceChange={(appearance) => {
-                                        const newAppearance = {
-                                            ...editableSurveyConfig,
-                                            ...appearance,
-                                        }
-                                        const errors = validateSurveyAppearance(
-                                            newAppearance,
-                                            true,
-                                            templatedSurvey.type
-                                        )
-                                        setValidationErrors(errors)
-                                        setEditableSurveyConfig(newAppearance)
-                                        setTemplatedSurvey({
-                                            ...templatedSurvey,
-                                            appearance: newAppearance,
-                                        })
-                                    }}
-                                    validationErrors={validationErrors}
-                                />
-                            </div>
-                            {globalSurveyAppearanceConfigAvailable && (
-                                <div className="max-w-1/2 pt-8 pr-8 overflow-auto">
-                                    <SurveyAppearancePreview survey={templatedSurvey} previewPageIndex={0} />
-                                </div>
-                            )}
-                        </div>
+            <div className="flex gap-8">
+                <div className="min-w-1/2">
+                    <Customization
+                        survey={templatedSurvey}
+                        hasBranchingLogic={false}
+                        hasRatingButtons={true}
+                        hasPlaceholderText={true}
+                        onAppearanceChange={(appearance) => {
+                            const newAppearance = {
+                                ...editableSurveyConfig,
+                                ...appearance,
+                            }
+                            const errors = validateSurveyAppearance(newAppearance, true, templatedSurvey.type)
+                            setValidationErrors(errors)
+                            setEditableSurveyConfig(newAppearance)
+                            setTemplatedSurvey({
+                                ...templatedSurvey,
+                                appearance: newAppearance,
+                            })
+                        }}
+                        validationErrors={validationErrors}
+                    />
+                </div>
+                {globalSurveyAppearanceConfigAvailable && (
+                    <div className="max-w-1/2 pt-8 pr-8 overflow-auto">
+                        <SurveyAppearancePreview survey={templatedSurvey} previewPageIndex={0} />
                     </div>
-                )
-            }}
-        </AccessControlAction>
+                )}
+            </div>
+        </div>
     )
 }
 

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
@@ -7,6 +7,8 @@ import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonModal, LemonSelect, LemonSwitch, LemonTabs } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { defaultSurveyAppearance } from 'scenes/surveys/constants'
 import {
@@ -149,6 +151,10 @@ export function SurveyAppearanceModal({
 }: CommonProps): JSX.Element | null {
     const { setIsAppearanceModalOpen } = useActions(surveysLogic)
     const { surveysStylingAvailable, isAppearanceModalOpen } = useValues(surveysLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     if (survey.type === SurveyType.API || survey.type === SurveyType.ExternalSurvey) {
         return null
@@ -167,6 +173,7 @@ export function SurveyAppearanceModal({
                 onClick={() => {
                     setIsAppearanceModalOpen(true)
                 }}
+                disabledReason={restrictedReason}
             >
                 Full-screen survey editor
             </LemonButton>

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -4,6 +4,8 @@ import { DeepPartialMap, ValidationErrorType } from 'kea-forms'
 import { IconCheck } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { WEB_SAFE_FONTS } from 'scenes/surveys/constants'
 import { surveysLogic } from 'scenes/surveys/surveysLogic'
@@ -70,6 +72,7 @@ interface SurveyAppearanceInputProps {
     label: string
     info?: string
     placeholder?: string
+    disabledReason?: string | null
 }
 
 function SurveyAppearanceInput({
@@ -79,6 +82,7 @@ function SurveyAppearanceInput({
     label,
     info,
     placeholder,
+    disabledReason,
 }: SurveyAppearanceInputProps): JSX.Element {
     const { surveysStylingAvailable } = useValues(surveysLogic)
 
@@ -90,6 +94,7 @@ function SurveyAppearanceInput({
                 disabled={!surveysStylingAvailable}
                 className={IGNORE_ERROR_BORDER_CLASS}
                 placeholder={placeholder}
+                disabledReason={disabledReason}
             />
             {error && <LemonField.Error error={error} />}
         </LemonField.Pure>
@@ -103,6 +108,10 @@ export function SurveyContainerAppearance({
     surveyType,
 }: CommonProps): JSX.Element | null {
     const { surveysStylingAvailable } = useValues(surveysLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     return (
         <SurveyOptionsGroup sectionTitle="Container options">
@@ -113,6 +122,7 @@ export function SurveyContainerAppearance({
                 value={appearance.maxWidth}
                 onChange={(maxWidth) => onAppearanceChange({ maxWidth })}
                 error={validationErrors?.maxWidth}
+                disabledReason={restrictedReason}
                 label="Survey width"
                 info="Min-width is always set to 300px"
             />
@@ -120,18 +130,21 @@ export function SurveyContainerAppearance({
                 value={appearance.boxPadding}
                 onChange={(boxPadding) => onAppearanceChange({ boxPadding })}
                 error={validationErrors?.boxPadding}
+                disabledReason={restrictedReason}
                 label="Box padding"
             />
             <SurveyAppearanceInput
                 value={appearance.boxShadow}
                 onChange={(boxShadow) => onAppearanceChange({ boxShadow })}
                 error={validationErrors?.boxShadow}
+                disabledReason={restrictedReason}
                 label="Box shadow"
             />
             <SurveyAppearanceInput
                 value={appearance.borderRadius}
                 onChange={(borderRadius) => onAppearanceChange({ borderRadius })}
                 error={validationErrors?.borderRadius}
+                disabledReason={restrictedReason}
                 label="Border radius"
             />
             <LemonField.Pure
@@ -147,7 +160,7 @@ export function SurveyContainerAppearance({
                     <SurveyPositionSelector
                         currentPosition={appearance.position}
                         onAppearanceChange={onAppearanceChange}
-                        disabled={!surveysStylingAvailable}
+                        disabled={!surveysStylingAvailable || !!restrictedReason}
                     />
                     <LemonSelect
                         value={appearance.position}
@@ -157,6 +170,7 @@ export function SurveyContainerAppearance({
                             value: position,
                         }))}
                         disabled={!surveysStylingAvailable}
+                        disabledReason={restrictedReason}
                     />
                 </div>
                 {surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector && (
@@ -171,6 +185,7 @@ export function SurveyContainerAppearance({
                             }
                             active={appearance.position === SurveyPosition.NextToTrigger}
                             disabled={!surveysStylingAvailable}
+                            disabledReason={restrictedReason}
                         >
                             {positionDisplayNames[SurveyPosition.NextToTrigger]}
                             {appearance.position === SurveyPosition.NextToTrigger && (
@@ -196,12 +211,14 @@ export function SurveyContainerAppearance({
                     })}
                     className="ignore-error-border"
                     disabled={!surveysStylingAvailable}
+                    disabledReason={restrictedReason}
                 />
             </LemonField.Pure>
             <SurveyAppearanceInput
                 value={appearance.zIndex}
                 onChange={(zIndex) => onAppearanceChange({ zIndex })}
                 error={validationErrors?.zIndex}
+                disabledReason={restrictedReason}
                 label="Survey form zIndex"
                 info="If the survey popup is hidden, set this value higher than the overlapping element's zIndex."
             />
@@ -228,6 +245,11 @@ export function SurveyColorsAppearance({
     customizeRatingButtons: boolean
     customizePlaceholderText: boolean
 }): JSX.Element {
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
     return (
         <SurveyOptionsGroup sectionTitle="Colors and placeholder customization">
             <SurveyColorsSubgroup title="Survey background">
@@ -235,12 +257,14 @@ export function SurveyColorsAppearance({
                     value={appearance.backgroundColor}
                     onChange={(backgroundColor) => onAppearanceChange({ backgroundColor })}
                     error={validationErrors?.backgroundColor}
+                    disabledReason={restrictedReason}
                     label="Background color"
                 />
                 <SurveyAppearanceInput
                     value={appearance.textColor}
                     onChange={(textColor) => onAppearanceChange({ textColor })}
                     error={validationErrors?.textColor}
+                    disabledReason={restrictedReason}
                     label="Text color"
                     placeholder="Leave empty for auto-contrast"
                 />
@@ -248,6 +272,7 @@ export function SurveyColorsAppearance({
                     value={appearance.borderColor}
                     onChange={(borderColor) => onAppearanceChange({ borderColor })}
                     error={validationErrors?.borderColor}
+                    disabledReason={restrictedReason}
                     label="Border color"
                 />
             </SurveyColorsSubgroup>
@@ -259,12 +284,14 @@ export function SurveyColorsAppearance({
                         onAppearanceChange({ inputBackground, ratingButtonColor: inputBackground })
                     }
                     error={validationErrors?.inputBackground || validationErrors?.ratingButtonColor}
+                    disabledReason={restrictedReason}
                     label="Background color"
                 />
                 <SurveyAppearanceInput
                     value={appearance.inputTextColor}
                     onChange={(inputTextColor) => onAppearanceChange({ inputTextColor })}
                     error={validationErrors?.inputTextColor}
+                    disabledReason={restrictedReason}
                     label="Text color"
                     placeholder="Leave empty for auto-contrast"
                 />
@@ -273,6 +300,7 @@ export function SurveyColorsAppearance({
                         value={appearance.ratingButtonActiveColor}
                         onChange={(ratingButtonActiveColor) => onAppearanceChange({ ratingButtonActiveColor })}
                         error={validationErrors?.ratingButtonActiveColor}
+                        disabledReason={restrictedReason}
                         label="Active rating background"
                     />
                 )}
@@ -281,6 +309,7 @@ export function SurveyColorsAppearance({
                         value={appearance.placeholder}
                         onChange={(placeholder) => onAppearanceChange({ placeholder })}
                         error={validationErrors?.placeholder}
+                        disabledReason={restrictedReason}
                         label="Placeholder text"
                     />
                 )}
@@ -291,12 +320,14 @@ export function SurveyColorsAppearance({
                     value={appearance.submitButtonColor}
                     onChange={(submitButtonColor) => onAppearanceChange({ submitButtonColor })}
                     error={validationErrors?.submitButtonColor}
+                    disabledReason={restrictedReason}
                     label="Background color"
                 />
                 <SurveyAppearanceInput
                     value={appearance.submitButtonTextColor}
                     onChange={(submitButtonTextColor) => onAppearanceChange({ submitButtonTextColor })}
                     error={validationErrors?.submitButtonTextColor}
+                    disabledReason={restrictedReason}
                     label="Text color"
                     placeholder="Leave empty for auto-contrast"
                 />

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
@@ -3,7 +3,9 @@ import { useValues } from 'kea'
 import { LemonCheckbox, LemonDialog, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { defaultSurveyAppearance } from 'scenes/surveys/constants'
 import { SurveyAppearanceModal } from 'scenes/surveys/survey-appearance/SurveyAppearanceModal'
@@ -32,6 +34,10 @@ export function Customization({
         ? ''
         : 'Please add more than one question to the survey to enable shuffling questions'
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const surveyAppearance = { ...defaultSurveyAppearance, ...survey.appearance }
 
@@ -86,10 +92,11 @@ export function Customization({
                             }
                         }}
                         checked={survey.appearance?.whiteLabel}
+                        disabledReason={restrictedReason}
                     />
                     <div className="flex flex-col gap-2">
                         <LemonCheckbox
-                            disabledReason={surveyShufflingQuestionsDisabledReason}
+                            disabledReason={restrictedReason ?? surveyShufflingQuestionsDisabledReason}
                             label={
                                 <div className="flex items-center">
                                     <span>Shuffle questions</span>
@@ -137,6 +144,7 @@ export function Customization({
                                         const surveyPopupDelaySeconds = checked ? 5 : undefined
                                         onAppearanceChange({ surveyPopupDelaySeconds })
                                     }}
+                                    disabledReason={restrictedReason}
                                 />
                                 Delay survey popup by at least{' '}
                                 <LemonInput
@@ -154,6 +162,7 @@ export function Customization({
                                         }
                                     }}
                                     className="w-12 ignore-error-border"
+                                    disabledReason={restrictedReason}
                                 />{' '}
                                 seconds once the display conditions are met.
                             </div>


### PR DESCRIPTION
## Problem
The settings for surveys check the wrong permissions or do not perform permission checks at all.

## Changes
Make sure all settings on surveys settings page require project-level admin permissions to make changes.

## How did you test this code
Manually