### PR TITLE
feat(flags): add approvals promo banner on feature flags list

### DIFF
--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -36,7 +36,7 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
 
     return (
         <LemonBanner type="info" hideIcon>
-            <div className="flex flex-row gap-8 px-8 items-center justify-evenly">
+            <div className="flex flex-row gap-8 px-8 py-3 items-center justify-evenly">
                 <div>
                     <h3 className="mb-1 text-lg font-semibold">Stop yolo-shipping flag changes</h3>
                     <p className="mb-3">

--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -63,7 +63,7 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
                         </LemonButton>
                     </div>
                 </div>
-                <JudgeHog className="h-30 w-fit shrink-0" />
+                <JudgeHog className="h-30 w-fit shrink-0" alt="Judge hedgehog illustration" />
             </div>
         </LemonBanner>
     )

--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -1,0 +1,70 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { JudgeHog } from 'lib/components/hedgehogs'
+import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { AvailableFeature } from '~/types'
+
+const DISMISS_KEY = 'feature-flags-approvals-promo'
+
+export function ApprovalsPromoBanner(): JSX.Element | null {
+    const { hasAvailableFeature } = useValues(userLogic)
+    const { isAdminOrOwner } = useValues(organizationLogic)
+    const bannerLogic = lemonBannerLogic({ dismissKey: DISMISS_KEY })
+    const { isDismissed } = useValues(bannerLogic)
+    const { dismiss } = useActions(bannerLogic)
+
+    const shouldShow = isAdminOrOwner && hasAvailableFeature(AvailableFeature.APPROVALS)
+
+    useEffect(() => {
+        if (shouldShow && !isDismissed) {
+            posthog.capture('feature flags approvals promo shown')
+        }
+    }, [shouldShow, isDismissed])
+
+    if (!shouldShow || isDismissed) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info" hideIcon>
+            <div className="flex flex-row gap-8 px-8 items-center justify-evenly">
+                <div>
+                    <h3 className="mb-1 text-lg font-semibold">Stop yolo-shipping flag changes</h3>
+                    <p className="mb-3">
+                        Require a second pair of eyes before feature flags go live. Because "I swear I only changed one
+                        condition" is not a rollback strategy.
+                    </p>
+                    <div className="flex flex-row gap-2">
+                        <LemonButton
+                            type="primary"
+                            className="w-fit"
+                            to={urls.approvals()}
+                            onClick={() => posthog.capture('feature flags approvals promo cta clicked')}
+                        >
+                            Set up approvals
+                        </LemonButton>
+                        <LemonButton
+                            type="tertiary"
+                            onClick={() => {
+                                posthog.capture('feature flags approvals promo dismissed')
+                                dismiss()
+                            }}
+                        >
+                            I'm not interested
+                        </LemonButton>
+                    </div>
+                </div>
+                <JudgeHog className="h-30 w-fit shrink-0" />
+            </div>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -49,6 +49,7 @@ import {
     FeatureFlagType,
 } from '~/types'
 
+import { ApprovalsPromoBanner } from './ApprovalsPromoBanner'
 import { BulkDeleteResultsModal } from './BulkDeleteResultsModal'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
 import { FeatureFlagFiltersSection } from './FeatureFlagFilters'
@@ -532,6 +533,7 @@ export function OverViewTab({
                 customHog={FeatureFlagHog}
                 className={cn('my-0')}
             />
+            <ApprovalsPromoBanner />
             <div>{filtersSection}</div>
             <LemonDivider className="my-0" />
             <div className="flex items-center justify-between min-h-9">


### PR DESCRIPTION
## Problem

We need to advertise Approvals a little.

## Changes

Adds a dismissable promo banner to the feature flags list page (Overview tab) that promotes the Approvals feature.

**Visibility conditions:**
- Org is on Scale or Enterprise plan (checked via `hasAvailableFeature(AvailableFeature.APPROVALS)`)
- Current user is admin or owner

<img width="1326" height="488" alt="image" src="https://github.com/user-attachments/assets/e96d3fee-edb6-437a-a52f-49dc16fc757f" />

Stolen from @ReeceJones sorry not sorry 
