### PR TITLE
fix(experiments): Filter precomputed exposures by exp dates

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_experiment_exposure_preaggregation.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_exposure_preaggregation.py
@@ -502,8 +502,8 @@ class TestExperimentExposurePreaggregation(ExperimentQueryRunnerBaseTest):
         # Create experiment with narrow range (Jan 5-9)
         experiment = self.create_experiment(
             feature_flag=feature_flag,
-            start_date=datetime(2024, 1, 5, tzinfo=UTC),
-            end_date=datetime(2024, 1, 9, tzinfo=UTC),
+            start_date=datetime(2024, 1, 5),
+            end_date=datetime(2024, 1, 9),
         )
 
         # Create precomputation job for BROAD range (Jan 1-10) - includes exposures before experiment


### PR DESCRIPTION
## Changes
Fixed missing timestamp filtering in experiment exposure precomputation read query. Jobs cover broader time ranges for reusability and aren't invalidated when experiment dates change, so the read query must filter by current experiment dates to avoid overcounting. Added `first_exposure_time >= date_from AND <= date_to` to match direct scan behavior.

## How did you test this code?
Added a test