### PR TITLE
fix(devenv): create local symlink when resolving worktree config

### DIFF
--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -389,6 +389,11 @@ def get_generated_mprocs_path() -> Path:
     if main_repo:
         main_path = main_repo / ".posthog" / ".generated" / "mprocs.yaml"
         if main_path.exists():
+            # Create local symlink so bin/start (which uses $REPOSITORY_ROOT) finds it
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            if local_path.is_symlink():
+                local_path.unlink()
+            local_path.symlink_to(main_path)
             return main_path
 
     return local_path


### PR DESCRIPTION
`dev:generate` falls through to the main repo config when run from a worktree without a local config. But `bin/start` only checks the local `$REPOSITORY_ROOT` path, so it never finds the generated config and silently falls back to the raw `bin/mprocs.yaml` with all processes enabled and no intent filtering.

The wizard (`dev:setup`) already handles this by creating a symlink from the worktree to the main repo config — `dev:generate` now does the same in `get_generated_mprocs_path()`.