### PR TITLE
fix: taxonomic suggested filters behaviour

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1042,7 +1042,22 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         FEATURE_FLAGS.TAXONOMIC_QUICK_FILTER_AUTOCAPTURE_EVENTS,
                 }
 
+                const mutuallyExclusivePairs: [TaxonomicFilterGroupType, TaxonomicFilterGroupType][] = [
+                    [TaxonomicFilterGroupType.PageviewUrls, TaxonomicFilterGroupType.PageviewEvents],
+                    [TaxonomicFilterGroupType.Screens, TaxonomicFilterGroupType.ScreenEvents],
+                ]
+                const excluded = new Set<TaxonomicFilterGroupType>()
+                for (const [a, b] of mutuallyExclusivePairs) {
+                    if (resolvedGroupTypes.includes(a) && resolvedGroupTypes.includes(b)) {
+                        console.warn(`TaxonomicFilter: ${a} and ${b} are mutually exclusive, ignoring ${b}`)
+                        excluded.add(b)
+                    }
+                }
+
                 return resolvedGroupTypes.filter((groupType) => {
+                    if (excluded.has(groupType)) {
+                        return false
+                    }
                     if (!availableGroupTypes.has(groupType)) {
                         return false
                     }

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.test.ts
@@ -133,6 +133,52 @@ describe('universalFiltersLogic', () => {
         })
     })
 
+    describe('addGroupFilter with quick filter group types', () => {
+        it.each([
+            {
+                groupType: TaxonomicFilterGroupType.PageviewUrls,
+                propertyKey: 'https://example.com/blog',
+                expected: {
+                    key: '$current_url',
+                    value: 'https://example.com/blog',
+                    operator: PropertyOperator.IContains,
+                    type: PropertyFilterType.Event,
+                },
+            },
+            {
+                groupType: TaxonomicFilterGroupType.Screens,
+                propertyKey: 'HomeScreen',
+                expected: {
+                    key: '$screen_name',
+                    value: 'HomeScreen',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Event,
+                },
+            },
+            {
+                groupType: TaxonomicFilterGroupType.EmailAddresses,
+                propertyKey: 'user@example.com',
+                expected: {
+                    key: 'email',
+                    value: 'user@example.com',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Person,
+                },
+            },
+        ])('creates a property filter for $groupType', async ({ groupType, propertyKey, expected }) => {
+            await expectLogic(logic, () => {
+                logic.actions.addGroupFilter({ type: groupType } as TaxonomicFilterGroup, propertyKey, {
+                    name: propertyKey,
+                })
+            }).toMatchValues({
+                filterGroup: {
+                    ...defaultFilter,
+                    values: [...defaultFilter.values, expected],
+                },
+            })
+        })
+    })
+
     describe('addGroupFilter with QuickFilterItem', () => {
         it.each([
             {

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -13,6 +13,7 @@ import {
     EventPropertyFilter,
     FeaturePropertyFilter,
     FilterLogicalOperator,
+    PersonPropertyFilter,
     PropertyFilterType,
     PropertyOperator,
     UniversalFiltersGroup,
@@ -162,38 +163,52 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
                 return
             }
 
-            if (taxonomicGroup.type === TaxonomicFilterGroupType.PageviewEvents) {
+            if (
+                taxonomicGroup.type === TaxonomicFilterGroupType.PageviewEvents ||
+                taxonomicGroup.type === TaxonomicFilterGroupType.PageviewUrls
+            ) {
                 const urlFilter: EventPropertyFilter = {
                     key: '$current_url',
                     value: propertyKey ? String(propertyKey) : '',
                     operator: PropertyOperator.IContains,
                     type: PropertyFilterType.Event,
                 }
-                const eventFilter: ActionFilter = {
-                    id: '$pageview',
-                    name: '$pageview',
-                    type: EntityTypes.EVENTS,
-                    properties: [urlFilter],
+                if (taxonomicGroup.type === TaxonomicFilterGroupType.PageviewEvents) {
+                    const eventFilter: ActionFilter = {
+                        id: '$pageview',
+                        name: '$pageview',
+                        type: EntityTypes.EVENTS,
+                        properties: [urlFilter],
+                    }
+                    newValues.push(eventFilter)
+                } else {
+                    newValues.push(urlFilter)
                 }
-                newValues.push(eventFilter)
                 actions.setGroupValues(newValues)
                 return
             }
 
-            if (taxonomicGroup.type === TaxonomicFilterGroupType.ScreenEvents) {
+            if (
+                taxonomicGroup.type === TaxonomicFilterGroupType.ScreenEvents ||
+                taxonomicGroup.type === TaxonomicFilterGroupType.Screens
+            ) {
                 const screenNameFilter: EventPropertyFilter = {
                     key: '$screen_name',
                     value: propertyKey ? String(propertyKey) : '',
                     operator: PropertyOperator.Exact,
                     type: PropertyFilterType.Event,
                 }
-                const eventFilter: ActionFilter = {
-                    id: '$screen',
-                    name: '$screen',
-                    type: EntityTypes.EVENTS,
-                    properties: [screenNameFilter],
+                if (taxonomicGroup.type === TaxonomicFilterGroupType.ScreenEvents) {
+                    const eventFilter: ActionFilter = {
+                        id: '$screen',
+                        name: '$screen',
+                        type: EntityTypes.EVENTS,
+                        properties: [screenNameFilter],
+                    }
+                    newValues.push(eventFilter)
+                } else {
+                    newValues.push(screenNameFilter)
                 }
-                newValues.push(eventFilter)
                 actions.setGroupValues(newValues)
                 return
             }
@@ -212,6 +227,18 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
                     properties: [elTextFilter],
                 }
                 newValues.push(eventFilter)
+                actions.setGroupValues(newValues)
+                return
+            }
+
+            if (taxonomicGroup.type === TaxonomicFilterGroupType.EmailAddresses) {
+                const emailFilter: PersonPropertyFilter = {
+                    key: 'email',
+                    value: propertyKey ? String(propertyKey) : '',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Person,
+                }
+                newValues.push(emailFilter)
                 actions.setGroupValues(newValues)
                 return
             }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -367,7 +367,9 @@ export function ActionFilterRow({
         <TaxonomicPopover
             data-attr={'trend-element-subject-' + index}
             fullWidth
-            groupType={filter.type as TaxonomicFilterGroupType}
+            groupType={
+                showQuickFilters ? TaxonomicFilterGroupType.SuggestedFilters : (filter.type as TaxonomicFilterGroupType)
+            }
             value={getValue(value, filter)}
             filter={filter}
             onChange={(changedValue, taxonomicGroupType, item) => {

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -40,6 +40,7 @@ import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconUnverifiedEvent } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
@@ -511,6 +512,7 @@ const ReplayFiltersTab = ({
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
+    const { hasPageview, hasScreen } = getProjectEventExistence()
 
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.Replay,
@@ -521,6 +523,10 @@ const ReplayFiltersTab = ({
         TaxonomicFilterGroupType.PersonProperties,
         TaxonomicFilterGroupType.SessionProperties,
         ...groupsTaxonomicTypes,
+        ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
+        ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
+        TaxonomicFilterGroupType.EmailAddresses,
+        TaxonomicFilterGroupType.AutocaptureEvents,
     ]
 
     if (allowReplayHogQLFilters) {


### PR DESCRIPTION
in the revert and reapply dance after yesterday's incident 
i broke some of the flow in applying these fancy filters

but not any more

![CleanShot 2026-02-19 at 22.15.52.gif](https://app.graphite.com/user-attachments/assets/71e5eb14-b7ca-439c-b133-4faa31a8e33a.gif)

![CleanShot 2026-02-19 at 22.15.08.gif](https://app.graphite.com/user-attachments/assets/dcb64b43-3584-484a-8fd0-5569fa79bcde.gif)

