### PR TITLE
fix(settings): apply correct access control rules in customer and revenue analytics settings

### DIFF
--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetImpactModal.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetImpactModal.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonInput, LemonModal, LemonTag } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 
 import { DataWarehouseManagedViewsetSavedQuery } from '~/types'
@@ -34,6 +36,10 @@ export function DataWarehouseManagedViewsetImpactModal({
     const logic = disableDataWarehouseManagedViewsetModalLogic({ type })
     const { isOpen, confirmationInput, views: logicViews, viewsLoading, isDeleting } = useValues(logic)
     const { closeModal, setIsDeleting, setConfirmationInput } = useActions(logic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const isConfirmationValid = confirmationInput === confirmText
     const views = propViews !== undefined ? propViews : logicViews
@@ -57,7 +63,7 @@ export function DataWarehouseManagedViewsetImpactModal({
                     <LemonButton
                         type="secondary"
                         onClick={closeModal}
-                        disabledReason={isDeleting ? 'Deleting...' : undefined}
+                        disabledReason={isDeleting ? 'Deleting...' : restrictedReason}
                     >
                         Cancel
                     </LemonButton>
@@ -65,7 +71,9 @@ export function DataWarehouseManagedViewsetImpactModal({
                         type="primary"
                         status="danger"
                         loading={isDeleting}
-                        disabledReason={!isConfirmationValid ? 'Please type the correct confirmation text' : undefined}
+                        disabledReason={
+                            !isConfirmationValid ? 'Please type the correct confirmation text' : restrictedReason
+                        }
                         onClick={onConfirm}
                     >
                         {confirmButtonText}
@@ -112,7 +120,7 @@ export function DataWarehouseManagedViewsetImpactModal({
                         value={confirmationInput}
                         onChange={setConfirmationInput}
                         placeholder={`Type "${confirmText}" to confirm`}
-                        disabledReason={isDeleting ? 'Deleting...' : undefined}
+                        disabledReason={isDeleting ? 'Deleting...' : restrictedReason}
                         autoFocus
                     />
                 </div>

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -12,7 +12,6 @@ import { ExternalDataSourceConfiguration } from '@posthog/products-revenue-analy
 import { FilterTestAccountsConfiguration as RevenueAnalyticsFilterTestAccountsConfiguration } from '@posthog/products-revenue-analytics/frontend/settings/FilterTestAccountsConfiguration'
 import { GoalsConfiguration } from '@posthog/products-revenue-analytics/frontend/settings/GoalsConfiguration'
 
-import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { BaseCurrency } from 'lib/components/BaseCurrency/BaseCurrency'
 import { FEATURE_SUPPORT } from 'lib/components/SupportedPlatforms/featureSupport'
 import { OrganizationMembershipLevel } from 'lib/constants'
@@ -320,6 +319,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 hideOn: [Realm.SelfHostedClickHouse, Realm.SelfHostedPostgres],
             },
             {
+                // FIXME: changelog should probably not be here since it updates user's settings. Maybe belongs under account settings?
                 id: 'changelog',
                 title: 'Changelog',
                 description:
@@ -560,21 +560,16 @@ export const SETTINGS_MAP: SettingSection[] = [
         },
         settings: [
             {
+                // FIXME: remove from "Revenue definitions" page
                 id: 'revenue-base-currency',
                 title: 'Base currency',
                 description: 'Set the base currency for revenue analytics calculations.',
-                component: (
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.RevenueAnalytics}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
-                        <BaseCurrency hideTitle />
-                    </AccessControlAction>
-                ),
+                component: <BaseCurrency hideTitle />,
                 hideWhenNoSection: true,
                 keywords: ['money', 'currency', 'usd', 'eur'],
             },
             {
+                // FIXME: remove from "Revenue definitions" page
                 id: 'revenue-analytics-filter-test-accounts',
                 title: 'Filter out internal and test users from revenue analytics',
                 description: 'Exclude test accounts from revenue calculations and reports.',
@@ -582,6 +577,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['test account', 'internal', 'exclude', 'filter', 'revenue'],
             },
             {
+                // FIXME: should not be in settings
                 id: 'revenue-analytics-goals',
                 title: 'Revenue goals',
                 description: 'Set revenue targets to track performance against your business objectives.',
@@ -589,6 +585,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['target', 'mrr', 'arr', 'goal'],
             },
             {
+                // FIXME: should not be in settings
                 id: 'revenue-analytics-events',
                 title: 'Revenue events',
                 description: 'Configure which events represent revenue-generating actions.',
@@ -597,6 +594,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['purchase', 'payment', 'subscription', 'charge'],
             },
             {
+                // FIXME: should not be in settings
                 id: 'revenue-analytics-external-data-sources',
                 title: 'External data sources',
                 description: 'Connect external data sources like Stripe for revenue tracking.',

--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -141,7 +141,7 @@ export function Invites(): JSX.Element {
         scope: RestrictionScope.Organization,
     })
 
-    const userCannotInvite = restrictionReason && !currentOrganization?.members_can_invite
+    const userCannotInvite = restrictionReason || !currentOrganization?.members_can_invite
 
     return (
         <div className="deprecated-space-y-4">

--- a/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
@@ -2,17 +2,22 @@ import { useActions, useValues } from 'kea'
 
 import { LemonSwitch, Link } from '@posthog/lemon-ui'
 
-import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { revenueAnalyticsSettingsLogic } from './revenueAnalyticsSettingsLogic'
 
 export function FilterTestAccountsConfiguration(): JSX.Element {
     const { filterTestAccounts } = useValues(revenueAnalyticsSettingsLogic)
     const { updateFilterTestAccounts } = useActions(revenueAnalyticsSettingsLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
     return (
         <SceneSection
             title="Filter out internal and test users from revenue analytics"
@@ -24,17 +29,13 @@ export function FilterTestAccountsConfiguration(): JSX.Element {
                 </>
             }
         >
-            <AccessControlAction
-                resourceType={AccessControlResourceType.RevenueAnalytics}
-                minAccessLevel={AccessControlLevel.Editor}
-            >
-                <LemonSwitch
-                    onChange={updateFilterTestAccounts}
-                    checked={filterTestAccounts}
-                    label="Filter out internal and test users"
-                    bordered
-                />
-            </AccessControlAction>
+            <LemonSwitch
+                onChange={updateFilterTestAccounts}
+                checked={filterTestAccounts}
+                label="Filter out internal and test users"
+                bordered
+                disabledReason={restrictedReason}
+            />
         </SceneSection>
     )
 }


### PR DESCRIPTION
## Problem
The settings for customer and revenue analytics check the wrong permissions or do not perform permission checks at all.

## Changes
Make sure all settings on customer and revenue analytics settings pages require project-level admin permissions to make changes.

## How did you test this code
Manually