### PR TITLE
perf: Add passive event listeners to scroll and touch events

### DIFF
--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -139,7 +139,7 @@ export function ResizableElement({
     useEffect(() => {
         document.addEventListener('mousemove', handleMouseMove)
         document.addEventListener('mouseup', handleEnd)
-        document.addEventListener('touchmove', handleTouchMove)
+        document.addEventListener('touchmove', handleTouchMove, { passive: true })
         document.addEventListener('touchend', handleEnd)
 
         return () => {

--- a/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
@@ -16,8 +16,13 @@ export function VisibilitySensor({ id, offset, children }: VisibilityProps): JSX
 
     useEffect(() => {
         const element = ref.current
-        document.addEventListener('scroll', () => element && scrolling(element))
-        return () => document.removeEventListener('scroll', () => element && scrolling(element))
+        const handler = (): void => {
+            if (element) {
+                scrolling(element)
+            }
+        }
+        document.addEventListener('scroll', handler, { passive: true })
+        return () => document.removeEventListener('scroll', handler)
     }, [ref.current]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return <div ref={ref}>{children}</div>

--- a/frontend/src/lib/hooks/useScrollObserver.tsx
+++ b/frontend/src/lib/hooks/useScrollObserver.tsx
@@ -45,7 +45,7 @@ export function useScrollObserver({ onScrollTop, onScrollBottom }: ScrollObserve
                 }
             } else {
                 containerRef.current = el
-                el.addEventListener('scroll', handleScroll)
+                el.addEventListener('scroll', handleScroll, { passive: true })
             }
         },
         [handleScroll]

--- a/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
+++ b/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
@@ -57,7 +57,7 @@ export function ThreadAutoScroller({ children }: { children: React.ReactNode }):
                 scrollOrigin.current.user = true
             }
         }
-        scrollableContainer.addEventListener('scroll', scrollListener)
+        scrollableContainer.addEventListener('scroll', scrollListener, { passive: true })
 
         // When the thread is resized during generation, we need to scroll to the bottom
         let resizeTimeout: NodeJS.Timeout | null = null


### PR DESCRIPTION
## Problem

The application is experiencing performance issues with scroll and touch events. These events are not marked as passive, which can cause unnecessary browser repainting and lead to jank during scrolling, especially on mobile devices.

## Changes

Added the `{ passive: true }` option to event listeners for:
- `touchmove` in ResizeElement component
- `scroll` in VisibilitySensor component (also fixed a memory leak by properly defining the handler function)
- `scroll` in useScrollObserver hook
- `scroll` in ThreadAutoScroller component

These changes improve scrolling performance by telling the browser that the event handlers won't call `preventDefault()`, allowing the browser to optimize scrolling operations.

## How did you test this code?

Tested scrolling performance on both desktop and mobile devices, particularly focusing on areas with the ResizeElement, VisibilitySensor, and thread scrolling functionality. Verified that scrolling remains smooth without any functional regressions.

## Publish to changelog?

No