### PR TITLE
feat(llma): add cluster color border to cluster cards

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -55,7 +55,11 @@ export function ClusterCard({
                 isOutlierCluster ? 'bg-surface-primary border-dashed border-warning-dark' : 'bg-surface-primary'
             }`}
             // eslint-disable-next-line react/forbid-dom-props
-            style={{ borderLeftWidth: 3, borderLeftColor: clusterColor, borderLeftStyle: 'solid' }}
+            style={{
+                borderLeftWidth: 3,
+                borderLeftColor: clusterColor,
+                borderLeftStyle: isOutlierCluster ? 'dashed' : 'solid',
+            }}
         >
             {/* Card Header */}
             <div

--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -1,12 +1,13 @@
 import { IconChevronDown, IconChevronRight } from '@posthog/icons'
 import { LemonButton, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
+import { getSeriesColor } from 'lib/colors'
 import { urls } from 'scenes/urls'
 
 import { formatErrorRate, formatLLMCost, formatLLMLatency, formatTokens } from '../utils'
 import { ClusterDescription } from './ClusterDescriptionComponents'
 import { ClusterTraceList } from './ClusterTraceList'
-import { NOISE_CLUSTER_ID } from './constants'
+import { NOISE_CLUSTER_ID, OUTLIER_COLOR } from './constants'
 import { Cluster, ClusterMetrics, ClusteringLevel, TraceSummary } from './types'
 
 interface ClusterCardProps {
@@ -38,6 +39,8 @@ export function ClusterCard({
     const isOutlierCluster = cluster.cluster_id === NOISE_CLUSTER_ID
     const itemLabel = clusteringLevel === 'generation' ? 'generations' : 'traces'
 
+    const clusterColor = isOutlierCluster ? OUTLIER_COLOR : getSeriesColor(cluster.cluster_id)
+
     // Check if we have any metrics to show
     const hasMetrics =
         metrics &&
@@ -51,6 +54,8 @@ export function ClusterCard({
             className={`border rounded-lg overflow-hidden transition-all ${
                 isOutlierCluster ? 'bg-surface-primary border-dashed border-warning-dark' : 'bg-surface-primary'
             }`}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ borderLeftWidth: 3, borderLeftColor: clusterColor, borderLeftStyle: 'solid' }}
         >
             {/* Card Header */}
             <div


### PR DESCRIPTION
## Changes

Add a colored left border to each cluster card using the same series color as the distribution bar and scatter plot, visually linking cards to their corresponding cluster.

## How did you test this code?

- Verified TypeScript compiles without errors
- Color logic reuses existing `getSeriesColor()` / `OUTLIER_COLOR` from the distribution bar