### PR TITLE
fix(mcp): return plaintext client_secret in DCR response

### DIFF
--- a/posthog/api/oauth/dcr.py
+++ b/posthog/api/oauth/dcr.py
@@ -156,8 +156,8 @@ class DynamicClientRegistrationView(APIView):
             if plaintext_secret:
                 create_kwargs["client_secret"] = plaintext_secret
             app = OAuthApplication.objects.create(
-                **create_kwargs
-            )  # nosemgrep: no-request-param-orm-filter (create_kwargs is built from validated serializer fields, not raw request params)
+                **create_kwargs  # nosemgrep: no-request-param-orm-filter (create_kwargs is built from validated serializer fields, not raw request params)
+            )
         except ValidationError as e:
             # Only expose redirect_uri validation errors to clients
             # Other validation errors (like missing RSA key) are internal and should not be leaked

--- a/posthog/api/oauth/dcr.py
+++ b/posthog/api/oauth/dcr.py
@@ -155,7 +155,9 @@ class DynamicClientRegistrationView(APIView):
             }
             if plaintext_secret:
                 create_kwargs["client_secret"] = plaintext_secret
-            app = OAuthApplication.objects.create(**create_kwargs)
+            app = OAuthApplication.objects.create(
+                **create_kwargs
+            )  # nosemgrep: no-request-param-orm-filter (create_kwargs is built from validated serializer fields, not raw request params)
         except ValidationError as e:
             # Only expose redirect_uri validation errors to clients
             # Other validation errors (like missing RSA key) are internal and should not be leaked

--- a/posthog/api/oauth/dcr.py
+++ b/posthog/api/oauth/dcr.py
@@ -17,6 +17,7 @@ from django.core.validators import RegexValidator
 from django.utils import timezone
 
 import structlog
+from oauth2_provider.generators import generate_client_secret
 from oauth2_provider.models import AbstractApplication
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -132,23 +133,29 @@ class DynamicClientRegistrationView(APIView):
         is_confidential = data.get("token_endpoint_auth_method") == "client_secret_post"
         client_type = AbstractApplication.CLIENT_CONFIDENTIAL if is_confidential else AbstractApplication.CLIENT_PUBLIC
 
+        # For confidential clients, generate the secret before create() so we
+        # can return the plaintext. The model's ClientSecretField.pre_save()
+        # will hash it automatically on save.
+        plaintext_secret = generate_client_secret() if is_confidential else None
+
         # Create the OAuth application
         # Model's clean() validates redirect URIs (HTTPS, loopback, custom schemes)
         try:
-            app = OAuthApplication.objects.create(
-                name=data.get("client_name", "MCP Client"),
-                redirect_uris=" ".join(data["redirect_uris"]),
-                client_type=client_type,
-                authorization_grant_type=AbstractApplication.GRANT_AUTHORIZATION_CODE,
-                algorithm="RS256",
-                skip_authorization=False,
-                # DCR-specific fields
-                is_dcr_client=True,
-                dcr_client_id_issued_at=now,
-                # No organization or user - DCR clients are anonymous
-                organization=None,
-                user=None,
-            )
+            create_kwargs: dict[str, Any] = {
+                "name": data.get("client_name", "MCP Client"),
+                "redirect_uris": " ".join(data["redirect_uris"]),
+                "client_type": client_type,
+                "authorization_grant_type": AbstractApplication.GRANT_AUTHORIZATION_CODE,
+                "algorithm": "RS256",
+                "skip_authorization": False,
+                "is_dcr_client": True,
+                "dcr_client_id_issued_at": now,
+                "organization": None,
+                "user": None,
+            }
+            if plaintext_secret:
+                create_kwargs["client_secret"] = plaintext_secret
+            app = OAuthApplication.objects.create(**create_kwargs)
         except ValidationError as e:
             # Only expose redirect_uri validation errors to clients
             # Other validation errors (like missing RSA key) are internal and should not be leaked
@@ -194,8 +201,8 @@ class DynamicClientRegistrationView(APIView):
             "client_id_issued_at": int(now.timestamp()),
         }
 
-        if is_confidential:
-            response_data["client_secret"] = app.client_secret
+        if is_confidential and plaintext_secret:
+            response_data["client_secret"] = plaintext_secret
             response_data["client_secret_expires_at"] = 0  # 0 = never expires per RFC 7591
 
         if data.get("client_name"):

--- a/posthog/api/oauth/test_dcr.py
+++ b/posthog/api/oauth/test_dcr.py
@@ -248,6 +248,12 @@ class TestDynamicClientRegistration(APIBaseTest):
         self.assertEqual(app.client_type, "confidential")
         self.assertTrue(app.is_dcr_client)
 
+        # The returned secret must be plaintext (not a hash) and must verify against the stored hash
+        from django.contrib.auth.hashers import check_password
+
+        self.assertFalse(data["client_secret"].startswith("pbkdf2_sha256$"))
+        self.assertTrue(check_password(data["client_secret"], app.client_secret))
+
     def test_unsupported_auth_method_rejected(self):
         response = self.client.post(
             "/oauth/register/",


### PR DESCRIPTION
## Problem

Follow-up to #48397. Django OAuth Toolkit hashes `client_secret` on save via `ClientSecretField.pre_save()`. Reading `app.client_secret` after save returns the pbkdf2 hash (e.g. `pbkdf2_sha256$600000$...`), not the plaintext.

This caused `invalid_client` errors during token exchange because Claude would store the hash as its "secret", send it in the token request, and django-oauth-toolkit would hash it *again* — so it never matched.

## Changes

- Generate the plaintext secret before `create()` using `generate_client_secret()`
- Pass the plaintext explicitly to `create()` (the model still hashes it on save)
- Return the plaintext in the DCR response
- Added test asserting the returned secret is plaintext and verifies against the stored hash

## How did you test this code?

- All 22 DCR tests pass
- Verified locally: DCR now returns a plaintext secret like `MVUX9bNGl3hRud...` instead of `pbkdf2_sha256$600000$...`
- User confirmed the full Claude Desktop OAuth flow works after this fix

## Changelog

Fix OAuth Dynamic Client Registration returning hashed client_secret instead of plaintext, which caused `invalid_client` errors for confidential MCP clients like Claude Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)