### PR TITLE
feat(surveys): trim option whitespaces

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -504,11 +504,21 @@ interface SanitizeSurveyOptions {
 
 export function sanitizeSurvey(survey: Partial<Survey>, options?: SanitizeSurveyOptions): Partial<Survey> {
     const sanitizedQuestions =
-        survey.questions?.map((question) => ({
-            ...question,
-            question: sanitizeHTML(question.question ?? ''),
-            description: sanitizeHTML(question.description ?? ''),
-        })) || []
+        survey.questions?.map((question) => {
+            const sanitized = {
+                ...question,
+                question: sanitizeHTML(question.question ?? ''),
+                description: sanitizeHTML(question.description ?? ''),
+            }
+            if (
+                (sanitized.type === SurveyQuestionType.SingleChoice ||
+                    sanitized.type === SurveyQuestionType.MultipleChoice) &&
+                sanitized.choices
+            ) {
+                sanitized.choices = sanitized.choices.map((choice) => choice.trim())
+            }
+            return sanitized
+        }) || []
 
     const sanitizedAppearance = sanitizeSurveyAppearance(
         survey.appearance,


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/50928 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52532) 

Options you set can mistakenly have whitespaces at the start/end.

## Changes

Sanitize the options 

## Publish to changelog?

no