### PR TITLE
feat(product tours): product tour draft frontend

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4439,6 +4439,18 @@ const api = {
             const apiRequest = new ApiRequest().productTour(tourId).withAction('generate')
             return await apiRequest.create({ data: { title, steps, goal } })
         },
+        async saveDraft(tourId: ProductTour['id'], data: Partial<ProductTour>): Promise<ProductTour> {
+            return await new ApiRequest().productTour(tourId).withAction('draft').update({ data })
+        },
+        async publishDraft(tourId: ProductTour['id'], data?: Record<string, any>): Promise<ProductTour> {
+            return await new ApiRequest().productTour(tourId).withAction('publish_draft').create({ data })
+        },
+        async discardDraft(tourId: ProductTour['id']): Promise<void> {
+            await new ApiRequest().productTour(tourId).withAction('discard_draft').delete()
+        },
+        async draftStatus(tourId: ProductTour['id']): Promise<{ updated_at: string; has_draft: boolean }> {
+            return await new ApiRequest().productTour(tourId).withAction('draft_status').get()
+        },
     },
 
     dataWarehouseTables: {

--- a/frontend/src/scenes/product-tours/ProductTour.tsx
+++ b/frontend/src/scenes/product-tours/ProductTour.tsx
@@ -67,7 +67,6 @@ export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element
                                 addText="Add authorized URL"
                                 productTourId={id}
                                 userIntent={toolbarMode === 'edit' ? 'edit-product-tour' : 'preview-product-tour'}
-                                launchInSameTab={false}
                             />
                         </div>
                     </LemonModal>

--- a/frontend/src/scenes/product-tours/ProductTour.tsx
+++ b/frontend/src/scenes/product-tours/ProductTour.tsx
@@ -67,7 +67,7 @@ export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element
                                 addText="Add authorized URL"
                                 productTourId={id}
                                 userIntent={toolbarMode === 'edit' ? 'edit-product-tour' : 'preview-product-tour'}
-                                launchInSameTab={isEditingProductTour}
+                                launchInSameTab={false}
                             />
                         </div>
                     </LemonModal>

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -15,7 +15,9 @@ import { ProductTourStepsEditor } from './editor'
 import { productTourLogic } from './productTourLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
-    const { productTour, productTourForm } = useValues(productTourLogic({ id }))
+    const { productTour, productTourForm, isEditingProductTour, draftSaveStatus, draftActionInProgress } = useValues(
+        productTourLogic({ id })
+    )
     const { discardDraft, publishDraft, setProductTourFormValue, openToolbarModal } = useActions(
         productTourLogic({ id })
     )
@@ -41,14 +43,30 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     }}
                     actions={
                         <div className="flex items-center gap-2">
-                            <ProductTourStatusTag tour={productTour} />
+                            <ProductTourStatusTag
+                                tour={productTour}
+                                isEditing={isEditingProductTour}
+                                draftSaveStatus={draftSaveStatus}
+                            />
                             <LemonButton type="secondary" size="small" onClick={() => openToolbarModal('preview')}>
                                 Preview
                             </LemonButton>
-                            <LemonButton type="secondary" size="small" onClick={discardDraft}>
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                onClick={discardDraft}
+                                loading={draftActionInProgress === 'discard'}
+                                disabledReason={draftActionInProgress ? 'Discarding draft...' : undefined}
+                            >
                                 Cancel
                             </LemonButton>
-                            <LemonButton type="primary" size="small" onClick={publishDraft}>
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={publishDraft}
+                                loading={draftActionInProgress === 'publish'}
+                                disabledReason={draftActionInProgress ? 'Saving...' : undefined}
+                            >
                                 Save
                             </LemonButton>
                         </div>

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -15,10 +15,8 @@ import { ProductTourStepsEditor } from './editor'
 import { productTourLogic } from './productTourLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
-    const { productTour, productTourForm, isProductTourFormSubmitting, pendingToolbarOpen } = useValues(
-        productTourLogic({ id })
-    )
-    const { editingProductTour, setProductTourFormValue, submitProductTourForm, submitAndOpenToolbar } = useActions(
+    const { productTour, productTourForm } = useValues(productTourLogic({ id }))
+    const { discardDraft, publishDraft, setProductTourFormValue, openToolbarModal } = useActions(
         productTourLogic({ id })
     )
 
@@ -44,23 +42,13 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     actions={
                         <div className="flex items-center gap-2">
                             <ProductTourStatusTag tour={productTour} />
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                onClick={() => submitAndOpenToolbar('preview')}
-                                loading={pendingToolbarOpen}
-                            >
+                            <LemonButton type="secondary" size="small" onClick={() => openToolbarModal('preview')}>
                                 Preview
                             </LemonButton>
-                            <LemonButton type="secondary" size="small" onClick={() => editingProductTour(false)}>
+                            <LemonButton type="secondary" size="small" onClick={discardDraft}>
                                 Cancel
                             </LemonButton>
-                            <LemonButton
-                                type="primary"
-                                size="small"
-                                onClick={() => submitProductTourForm()}
-                                loading={isProductTourFormSubmitting && !pendingToolbarOpen}
-                            >
+                            <LemonButton type="primary" size="small" onClick={publishDraft}>
                                 Save
                             </LemonButton>
                         </div>

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -303,7 +303,7 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
             />
 
             {hasDraft && (
-                <LemonBanner type="info" className="mb-4" dismissKey={`product-tour-draft-${id}`}>
+                <LemonBanner type="info" className="mb-4">
                     <div className="flex items-center justify-between w-full">
                         <span>You have unsaved changes</span>
                         <div className="flex items-center gap-2">

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconCode, IconCursorClick, IconDocument, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDialog, LemonDivider, LemonSelect, LemonTag } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -116,12 +116,14 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
         dateRange,
         targetingFlagFilters,
         launchValidationIssues,
+        hasDraft,
     } = useValues(productTourLogic({ id }))
     const {
         editingProductTour,
         launchProductTour,
         stopProductTour,
         resumeProductTour,
+        discardDraft,
         setDateRange,
         openToolbarModal,
     } = useActions(productTourLogic({ id }))
@@ -299,6 +301,22 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                     </>
                 }
             />
+
+            {hasDraft && (
+                <LemonBanner type="info" className="mb-4" dismissKey={`product-tour-draft-${id}`}>
+                    <div className="flex items-center justify-between w-full">
+                        <span>You have unsaved changes</span>
+                        <div className="flex items-center gap-2">
+                            <LemonButton type="secondary" size="xsmall" onClick={discardDraft}>
+                                Discard
+                            </LemonButton>
+                            <LemonButton type="primary" size="xsmall" onClick={() => editingProductTour(true)}>
+                                Continue editing
+                            </LemonButton>
+                        </div>
+                    </div>
+                </LemonBanner>
+            )}
 
             <LemonTabs
                 activeKey={tabKey}

--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -27,7 +27,6 @@ import { urls } from 'scenes/urls'
 
 import { ProductTour, ProgressStatus } from '~/types'
 
-import { productTourLogic } from '../productTourLogic'
 import {
     ProductToursTabs,
     getProductTourStatus,
@@ -36,9 +35,16 @@ import {
     productToursLogic,
 } from '../productToursLogic'
 
-export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Element {
+export function ProductTourStatusTag({
+    tour,
+    isEditing,
+    draftSaveStatus,
+}: {
+    tour: ProductTour
+    isEditing?: boolean
+    draftSaveStatus?: 'unsaved' | 'saving' | 'saved' | null
+}): JSX.Element {
     const status = getProductTourStatus(tour)
-    const { isEditingProductTour, draftSaveStatus } = useValues(productTourLogic({ id: tour.id }))
 
     const statusConfig: Record<
         ProgressStatus,
@@ -52,7 +58,7 @@ export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Eleme
     const config = statusConfig[status]
     return (
         <LemonTag type={config.type}>
-            {isEditingProductTour && (
+            {isEditing && (
                 <>
                     {draftSaveStatus === 'unsaved' && <IconCircleDashed />}
                     {draftSaveStatus === 'saving' && <Spinner />}

--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -3,6 +3,8 @@ import { router } from 'kea-router'
 
 import {
     IconArchive,
+    IconCheckCircle,
+    IconCircleDashed,
     IconCopy,
     IconCursorClick,
     IconEye,
@@ -12,7 +14,7 @@ import {
     IconStopFilled,
     IconTrash,
 } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider, LemonInput, LemonTable, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonDivider, LemonInput, LemonTable, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -25,6 +27,7 @@ import { urls } from 'scenes/urls'
 
 import { ProductTour, ProgressStatus } from '~/types'
 
+import { productTourLogic } from '../productTourLogic'
 import {
     ProductToursTabs,
     getProductTourStatus,
@@ -35,6 +38,7 @@ import {
 
 export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Element {
     const status = getProductTourStatus(tour)
+    const { isEditingProductTour, draftSaveStatus } = useValues(productTourLogic({ id: tour.id }))
 
     const statusConfig: Record<
         ProgressStatus,
@@ -46,7 +50,18 @@ export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Eleme
     }
 
     const config = statusConfig[status]
-    return <LemonTag type={config.type}>{config.label}</LemonTag>
+    return (
+        <LemonTag type={config.type}>
+            {isEditingProductTour && (
+                <>
+                    {draftSaveStatus === 'unsaved' && <IconCircleDashed />}
+                    {draftSaveStatus === 'saving' && <Spinner />}
+                    {draftSaveStatus === 'saved' && <IconCheckCircle className="text-success" />}
+                </>
+            )}
+            {config.label}
+        </LemonTag>
+    )
 }
 
 export function ProductToursTable(): JSX.Element {

--- a/frontend/src/scenes/product-tours/components/StepSettings.tsx
+++ b/frontend/src/scenes/product-tours/components/StepSettings.tsx
@@ -30,7 +30,7 @@ function ElementEmptyState({ onClick }: { onClick: () => void }): JSX.Element {
 
 function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null {
     const { productTourForm, selectedStepIndex } = useValues(productTourLogic({ id: tourId }))
-    const { updateSelectedStep, submitAndOpenToolbar } = useActions(productTourLogic({ id: tourId }))
+    const { updateSelectedStep, openToolbarModal } = useActions(productTourLogic({ id: tourId }))
 
     const steps = productTourForm.content?.steps ?? []
     const step = steps[selectedStepIndex]
@@ -187,7 +187,7 @@ function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null
                             size="small"
                             type="secondary"
                             icon={<IconCursorClick />}
-                            onClick={() => submitAndOpenToolbar('edit')}
+                            onClick={() => openToolbarModal('edit')}
                         >
                             {step.inferenceData ? 'Change' : 'Select element in Toolbar'}
                         </LemonButton>

--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -33,6 +33,7 @@ export function ProductToursSidebar(): JSX.Element | null {
         isPreviewing,
         sessionRecordingConsent,
         sidebarPosition,
+        launchedFromMainApp,
     } = useValues(productToursLogic)
     const {
         selectTour,
@@ -213,7 +214,7 @@ export function ProductToursSidebar(): JSX.Element | null {
                             center
                             className="flex-1"
                         >
-                            Save
+                            {launchedFromMainApp && tourForm?.id ? 'Done' : 'Save'}
                         </LemonButton>
                     </div>
                 </div>

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -2,6 +2,7 @@ import { actions, connect, events, kea, listeners, path, reducers, selectors } f
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
+import isEqual from 'lodash.isequal'
 import { findElement } from 'posthog-js/dist/element-inference'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -68,10 +69,12 @@ function newTour(): TourForm {
 }
 
 function tourToForm(tour: ProductTour): TourForm {
+    const draft = tour.draft_content
+    const content = draft?.content ?? tour.content
     return {
         id: tour.id,
-        name: tour.name,
-        steps: (tour.content?.steps ?? []).map((step) => ({
+        name: draft?.name ?? tour.name,
+        steps: (content?.steps ?? []).map((step) => ({
             ...step,
             id: step.id || uuid(),
         })),
@@ -144,6 +147,21 @@ function getUpdatedStepOrderHistory(
     return history
 }
 
+function buildDraftPayload(form: TourForm, tours: ProductTour[]): Record<string, unknown> {
+    const stepsForApi = form.steps.map(({ element: _, ...step }) => prepareStepForRender(step))
+    const existingTour = form.id ? tours.find((t) => t.id === form.id) : null
+    const stepOrderHistory = getUpdatedStepOrderHistory(stepsForApi, existingTour?.content?.step_order_history)
+    return {
+        name: form.name,
+        content: {
+            appearance: DEFAULT_APPEARANCE,
+            ...existingTour?.content,
+            steps: stepsForApi,
+            step_order_history: stepOrderHistory,
+        },
+    }
+}
+
 export const productToursLogic = kea<productToursLogicType>([
     path(['toolbar', 'product-tours', 'productToursLogic']),
 
@@ -188,6 +206,8 @@ export const productToursLogic = kea<productToursLogicType>([
 
         // Sidebar position toggle
         toggleSidebarPosition: true,
+
+        draftAutoSave: true,
     }),
 
     loaders(() => ({
@@ -304,9 +324,20 @@ export const productToursLogic = kea<productToursLogicType>([
                 toggleSidebarPosition: (state) => (state === 'right' ? 'left' : 'right'),
             },
         ],
+        draftSaveStatus: [
+            null as 'unsaved' | 'saving' | 'saved' | null,
+            {
+                draftAutoSave: () => 'unsaved' as const,
+                submitTourForm: () => 'saving' as const,
+                submitTourFormSuccess: () => 'saved' as const,
+                submitTourFormFailure: () => null,
+                selectTour: () => null,
+                newTour: () => null,
+            },
+        ],
     }),
 
-    forms(({ values, actions }) => ({
+    forms(({ values }) => ({
         tourForm: {
             defaults: { name: '', steps: [] } as TourForm,
             errors: ({ name, id, steps }) => {
@@ -329,63 +360,17 @@ export const productToursLogic = kea<productToursLogicType>([
                 return {}
             },
             submit: async (formValues) => {
-                const { id, name, steps } = formValues
-                const isUpdate = !!id
-
-                // Strip element references and add pre-computed HTML
-                const stepsForApi = steps.map(({ element: _, ...step }) => prepareStepForRender(step))
-
-                // Get existing step_order_history if updating an existing tour
-                const existingTour = id ? values.tours.find((t: ProductTour) => t.id === id) : null
-                const existingHistory = existingTour?.content?.step_order_history
-
-                // Update history if step order changed (or create initial version for new tours)
-                const stepOrderHistory = getUpdatedStepOrderHistory(stepsForApi, existingHistory)
-
-                const payload = {
-                    name,
-                    content: {
-                        // Preserve existing content fields (appearance, conditions) when updating
-                        appearance: DEFAULT_APPEARANCE,
-                        ...existingTour?.content,
-                        steps: stepsForApi,
-                        step_order_history: stepOrderHistory,
-                    },
-                    creation_context: 'toolbar',
+                if (!formValues.id) {
+                    return
                 }
-                const url = isUpdate
-                    ? `/api/projects/@current/product_tours/${id}/`
-                    : '/api/projects/@current/product_tours/'
-                const method = isUpdate ? 'PATCH' : 'POST'
-
-                const response = await toolbarFetch(url, method, payload)
-
+                const response = await toolbarFetch(
+                    `/api/projects/@current/product_tours/${formValues.id}/draft/`,
+                    'PATCH',
+                    buildDraftPayload(formValues, values.tours)
+                )
                 if (!response.ok) {
-                    const error = await response.json()
-                    lemonToast.error(error.detail || 'Failed to save tour')
-                    throw new Error(error.detail || 'Failed to save tour')
+                    throw new Error('Failed to save draft')
                 }
-
-                const savedTour = await response.json()
-                const { uiHost, launchedFromMainApp } = values
-
-                const editUrl = joinWithUiHost(uiHost, urls.productTour(savedTour.id, 'edit=true'))
-
-                // always go back to posthog on save if that's where the user started
-                if (launchedFromMainApp) {
-                    window.location.href = editUrl
-                } else {
-                    lemonToast.success(isUpdate ? 'Tour updated' : 'Tour created', {
-                        button: {
-                            label: 'Open in PostHog',
-                            action: () => window.open(editUrl, '_blank'),
-                        },
-                    })
-                }
-                actions.loadTours()
-                // Close the editing bar after successful save
-                actions.selectTour(null)
-                return savedTour
             },
         },
     })),
@@ -453,20 +438,34 @@ export const productToursLogic = kea<productToursLogicType>([
         ],
     }),
 
-    subscriptions(({ actions }) => ({
+    subscriptions(({ actions, values, cache }) => ({
         selectedTour: (selectedTour: TourForm | null) => {
             if (!selectedTour) {
                 actions.resetTourForm()
+                cache.lastDraftPayload = null
             } else {
-                // Always set id (or clear it for new tours)
-                actions.setTourFormValue('id', selectedTour.id)
-                actions.setTourFormValue('name', selectedTour.name)
-                actions.setTourFormValue('steps', selectedTour.steps)
+                const incomingPayload = buildDraftPayload(selectedTour, values.tours)
+                if (!isEqual(incomingPayload, cache.lastDraftPayload)) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    ;(actions.setTourFormValues as any)(selectedTour)
+                    cache.lastDraftPayload = incomingPayload
+                }
             }
+        },
+        tourForm: (tourForm: TourForm) => {
+            if (!values.selectedTourId || values.selectedTourId === 'new') {
+                return
+            }
+            const payload = buildDraftPayload(tourForm, values.tours)
+            if (isEqual(cache.lastDraftPayload, payload)) {
+                return
+            }
+            cache.lastDraftPayload = payload
+            actions.draftAutoSave()
         },
     })),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         addStep: ({ stepType }) => {
             const nextIndex = values.tourForm?.steps?.length ?? 0
             toolbarPosthogJS.capture(ProductTourEvent.STEP_ADDED, {
@@ -583,16 +582,85 @@ export const productToursLogic = kea<productToursLogicType>([
             }
         },
         selectTour: ({ id }) => {
-            if (id !== null) {
+            if (id !== null && id !== 'new') {
                 toolbarLogic.actions.setVisibleMenu('none')
                 if (values.sessionRecordingConsent) {
                     startRecording()
                 }
-            } else if (!values.isPreviewing && values.sessionRecordingConsent) {
+
+                cache.disposables.add(() => {
+                    const canFetch = (): boolean =>
+                        values.draftSaveStatus !== 'unsaved' && values.draftSaveStatus !== 'saving'
+
+                    if (canFetch()) {
+                        actions.loadTours()
+                    }
+                    const intervalId = setInterval(() => {
+                        if (canFetch()) {
+                            actions.loadTours()
+                        }
+                    }, 3000)
+                    return () => clearInterval(intervalId)
+                }, 'draftPoll')
+
+                return
+            }
+            cache.disposables.dispose('draftPoll')
+
+            if (id === 'new') {
+                toolbarLogic.actions.setVisibleMenu('none')
+                if (values.sessionRecordingConsent) {
+                    startRecording()
+                }
+                return
+            }
+
+            if (!values.isPreviewing && values.sessionRecordingConsent) {
                 toolbarPosthogJS.stopSessionRecording()
             }
         },
-        saveTour: () => {
+        saveTour: async () => {
+            const { tourForm, tours, uiHost, launchedFromMainApp } = values
+            if (!tourForm?.name) {
+                return
+            }
+            const isUpdate = !!tourForm.id
+            const payload = { ...buildDraftPayload(tourForm, tours), creation_context: 'toolbar' }
+            const url = isUpdate
+                ? `/api/projects/@current/product_tours/${tourForm.id}/draft/`
+                : '/api/projects/@current/product_tours/'
+            const method = isUpdate ? 'PATCH' : 'POST'
+            try {
+                const response = await toolbarFetch(url, method, payload)
+                if (!response.ok) {
+                    const error = await response.json()
+                    lemonToast.error(error.detail || 'Failed to save tour')
+                    return
+                }
+                const savedTour = await response.json()
+                const editUrl = joinWithUiHost(uiHost, urls.productTour(savedTour.id, 'edit=true'))
+                if (launchedFromMainApp) {
+                    window.close()
+                } else {
+                    lemonToast.success(isUpdate ? 'Tour saved' : 'Tour created', {
+                        button: {
+                            label: 'Open in PostHog',
+                            action: () => window.open(editUrl, '_blank'),
+                        },
+                    })
+                    actions.loadTours()
+                    actions.selectTour(null)
+                }
+            } catch (e: any) {
+                lemonToast.error(e.detail || 'Failed to save tour')
+            }
+        },
+        draftAutoSave: async (_, breakpoint) => {
+            await breakpoint(1000)
+            const { selectedTourId, tourForm } = values
+            if (!selectedTourId || selectedTourId === 'new' || !tourForm?.name) {
+                return
+            }
             actions.submitTourForm()
         },
         previewTour: () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3512,6 +3512,10 @@ export interface ProductTourContent {
     displayFrequency?: ProductTourDisplayFrequency
 }
 
+export type ProductTourDraftContent = Partial<
+    Pick<ProductTour, 'name' | 'description' | 'content' | 'auto_launch' | 'targeting_flag_filters' | 'linked_flag_id'>
+>
+
 export interface ProductTour {
     id: string
     name: string
@@ -3528,6 +3532,8 @@ export interface ProductTour {
     created_by: UserBasicType | null
     updated_at: string
     archived: boolean
+    draft_content: ProductTourDraftContent | null
+    has_draft: boolean
 }
 
 export interface Survey extends WithAccessControl {


### PR DESCRIPTION
## Problem

tours have no "draft" state, which mostly means we have poor UX in a few places:

- main app -> toolbar requires a full save and window replace, to mitigate risk of content overwriting
- toolbar -> main app is the same deal
- no auto-save

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

[tour-draft-demo.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5666d6c1-f651-4c29-a762-488e15e6c7a8.mp4" />](https://app.graphite.com/user-attachments/video/5666d6c1-f651-4c29-a762-488e15e6c7a8.mp4)



integrates the new draft system with the main app frontend and toolbar

- on visibility change (main app + toolbar), we trigger a reload + start a 3s polling interval
- auto-saves tour to `draft_content` on a 1s debounce with status indicators
- adds "you have draft content..." warning on tour view
    - under normal operation this is never seen, as clicking save or cancel clears the draft, but helpful in case a tab is closed etc and draft content still exists from your previous session

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->