### PR TITLE
fix(hooks): fix stale closure in useLocalStorage setValue

### DIFF
--- a/frontend/src/lib/hooks/useLocalStorage.ts
+++ b/frontend/src/lib/hooks/useLocalStorage.ts
@@ -43,12 +43,13 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: T 
 
     const setValue = useCallback(
         (value: T | ((prev: T) => T)) => {
-            const valueToStore = value instanceof Function ? value(storedValue) : value
-            setStoredValue(valueToStore)
-            setStoredValueInStorage(key, valueToStore)
-            getStoredValue(key, defaultValue)
+            setStoredValue((prev) => {
+                const valueToStore = value instanceof Function ? value(prev) : value
+                setStoredValueInStorage(key, valueToStore)
+                return valueToStore
+            })
         },
-        [key, storedValue, defaultValue]
+        [key]
     )
 
     return [storedValue, setValue]

--- a/frontend/src/lib/hooks/useLocalStorage.ts
+++ b/frontend/src/lib/hooks/useLocalStorage.ts
@@ -45,6 +45,9 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: T 
         (value: T | ((prev: T) => T)) => {
             setStoredValue((prev) => {
                 const valueToStore = value instanceof Function ? value(prev) : value
+                if (JSON.stringify(valueToStore) === JSON.stringify(prev)) {
+                    return prev
+                }
                 setStoredValueInStorage(key, valueToStore)
                 return valueToStore
             })


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks 

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change