### PR TITLE
fix(llma): refactor generation-level clustering to use subqueries

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/activities.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/activities.py
@@ -78,7 +78,7 @@ def _perform_clustering_compute(inputs: ClusteringActivityInputs) -> ClusteringC
         event_filters=inputs.event_filters if inputs.event_filters else None,
     )
 
-    logger.debug(
+    logger.info(
         "perform_clustering_compute_fetched_embeddings",
         num_items=len(item_ids),
         analysis_level=inputs.analysis_level,
@@ -141,6 +141,27 @@ def _perform_clustering_compute(inputs: ClusteringActivityInputs) -> ClusteringC
             "Skipped generations missing trace_id",
             skipped_count=skipped_missing_trace_id,
             team_id=inputs.team_id,
+        )
+
+    if not items:
+        logger.warning(
+            "All items filtered out after summary join",
+            team_id=inputs.team_id,
+            analysis_level=inputs.analysis_level,
+            original_item_count=len(item_ids),
+        )
+        return ClusteringComputeResult(
+            clustering_run_id=clustering_run_id,
+            items=[],
+            labels=[],
+            centroids=[],
+            distances=[],
+            coords_2d=[],
+            centroid_coords_2d=[],
+            probabilities=[],
+            analysis_level=inputs.analysis_level,
+            num_noise_points=0,
+            batch_run_ids={},
         )
 
     embeddings_array = np.array(filtered_embeddings)

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -13,11 +13,6 @@ DEFAULT_MAX_K = 10
 # Minimum traces required for clustering
 MIN_TRACES_FOR_CLUSTERING = 20
 
-# Maximum eligible IDs to return from filter pre-query.
-# These IDs are expanded into an IN(...) clause in subsequent queries;
-# ClickHouse max_query_size is 1MB so we cap to avoid oversized SQL strings.
-MAX_ELIGIBLE_IDS = 20_000
-
 # Coordinator concurrency settings
 DEFAULT_MAX_CONCURRENT_TEAMS = 4  # Max teams to process in parallel
 

--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -31,131 +31,13 @@ logger = structlog.get_logger(__name__)
 AI_EVENT_TYPES = ("$ai_span", "$ai_generation", "$ai_embedding", "$ai_metric", "$ai_feedback", "$ai_trace")
 
 
-def fetch_eligible_trace_ids(
-    team: Team,
-    window_start: datetime,
-    window_end: datetime,
-    event_filters: list[dict],
-    max_samples: int,
-) -> list[ItemId]:
-    """Query trace IDs that have at least one AI event matching the given property filters.
-
-    Queries across all AI event types ($ai_span, $ai_generation, $ai_embedding, etc.)
-    to find traces where at least one event matches the filter criteria. This allows
-    filtering on properties from any event type (e.g., $ai_model on generations,
-    custom properties on spans, etc.).
-
-    Args:
-        team: Team object to query traces for
-        window_start: Start of time window
-        window_end: End of time window
-        event_filters: List of property filter dicts (PostHog standard format)
-        max_samples: Maximum number of traces to return
-
-    Returns:
-        List of trace IDs where at least one event matches the filter criteria
-    """
-    if not event_filters:
-        return []
-
-    # Build property filter expression from the list of filters
+def _build_property_filter_expr(event_filters: list[dict], team: Team) -> ast.Expr:
+    """Build an AND-combined property filter AST expression from a list of filter dicts."""
     property_exprs: list[ast.Expr] = []
     for prop in event_filters:
         property_exprs.append(property_to_expr(prop, team))
 
-    # Combine filters with AND logic
-    property_filter_expr = ast.And(exprs=property_exprs) if len(property_exprs) > 1 else property_exprs[0]
-
-    # Build event types tuple for IN clause
-    event_types_tuple = ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES])
-
-    query = parse_select(
-        """
-        SELECT DISTINCT properties.$ai_trace_id as trace_id
-        FROM events
-        WHERE event IN {event_types}
-            AND timestamp >= {start_dt}
-            AND timestamp < {end_dt}
-            AND isNotNull(properties.$ai_trace_id)
-            AND properties.$ai_trace_id != ''
-            AND {property_filters}
-        ORDER BY rand()
-        LIMIT {max_samples}
-        """
-    )
-
-    with tags_context(product=Product.LLM_ANALYTICS):
-        result = execute_hogql_query(
-            query_type="EligibleTraceIdsForClustering",
-            query=query,
-            placeholders={
-                "event_types": event_types_tuple,
-                "start_dt": ast.Constant(value=window_start),
-                "end_dt": ast.Constant(value=window_end),
-                "property_filters": property_filter_expr,
-                "max_samples": ast.Constant(
-                    value=min(max_samples * 50, constants.MAX_ELIGIBLE_IDS)
-                ),  # Oversample generously but cap to avoid oversized IN-clause queries
-            },
-            team=team,
-        )
-
-    rows = result.results or []
-    return [row[0] for row in rows if row[0]]
-
-
-def fetch_generation_ids_for_traces(
-    team: Team,
-    trace_ids: list[ItemId],
-    window_start: datetime,
-    window_end: datetime,
-) -> list[ItemId]:
-    """Map trace IDs to generation event UUIDs by querying $ai_generation events.
-
-    Generation embeddings are keyed by event UUID (not $ai_generation_id), matching
-    the sampling logic in trace_summarization/sampling.py which uses
-    argMaxIf(uuid, timestamp, ...) as the generation identifier.
-
-    Args:
-        team: Team object to query for
-        trace_ids: List of trace IDs to find generations for
-        window_start: Start of time window
-        window_end: End of time window
-
-    Returns:
-        List of generation event UUIDs belonging to the given traces
-    """
-    if not trace_ids:
-        return []
-
-    trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids])
-
-    query = parse_select(
-        """
-        SELECT DISTINCT uuid
-        FROM events
-        WHERE event = {event_name}
-            AND timestamp >= {start_dt}
-            AND timestamp < {end_dt}
-            AND properties.$ai_trace_id IN {trace_ids}
-        """
-    )
-
-    with tags_context(product=Product.LLM_ANALYTICS):
-        result = execute_hogql_query(
-            query_type="GenerationIdsForTraces",
-            query=query,
-            placeholders={
-                "event_name": ast.Constant(value="$ai_generation"),
-                "start_dt": ast.Constant(value=window_start),
-                "end_dt": ast.Constant(value=window_end),
-                "trace_ids": trace_ids_tuple,
-            },
-            team=team,
-        )
-
-    rows = result.results or []
-    return [str(row[0]) for row in rows if row[0]]
+    return ast.And(exprs=property_exprs) if len(property_exprs) > 1 else property_exprs[0]
 
 
 def fetch_item_embeddings_for_clustering(
@@ -168,8 +50,9 @@ def fetch_item_embeddings_for_clustering(
 ) -> tuple[list[ItemId], ItemEmbeddings, ItemBatchRunIds]:
     """Query item IDs and embeddings from document_embeddings table using HogQL.
 
-    If event_filters are provided, first queries for eligible trace IDs from AI events
-    matching the filter criteria, then fetches embeddings only for those items.
+    When event_filters are provided, uses ClickHouse subqueries to push the
+    trace→generation→embedding join into the database rather than materializing
+    intermediate ID lists in Python.
 
     Args:
         team: Team object to query embeddings for
@@ -190,39 +73,15 @@ def fetch_item_embeddings_for_clustering(
         else constants.LLMA_TRACE_DOCUMENT_TYPE
     )
 
-    # If filters provided, first get eligible item IDs.
-    # For trace-level: eligible IDs are trace IDs directly.
-    # For generation-level: find eligible trace IDs, then map to generation IDs.
-    eligible_item_ids: list[ItemId] | None = None
-    if event_filters:
-        eligible_trace_ids = fetch_eligible_trace_ids(
-            team=team,
-            window_start=window_start,
-            window_end=window_end,
-            event_filters=event_filters,
-            max_samples=max_samples,
-        )
-        if not eligible_trace_ids:
-            return [], {}, {}
+    has_filters = bool(event_filters)
 
-        if analysis_level == "generation":
-            eligible_item_ids = fetch_generation_ids_for_traces(
-                team=team,
-                trace_ids=eligible_trace_ids,
-                window_start=window_start,
-                window_end=window_end,
-            )
-            if not eligible_item_ids:
-                return [], {}, {}
-        else:
-            eligible_item_ids = eligible_trace_ids
-
-    # Build base query - add IN clause if we have eligible item IDs
-    # We also fetch rendering to link embeddings to their source summarization run
+    # Build the appropriate query based on (has_filters, analysis_level)
     # Backwards compatibility: support both old and new document type formats
     # - New format: document_type = "llm-trace-summary-detailed" (mode in document_type, batch_run_id in rendering)
     # - Old format: document_type = "llm-trace-summary" AND rendering = "llma_trace_detailed"
-    if eligible_item_ids:
+    if has_filters and analysis_level == "generation":
+        # Generation-level with filters: 2-level nested subquery
+        # embeddings WHERE document_id IN (SELECT generation UUIDs WHERE trace_id IN (SELECT filtered trace_ids))
         query = parse_select(
             """
             SELECT document_id, embedding, rendering
@@ -235,13 +94,58 @@ def fetch_item_embeddings_for_clustering(
                     OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
                 )
                 AND length(embedding) > 0
-                AND document_id IN {eligible_ids}
+                AND document_id IN (
+                    SELECT DISTINCT toString(uuid)
+                    FROM events
+                    WHERE event = {generation_event}
+                        AND timestamp >= {start_dt}
+                        AND timestamp < {end_dt}
+                        AND properties.$ai_trace_id IN (
+                            SELECT DISTINCT properties.$ai_trace_id
+                            FROM events
+                            WHERE event IN {event_types}
+                                AND timestamp >= {start_dt}
+                                AND timestamp < {end_dt}
+                                AND isNotNull(properties.$ai_trace_id)
+                                AND properties.$ai_trace_id != ''
+                                AND {property_filters}
+                        )
+                )
             ORDER BY rand()
             LIMIT {max_samples}
             """
         )
-        eligible_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=iid) for iid in eligible_item_ids])
+    elif has_filters:
+        # Trace-level with filters: 1-level subquery
+        # embeddings WHERE document_id IN (SELECT filtered trace_ids)
+        query = parse_select(
+            """
+            SELECT document_id, embedding, rendering
+            FROM raw_document_embeddings
+            WHERE timestamp >= {start_dt}
+                AND timestamp < {end_dt}
+                AND product = {product}
+                AND (
+                    document_type = {document_type_new}
+                    OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
+                )
+                AND length(embedding) > 0
+                AND document_id IN (
+                    SELECT DISTINCT properties.$ai_trace_id
+                    FROM events
+                    WHERE event IN {event_types}
+                        AND timestamp >= {start_dt}
+                        AND timestamp < {end_dt}
+                        AND isNotNull(properties.$ai_trace_id)
+                        AND properties.$ai_trace_id != ''
+                        AND {property_filters}
+                )
+            ORDER BY rand()
+            LIMIT {max_samples}
+            """
+        )
     else:
+        # No filters: simple query on embeddings table
         query = parse_select(
             """
             SELECT document_id, embedding, rendering
@@ -258,7 +162,6 @@ def fetch_item_embeddings_for_clustering(
             LIMIT {max_samples}
             """
         )
-        eligible_ids_tuple = None
 
     placeholders: dict[str, ast.Expr] = {
         "start_dt": ast.Constant(value=window_start),
@@ -269,8 +172,15 @@ def fetch_item_embeddings_for_clustering(
         "rendering_legacy": ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY),
         "max_samples": ast.Constant(value=max_samples),
     }
-    if eligible_ids_tuple:
-        placeholders["eligible_ids"] = eligible_ids_tuple
+
+    if has_filters:
+        assert event_filters is not None
+        event_types_tuple = ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES])
+        placeholders["event_types"] = event_types_tuple
+        placeholders["property_filters"] = _build_property_filter_expr(event_filters, team)
+
+        if analysis_level == "generation":
+            placeholders["generation_event"] = ast.Constant(value="$ai_generation")
 
     with tags_context(product=Product.LLM_ANALYTICS):
         result = execute_hogql_query(
@@ -282,9 +192,11 @@ def fetch_item_embeddings_for_clustering(
 
     rows = result.results or []
 
-    logger.debug(
+    logger.info(
         "fetch_item_embeddings_for_clustering_result",
         num_rows=len(rows),
+        analysis_level=analysis_level,
+        has_filters=has_filters,
     )
 
     # Build all maps in single loop to ensure item_ids, embeddings_map, and batch_run_ids are aligned

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_data.py
@@ -9,8 +9,7 @@ from parameterized import parameterized
 
 from posthog.temporal.llm_analytics.trace_clustering.data import (
     AI_EVENT_TYPES,
-    fetch_eligible_trace_ids,
-    fetch_generation_ids_for_traces,
+    _build_property_filter_expr,
     fetch_item_embeddings_for_clustering,
     fetch_item_summaries,
 )
@@ -30,125 +29,28 @@ def mock_team(db):
     return team
 
 
-class TestFetchEligibleTraceIds:
-    def test_returns_empty_list_when_no_filters(self, mock_team):
-        result = fetch_eligible_trace_ids(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            event_filters=[],
-            max_samples=100,
+class TestBuildPropertyFilterExpr:
+    def test_single_filter_returns_expr_directly(self, mock_team):
+        from posthog.hogql import ast
+
+        result = _build_property_filter_expr(
+            [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}],
+            mock_team,
         )
+        assert not isinstance(result, ast.And)
 
-        assert result == []
+    def test_multiple_filters_returns_and_expr(self, mock_team):
+        from posthog.hogql import ast
 
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_builds_property_filter_expression(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = [("trace_1",), ("trace_2",), ("trace_3",)]
-        mock_execute.return_value = mock_result
-
-        event_filters = [
-            {"key": "$ai_model", "value": "gpt-4", "operator": "exact"},
-        ]
-
-        result = fetch_eligible_trace_ids(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            event_filters=event_filters,
-            max_samples=100,
+        result = _build_property_filter_expr(
+            [
+                {"key": "$ai_model", "value": "gpt-4", "operator": "exact"},
+                {"key": "environment", "value": "production", "operator": "exact"},
+            ],
+            mock_team,
         )
-
-        assert result == ["trace_1", "trace_2", "trace_3"]
-        mock_execute.assert_called_once()
-        call_kwargs = mock_execute.call_args.kwargs
-        assert call_kwargs["query_type"] == "EligibleTraceIdsForClustering"
-        assert "placeholders" in call_kwargs
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_combines_multiple_filters_with_and(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = [("trace_1",)]
-        mock_execute.return_value = mock_result
-
-        event_filters = [
-            {"key": "$ai_model", "value": "gpt-4", "operator": "exact"},
-            {"key": "environment", "value": "production", "operator": "exact"},
-        ]
-
-        result = fetch_eligible_trace_ids(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            event_filters=event_filters,
-            max_samples=100,
-        )
-
-        assert result == ["trace_1"]
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_handles_empty_results(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = []
-        mock_execute.return_value = mock_result
-
-        event_filters = [{"key": "$ai_model", "value": "nonexistent", "operator": "exact"}]
-
-        result = fetch_eligible_trace_ids(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            event_filters=event_filters,
-            max_samples=100,
-        )
-
-        assert result == []
-
-
-class TestFetchGenerationIdsForTraces:
-    def test_returns_empty_list_when_no_trace_ids(self, mock_team):
-        result = fetch_generation_ids_for_traces(
-            team=mock_team,
-            trace_ids=[],
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-        )
-
-        assert result == []
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_maps_trace_ids_to_generation_ids(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = [("gen_1",), ("gen_2",), ("gen_3",)]
-        mock_execute.return_value = mock_result
-
-        result = fetch_generation_ids_for_traces(
-            team=mock_team,
-            trace_ids=["trace_1", "trace_2"],
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-        )
-
-        assert result == ["gen_1", "gen_2", "gen_3"]
-        mock_execute.assert_called_once()
-        call_kwargs = mock_execute.call_args.kwargs
-        assert call_kwargs["query_type"] == "GenerationIdsForTraces"
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_handles_empty_results(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = []
-        mock_execute.return_value = mock_result
-
-        result = fetch_generation_ids_for_traces(
-            team=mock_team,
-            trace_ids=["trace_1"],
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-        )
-
-        assert result == []
+        assert isinstance(result, ast.And)
+        assert len(result.exprs) == 2
 
 
 class TestFetchItemEmbeddingsForClustering:
@@ -198,14 +100,28 @@ class TestFetchItemEmbeddingsForClustering:
         assert batch_run_ids == {}
         assert trace_ids == ["trace_1", "trace_2"]
 
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_eligible_trace_ids")
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_with_event_filters_fetches_eligible_ids_first(self, mock_execute, mock_fetch_eligible, mock_team):
-        mock_fetch_eligible.return_value = ["trace_1", "trace_2"]
+    def test_no_filters_uses_simple_query(self, mock_execute, mock_team):
         mock_result = MagicMock()
-        mock_result.results = [
-            ("trace_1", [0.1, 0.2], "batch_123"),
-        ]
+        mock_result.results = [("trace_1", [0.1, 0.2], "batch_123")]
+        mock_execute.return_value = mock_result
+
+        fetch_item_embeddings_for_clustering(
+            team=mock_team,
+            window_start=datetime(2025, 1, 1, tzinfo=UTC),
+            window_end=datetime(2025, 1, 8, tzinfo=UTC),
+            max_samples=100,
+        )
+
+        call_kwargs = mock_execute.call_args.kwargs
+        # No filters: placeholders should not contain event_types or property_filters
+        assert "event_types" not in call_kwargs["placeholders"]
+        assert "property_filters" not in call_kwargs["placeholders"]
+
+    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
+    def test_trace_level_with_filters_uses_subquery(self, mock_execute, mock_team):
+        mock_result = MagicMock()
+        mock_result.results = [("trace_1", [0.1, 0.2], "batch_123")]
         mock_execute.return_value = mock_result
 
         event_filters = [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}]
@@ -218,35 +134,17 @@ class TestFetchItemEmbeddingsForClustering:
             event_filters=event_filters,
         )
 
-        mock_fetch_eligible.assert_called_once()
         assert trace_ids == ["trace_1"]
+        mock_execute.assert_called_once()
+        call_kwargs = mock_execute.call_args.kwargs
+        # With filters: placeholders should contain event_types and property_filters
+        assert "event_types" in call_kwargs["placeholders"]
+        assert "property_filters" in call_kwargs["placeholders"]
+        # Trace-level should not have generation_event placeholder
+        assert "generation_event" not in call_kwargs["placeholders"]
 
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_eligible_trace_ids")
-    def test_with_filters_returns_empty_when_no_eligible_traces(self, mock_fetch_eligible, mock_team):
-        mock_fetch_eligible.return_value = []
-
-        event_filters = [{"key": "$ai_model", "value": "nonexistent", "operator": "exact"}]
-
-        trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            max_samples=100,
-            event_filters=event_filters,
-        )
-
-        assert trace_ids == []
-        assert embeddings_map == {}
-        assert batch_run_ids == {}
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_generation_ids_for_traces")
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_eligible_trace_ids")
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_generation_level_with_filters_maps_trace_ids_to_generation_ids(
-        self, mock_execute, mock_fetch_eligible, mock_fetch_gen_ids, mock_team
-    ):
-        mock_fetch_eligible.return_value = ["trace_1", "trace_2"]
-        mock_fetch_gen_ids.return_value = ["gen_1", "gen_2", "gen_3"]
+    def test_generation_level_with_filters_uses_nested_subquery(self, mock_execute, mock_team):
         mock_result = MagicMock()
         mock_result.results = [
             ("gen_1", [0.1, 0.2], "batch_123"),
@@ -265,26 +163,44 @@ class TestFetchItemEmbeddingsForClustering:
             event_filters=event_filters,
         )
 
-        mock_fetch_eligible.assert_called_once()
-        mock_fetch_gen_ids.assert_called_once_with(
+        assert item_ids == ["gen_1", "gen_2"]
+        mock_execute.assert_called_once()
+        call_kwargs = mock_execute.call_args.kwargs
+        # Generation-level with filters should have generation_event placeholder
+        assert "generation_event" in call_kwargs["placeholders"]
+        assert "event_types" in call_kwargs["placeholders"]
+        assert "property_filters" in call_kwargs["placeholders"]
+
+    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
+    def test_with_filters_returns_empty_when_no_results(self, mock_execute, mock_team):
+        mock_result = MagicMock()
+        mock_result.results = []
+        mock_execute.return_value = mock_result
+
+        event_filters = [{"key": "$ai_model", "value": "nonexistent", "operator": "exact"}]
+
+        trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
             team=mock_team,
-            trace_ids=["trace_1", "trace_2"],
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
+            max_samples=100,
+            event_filters=event_filters,
         )
-        assert item_ids == ["gen_1", "gen_2"]
 
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_generation_ids_for_traces")
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.fetch_eligible_trace_ids")
-    def test_generation_level_with_filters_returns_empty_when_no_generation_ids(
-        self, mock_fetch_eligible, mock_fetch_gen_ids, mock_team
-    ):
-        mock_fetch_eligible.return_value = ["trace_1"]
-        mock_fetch_gen_ids.return_value = []
+        assert trace_ids == []
+        assert embeddings_map == {}
+        assert batch_run_ids == {}
 
-        event_filters = [{"key": "ai_product", "value": "posthog_ai", "operator": "exact"}]
+    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
+    def test_single_query_for_all_cases(self, mock_execute, mock_team):
+        """All cases (no filters, trace+filters, generation+filters) use a single execute_hogql_query call."""
+        mock_result = MagicMock()
+        mock_result.results = [("id_1", [0.1], "batch_1")]
+        mock_execute.return_value = mock_result
 
-        item_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
+        # Generation-level with filters — previously required 3 separate queries
+        event_filters = [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}]
+        fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
@@ -293,9 +209,8 @@ class TestFetchItemEmbeddingsForClustering:
             event_filters=event_filters,
         )
 
-        assert item_ids == []
-        assert embeddings_map == {}
-        assert batch_run_ids == {}
+        # Should be exactly 1 query, not 3
+        assert mock_execute.call_count == 1
 
 
 class TestFetchItemSummaries:


### PR DESCRIPTION
## Problem

Generation-level clustering returns 0 items for teams despite matching embeddings existing in ClickHouse. The root cause is the data pipeline materializing ~117K generation UUIDs into Python and building a massive `IN ('uuid1', ..., 'uuid117550')` clause (~4.7 MB), which silently fails. When the same logic is expressed as a ClickHouse subquery (`IN (SELECT ...)`), it works correctly.

## Changes

**`data.py`** - Replace 3-hop Python ID materialization with inline ClickHouse subqueries:
- Remove `fetch_eligible_trace_ids` and `fetch_generation_ids_for_traces` (only used here)
- Three query templates based on `(has_filters, analysis_level)`:
  - No filters: simple embeddings query (unchanged)
  - Trace-level + filters: 1-level subquery (`document_id IN (SELECT trace_ids)`)
  - Generation-level + filters: 2-level nested subquery (`document_id IN (SELECT gen_uuids WHERE trace_id IN (SELECT filtered_traces))`)
- Extract `_build_property_filter_expr` helper
- Upgrade logging from debug to info for production visibility

**`constants.py`** - Remove `MAX_ELIGIBLE_IDS` constant (no longer needed without Python-side materialization)

**`activities.py`** - Add empty-items guard after summary filtering loop to return early instead of crashing on empty numpy array. Upgrade embedding count logging to info level.

**`tests/test_data.py`** - Remove tests for deleted functions, add tests for new subquery approach and `_build_property_filter_expr` helper.

## How did you test this code?

- All 105 clustering tests pass: `pytest posthog/temporal/llm_analytics/trace_clustering/`
- Verified generation-level subquery returns 1,516 results for team 2 via ClickHouse (previously returned 0)

## Publish to changelog?

No