### PR TITLE
fix: suppress error toast on sensitive action reauth prompt

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -108,11 +108,12 @@ export function initKea({
                     let errorMessage = error.detail || error.statusText
                     const isTwoFactorError =
                         error.code === 'two_factor_setup_required' || error.code === 'two_factor_verification_required'
+                    const isSensitiveActionError = error.code === 'sensitive_action_required_reauth'
 
                     if (!errorMessage && error.status === 404) {
                         errorMessage = 'URL not found'
                     }
-                    if (isTwoFactorError) {
+                    if (isTwoFactorError || isSensitiveActionError) {
                         errorMessage = null
                     }
                     if (errorMessage) {

--- a/frontend/src/lib/logic/apiStatusLogic.ts
+++ b/frontend/src/lib/logic/apiStatusLogic.ts
@@ -60,16 +60,16 @@ export const apiStatusLogic = kea<apiStatusLogicType>([
             try {
                 if (response?.status === 403) {
                     const responseData = await response?.json()
-                    if (responseData.detail === 'This action requires you to be recently authenticated.') {
+                    if (responseData.code === 'sensitive_action_required_reauth') {
                         actions.setTimeSensitiveAuthenticationRequired(true)
                     } else if (
-                        responseData.detail === '2FA setup required' &&
+                        responseData.code === 'two_factor_setup_required' &&
                         !values.timeSensitiveAuthenticationRequired &&
                         !twoFactorLogic.findMounted()?.values.isTwoFactorSetupModalOpen
                     ) {
                         twoFactorLogic.findMounted()?.actions.openTwoFactorSetupModal(true)
                     } else if (
-                        responseData.detail === '2FA verification required' &&
+                        responseData.code === 'two_factor_verification_required' &&
                         !values.twoFactorVerificationExpiredToastShown
                     ) {
                         actions.setTwoFactorVerificationExpiredToastShown(true)

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -1623,7 +1623,7 @@ class TestTimeSensitivePermissions(APIBaseTest):
             assert res.status_code == 403
             assert res.json() == {
                 "type": "authentication_error",
-                "code": "permission_denied",
+                "code": "sensitive_action_required_reauth",
                 "detail": "This action requires you to be recently authenticated.",
                 "attr": None,
             }
@@ -1646,7 +1646,7 @@ class TestTimeSensitivePermissions(APIBaseTest):
             assert res.status_code == 403
             assert res.json() == {
                 "type": "authentication_error",
-                "code": "permission_denied",
+                "code": "sensitive_action_required_reauth",
                 "detail": "This action requires you to be recently authenticated.",
                 "attr": None,
             }

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -337,6 +337,7 @@ class TimeSensitiveActionPermission(BasePermission):
     """
 
     message = "This action requires you to be recently authenticated."
+    code = "sensitive_action_required_reauth"
 
     def has_permission(self, request, view) -> bool:
         if not isinstance(request.successful_authenticator, SessionAuthentication):


### PR DESCRIPTION
## Problem

When a sensitive action (e.g. invite team member) triggers reauth, both the reauth modal **and** an error toast appear. The toast fires because the kea-loaders `onFailure` handler doesn't recognize the 403 as a reauth prompt.

[Bug report](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771455189694329)

## Changes

- Add `code = "sensitive_action_required_reauth"` to `TimeSensitiveActionPermission` (DRF standard pattern)
- Suppress toast in `initKea.ts` `onFailure` for the new code
- Migrate all 403 detection in `apiStatusLogic.ts` from fragile `detail` string matching to structured `code` field (reauth + both 2FA cases)
- Update backend test assertions for the new code
