### PR TITLE
chore(alerts): centralise validation logic into model methods

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -446,8 +446,6 @@ posthog/migrations/0284_improved_caching_state_idx.py:0: error: Cannot override 
 posthog/migrations/0973_alter_integration_kind.py:0: error: Need type annotation for "field"  [var-annotated]
 posthog/models/action/action.py:0: error: Argument 1 to "len" has incompatible type "str | None"; expected "Sized"  [arg-type]
 posthog/models/action/action.py:0: error: Need type annotation for "events"  [var-annotated]
-posthog/models/alert.py:0: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
-posthog/models/alert.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/models/cohort/cohort.py:0: error: Need type annotation for "people"  [var-annotated]
 posthog/models/dashboard.py:0: error: Need type annotation for "insights"  [var-annotated]
 posthog/models/event/util.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "datetime")  [assignment]

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -16,16 +16,9 @@ from posthog.api.documentation import extend_schema_field
 from posthog.api.insight import InsightBasicSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.constants import AvailableFeature
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
-from posthog.models.alert import (
-    AlertCheck,
-    AlertConfiguration,
-    AlertSubscription,
-    Threshold,
-    are_alerts_supported_for_insight,
-)
+from posthog.models.alert import AlertCheck, AlertConfiguration, AlertSubscription, Threshold
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.utils import relative_date_parse
 
@@ -246,17 +239,12 @@ class AlertSerializer(serializers.ModelSerializer):
                     user=user, alert_configuration=instance, defaults={"created_by": self.context["request"].user}
                 )
 
-        if conditions_or_threshold_changed:
-            # If anything changed we set to NOT_FIRING, so it's firing and notifying with the new settings
-            instance.state = AlertState.NOT_FIRING
-
         calculation_interval_changed = (
             "calculation_interval" in validated_data
             and validated_data["calculation_interval"] != instance.calculation_interval
         )
         if conditions_or_threshold_changed or calculation_interval_changed:
-            # calculate alert right now, don't wait until preset time
-            self.next_check_at = None
+            instance.mark_for_recheck(reset_state=conditions_or_threshold_changed)
 
         return super().update(instance, validated_data)
 
@@ -267,7 +255,7 @@ class AlertSerializer(serializers.ModelSerializer):
         return value
 
     def validate_insight(self, value):
-        if value and not are_alerts_supported_for_insight(value):
+        if value and not value.are_alerts_supported:
             raise ValidationError("Alerts are not supported for this insight.")
         return value
 
@@ -285,26 +273,10 @@ class AlertSerializer(serializers.ModelSerializer):
         if self.context["request"].method != "POST":
             return attrs
 
-        user_org = self.context["request"].user.organization
-
-        alerts_feature = user_org.get_available_feature(AvailableFeature.ALERTS)
-        existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
-
-        if alerts_feature:
-            allowed_alerts_count = alerts_feature.get("limit")
-            # If allowed_alerts_count is None then the user is allowed unlimited alerts
-            if allowed_alerts_count is not None:
-                # Check current count against allowed limit
-                if existing_alerts_count >= allowed_alerts_count:
-                    raise ValidationError(
-                        {"alert": [f"Your team has reached the limit of {allowed_alerts_count} alerts on your plan."]}
-                    )
-        else:
-            # If the org doesn't have alerts feature, limit to that on free tier
-            if existing_alerts_count >= AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER:
-                raise ValidationError(
-                    {"alert": [f"Your plan is limited to {AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER} alerts"]}
-                )
+        if msg := AlertConfiguration.check_alert_limit(
+            self.context["team_id"], self.context["request"].user.organization
+        ):
+            raise ValidationError({"alert": [msg]})
 
         return attrs
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -76,7 +76,7 @@ from posthog.models.activity_logging.activity_log import (
     log_activity,
 )
 from posthog.models.activity_logging.activity_page import activity_page_response
-from posthog.models.alert import AlertConfiguration, are_alerts_supported_for_insight
+from posthog.models.alert import AlertConfiguration
 from posthog.models.dashboard import Dashboard
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import get_filter
@@ -533,7 +533,7 @@ class InsightSerializer(InsightBasicSerializer):
                 self._update_insight_dashboards(dashboards, instance)
 
         updated_insight = super().update(instance, validated_data)
-        if not are_alerts_supported_for_insight(updated_insight):
+        if not updated_insight.are_alerts_supported:
             instance.alertconfiguration_set.all().delete()
 
         self._log_insight_update(before_update, dashboards_before_change, updated_insight, current_url, session_id)
@@ -705,7 +705,7 @@ class InsightSerializer(InsightBasicSerializer):
         return self.insight_result(insight).resolved_date_range
 
     def get_alerts(self, insight: Insight):
-        if not are_alerts_supported_for_insight(insight):
+        if not insight.are_alerts_supported:
             return []
 
         # Use prefetched alerts data

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.db import models
+
+if TYPE_CHECKING:
+    from posthog.models.organization import Organization
 
 import pydantic
 
@@ -154,7 +160,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         super().save(*args, **kwargs)
 
     @classmethod
-    def check_alert_limit(cls, team_id: int, organization) -> str | None:
+    def check_alert_limit(cls, team_id: int, organization: Organization) -> str | None:
         """Return an error message if the team has reached its alert limit, else None."""
         from posthog.constants import AvailableFeature
 

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -50,15 +50,10 @@ class Threshold(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         upper: float | None = None,
         existing: dict | None = None,
     ) -> dict:
-        """Build a threshold configuration dict, optionally merging into existing config."""
-        if existing is not None:
-            config = dict(existing)
-            bounds = dict(config.get("bounds", {}))
-            if threshold_type is not None:
-                config["type"] = threshold_type
-        else:
-            config: dict = {"type": threshold_type}
-            bounds = {}
+        config = dict(existing) if existing is not None else {}
+        bounds = dict(config.get("bounds", {}))
+        if threshold_type is not None:
+            config["type"] = threshold_type
 
         if lower is not None:
             bounds["lower"] = lower
@@ -140,10 +135,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         )
 
     def mark_for_recheck(self, *, reset_state: bool = False) -> list[str]:
-        """Mark this alert for rechecking, optionally resetting state to NOT_FIRING.
-
-        Returns list of field names that were modified (for use with update_fields).
-        """
+        """Returns list of field names that were modified (for use with update_fields)."""
         updated: list[str] = []
         if reset_state:
             self.state = AlertState.NOT_FIRING

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -58,8 +58,7 @@ class Threshold(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
     ) -> dict:
         config = dict(existing) if existing is not None else {}
         bounds = dict(config.get("bounds", {}))
-        if threshold_type is not None:
-            config["type"] = threshold_type
+        config["type"] = threshold_type
 
         if lower is not None:
             bounds["lower"] = lower

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -5,12 +5,10 @@ from django.db import models
 
 import pydantic
 
-from posthog.schema import AlertCalculationInterval, AlertState, InsightThreshold
+from posthog.schema import AlertCalculationInterval, AlertState, InsightThreshold, InsightThresholdType
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
-from posthog.models.insight import Insight
 from posthog.models.utils import CreatedMetaFields, UUIDTModel
-from posthog.schema_migrations.upgrade_manager import upgrade_query
 
 ALERT_STATE_CHOICES = [
     (AlertState.FIRING, AlertState.FIRING),
@@ -18,16 +16,6 @@ ALERT_STATE_CHOICES = [
     (AlertState.ERRORED, AlertState.ERRORED),
     (AlertState.SNOOZED, AlertState.SNOOZED),
 ]
-
-
-def are_alerts_supported_for_insight(insight: Insight) -> bool:
-    with upgrade_query(insight):
-        query = insight.query
-        while query.get("source"):
-            query = query["source"]
-        if query is None or query.get("kind") != "TrendsQuery":
-            return False
-    return True
 
 
 # TODO: Enable `@deprecated` once we move to Python 3.13
@@ -52,6 +40,32 @@ class Threshold(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
     name = models.CharField(max_length=255, blank=True)
     configuration = models.JSONField(default=dict)
+
+    @classmethod
+    def build_configuration(
+        cls,
+        *,
+        threshold_type: InsightThresholdType = InsightThresholdType.ABSOLUTE,
+        lower: float | None = None,
+        upper: float | None = None,
+        existing: dict | None = None,
+    ) -> dict:
+        """Build a threshold configuration dict, optionally merging into existing config."""
+        if existing is not None:
+            config = dict(existing)
+            bounds = dict(config.get("bounds", {}))
+            if threshold_type is not None:
+                config["type"] = threshold_type
+        else:
+            config: dict = {"type": threshold_type}
+            bounds = {}
+
+        if lower is not None:
+            bounds["lower"] = lower
+        if upper is not None:
+            bounds["upper"] = upper
+        config["bounds"] = bounds
+        return config
 
     def clean(self):
         try:
@@ -125,6 +139,19 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             )
         )
 
+    def mark_for_recheck(self, *, reset_state: bool = False) -> list[str]:
+        """Mark this alert for rechecking, optionally resetting state to NOT_FIRING.
+
+        Returns list of field names that were modified (for use with update_fields).
+        """
+        updated: list[str] = []
+        if reset_state:
+            self.state = AlertState.NOT_FIRING
+            updated.append("state")
+        self.next_check_at = None
+        updated.append("next_check_at")
+        return updated
+
     def save(self, *args, **kwargs):
         if not self.enabled:
             # When disabling an alert, set the state to not firing
@@ -133,6 +160,26 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
                 kwargs["update_fields"].append("state")
 
         super().save(*args, **kwargs)
+
+    @classmethod
+    def check_alert_limit(cls, team_id: int, organization) -> str | None:
+        """Return an error message if the team has reached its alert limit, else None."""
+        from posthog.constants import AvailableFeature
+
+        alerts_feature = organization.get_available_feature(AvailableFeature.ALERTS)
+        existing_count = cls.objects.filter(team_id=team_id).count()
+
+        if alerts_feature:
+            allowed = alerts_feature.get("limit")
+            # If allowed is None then the user is allowed unlimited alerts
+            if allowed is not None and existing_count >= allowed:
+                return f"Your team has reached the limit of {allowed} alerts on your plan."
+        else:
+            # If the org doesn't have alerts feature, limit to that on free tier
+            if existing_count >= cls.ALERTS_ALLOWED_ON_FREE_TIER:
+                return f"Your plan is limited to {cls.ALERTS_ALLOWED_ON_FREE_TIER} alerts."
+
+        return None
 
 
 class AlertSubscription(ModelActivityMixin, CreatedMetaFields, UUIDTModel):

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 import pydantic
 
-from posthog.schema import AlertCalculationInterval, AlertState, InsightThreshold, InsightThresholdType
+from posthog.schema import AlertCalculationInterval, AlertState, InsightThreshold
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.utils import CreatedMetaFields, UUIDTModel
@@ -46,26 +46,6 @@ class Threshold(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
     name = models.CharField(max_length=255, blank=True)
     configuration = models.JSONField(default=dict)
-
-    @classmethod
-    def build_configuration(
-        cls,
-        *,
-        threshold_type: InsightThresholdType = InsightThresholdType.ABSOLUTE,
-        lower: float | None = None,
-        upper: float | None = None,
-        existing: dict | None = None,
-    ) -> dict:
-        config = dict(existing) if existing is not None else {}
-        bounds = dict(config.get("bounds", {}))
-        config["type"] = threshold_type
-
-        if lower is not None:
-            bounds["lower"] = lower
-        if upper is not None:
-            bounds["upper"] = upper
-        config["bounds"] = bounds
-        return config
 
     def clean(self):
         try:

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -309,14 +309,13 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
     def are_alerts_supported(self) -> bool:
         from posthog.schema_migrations.upgrade_manager import upgrade_query
 
-        if self.query is None:
-            return False
-
         with upgrade_query(self):
             query = self.query
+            if query is None:
+                return False
             while query.get("source"):
                 query = query["source"]
-            if query is None or query.get("kind") != "TrendsQuery":
+            if query.get("kind") != "TrendsQuery":
                 return False
         return True
 

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -309,6 +309,9 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
     def are_alerts_supported(self) -> bool:
         from posthog.schema_migrations.upgrade_manager import upgrade_query
 
+        if self.query is None:
+            return False
+
         with upgrade_query(self):
             query = self.query
             while query.get("source"):

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -305,6 +305,18 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
         except (AttributeError, TypeError, KeyError):
             return False
 
+    @property
+    def are_alerts_supported(self) -> bool:
+        from posthog.schema_migrations.upgrade_manager import upgrade_query
+
+        with upgrade_query(self):
+            query = self.query
+            while query.get("source"):
+                query = query["source"]
+            if query is None or query.get("kind") != "TrendsQuery":
+                return False
+        return True
+
     def generate_query_metadata(self):
         from posthog.hogql_queries.query_metadata import extract_query_metadata
 


### PR DESCRIPTION
## Problem

Currently the validation logic for alert creation is spread across multiple paths:

1. There is a bit of logic inside the Alert API flow
2. There is a bit of logic inside the Alert models

Whilst this is fine up until now (as effectively all crud methods go through the API), if we want to add Alerts to PostHog AI, it would introduce another layer where we would need these validations and therefore avoid the DRY principle.

In order to avoid copy pasting logic, I would propose to centralise the logic so that we can re-use it when creating alert models / resources inside the AI flow.

## Changes

- Effectively pulled out the alerting functionality to a corresponding central logcation and updated the refererence to use the new functions.

## How did you test this code?

:white_check_mark: CI is passing

✅ The logic is a like for like change

:white_check_mark: Alerts can still be created through the UI

![CleanShot 2026-02-19 at 10.58.39@2x.png](https://app.graphite.com/user-attachments/assets/02890c89-4259-4ddc-ab3c-5ce627469e72.png)

![CleanShot 2026-02-19 at 11.01.11@2x.png](https://app.graphite.com/user-attachments/assets/307b20b4-1e6f-4512-a973-1047df493698.png)