### PR TITLE
feat(kafka): expose client rack and ID awareness on Rust SingleTopicConsumer

### DIFF
--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -22,6 +22,12 @@ pub struct KafkaConfig {
 
     #[envconfig(default = "localhost:9092")]
     pub kafka_hosts: String,
+
+    #[envconfig(default = "")]
+    pub kafka_client_rack: String,
+
+    #[envconfig(default = "")]
+    pub kafka_client_id: String,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -56,6 +56,14 @@ impl SingleTopicConsumer {
                 &consumer_config.kafka_consumer_offset_reset,
             );
 
+        if !common_config.kafka_client_rack.is_empty() {
+            client_config.set("client.rack", &common_config.kafka_client_rack);
+        }
+
+        if !common_config.kafka_client_id.is_empty() {
+            client_config.set("client.id", &common_config.kafka_client_id);
+        }
+
         // IMPORTANT: this means *by default* all consumers are
         // responsible for storing their own offsets, regardless
         // of whether automatic offset commit is enabled or disabled!

--- a/rust/common/kafka/src/test.rs
+++ b/rust/common/kafka/src/test.rs
@@ -23,6 +23,8 @@ pub async fn create_mock_kafka() -> (
         kafka_hosts: cluster.bootstrap_servers(),
         kafka_tls: false,
         kafka_producer_queue_messages: 1000,
+        kafka_client_rack: String::new(),
+        kafka_client_id: String::new(),
     };
 
     (

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -349,6 +349,8 @@ impl KafkaDeduplicatorService {
             kafka_message_timeout_ms: self.config.kafka_message_timeout_ms,
             kafka_compression_codec: self.config.kafka_compression_codec.clone(),
             kafka_tls: self.config.kafka_tls,
+            kafka_client_rack: String::new(),
+            kafka_client_id: String::new(),
         };
 
         // Normalize empty strings to None for optional topic configs


### PR DESCRIPTION
## Problem
We need to expose two new Kafka consumer configs in Rust clients to ensure they can consume exclusively from WS deploys inside their AZ in production. Part 2 of a series to ensure `property-defs-rs` is AZ-aware when consuming our WS ingestion pipeline output topics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose `client.rack` and consumer group client ID env var configs in `SingleTopicConsumer`
* Ensure these are not set if the vars aren't set for back compatibility
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
