### PR TITLE
perf: Use lazy initialization for useState calls

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -17,7 +17,7 @@ import { ImpersonationReasonModal } from './ImpersonationReasonModal'
 import { impersonationNoticeLogic } from './impersonationNoticeLogic'
 
 function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
-    const [now, setNow] = useState(dayjs())
+    const [now, setNow] = useState(() => dayjs())
     const { isVisible: isPageVisible } = usePageVisibility()
 
     const duration = dayjs.duration(datetime.diff(now))

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -272,7 +272,7 @@ function DictionaryField({
     sampleGlobalsWithInputs: CyclotronJobInvocationGlobalsWithInputs | null
 }): JSX.Element {
     const value = input.value ?? {}
-    const [entries, setEntries] = useState<[string, string][]>(Object.entries(value))
+    const [entries, setEntries] = useState<[string, string][]>(() => Object.entries(value))
     const prevFilteredEntriesRef = useRef<[string, string][]>(entries)
 
     useEffect(() => {

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -203,7 +203,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
             : displayTime.fromNow()
     }, [formatDate, formatTime, displayTime, timestampStyle, displayTimezone])
 
-    const [formattedContent, setFormattedContent] = useState(format())
+    const [formattedContent, setFormattedContent] = useState(format)
 
     const { isVisible: isPageVisible } = usePageVisibility()
 

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
@@ -56,7 +56,9 @@ export const LemonCalendar = forwardRef(function LemonCalendar(
     const weekStartDay = props.weekStartDay ?? teamWeekStartDay
     const today = dayjs().startOf('day')
 
-    const [leftmostMonth, setLeftmostMonth] = useState<dayjs.Dayjs>((props.leftmostMonth ?? today).startOf('month'))
+    const [leftmostMonth, setLeftmostMonth] = useState<dayjs.Dayjs>(() =>
+        (props.leftmostMonth ?? today).startOf('month')
+    )
     useEffect(() => {
         if (props.leftmostMonth && props.leftmostMonth.isSame(leftmostMonth, 'd')) {
             setLeftmostMonth(props.leftmostMonth)

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
@@ -30,7 +30,7 @@ export function LemonCalendarRange({
     onToggleTime,
 }: LemonCalendarRangeProps): JSX.Element {
     // Keep a sanitised and cached copy of the selected range
-    const [[rangeStart, rangeEnd], setRange] = useState([
+    const [[rangeStart, rangeEnd], setRange] = useState(() => [
         value?.[0] ? value[0].startOf('day') : null,
         value?.[1] ? value[1].endOf('day') : null,
     ])

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -38,7 +38,7 @@ export function LemonCalendarRangeInline({
             typeof window === 'undefined' ? WIDTH_OF_ONE_CALENDAR_MONTH * CALENDARS_IF_NO_WINDOW : window.innerWidth
         return Math.min(Math.max(1, Math.floor(width / WIDTH_OF_ONE_CALENDAR_MONTH)), 2)
     }
-    const [autoMonthCount, setAutoMonthCount] = useState(getMonthCount())
+    const [autoMonthCount, setAutoMonthCount] = useState(getMonthCount)
     useEffect(() => {
         const listener = (): void => {
             if (autoMonthCount !== getMonthCount()) {

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -100,7 +100,7 @@ export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }:
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
 
-    const [radioValue, setRadioValue] = useState(
+    const [radioValue, setRadioValue] = useState(() =>
         getInitialRadioState(schema, !incrementalSyncSupported.disabled, !appendSyncSupported.disabled)
     )
     const [incrementalFieldValue, setIncrementalFieldValue] = useState(schema.incremental_field ?? null)

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -28,7 +28,7 @@ export function VariantScreenshot({
         return Array.isArray(variantImages) ? variantImages : [variantImages]
     }
 
-    const [mediaIds, setMediaIds] = useState<string[]>(getInitialMediaIds())
+    const [mediaIds, setMediaIds] = useState<string[]>(getInitialMediaIds)
     const [loadingImages, setLoadingImages] = useState<Record<string, boolean>>({})
     const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null)
 

--- a/frontend/src/scenes/max/Intro.tsx
+++ b/frontend/src/scenes/max/Intro.tsx
@@ -11,7 +11,7 @@ const LOGOMARK_AIRTIME_MS = 400 // Sync with --logomark-airtime in base.scss
 
 export function Intro(): JSX.Element {
     const { headline } = useValues(maxLogic)
-    const [hedgehogLastJumped, setHedgehogLastJumped] = useState<number | null>(Date.now())
+    const [hedgehogLastJumped, setHedgehogLastJumped] = useState<number | null>(() => Date.now())
     const [hedgehogJumpIteration, setHedgehogJumpIteration] = useState(0)
 
     const handleLogomarkClick = (): void => {

--- a/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
@@ -183,7 +183,7 @@ export function CoreEventsSettings(): JSX.Element {
     const { addCoreEvent, updateCoreEvent, removeCoreEvent } = useActions(coreEventsLogic)
 
     const [isModalOpen, setIsModalOpen] = useState(false)
-    const [formState, setFormState] = useState<FormState>(createEmptyFormState())
+    const [formState, setFormState] = useState<FormState>(createEmptyFormState)
 
     const isEditing = formState.id !== null
 

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -211,7 +211,7 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
         return []
     }
 
-    const [rules, setRules] = useState<ConditionRule[]>(parseExistingConditions())
+    const [rules, setRules] = useState<ConditionRule[]>(parseExistingConditions)
 
     useEffect(() => {
         loadAllMembers()

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
@@ -43,7 +43,7 @@ export function ConversionGoalsConfiguration({
 }): JSX.Element {
     const { conversion_goals } = useValues(marketingAnalyticsSettingsLogic)
     const { addOrUpdateConversionGoal, removeConversionGoal } = useActions(marketingAnalyticsSettingsLogic)
-    const [formState, setFormState] = useState<ConversionGoalFormState>(createEmptyFormState())
+    const [formState, setFormState] = useState<ConversionGoalFormState>(createEmptyFormState)
     const [editingGoalId, setEditingGoalId] = useState<string | null>(null)
     const [editingGoal, setEditingGoal] = useState<ConversionGoalFilter | null>(null)
 


### PR DESCRIPTION
## Problem

The current implementation of useState hooks in various components is not following the recommended pattern for expensive initial state calculations. When a function is passed directly to useState without wrapping it in a function, it gets executed on every render rather than just once during initialization.

## Changes

Updated useState hooks across multiple components to use the function initialization pattern `useState(() => ...)` instead of `useState(...)` when the initial state requires computation. This optimization ensures that expensive calculations for initial state only run during component initialization rather than on every render.

Components updated include:
- ImpersonationNotice's CountDown component
- CyclotronJobInputs' DictionaryField
- TZLabel
- LemonCalendar
- LemonCalendarRange
- LemonCalendarRangeInline
- SyncMethodForm
- VariantScreenshot
- Max Intro
- CoreEventsSettings
- ApprovalPolicies
- ConversionGoalsConfiguration

## How did you test this code?

Verified that all components continue to function correctly after the changes. Confirmed that initial state calculations are only performed once during component initialization by adding console logs to track execution. Tested components in various states to ensure they maintain the same behavior as before.