### PR TITLE
fix(filters): prioritize existing filter type over suggested filters

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -297,10 +297,16 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         activeTab: [
             (state: any): TaxonomicFilterGroupType => {
                 const groupTypes = selectors.taxonomicGroupTypes(state)
+                const propsGroupType = selectors.groupType(state)
+                // If there's an existing filter type (e.g., SQL expression being edited),
+                // use that instead of defaulting to SuggestedFilters
+                if (propsGroupType && groupTypes.includes(propsGroupType)) {
+                    return propsGroupType
+                }
                 if (groupTypes.includes(TaxonomicFilterGroupType.SuggestedFilters)) {
                     return TaxonomicFilterGroupType.SuggestedFilters
                 }
-                return selectors.groupType(state) || groupTypes[0]
+                return propsGroupType || groupTypes[0]
             },
             {
                 setActiveTab: (_, { activeTab }) => activeTab,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -306,7 +306,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 if (groupTypes.includes(TaxonomicFilterGroupType.SuggestedFilters)) {
                     return TaxonomicFilterGroupType.SuggestedFilters
                 }
-                return propsGroupType || groupTypes[0]
+                return groupTypes[0]
             },
             {
                 setActiveTab: (_, { activeTab }) => activeTab,


### PR DESCRIPTION
## Problem

When trying to edit an existing SQL expression, we were always defaulting to the Suggested Filters.

## Changes

When editing an existing filter (e.g., SQL expression), the active tab now correctly shows the filter type being edited instead of defaulting to "Suggested filters". This fixes the issue where SQL expression filters would show the wrong tab when clicked for editing.

https://claude.ai/code/session_01JXAwxftF4WbM7o4oMHigmK