### PR TITLE
fix(hooks): use RefObject type and null init in useD3

### DIFF
--- a/frontend/src/lib/hooks/useD3.ts
+++ b/frontend/src/lib/hooks/useD3.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import { MutableRefObject, useEffect, useRef } from 'react'
+import { RefObject, useEffect, useRef } from 'react'
 
 export type D3Selector = d3.Selection<any, any, any, any>
 export type D3Transition = d3.Transition<any, any, any, any>
@@ -7,15 +7,14 @@ export type D3Transition = d3.Transition<any, any, any, any>
 export const useD3 = (
     renderChartFn: (svg: D3Selector) => void,
     dependencies: any[] = []
-): MutableRefObject<any> | null => {
-    const ref = useRef<HTMLDivElement>()
+): RefObject<HTMLDivElement> => {
+    const ref = useRef<HTMLDivElement>(null)
 
     useEffect(
         () => {
-            if (ref.current !== undefined) {
+            if (ref.current) {
                 renderChartFn(d3.select(ref.current))
             }
-            return () => {}
         },
 
         dependencies


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change