### PR TITLE
fix(hooks): remove manual deps from useFileSystemLogView

### DIFF
--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -1,4 +1,4 @@
-import { DependencyList, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import api from 'lib/api'
 
@@ -23,10 +23,6 @@ interface TrackFileSystemLogViewOptions {
     enabled?: boolean
 }
 
-export interface UseFileSystemLogViewOptions extends TrackFileSystemLogViewOptions {
-    deps: DependencyList
-}
-
 export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
     if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined) {
         return
@@ -35,8 +31,8 @@ export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileS
     void api.fileSystemLogView.create({ type, ref: String(ref) })
 }
 
-export function useFileSystemLogView({ deps, ...options }: UseFileSystemLogViewOptions): void {
+export function useFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
     useEffect(() => {
-        trackFileSystemLogView(options)
-    }, deps)
+        trackFileSystemLogView({ type, ref, enabled })
+    }, [type, ref, enabled])
 }

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -107,7 +107,6 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
         type: 'cohort',
         ref: cohortId,
         enabled: Boolean(cohortId && !cohortLoading && !cohortMissing && !cohort.deleted),
-        deps: [cohortId, cohortLoading, cohortMissing, cohort.deleted],
     })
 
     if (cohortMissing) {

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -78,7 +78,6 @@ function DashboardScene(): JSX.Element {
         type: 'dashboard',
         ref: dashboard?.id,
         enabled: Boolean(currentTeamId && dashboard?.id && !dashboardFailedToLoad && !accessDeniedToDashboard),
-        deps: [currentTeamId, dashboard?.id, dashboardFailedToLoad, accessDeniedToDashboard],
     })
 
     useOnMountEffect(() => {

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -41,7 +41,6 @@ export function Experiment(props: ExperimentSceneLogicProps): JSX.Element {
         type: 'experiment',
         ref: experimentId,
         enabled: Boolean(currentTeamId && !experimentMissing && typeof experimentId === 'number'),
-        deps: [currentTeamId, experimentId, experimentMissing],
     })
 
     const logicProps: ExperimentLogicProps = { experimentId, formMode, tabId }

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -198,7 +198,6 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
             props.id !== 'link' &&
             featureFlag?.id
         ),
-        deps: [currentTeamId, featureFlag?.id, featureFlagMissing, accessDeniedToFeatureFlag, props.id],
     })
 
     if (featureFlagMissing) {

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -367,7 +367,6 @@ export function HogFunctionScene(): JSX.Element {
         type: `hog_function/${type ?? ''}`,
         ref: id ?? null,
         enabled: Boolean(id && type && loaded),
-        deps: [id, type, loaded],
     })
 
     if (loading && !loaded) {

--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -54,7 +54,6 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
         type: 'insight',
         ref: insight?.short_id,
         enabled: Boolean(currentTeamId && insight?.short_id && insight?.saved && !accessDeniedToInsight),
-        deps: [currentTeamId, insight?.short_id, insight?.saved, accessDeniedToInsight],
     })
 
     // other logics

--- a/frontend/src/scenes/notebooks/NotebookScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookScene.tsx
@@ -79,7 +79,6 @@ export function NotebookScene(): JSX.Element {
         type: 'notebook',
         ref: notebook?.short_id,
         enabled: Boolean(notebook?.short_id && notebookId !== 'new' && !loading && !conflictWarningVisible),
-        deps: [notebook?.short_id, notebookId, loading, conflictWarningVisible],
     })
 
     if (accessDeniedToNotebook) {

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -98,7 +98,6 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
         type: 'session_recording_playlist',
         ref: playlist?.short_id,
         enabled: Boolean(playlist?.short_id && !playlistLoading && !playlist?.is_synthetic),
-        deps: [playlist?.short_id, playlistLoading, playlist?.is_synthetic],
     })
 
     if (playlistLoading) {

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -106,7 +106,6 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
         type: 'survey',
         ref: surveyId,
         enabled: Boolean(surveyId && !surveyLoading),
-        deps: [surveyId, surveyLoading],
     })
 
     useEffect(() => {

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -82,7 +82,6 @@ export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEd
         type: 'action',
         ref: actionId,
         enabled: Boolean(actionId && !actionLoading),
-        deps: [actionId, actionLoading],
     })
 
     // Handle 404 when loading is done and action is missing

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -112,7 +112,6 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
         type: 'early_access_feature',
         ref: earlyAccessFeatureId,
         enabled: Boolean(currentTeamId && earlyAccessFeatureId && !earlyAccessFeatureLoading),
-        deps: [currentTeamId, earlyAccessFeatureId, earlyAccessFeatureLoading],
     })
 
     if (earlyAccessFeatureMissing) {
@@ -704,7 +703,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
         <div className="relative">
             {/*
             NOTE: This is a bit of a placement hack - ideally we would be able to add it to the Query
-            UPDATE: Absolute postion was overlapping with filters, so we put a bit on top. Still need to find a better solution.       
+            UPDATE: Absolute postion was overlapping with filters, so we put a bit on top. Still need to find a better solution.
              */}
             <div className="flex justify-end mb-2">
                 <LemonButton

--- a/products/links/frontend/LinkScene.tsx
+++ b/products/links/frontend/LinkScene.tsx
@@ -81,7 +81,6 @@ export function LinkScene({ id }: LinkLogicProps): JSX.Element {
         type: 'link',
         ref: linkId,
         enabled: Boolean(linkId && !linkLoading),
-        deps: [linkId, linkLoading],
     })
 
     if (linkMissing) {


### PR DESCRIPTION
after finding one bug from a funky useEffect in one of our `lib/hooks` hooks 

i asked the robot to review the rest of them

it insists these are all "idiomatic" improvements

created as a stack to avoid a large blast radius from this change