### PR TITLE
feat(llma): add prompt usage tab and resolve endpoint

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1828,6 +1828,10 @@ export class ApiRequest {
         return this.llmPrompts(teamId).addPathComponent('name').addPathComponent(name)
     }
 
+    public llmPromptResolveByName(name: string, teamId?: TeamType['id']): ApiRequest {
+        return this.llmPrompts(teamId).addPathComponent('resolve').addPathComponent('name').addPathComponent(name)
+    }
+
     public evaluationRuns(teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('evaluation_runs')
     }
@@ -5449,6 +5453,10 @@ const api = {
 
         getByName(promptName: string): Promise<LLMPrompt> {
             return new ApiRequest().llmPromptByName(promptName).get()
+        },
+
+        resolveByName(promptName: string): Promise<LLMPrompt> {
+            return new ApiRequest().llmPromptResolveByName(promptName).get()
         },
 
         async create(data: Omit<Partial<LLMPrompt>, 'created_by'>): Promise<LLMPrompt> {

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1,6 +1,8 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import override_settings
+
 from rest_framework import status
 
 from posthog.models.llm_prompt import LLMPrompt
@@ -220,6 +222,54 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.json()["id"] == str(prompt.id)
         assert response.json()["name"] == "test-prompt"
         assert response.json()["prompt"] == "You are a helpful assistant."
+
+    def test_resolve_prompt_by_name_succeeds_for_session_auth(self, mock_feature_enabled):
+        prompt = LLMPrompt.objects.create(
+            team=self.team,
+            name="test-prompt",
+            prompt="You are a helpful assistant.",
+            created_by=self.user,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/resolve/name/test-prompt/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == str(prompt.id)
+        assert response.json()["name"] == "test-prompt"
+        assert response.json()["prompt"] == "You are a helpful assistant."
+
+    def test_resolve_prompt_by_name_forbidden_for_personal_api_key_auth(self, mock_feature_enabled):
+        LLMPrompt.objects.create(
+            team=self.team,
+            name="test-prompt",
+            prompt="You are a helpful assistant.",
+            created_by=self.user,
+        )
+
+        api_key = self.create_personal_api_key_with_scopes(["llm_prompt:read"])
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/resolve/name/test-prompt/")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == "This endpoint is only available to web-authenticated users."
+
+    @override_settings(TEST=False)
+    @patch("posthog.api.llm_prompt.capture_internal")
+    def test_resolve_prompt_by_name_does_not_emit_prompt_fetched_event(
+        self, mock_capture_internal, mock_feature_enabled
+    ):
+        LLMPrompt.objects.create(
+            team=self.team,
+            name="test-prompt",
+            prompt="You are a helpful assistant.",
+            created_by=self.user,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/resolve/name/test-prompt/")
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_capture_internal.assert_not_called()
 
     def test_fetch_prompt_by_name_not_found(self, mock_feature_enabled):
         response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/non-existent/")

--- a/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
+++ b/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
+import { useState } from 'react'
 
 import { IconPencil, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTabs, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { NotFound } from 'lib/components/NotFound'
@@ -15,13 +16,24 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { Query } from '~/queries/Query/Query'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
-import { ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
+import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    AnyPropertyFilter,
+    LLMPrompt,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
 
 import { useTracesQueryContext } from '../LLMAnalyticsTracesScene'
 import { PromptLogicProps, PromptMode, isPrompt, llmPromptLogic } from './llmPromptLogic'
 import { openDeletePromptDialog } from './utils'
+
+const PROMPT_FETCHED_EVENT = '$llm_prompt_fetched'
 
 export const scene: SceneExport<PromptLogicProps> = {
     component: LLMPromptScene,
@@ -45,6 +57,7 @@ export function LLMPromptScene(): JSX.Element {
         prompt,
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
+    const [activeViewTab, setActiveViewTab] = useState('overview')
 
     const { submitPromptForm, deletePrompt, setMode } = useActions(llmPromptLogic)
 
@@ -105,9 +118,35 @@ export function LLMPromptScene(): JSX.Element {
                     }
                 />
 
-                <PromptViewDetails />
-
-                <PromptRelatedTraces />
+                {prompt && isPrompt(prompt) ? (
+                    <LemonTabs
+                        activeKey={activeViewTab}
+                        onChange={(tab) => setActiveViewTab(tab)}
+                        tabs={[
+                            {
+                                key: 'overview',
+                                label: 'Overview',
+                                content: (
+                                    <>
+                                        <PromptViewDetails />
+                                        <PromptRelatedTraces />
+                                    </>
+                                ),
+                            },
+                            {
+                                key: 'usage',
+                                label: 'Usage',
+                                content: <PromptUsage prompt={prompt} />,
+                            },
+                        ]}
+                        sceneInset
+                    />
+                ) : (
+                    <>
+                        <PromptViewDetails />
+                        <PromptRelatedTraces />
+                    </>
+                )}
             </SceneContent>
         )
     }
@@ -254,6 +293,76 @@ function PromptRelatedTraces(): JSX.Element {
                     uniqueKey="prompt-related-traces"
                 />
             )}
+        </div>
+    )
+}
+
+function PromptUsage({ prompt }: { prompt: LLMPrompt }): JSX.Element {
+    const propertyFilter: AnyPropertyFilter[] = [
+        {
+            key: 'prompt_id',
+            type: PropertyFilterType.Event,
+            value: prompt.id,
+            operator: PropertyOperator.Exact,
+        },
+    ]
+
+    return (
+        <div data-attr="prompt-usage-container">
+            <LemonBanner type="info" className="mb-4">
+                During the alpha and beta period, each prompt fetch is currently charged as a Product analytics event.
+                See the{' '}
+                <Link to="https://posthog.com/pricing" target="_blank">
+                    pricing page
+                </Link>
+                .
+            </LemonBanner>
+
+            <div className="mb-4">
+                <b>Trend</b>
+                <div className="text-secondary">{`Prompt fetches for "${prompt.name}" over time`}</div>
+            </div>
+            <Query
+                query={{
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            { kind: NodeKind.EventsNode, event: PROMPT_FETCHED_EVENT, name: PROMPT_FETCHED_EVENT },
+                        ],
+                        properties: {
+                            type: 'AND',
+                            values: [{ type: 'AND', values: propertyFilter }],
+                        },
+                        dateRange: { date_from: '-30d', explicitDate: false },
+                        interval: 'day',
+                        trendsFilter: { display: 'ActionsLineGraph' },
+                    },
+                    full: false,
+                    showLastComputation: true,
+                    showLastComputationRefresh: true,
+                }}
+            />
+
+            <div className="mt-6 mb-4">
+                <b>Log</b>
+                <div className="text-secondary">{`Prompt fetch events for "${prompt.name}"`}</div>
+            </div>
+            <Query
+                query={{
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.EventsQuery,
+                        select: [...defaultDataTableColumns(NodeKind.EventsQuery), 'properties.prompt_name'],
+                        event: PROMPT_FETCHED_EVENT,
+                        properties: propertyFilter,
+                        after: '-30d',
+                    },
+                    full: false,
+                    showDateRange: true,
+                    showReload: true,
+                }}
+            />
         </div>
     )
 }

--- a/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
+++ b/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
@@ -21,7 +21,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, LLMPrompt } from '~/types'
 
 import { useTracesQueryContext } from '../LLMAnalyticsTracesScene'
-import { PromptLogicProps, PromptMode, PromptViewTab, isPrompt, llmPromptLogic } from './llmPromptLogic'
+import { PromptLogicProps, PromptMode, isPrompt, llmPromptLogic } from './llmPromptLogic'
 import { openDeletePromptDialog } from './utils'
 
 export const scene: SceneExport<PromptLogicProps> = {
@@ -44,11 +44,11 @@ export function LLMPromptScene(): JSX.Element {
         promptForm,
         isViewMode,
         prompt,
-        activeViewTab,
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
+    const activeViewTab = searchParams?.tab === 'usage' ? 'usage' : 'overview'
 
-    const { submitPromptForm, deletePrompt, setMode, setActiveViewTab } = useActions(llmPromptLogic)
+    const { submitPromptForm, deletePrompt, setMode } = useActions(llmPromptLogic)
 
     if (isPromptMissing) {
         return <NotFound object="prompt" />
@@ -110,10 +110,12 @@ export function LLMPromptScene(): JSX.Element {
                 {prompt && isPrompt(prompt) ? (
                     <LemonTabs
                         activeKey={activeViewTab}
-                        onChange={(tab) => setActiveViewTab(tab as PromptViewTab)}
+                        onChange={(tab) =>
+                            router.actions.replace(urls.llmAnalyticsPrompt(prompt.name), { ...searchParams, tab })
+                        }
                         tabs={[
                             {
-                                key: PromptViewTab.Overview,
+                                key: 'overview',
                                 label: 'Overview',
                                 content: (
                                     <>
@@ -123,7 +125,7 @@ export function LLMPromptScene(): JSX.Element {
                                 ),
                             },
                             {
-                                key: PromptViewTab.Usage,
+                                key: 'usage',
                                 label: 'Usage',
                                 content: <PromptUsage prompt={prompt} />,
                             },

--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -83,7 +83,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
     loaders(({ props }) => ({
         prompt: {
             __default: null as LLMPrompt | PromptFormValues | null,
-            loadPrompt: () => api.llmPrompts.getByName(props.promptName),
+            loadPrompt: () => api.llmPrompts.resolveByName(props.promptName),
         },
     })),
 

--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -28,7 +28,14 @@ import {
 } from '~/queries/schema/schema-general'
 import { teamLogic } from '~/scenes/teamLogic'
 import { urls } from '~/scenes/urls'
-import { AnyPropertyFilter, Breadcrumb, LLMPrompt, PropertyFilterType, PropertyOperator } from '~/types'
+import {
+    AnyPropertyFilter,
+    Breadcrumb,
+    ChartDisplayType,
+    LLMPrompt,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
 
 import type { llmPromptLogicType } from './llmPromptLogicType'
 import { llmPromptsLogic } from './llmPromptsLogic'
@@ -36,11 +43,6 @@ import { llmPromptsLogic } from './llmPromptsLogic'
 export enum PromptMode {
     View = 'view',
     Edit = 'edit',
-}
-
-export enum PromptViewTab {
-    Overview = 'overview',
-    Usage = 'usage',
 }
 
 export interface PromptLogicProps {
@@ -76,7 +78,6 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         setPrompt: (prompt: LLMPrompt | PromptFormValues) => ({ prompt }),
         deletePrompt: true,
         setMode: (mode: PromptMode) => ({ mode }),
-        setActiveViewTab: (activeViewTab: PromptViewTab) => ({ activeViewTab }),
     }),
 
     reducers(({ props }) => ({
@@ -91,12 +92,6 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             props.mode ?? PromptMode.View,
             {
                 setMode: (_, { mode }) => mode,
-            },
-        ],
-        activeViewTab: [
-            PromptViewTab.Overview,
-            {
-                setActiveViewTab: (_, { activeViewTab }) => activeViewTab,
             },
         ],
     })),
@@ -325,13 +320,10 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 source: {
                     kind: NodeKind.TrendsQuery,
                     series: [{ kind: NodeKind.EventsNode, event: PROMPT_FETCHED_EVENT, name: PROMPT_FETCHED_EVENT }],
-                    properties: {
-                        type: 'AND',
-                        values: [{ type: 'AND', values: promptUsagePropertyFilter }],
-                    },
+                    properties: promptUsagePropertyFilter,
                     dateRange: { date_from: '-30d', explicitDate: false },
                     interval: 'day',
-                    trendsFilter: { display: 'ActionsLineGraph' },
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
                 },
                 full: false,
                 showLastComputation: true,
@@ -384,13 +376,11 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         }): {
             prompt: PromptFormValues | LLMPrompt | null
             promptForm: PromptFormValues
-            activeViewTab: PromptViewTab
         } => {
             if (props.promptName === 'new') {
                 return {
                     prompt: DEFAULT_PROMPT_FORM_VALUES,
                     promptForm: DEFAULT_PROMPT_FORM_VALUES,
-                    activeViewTab: PromptViewTab.Overview,
                 }
             }
 
@@ -400,14 +390,12 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 return {
                     prompt: existingPrompt,
                     promptForm: getPromptFormDefaults(existingPrompt),
-                    activeViewTab: PromptViewTab.Overview,
                 }
             }
 
             return {
                 prompt: null,
                 promptForm: DEFAULT_PROMPT_FORM_VALUES,
-                activeViewTab: PromptViewTab.Overview,
             }
         }
     ),


### PR DESCRIPTION
## Problem

Prompt management needed a usage view similar to feature flags, while avoiding counting prompt-detail page reads as prompt fetch usage events.

## Changes

- Added a `Usage` tab to prompt details with:
  - Trend for `$llm_prompt_fetched`
  - Log table for `$llm_prompt_fetched` (with reload button)
  - Billing notice linking to pricing during alpha/beta
- Added a separate web-only resolve endpoint:
  - `GET /api/environments/:team_id/llm_prompts/resolve/name/:prompt_name/`
  - Auth restricted to session/JWT web auth
  - Does not emit `$llm_prompt_fetched`
- Kept runtime `GET .../llm_prompts/name/:prompt_name/` behavior unchanged (still emits usage event)

## How did you test this code?

Automated tests.

## Publish to changelog?

no
