### PR TITLE
fix(settings): apply correct access control rules in marketing analytics settings

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -28,9 +28,15 @@ interface ConversionGoalDropdownProps {
     value: ConversionGoalFilter
     onChange: (filter: ConversionGoalFilter) => void
     typeKey: string
+    disabledReason?: string | null
 }
 
-export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionGoalDropdownProps): JSX.Element {
+export function ConversionGoalDropdown({
+    value,
+    onChange,
+    typeKey,
+    disabledReason,
+}: ConversionGoalDropdownProps): JSX.Element {
     const [error, setError] = useState<string | null>(null)
 
     // Create a proper ActionFilter-compatible filter object
@@ -177,6 +183,7 @@ export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionG
                 excludedProperties={{
                     [TaxonomicFilterGroupType.Events]: [null],
                 }}
+                disabled={!!disabledReason}
             />
             {error && <div className="text-danger mt-2 text-sm">{error}</div>}
         </div>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/AttributionSettings.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/AttributionSettings.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { IconInfo } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { debounce } from 'lib/utils'
@@ -32,6 +34,10 @@ export function AttributionSettings(): JSX.Element {
         updateAttributionMode: updateAttributionModeAction,
     } = useActions(marketingAnalyticsSettingsLogic)
     const { currentTeamLoading } = useValues(teamLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     // Get attribution settings from config with defaults
     const attribution_window_days = marketingAnalyticsConfig?.attribution_window_days ?? DEFAULT_ATTRIBUTION_WINDOW_DAYS
@@ -137,6 +143,7 @@ export function AttributionSettings(): JSX.Element {
                             options={ATTRIBUTION_WINDOW_OPTIONS}
                             data-attr="attribution-window-select"
                             className="w-50"
+                            disabledReason={restrictedReason}
                         />
                         <LemonInput
                             type="number"
@@ -149,6 +156,7 @@ export function AttributionSettings(): JSX.Element {
                             className="w-32"
                             status={hasError ? 'danger' : undefined}
                             data-attr="attribution-window-custom-input"
+                            disabledReason={restrictedReason}
                         />
                         <LemonButton
                             type="primary"
@@ -159,7 +167,7 @@ export function AttributionSettings(): JSX.Element {
                                     ? `Please enter a valid value between ${MIN_ATTRIBUTION_WINDOW_DAYS} and ${MAX_ATTRIBUTION_WINDOW_DAYS} days`
                                     : localDays === attribution_window_days
                                       ? 'No changes to save'
-                                      : undefined
+                                      : restrictedReason
                             }
                             data-attr="attribution-window-save-button"
                         >
@@ -190,6 +198,7 @@ export function AttributionSettings(): JSX.Element {
                                     onClick={() => handleAttributionModeChange(option.value)}
                                     data-attr={`attribution-mode-${option.value.toLowerCase().replace('_', '-')}`}
                                     className="flex-1"
+                                    disabledReason={restrictedReason}
                                 >
                                     {option.label}
                                 </LemonButton>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CampaignFieldPreferencesConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CampaignFieldPreferencesConfiguration.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 
 import { LemonSegmentedButton } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { CampaignFieldPreference, MatchField } from '~/queries/schema/schema-general'
@@ -21,6 +23,10 @@ export function CampaignFieldPreferencesConfiguration({
     const { marketingAnalyticsConfig } = useValues(marketingAnalyticsSettingsLogic)
     const { updateCampaignFieldPreferences } = useActions(marketingAnalyticsSettingsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const preferences = marketingAnalyticsConfig?.campaign_field_preferences || {}
 
@@ -80,6 +86,7 @@ export function CampaignFieldPreferencesConfiguration({
                                             { value: MatchField.CAMPAIGN_NAME, label: 'Campaign name' },
                                             { value: MatchField.CAMPAIGN_ID, label: 'Campaign ID' },
                                         ]}
+                                        disabledReason={restrictedReason ?? undefined}
                                     />
                                 </td>
                             </tr>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CampaignNameMappingsConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CampaignNameMappingsConfiguration.tsx
@@ -4,6 +4,9 @@ import { useEffect, useMemo, useState } from 'react'
 import { IconInfo, IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonInputSelect, LemonSelect, LemonTag, LemonTextArea, Tooltip } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
+
 import { MatchField, VALID_NATIVE_MARKETING_SOURCES, externalDataSources } from '~/queries/schema/schema-general'
 
 import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
@@ -35,6 +38,10 @@ export function CampaignNameMappingsConfiguration({
     const [selectedSource, setSelectedSource] = useState<string>(sourceFilter || '')
     const [newCleanName, setNewCleanName] = useState('')
     const [newRawValues, setNewRawValues] = useState(initialUtmValue || '')
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     useEffect(() => {
         if (initialUtmValue) {
@@ -199,6 +206,7 @@ export function CampaignNameMappingsConfiguration({
                                                   icon={<IconTrash />}
                                                   onClick={() => removeMapping(source, cleanName)}
                                                   tooltip="Remove mapping"
+                                                  disabledReason={restrictedReason}
                                               />
                                           </td>
                                       </tr>
@@ -217,6 +225,7 @@ export function CampaignNameMappingsConfiguration({
                                         ]}
                                         size="small"
                                         fullWidth
+                                        disabledReason={restrictedReason}
                                     />
                                 </td>
                             )}
@@ -235,6 +244,7 @@ export function CampaignNameMappingsConfiguration({
                                         allowCustomValues
                                         size="small"
                                         loading={integrationCampaignsLoading[currentIntegration]}
+                                        disabled={!!restrictedReason}
                                     />
                                     {newCleanName && (
                                         <div className="text-xs text-muted break-all">
@@ -288,6 +298,7 @@ export function CampaignNameMappingsConfiguration({
                                                                 ? `${suggestion.name} (${Math.round(suggestion.score * 100)}% match)`
                                                                 : `ID: ${suggestion.id} (${Math.round(suggestion.score * 100)}% match)`
                                                         }
+                                                        disabledReason={restrictedReason}
                                                     >
                                                         {matchField === MatchField.CAMPAIGN_ID
                                                             ? `${suggestion.id} (${suggestion.name})`
@@ -308,6 +319,7 @@ export function CampaignNameMappingsConfiguration({
                                         minRows={1}
                                         maxRows={4}
                                         className="text-sm"
+                                        disabled={!!restrictedReason}
                                     />
                                     {hasAlreadyMappedValues && (
                                         <div className="flex items-start gap-1 text-warning text-xs">
@@ -340,6 +352,7 @@ export function CampaignNameMappingsConfiguration({
                                             !newRawValues.trim() ||
                                             hasAlreadyMappedValues
                                         }
+                                        disabledReason={restrictedReason}
                                     />
                                 </Tooltip>
                             </td>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from 'react'
 import { IconCheck, IconPencil, IconPlusSmall, IconTrash, IconWarning, IconX } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { uuid } from 'lib/utils'
 import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
@@ -46,6 +48,10 @@ export function ConversionGoalsConfiguration({
     const [formState, setFormState] = useState<ConversionGoalFormState>(createEmptyFormState)
     const [editingGoalId, setEditingGoalId] = useState<string | null>(null)
     const [editingGoal, setEditingGoal] = useState<ConversionGoalFilter | null>(null)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const validationWarnings = useMemo(() => validateConversionGoals(conversion_goals), [conversion_goals])
 
@@ -107,6 +113,7 @@ export function ConversionGoalsConfiguration({
                             value={formState.name}
                             onChange={(value) => setFormState((prev) => ({ ...prev, name: value }))}
                             placeholder={conversionGoalNamePlaceholder}
+                            disabledReason={restrictedReason}
                         />
                     </div>
 
@@ -123,6 +130,7 @@ export function ConversionGoalsConfiguration({
                                     },
                                 }))
                             }
+                            disabledReason={restrictedReason}
                         />
                     </div>
 
@@ -133,6 +141,7 @@ export function ConversionGoalsConfiguration({
                             disabled={!isFormValid}
                             size="small"
                             icon={<IconPlusSmall />}
+                            disabledReason={restrictedReason}
                         >
                             Add conversion goal
                         </LemonButton>
@@ -171,6 +180,7 @@ export function ConversionGoalsConfiguration({
                                                 )
                                             }
                                             size="small"
+                                            disabledReason={restrictedReason}
                                         />
                                     )
                                 }
@@ -238,12 +248,14 @@ export function ConversionGoalsConfiguration({
                                                 type="primary"
                                                 onClick={handleSaveEdit}
                                                 tooltip="Save changes"
+                                                disabledReason={restrictedReason}
                                             />
                                             <LemonButton
                                                 icon={<IconX />}
                                                 size="small"
                                                 onClick={handleCancelEdit}
                                                 tooltip="Cancel"
+                                                disabledReason={restrictedReason}
                                             />
                                         </div>
                                     )
@@ -256,6 +268,7 @@ export function ConversionGoalsConfiguration({
                                             size="small"
                                             onClick={() => handleStartEdit(goal)}
                                             tooltip="Edit conversion goal"
+                                            disabledReason={restrictedReason}
                                         />
                                         <LemonButton
                                             icon={<IconTrash />}
@@ -263,6 +276,7 @@ export function ConversionGoalsConfiguration({
                                             status="danger"
                                             onClick={() => handleRemoveGoal(goal.conversion_goal_id)}
                                             tooltip="Remove conversion goal"
+                                            disabledReason={restrictedReason}
                                         />
                                     </div>
                                 )

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CustomSourceMappingsConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CustomSourceMappingsConfiguration.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { IconPlusSmall } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonTag } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { MARKETING_DEFAULT_SOURCE_MAPPINGS } from '~/queries/schema/schema-general'
@@ -24,6 +26,10 @@ export function CustomSourceMappingsConfiguration({
     const { marketingAnalyticsConfig } = useValues(marketingAnalyticsSettingsLogic)
     const { updateCustomSourceMappings } = useActions(marketingAnalyticsSettingsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const customMappings = marketingAnalyticsConfig?.custom_source_mappings || {}
     const [inputValues, setInputValues] = useState<Record<string, string>>(() =>
@@ -165,13 +171,14 @@ export function CustomSourceMappingsConfiguration({
                                                     placeholder="Add custom sources"
                                                     size="small"
                                                     className="w-40"
+                                                    disabledReason={restrictedReason}
                                                 />
                                                 <LemonButton
                                                     type="primary"
                                                     size="small"
                                                     icon={<IconPlusSmall />}
                                                     onClick={() => addMapping(integration)}
-                                                    disabledReason={validationError || undefined}
+                                                    disabledReason={validationError || restrictedReason}
                                                     tooltip={!validationError ? 'Add custom sources' : undefined}
                                                 />
                                             </div>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ExternalDataSourceConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ExternalDataSourceConfiguration.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { IconGear, IconPencil, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { DataWarehouseSourceIcon } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
 import { urls } from 'scenes/urls'
@@ -60,6 +62,10 @@ export function ExternalDataSourceConfiguration(): JSX.Element {
     const { allExternalTablesWithStatus, loading, hasNoConfiguredSources } = useValues(marketingAnalyticsLogic)
     const { updateSourceMapping } = useActions(marketingAnalyticsSettingsLogic)
     const [editingTable, setEditingTable] = useState<ExternalTable | null>(null)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     // Helper to get sync info for native sources
     const getSourceSyncInfo = (source: ExternalDataSource): { syncingTables: string[]; tablesToSync: string[] } => {
@@ -305,6 +311,7 @@ export function ExternalDataSourceConfiguration(): JSX.Element {
                                         size="small"
                                         to={item.sourceUrl}
                                         tooltip="Configure source schemas"
+                                        disabledReason={restrictedReason}
                                     />
                                 )
                             }
@@ -317,6 +324,7 @@ export function ExternalDataSourceConfiguration(): JSX.Element {
                                             size="small"
                                             onClick={() => setEditingTable(item.table!)}
                                             tooltip="Map columns"
+                                            disabledReason={restrictedReason}
                                         />
                                         {tableHasMapping && (
                                             <LemonButton
@@ -325,6 +333,7 @@ export function ExternalDataSourceConfiguration(): JSX.Element {
                                                 status="danger"
                                                 onClick={() => removeTableMapping(item.table!)}
                                                 tooltip="Remove all mappings"
+                                                disabledReason={restrictedReason}
                                             />
                                         )}
                                     </div>


### PR DESCRIPTION
## Problem
The settings for marketing analytics check the wrong permissions or do not perform permission checks at all.

## Changes
Make sure all settings on marketing analytics settings page require project-level admin permissions to make changes.

## How did you test this code
Manually