### PR TITLE
fix: poll for team data when no events have been ingested

### DIFF
--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -17,6 +17,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { OnboardingStepKey } from '~/types'
 
 import { ProjectNoticeVariant, navigationLogic } from './navigationLogic'
+import { projectNoticeLogic } from './projectNoticeLogic'
 
 interface ProjectNoticeBlueprint {
     message: JSX.Element | string
@@ -33,6 +34,9 @@ export function ProjectNotice({ className }: { className?: string }): JSX.Elemen
     const { showInviteModal } = useActions(inviteLogic)
     const { requestVerificationLink } = useActions(verifyEmailLogic)
     const { sceneConfig, activeSceneProductKey } = useValues(sceneLogic)
+
+    // Mount projectNoticeLogic to handle polling when "no events" banner is shown
+    useValues(projectNoticeLogic)
 
     if (!projectNoticeVariant) {
         return null

--- a/frontend/src/layout/navigation/projectNoticeLogic.ts
+++ b/frontend/src/layout/navigation/projectNoticeLogic.ts
@@ -1,5 +1,4 @@
-import { connect, kea, listeners, path, selectors } from 'kea'
-import { subscriptions } from 'kea-subscriptions'
+import { afterMount, beforeUnmount, connect, kea, listeners, path, selectors } from 'kea'
 
 import { liveEventsLogic } from 'scenes/activity/live/liveEventsLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -7,6 +6,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { ProjectNoticeVariant, navigationLogic } from './navigationLogic'
 import type { projectNoticeLogicType } from './projectNoticeLogicType'
 
+const POLL_INTERVAL_MS = 30_000
 const DEBOUNCE_MS = 2000
 
 export const projectNoticeLogic = kea<projectNoticeLogicType>([
@@ -26,33 +26,28 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
             if (!values.shouldPoll) {
                 return
             }
-            // Debounce team checks when events stream in
-            if (cache.eventDebounceTimer) {
-                clearTimeout(cache.eventDebounceTimer)
+            if (cache.debounceTimer) {
+                clearTimeout(cache.debounceTimer)
             }
-            cache.eventDebounceTimer = window.setTimeout(() => {
+            cache.debounceTimer = window.setTimeout(() => {
                 actions.loadCurrentTeam()
-                cache.eventDebounceTimer = null
+                cache.debounceTimer = null
             }, DEBOUNCE_MS)
         },
     })),
-    subscriptions(({ actions, cache }) => ({
-        shouldPoll: (shouldPoll: boolean) => {
-            if (shouldPoll) {
-                cache.disposables.add(() => {
-                    const timerId = window.setInterval(() => {
-                        actions.loadCurrentTeam()
-                    }, 30_000)
-                    return () => clearInterval(timerId)
-                }, 'noEventsPolling')
-            } else {
-                cache.disposables.dispose('noEventsPolling')
-                // Clean up debounce timer if banner dismissed
-                if (cache.eventDebounceTimer) {
-                    clearTimeout(cache.eventDebounceTimer)
-                    cache.eventDebounceTimer = null
-                }
-            }
-        },
-    })),
+    afterMount(({ actions, values, cache }) => {
+        if (values.shouldPoll) {
+            cache.pollTimer = window.setInterval(() => {
+                actions.loadCurrentTeam()
+            }, POLL_INTERVAL_MS)
+        }
+    }),
+    beforeUnmount(({ cache }) => {
+        if (cache.pollTimer) {
+            clearInterval(cache.pollTimer)
+        }
+        if (cache.debounceTimer) {
+            clearTimeout(cache.debounceTimer)
+        }
+    }),
 ])

--- a/frontend/src/layout/navigation/projectNoticeLogic.ts
+++ b/frontend/src/layout/navigation/projectNoticeLogic.ts
@@ -1,9 +1,8 @@
-import { afterMount, beforeUnmount, connect, kea, listeners, path, selectors } from 'kea'
+import { afterMount, beforeUnmount, connect, kea, listeners, path } from 'kea'
 
 import { liveEventsLogic } from 'scenes/activity/live/liveEventsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { ProjectNoticeVariant, navigationLogic } from './navigationLogic'
 import type { projectNoticeLogicType } from './projectNoticeLogicType'
 
 const POLL_INTERVAL_MS = 30_000
@@ -12,20 +11,10 @@ const DEBOUNCE_MS = 2000
 export const projectNoticeLogic = kea<projectNoticeLogicType>([
     path(['layout', 'navigation', 'projectNoticeLogic']),
     connect(() => ({
-        values: [navigationLogic, ['projectNoticeVariant']],
         actions: [teamLogic, ['loadCurrentTeam'], liveEventsLogic, ['addEvents']],
     })),
-    selectors({
-        shouldPoll: [
-            (s) => [s.projectNoticeVariant],
-            (variant: ProjectNoticeVariant | null): boolean => variant === 'real_project_with_no_events',
-        ],
-    }),
-    listeners(({ actions, values, cache }) => ({
+    listeners(({ actions, cache }) => ({
         addEvents: () => {
-            if (!values.shouldPoll) {
-                return
-            }
             if (cache.debounceTimer) {
                 clearTimeout(cache.debounceTimer)
             }
@@ -35,12 +24,10 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
             }, DEBOUNCE_MS)
         },
     })),
-    afterMount(({ actions, values, cache }) => {
-        if (values.shouldPoll) {
-            cache.pollTimer = window.setInterval(() => {
-                actions.loadCurrentTeam()
-            }, POLL_INTERVAL_MS)
-        }
+    afterMount(({ actions, cache }) => {
+        cache.pollTimer = window.setInterval(() => {
+            actions.loadCurrentTeam()
+        }, POLL_INTERVAL_MS)
     }),
     beforeUnmount(({ cache }) => {
         if (cache.pollTimer) {

--- a/frontend/src/layout/navigation/projectNoticeLogic.ts
+++ b/frontend/src/layout/navigation/projectNoticeLogic.ts
@@ -1,0 +1,35 @@
+import { connect, kea, path, selectors } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProjectNoticeVariant, navigationLogic } from './navigationLogic'
+import type { projectNoticeLogicType } from './projectNoticeLogicType'
+
+export const projectNoticeLogic = kea<projectNoticeLogicType>([
+    path(['layout', 'navigation', 'projectNoticeLogic']),
+    connect(() => ({
+        values: [navigationLogic, ['projectNoticeVariant']],
+        actions: [teamLogic, ['loadCurrentTeam']],
+    })),
+    selectors({
+        shouldPoll: [
+            (s) => [s.projectNoticeVariant],
+            (variant: ProjectNoticeVariant | null): boolean => variant === 'real_project_with_no_events',
+        ],
+    }),
+    subscriptions(({ actions, cache }) => ({
+        shouldPoll: (shouldPoll: boolean) => {
+            if (shouldPoll) {
+                cache.disposables.add(() => {
+                    const timerId = window.setInterval(() => {
+                        actions.loadCurrentTeam()
+                    }, 30_000)
+                    return () => clearInterval(timerId)
+                }, 'noEventsPolling')
+            } else {
+                cache.disposables.dispose('noEventsPolling')
+            }
+        },
+    })),
+])

--- a/frontend/src/layout/navigation/projectNoticeLogic.ts
+++ b/frontend/src/layout/navigation/projectNoticeLogic.ts
@@ -1,16 +1,19 @@
-import { connect, kea, path, selectors } from 'kea'
+import { connect, kea, listeners, path, selectors } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 
+import { liveEventsLogic } from 'scenes/activity/live/liveEventsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProjectNoticeVariant, navigationLogic } from './navigationLogic'
 import type { projectNoticeLogicType } from './projectNoticeLogicType'
 
+const DEBOUNCE_MS = 2000
+
 export const projectNoticeLogic = kea<projectNoticeLogicType>([
     path(['layout', 'navigation', 'projectNoticeLogic']),
     connect(() => ({
         values: [navigationLogic, ['projectNoticeVariant']],
-        actions: [teamLogic, ['loadCurrentTeam']],
+        actions: [teamLogic, ['loadCurrentTeam'], liveEventsLogic, ['addEvents']],
     })),
     selectors({
         shouldPoll: [
@@ -18,6 +21,21 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
             (variant: ProjectNoticeVariant | null): boolean => variant === 'real_project_with_no_events',
         ],
     }),
+    listeners(({ actions, values, cache }) => ({
+        addEvents: () => {
+            if (!values.shouldPoll) {
+                return
+            }
+            // Debounce team checks when events stream in
+            if (cache.eventDebounceTimer) {
+                clearTimeout(cache.eventDebounceTimer)
+            }
+            cache.eventDebounceTimer = window.setTimeout(() => {
+                actions.loadCurrentTeam()
+                cache.eventDebounceTimer = null
+            }, DEBOUNCE_MS)
+        },
+    })),
     subscriptions(({ actions, cache }) => ({
         shouldPoll: (shouldPoll: boolean) => {
             if (shouldPoll) {
@@ -29,6 +47,11 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
                 }, 'noEventsPolling')
             } else {
                 cache.disposables.dispose('noEventsPolling')
+                // Clean up debounce timer if banner dismissed
+                if (cache.eventDebounceTimer) {
+                    clearTimeout(cache.eventDebounceTimer)
+                    cache.eventDebounceTimer = null
+                }
             }
         },
     })),


### PR DESCRIPTION
## Problem

When a project has no events ingested, users see a "no events" banner. However, this banner doesn't automatically update when events are first received, requiring a manual page refresh to see the updated state.

## Changes

Let's poll for updates while the component is visible

## Publish to changelog?

No

https://claude.ai/code/session_01PfA7Wg394Kp6myNvpg18pE