### PR TITLE
chore(session-recording): remove _should_use_recording_api feature flag

### DIFF
--- a/posthog/session_recordings/test/test_session_recording_access_control.py
+++ b/posthog/session_recordings/test/test_session_recording_access_control.py
@@ -88,11 +88,11 @@ class TestSessionRecordingAccessControl(APIBaseTest):
         self.assertIn("You do not have editor access", response.json()["detail"])
 
     @patch(
-        "posthog.session_recordings.session_recording_api.SessionRecordingViewSet._should_use_recording_api",
-        return_value=False,
+        "posthog.session_recordings.session_recording_api.SessionRecordingViewSet._delete_via_recording_api",
+        return_value=True,
     )
     @patch("posthog.session_recordings.models.session_recording.SessionRecording.load_metadata", return_value=True)
-    def test_editor_can_delete_recording(self, mock_load_metadata, _mock_should_use_recording_api):
+    def test_editor_can_delete_recording(self, mock_load_metadata, _mock_delete_via_recording_api):
         """Test that a user with editor access can delete a recording"""
         self._create_access_control(self.editor_user, access_level="editor")
 
@@ -106,11 +106,11 @@ class TestSessionRecordingAccessControl(APIBaseTest):
         self.assertTrue(self.recording.deleted)
 
     @patch(
-        "posthog.session_recordings.session_recording_api.SessionRecordingViewSet._should_use_recording_api",
-        return_value=False,
+        "posthog.session_recordings.session_recording_api.SessionRecordingViewSet._bulk_delete_via_recording_api",
+        return_value=[],
     )
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
-    def test_editor_can_bulk_delete_recordings(self, mock_list_recordings, _mock_should_use_recording_api):
+    def test_editor_can_bulk_delete_recordings(self, mock_list_recordings, _mock_bulk_delete_via_recording_api):
         """Test that a user with editor access can bulk delete recordings"""
         # Create additional recordings
         recording2 = SessionRecording.objects.create(


### PR DESCRIPTION
## Summary

- Removes the `session-replay-use-recording-api` feature flag and `_should_use_recording_api()` method
- All block fetches now always go through the recording-api (`encrypted_block_storage`)
- All deletes always call the recording-api for crypto-shredding
- Fixes a latent bug where `only_evaluate_locally=True` could return `False` on flag cache miss, causing encrypted blocks to be served through the cleartext S3 path

## Context

The recording-api has been at 100% rollout in both US and EU regions. The feature flag branching is no longer needed and was masking a bug where local flag evaluation failures could route encrypted sessions through the wrong storage path.

## Test plan

- [x] All session recording tests pass (79 + 27 + 10 = 116 tests)
- [x] No remaining references to `_should_use_recording_api` or `session-replay-use-recording-api`
- [x] No remaining references to `cleartext_block_storage` in session recordings