### PR TITLE
refactor: Use functional state updates for state setters

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -17,7 +17,7 @@ import { ImpersonationReasonModal } from './ImpersonationReasonModal'
 import { impersonationNoticeLogic } from './impersonationNoticeLogic'
 
 function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
-    const [now, setNow] = useState(dayjs())
+    const [now, setNow] = useState(() => dayjs())
     const { isVisible: isPageVisible } = usePageVisibility()
 
     const duration = dayjs.duration(datetime.diff(now))

--- a/frontend/src/layout/navigation/PosthogStories/StoriesModal.tsx
+++ b/frontend/src/layout/navigation/PosthogStories/StoriesModal.tsx
@@ -387,7 +387,7 @@ export const StoriesModal = (): JSX.Element | null => {
                             }
                         }}
                         onStoryStart={handleStoryStart}
-                        onPauseToggle={() => setIsPaused(!isPaused)}
+                        onPauseToggle={() => setIsPaused((prev) => !prev)}
                         onClose={() => handleClose(true)}
                     />
 

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -103,7 +103,7 @@ export function AuthorizedUrlList({
                 }
 
                 return editUrlIndex === index ? (
-                    <div className="border rounded p-2 bg-surface-primary">
+                    <div key={index} className="border rounded p-2 bg-surface-primary">
                         <AuthorizedUrlForm
                             type={type}
                             actionId={actionId}

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -103,7 +103,7 @@ export function AuthorizedUrlList({
                 }
 
                 return editUrlIndex === index ? (
-                    <div key={index} className="border rounded p-2 bg-surface-primary">
+                    <div key={keyedURL.url} className="border rounded p-2 bg-surface-primary">
                         <AuthorizedUrlForm
                             type={type}
                             actionId={actionId}
@@ -113,7 +113,10 @@ export function AuthorizedUrlList({
                         />
                     </div>
                 ) : (
-                    <div key={index} className={clsx('border rounded flex items-center p-2 pl-4 bg-surface-primary')}>
+                    <div
+                        key={keyedURL.url}
+                        className={clsx('border rounded flex items-center p-2 pl-4 bg-surface-primary')}
+                    >
                         {keyedURL.type === 'suggestion' && (
                             <Tooltip title={'Seen in ' + keyedURL.count + ' events in the last 3 days'}>
                                 <LemonTag type="highlight" className="mr-4 uppercase cursor-pointer">

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -310,9 +310,11 @@ function DictionaryField({
                             disabled={key === EXTEND_OBJECT_KEY}
                             className="flex-1 min-w-60"
                             onChange={(key) => {
-                                const newEntries = [...entries]
-                                newEntries[index] = [key, newEntries[index][1]]
-                                setEntries(newEntries)
+                                setEntries((prev) => {
+                                    const newEntries = [...prev]
+                                    newEntries[index] = [key, newEntries[index][1]]
+                                    return newEntries
+                                })
                             }}
                             placeholder="Key"
                         />
@@ -322,12 +324,15 @@ function DictionaryField({
                         className="overflow-hidden flex-2"
                         input={{ ...input, value: val }}
                         onChange={(val) => {
-                            const newEntries = [...entries]
-                            newEntries[index] = [newEntries[index][0], val.value ?? '']
                             if (val.templating) {
                                 onChange?.({ ...input, templating: val.templating })
                             }
-                            setEntries(newEntries)
+
+                            setEntries((prev) => {
+                                const newEntries = [...prev]
+                                newEntries[index] = [newEntries[index][0], val.value ?? '']
+                                return newEntries
+                            })
                         }}
                         templating={templating}
                         sampleGlobalsWithInputs={sampleGlobalsWithInputs}
@@ -337,9 +342,11 @@ function DictionaryField({
                         icon={<IconX />}
                         size="small"
                         onClick={() => {
-                            const newEntries = [...entries]
-                            newEntries.splice(index, 1)
-                            setEntries(newEntries)
+                            setEntries((prev) => {
+                                const newEntries = [...prev]
+                                newEntries.splice(index, 1)
+                                return newEntries
+                            })
                         }}
                     />
                 </div>

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -292,7 +292,7 @@ function DictionaryField({
     }, [entries, onChange])
 
     const handleEnableIncludeObject = (): void => {
-        setEntries([[EXTEND_OBJECT_KEY, '{event.properties}'], ...entries])
+        setEntries((prev) => [[EXTEND_OBJECT_KEY, '{event.properties}'], ...prev])
     }
 
     return (
@@ -349,7 +349,7 @@ function DictionaryField({
                 size="small"
                 type="secondary"
                 onClick={() => {
-                    setEntries([...entries, ['', '']])
+                    setEntries((prev) => [...prev, ['', '']])
                 }}
             >
                 Add entry

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -272,7 +272,7 @@ function DictionaryField({
     sampleGlobalsWithInputs: CyclotronJobInvocationGlobalsWithInputs | null
 }): JSX.Element {
     const value = input.value ?? {}
-    const [entries, setEntries] = useState<[string, string][]>(Object.entries(value))
+    const [entries, setEntries] = useState<[string, string][]>(() => Object.entries(value))
     const prevFilteredEntriesRef = useRef<[string, string][]>(entries)
 
     useEffect(() => {

--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -89,7 +89,13 @@ export function IntegrationChoice({
                     ? {
                           items: [
                               ...(integrationsOfKind?.map((integ) => ({
-                                  icon: <img src={integ.icon_url} className="w-6 h-6 rounded" />,
+                                  icon: (
+                                      <img
+                                          src={integ.icon_url}
+                                          alt={`${integ.display_name} icon`}
+                                          className="w-6 h-6 rounded"
+                                      />
+                                  ),
                                   onClick: () => onChange?.(integ.id),
                                   active: integ.id === value,
                                   label: integ.display_name,

--- a/frontend/src/lib/components/ImageCarousel/ImageCarousel.tsx
+++ b/frontend/src/lib/components/ImageCarousel/ImageCarousel.tsx
@@ -36,7 +36,11 @@ export function ImageCarousel({ imageUrls, loading, onDelete }: ImageCarouselPro
 
     return (
         <div className="relative group border rounded bg-bg-light w-full max-w-[600px] aspect-[3/2] flex items-center justify-center overflow-hidden">
-            {loading ? <Spinner /> : <img src={currentImageUrl} className="max-w-[96%] max-h-[96%] object-contain" />}
+            {loading ? (
+                <Spinner />
+            ) : (
+                <img src={currentImageUrl} alt="Carousel image" className="max-w-[96%] max-h-[96%] object-contain" />
+            )}
 
             {onDelete && !loading && (
                 <LemonButton

--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -139,7 +139,7 @@ export function ResizableElement({
     useEffect(() => {
         document.addEventListener('mousemove', handleMouseMove)
         document.addEventListener('mouseup', handleEnd)
-        document.addEventListener('touchmove', handleTouchMove)
+        document.addEventListener('touchmove', handleTouchMove, { passive: true })
         document.addEventListener('touchend', handleEnd)
 
         return () => {

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneNotebookMenuItems.tsx
@@ -154,8 +154,11 @@ export function SceneNotebookMenuItems({
                                             notebooksContainingResource.map(
                                                 (notebook: NotebookListItemType) =>
                                                     notebook && (
-                                                        <Combobox.Group value={[notebook.title ?? '']}>
-                                                            <Combobox.Item key={notebook.short_id} asChild>
+                                                        <Combobox.Group
+                                                            key={notebook.short_id}
+                                                            value={[notebook.title ?? '']}
+                                                        >
+                                                            <Combobox.Item asChild>
                                                                 <ButtonPrimitive
                                                                     menuItem
                                                                     onClick={() => {
@@ -188,8 +191,11 @@ export function SceneNotebookMenuItems({
                                             notebooksNotContainingResource.map(
                                                 (notebook: NotebookListItemType) =>
                                                     notebook && (
-                                                        <Combobox.Group value={[notebook.title ?? '']}>
-                                                            <Combobox.Item key={notebook.short_id} asChild>
+                                                        <Combobox.Group
+                                                            key={notebook.short_id}
+                                                            value={[notebook.title ?? '']}
+                                                        >
+                                                            <Combobox.Item asChild>
                                                                 <ButtonPrimitive
                                                                     menuItem
                                                                     onClick={() => {

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -203,7 +203,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
             : displayTime.fromNow()
     }, [formatDate, formatTime, displayTime, timestampStyle, displayTimezone])
 
-    const [formattedContent, setFormattedContent] = useState(format())
+    const [formattedContent, setFormattedContent] = useState(format)
 
     const { isVisible: isPageVisible } = usePageVisibility()
 

--- a/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
@@ -16,8 +16,13 @@ export function VisibilitySensor({ id, offset, children }: VisibilityProps): JSX
 
     useEffect(() => {
         const element = ref.current
-        document.addEventListener('scroll', () => element && scrolling(element))
-        return () => document.removeEventListener('scroll', () => element && scrolling(element))
+        const handler = (): void => {
+            if (element) {
+                scrolling(element)
+            }
+        }
+        document.addEventListener('scroll', handler, { passive: true })
+        return () => document.removeEventListener('scroll', handler)
     }, [ref.current]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return <div ref={ref}>{children}</div>

--- a/frontend/src/lib/components/hedgehogs.tsx
+++ b/frontend/src/lib/components/hedgehogs.tsx
@@ -50,11 +50,11 @@ type HedgehogProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>
 
 // w400 x h400
 const SquaredHedgehog = (props: ImgHTMLAttributes<HTMLImageElement>): JSX.Element => {
-    return <img src={props.src} width={400} height={400} {...props} />
+    return <img src={props.src} width={400} height={400} alt="PostHog hedgehog" {...props} />
 }
 // any width x h400
 const RectangularHedgehog = (props: ImgHTMLAttributes<HTMLImageElement>): JSX.Element => {
-    return <img src={props.src} height={400} {...props} />
+    return <img src={props.src} height={400} alt="PostHog hedgehog" {...props} />
 }
 
 export const SurprisedHog = (props: HedgehogProps): JSX.Element => {

--- a/frontend/src/lib/hooks/useScrollObserver.tsx
+++ b/frontend/src/lib/hooks/useScrollObserver.tsx
@@ -45,7 +45,7 @@ export function useScrollObserver({ onScrollTop, onScrollBottom }: ScrollObserve
                 }
             } else {
                 containerRef.current = el
-                el.addEventListener('scroll', handleScroll)
+                el.addEventListener('scroll', handleScroll, { passive: true })
             }
         },
         [handleScroll]

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -57,7 +57,11 @@ export function IntegrationView({
         <div className="rounded border bg-surface-primary">
             <div className="flex justify-between items-center p-2">
                 <div className="flex gap-4 items-center ml-2">
-                    <img src={integration.icon_url} className="w-10 h-10 rounded" />
+                    <img
+                        src={integration.icon_url}
+                        alt={`${integration.kind} integration`}
+                        className="w-10 h-10 rounded"
+                    />
                     <div>
                         <div className="flex gap-2">
                             <span>

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
@@ -56,7 +56,9 @@ export const LemonCalendar = forwardRef(function LemonCalendar(
     const weekStartDay = props.weekStartDay ?? teamWeekStartDay
     const today = dayjs().startOf('day')
 
-    const [leftmostMonth, setLeftmostMonth] = useState<dayjs.Dayjs>((props.leftmostMonth ?? today).startOf('month'))
+    const [leftmostMonth, setLeftmostMonth] = useState<dayjs.Dayjs>(() =>
+        (props.leftmostMonth ?? today).startOf('month')
+    )
     useEffect(() => {
         if (props.leftmostMonth && props.leftmostMonth.isSame(leftmostMonth, 'd')) {
             setLeftmostMonth(props.leftmostMonth)

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
@@ -30,7 +30,7 @@ export function LemonCalendarRange({
     onToggleTime,
 }: LemonCalendarRangeProps): JSX.Element {
     // Keep a sanitised and cached copy of the selected range
-    const [[rangeStart, rangeEnd], setRange] = useState([
+    const [[rangeStart, rangeEnd], setRange] = useState(() => [
         value?.[0] ? value[0].startOf('day') : null,
         value?.[1] ? value[1].endOf('day') : null,
     ])

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -38,7 +38,7 @@ export function LemonCalendarRangeInline({
             typeof window === 'undefined' ? WIDTH_OF_ONE_CALENDAR_MONTH * CALENDARS_IF_NO_WINDOW : window.innerWidth
         return Math.min(Math.max(1, Math.floor(width / WIDTH_OF_ONE_CALENDAR_MONTH)), 2)
     }
-    const [autoMonthCount, setAutoMonthCount] = useState(getMonthCount())
+    const [autoMonthCount, setAutoMonthCount] = useState(getMonthCount)
     useEffect(() => {
         const listener = (): void => {
             if (autoMonthCount !== getMonthCount()) {

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
@@ -174,7 +174,7 @@ WithExpandableRows.args = {
     expandable: {
         rowExpandable: (record) => record.occupation !== 'Retired',
         expandedRowRender: function RenderCow() {
-            return <img src="https://c.tenor.com/WAFH6TX2VIYAAAAC/polish-cow.gif" />
+            return <img src="https://c.tenor.com/WAFH6TX2VIYAAAAC/polish-cow.gif" alt="Dancing cow" />
         },
     },
 }

--- a/frontend/src/lib/lemon-ui/UploadedLogo/UploadedLogo.tsx
+++ b/frontend/src/lib/lemon-ui/UploadedLogo/UploadedLogo.tsx
@@ -52,6 +52,7 @@ export const UploadedLogo = React.forwardRef<HTMLDivElement, UploadedLogoProps>(
             <img
                 className="size-full object-cover"
                 src={mediaId.startsWith('data:') ? mediaId : `/uploaded_media/${mediaId}`}
+                alt="Uploaded logo"
                 onError={() => setIsLoadingImage(false)}
                 onLoad={() => setIsLoadingImage(false)}
             />

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -772,7 +772,7 @@ export function DataTable({
 
     const secondRowRight = [
         sourceFeatures.has(QueryFeature.linkDataButton) && hasCustomerAnalyticsEnabled ? (
-            <ViewLinkButton tableName="groups" />
+            <ViewLinkButton key="view-link-button" tableName="groups" />
         ) : null,
         (showColumnConfigurator || showPersistentColumnConfigurator) &&
         sourceFeatures.has(QueryFeature.columnConfigurator) ? (

--- a/frontend/src/scenes/authentication/TwoFactorSetup.tsx
+++ b/frontend/src/scenes/authentication/TwoFactorSetup.tsx
@@ -27,7 +27,11 @@ export function TwoFactorSetup({ onSuccess }: { onSuccess: () => void }): JSX.El
             >
                 <div className="flex flex-col items-center">
                     <div className="bg-white p-4 rounded">
-                        <img src="/account/two_factor/qrcode/" className="Setup2FA__image" />
+                        <img
+                            src="/account/two_factor/qrcode/"
+                            className="Setup2FA__image"
+                            alt="QR code for two-factor authentication setup"
+                        />
                     </div>
 
                     {/* Secret key for manual entry */}

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -100,7 +100,7 @@ export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }:
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
 
-    const [radioValue, setRadioValue] = useState(
+    const [radioValue, setRadioValue] = useState(() =>
         getInitialRadioState(schema, !incrementalSyncSupported.disabled, !appendSyncSupported.disabled)
     )
     const [incrementalFieldValue, setIncrementalFieldValue] = useState(schema.incremental_field ?? null)

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -34,20 +34,23 @@ export function VariantScreenshot({
 
     const { setFilesToUpload, filesToUpload, uploading } = useUploadFiles({
         onUpload: (_, __, id) => {
-            if (id && mediaIds.length < 5) {
-                const newMediaIds = [...mediaIds, id]
-                setMediaIds(newMediaIds)
-
+            if (!id) {
+                return
+            }
+            setMediaIds((prev) => {
+                if (prev.length >= 5) {
+                    lemonToast.error('Maximum of 5 images allowed')
+                    return prev
+                }
+                const newMediaIds = [...prev, id]
                 const updatedVariantImages = {
                     ...experiment.parameters?.variant_screenshot_media_ids,
                     [variantKey]: newMediaIds,
                 }
-
                 updateExperimentVariantImages(updatedVariantImages)
                 reportExperimentVariantScreenshotUploaded(experiment.id)
-            } else if (mediaIds.length >= 5) {
-                lemonToast.error('Maximum of 5 images allowed')
-            }
+                return newMediaIds
+            })
         },
         onError: (detail) => {
             lemonToast.error(`Error uploading image: ${detail}`)

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -37,16 +37,18 @@ export function VariantScreenshot({
             if (!id) {
                 return
             }
+            if (mediaIds.length >= 5) {
+                lemonToast.error('Maximum of 5 images allowed')
+                return
+            }
+
             setMediaIds((prev) => {
-                if (prev.length >= 5) {
-                    lemonToast.error('Maximum of 5 images allowed')
-                    return prev
-                }
                 const newMediaIds = [...prev, id]
                 const updatedVariantImages = {
                     ...experiment.parameters?.variant_screenshot_media_ids,
                     [variantKey]: newMediaIds,
                 }
+
                 updateExperimentVariantImages(updatedVariantImages)
                 reportExperimentVariantScreenshotUploaded(experiment.id)
                 return newMediaIds

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -28,7 +28,7 @@ export function VariantScreenshot({
         return Array.isArray(variantImages) ? variantImages : [variantImages]
     }
 
-    const [mediaIds, setMediaIds] = useState<string[]>(getInitialMediaIds())
+    const [mediaIds, setMediaIds] = useState<string[]>(getInitialMediaIds)
     const [loadingImages, setLoadingImages] = useState<Record<string, boolean>>({})
     const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null)
 

--- a/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/VariantScreenshot.tsx
@@ -108,6 +108,7 @@ export function VariantScreenshot({
                                     <img
                                         className="w-full h-full object-cover"
                                         src={mediaId.startsWith('data:') ? mediaId : `/uploaded_media/${mediaId}`}
+                                        alt={`Variant screenshot thumbnail ${index + 1}`}
                                         onError={() => handleImageError(mediaId)}
                                         onLoad={() => handleImageLoad(mediaId)}
                                     />

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -116,7 +116,7 @@ const featureFlagActionsMapping: Record<
                                     )
                                 }) || []
                             newButtons[0] = (
-                                <>
+                                <Fragment key={nonEmptyProperties[0].key ?? 0}>
                                     <span>
                                         <strong>{rollout_percentage ?? 100}%</strong> of{' '}
                                     </span>
@@ -124,7 +124,7 @@ const featureFlagActionsMapping: Record<
                                         key={nonEmptyProperties[0].key}
                                         item={nonEmptyProperties[0]}
                                     />
-                                </>
+                                </Fragment>
                             )
                             groupAdditions.push(...newButtons)
                         } else {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import {
     ActivityChange,
@@ -102,15 +104,15 @@ const featureFlagActionsMapping: Record<
                             const newButtons =
                                 nonEmptyProperties.map((property, idx) => {
                                     return (
-                                        <>
+                                        <Fragment key={property.key ?? idx}>
                                             {' '}
                                             {idx === 0 && (
                                                 <span>
                                                     <strong>{rollout_percentage ?? 100}%</strong> of{' '}
                                                 </span>
                                             )}
-                                            <PropertyFilterButton key={property.key} item={property} />
-                                        </>
+                                            <PropertyFilterButton item={property} />
+                                        </Fragment>
                                     )
                                 }) || []
                             newButtons[0] = (

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -182,6 +182,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                         <img
                                             id="heatmap-screenshot"
                                             src={screenshotUrl}
+                                            alt="Website screenshot for heatmap analysis"
                                             style={{
                                                 width: '100%',
                                                 height: 'auto',

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionIcon.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionIcon.tsx
@@ -164,6 +164,7 @@ export function HogFunctionIcon({
                             loaded ? 'opacity-100' : 'opacity-0'
                         )}
                         src={src}
+                        alt="Hog function icon"
                         onLoad={() => setLoaded(true)}
                     />
                     {!loaded && <LemonSkeleton className="absolute w-full h-full" />}

--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -43,9 +43,8 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
                 </>
             ) : (
                 conversationHistory.slice(0, 3).map((conversation) => (
-                    <span className="flex items-center gap-2">
+                    <span key={conversation.id} className="flex items-center gap-2">
                         <Link
-                            key={conversation.id}
                             className="grow text-sm text-primary hover:text-accent-hover active:text-accent-active"
                             to={urls.ai(conversation.id)}
                             onClick={(e) => {

--- a/frontend/src/scenes/max/Intro.tsx
+++ b/frontend/src/scenes/max/Intro.tsx
@@ -11,7 +11,7 @@ const LOGOMARK_AIRTIME_MS = 400 // Sync with --logomark-airtime in base.scss
 
 export function Intro(): JSX.Element {
     const { headline } = useValues(maxLogic)
-    const [hedgehogLastJumped, setHedgehogLastJumped] = useState<number | null>(Date.now())
+    const [hedgehogLastJumped, setHedgehogLastJumped] = useState<number | null>(() => Date.now())
     const [hedgehogJumpIteration, setHedgehogJumpIteration] = useState(0)
 
     const handleLogomarkClick = (): void => {

--- a/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
+++ b/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
@@ -57,7 +57,7 @@ export function ThreadAutoScroller({ children }: { children: React.ReactNode }):
                 scrollOrigin.current.user = true
             }
         }
-        scrollableContainer.addEventListener('scroll', scrollListener)
+        scrollableContainer.addEventListener('scroll', scrollListener, { passive: true })
 
         // When the thread is resized during generation, we need to scroll to the bottom
         let resizeTimeout: NodeJS.Timeout | null = null

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -51,7 +51,7 @@ export function personActivityDescriber(logItem: ActivityLogItem, asNotification
                             </>
                         }
                         listParts={logItem.detail.merge.source.flatMap((di, idx) => (
-                            <span key={idx} className="highlighted-activity">
+                            <span key={di.id || di.uuid || idx} className="highlighted-activity">
                                 <PersonDisplay person={di} />
                             </span>
                         ))}

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -50,8 +50,8 @@ export function personActivityDescriber(logItem: ActivityLogItem, asNotification
                                 <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> merged
                             </>
                         }
-                        listParts={logItem.detail.merge.source.flatMap((di) => (
-                            <span className="highlighted-activity">
+                        listParts={logItem.detail.merge.source.flatMap((di, idx) => (
+                            <span key={idx} className="highlighted-activity">
                                 <PersonDisplay person={di} />
                             </span>
                         ))}

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -1,6 +1,7 @@
 import '../../lib/components/Cards/InsightCard/InsightCard.scss'
 
 import posthog from 'posthog-js'
+import { Fragment } from 'react'
 
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import {
@@ -194,7 +195,7 @@ const insightActionsMapping: Record<
                     </>
                 }
                 listParts={addedDashboards.map((d) => (
-                    <>{linkToDashboard(d)}</>
+                    <Fragment key={d.id}>{linkToDashboard(d)}</Fragment>
                 ))}
             />
         ) : null
@@ -208,7 +209,7 @@ const insightActionsMapping: Record<
                     </>
                 }
                 listParts={removedDashboards.map((d) => (
-                    <>{linkToDashboard(d)}</>
+                    <Fragment key={d.id}>{linkToDashboard(d)}</Fragment>
                 ))}
             />
         ) : null

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarLinkedIssuesTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarLinkedIssuesTab.tsx
@@ -37,7 +37,7 @@ type IssueConfig = Record<string, string>
 
 const IntegrationIcon = ({ kind }: { kind: IntegrationKind }): JSX.Element => {
     const className = kind === 'github' ? 'w-5 h-5 rounded-sm dark:invert' : 'w-5 h-5 rounded-sm'
-    return <img src={ICONS[kind]} className={className} />
+    return <img src={ICONS[kind]} alt={`${kind} integration`} className={className} />
 }
 
 export function PlayerSidebarLinkedIssuesTab(): JSX.Element | null {

--- a/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/CoreEventsSettings.tsx
@@ -183,7 +183,7 @@ export function CoreEventsSettings(): JSX.Element {
     const { addCoreEvent, updateCoreEvent, removeCoreEvent } = useActions(coreEventsLogic)
 
     const [isModalOpen, setIsModalOpen] = useState(false)
-    const [formState, setFormState] = useState<FormState>(createEmptyFormState())
+    const [formState, setFormState] = useState<FormState>(createEmptyFormState)
 
     const isEditing = formState.id !== null
 

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -211,7 +211,7 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
         return []
     }
 
-    const [rules, setRules] = useState<ConditionRule[]>(parseExistingConditions())
+    const [rules, setRules] = useState<ConditionRule[]>(parseExistingConditions)
 
     useEffect(() => {
         loadAllMembers()

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -219,17 +219,15 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
     }, [loadAllMembers, loadRoles])
 
     const addRule = (field: string): void => {
-        setRules([...rules, { field, type: 'any_change' }])
+        setRules((prev) => [...prev, { field, type: 'any_change' }])
     }
 
     const updateRule = (index: number, updates: Partial<ConditionRule>): void => {
-        const newRules = [...rules]
-        newRules[index] = { ...newRules[index], ...updates }
-        setRules(newRules)
+        setRules((prev) => prev.map((rule, i) => (i === index ? { ...rule, ...updates } : rule)))
     }
 
     const removeRule = (index: number): void => {
-        setRules(rules.filter((_, i) => i !== index))
+        setRules((prev) => prev.filter((_, i) => i !== index))
     }
 
     const usedFields = new Set(rules.map((r) => r.field))

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -124,6 +124,7 @@ export const WebAnalyticsMenu = (): JSX.Element => {
                     <ScenePanelLabel title="Visible tiles" className="px-1.5">
                         {availableTiles.map((tileId) => (
                             <ButtonPrimitive
+                                key={tileId}
                                 menuItem
                                 onClick={() => {
                                     setTileVisibility(tileId, hiddenTiles.includes(tileId))

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ConversionGoalsConfiguration.tsx
@@ -43,7 +43,7 @@ export function ConversionGoalsConfiguration({
 }): JSX.Element {
     const { conversion_goals } = useValues(marketingAnalyticsSettingsLogic)
     const { addOrUpdateConversionGoal, removeConversionGoal } = useActions(marketingAnalyticsSettingsLogic)
-    const [formState, setFormState] = useState<ConversionGoalFormState>(createEmptyFormState())
+    const [formState, setFormState] = useState<ConversionGoalFormState>(createEmptyFormState)
     const [editingGoalId, setEditingGoalId] = useState<string | null>(null)
     const [editingGoal, setEditingGoal] = useState<ConversionGoalFilter | null>(null)
 


### PR DESCRIPTION
## Problem

The current state management in several components is using direct state updates, which can lead to race conditions when the new state depends on the previous state. This pattern is not recommended in React as it may not correctly capture the latest state value.

## Changes

Updated state update functions in multiple components to use the functional update pattern (`setState(prev => ...)`) instead of directly referencing the current state value. This ensures that state updates are based on the most recent state value, preventing potential race conditions.

Specific changes:
- Fixed `setIsPaused` in StoriesModal
- Updated `setEntries` in DictionaryField to use functional updates
- Refactored the variant screenshot upload logic to use functional updates and improve code organization
- Improved ApprovalPolicies component to use functional updates for rules management

## How did you test this code?

Manually tested each component to ensure the state updates work correctly. Verified that toggling pause in stories, adding dictionary entries, uploading variant screenshots, and managing approval policies all function as expected with the new state update pattern.