### PR TITLE
feat(logs): send posthog events on log errors/timeouts

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -7,6 +8,7 @@ import { initKeaTests } from '~/test/init'
 
 import { logsViewerDataLogic } from './logsViewerDataLogic'
 
+jest.mock('posthog-js')
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
     lemonToast: {
@@ -51,6 +53,7 @@ describe('logsViewerDataLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             expect(lemonToast.error).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it.each([['Network error'], ['Server returned 500'], ['Timeout exceeded']])(
@@ -71,6 +74,7 @@ describe('logsViewerDataLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             expect(lemonToast.error).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it('shows toast for legitimate fetchNextLogsPage error', async () => {
@@ -79,5 +83,61 @@ describe('logsViewerDataLogic', () => {
 
             expect(lemonToast.error).toHaveBeenCalledWith('Failed to load more logs: Network error')
         })
+    })
+
+    describe('query failure event capture', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it.each([
+            ['fetchLogsFailure' as const, 'logs'],
+            ['fetchNextLogsPageFailure' as const, 'logs_next_page'],
+            ['fetchSparklineFailure' as const, 'sparkline'],
+        ])('captures %s with query_type "%s"', async (action, expectedQueryType) => {
+            logic.actions[action]('Some server error')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(posthog.capture).toHaveBeenCalledWith('logs query failed', {
+                query_type: expectedQueryType,
+                error_type: 'unknown',
+                status_code: null,
+                error_message: 'Some server error',
+            })
+        })
+
+        it.each([
+            [{ status: 504, message: 'Gateway Timeout' }, 'timeout', 504],
+            ['Query timed out', 'timeout', null],
+            [{ status: 500, message: 'Internal Server Error' }, 'server_error', 500],
+            [{ status: 429, message: 'Too Many Requests' }, 'rate_limited', 429],
+            ['memory limit exceeded', 'out_of_memory', null],
+        ])(
+            'classifies error %j as error_type "%s" with status_code %s',
+            async (errorObject, expectedType, expectedStatus) => {
+                logic.actions.fetchLogsFailure(String(errorObject), errorObject)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(posthog.capture).toHaveBeenCalledWith(
+                    'logs query failed',
+                    expect.objectContaining({
+                        error_type: expectedType,
+                        status_code: expectedStatus,
+                    })
+                )
+            }
+        )
+
+        it.each([['new query started'], ['Fetch is aborted'], ['ABORTED']])(
+            'does not capture event for user-initiated error "%s"',
+            async (error) => {
+                logic.actions.fetchLogsFailure(error)
+                logic.actions.fetchNextLogsPageFailure(error)
+                logic.actions.fetchSparklineFailure(error)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(posthog.capture).not.toHaveBeenCalled()
+            }
+        )
     })
 })


### PR DESCRIPTION
## Problem

we aren't currently tracking logs errors, except via error tracking but they can be noisy, track whenever a customer receives an error

## Changes

apparently these things called analytics events are pretty cool so trying them out

## How did you test this code?

ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
