### PR TITLE
fix(cdp): preserve URL hash during OAuth redirect for sub-template config

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/CyclotronJobInputIntegration.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/CyclotronJobInputIntegration.tsx
@@ -17,7 +17,7 @@ export function CyclotronJobInputIntegration({
             {...props}
             schema={schema}
             integration={schema.integration}
-            redirectUrl={`${window.location.pathname}?integration_target=${schema.key}`}
+            redirectUrl={`${window.location.pathname}?integration_target=${schema.key}${window.location.hash}`}
             beforeRedirect={() => persistForUnload?.()}
         />
     )

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -181,15 +181,9 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 })
 
                 // Add the integration ID to the replaceUrl so that the landing page can use it
-                // Insert before any hash fragment so integration_id is a search param, not part of the hash
-                const hashIndex = replaceUrl.indexOf('#')
-                if (hashIndex !== -1) {
-                    const beforeHash = replaceUrl.substring(0, hashIndex)
-                    const hash = replaceUrl.substring(hashIndex)
-                    replaceUrl = `${beforeHash}${beforeHash.includes('?') ? '&' : '?'}integration_id=${integration.id}${hash}`
-                } else {
-                    replaceUrl += `${replaceUrl.includes('?') ? '&' : '?'}integration_id=${integration.id}`
-                }
+                const url = new URL(replaceUrl, window.location.origin)
+                url.searchParams.set('integration_id', String(integration.id))
+                replaceUrl = url.pathname + url.search + url.hash
 
                 actions.loadIntegrations()
                 lemonToast.success(`Integration successful.`)

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -181,7 +181,15 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 })
 
                 // Add the integration ID to the replaceUrl so that the landing page can use it
-                replaceUrl += `${replaceUrl.includes('?') ? '&' : '?'}integration_id=${integration.id}`
+                // Insert before any hash fragment so integration_id is a search param, not part of the hash
+                const hashIndex = replaceUrl.indexOf('#')
+                if (hashIndex !== -1) {
+                    const beforeHash = replaceUrl.substring(0, hashIndex)
+                    const hash = replaceUrl.substring(hashIndex)
+                    replaceUrl = `${beforeHash}${beforeHash.includes('?') ? '&' : '?'}integration_id=${integration.id}${hash}`
+                } else {
+                    replaceUrl += `${replaceUrl.includes('?') ? '&' : '?'}integration_id=${integration.id}`
+                }
 
                 actions.loadIntegrations()
                 lemonToast.success(`Integration successful.`)


### PR DESCRIPTION
## Problem

When creating an internal destination (e.g. error tracking > Slack alert) that requires a first-time OAuth connection, the URL hash containing the
sub-template configuration (type, name, filters, sub_template_id) was lost during the OAuth redirect flow. See: https://posthog.slack.com/archives/C09BDQLM8KA/p1771436224001749 for more context. 

The result is that the newly created function does not do what the user expects it to do, as all context has been lost in the redirect. This is difficult to detect unless you know what to look for and can therefore cause a fair amount of frustration for the user.

## Changes

- Modified `CyclotronJobInputIntegration.tsx` to preserve the URL hash fragment when constructing the redirect URL
- Updated `integrationsLogic.ts` to properly handle URL hash fragments when adding integration ID to the URL
    - Now correctly inserts the integration_id parameter before any hash fragment

## How did you test this code?

Tested integration flows with URLs containing hash fragments to verify that:

1. The hash fragment is preserved during the redirect process
2. The integration_id parameter is correctly added as a search parameter
3. The user is properly redirected back to the original location with both the integration_id and hash fragment intact

Also refer to the videos posted alongisde this PR on Slack (left out here as it exposes our internal Slack channels and I did not want to figure out how to blur it :smiley:)