### PR TITLE
feat(twig): twig cloud runs signals ux improvements

### DIFF
--- a/products/tasks/frontend/components/CollapsibleContent.tsx
+++ b/products/tasks/frontend/components/CollapsibleContent.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { IconChevronDown } from '@posthog/icons'
+
+const DEFAULT_MAX_HEIGHT = 120
+
+interface CollapsibleContentProps {
+    maxHeight?: number
+    gradientColor?: string
+    children: React.ReactNode
+}
+
+export function CollapsibleContent({
+    maxHeight = DEFAULT_MAX_HEIGHT,
+    gradientColor = '--bg-light',
+    children,
+}: CollapsibleContentProps): JSX.Element {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [isOverflowing, setIsOverflowing] = useState(false)
+    const contentRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const el = contentRef.current
+        if (el) {
+            setIsOverflowing(el.scrollHeight > maxHeight)
+        }
+    }, [children, maxHeight])
+
+    return (
+        <>
+            <div
+                ref={contentRef}
+                className="relative overflow-hidden transition-all"
+                style={!isExpanded && isOverflowing ? { maxHeight } : undefined}
+            >
+                {children}
+                {!isExpanded && isOverflowing && (
+                    <div
+                        className="pointer-events-none absolute inset-x-0 bottom-0 h-16"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ background: `linear-gradient(transparent, var(${gradientColor}))` }}
+                    />
+                )}
+            </div>
+            {isOverflowing && (
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded((prev) => !prev)}
+                    className="mt-1 flex items-center gap-1 text-xs text-muted hover:text-default cursor-pointer"
+                >
+                    <IconChevronDown
+                        className="transition-transform"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={isExpanded ? { transform: 'rotate(180deg)' } : undefined}
+                    />
+                    {isExpanded ? 'Show less' : 'Show more'}
+                </button>
+            )}
+        </>
+    )
+}

--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -4,6 +4,7 @@ import { IconArchive, IconExternal, IconGithub, IconPlay } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { urls } from 'scenes/urls'
 
@@ -17,6 +18,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { taskDetailSceneLogic } from '../logics/taskDetailSceneLogic'
+import { CollapsibleContent } from './CollapsibleContent'
 import { TaskRunItem } from './TaskRunItem'
 import { TaskSessionView } from './TaskSessionView'
 
@@ -98,7 +100,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
 
             <SceneTitleSection
                 name={task?.title}
-                description={task?.description}
+                description={null}
                 resourceType={{ type: 'task' }}
                 isLoading={false}
                 canEdit={false}
@@ -135,6 +137,16 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                     </div>
                 }
             />
+
+            {task.description && (
+                <div className="relative -mt-2 mb-2 px-2">
+                    <CollapsibleContent>
+                        <LemonMarkdown lowKeyHeadings className="text-sm">
+                            {task.description}
+                        </LemonMarkdown>
+                    </CollapsibleContent>
+                </div>
+            )}
 
             {runsLoading ? (
                 <div className="flex items-center justify-center h-32">

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -8,6 +8,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { LogEntry, parseLogs } from '../lib/parse-logs'
 import { TaskRun } from '../types'
+import { CollapsibleContent } from './CollapsibleContent'
 import { TaskRunStatusBadge } from './TaskRunStatusBadge'
 import { ConsoleLogEntry } from './session/ConsoleLogEntry'
 import { ToolCallEntry } from './session/ToolCallEntry'
@@ -86,7 +87,9 @@ function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
                         )}
                     </div>
                     <div className="border-r-2 border-muted pr-3 max-w-[90%] text-right">
-                        <div className="text-sm whitespace-pre-wrap">{entry.message}</div>
+                        <CollapsibleContent gradientColor="--bg-3000">
+                            <div className="text-sm whitespace-pre-wrap">{entry.message}</div>
+                        </CollapsibleContent>
                     </div>
                 </div>
             )


### PR DESCRIPTION
## Problem

- Task descriptions and user message in run logs collapsible
- Fixed required_scopes on signal report artifacts endpoint

**Before**:

<img width="1209" height="1211" alt="CleanShot 2026-02-19 at 5  02 01" src="https://github.com/user-attachments/assets/8ca9a9e4-7d2a-49ac-a719-5cf5f773d6d6" />
<img width="1191" height="752" alt="CleanShot 2026-02-19 at 5  02 13" src="https://github.com/user-attachments/assets/97c42977-0463-4abe-9bbb-f47b14d204c8" />


**After**:
<img width="1190" height="632" alt="CleanShot 2026-02-19 at 4  50 22" src="https://github.com/user-attachments/assets/cfb61244-45d9-4464-9f79-054a52d679be" />
