### PR TITLE
fix(hooks): convert useSecondRender to TypeScript

### DIFF
--- a/frontend/src/lib/hooks/useSecondRender.ts
+++ b/frontend/src/lib/hooks/useSecondRender.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-export function useSecondRender(callback) {
+export function useSecondRender(callback: () => void): boolean {
     const [secondRender, setSecondRender] = useState(false)
 
     useEffect(() => {


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change