### PR TITLE
fix: Add missing key props to React components

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -103,7 +103,7 @@ export function AuthorizedUrlList({
                 }
 
                 return editUrlIndex === index ? (
-                    <div className="border rounded p-2 bg-surface-primary">
+                    <div key={index} className="border rounded p-2 bg-surface-primary">
                         <AuthorizedUrlForm
                             type={type}
                             actionId={actionId}

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -103,7 +103,7 @@ export function AuthorizedUrlList({
                 }
 
                 return editUrlIndex === index ? (
-                    <div key={index} className="border rounded p-2 bg-surface-primary">
+                    <div key={keyedURL.url} className="border rounded p-2 bg-surface-primary">
                         <AuthorizedUrlForm
                             type={type}
                             actionId={actionId}
@@ -113,7 +113,10 @@ export function AuthorizedUrlList({
                         />
                     </div>
                 ) : (
-                    <div key={index} className={clsx('border rounded flex items-center p-2 pl-4 bg-surface-primary')}>
+                    <div
+                        key={keyedURL.url}
+                        className={clsx('border rounded flex items-center p-2 pl-4 bg-surface-primary')}
+                    >
                         {keyedURL.type === 'suggestion' && (
                             <Tooltip title={'Seen in ' + keyedURL.count + ' events in the last 3 days'}>
                                 <LemonTag type="highlight" className="mr-4 uppercase cursor-pointer">

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
@@ -154,8 +154,11 @@ export function SceneNotebookMenuItems({
                                             notebooksContainingResource.map(
                                                 (notebook: NotebookListItemType) =>
                                                     notebook && (
-                                                        <Combobox.Group value={[notebook.title ?? '']}>
-                                                            <Combobox.Item key={notebook.short_id} asChild>
+                                                        <Combobox.Group
+                                                            key={notebook.short_id}
+                                                            value={[notebook.title ?? '']}
+                                                        >
+                                                            <Combobox.Item asChild>
                                                                 <ButtonPrimitive
                                                                     menuItem
                                                                     onClick={() => {
@@ -188,8 +191,11 @@ export function SceneNotebookMenuItems({
                                             notebooksNotContainingResource.map(
                                                 (notebook: NotebookListItemType) =>
                                                     notebook && (
-                                                        <Combobox.Group value={[notebook.title ?? '']}>
-                                                            <Combobox.Item key={notebook.short_id} asChild>
+                                                        <Combobox.Group
+                                                            key={notebook.short_id}
+                                                            value={[notebook.title ?? '']}
+                                                        >
+                                                            <Combobox.Item asChild>
                                                                 <ButtonPrimitive
                                                                     menuItem
                                                                     onClick={() => {

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -772,7 +772,7 @@ export function DataTable({
 
     const secondRowRight = [
         sourceFeatures.has(QueryFeature.linkDataButton) && hasCustomerAnalyticsEnabled ? (
-            <ViewLinkButton tableName="groups" />
+            <ViewLinkButton key="view-link-button" tableName="groups" />
         ) : null,
         (showColumnConfigurator || showPersistentColumnConfigurator) &&
         sourceFeatures.has(QueryFeature.columnConfigurator) ? (

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -116,7 +116,7 @@ const featureFlagActionsMapping: Record<
                                     )
                                 }) || []
                             newButtons[0] = (
-                                <>
+                                <Fragment key={nonEmptyProperties[0].key ?? 0}>
                                     <span>
                                         <strong>{rollout_percentage ?? 100}%</strong> of{' '}
                                     </span>
@@ -124,7 +124,7 @@ const featureFlagActionsMapping: Record<
                                         key={nonEmptyProperties[0].key}
                                         item={nonEmptyProperties[0]}
                                     />
-                                </>
+                                </Fragment>
                             )
                             groupAdditions.push(...newButtons)
                         } else {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import {
     ActivityChange,
@@ -102,15 +104,15 @@ const featureFlagActionsMapping: Record<
                             const newButtons =
                                 nonEmptyProperties.map((property, idx) => {
                                     return (
-                                        <>
+                                        <Fragment key={property.key ?? idx}>
                                             {' '}
                                             {idx === 0 && (
                                                 <span>
                                                     <strong>{rollout_percentage ?? 100}%</strong> of{' '}
                                                 </span>
                                             )}
-                                            <PropertyFilterButton key={property.key} item={property} />
-                                        </>
+                                            <PropertyFilterButton item={property} />
+                                        </Fragment>
                                     )
                                 }) || []
                             newButtons[0] = (

--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -43,9 +43,8 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
                 </>
             ) : (
                 conversationHistory.slice(0, 3).map((conversation) => (
-                    <span className="flex items-center gap-2">
+                    <span key={conversation.id} className="flex items-center gap-2">
                         <Link
-                            key={conversation.id}
                             className="grow text-sm text-primary hover:text-accent-hover active:text-accent-active"
                             to={urls.ai(conversation.id)}
                             onClick={(e) => {

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -51,7 +51,7 @@ export function personActivityDescriber(logItem: ActivityLogItem, asNotification
                             </>
                         }
                         listParts={logItem.detail.merge.source.flatMap((di, idx) => (
-                            <span key={idx} className="highlighted-activity">
+                            <span key={di.id || di.uuid || idx} className="highlighted-activity">
                                 <PersonDisplay person={di} />
                             </span>
                         ))}

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -50,8 +50,8 @@ export function personActivityDescriber(logItem: ActivityLogItem, asNotification
                                 <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> merged
                             </>
                         }
-                        listParts={logItem.detail.merge.source.flatMap((di) => (
-                            <span className="highlighted-activity">
+                        listParts={logItem.detail.merge.source.flatMap((di, idx) => (
+                            <span key={idx} className="highlighted-activity">
                                 <PersonDisplay person={di} />
                             </span>
                         ))}

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -1,6 +1,7 @@
 import '../../lib/components/Cards/InsightCard/InsightCard.scss'
 
 import posthog from 'posthog-js'
+import { Fragment } from 'react'
 
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import {
@@ -194,7 +195,7 @@ const insightActionsMapping: Record<
                     </>
                 }
                 listParts={addedDashboards.map((d) => (
-                    <>{linkToDashboard(d)}</>
+                    <Fragment key={d.id}>{linkToDashboard(d)}</Fragment>
                 ))}
             />
         ) : null
@@ -208,7 +209,7 @@ const insightActionsMapping: Record<
                     </>
                 }
                 listParts={removedDashboards.map((d) => (
-                    <>{linkToDashboard(d)}</>
+                    <Fragment key={d.id}>{linkToDashboard(d)}</Fragment>
                 ))}
             />
         ) : null

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -124,6 +124,7 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                     <ScenePanelLabel title="Visible tiles" className="px-1.5">
                         {availableTiles.map((tileId) => (
                             <ButtonPrimitive
+                                key={tileId}
                                 menuItem
                                 onClick={() => {
                                     setTileVisibility(tileId, hiddenTiles.includes(tileId))


### PR DESCRIPTION
## Problem

React components are missing required `key` props when rendering lists, which can cause performance issues and unexpected behavior in the UI.

## Changes

Added missing `key` props to various components that render lists:
- Added `key={index}` to the edit URL form in `AuthorizedUrlList`
- Fixed key placement in `SceneNotebookMenuItems` by moving it from `Combobox.Item` to `Combobox.Group`
- Added `key="view-link-button"` to `ViewLinkButton` in `DataTable`
- Added `key` props to fragments in feature flag activity descriptions
- Fixed key placement in `HistoryPreview` by moving it from the `Link` to the parent `span`
- Added `key={idx}` to person activity descriptions
- Added `key={d.id}` to fragments in saved insights activity descriptions
- Added `key={tileId}` to `ButtonPrimitive` in `WebAnalyticsMenu`

## How did you test this code?

Verified that the components render correctly with the added keys by checking that:
1. No React key warnings appear in the console
2. Lists render correctly and maintain proper state during updates
3. Component behavior remains unchanged

## Publish to changelog?

No