### PR TITLE
fix(notebooks): inline menu breaking when adding or clicking links

### DIFF
--- a/frontend/src/scenes/notebooks/Marks/NotebookMarkLink.tsx
+++ b/frontend/src/scenes/notebooks/Marks/NotebookMarkLink.tsx
@@ -41,21 +41,32 @@ export const NotebookMarkLink = Mark.create({
                 props: {
                     handleDOMEvents: {
                         click(_, event) {
-                            if (event.metaKey) {
-                                const link = event.target as HTMLAnchorElement
-                                const href = link.href
+                            const link = (event.target as HTMLElement).closest?.('a')
+                            if (link) {
+                                event.preventDefault()
 
-                                if (href && isSafeProtocol(href)) {
-                                    event.preventDefault()
-                                    window.open(href, link.target)
-                                }
-                            } else {
-                                const range = getMarkRange(editor.state.selection.$anchor, markType)
-                                if (range) {
-                                    editor.commands.setTextSelection(range)
+                                if (event.metaKey) {
+                                    const href = link.href
+                                    if (href && isSafeProtocol(href)) {
+                                        window.open(href, link.target)
+                                    }
                                 }
                             }
                         },
+                    },
+                    handleClick(view, pos, event) {
+                        if (event.metaKey) {
+                            return false
+                        }
+
+                        const $pos = view.state.doc.resolve(pos)
+                        const range = getMarkRange($pos, markType)
+                        if (range) {
+                            editor.commands.setTextSelection(range)
+                            return true
+                        }
+
+                        return false
                     },
                 },
             }),

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -352,9 +352,12 @@ export const notebookLogic = kea<notebookLogicType>([
                             values.localContent &&
                             notebook.content === values.localContent
                         ) {
-                            const currentPosition = values.editor.getCurrentPosition()
-                            values.editor.setContent(response.content)
-                            values.editor.setTextSelection(currentPosition)
+                            const currentEditorContent = values.editor.getJSON()
+                            if (JSON.stringify(response.content) !== JSON.stringify(currentEditorContent)) {
+                                const currentPosition = values.editor.getCurrentPosition()
+                                values.editor.setContent(response.content)
+                                values.editor.setTextSelection(currentPosition)
+                            }
                         }
 
                         // If the object is identical then no edits were made, so we can safely clear the local changes


### PR DESCRIPTION
## Problem

The notebook inline menu (BubbleMenu) breaks in two ways when working with links:

1. **Clicking the link button** makes the BubbleMenu disappear instead of transitioning to the URL input.

2. **Clicking on existing link text** doesn't show the URL editor. 

A secondary issue: the auto-save response (`setContent`) fires every ~1s and replaces the full editor state even when content is identical, collapsing active selections and disrupting menu interactions.

[LOOM](https://www.loom.com/share/6e2eaa2211ca473c8c561792144ce007)

## Changes

  - BubbleMenu no longer disappears when clicking the link button (focus theft prevented during mousedown)
  - BubbleMenu stays visible while typing in the URL input (menu checks internal focus before ProseMirror focus)                                                
  - Clicking existing link text now selects the full link and shows the URL editor (was silently broken)                                                        
  - Link/formatting toggle is now reactive to selection changes (opts in via useEditorState since the editor disables re-renders on transactions)               
  - Auto-save no longer replaces editor state when content is unchanged (was collapsing active selections every ~30s)        
 
## How did you test this code?

Manual testing

## Publish to changelog?

No