### PR TITLE
chore(cdp): mark hog transformations as stable and hide PII hashing template

### DIFF
--- a/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-bot-detection',
     name: 'Filter Bot Events',

--- a/nodejs/src/cdp/templates/_transformations/default/default.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/default/default.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-blank-transformation',
     name: 'Custom transformation',

--- a/nodejs/src/cdp/templates/_transformations/drop-events/drop-events.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/drop-events/drop-events.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-drop-events',
     name: 'Drop Events',

--- a/nodejs/src/cdp/templates/_transformations/filter-properties/filter-properties.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/filter-properties/filter-properties.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'alpha',
+    status: 'stable',
     type: 'transformation',
     id: 'template-filter-properties',
     name: 'Filter Properties',

--- a/nodejs/src/cdp/templates/_transformations/hash-properties/hash-properties.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/hash-properties/hash-properties.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-hash-properties',
     name: 'Hash properties',

--- a/nodejs/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-ip-anonymization',
     name: 'IP Anonymization',

--- a/nodejs/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'hidden',
     type: 'transformation',
     id: 'template-pii-hashing',
     name: 'PII Data Hashing',

--- a/nodejs/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-remove-null-properties',
     name: 'Remove Null Properties',

--- a/nodejs/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-url-masking',
     name: 'URL Parameter Masking',

--- a/nodejs/src/cdp/templates/_transformations/url-normalization/url-normalization.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/url-normalization/url-normalization.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'beta',
+    status: 'stable',
     type: 'transformation',
     id: 'template-url-normalization',
     name: 'URL Normalization',


### PR DESCRIPTION
Marks all hog transformation templates as stable and hides the PII Data Hashing template (in favor of the Hash properties template which also handles $set/$set_once properties).