### PR TITLE
chore: add .watchmanconfig to reduce recrawl warnings

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,13 @@
+{
+  "ignore_dirs": [
+    ".git",
+    "node_modules",
+    "rust/target",
+    ".mypy_cache",
+    "__pycache__",
+    ".pytest_cache",
+    ".dagster_home",
+    ".posthog",
+    ".flox"
+  ]
+}


### PR DESCRIPTION
Django's autoreload (used by celery worker/beat in dev) picks watchman when available, creating ~2000 subscriptions on the repo root. Without an ignore list, watchman indexes everything — node_modules, rust/target, .git, .flox, etc. — causing frequent recrawls (73 observed in a single session).

Adds a `.watchmanconfig` ignoring heavy dirs that no subscriber cares about. Only active watchman consumers are celery beat + worker, which only watch `.py` files in `posthog/`, `ee/`, `products/`.