### PR TITLE
feat: Redirect to project homepage instead of onboarding after project creation

### DIFF
--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -144,7 +144,7 @@ export const projectLogic = kea<projectLogicType>([
         },
         createProjectSuccess: ({ currentProject }) => {
             if (currentProject) {
-                actions.switchTeam(currentProject.id, urls.onboarding())
+                actions.switchTeam(currentProject.id, urls.projectHomepage())
             }
         },
 

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -632,7 +632,12 @@ export const sceneLogic = kea<sceneLogicType>([
         lastSetScenePayload: [
             {} as Record<string, any>,
             {
-                setScene: (_, { sceneId, sceneKey, tabId, params }) => ({ sceneId, sceneKey, tabId, params }),
+                setScene: (_, { sceneId, sceneKey, tabId, params }) => ({
+                    sceneId,
+                    sceneKey,
+                    tabId,
+                    params,
+                }),
             },
         ],
         tabScrollDepths: [
@@ -1141,8 +1146,8 @@ export const sceneLogic = kea<sceneLogicType>([
                     return
                 }
 
-                // Redirect to org/project creation if there's no org/project respectively, unless using invite
                 if (sceneId !== Scene.InviteSignup) {
+                    // Redirect to org/project creation if there's no org/project respectively, unless using invite
                     if (organizationLogic.values.isCurrentOrganizationUnavailable) {
                         if (
                             location.pathname !== urls.organizationCreateFirst() &&
@@ -1174,6 +1179,8 @@ export const sceneLogic = kea<sceneLogicType>([
                             }
                         }
                     } else if (
+                        // Or redirect to onboarding in case we detect people have to do onboarding for their first project
+                        user.organization?.teams.length === 1 &&
                         teamLogic.values.currentTeam &&
                         !teamLogic.values.currentTeam.is_demo &&
                         !teamLogic.values.hasOnboardedAnyProduct &&


### PR DESCRIPTION
## Problem

After creating a new project, users are redirected to the onboarding page instead of the project homepage. Additionally, the logic for redirecting users to onboarding needs improvement to only trigger for users with a single project that hasn't completed onboarding.

## Changes

- Changed the redirect after project creation from `urls.onboarding()` to `urls.projectHomepage()`
- Improved the onboarding redirect logic to only trigger when a user has exactly one team and hasn't onboarded any product yet
- Moved a comment to be properly aligned with the code it describes
- Reformatted the `setScene` reducer for better readability

## How did you test this code?

Tested the user flow by creating new projects and verifying the correct redirect behavior. Also verified that existing users with multiple projects aren't unnecessarily redirected to onboarding.

## Publish to changelog?

No