### PR TITLE
fix(hooks): simplify useKeyHeld from Set to boolean ref

### DIFF
--- a/frontend/src/lib/hooks/useKeyHeld.tsx
+++ b/frontend/src/lib/hooks/useKeyHeld.tsx
@@ -1,56 +1,29 @@
-import { DependencyList, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useEventListener } from 'lib/hooks/useEventListener'
 
-export function useKeyHeld(key: string, deps?: DependencyList): boolean {
-    const keysHeldRef = useRef(new Set<string>())
+export function useKeyHeld(key: string): boolean {
+    const isHeldRef = useRef(false)
     const [keyHeld, setKeyHeld] = useState(false)
 
-    const checkKeysHeld = (): void => {
-        setKeyHeld(keysHeldRef.current.has(key))
-    }
-
     useEffect(() => {
-        checkKeysHeld()
-    }, [key, ...(deps || [])]) // oxlint-disable-line react-hooks/exhaustive-deps
+        isHeldRef.current = false
+        setKeyHeld(false)
+    }, [key])
 
-    useEventListener(
-        'keydown',
-        (event) => {
-            const eventKey = event.key
-            // Only update state if this is the key we're watching
-            if (eventKey !== key) {
-                return
-            }
-            if (!keysHeldRef.current.has(eventKey)) {
-                const keysHeldCopy = new Set(keysHeldRef.current)
-                keysHeldCopy.add(eventKey)
-                keysHeldRef.current = keysHeldCopy
-                checkKeysHeld()
-            }
-        },
-        undefined,
-        [...(deps || [])]
-    )
+    useEventListener('keydown', (event) => {
+        if (event.key === key && !isHeldRef.current) {
+            isHeldRef.current = true
+            setKeyHeld(true)
+        }
+    })
 
-    useEventListener(
-        'keyup',
-        (event) => {
-            const eventKey = event.key
-            // Only update state if this is the key we're watching
-            if (eventKey !== key) {
-                return
-            }
-            if (keysHeldRef.current.has(eventKey)) {
-                const keysHeldCopy = new Set(keysHeldRef.current)
-                keysHeldCopy.delete(eventKey)
-                keysHeldRef.current = keysHeldCopy
-                checkKeysHeld()
-            }
-        },
-        undefined,
-        [...(deps || [])]
-    )
+    useEventListener('keyup', (event) => {
+        if (event.key === key && isHeldRef.current) {
+            isHeldRef.current = false
+            setKeyHeld(false)
+        }
+    })
 
     return keyHeld
 }


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks 

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change