### PR TITLE
fix(experiments): avoid metric header clipping before launch

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -27,6 +27,11 @@ import {
 } from './constants'
 import { useAxisScale } from './useAxisScale'
 
+const CHART_CELL_HEIGHT_STYLE = {
+    height: `${CELL_HEIGHT}px`,
+    maxHeight: `${CELL_HEIGHT}px`,
+}
+
 interface ChartCellProps {
     variantResult: ExperimentVariantResult
     metric: ExperimentMetric
@@ -82,7 +87,7 @@ export function ChartCell({
             className={`p-0 align-top text-center relative overflow-hidden ${
                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
             } ${isLastRow ? 'border-b' : ''}`}
-            style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+            style={CHART_CELL_HEIGHT_STYLE}
         >
             <div className="relative h-full">
                 <svg

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -51,11 +51,28 @@ import { TimeseriesModal } from './TimeseriesModal'
 import {
     CELL_HEIGHT,
     CHART_CELL_VIEW_BOX_HEIGHT,
+    EMPTY_STATE_ROW_MIN_HEIGHT,
     GRID_LINES_OPACITY,
     SVG_EDGE_MARGIN,
     VIEW_BOX_WIDTH,
 } from './constants'
 import { useAxisScale } from './useAxisScale'
+
+const FIXED_HEIGHT_STYLE: React.CSSProperties = {
+    height: `${CELL_HEIGHT}px`,
+    maxHeight: `${CELL_HEIGHT}px`,
+}
+
+const getScaledHeightStyle = (rowCount: number): React.CSSProperties => {
+    const scaledHeight = `${CELL_HEIGHT * rowCount}px`
+
+    return {
+        height: scaledHeight,
+        maxHeight: scaledHeight,
+    }
+}
+
+const getMinHeightStyle = (height: number): React.CSSProperties => ({ minHeight: `${height}px` })
 
 interface BreakdownErrorStateProps {
     metric: ExperimentMetric
@@ -126,6 +143,7 @@ function CollapsibleBreakdownSection({
     const nestedTableRef = useRef<HTMLTableElement>(null)
 
     const totalRows = 1 + (breakdownResults[0]?.variants?.length || 0)
+    const totalRowsHeightStyle = getScaledHeightStyle(totalRows)
 
     // Sync nested breakdown table column widths with parent table (only when expanded)
     useColumnWidthSync(
@@ -187,10 +205,7 @@ function CollapsibleBreakdownSection({
                                                         <tr
                                                             key={breakdownResult.breakdown_value}
                                                             className="hover:bg-bg-hover"
-                                                            style={{
-                                                                height: `${CELL_HEIGHT}px`,
-                                                                maxHeight: `${CELL_HEIGHT}px`,
-                                                            }}
+                                                            style={FIXED_HEIGHT_STYLE}
                                                         >
                                                             <td
                                                                 className={`w-1/5 border-r p-3 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
@@ -207,10 +222,7 @@ function CollapsibleBreakdownSection({
                                                             <td
                                                                 colSpan={6}
                                                                 className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 {isLoading || exposuresLoading ? (
                                                                     <ChartLoadingState height={CELL_HEIGHT} />
@@ -231,20 +243,11 @@ function CollapsibleBreakdownSection({
                                                 return (
                                                     <React.Fragment key={breakdownResult.breakdown_value}>
                                                         {/* Baseline row */}
-                                                        <tr
-                                                            className="hover:bg-bg-hover"
-                                                            style={{
-                                                                height: `${CELL_HEIGHT}px`,
-                                                                maxHeight: `${CELL_HEIGHT}px`,
-                                                            }}
-                                                        >
+                                                        <tr className="hover:bg-bg-hover" style={FIXED_HEIGHT_STYLE}>
                                                             <td
                                                                 className={`w-1/5 border-r p-3 align-top border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} text-xs`}
                                                                 rowSpan={totalRows}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT * totalRows}px`,
-                                                                    maxHeight: `${CELL_HEIGHT * totalRows}px`,
-                                                                }}
+                                                                style={totalRowsHeightStyle}
                                                             >
                                                                 {formatBreakdownLabel(
                                                                     breakdownResult.breakdown_value,
@@ -258,20 +261,14 @@ function CollapsibleBreakdownSection({
 
                                                             <td
                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <VariantTag variantKey={baselineResult.key} />
                                                             </td>
 
                                                             <td
                                                                 className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <div className="metric-cell">
                                                                     <div>
@@ -283,20 +280,14 @@ function CollapsibleBreakdownSection({
 
                                                             <td
                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <div />
                                                             </td>
 
                                                             <td
                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 <div />
                                                             </td>
@@ -305,18 +296,12 @@ function CollapsibleBreakdownSection({
                                                             <td
                                                                 className={`w-20 pt-3 align-top relative overflow-hidden border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                                                                 rowSpan={totalRows}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT * totalRows}px`,
-                                                                    maxHeight: `${CELL_HEIGHT * totalRows}px`,
-                                                                }}
+                                                                style={totalRowsHeightStyle}
                                                             />
 
                                                             <td
                                                                 className={`p-0 align-top text-center relative overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                style={{
-                                                                    height: `${CELL_HEIGHT}px`,
-                                                                    maxHeight: `${CELL_HEIGHT}px`,
-                                                                }}
+                                                                style={FIXED_HEIGHT_STYLE}
                                                             >
                                                                 {axisRange && axisRange > 0 ? (
                                                                     <div className="relative h-full">
@@ -361,10 +346,7 @@ function CollapsibleBreakdownSection({
                                                                     <tr
                                                                         key={`${metric.uuid}-${variant.key}`}
                                                                         className="hover:bg-bg-hover"
-                                                                        style={{
-                                                                            height: `${CELL_HEIGHT}px`,
-                                                                            maxHeight: `${CELL_HEIGHT}px`,
-                                                                        }}
+                                                                        style={FIXED_HEIGHT_STYLE}
                                                                         onMouseEnter={(e) =>
                                                                             handleTooltipMouseEnter(e, variant)
                                                                         }
@@ -375,20 +357,14 @@ function CollapsibleBreakdownSection({
                                                                     >
                                                                         <td
                                                                             className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                            style={{
-                                                                                height: `${CELL_HEIGHT}px`,
-                                                                                maxHeight: `${CELL_HEIGHT}px`,
-                                                                            }}
+                                                                            style={FIXED_HEIGHT_STYLE}
                                                                         >
                                                                             <VariantTag variantKey={variant.key} />
                                                                         </td>
 
                                                                         <td
                                                                             className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                            style={{
-                                                                                height: `${CELL_HEIGHT}px`,
-                                                                                maxHeight: `${CELL_HEIGHT}px`,
-                                                                            }}
+                                                                            style={FIXED_HEIGHT_STYLE}
                                                                         >
                                                                             <div className="metric-cell">
                                                                                 <div>
@@ -400,10 +376,7 @@ function CollapsibleBreakdownSection({
 
                                                                         <td
                                                                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                            style={{
-                                                                                height: `${CELL_HEIGHT}px`,
-                                                                                maxHeight: `${CELL_HEIGHT}px`,
-                                                                            }}
+                                                                            style={FIXED_HEIGHT_STYLE}
                                                                         >
                                                                             <div className="flex items-center gap-1">
                                                                                 <span
@@ -439,8 +412,7 @@ function CollapsibleBreakdownSection({
                                                                         <td
                                                                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden ${!significant ? (isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light') : ''} ${isLastRow ? 'border-b' : ''}`}
                                                                             style={{
-                                                                                height: `${CELL_HEIGHT}px`,
-                                                                                maxHeight: `${CELL_HEIGHT}px`,
+                                                                                ...FIXED_HEIGHT_STYLE,
                                                                                 backgroundColor: significant
                                                                                     ? winning
                                                                                         ? `${colors.BAR_POSITIVE}30`
@@ -573,9 +545,6 @@ export function MetricRowGroup({
 
     const timeseriesEnabled = experiment.scheduling_config?.timeseries
 
-    // Calculate total rows for loading/error states
-    const totalRows = isLoading || error || !result ? 1 : 1 + (result.variant_results?.length || 0)
-
     // Helper function to calculate tooltip position
     const calculateTooltipPosition = (
         chartCell: HTMLElement,
@@ -668,30 +637,18 @@ export function MetricRowGroup({
 
     if (isLoading || error || !result) {
         const hasError = !!error
+        const noResultHeight = hasError ? CELL_HEIGHT : Math.max(CELL_HEIGHT, EMPTY_STATE_ROW_MIN_HEIGHT)
+        const noResultStateStyle = getMinHeightStyle(noResultHeight)
 
         return (
             <>
-                <tr
-                    className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
-                    style={
-                        hasError
-                            ? { minHeight: `${CELL_HEIGHT}px` }
-                            : { height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }
-                    }
-                >
+                <tr className="hover:bg-bg-hover group [&:last-child>td]:border-b-0" style={noResultStateStyle}>
                     {/* Metric column - always visible */}
                     <td
                         className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                        style={
-                            hasError
-                                ? { minHeight: `${CELL_HEIGHT}px` }
-                                : {
-                                      height: `${CELL_HEIGHT}px`,
-                                      maxHeight: `${CELL_HEIGHT}px`,
-                                  }
-                        }
+                        style={noResultStateStyle}
                     >
                         <MetricHeader
                             displayOrder={displayOrder}
@@ -710,17 +667,13 @@ export function MetricRowGroup({
                         className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
                             !isLastMetric ? 'border-b' : ''
                         }`}
-                        style={
-                            hasError
-                                ? { minHeight: `${CELL_HEIGHT}px` }
-                                : { height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }
-                        }
+                        style={noResultStateStyle}
                     >
                         {isLoading || exposuresLoading ? (
-                            <ChartLoadingState height={CELL_HEIGHT} />
+                            <ChartLoadingState height={noResultHeight} />
                         ) : (
                             <ChartEmptyState
-                                height={CELL_HEIGHT}
+                                height={noResultHeight}
                                 experimentStarted={!!experiment.start_date}
                                 metric={metric}
                                 error={error}
@@ -744,6 +697,8 @@ export function MetricRowGroup({
     // At this point, we know result is defined, so we can safely access its properties
     const baselineResult = result.baseline
     const variantResults = result.variant_results || []
+    const totalRows = 1 + variantResults.length
+    const totalRowsHeightStyle = getScaledHeightStyle(totalRows)
 
     const ratioMetricLabel = (variant: ExperimentStatsBaseValidated, metric: ExperimentMetric): JSX.Element => {
         return (
@@ -781,18 +736,12 @@ export function MetricRowGroup({
                 )}
 
             {/* Baseline row */}
-            <tr
-                className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
-                style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
-            >
+            <tr className="hover:bg-bg-hover group [&:last-child>td]:border-b-0" style={FIXED_HEIGHT_STYLE}>
                 {/* Metric column - with rowspan */}
                 <td
                     className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                     rowSpan={totalRows}
-                    style={{
-                        height: `${CELL_HEIGHT * totalRows}px`,
-                        maxHeight: `${CELL_HEIGHT * totalRows}px`,
-                    }}
+                    style={totalRowsHeightStyle}
                 >
                     <MetricHeader
                         displayOrder={displayOrder}
@@ -810,7 +759,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     <VariantTag variantKey={baselineResult.key} />
                 </td>
@@ -820,7 +769,7 @@ export function MetricRowGroup({
                     className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     <div className="metric-cell">
                         <div>{formatMetricValue(baselineResult, metric)}</div>
@@ -833,7 +782,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     <div />
                 </td>
@@ -843,7 +792,7 @@ export function MetricRowGroup({
                     className={`w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     <div />
                 </td>
@@ -854,10 +803,7 @@ export function MetricRowGroup({
                         !isLastMetric ? 'border-b' : ''
                     } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                     rowSpan={totalRows}
-                    style={{
-                        height: `${CELL_HEIGHT * totalRows}px`,
-                        maxHeight: `${CELL_HEIGHT * totalRows}px`,
-                    }}
+                    style={totalRowsHeightStyle}
                 >
                     {showDetailsModal && (
                         <>
@@ -880,7 +826,7 @@ export function MetricRowGroup({
                     className={`p-0 align-top text-center relative overflow-hidden ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     } ${variantResults.length === 0 ? 'border-b' : ''}`}
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     {axisRange && axisRange > 0 ? (
                         <div className="relative h-full">
@@ -920,7 +866,7 @@ export function MetricRowGroup({
                     <tr
                         key={`${metric.uuid}-${variant.key}`}
                         className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
-                        style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                        style={FIXED_HEIGHT_STYLE}
                         onMouseEnter={(e) => handleTooltipMouseEnter(e, variant)}
                         onMouseLeave={handleTooltipMouseLeave}
                         onMouseMove={(e) => handleTooltipMouseMove(e, variant)}
@@ -930,7 +876,7 @@ export function MetricRowGroup({
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                            style={FIXED_HEIGHT_STYLE}
                         >
                             <VariantTag variantKey={variant.key} />
                         </td>
@@ -940,7 +886,7 @@ export function MetricRowGroup({
                             className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                            style={FIXED_HEIGHT_STYLE}
                         >
                             <div className="metric-cell">
                                 <div>{formatMetricValue(variant, metric)}</div>
@@ -953,7 +899,7 @@ export function MetricRowGroup({
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
                                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                            style={FIXED_HEIGHT_STYLE}
                         >
                             <div className="flex items-center gap-1">
                                 <span
@@ -979,8 +925,7 @@ export function MetricRowGroup({
                                 !significant ? (isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light') : ''
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{
-                                height: `${CELL_HEIGHT}px`,
-                                maxHeight: `${CELL_HEIGHT}px`,
+                                ...FIXED_HEIGHT_STYLE,
                                 backgroundColor: significant
                                     ? winning
                                         ? `${colors.BAR_POSITIVE}30`

--- a/frontend/src/scenes/experiments/MetricsView/new/constants.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/constants.ts
@@ -6,6 +6,7 @@ export const SVG_EDGE_MARGIN = 20
 export const CHART_CELL_VIEW_BOX_HEIGHT = 51
 export const CHART_CELL_BAR_HEIGHT_PERCENT = 15
 export const CELL_HEIGHT = 51
+export const EMPTY_STATE_ROW_MIN_HEIGHT = 80
 export const CHART_BAR_OPACITY = 0.9
 export const GRID_LINES_OPACITY = 0.8
 


### PR DESCRIPTION
## Problem
Before an experiment starts, metric rows were forced to a fixed 51px height in the no-result state.
This clipped the metric type tag (for example, Mean/Funnel) and could hide the add-breakdown button in the metric cell. This leaves a bad impression when using the experiment product for the first time.

<img width="1810" height="194" alt="Screenshot 2026-02-19 at 15 58 11" src="https://github.com/user-attachments/assets/81e39a34-6793-416a-b6e9-07a0b5babb76" />

Also when metrics were loading, we cut off the breakdown button.

## Changes
- Added `EMPTY_STATE_ROW_MIN_HEIGHT` for pre-launch/no-result rows.
- Updated the no-result branch in `MetricRowGroup` to use a minimum height instead of fixed height/maxHeight, so metric header content can fully render.
- Kept regular result rows at `CELL_HEIGHT` and refactored repeated row height style objects into shared helpers/constants to reduce duplication.

<img width="1813" height="290" alt="Screenshot 2026-02-19 at 16 25 39" src="https://github.com/user-attachments/assets/5976785d-2128-45a4-b23e-b2c57b139331" />

Also fixes the cutoff when metrics are loading
<img width="1558" height="682" alt="Screenshot 2026-02-19 at 16 19 41" src="https://github.com/user-attachments/assets/46052eb6-5453-4edb-a40a-8cf54248d755" />


## Testing
- `pnpm --filter=@posthog/frontend exec oxlint src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx src/scenes/experiments/MetricsView/new/ChartCell.tsx src/scenes/experiments/MetricsView/new/constants.ts`