### PR TITLE
fix(Inisghts): Setting dataset colours is quadratic

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -226,22 +226,21 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                     )
                 }
 
-                /** Unique series in the results, determined by `item.label` and `item.action.order`. */
-                const uniqSeries = Array.from(
-                    new Set(
-                        indexedResults
-                            .slice()
-                            .sort((a, b) => (a.action?.order ?? 0) - (b.action?.order ?? 0))
-                            .map((item) => `${item.label}_${item.action?.order}_${item?.breakdown_value}`)
-                    )
-                )
+                const colorIndexMap = new Map<string, number>()
+                indexedResults
+                    .slice()
+                    .sort((a, b) => (a.action?.order ?? 0) - (b.action?.order ?? 0))
+                    .forEach((item) => {
+                        const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
+                        if (!colorIndexMap.has(key)) {
+                            colorIndexMap.set(key, colorIndexMap.size)
+                        }
+                    })
 
-                // Give current and previous versions of the same dataset the same colorIndex
                 return indexedResults.map((item, index) => {
-                    const colorIndex = uniqSeries.findIndex(
-                        (identifier) => identifier === `${item.label}_${item.action?.order}_${item?.breakdown_value}`
-                    )
-                    return { ...item, colorIndex: colorIndex, id: index }
+                    const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
+                    const colorIndex = colorIndexMap.get(key) ?? 0
+                    return { ...item, colorIndex, id: index }
                 })
             },
         ],


### PR DESCRIPTION
## Problem
Setting colours here was 0(n^2), every dataset we `map` and `findIndex` causing this to increase exponentially with results.
I measured it and it takes 20-30 ms for a chart I was fixing, so not much. Thought it would be good to fix anyway. Plus maybe theres other charts it can improve/dashboards with tonnes of graphs. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Assigning colour goes from 0(n^2) -> 0(n) 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Added some performance timers and measured the differences. Saves 20-30ms on a graph

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
