### PR TITLE
chore: Remove unnecessary accessibility attributes

### DIFF
--- a/frontend/src/layout/navigation/PosthogStories/StoriesPlayer.tsx
+++ b/frontend/src/layout/navigation/PosthogStories/StoriesPlayer.tsx
@@ -324,7 +324,6 @@ export const StoriesPlayer = ({
                                   ? 'bg-white/35 hover:bg-white/45'
                                   : 'bg-white/25 hover:bg-white/30'
                         }`}
-                        role="button"
                         aria-label="See more about this story - swipe up for more"
                     >
                         <span>{currentStory.seeMoreOptions?.text || currentStory.seeMoreText || 'See more'}</span>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -488,7 +488,6 @@ export function DashboardHeader(): JSX.Element | null {
                                         setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
                                     }
                                     size="small"
-                                    tabIndex={9}
                                 >
                                     Cancel
                                 </LemonButton>
@@ -506,7 +505,6 @@ export function DashboardHeader(): JSX.Element | null {
                                             setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)
                                         }
                                         size="small"
-                                        tabIndex={10}
                                         disabledReason={
                                             dashboardLoading
                                                 ? 'Wait for dashboard to finish loading'


### PR DESCRIPTION
## Problem

Removed unnecessary accessibility attributes from UI elements that could cause confusion or redundancy.

## Changes

- Removed `role="button"` from the "See more" element in StoriesPlayer, as it's already semantically a button
- Removed `tabIndex` attributes from the "Cancel" and "Save" buttons in the DashboardHeader, as these buttons are already naturally focusable elements

## How did you test this code?

Verified that the UI elements maintain their expected functionality and accessibility without the removed attributes. Tested keyboard navigation to ensure the buttons remain properly focusable in the tab order.