### PR TITLE
chore(dagster): publish distinct_id_usage reports to #ingestion-reports

### DIFF
--- a/posthog/dags/distinct_id_usage.py
+++ b/posthog/dags/distinct_id_usage.py
@@ -11,8 +11,9 @@ from clickhouse_driver import Client
 from posthog import settings
 from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.dags.common import JobOwners, settings_with_log_comment
-from posthog.dags.slack_alerts import notification_channel_per_team
 from posthog.models.distinct_id_usage.sql import TABLE_BASE_NAME
+
+INGESTION_REPORTS_SLACK_CHANNEL = "#ingestion-reports"
 
 JOB_NAME = "distinct_id_usage_monitoring"
 
@@ -355,12 +356,9 @@ def send_alerts(
 
     try:
         slack_client = slack.get_client()
-        channel = notification_channel_per_team.get(
-            JobOwners.TEAM_INGESTION.value, settings.DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL
-        )
 
         # Post the summary message
-        response = slack_client.chat_postMessage(channel=channel, blocks=blocks)
+        response = slack_client.chat_postMessage(channel=INGESTION_REPORTS_SLACK_CHANNEL, blocks=blocks)
 
         # Get channel ID from the response (files_upload_v2 requires channel ID, not name)
         channel_id = response.get("channel")


### PR DESCRIPTION
Change the distinct_id_usage dagster job to publish alerts to the #ingestion-reports Slack channel instead of #alerts-ingestion.

This separates informational reports from critical alerts, reducing noise in the alerts channel.


## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
