### PR TITLE
fix: Add title attributes to iframe elements

### DIFF
--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -37,6 +37,7 @@ function ExportHeatmap(): JSX.Element {
                 <iframe
                     id="heatmap-iframe"
                     ref={null}
+                    title="Heatmap export"
                     className="h-screen bg-white w-screen"
                     // eslint-disable-next-line react/forbid-dom-props
                     src={exportedData.heatmap_url ?? ''}

--- a/frontend/src/lib/components/IframedToolbarBrowser/IframedToolbarBrowser.tsx
+++ b/frontend/src/lib/components/IframedToolbarBrowser/IframedToolbarBrowser.tsx
@@ -55,6 +55,7 @@ export function IframedToolbarBrowser({
             <LoadingOverlay />
             <iframe
                 ref={iframeRef}
+                title="Toolbar browser preview"
                 className="w-full h-full bg-white"
                 src={appEditorUrl(browserUrl + '/' + initialPath, {
                     userIntent: userIntent,

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -411,6 +411,7 @@ export function SharingModalContent({
                                                         <iframe
                                                             className="block"
                                                             {...iframeProperties}
+                                                            title="Shared insight preview"
                                                             onLoad={() => setIframeLoaded(true)}
                                                             sandbox="allow-scripts allow-same-origin allow-popups"
                                                         />
@@ -484,7 +485,7 @@ function createRenderQuerySnippet({
     const escapedResults = escapeScriptJson(serializedResults)
     const escapedQuery = escapeScriptJson(serializedQuery)
 
-    return `<iframe id="${iframeId}" src="${renderQueryUrl}" style="width: 100%; height: 600px; border: 0;" loading="lazy"></iframe>
+    return `<iframe id="${iframeId}" title="PostHog embedded query" src="${renderQueryUrl}" style="width: 100%; height: 600px; border: 0;" loading="lazy"></iframe>
 <script>
   (function () {
     const iframe = document.getElementById('${iframeId}')

--- a/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
@@ -27,6 +27,7 @@ export function FixedReplayHeatmapBrowser({
                         <iframe
                             id="heatmap-iframe"
                             ref={iframeRef}
+                            title="Heatmap replay browser"
                             className="bg-white"
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ width: widthOverride, height: heightOverride }}

--- a/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
@@ -26,6 +26,7 @@ export function IframeHeatmapBrowser({
                     <iframe
                         id="heatmap-iframe"
                         ref={iframeRef}
+                        title="Heatmap browser"
                         className="bg-white"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ width: widthOverride, height: heightOverride }}

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -211,6 +211,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                 />
                                 <iframe
                                     id="heatmap-iframe"
+                                    title="Heatmap browser"
                                     className="bg-white rounded-b-lg"
                                     // eslint-disable-next-line react/forbid-dom-props
                                     style={{ width: '100%', height: heightOverride }}

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -199,7 +199,7 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
                                     </LemonButton>
                                 </div>
 
-                                <iframe srcDoc={value} sandbox="" className="flex-1" />
+                                <iframe srcDoc={value} sandbox="" title="Email template preview" className="flex-1" />
                             </>
                         )}
                     </LemonField>
@@ -557,6 +557,7 @@ function NativeEmailTemplaterForm({
                                 <iframe
                                     srcDoc={previewTemplate?.content.email.html}
                                     sandbox=""
+                                    title="Email template preview"
                                     className="w-full h-full border-0"
                                 />
                             </div>
@@ -578,7 +579,7 @@ function NativeEmailTemplaterForm({
                                     </LemonButton>
                                 </div>
 
-                                <iframe srcDoc={value} sandbox="" className="flex-1" />
+                                <iframe srcDoc={value} sandbox="" title="Email template preview" className="flex-1" />
                             </>
                         )}
                     </LemonField>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeEmbed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeEmbed.tsx
@@ -65,6 +65,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeEmbedAttributes
                     <iframe
                         className="w-full h-full"
                         src={validUrl.toString()}
+                        title="Embedded content"
                         allowFullScreen
                         onLoad={() => {
                             setLoaded(true)

--- a/frontend/src/scenes/product-tours/editor/EmbedExtension.tsx
+++ b/frontend/src/scenes/product-tours/editor/EmbedExtension.tsx
@@ -71,6 +71,7 @@ function EmbedNodeView({ node }: { node: { attrs: Record<string, any> } }): JSX.
             >
                 <iframe
                     src={embedUrl}
+                    title="Embedded media"
                     style={{
                         position: 'absolute',
                         top: 0,

--- a/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
+++ b/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
@@ -60,6 +60,7 @@ export function SessionRecordingPlayerExplorer({
                 <iframe
                     key={iframeKey}
                     srcDoc={html}
+                    title="Session recording DOM explorer"
                     sandbox=""
                     width={width}
                     height={height}

--- a/frontend/src/scenes/sites/Site.tsx
+++ b/frontend/src/scenes/sites/Site.tsx
@@ -27,6 +27,7 @@ export function Site({ url }: SiteLogicProps): JSX.Element {
     return (
         <iframe
             className="Site"
+            title="Site preview"
             src={launchUrl(decodedUrl)}
             // allow-same-origin is particularly important here, because otherwise redirect_to_site cannot work
             // Note that combining allow-scripts and allow-same-origin effectively allows the iframe access to the

--- a/products/workflows/frontend/TemplateLibrary/MessageTemplateCard.tsx
+++ b/products/workflows/frontend/TemplateLibrary/MessageTemplateCard.tsx
@@ -30,6 +30,7 @@ export function MessageTemplateCard({
                         <iframe
                             srcDoc={emailHtml}
                             sandbox="allow-same-origin"
+                            title="Message template preview"
                             className="w-full h-full border-0 bg-white pointer-events-none"
                         />
                     ) : (


### PR DESCRIPTION
## Problem

Accessibility is a key aspect of web development, and our application currently lacks proper title attributes for iframe elements. This is important for screen reader users to understand the content of iframes, and it's a requirement for WCAG compliance.

## Changes

Added title attributes to all iframe elements across the application to improve accessibility. This includes:
- Heatmap exports and browsers
- Toolbar browser previews
- Shared insight previews
- Embedded queries
- Email template previews
- Embedded content in notebooks
- Session recording DOM explorer
- Site previews
- Message template previews

## How did you test this code?

Manually verified that all iframe elements now have descriptive title attributes that accurately describe their content. Used browser developer tools to inspect the rendered HTML and confirm the presence of the title attributes.

## Publish to changelog?

No