### PR TITLE
feat(experiments): remove "stop experiment" and sharpen wording for lifecycle actions

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -55,7 +55,6 @@ import {
     LegacyResultsQuery,
     LoadingState,
     PageHeaderCustom,
-    StopExperimentModal,
 } from './components'
 
 const MetricsTab = (): JSX.Element => {
@@ -375,7 +374,6 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                     <DistributionModal />
                     <ReleaseConditionsModal />
 
-                    <StopExperimentModal />
                     <EditConclusionModal />
 
                     <VariantDeltaTimeseries />

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -399,14 +399,14 @@ export function PageHeaderCustom(): JSX.Element {
                         )}
                         {shouldShowShipVariantButton && (
                             <>
-                                <Tooltip title="Choose a variant and roll it out to all users">
+                                <Tooltip title="Conclude this experiment and decide which variant to keep">
                                     <LemonButton
                                         type="primary"
                                         icon={<IconFlask />}
                                         onClick={() => openShipVariantModal()}
                                         size="small"
                                     >
-                                        <b>Ship a variant</b>
+                                        <b>End experiment</b>
                                     </LemonButton>
                                 </Tooltip>
                                 <ShipVariantModal />
@@ -674,7 +674,7 @@ export function StopExperimentModal(): JSX.Element {
                     later if needed.
                 </div>
                 <div>
-                    To roll out a specific variant to all users instead, use the 'Ship a variant' button or adjust the
+                    To roll out a specific variant to all users instead, use the 'End experiment' button or adjust the
                     feature flag settings.
                 </div>
                 <ConclusionForm />
@@ -794,7 +794,7 @@ export function ShipVariantModal(): JSX.Element {
                     closeShipVariantModal()
                 }}
                 width={600}
-                title="Ship a variant"
+                title="End experiment"
                 footer={
                     <div className="flex items-center gap-2">
                         <LemonButton
@@ -813,18 +813,18 @@ export function ShipVariantModal(): JSX.Element {
                             type="primary"
                             disabledReason={!experiment.conclusion && 'Select a conclusion'}
                         >
-                            Ship variant
+                            End experiment
                         </LemonButton>
                     </div>
                 }
             >
-                <div className="deprecated-space-y-6">
-                    <div className="text-sm">
-                        This will roll out the selected variant to <b>100% of {aggregationTargetName}</b> and stop the
-                        experiment.
-                    </div>
-                    <div className="flex items-center">
-                        <div className="w-1/2 pr-4">
+                <div className="space-y-4">
+                    <div>
+                        <LemonLabel>Variant to keep</LemonLabel>
+                        <div className="text-sm text-secondary">
+                            The selected variant will be rolled out to <b>100% of {aggregationTargetName}</b>.
+                        </div>
+                        <div className="w-1/2">
                             <LemonSelect
                                 className="w-full"
                                 data-attr="metrics-selector"

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -297,7 +297,7 @@ export function PageHeaderCustom(): JSX.Element {
         updateExperiment,
         setHogfettiTrigger,
     } = useActions(experimentLogic)
-    const { openShipVariantModal, openPauseExperimentModal, openResumeExperimentModal } = useActions(modalsLogic)
+    const { openFinishExperimentModal, openPauseExperimentModal, openResumeExperimentModal } = useActions(modalsLogic)
     const [duplicateModalOpen, setDuplicateModalOpen] = useState(false)
     const [surveyModalOpen, setSurveyModalOpen] = useState(false)
     const { newTab } = useActions(sceneLogic)
@@ -309,7 +309,7 @@ export function PageHeaderCustom(): JSX.Element {
 
     const exposureCohortId = experiment?.exposure_cohort
 
-    const shouldShowShipVariantButton =
+    const shouldShowFinishExperimentButton =
         !isExperimentDraft &&
         !isSingleVariantShipped &&
         hasMinimumExposureForResults &&
@@ -387,19 +387,19 @@ export function PageHeaderCustom(): JSX.Element {
                                 )}
                             </div>
                         )}
-                        {shouldShowShipVariantButton && (
+                        {shouldShowFinishExperimentButton && (
                             <>
                                 <Tooltip title="Conclude this experiment and decide which variant to keep">
                                     <LemonButton
                                         type="primary"
                                         icon={<IconFlask />}
-                                        onClick={() => openShipVariantModal()}
+                                        onClick={() => openFinishExperimentModal()}
                                         size="small"
                                     >
                                         <b>End experiment</b>
                                     </LemonButton>
                                 </Tooltip>
-                                <ShipVariantModal />
+                                <FinishExperimentModal />
                             </>
                         )}
                         {experiment && (
@@ -688,11 +688,11 @@ export function ResumeExperimentModal(): JSX.Element {
     )
 }
 
-export function ShipVariantModal(): JSX.Element {
+export function FinishExperimentModal(): JSX.Element {
     const { experiment } = useValues(experimentLogic)
-    const { shipVariant, restoreUnmodifiedExperiment } = useActions(experimentLogic)
-    const { closeShipVariantModal } = useActions(modalsLogic)
-    const { isShipVariantModalOpen } = useValues(modalsLogic)
+    const { finishExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
+    const { closeFinishExperimentModal } = useActions(modalsLogic)
+    const { isFinishExperimentModalOpen } = useValues(modalsLogic)
     const { aggregationLabel } = useValues(groupsModel)
 
     const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
@@ -716,10 +716,10 @@ export function ShipVariantModal(): JSX.Element {
     return (
         <>
             <LemonModal
-                isOpen={isShipVariantModalOpen}
+                isOpen={isFinishExperimentModalOpen}
                 onClose={() => {
                     restoreUnmodifiedExperiment()
-                    closeShipVariantModal()
+                    closeFinishExperimentModal()
                 }}
                 width={600}
                 title="End experiment"
@@ -729,14 +729,14 @@ export function ShipVariantModal(): JSX.Element {
                             type="secondary"
                             onClick={() => {
                                 restoreUnmodifiedExperiment()
-                                closeShipVariantModal()
+                                closeFinishExperimentModal()
                             }}
                         >
                             Cancel
                         </LemonButton>
                         <LemonButton
                             onClick={() => {
-                                shipVariant({ selectedVariantKey })
+                                finishExperiment({ selectedVariantKey })
                             }}
                             type="primary"
                             disabledReason={!experiment.conclusion && 'Select a conclusion'}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -3,16 +3,7 @@ import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 import { TextMorph } from 'torph/react'
 
-import {
-    IconCopy,
-    IconEye,
-    IconFlask,
-    IconPause,
-    IconPlay,
-    IconPlusSmall,
-    IconRefresh,
-    IconStopFilled,
-} from '@posthog/icons'
+import { IconCopy, IconEye, IconFlask, IconPause, IconPlay, IconPlusSmall, IconRefresh } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -306,8 +297,7 @@ export function PageHeaderCustom(): JSX.Element {
         updateExperiment,
         setHogfettiTrigger,
     } = useActions(experimentLogic)
-    const { openShipVariantModal, openStopExperimentModal, openPauseExperimentModal, openResumeExperimentModal } =
-        useActions(modalsLogic)
+    const { openShipVariantModal, openPauseExperimentModal, openResumeExperimentModal } = useActions(modalsLogic)
     const [duplicateModalOpen, setDuplicateModalOpen] = useState(false)
     const [surveyModalOpen, setSurveyModalOpen] = useState(false)
     const { newTab } = useActions(sceneLogic)
@@ -504,16 +494,6 @@ export function PageHeaderCustom(): JSX.Element {
                                 </ButtonPrimitive>
                             ))}
 
-                        {!experiment.end_date && (
-                            <ButtonPrimitive
-                                variant="danger"
-                                menuItem
-                                data-attr="stop-experiment"
-                                onClick={() => openStopExperimentModal()}
-                            >
-                                <IconStopFilled /> Stop
-                            </ButtonPrimitive>
-                        )}
                         <PauseExperimentModal />
                         <ResumeExperimentModal />
                     </ScenePanelActionsSection>
@@ -627,58 +607,6 @@ export function EditConclusionModal(): JSX.Element {
             }
         >
             <ConclusionForm />
-        </LemonModal>
-    )
-}
-
-export function StopExperimentModal(): JSX.Element {
-    const { experiment } = useValues(experimentLogic)
-    const { endExperiment, restoreUnmodifiedExperiment } = useActions(experimentLogic)
-    const { closeStopExperimentModal } = useActions(modalsLogic)
-    const { isStopExperimentModalOpen } = useValues(modalsLogic)
-
-    return (
-        <LemonModal
-            isOpen={isStopExperimentModalOpen}
-            onClose={() => {
-                restoreUnmodifiedExperiment()
-                closeStopExperimentModal()
-            }}
-            title="Stop experiment"
-            width={600}
-            footer={
-                <div className="flex items-center gap-2">
-                    <LemonButton
-                        type="secondary"
-                        onClick={() => {
-                            restoreUnmodifiedExperiment()
-                            closeStopExperimentModal()
-                        }}
-                    >
-                        Cancel
-                    </LemonButton>
-                    <LemonButton
-                        onClick={() => endExperiment()}
-                        type="primary"
-                        disabledReason={!experiment.conclusion && 'Select a conclusion'}
-                    >
-                        Stop experiment
-                    </LemonButton>
-                </div>
-            }
-        >
-            <div className="space-y-4">
-                <div>
-                    Stopping the experiment will mark when to stop counting events in the results. Your feature flag
-                    will continue working normally and events will still be tracked. You can restart the experiment
-                    later if needed.
-                </div>
-                <div>
-                    To roll out a specific variant to all users instead, use the 'End experiment' button or adjust the
-                    feature flag settings.
-                </div>
-                <ConclusionForm />
-            </div>
         </LemonModal>
     )
 }
@@ -808,7 +736,7 @@ export function ShipVariantModal(): JSX.Element {
                         </LemonButton>
                         <LemonButton
                             onClick={() => {
-                                shipVariant({ selectedVariantKey, shouldStopExperiment: true })
+                                shipVariant({ selectedVariantKey })
                             }}
                             type="primary"
                             disabledReason={!experiment.conclusion && 'Select a conclusion'}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -798,7 +798,7 @@ export const ResetButton = (): JSX.Element => {
 
     const onClickReset = (): void => {
         LemonDialog.open({
-            title: 'Reset measurements?',
+            title: 'Reset analysis?',
             content: (
                 <>
                     <div className="text-sm text-secondary max-w-md">
@@ -810,7 +810,9 @@ export const ResetButton = (): JSX.Element => {
                             All events collected thus far will still exist, but won't be applied to the experiment
                             unless you manually change the start date after launching the experiment again.
                         </p>
-                        <p>The feature flag remains untouched, so variants stay visible to users.</p>
+                        <p>
+                            The <b>feature flag remains untouched</b>, so variants stay visible to users.
+                        </p>
                     </div>
                     {experiment.archived && (
                         <div className="text-sm text-secondary">Resetting will also unarchive the experiment.</div>
@@ -833,7 +835,7 @@ export const ResetButton = (): JSX.Element => {
 
     return (
         <ButtonPrimitive variant="danger" menuItem onClick={onClickReset} data-attr="reset-experiment">
-            <IconRefresh /> Reset measurements
+            <IconRefresh /> Reset analysis
         </ButtonPrimitive>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -471,8 +471,6 @@ export function PageHeaderCustom(): JSX.Element {
 
                         <LemonDivider />
 
-                        <ResetButton />
-
                         {!experiment.end_date &&
                             experiment.feature_flag &&
                             (experiment.feature_flag.active ? (
@@ -493,6 +491,8 @@ export function PageHeaderCustom(): JSX.Element {
                                     <IconPlay /> Resume experiment
                                 </ButtonPrimitive>
                             ))}
+
+                        <ResetButton />
 
                         <PauseExperimentModal />
                         <ResumeExperimentModal />

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -798,7 +798,7 @@ export const ResetButton = (): JSX.Element => {
 
     const onClickReset = (): void => {
         LemonDialog.open({
-            title: 'Reset this experiment?',
+            title: 'Reset measurements?',
             content: (
                 <>
                     <div className="text-sm text-secondary max-w-md">
@@ -810,6 +810,7 @@ export const ResetButton = (): JSX.Element => {
                             All events collected thus far will still exist, but won't be applied to the experiment
                             unless you manually change the start date after launching the experiment again.
                         </p>
+                        <p>The feature flag remains untouched, so variants stay visible to users.</p>
                     </div>
                     {experiment.archived && (
                         <div className="text-sm text-secondary">Resetting will also unarchive the experiment.</div>
@@ -832,7 +833,7 @@ export const ResetButton = (): JSX.Element => {
 
     return (
         <ButtonPrimitive variant="danger" menuItem onClick={onClickReset} data-attr="reset-experiment">
-            <IconRefresh /> Reset experiment
+            <IconRefresh /> Reset measurements
         </ButtonPrimitive>
     )
 }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1385,7 +1385,7 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         shipVariantSuccess: ({ payload }) => {
-            lemonToast.success('The selected variant has been shipped')
+            lemonToast.success('Experiment ended. The selected variant has been rolled out to all users.')
             actions.closeShipVariantModal()
             if (payload.shouldStopExperiment && !values.isExperimentStopped) {
                 actions.endExperiment()

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -456,8 +456,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 'closeSecondaryMetricModal',
                 'openPrimarySharedMetricModal',
                 'openSecondarySharedMetricModal',
-                'openStopExperimentModal',
-                'closeStopExperimentModal',
                 'closePauseExperimentModal',
                 'closeResumeExperimentModal',
                 'closeShipVariantModal',
@@ -1284,7 +1282,6 @@ export const experimentLogic = kea<experimentLogicType>([
                         ? values.isPrimaryMetricSignificant(values.experiment.metrics[0].uuid)
                         : false
                 )
-            actions.closeStopExperimentModal()
             values.experiment && eventUsageLogic.actions.reportExperimentStopped(values.experiment)
         },
         pauseExperiment: async () => {
@@ -1384,10 +1381,10 @@ export const experimentLogic = kea<experimentLogicType>([
                 })
             }
         },
-        shipVariantSuccess: ({ payload }) => {
+        shipVariantSuccess: () => {
             lemonToast.success('Experiment ended. The selected variant has been rolled out to all users.')
             actions.closeShipVariantModal()
-            if (payload.shouldStopExperiment && !values.isExperimentStopped) {
+            if (!values.isExperimentStopped) {
                 actions.endExperiment()
             }
             actions.reportExperimentVariantShipped(values.experiment)
@@ -1949,7 +1946,7 @@ export const experimentLogic = kea<experimentLogicType>([
         featureFlag: [
             null as FeatureFlagType | null,
             {
-                shipVariant: async ({ selectedVariantKey, shouldStopExperiment }) => {
+                shipVariant: async ({ selectedVariantKey }) => {
                     if (!values.experiment.feature_flag) {
                         throw new Error('Experiment does not have a feature flag linked')
                     }
@@ -1962,7 +1959,7 @@ export const experimentLogic = kea<experimentLogicType>([
                         { filters: newFilters }
                     )
 
-                    return shouldStopExperiment
+                    return null
                 },
             },
         ],

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -458,7 +458,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 'openSecondarySharedMetricModal',
                 'closePauseExperimentModal',
                 'closeResumeExperimentModal',
-                'closeShipVariantModal',
+                'closeFinishExperimentModal',
                 'openReleaseConditionsModal',
             ],
         ],
@@ -1381,9 +1381,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 })
             }
         },
-        shipVariantSuccess: () => {
+        finishExperimentSuccess: () => {
             lemonToast.success('Experiment ended. The selected variant has been rolled out to all users.')
-            actions.closeShipVariantModal()
+            actions.closeFinishExperimentModal()
             if (!values.isExperimentStopped) {
                 actions.endExperiment()
             }
@@ -1395,9 +1395,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 ;[0, 400, 800].forEach((delay) => setTimeout(trigger, delay))
             }
         },
-        shipVariantFailure: ({ error }) => {
+        finishExperimentFailure: ({ error }) => {
             lemonToast.error(error)
-            actions.closeShipVariantModal()
+            actions.closeFinishExperimentModal()
         },
         updateExperimentVariantImages: async ({ variantPreviewMediaIds }) => {
             try {
@@ -1946,7 +1946,7 @@ export const experimentLogic = kea<experimentLogicType>([
         featureFlag: [
             null as FeatureFlagType | null,
             {
-                shipVariant: async ({ selectedVariantKey }) => {
+                finishExperiment: async ({ selectedVariantKey }) => {
                     if (!values.experiment.feature_flag) {
                         throw new Error('Experiment does not have a feature flag linked')
                     }

--- a/frontend/src/scenes/experiments/modalsLogic.ts
+++ b/frontend/src/scenes/experiments/modalsLogic.ts
@@ -20,8 +20,6 @@ export const modalsLogic = kea<modalsLogicType>([
         closeExposureCriteriaModal: true,
         openShipVariantModal: true,
         closeShipVariantModal: true,
-        openStopExperimentModal: true,
-        closeStopExperimentModal: true,
         openPauseExperimentModal: true,
         closePauseExperimentModal: true,
         openResumeExperimentModal: true,
@@ -79,13 +77,6 @@ export const modalsLogic = kea<modalsLogicType>([
             {
                 openShipVariantModal: () => true,
                 closeShipVariantModal: () => false,
-            },
-        ],
-        isStopExperimentModalOpen: [
-            false,
-            {
-                openStopExperimentModal: () => true,
-                closeStopExperimentModal: () => false,
             },
         ],
         isPauseExperimentModalOpen: [

--- a/frontend/src/scenes/experiments/modalsLogic.ts
+++ b/frontend/src/scenes/experiments/modalsLogic.ts
@@ -18,8 +18,8 @@ export const modalsLogic = kea<modalsLogicType>([
         closeExperimentCollectionGoalModal: true,
         openExposureCriteriaModal: true,
         closeExposureCriteriaModal: true,
-        openShipVariantModal: true,
-        closeShipVariantModal: true,
+        openFinishExperimentModal: true,
+        closeFinishExperimentModal: true,
         openPauseExperimentModal: true,
         closePauseExperimentModal: true,
         openResumeExperimentModal: true,
@@ -72,11 +72,11 @@ export const modalsLogic = kea<modalsLogicType>([
                 closeExposureCriteriaModal: () => false,
             },
         ],
-        isShipVariantModalOpen: [
+        isFinishExperimentModalOpen: [
             false,
             {
-                openShipVariantModal: () => true,
-                closeShipVariantModal: () => false,
+                openFinishExperimentModal: () => true,
+                closeFinishExperimentModal: () => false,
             },
         ],
         isPauseExperimentModalOpen: [

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -142,7 +142,7 @@ describe('utils', () => {
                 {
                     properties: [],
                     rollout_percentage: 100,
-                    description: 'Added automatically when the experiment variant was shipped',
+                    description: 'Added automatically when the experiment was ended to keep only one variant.',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],
@@ -226,7 +226,7 @@ describe('utils', () => {
                 {
                     properties: [],
                     rollout_percentage: 100,
-                    description: 'Added automatically when the experiment variant was shipped',
+                    description: 'Added automatically when the experiment was ended to keep only one variant.',
                 },
                 { properties: [], rollout_percentage: 100 },
             ],

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -102,7 +102,7 @@ export function transformFiltersForWinningVariant(
             {
                 properties: [],
                 rollout_percentage: 100,
-                description: 'Added automatically when the experiment variant was shipped',
+                description: 'Added automatically when the experiment was ended to keep only one variant.',
             },
             // Preserve existing groups so that users can roll back this action
             // by deleting the newly added release condition


### PR DESCRIPTION
## Problem

We saw users misunderstanding the "stop experiment" action, which did not stop/revert the variant rollout but only stop measurements. The shipping button however does both. Since it can be used for successful experiments but also unsuccessful ones, this PR introduces this button as the only button to use.

This PR is the start of a broader initiative, the following improvements will be done in separate PRs:
- This PR: Sharpen wording and remove stop action
- The shipping popup will be made clearer
- https://github.com/PostHog/posthog/pull/48449 Inconsistent states between rollout and experiment measurement state will be highlighted (e.g. multiple variants shown to users while measurements are stopped)

## Changes

- Wording changes:
  - Rename "shipping" to "ending". Add "variant to keep" as a phrase to make that part clear too
  - Rename "reset experiments" to "reset measurements" to sharpen wording here too. In the modal add explanation about it not having implications on rollout
- Remove stopping experiment entirely
- Switch order of reset and pause buttons in sidebar as it felt to be the more natural order

Technical note:
- Renamed code from ShipVariant to FinishExperiment and not endExperiment for two reasons:
  - There is one function called endExperiment already for which I'll have a separate PR that introduces moving the entire action to backend
  - finishExperiment offers better keyword/search in the codebase in comparison to "end". However I kept "end experiment" in the UI as finish sounds a little bit more like success-cases only
  - (so slight inconsistency, but I believe it offers best of both worlds)

| state | before | after |
| -  | - | - |
| Main page and sidebar | <img width="889" height="326" alt="ship-before" src="https://github.com/user-attachments/assets/f65c4d61-878e-4733-99b5-f6f6a6358f3e" /> | <img width="781" height="336" alt="ship-after" src="https://github.com/user-attachments/assets/9c5b8888-5fd1-472b-b923-234a55db9560" /> |
| Ship modal | <img width="584" height="587" alt="modal1-before" src="https://github.com/user-attachments/assets/e5be5b48-390d-42b3-aaef-3b2939e059c6" /> | <img width="598" height="594" alt="modal1-after" src="https://github.com/user-attachments/assets/d8e916e4-9b68-4aa4-be6c-a57cf908d848" /> |
| Reset modal | <img width="516" height="317" alt="modal2-before" src="https://github.com/user-attachments/assets/d8db3bf9-e9b1-417c-be97-979bbd8c5699" /> | <img width="524" height="340" alt="modal2-after" src="https://github.com/user-attachments/assets/fcef6841-b0f6-442e-b082-4bc911c25f8b" /> |








## How did you test this code?

- Manually

## Publish to changelog?

No