### PR TITLE
fix: Check if table is incompatible in Snowflake batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -371,6 +371,9 @@ class SnowflakeField(Field):
     def to_destination_field(self) -> SnowflakeDestinationField:
         return SnowflakeDestinationField(name=self.name, type=self.snowflake_type_name, is_nullable=self.nullable)
 
+    def with_new_arrow_type(self, new_type: pa.DataType) -> "SnowflakeField":
+        return SnowflakeField(self.name, data_type_to_snowflake_type(new_type), new_type, self.nullable)
+
 
 class SnowflakeTable(Table):
     def __init__(

--- a/products/batch_exports/backend/temporal/pipeline/table.py
+++ b/products/batch_exports/backend/temporal/pipeline/table.py
@@ -150,6 +150,9 @@ class Field[T](typing.Protocol):
     def __hash__(self) -> int:
         return self.name.__hash__()
 
+    def __eq__(self, other) -> bool:
+        return self.name == other.name and self.alias == other.alias and self.data_type == other.data_type
+
 
 FieldType = typing.TypeVar("FieldType", bound=Field)
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -185,6 +185,21 @@ async def test_get_table_does_not_fail_with_additional_fields(snowflake_client, 
     assert test_table.fields == get_result.fields
 
 
+async def test_get_table_does_not_fail_with_missing_fields(snowflake_client, database, schema, test_table):
+    """Test getting a table when missing fields that are not part of the primary key."""
+    _ = await snowflake_client.execute_async_query(
+        f'ALTER TABLE "{test_table.name}" DROP COLUMN "text";',
+        timeout=60.0,
+    )
+
+    get_result = await snowflake_client.get_table(test_table)
+
+    assert test_table.name == get_result.name
+    # This time the fields will differ as we don't include missing fields
+    assert test_table.fields != get_result.fields
+    assert "text" not in get_result
+
+
 async def test_get_table_raises_incompatible_schema_on_missing_primary_key_fields(
     snowflake_client, database, schema, test_table
 ):

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -189,11 +189,11 @@ async def test_get_table_raises_incompatible_schema_on_missing_fields(snowflake_
     """Test attempting to get a table with an incompatible schema fails"""
     table = SnowflakeTable(
         name=test_table.name,
-        fields=test_table.fields
-        + [
+        fields=(
+            *test_table.fields,
             SnowflakeField("missing_one", SnowflakeType("INTEGER", False), pa.int64(), True),
             SnowflakeField("missing_two", SnowflakeType("INTEGER", False), pa.int64(), True),
-        ],
+        ),
         parents=test_table.parents,
     )
 


### PR DESCRIPTION
## Problem

When getting a mutable table from Snowflake, we should ensure it has all the required primary key fields based on the requested table. Otherwise, we could be letting incompatible schema errors by.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This raises an exception if any primary key fields are missing from the mutable table that was requested when calling `get_table`. Important to note we still allow additional fields to exist, they are just ignored, and that we still allow missing fields that are not part of the primary key.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New unit tests included, old unit tests passing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Nope
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
