### PR TITLE
fix(insights): Tooltips going off screen

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -137,7 +137,7 @@ export function positionTooltip(
     left = Math.max(window.scrollX + 8, left)
 
     const viewportBottom = window.scrollY + document.documentElement.clientHeight
-    const clampedTop = Math.min(top, viewportBottom - Math.max(tooltipEl.offsetHeight, 0) - 8)
+const clampedTop = Math.min(Math.max(window.scrollY + 8, top), viewportBottom - Math.max(tooltipEl.offsetHeight, 0) - 8)
 
     tooltipEl.style.left = `${left}px`
     tooltipEl.style.top = `${clampedTop}px`

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -112,11 +112,32 @@ export function cleanupTooltip(id: string): void {
     }
 }
 
+export function positionTooltip(tooltipEl: HTMLElement, canvasBounds: DOMRect, caretX: number, caretY: number): void {
+    tooltipEl.style.position = 'absolute'
+    tooltipEl.style.maxWidth = ''
+
+    let left = canvasBounds.left + window.scrollX + caretX + 8
+    const top = canvasBounds.top + window.scrollY + caretY + 8
+
+    const viewportRight = window.scrollX + document.documentElement.clientWidth
+    if (tooltipEl.offsetWidth > 0 && left + tooltipEl.offsetWidth > viewportRight - 8) {
+        left = canvasBounds.left + window.scrollX + caretX - tooltipEl.offsetWidth - 8
+    }
+
+    const viewportBottom = window.scrollY + document.documentElement.clientHeight
+    const clampedTop = Math.min(top, viewportBottom - tooltipEl.offsetHeight - 8)
+
+    tooltipEl.style.left = `${left}px`
+    tooltipEl.style.top = `${clampedTop}px`
+    tooltipEl.style.maxWidth = `${viewportRight - left - 8}px`
+}
+
 export function useInsightTooltip(): {
     tooltipId: string
     getTooltip: () => [Root, HTMLElement]
     hideTooltip: () => void
     cleanupTooltip: () => void
+    positionTooltip: typeof positionTooltip
 } {
     const tooltipId = useMemo(() => Math.random().toString(36).substring(2, 11), [])
 
@@ -136,5 +157,5 @@ export function useInsightTooltip(): {
     const hide = useCallback((): void => hideTooltip(tooltipId), [tooltipId])
     const cleanup = useCallback((): void => cleanupTooltip(tooltipId), [tooltipId])
 
-    return { tooltipId, getTooltip, hideTooltip: hide, cleanupTooltip: cleanup }
+    return { tooltipId, getTooltip, hideTooltip: hide, cleanupTooltip: cleanup, positionTooltip }
 }

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -137,7 +137,10 @@ export function positionTooltip(
     left = Math.max(window.scrollX + 8, left)
 
     const viewportBottom = window.scrollY + document.documentElement.clientHeight
-const clampedTop = Math.min(Math.max(window.scrollY + 8, top), viewportBottom - Math.max(tooltipEl.offsetHeight, 0) - 8)
+    const clampedTop = Math.min(
+        Math.max(window.scrollY + 8, top),
+        viewportBottom - Math.max(tooltipEl.offsetHeight, 0) - 8
+    )
 
     tooltipEl.style.left = `${left}px`
     tooltipEl.style.top = `${clampedTop}px`

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -112,24 +112,28 @@ export function cleanupTooltip(id: string): void {
     }
 }
 
+const TOOLTIP_MAX_WIDTH = 480
+
 export function positionTooltip(tooltipEl: HTMLElement, canvasBounds: DOMRect, caretX: number, caretY: number): void {
     tooltipEl.style.position = 'absolute'
     tooltipEl.style.maxWidth = ''
 
-    let left = canvasBounds.left + window.scrollX + caretX + 8
+    const caretLeft = canvasBounds.left + window.scrollX + caretX
+    let left = caretLeft + 8
     const top = canvasBounds.top + window.scrollY + caretY + 8
 
     const viewportRight = window.scrollX + document.documentElement.clientWidth
-    if (tooltipEl.offsetWidth > 0 && left + tooltipEl.offsetWidth > viewportRight - 8) {
-        left = canvasBounds.left + window.scrollX + caretX - tooltipEl.offsetWidth - 8
+    const tooltipWidth = tooltipEl.offsetWidth || TOOLTIP_MAX_WIDTH
+    if (left + tooltipWidth > viewportRight - 8) {
+        left = caretLeft - tooltipWidth - 8
     }
+    left = Math.max(window.scrollX + 8, left)
 
     const viewportBottom = window.scrollY + document.documentElement.clientHeight
-    const clampedTop = Math.min(top, viewportBottom - tooltipEl.offsetHeight - 8)
+    const clampedTop = Math.min(top, viewportBottom - Math.max(tooltipEl.offsetHeight, 0) - 8)
 
     tooltipEl.style.left = `${left}px`
     tooltipEl.style.top = `${clampedTop}px`
-    tooltipEl.style.maxWidth = `${viewportRight - left - 8}px`
 }
 
 export function useInsightTooltip(): {

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -114,13 +114,20 @@ export function cleanupTooltip(id: string): void {
 
 const TOOLTIP_MAX_WIDTH = 480
 
-export function positionTooltip(tooltipEl: HTMLElement, canvasBounds: DOMRect, caretX: number, caretY: number): void {
+export function positionTooltip(
+    tooltipEl: HTMLElement,
+    canvasBounds: DOMRect,
+    caretX: number,
+    caretY: number,
+    centerVertically = false
+): void {
     tooltipEl.style.position = 'absolute'
     tooltipEl.style.maxWidth = ''
 
     const caretLeft = canvasBounds.left + window.scrollX + caretX
     let left = caretLeft + 8
-    const top = canvasBounds.top + window.scrollY + caretY + 8
+    const verticalOffset = centerVertically ? -tooltipEl.clientHeight / 2 : 8
+    const top = canvasBounds.top + window.scrollY + caretY + verticalOffset
 
     const viewportRight = window.scrollX + document.documentElement.clientWidth
     const tooltipWidth = tooltipEl.offsetWidth || TOOLTIP_MAX_WIDTH

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -294,7 +294,7 @@ export function LineGraph_({
     const { theme, getTrendsColor, getTrendsHidden, hoveredDatasetIndex } = useValues(trendsDataLogic(insightProps))
     const { setHoveredDatasetIndex } = useActions(trendsDataLogic(insightProps))
 
-    const { tooltipId, hideTooltip, getTooltip } = useInsightTooltip()
+    const { tooltipId, hideTooltip, getTooltip, positionTooltip } = useInsightTooltip()
 
     const colors = getGraphColors()
     const isHorizontal = type === GraphType.HorizontalBar
@@ -816,24 +816,9 @@ export function LineGraph_({
                             }
 
                             const bounds = canvas.getBoundingClientRect()
-                            const verticalBarTopOffset =
-                                isHighlightBarMode && !isHorizontal ? tooltip.caretY - tooltipEl.clientHeight / 2 : 0
-                            const horizontalBarTopOffset = isHorizontal
-                                ? tooltip.caretY - tooltipEl.clientHeight / 2
-                                : 0
-                            const tooltipClientTop =
-                                bounds.top + window.pageYOffset + horizontalBarTopOffset + verticalBarTopOffset
-
-                            const chartClientLeft = bounds.left + window.pageXOffset
-                            const defaultOffsetLeft = Math.max(chartClientLeft, chartClientLeft + tooltip.caretX + 8)
-                            const maxXPosition = bounds.right - tooltipEl.clientWidth
-                            const tooltipClientLeft =
-                                defaultOffsetLeft > maxXPosition
-                                    ? chartClientLeft + tooltip.caretX - tooltipEl.clientWidth - 8
-                                    : defaultOffsetLeft
-
-                            tooltipEl.style.top = tooltipClientTop + 'px'
-                            tooltipEl.style.left = tooltipClientLeft + 'px'
+                            const isBarChart = isHighlightBarMode || isHorizontal
+                            const caretY = isBarChart ? tooltip.caretY : 0
+                            positionTooltip(tooltipEl, bounds, tooltip.caretX, caretY)
                         },
                     },
                     ...(!isBar

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -816,9 +816,9 @@ export function LineGraph_({
                             }
 
                             const bounds = canvas.getBoundingClientRect()
-                            const isBarChart = isHighlightBarMode || isHorizontal
-                            const caretY = isBarChart ? tooltip.caretY : 0
-                            positionTooltip(tooltipEl, bounds, tooltip.caretX, caretY, isBarChart)
+                            const centerVertically = isHighlightBarMode || isHorizontal
+                            const caretY = centerVertically ? tooltip.caretY : 0
+                            positionTooltip(tooltipEl, bounds, tooltip.caretX, caretY, centerVertically)
                         },
                     },
                     ...(!isBar

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -818,7 +818,7 @@ export function LineGraph_({
                             const bounds = canvas.getBoundingClientRect()
                             const isBarChart = isHighlightBarMode || isHorizontal
                             const caretY = isBarChart ? tooltip.caretY : 0
-                            positionTooltip(tooltipEl, bounds, tooltip.caretX, caretY)
+                            positionTooltip(tooltipEl, bounds, tooltip.caretX, caretY, isBarChart)
                         },
                     },
                     ...(!isBar

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -215,7 +215,6 @@ export function PieChart({
                                                         )}
                                                         <div className="flex flex-col">
                                                             {hasBreakdown && !formula && datum.breakdown_value}
-                                                            "This_is_a_very_long_value_that_should_be_wrapped_to_the_next_line"
                                                         </div>
                                                     </div>
                                                 )

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -67,7 +67,7 @@ export function PieChart({
 
     const { aggregationLabel } = useValues(groupsModel)
     const { highlightSeries } = useActions(insightLogic)
-    const { getTooltip, hideTooltip } = useInsightTooltip()
+    const { getTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
 
     const { canvasRef } = useChart<'pie'>({
         getConfig: () => {
@@ -249,12 +249,8 @@ export function PieChart({
                                     )
                                 }
 
-                                const position = chart.canvas.getBoundingClientRect()
-                                tooltipEl.style.position = 'absolute'
-                                tooltipEl.style.left =
-                                    position.left + window.pageXOffset + (tooltip.caretX || 0) + 8 + 'px'
-                                tooltipEl.style.top =
-                                    position.top + window.pageYOffset + (tooltip.caretY || 0) + 8 + 'px'
+                                const bounds = chart.canvas.getBoundingClientRect()
+                                positionTooltip(tooltipEl, bounds, tooltip.caretX || 0, tooltip.caretY || 0)
                             },
                         },
                     },

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -215,7 +215,7 @@ export function PieChart({
                                                         )}
                                                         <div className="flex flex-col">
                                                             {hasBreakdown && !formula && datum.breakdown_value}
-                                                            {value}
+                                                            "This_is_a_very_long_value_that_should_be_wrapped_to_the_next_line"
                                                         </div>
                                                     </div>
                                                 )

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -215,6 +215,7 @@ export function PieChart({
                                                         )}
                                                         <div className="flex flex-col">
                                                             {hasBreakdown && !formula && datum.breakdown_value}
+                                                            {value}
                                                         </div>
                                                     </div>
                                                 )


### PR DESCRIPTION
## Problem
Tooltips can go off screen still if you put a small pie chart right up to the edge. 

<img width="359" height="440" alt="Screenshot 2026-02-19 at 17 42 11" src="https://github.com/user-attachments/assets/770c078a-49bb-479c-9f80-b19db687cdc6" />

## Changes

Stops them going off screen:
<img width="509" height="552" alt="Screenshot 2026-02-19 at 17 41 52" src="https://github.com/user-attachments/assets/0e8784fc-70b5-4313-8d78-a155cae72202" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
