### PR TITLE
fix(flags): improve error messages and status codes for data parsing failures

### DIFF
--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -998,7 +998,10 @@ mod tests {
             .expect("Failed to set malformed JSON in Redis");
 
         let result = get_flags_from_redis(redis_client, team.id).await;
-        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+        assert!(matches!(
+            result,
+            Err(FlagError::DataParsingErrorWithContext(_))
+        ));
 
         // Test database query error (using a non-existent table)
         let result = sqlx::query("SELECT * FROM non_existent_table")

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -613,7 +613,7 @@ mod tests {
         #[case(FlagError::SecretApiTokenInvalid, 401, "secret_api_token_invalid")]
         #[case(FlagError::NoAuthenticationProvided, 401, "no_authentication")]
         #[case(FlagError::RowNotFound, 500, "row_not_found")]
-        #[case(FlagError::RedisDataParsingError, 503, "redis_parsing_error")]
+        #[case(FlagError::DataParsingErrorWithContext("test".into()), 500, "flag_data_parsing_error")]
         #[case(FlagError::DeserializeFiltersError, 500, "deserialize_filters_error")]
         #[case(FlagError::RedisUnavailable, 503, "redis_unavailable")]
         #[case(FlagError::DatabaseUnavailable, 503, "database_unavailable")]
@@ -635,11 +635,11 @@ mod tests {
             500,
             "cohort_filters_parsing_error"
         )]
-        #[case(FlagError::PersonNotFound, 400, "person_not_found")]
-        #[case(FlagError::PropertiesNotInCache, 400, "properties_not_in_cache")]
+        #[case(FlagError::PersonNotFound, 503, "person_not_found")]
+        #[case(FlagError::PropertiesNotInCache, 503, "properties_not_in_cache")]
         #[case(
             FlagError::StaticCohortMatchesNotCached,
-            400,
+            503,
             "static_cohort_not_cached"
         )]
         #[case(FlagError::CacheMiss, 503, "cache_miss")]


### PR DESCRIPTION
## Summary

Improves error handling in the Rust feature flags service to provide clearer error messages and more appropriate HTTP status codes.

### Changes

1. **Better error handling for data parsing failures**
   - Replaced `RedisDataParsingError` with `DataParsingErrorWithContext(String)` 
   - Full error details logged server-side for debugging
   - Generic client-facing message (no internal implementation details exposed)

2. **Fixed status code for data parsing errors**
   - Changed from 503 (Service Unavailable) to 500 (Internal Server Error)
   - These are data integrity/schema issues, not transient service availability problems

3. **Consistent cache miss error handling**
   - Reclassified `PersonNotFound`, `PropertiesNotInCache`, `StaticCohortMatchesNotCached` from 400 to 503
   - Now consistent with `CacheMiss` which was already 503
   - These represent transient states where data may not be populated yet

### Before/After

| Error | Before | After |
|-------|--------|-------|
| Data parsing error | 503 Failed to parse internal data | 500 Failed to parse flag configuration data. This may indicate a misconfigured feature flag. |
| PersonNotFound | 400 Please check your distinct_id | 503 Person data not yet available. This is temporary. |
| PropertiesNotInCache | 400 | 503 |
| StaticCohortMatchesNotCached | 400 | 503 |