### PR TITLE
fix: Add alt attributes to images for accessibility

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -89,7 +89,13 @@ export function IntegrationChoice({
                     ? {
                           items: [
                               ...(integrationsOfKind?.map((integ) => ({
-                                  icon: <img src={integ.icon_url} className="w-6 h-6 rounded" />,
+                                  icon: (
+                                      <img
+                                          src={integ.icon_url}
+                                          alt={`${integ.display_name} icon`}
+                                          className="w-6 h-6 rounded"
+                                      />
+                                  ),
                                   onClick: () => onChange?.(integ.id),
                                   active: integ.id === value,
                                   label: integ.display_name,

--- a/frontend/src/lib/components/ImageCarousel/ImageCarousel.tsx
+++ b/frontend/src/lib/components/ImageCarousel/ImageCarousel.tsx
@@ -36,7 +36,11 @@ export function ImageCarousel({ imageUrls, loading, onDelete }: ImageCarouselPro
 
     return (
         <div className="relative group border rounded bg-bg-light w-full max-w-[600px] aspect-[3/2] flex items-center justify-center overflow-hidden">
-            {loading ? <Spinner /> : <img src={currentImageUrl} className="max-w-[96%] max-h-[96%] object-contain" />}
+            {loading ? (
+                <Spinner />
+            ) : (
+                <img src={currentImageUrl} alt="Carousel image" className="max-w-[96%] max-h-[96%] object-contain" />
+            )}
 
             {onDelete && !loading && (
                 <LemonButton

--- a/frontend/src/lib/components/hedgehogs.tsx
+++ b/frontend/src/lib/components/hedgehogs.tsx
@@ -50,11 +50,11 @@ type HedgehogProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>
 
 // w400 x h400
 const SquaredHedgehog = (props: ImgHTMLAttributes<HTMLImageElement>): JSX.Element => {
-    return <img src={props.src} width={400} height={400} {...props} />
+    return <img src={props.src} width={400} height={400} alt="PostHog hedgehog" {...props} />
 }
 // any width x h400
 const RectangularHedgehog = (props: ImgHTMLAttributes<HTMLImageElement>): JSX.Element => {
-    return <img src={props.src} height={400} {...props} />
+    return <img src={props.src} height={400} alt="PostHog hedgehog" {...props} />
 }
 
 export const SurprisedHog = (props: HedgehogProps): JSX.Element => {

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -57,7 +57,11 @@ export function IntegrationView({
         <div className="rounded border bg-surface-primary">
             <div className="flex justify-between items-center p-2">
                 <div className="flex gap-4 items-center ml-2">
-                    <img src={integration.icon_url} className="w-10 h-10 rounded" />
+                    <img
+                        src={integration.icon_url}
+                        alt={`${integration.kind} integration`}
+                        className="w-10 h-10 rounded"
+                    />
                     <div>
                         <div className="flex gap-2">
                             <span>

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
@@ -174,7 +174,7 @@ WithExpandableRows.args = {
     expandable: {
         rowExpandable: (record) => record.occupation !== 'Retired',
         expandedRowRender: function RenderCow() {
-            return <img src="https://c.tenor.com/WAFH6TX2VIYAAAAC/polish-cow.gif" />
+            return <img src="https://c.tenor.com/WAFH6TX2VIYAAAAC/polish-cow.gif" alt="Dancing cow" />
         },
     },
 }

--- a/frontend/src/lib/lemon-ui/UploadedLogo/UploadedLogo.tsx
+++ b/frontend/src/lib/lemon-ui/UploadedLogo/UploadedLogo.tsx
@@ -52,6 +52,7 @@ export const UploadedLogo = React.forwardRef<HTMLDivElement, UploadedLogoProps>(
             <img
                 className="size-full object-cover"
                 src={mediaId.startsWith('data:') ? mediaId : `/uploaded_media/${mediaId}`}
+                alt="Uploaded logo"
                 onError={() => setIsLoadingImage(false)}
                 onLoad={() => setIsLoadingImage(false)}
             />

--- a/frontend/src/scenes/authentication/TwoFactorSetup.tsx
+++ b/frontend/src/scenes/authentication/TwoFactorSetup.tsx
@@ -27,7 +27,11 @@ export function TwoFactorSetup({ onSuccess }: { onSuccess: () => void }): JSX.El
             >
                 <div className="flex flex-col items-center">
                     <div className="bg-white p-4 rounded">
-                        <img src="/account/two_factor/qrcode/" className="Setup2FA__image" />
+                        <img
+                            src="/account/two_factor/qrcode/"
+                            className="Setup2FA__image"
+                            alt="QR code for two-factor authentication setup"
+                        />
                     </div>
 
                     {/* Secret key for manual entry */}

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -108,6 +108,7 @@ export function VariantScreenshot({
                                     <img
                                         className="w-full h-full object-cover"
                                         src={mediaId.startsWith('data:') ? mediaId : `/uploaded_media/${mediaId}`}
+                                        alt={`Variant screenshot thumbnail ${index + 1}`}
                                         onError={() => handleImageError(mediaId)}
                                         onLoad={() => handleImageLoad(mediaId)}
                                     />

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -182,6 +182,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                         <img
                                             id="heatmap-screenshot"
                                             src={screenshotUrl}
+                                            alt="Website screenshot for heatmap analysis"
                                             style={{
                                                 width: '100%',
                                                 height: 'auto',

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionIcon.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionIcon.tsx
@@ -164,6 +164,7 @@ export function HogFunctionIcon({
                             loaded ? 'opacity-100' : 'opacity-0'
                         )}
                         src={src}
+                        alt="Hog function icon"
                         onLoad={() => setLoaded(true)}
                     />
                     {!loaded && <LemonSkeleton className="absolute w-full h-full" />}

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarLinkedIssuesTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarLinkedIssuesTab.tsx
@@ -37,7 +37,7 @@ type IssueConfig = Record<string, string>
 
 const IntegrationIcon = ({ kind }: { kind: IntegrationKind }): JSX.Element => {
     const className = kind === 'github' ? 'w-5 h-5 rounded-sm dark:invert' : 'w-5 h-5 rounded-sm'
-    return <img src={ICONS[kind]} className={className} />
+    return <img src={ICONS[kind]} alt={`${kind} integration`} className={className} />
 }
 
 export function PlayerSidebarLinkedIssuesTab(): JSX.Element | null {


### PR DESCRIPTION
## Problem

Images across the application are missing `alt` attributes, which is an accessibility issue. Screen readers rely on these attributes to provide context for visually impaired users.

## Changes

Added appropriate `alt` attributes to images throughout the application, including:
- Integration icons in dropdown menus and integration views
- Image carousel components
- Hedgehog illustrations
- Uploaded logos
- Two-factor authentication QR code
- Variant screenshots in experiments
- Heatmap screenshots
- Hog function icons
- Integration icons in linked issues tab

## How did you test this code?

Manually verified that all images now have descriptive alt text that provides appropriate context for screen readers. Tested with a screen reader to ensure the alt text is properly announced.

## Publish to changelog?

No