### PR TITLE
fix: orange should be clickable, and text should be true

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -434,6 +434,7 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
         groupType,
         value,
         taxonomicGroups,
+        taxonomicGroupTypes,
         selectedProperties,
         dataWarehousePopoverFields,
         anyGroupLoading,
@@ -512,9 +513,7 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
                             <span className="text-secondary text-center">
                                 Start searching and we'll suggest filters...
                             </span>
-                            <span className="text-center text-primary-3000">
-                                Try searching for an email, URL, or screen name
-                            </span>
+                            <SuggestedFiltersSearchHint taxonomicGroupTypes={taxonomicGroupTypes} />
                         </>
                     ) : (
                         <>
@@ -611,6 +610,34 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
             ) : null}
         </div>
     )
+}
+
+function SuggestedFiltersSearchHint({
+    taxonomicGroupTypes,
+}: {
+    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+}): JSX.Element | null {
+    const groupSet = new Set(taxonomicGroupTypes)
+    const hints: string[] = []
+    if (groupSet.has(TaxonomicFilterGroupType.EmailAddresses)) {
+        hints.push('an email')
+    }
+    if (groupSet.has(TaxonomicFilterGroupType.PageviewUrls) || groupSet.has(TaxonomicFilterGroupType.PageviewEvents)) {
+        hints.push('a URL')
+    }
+    if (groupSet.has(TaxonomicFilterGroupType.Screens) || groupSet.has(TaxonomicFilterGroupType.ScreenEvents)) {
+        hints.push('a screen name')
+    }
+    if (hints.length === 0) {
+        return null
+    }
+    const joined =
+        hints.length === 1
+            ? hints[0]
+            : hints.length === 2
+              ? `${hints[0]} or ${hints[1]}`
+              : `${hints.slice(0, -1).join(', ')}, or ${hints[hints.length - 1]}`
+    return <span className="text-center text-secondary italic">Try searching for {joined}</span>
 }
 
 export function getItemGroup(


### PR DESCRIPTION
![CleanShot 2026-02-19 at 20.02.25@2x.png](https://app.graphite.com/user-attachments/assets/50bfa269-14ac-4362-9447-0bba24e2241a.png)

![CleanShot 2026-02-19 at 20.02.18@2x.png](https://app.graphite.com/user-attachments/assets/a8b67ca1-3c53-4b6b-ae6b-8a56f3ef98c4.png)

i had to turn the flag for this off, so now in prod the text is lying because we won't do anything when you search for an email

and the text is orange so looks clickable

let's make it not orange, and depend on which groups are active that do something magical