### PR TITLE
fix(hooks): use strict equality in useResizeObserver

### DIFF
--- a/frontend/src/lib/hooks/useResizeObserver.ts
+++ b/frontend/src/lib/hooks/useResizeObserver.ts
@@ -40,7 +40,7 @@ export function useResizeBreakpoints<T extends string>(
                     newSize = breakpoints[key]
                 }
             }
-            if (newSize != size) {
+            if (newSize !== size) {
                 setSize(newSize)
             }
         },


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change