### PR TITLE
fix(insights): optimize line graph callback performance for large datasets

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -407,6 +407,13 @@ export const LineGraph = ({
                                 const filteredSeriesData = isHighlightBarMode
                                     ? ySeriesData.filter((_, index) => index === referenceDataPoint.datasetIndex)
                                     : ySeriesData
+                                const stackedSeriesTotalAtIndex =
+                                    isStackedBarChart && chartSettings.stackBars100
+                                        ? ySeriesData.reduce(
+                                              (acc, series) => acc + series.data[referenceDataPoint.dataIndex],
+                                              0
+                                          )
+                                        : null
 
                                 const tooltipData = filteredSeriesData.map((series, index) => {
                                     const seriesName =
@@ -423,6 +430,7 @@ export const LineGraph = ({
                                         dataIndex: referenceDataPoint.dataIndex,
                                         isTotalRow: false,
                                         seriesIndex: seriesIndex,
+                                        stackedSeriesTotalAtIndex,
                                     }
                                 })
 
@@ -450,6 +458,7 @@ export const LineGraph = ({
                                         dataIndex: referenceDataPoint.dataIndex,
                                         isTotalRow: true,
                                         seriesIndex: -1,
+                                        stackedSeriesTotalAtIndex,
                                     })
                                 }
 
@@ -489,9 +498,14 @@ export const LineGraph = ({
                                                     dataIndex: 'data',
                                                     render: (value, record) => {
                                                         if (isStackedBarChart && chartSettings.stackBars100) {
-                                                            const total = ySeriesData
-                                                                .map((n) => n.data[record.dataIndex])
-                                                                .reduce((acc, cur) => acc + cur, 0)
+                                                            const total = record.stackedSeriesTotalAtIndex
+                                                            if (!total) {
+                                                                return (
+                                                                    <div className="series-data-cell">
+                                                                        {String(value)}
+                                                                    </div>
+                                                                )
+                                                            }
                                                             const percentageLabel: number = parseFloat(
                                                                 ((record.rawData / total) * 100).toFixed(1)
                                                             )

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -454,7 +454,7 @@ export function LineGraph_({
     function generateYaxesForLineGraph(
         dataSetCount: number,
         seriesNonZeroMin: number,
-        goalLinesWithColor: GoalLine[],
+        goalLineColorByValue: Map<number | string, string | undefined>,
         tickOptions: Partial<TickOptions>,
         precision: number,
         gridOptions: Partial<GridLineOptions>
@@ -472,11 +472,11 @@ export function LineGraph_({
                 ...(yAxisScaleType !== 'log10' && { precision }), // Precision is not supported for the log scale
                 callback: formatYAxisTick,
                 color: (context: any) => {
-                    if (context.tick) {
-                        for (const annotation of goalLinesWithColor) {
-                            if (context.tick.value === annotation.value) {
-                                return resolveVariableColor(annotation.borderColor)
-                            }
+                    const tickValue = context.tick?.value
+                    if (tickValue !== undefined) {
+                        const goalLineColor = goalLineColorByValue.get(tickValue)
+                        if (goalLineColor) {
+                            return goalLineColor
                         }
                     }
 
@@ -521,19 +521,50 @@ export function LineGraph_({
             }
 
             const processedDatasets = filteredDatasets.map(processDataset)
-
-            const seriesNonZeroMax = Math.max(
-                ...processedDatasets.flatMap((d) => d.data).filter((n) => !!n && n !== LOG_ZERO)
-            )
-            const seriesNonZeroMin = Math.min(
-                ...processedDatasets.flatMap((d) => d.data).filter((n) => !!n && n !== LOG_ZERO)
-            )
+            let seriesNonZeroMax = Number.NEGATIVE_INFINITY
+            let seriesNonZeroMin = Number.POSITIVE_INFINITY
+            for (const dataset of processedDatasets) {
+                if (!Array.isArray(dataset.data)) {
+                    continue
+                }
+                for (const rawValue of dataset.data) {
+                    const value = Number(rawValue)
+                    if (!value || value === LOG_ZERO || Number.isNaN(value)) {
+                        continue
+                    }
+                    if (value > seriesNonZeroMax) {
+                        seriesNonZeroMax = value
+                    }
+                    if (value < seriesNonZeroMin) {
+                        seriesNonZeroMin = value
+                    }
+                }
+            }
             const precision = seriesNonZeroMax < 2 ? 2 : seriesNonZeroMax < 5 ? 1 : 0
             const goalLines = (_goalLines || []).filter(
                 (goalLine) => goalLine.displayIfCrossed !== false || goalLine.value >= seriesNonZeroMax
             )
-            const goalLinesY = goalLines.map((a) => a.value)
+            const goalLineValueSet = new Set<number | string>(goalLines.map((goalLine) => goalLine.value))
             const goalLinesWithColor = goalLines.filter((goalLine) => Boolean(goalLine.borderColor))
+            const goalLineColorByValue = new Map<number | string, string | undefined>()
+            for (const goalLine of goalLinesWithColor) {
+                if (!goalLineColorByValue.has(goalLine.value)) {
+                    goalLineColorByValue.set(goalLine.value, resolveVariableColor(goalLine.borderColor))
+                }
+            }
+            const hasAnyDottedDataset = processedDatasets.some((dataset) => dataset.dotted)
+            const datalabelTotalsByDatasetIndex = processedDatasets.map((dataset) => {
+                const totalResponses = (dataset as any).totalResponses
+                if (totalResponses !== undefined && totalResponses !== null) {
+                    return totalResponses
+                }
+                return Array.isArray(dataset.data)
+                    ? dataset.data.reduce(
+                          (sum: number, value: unknown) => sum + (typeof value === 'number' ? value : 0),
+                          0
+                      )
+                    : 0
+            })
 
             const tickOptions: Partial<TickOptions> = {
                 color: colors.axisLabel as Color,
@@ -545,14 +576,14 @@ export function LineGraph_({
             }
             const gridOptions: Partial<GridLineOptions> = {
                 color: (context) => {
-                    if (goalLinesY.includes(context.tick?.value) || showMultipleYAxes) {
+                    if (goalLineValueSet.has(context.tick?.value) || showMultipleYAxes) {
                         return 'transparent'
                     }
 
                     return colors.axisLine as Color
                 },
                 tickColor: (context) => {
-                    if (goalLinesY.includes(context.tick?.value)) {
+                    if (goalLineValueSet.has(context.tick?.value)) {
                         return 'transparent'
                     }
 
@@ -602,12 +633,8 @@ export function LineGraph_({
                         },
                         formatter: (value: number, context) => {
                             if (value !== 0 && inSurveyView && showValuesOnSeries) {
-                                const dataset = context.dataset as any
                                 // Use totalResponses if provided (for per-respondent %), otherwise sum of values
-                                const total =
-                                    dataset.totalResponses ??
-                                    dataset.data?.reduce((sum: number, val: number) => sum + val, 0) ??
-                                    1
+                                const total = datalabelTotalsByDatasetIndex[context.datasetIndex] ?? 1
                                 const percentage = ((value / total) * 100).toFixed(1)
                                 return `${value} (${percentage}%)`
                             }
@@ -693,7 +720,7 @@ export function LineGraph_({
                                     }
 
                                     const hasDotted =
-                                        processedDatasets.some((d) => d.dotted) &&
+                                        hasAnyDottedDataset &&
                                         dp.dataIndex - processedDatasets?.[dp.datasetIndex]?.data?.length >=
                                             incompletenessOffsetFromEnd
                                     return (
@@ -916,7 +943,7 @@ export function LineGraph_({
                         (showMultipleYAxes && new Set(processedDatasets.map((d) => d.yAxisID)).size) ||
                             processedDatasets.length,
                         seriesNonZeroMin,
-                        goalLinesWithColor,
+                        goalLineColorByValue,
                         tickOptions,
                         precision,
                         gridOptions


### PR DESCRIPTION
## Problem

More LineGraph performance improvements.

## Changes

Regular insights:
- Replaced double flatMap/filter min/max computation with a single pass.
- Cached dotted-series presence instead of recalculating in tooltip filtering.
- Cached per-dataset totals used by datalabel formatter.
- Replaced repeated goal-line linear lookups with Set/Map lookups.
- Kept previous incomplete-segment optimization (single pattern creation per dataset, callback gating).

SQL insights:
- Precomputed stacked total once per tooltip render instead of recomputing per table cell.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
