### PR TITLE
feat(product tours): draft state - toolbar and toolbar back-and-forth improvements

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTour.tsx
+++ b/frontend/src/scenes/product-tours/ProductTour.tsx
@@ -67,7 +67,6 @@ export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element
                                 addText="Add authorized URL"
                                 productTourId={id}
                                 userIntent={toolbarMode === 'edit' ? 'edit-product-tour' : 'preview-product-tour'}
-                                launchInSameTab={isEditingProductTour}
                             />
                         </div>
                     </LemonModal>

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -15,8 +15,8 @@ import { ProductTourStepsEditor } from './editor'
 import { productTourLogic } from './productTourLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
-    const { productTour, productTourForm, pendingToolbarOpen } = useValues(productTourLogic({ id }))
-    const { discardDraft, publishDraft, setProductTourFormValue, submitAndOpenToolbar } = useActions(
+    const { productTour, productTourForm } = useValues(productTourLogic({ id }))
+    const { discardDraft, publishDraft, setProductTourFormValue, openToolbarModal } = useActions(
         productTourLogic({ id })
     )
 
@@ -42,12 +42,7 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     actions={
                         <div className="flex items-center gap-2">
                             <ProductTourStatusTag tour={productTour} />
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                onClick={() => submitAndOpenToolbar('preview')}
-                                loading={pendingToolbarOpen}
-                            >
+                            <LemonButton type="secondary" size="small" onClick={() => openToolbarModal('preview')}>
                                 Preview
                             </LemonButton>
                             <LemonButton type="secondary" size="small" onClick={discardDraft}>

--- a/frontend/src/scenes/product-tours/components/StepSettings.tsx
+++ b/frontend/src/scenes/product-tours/components/StepSettings.tsx
@@ -30,7 +30,7 @@ function ElementEmptyState({ onClick }: { onClick: () => void }): JSX.Element {
 
 function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null {
     const { productTourForm, selectedStepIndex } = useValues(productTourLogic({ id: tourId }))
-    const { updateSelectedStep, submitAndOpenToolbar } = useActions(productTourLogic({ id: tourId }))
+    const { updateSelectedStep, openToolbarModal } = useActions(productTourLogic({ id: tourId }))
 
     const steps = productTourForm.content?.steps ?? []
     const step = steps[selectedStepIndex]
@@ -187,7 +187,7 @@ function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null
                             size="small"
                             type="secondary"
                             icon={<IconCursorClick />}
-                            onClick={() => submitAndOpenToolbar('edit')}
+                            onClick={() => openToolbarModal('edit')}
                         >
                             {step.inferenceData ? 'Change' : 'Select element in Toolbar'}
                         </LemonButton>

--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -33,6 +33,7 @@ export function ProductToursSidebar(): JSX.Element | null {
         isPreviewing,
         sessionRecordingConsent,
         sidebarPosition,
+        launchedFromMainApp,
     } = useValues(productToursLogic)
     const {
         selectTour,
@@ -213,7 +214,7 @@ export function ProductToursSidebar(): JSX.Element | null {
                             center
                             className="flex-1"
                         >
-                            Save
+                            {launchedFromMainApp && tourForm?.id ? 'Done' : 'Save'}
                         </LemonButton>
                     </div>
                 </div>


### PR DESCRIPTION
## Problem

closes https://github.com/PostHog/posthog/issues/48338

tours have no "draft" state, which mostly means we have poor UX in a few places:

- main app -> toolbar requires a full save and window replace, to mitigate risk of content overwriting
- toolbar -> main app is the same deal
- no auto-save

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

integrates draft system with the product tours toolbar, and enhances the back-and-forth flow

- adds polling and viz change handling for updated content
- opening toolbar from main app now always opens a new tab
- if you got to the toolbar from posthog main app (e.g. "attach elemnet" or "preview" flows), the "Save" button becomes a "Done" button, and we just close the tab when you're done
    - if you came directly via toolbar, this just saves as normal
- cleans up some toolbar logic that is no longer necessary

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->