### PR TITLE
feat(capture-logs): override timestamp if not within 24 hours of now

### DIFF
--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -123,7 +123,10 @@ pub fn extract_trace_span_ids(extra: &HashMap<String, serde_json::Value>) -> (St
     (trace_id, span_id)
 }
 
-pub fn datadog_log_to_kafka_row(log: DatadogLog, query_params: &DatadogQueryParams) -> (KafkaLogRow, bool) {
+pub fn datadog_log_to_kafka_row(
+    log: DatadogLog,
+    query_params: &DatadogQueryParams,
+) -> (KafkaLogRow, bool) {
     // Body values take precedence over query params
     let status = log.status.as_deref().or(query_params.status.as_deref());
     let (severity_text, severity_number) = normalize_datadog_severity(status);

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -1,4 +1,4 @@
-use crate::log_record::KafkaLogRow;
+use crate::log_record::{override_timestamp, KafkaLogRow};
 use crate::service::Service;
 use axum::{
     extract::State,
@@ -123,18 +123,21 @@ pub fn extract_trace_span_ids(extra: &HashMap<String, serde_json::Value>) -> (St
     (trace_id, span_id)
 }
 
-pub fn datadog_log_to_kafka_row(log: DatadogLog, query_params: &DatadogQueryParams) -> KafkaLogRow {
+pub fn datadog_log_to_kafka_row(log: DatadogLog, query_params: &DatadogQueryParams) -> (KafkaLogRow, bool) {
     // Body values take precedence over query params
     let status = log.status.as_deref().or(query_params.status.as_deref());
     let (severity_text, severity_number) = normalize_datadog_severity(status);
 
-    let timestamp = log
+    let raw_timestamp = log
         .timestamp
         .and_then(|ts| {
             // Datadog uses milliseconds since epoch
             Utc.timestamp_millis_opt(ts).single()
         })
         .unwrap_or_else(Utc::now);
+
+    let (timestamp, original_timestamp) = override_timestamp(raw_timestamp);
+    let was_overridden = original_timestamp.is_some();
 
     let service = log.service.or_else(|| query_params.service.clone());
     let hostname = log.hostname.or_else(|| query_params.hostname.clone());
@@ -190,22 +193,29 @@ pub fn datadog_log_to_kafka_row(log: DatadogLog, query_params: &DatadogQueryPara
         attributes.insert(key.clone(), value.to_string());
     }
 
-    KafkaLogRow {
-        uuid: Uuid::now_v7().to_string(),
-        trace_id,
-        span_id,
-        trace_flags: 0,
-        timestamp,
-        observed_timestamp: Utc::now(),
-        body: message.unwrap_or_default(),
-        severity_text,
-        severity_number,
-        service_name: service.unwrap_or_default(),
-        resource_attributes,
-        instrumentation_scope,
-        event_name,
-        attributes,
+    if let Some(original) = original_timestamp {
+        attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
     }
+
+    (
+        KafkaLogRow {
+            uuid: Uuid::now_v7().to_string(),
+            trace_id,
+            span_id,
+            trace_flags: 0,
+            timestamp,
+            observed_timestamp: Utc::now(),
+            body: message.unwrap_or_default(),
+            severity_text,
+            severity_number,
+            service_name: service.unwrap_or_default(),
+            resource_attributes,
+            instrumentation_scope,
+            event_name,
+            attributes,
+        },
+        was_overridden,
+    )
 }
 
 #[derive(Deserialize, Debug)]
@@ -284,13 +294,19 @@ pub async fn export_datadog_logs_http(
         },
     };
 
-    let rows: Vec<KafkaLogRow> = logs
+    let results: Vec<(KafkaLogRow, bool)> = logs
         .into_iter()
         .map(|log| datadog_log_to_kafka_row(log, &query_params))
         .collect();
 
-    let row_count = rows.len();
-    if let Err(e) = service.sink.write(&token, rows, body.len() as u64).await {
+    let row_count = results.len();
+    let timestamps_overridden = results.iter().filter(|(_, overridden)| *overridden).count() as u64;
+    let rows: Vec<KafkaLogRow> = results.into_iter().map(|(row, _)| row).collect();
+    if let Err(e) = service
+        .sink
+        .write(&token, rows, body.len() as u64, timestamps_overridden)
+        .await
+    {
         error!("Failed to send logs to Kafka: {}", e);
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn test_override_timestamp_just_past_boundary_is_overridden() {
         let now = Utc::now();
-        let just_outside = now - TimeDelta::hours(24);
+        let just_outside = now - TimeDelta::hours(24) - TimeDelta::seconds(1);
         let (final_ts, original) = override_timestamp(just_outside);
         assert!((final_ts - now).num_seconds().abs() < 2);
         assert_eq!(original.unwrap(), just_outside);

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -109,10 +109,7 @@ impl KafkaLogRow {
         let (timestamp, original_timestamp) = override_timestamp(raw_timestamp);
         let was_overridden = original_timestamp.is_some();
         if let Some(original) = original_timestamp {
-            attributes.insert(
-                "$originalTimestamp".to_string(),
-                original.to_rfc3339(),
-            );
+            attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
         }
 
         let observed_timestamp = Utc::now();

--- a/rust/capture-logs/tests/datadog_test.rs
+++ b/rust/capture-logs/tests/datadog_test.rs
@@ -700,7 +700,7 @@ fn test_datadog_log_overridden_timestamp_tracking() {
     assert!(row_overridden.attributes.contains_key("$originalTimestamp"));
 
     // Test with a recent timestamp (should not be overridden)
-    let recent = Utc::now().timestamp_millis() - (1 * 3600 * 1000); // 1 hour ago
+    let recent = Utc::now().timestamp_millis() - (3600 * 1000); // 1 hour ago
     let log_recent = DatadogLog {
         ddsource: None,
         ddtags: None,

--- a/rust/capture-logs/tests/datadog_test.rs
+++ b/rust/capture-logs/tests/datadog_test.rs
@@ -739,4 +739,3 @@ fn test_datadog_log_overridden_timestamp_tracking() {
     // User's originalTimestamp should still be in attributes
     assert!(row_user_attr.attributes.contains_key("originalTimestamp"));
 }
-

--- a/rust/capture-logs/tests/service_test.rs
+++ b/rust/capture-logs/tests/service_test.rs
@@ -579,7 +579,9 @@ fn test_otel_log_row_overridden_timestamp_tracking() {
     };
 
     // Test with a timestamp far in the past (should be overridden)
-    let far_past_nanos = (Utc::now() - TimeDelta::hours(48)).timestamp_nanos_opt().unwrap();
+    let far_past_nanos = (Utc::now() - TimeDelta::hours(48))
+        .timestamp_nanos_opt()
+        .unwrap();
     let log_record_overridden = LogRecord {
         time_unix_nano: far_past_nanos as u64,
         severity_text: "INFO".to_string(),
@@ -590,12 +592,15 @@ fn test_otel_log_row_overridden_timestamp_tracking() {
         ..Default::default()
     };
 
-    let (row_overridden, was_overridden) = KafkaLogRow::new(log_record_overridden, None, None).unwrap();
+    let (row_overridden, was_overridden) =
+        KafkaLogRow::new(log_record_overridden, None, None).unwrap();
     assert!(was_overridden);
     assert!(row_overridden.attributes.contains_key("$originalTimestamp"));
 
     // Test with a timestamp far in the future (should be overridden)
-    let far_future_nanos = (Utc::now() + TimeDelta::hours(25)).timestamp_nanos_opt().unwrap();
+    let far_future_nanos = (Utc::now() + TimeDelta::hours(25))
+        .timestamp_nanos_opt()
+        .unwrap();
     let log_record_overridden = LogRecord {
         time_unix_nano: far_future_nanos as u64,
         severity_text: "INFO".to_string(),
@@ -606,12 +611,15 @@ fn test_otel_log_row_overridden_timestamp_tracking() {
         ..Default::default()
     };
 
-    let (row_overridden, was_overridden) = KafkaLogRow::new(log_record_overridden, None, None).unwrap();
+    let (row_overridden, was_overridden) =
+        KafkaLogRow::new(log_record_overridden, None, None).unwrap();
     assert!(was_overridden);
     assert!(row_overridden.attributes.contains_key("$originalTimestamp"));
 
     // Test with a recent timestamp (should not be overridden)
-    let recent_nanos = (Utc::now() - TimeDelta::hours(1)).timestamp_nanos_opt().unwrap();
+    let recent_nanos = (Utc::now() - TimeDelta::hours(1))
+        .timestamp_nanos_opt()
+        .unwrap();
     let log_record_recent = LogRecord {
         time_unix_nano: recent_nanos as u64,
         severity_text: "INFO".to_string(),

--- a/rust/capture-logs/tests/service_test.rs
+++ b/rust/capture-logs/tests/service_test.rs
@@ -569,3 +569,60 @@ fn test_parse_jsonl_with_empty_resource_logs() {
     // Both lines have empty resourceLogs, so merged result is also empty
     assert_eq!(request.resource_logs.len(), 0);
 }
+#[test]
+fn test_otel_log_row_overridden_timestamp_tracking() {
+    use capture_logs::log_record::KafkaLogRow;
+    use chrono::{TimeDelta, Utc};
+    use opentelemetry_proto::tonic::{
+        common::v1::{any_value, AnyValue},
+        logs::v1::LogRecord,
+    };
+
+    // Test with a timestamp far in the past (should be overridden)
+    let far_past_nanos = (Utc::now() - TimeDelta::hours(48)).timestamp_nanos_opt().unwrap();
+    let log_record_overridden = LogRecord {
+        time_unix_nano: far_past_nanos as u64,
+        severity_text: "INFO".to_string(),
+        severity_number: 9,
+        body: Some(AnyValue {
+            value: Some(any_value::Value::StringValue("Test".to_string())),
+        }),
+        ..Default::default()
+    };
+
+    let (row_overridden, was_overridden) = KafkaLogRow::new(log_record_overridden, None, None).unwrap();
+    assert!(was_overridden);
+    assert!(row_overridden.attributes.contains_key("$originalTimestamp"));
+
+    // Test with a timestamp far in the future (should be overridden)
+    let far_future_nanos = (Utc::now() + TimeDelta::hours(25)).timestamp_nanos_opt().unwrap();
+    let log_record_overridden = LogRecord {
+        time_unix_nano: far_future_nanos as u64,
+        severity_text: "INFO".to_string(),
+        severity_number: 9,
+        body: Some(AnyValue {
+            value: Some(any_value::Value::StringValue("Test".to_string())),
+        }),
+        ..Default::default()
+    };
+
+    let (row_overridden, was_overridden) = KafkaLogRow::new(log_record_overridden, None, None).unwrap();
+    assert!(was_overridden);
+    assert!(row_overridden.attributes.contains_key("$originalTimestamp"));
+
+    // Test with a recent timestamp (should not be overridden)
+    let recent_nanos = (Utc::now() - TimeDelta::hours(1)).timestamp_nanos_opt().unwrap();
+    let log_record_recent = LogRecord {
+        time_unix_nano: recent_nanos as u64,
+        severity_text: "INFO".to_string(),
+        severity_number: 9,
+        body: Some(AnyValue {
+            value: Some(any_value::Value::StringValue("Test".to_string())),
+        }),
+        ..Default::default()
+    };
+
+    let (row_recent, was_not_overridden) = KafkaLogRow::new(log_record_recent, None, None).unwrap();
+    assert!(!was_not_overridden);
+    assert!(!row_recent.attributes.contains_key("$originalTimestamp"));
+}


### PR DESCRIPTION
## Problem

we're getting a bunch of wild timestamps from browser logs which are messing up clickhouse partitioning

as we partition on timestamp, we need to ensure we don't accept wildly out of date (or future dated) logs

## Changes

if timestamp is more than 24 hours from now, replace it with `now`

## How did you test this code?

ran locally, new tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
