### PR TITLE
chore: Add clarification about trailing slash handling in exact URL matching

### DIFF
--- a/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
@@ -324,6 +324,9 @@ export function AutoShowSection({ id }: { id: string }): JSX.Element | null {
                         />
                     )}
                 </div>
+                {conditions.urlMatchType === SurveyMatchType.Exact && (
+                    <span className="text-xs text-muted">Trailing slashes are stripped when matching exact URLs.</span>
+                )}
             </div>
 
             <div>


### PR DESCRIPTION
## Problem

Users may be confused about how exact URL matching works in product tours, specifically regarding trailing slashes. This change adds a helpful clarification message to explain the behavior.

## Changes

Added an informational message that appears when "Exact" URL match type is selected, explaining that trailing slashes are stripped during URL matching. This helps users understand the matching behavior and avoid confusion when configuring URL-based tour triggers.

## How did you test this code?

No testing needed - this is a simple UI text addition that displays a clarification message under specific conditions (when `SurveyMatchType.Exact` is selected).

## Publish to changelog?

No

https://claude.ai/code/session_01Ehty1owY9bcLLkvERRqv7v