### PR TITLE
chore(flox): remove gh CLI from manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -42,7 +42,6 @@ cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
 ffmpeg = { pkg-path = "ffmpeg_5", version = "5.1.4", pkg-group = "ffmpeg" }
-gh = { pkg-path = "gh" }
 protobuf = { pkg-path = "protobuf" } # protoc compiler for gRPC code generation
 ninja.pkg-path = "ninja"
 emscripten = { pkg-path = "emscripten", pkg-group = "emscripten", version = "4.0.23" }


### PR DESCRIPTION
Flox catalog resolves `gh` to 2.69.0 which is massively outdated compared to the current release (2.86.0+). Having two different `gh` versions depending on whether you're inside or outside the flox env is super annoying — different flags, different behavior, auth issues, etc.

Same reasoning as #47800 which removed `git` from the manifest: `gh` is a general-purpose dev CLI that everyone already has via homebrew or system package manager. No need for flox to provide (and pin) a stale version.

All `gh` usage in the repo is either CI workflows (runners have it preinstalled) or local scripts (`bin/posthog-worktree`, hogli, storybook timings) that just need it on PATH.