### PR TITLE
fix(settings): apply correct access control rules in experiments settings

### DIFF
--- a/frontend/src/scenes/settings/environment/DefaultExperimentConfidenceLevel.tsx
+++ b/frontend/src/scenes/settings/environment/DefaultExperimentConfidenceLevel.tsx
@@ -1,13 +1,21 @@
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { CONFIDENCE_LEVEL_OPTIONS } from 'scenes/experiments/constants'
 
 import { TeamSettingSelect } from '../components/TeamSettingSelect'
 
 export function DefaultExperimentConfidenceLevel(): JSX.Element {
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
     return (
         <TeamSettingSelect
             field="default_experiment_confidence_level"
             options={CONFIDENCE_LEVEL_OPTIONS}
             defaultValue={0.95}
+            disabledReason={restrictedReason}
         />
     )
 }

--- a/frontend/src/scenes/settings/environment/DefaultExperimentStatsMethod.tsx
+++ b/frontend/src/scenes/settings/environment/DefaultExperimentStatsMethod.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
-import { useRestrictedArea } from 'lib/components/RestrictedArea'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 
 import { StatsMethodSelector } from '~/scenes/experiments/components/StatsMethodSelector'
 import { teamLogic } from '~/scenes/teamLogic'
@@ -11,9 +11,9 @@ export function DefaultExperimentStatsMethod(): JSX.Element {
     const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
 
-    // TODO: This should probably be looking at the Experiment resource access level
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
     const handleChange = (value: ExperimentStatsMethod): void => {

--- a/frontend/src/scenes/settings/environment/ExperimentRecalculationTime.tsx
+++ b/frontend/src/scenes/settings/environment/ExperimentRecalculationTime.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
-import { useRestrictedArea } from 'lib/components/RestrictedArea'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 
@@ -38,8 +38,9 @@ export function ExperimentRecalculationTime(): JSX.Element {
     const { currentTeam, currentTeamLoading, timezone: projectTimezone } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
 
-    const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
     const handleChange = (value: string): void => {
@@ -55,7 +56,7 @@ export function ExperimentRecalculationTime(): JSX.Element {
             value={currentLocalHour.toString()}
             onChange={handleChange}
             options={hourOptions}
-            disabledReason={restrictionReason || (currentTeamLoading ? 'Loading...' : undefined)}
+            disabledReason={restrictedReason || (currentTeamLoading ? 'Loading...' : undefined)}
             data-attr="team-experiment-recalculation-time"
             placeholder="Select recalculation time"
         />


### PR DESCRIPTION
## Problem
The settings for experiments check the wrong permissions or do not perform permission checks at all.

## Changes
Make sure all settings on experiments settings page require project-level admin permissions to make changes.

## How did you test this code
Manually