### PR TITLE
feat(ux/search): promote search opt count=false

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -16,9 +16,8 @@ import {
 } from 'react'
 import { TextMorph } from 'torph/react'
 
-import { IconInfo, IconSearch, IconX } from '@posthog/icons'
+import { IconSearch, IconX } from '@posthog/icons'
 import { LemonTag, Link, Spinner } from '@posthog/lemon-ui'
-import { LemonSwitch } from '@posthog/lemon-ui'
 
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -523,9 +522,7 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
 // ============================================================================
 
 function SearchStatus(): JSX.Element {
-    const { isSearching, searchValue, filteredItems, logicKey } = useSearchContext()
-    const { showSearchDebug, includeCounts, searchElapsedMs, searchResultCount } = useValues(searchLogic({ logicKey }))
-    const { toggleIncludeCounts } = useActions(searchLogic({ logicKey }))
+    const { isSearching, searchValue, filteredItems } = useSearchContext()
 
     const statusMessage = useMemo(() => {
         if (isSearching) {
@@ -551,26 +548,6 @@ function SearchStatus(): JSX.Element {
     return (
         <Autocomplete.Status className="px-3 pt-1 pb-2 text-xs text-muted flex items-center">
             <span>{statusMessage}</span>
-            {showSearchDebug && (
-                <span className="ml-auto flex items-center gap-2 text-xs text-muted border border-dashed border-[#0cb762] rounded group">
-                    <LemonSwitch checked={includeCounts} onChange={toggleIncludeCounts} label="Counts" size="small" />
-                    <span>
-                        elapsed: {searchElapsedMs.toFixed(2)}ms, found: {searchResultCount} items
-                    </span>
-                    <ButtonPrimitive
-                        iconOnly
-                        size="sm"
-                        tooltip={
-                            <>
-                                Posthog ONLY: This is a flagged feature that shows the search debug information as we
-                                optimize search.
-                            </>
-                        }
-                    >
-                        <IconInfo className="size-4 text-tertiary group-hover:text-primary" />
-                    </ButtonPrimitive>
-                </span>
-            )}
         </Autocomplete.Status>
     )
 }

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -5,7 +5,6 @@ import { IconClock, IconDownload } from '@posthog/icons'
 
 import api from 'lib/api'
 import { commandLogic } from 'lib/components/Command/commandLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toSentenceCase } from 'lib/utils'
 import { GroupQueryResult, mapGroupQueryResponse } from 'lib/utils/groups'
@@ -70,10 +69,8 @@ export const searchLogic = kea<searchLogicType>([
     })),
     actions({
         setSearch: (search: string) => ({ search }),
-        toggleIncludeCounts: true,
-        setSearchElapsedMs: (elapsed: number) => ({ elapsed }),
     }),
-    loaders(({ values, actions }) => ({
+    loaders(({ values }) => ({
         sceneLogViews: [
             [] as FileSystemViewLogEntry[],
             {
@@ -110,16 +107,13 @@ export const searchLogic = kea<searchLogicType>([
                     const trimmed = searchTerm.trim()
 
                     if (trimmed === '') {
-                        actions.setSearchElapsedMs(0)
                         return null
                     }
 
-                    const start = performance.now()
                     const response = await api.search.list({
                         q: trimmed,
-                        include_counts: values.includeCounts,
+                        include_counts: false,
                     })
-                    actions.setSearchElapsedMs(performance.now() - start)
                     breakpoint()
 
                     return response
@@ -205,18 +199,6 @@ export const searchLogic = kea<searchLogicType>([
         ],
     })),
     reducers({
-        includeCounts: [
-            false,
-            {
-                toggleIncludeCounts: (state) => !state,
-            },
-        ],
-        searchElapsedMs: [
-            0,
-            {
-                setSearchElapsedMs: (_, { elapsed }) => elapsed,
-            },
-        ],
         search: [
             '',
             {
@@ -254,15 +236,6 @@ export const searchLogic = kea<searchLogicType>([
         ],
     }),
     selectors({
-        showSearchDebug: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean =>
-                !!(featureFlags as Record<string, boolean>)[FEATURE_FLAGS.UX_SEARCH_WITH_COUNT_NONE],
-        ],
-        searchResultCount: [
-            (s) => [s.unifiedSearchResults],
-            (unifiedSearchResults): number => unifiedSearchResults?.results?.length ?? 0,
-        ],
         sceneLogViewsByRef: [
             (s) => [s.sceneLogViews],
             (sceneLogViews): Record<string, string> => {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -169,7 +169,6 @@ export const FEATURE_FLAGS = {
     // UX flags, used to control the UX of the app
     AI_FIRST: 'ai-first', // this a larger change, not released to team yet
     UX_REMOVE_SIDEPANEL: 'ux-remove-sidepanel', // used to remove the sidepanel from the experience
-    UX_SEARCH_WITH_COUNT_NONE: 'ux-search-with-count-none', // used to toggle include_counts on/off in unified search
 
     // Feature flags used to control opt-in for different behaviors, should not be removed
     CONTROL_SUPPORT_LOGIN: 'control_support_login', // owner: #team-security, used to control whether users can opt out of support impersonation


### PR DESCRIPTION
[This PR when tested on prod showed search is now 53–67% faster](https://github.com/PostHog/posthog/pull/48437) faster searching for things in `/search` 

## Changes
* Remove flag
* Remove extra logic and default to `include_counts=false` in the query param in `searchLogic`

| Include counts | Search query | Search elapsed time | Delta |
  |:---:|:---:|---:|---:|
  | ON | experiment | 5586.40ms | baseline |
  | OFF | experiment  | 2165.80ms | -3420.60ms (-61%) |
  | ON | feature | 6030.40ms | baseline |
  | OFF | feature | 2825.30ms | -3205.10ms (-53%) |
  | ON | @  | 4719.00ms | baseline |
  | OFF | @  | 1762.80ms | -2956.20ms (-63%) |
  | ON | capture  | 5268.00ms | baseline |
  | OFF | capture  | 1762.80ms | -3505.20ms (-67%) |
  | ON | x@posthog.com | 4851.60ms | baseline |
  | OFF | x@posthog.com | 1871.60ms | -2980.00ms (-61%) |

## How did you test this code?
Locally

## Publish to changelog?
Yes