### PR TITLE
feat: Add aria-expanded attribute to Combobox search input

### DIFF
--- a/frontend/src/lib/ui/Combobox/Combobox.tsx
+++ b/frontend/src/lib/ui/Combobox/Combobox.tsx
@@ -160,6 +160,7 @@ const Search = ({
                 autoFocus={autoFocus}
                 role="combobox"
                 size="default"
+                aria-expanded={true}
                 aria-controls="combobox-listbox"
                 showFocusPulse
             />

--- a/frontend/src/lib/ui/Combobox/Combobox.tsx
+++ b/frontend/src/lib/ui/Combobox/Combobox.tsx
@@ -160,7 +160,7 @@ const Search = ({
                 autoFocus={autoFocus}
                 role="combobox"
                 size="default"
-                aria-expanded={true}
+                aria-expanded={context.searchValue !== ''}
                 aria-controls="combobox-listbox"
                 showFocusPulse
             />


### PR DESCRIPTION
## Problem

The Combobox component is missing the `aria-expanded` attribute, which is important for accessibility. Screen readers need this attribute to announce whether the combobox dropdown is expanded or collapsed.

## Changes

Added the `aria-expanded={true}` attribute to the input element in the Combobox component to improve accessibility and comply with ARIA standards for combobox components.


## Publish to changelog?

No