### PR TITLE
fix: Project token naming

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -146,8 +146,8 @@ export const SETTINGS_MAP: SettingSection[] = [
         settings: [
             {
                 id: 'variables',
-                title: 'Project API key & ID',
-                description: 'Your project API key and ID used to connect SDKs and APIs to this environment.',
+                title: 'Project token & ID',
+                description: 'Your project token and ID used to connect SDKs and APIs to this environment.',
                 component: <TeamVariables />,
                 keywords: ['api key', 'token', 'project id'],
             },

--- a/frontend/src/scenes/settings/environment/TeamSettings.tsx
+++ b/frontend/src/scenes/settings/environment/TeamSettings.tsx
@@ -128,9 +128,9 @@ export function TeamVariables(): JSX.Element {
     const openDialog = (): void => {
         LemonDialog.openForm({
             maxWidth: 480,
-            title: 'Reset project API key?',
+            title: 'Reset project token?',
             description:
-                'This will immediately invalidate your current API key. Any apps, websites, or services using it will stop sending data to PostHog until you update them with the new key. This action cannot be undone.',
+                'This will immediately invalidate your current project token. Any apps, websites, or services using it will stop sending data to PostHog until you update them with the new token. This action cannot be undone.',
             initialValues: { confirmation: '' },
             content: (
                 <LemonField name="confirmation">
@@ -149,7 +149,7 @@ export function TeamVariables(): JSX.Element {
             },
             primaryButtonProps: {
                 status: 'danger',
-                children: 'Reset API key',
+                children: 'Reset token',
             },
             onSubmit: () => {
                 resetToken()
@@ -160,17 +160,17 @@ export function TeamVariables(): JSX.Element {
     return (
         <div className="space-y-4 max-w-200">
             <div className="border rounded p-4 space-y-3 bg-bg-light">
-                <LemonLabel className="mb-0">Project API key</LemonLabel>
+                <LemonLabel className="mb-0">Project token</LemonLabel>
                 <CodeSnippet
                     compact
-                    thing="project API key"
+                    thing="project token"
                     actions={
                         isTeamTokenResetAvailable ? (
                             <LemonButton
                                 icon={<IconRefresh />}
                                 noPadding
                                 onClick={openDialog}
-                                tooltip="Reset API key"
+                                tooltip="Reset token"
                             />
                         ) : undefined
                     }

--- a/frontend/src/scenes/settings/environment/TeamSettings.tsx
+++ b/frontend/src/scenes/settings/environment/TeamSettings.tsx
@@ -166,12 +166,7 @@ export function TeamVariables(): JSX.Element {
                     thing="project token"
                     actions={
                         isTeamTokenResetAvailable ? (
-                            <LemonButton
-                                icon={<IconRefresh />}
-                                noPadding
-                                onClick={openDialog}
-                                tooltip="Reset token"
-                            />
+                            <LemonButton icon={<IconRefresh />} noPadding onClick={openDialog} tooltip="Reset token" />
                         ) : undefined
                     }
                 >


### PR DESCRIPTION
## Problem

To improve clarity and consistency, the term "Project API key" is being updated to "Project token" across the UI.

## Changes

- **`SettingsMap.tsx`**: Updated section title and description to "Project token & ID".
- **`TeamSettings.tsx`**: Renamed all instances of "Project API key" to "Project token" in labels, reset dialogs, tooltips, and code snippets.

## How did you test this code?

- Verified changes compile and adhere to formatting standards using `yarn lint --fix` and `yarn prettier --write`.
- Manually checked the relevant settings UI pages to confirm the text changes.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771521112855819?thread_ts=1771521112.855819&cid=C0ACRAMJUAG)

<p><a href="https://cursor.com/background-agent?bcId=bc-6675a815-bcc8-5a82-9c86-d828df8f4bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6675a815-bcc8-5a82-9c86-d828df8f4bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

