### PR TITLE
fix(hooks): use useLayoutEffect in useFloatingContainerContext

### DIFF
--- a/frontend/src/lib/hooks/useFloatingContainerContext.ts
+++ b/frontend/src/lib/hooks/useFloatingContainerContext.ts
@@ -1,4 +1,4 @@
-import { RefObject, createContext, useContext, useEffect, useState } from 'react'
+import { RefObject, createContext, useContext, useLayoutEffect, useState } from 'react'
 
 /**
  * Typically floating things like popovers and tooltips are portaled to the root of the document, but sometimes
@@ -15,7 +15,7 @@ export const useFloatingContainer = (): HTMLElement | null | undefined => {
     const ref = useContext(FloatingContainerContext)
     const [el, setEl] = useState<HTMLElement | null | undefined>(undefined)
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         setEl(ref?.current)
     }, [ref])
 


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change