### PR TITLE
fix(hooks): clean up requestAnimationFrame in useColumnWidths

### DIFF
--- a/frontend/src/lib/hooks/useColumnWidths.ts
+++ b/frontend/src/lib/hooks/useColumnWidths.ts
@@ -48,13 +48,13 @@ export function useColumnWidths({ columnKeys, columns }: UseColumnWidthsProps): 
         }
     }, [columnKeys, columns])
 
-    // Measure column widths after table renders
+    // Measure column widths after table renders, using rAF to ensure DOM is ready
     useEffect(() => {
         if (columnKeys && columnKeys.length > 0) {
-            // Use requestAnimationFrame to ensure DOM is ready
-            requestAnimationFrame(() => {
+            const id = requestAnimationFrame(() => {
                 measureColumnWidths()
             })
+            return () => cancelAnimationFrame(id)
         }
     }, [measureColumnWidths, columnKeys])
 


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change