### PR TITLE
fix: run label filter on timing guard drop

### DIFF
--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -160,7 +160,9 @@ impl TimingGuard<'_> {
 impl Drop for TimingGuard<'_> {
     fn drop(&mut self) {
         let labels = self.labels.as_slice();
-        metrics::histogram!(self.name, labels).record(self.start.elapsed().as_millis() as f64);
+        let filtered_labels = apply_label_filter(labels);
+        metrics::histogram!(self.name, &filtered_labels)
+            .record(self.start.elapsed().as_millis() as f64);
     }
 }
 

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -111,8 +111,9 @@ fn apply_label_filter(labels: &[(String, String)]) -> Vec<(String, String)> {
     }
 }
 
-pub fn gauge(name: &'static str, lables: &[(String, String)], value: f64) {
-    metrics::gauge!(name, lables).set(value);
+pub fn gauge(name: &'static str, labels: &[(String, String)], value: f64) {
+    let filtered_labels = apply_label_filter(labels);
+    metrics::gauge!(name, &filtered_labels).set(value);
 }
 
 pub fn histogram(name: &'static str, labels: &[(String, String)], value: f64) {


### PR DESCRIPTION
## Problem

PR #46053 added `team_id` labels to DB query timing histograms (`flags_person_query_time`, `flags_cohort_query_time`, `flags_group_query_time`, `flags_definition_query_time`).
These metrics are recorded via `TimingGuard`, which writes directly to Prometheus without applying the global `team_id_label_filter`.

This means every unique team ID becomes a distinct label value (~6k teams), instead of collapsing untracked teams to `"unknown"` (~55 values).

## Fix

Apply `apply_label_filter()` in `TimingGuard::drop()` before recording the histogram, matching the behavior of the standalone `histogram()` helper.


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
