### PR TITLE
fix(ci): only comment on PR when there are actual test failures

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -593,9 +593,10 @@ jobs:
                       });
                       const existing = comments.find(c => c.body.includes(marker));
 
-                      // Only clean up the comment when we actually read results and they're clean
-                      if (resultsRead && !extraLines) {
-                          if (existing) {
+                      // No failures or flakies — nothing to comment about
+                      if (!extraLines) {
+                          // Clean up any existing comment, but only when we know tests actually ran and passed
+                          if (resultsRead && existing) {
                               await github.rest.issues.deleteComment({
                                   owner: context.repo.owner,
                                   repo: context.repo.repo,
@@ -604,9 +605,6 @@ jobs:
                           }
                           return;
                       }
-
-                      // Skip posting if there's nothing useful to show
-                      if (!extraLines && !reportUrl) return;
 
                       const reportLink = reportUrl ? ` · [View test results →](${reportUrl})` : '';
                       const footer = '\n\n---\n*Annoyed by this comment? Make the tests green and it\'ll disappear!*';

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -607,7 +607,7 @@ jobs:
                       }
 
                       const reportLink = reportUrl ? ` · [View test results →](${reportUrl})` : '';
-                      const footer = '\n\n---\n*Annoyed by this comment? Make the tests green and it\'ll disappear!*';
+                      const footer = '\n\n\n*These issues are not necessarily caused by your changes.*\n*Annoyed by this comment? Help fix flakies and failures and it\'ll disappear!*';
                       const body = `${marker}\n🎭 Playwright report${reportLink}${extraLines}${footer}`;
 
                       if (existing) {


### PR DESCRIPTION
Fixes a false-positive case in the playwright report PR comment logic.

**The bug:** when `results.json` is missing (setup/build failure) but the CF Pages deploy still succeeds — e.g. stale `playwright-report/` on the runner from a previous run — we'd post a comment with just the report URL and the "annoyed by this comment" footer, but no actual failures listed. Misleading and noisy.

**Fix:** gate comment creation on `extraLines` being non-empty (failed or flaky tests found). The report URL alone is not worth a comment. Cleanup of an existing comment still requires `resultsRead` to be true, so we don't delete info from a previous run when the current run's setup failed.