### PR TITLE
fix(mcp): support confidential clients in OAuth DCR endpoint

### DIFF
--- a/posthog/api/oauth/test_dcr.py
+++ b/posthog/api/oauth/test_dcr.py
@@ -210,8 +210,7 @@ class TestDynamicClientRegistration(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["error"], "invalid_client_metadata")
 
-    def test_client_secret_not_returned(self):
-        """DCR should never return client_secret since we only support public clients."""
+    def test_public_client_no_secret_returned(self):
         response = self.client.post(
             "/oauth/register/",
             {
@@ -222,21 +221,39 @@ class TestDynamicClientRegistration(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data = response.json()
-        # Response must not contain client_secret (public clients don't use secrets)
         self.assertNotIn("client_secret", data)
         self.assertNotIn("client_secret_expires_at", data)
 
-        # Verify the client type is public
         app = OAuthApplication.objects.get(client_id=data["client_id"])
         self.assertEqual(app.client_type, "public")
 
-    def test_only_public_client_type_supported(self):
-        """Requesting confidential client auth method should be rejected."""
+    def test_confidential_client_registration(self):
         response = self.client.post(
             "/oauth/register/",
             {
                 "redirect_uris": ["https://example.com/callback"],
                 "token_endpoint_auth_method": "client_secret_post",
+                "client_name": "Claude",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = response.json()
+        self.assertIn("client_secret", data)
+        self.assertEqual(data["client_secret_expires_at"], 0)
+        self.assertEqual(data["token_endpoint_auth_method"], "client_secret_post")
+
+        app = OAuthApplication.objects.get(client_id=data["client_id"])
+        self.assertEqual(app.client_type, "confidential")
+        self.assertTrue(app.is_dcr_client)
+
+    def test_unsupported_auth_method_rejected(self):
+        response = self.client.post(
+            "/oauth/register/",
+            {
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "client_secret_basic",
             },
             format="json",
         )


### PR DESCRIPTION
## Problem

Claude Desktop and claude.ai register as **confidential clients** (`token_endpoint_auth_method: "client_secret_post"`) during Dynamic Client Registration (DCR). Our DCR endpoint only accepted **public clients** (`"none"`), causing registration to fail with a 400 error and breaking the entire OAuth flow for these MCP clients.

We discovered this by setting up a local MCP server + PostHog backend with tunnels (cloudflared + ngrok) and inspecting the actual DCR request that Claude Desktop sends via ngrok's request inspection:

```json
{
  "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
  "token_endpoint_auth_method": "client_secret_post",
  "grant_types": ["authorization_code", "refresh_token"],
  "response_types": ["code"],
  "client_name": "Claude"
}
```

The response was:
```json
{
  "error": "invalid_client_metadata",
  "error_description": "'client_secret_post' is not a valid choice."
}
```

Note: our authorization server metadata already advertises `"token_endpoint_auth_methods_supported": ["none", "client_secret_post"]`, so this was an inconsistency between what we advertise and what DCR actually accepts.

## Changes

- Accept both `"none"` (public) and `"client_secret_post"` (confidential) in the DCR serializer
- Create `CLIENT_CONFIDENTIAL` type applications when `client_secret_post` is requested
- Return `client_secret` and `client_secret_expires_at` in the DCR response for confidential clients per RFC 7591
- Updated tests to cover confidential client registration and unsupported auth methods

## How did you test this code?

- All 22 DCR tests pass (`pytest posthog/api/oauth/test_dcr.py`)
- Tested locally with Claude Desktop connecting to a local MCP server (cloudflared tunnel) + PostHog backend (ngrok tunnel) — confirmed the DCR request now succeeds and the OAuth flow proceeds

## Changelog

Support confidential OAuth clients (like Claude Desktop and claude.ai) in MCP Dynamic Client Registration, fixing the OAuth flow that was previously broken for these clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)