### PR TITLE
fix(ux): sidepanel last minute updates

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -118,7 +118,7 @@ export function Navigation({
                             '@container/main-content-container main-content-container flex overflow-hidden lg:rounded border-t lg:border border-primary lg:mb-2 relative',
                             {
                                 'lg:rounded-tl-none': firstTabIsActive,
-                                'lg:mr-2': isRemovingSidePanelFlag,
+                                'lg:mr-1 lg:mb-1': isRemovingSidePanelFlag,
                                 'rounded-r-none': isRemovingSidePanelFlag && sidePanelOpen,
                             }
                         )}

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -108,7 +108,7 @@ export function SceneTitlePanelButton({
                     tooltip={
                         <>
                             Open context panel
-                            <RenderKeybind className="relative -top-px" keybind={[keyBinds.toggleRightNav]} />
+                            <RenderKeybind className="relative -top-px ml-1" keybind={[keyBinds.toggleRightNav]} />
                         </>
                     }
                     tooltipPlacement="bottom-end"

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -332,7 +332,7 @@ export const MaxInstance = React.memo(function MaxInstance({
                                     closeTabId(tabId, { source: 'open_in_side_panel' })
                                 }}
                             >
-                                Open in side panel
+                                {isRemovingSidePanelFlag ? 'Open in context panel' : 'Open in side panel'}
                             </LemonButton>
                         ) : undefined}
                     </>

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -65,7 +65,7 @@ export function AiFirstMaxInstance({ tabId }: AiFirstMaxInstanceProps): JSX.Elem
                                         closeTabId(tabId, { source: 'open_in_side_panel' })
                                     }}
                                 >
-                                    Open in side panel
+                                    Open in context panel
                                 </LemonButton>
                             ) : undefined}
                         </div>

--- a/frontend/src/scenes/notebooks/NotebookScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookScene.tsx
@@ -9,6 +9,7 @@ import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -50,6 +51,7 @@ export function NotebookScene(): JSX.Element {
     )
     const { selectNotebook, closeSidePanel } = useActions(notebookPanelLogic)
     const { selectedNotebook, visibility } = useValues(notebookPanelLogic)
+    const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
 
     useEffect(() => {
         if (notebookId === 'new') {
@@ -157,14 +159,15 @@ export function NotebookScene(): JSX.Element {
                         }}
                         tooltip={
                             <>
-                                Opens the notebook in a side panel, that can be accessed from anywhere in the PostHog
-                                app. This is great for dragging and dropping elements like insights, recordings or even
-                                feature flags into your active notebook.
+                                Opens the notebook in a {isRemovingSidePanelFlag ? 'context panel' : 'side panel'}, that
+                                can be accessed from anywhere in the PostHog app. This is great for dragging and
+                                dropping elements like insights, recordings or even feature flags into your active
+                                notebook.
                             </>
                         }
                         sideIcon={<IconOpenSidebar />}
                     >
-                        Open in side panel
+                        {isRemovingSidePanelFlag ? 'Open in context panel' : 'Open in side panel'}
                     </LemonButton>
                 </div>
             </div>


### PR DESCRIPTION
## Problem
* straggling words "side panel"
* open context panel tooltip spacing
* app window spacing around bottom and right a bit too much now that there's nothing outside there  
* survey create maxtool makes the header cluttered.

## Changes
* fix words
* fix spacing
* reduce window margin from 2 -> 1 
* migrate surveys maxtool to use scene title section.
 
<img width="868" height="855" alt="image" src="https://github.com/user-attachments/assets/25c56780-27f2-41ee-84d7-1c18e3e97d47" />

<img width="381" height="211" alt="image" src="https://github.com/user-attachments/assets/8cb8871a-92d3-44ef-acae-5ffbd01dcff8" />


## How did you test this code?
Locally

## Publish to changelog?
No