### PR TITLE
feat(signals): Auto-trigger clustering workflow when sessions SignalSourceConfig is created

### DIFF
--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -3,7 +3,7 @@ import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconGithub, IconLinear } from '@posthog/icons'
-import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
 
 import { RecordingsUniversalFiltersDisplay } from 'lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay'
 import { IconSlack } from 'lib/lemon-ui/icons'
@@ -13,6 +13,8 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import iconZendesk from 'public/services/zendesk.svg'
 
 import { signalSourcesLogic } from './signalSourcesLogic'
+import { inboxSceneLogic } from './inboxSceneLogic'
+import { SignalSourceConfigStatus } from './types'
 
 type SourceProps =
     | {
@@ -32,6 +34,7 @@ type SourceProps =
           configButtonLabel: string
           onConfigClick: () => void
           onClearClick?: () => void
+          statusSection?: React.ReactNode
       }
 
 function NotifyMeButton({ source }: { source: string }): JSX.Element {
@@ -70,22 +73,25 @@ function Source(props: SourceProps): JSX.Element {
                 </div>
                 <p className="text-xs text-secondary mt-0.25 mb-0">{props.description}</p>
                 {!isComingSoon && props.checked && (
-                    <div className="mt-2 border rounded">
-                        <div className="flex items-center justify-between px-2 pt-2">
-                            <span className="text-xs font-semibold text-secondary">Filters</span>
-                            <div className="flex items-center gap-1">
-                                {props.onClearClick && (
-                                    <LemonButton type="tertiary" size="xsmall" onClick={props.onClearClick}>
-                                        Clear
+                    <>
+                        <div className="mt-2 border rounded">
+                            <div className="flex items-center justify-between px-2 pt-2">
+                                <span className="text-xs font-semibold text-secondary">Filters</span>
+                                <div className="flex items-center gap-1">
+                                    {props.onClearClick && (
+                                        <LemonButton type="tertiary" size="xsmall" onClick={props.onClearClick}>
+                                            Clear
+                                        </LemonButton>
+                                    )}
+                                    <LemonButton type="secondary" size="xsmall" onClick={props.onConfigClick}>
+                                        {props.configButtonLabel}
                                     </LemonButton>
-                                )}
-                                <LemonButton type="secondary" size="xsmall" onClick={props.onConfigClick}>
-                                    {props.configButtonLabel}
-                                </LemonButton>
+                                </div>
                             </div>
+                            {props.configSection}
                         </div>
-                        {props.configSection}
-                    </div>
+                        {props.statusSection}
+                    </>
                 )}
             </div>
         </div>
@@ -94,6 +100,18 @@ function Source(props: SourceProps): JSX.Element {
 
 function isNonEmptyFilters(obj: unknown): boolean {
     return obj != null && typeof obj === 'object' && Object.keys(obj as Record<string, unknown>).length > 0
+}
+
+function ClusteringStatusIndicator({ status }: { status: SignalSourceConfigStatus | null }): JSX.Element | null {
+    if (status === SignalSourceConfigStatus.RUNNING) {
+        return (
+            <div className="mt-2 flex items-center gap-2 rounded bg-accent-light text-xs text-accent">
+                <Spinner className="size-3.5" />
+                <span>Session analysis run in progress now… (est. 30 min)</span>
+            </div>
+        )
+    }
+    return null
 }
 
 export function SourcesList(): JSX.Element {
@@ -120,6 +138,7 @@ export function SourcesList(): JSX.Element {
                 configButtonLabel={recordingFilters ? 'Edit' : 'Configure'}
                 onConfigClick={openSessionAnalysisSetup}
                 onClearClick={hasNonEmptyFilters ? clearSessionAnalysisFilters : undefined}
+                statusSection={<ClusteringStatusIndicator status={sessionAnalysisConfig?.status ?? null} />}
                 configSection={
                     recordingFilters ? (
                         <RecordingsUniversalFiltersDisplay filters={recordingFilters} />

--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -13,7 +13,6 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import iconZendesk from 'public/services/zendesk.svg'
 
 import { signalSourcesLogic } from './signalSourcesLogic'
-import { inboxSceneLogic } from './inboxSceneLogic'
 import { SignalSourceConfigStatus } from './types'
 
 type SourceProps =

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -20,11 +20,13 @@ const REPORTS_PAGE_SIZE = 200
 
 export type DetailTab = 'overview' | 'signals'
 
+const CLUSTERING_POLL_INTERVAL_MS = 5000
+
 export const inboxSceneLogic = kea<inboxSceneLogicType>([
     path(['scenes', 'inbox', 'inboxSceneLogic']),
 
     connect({
-        values: [signalSourcesLogic, ['hasNoSources']],
+        values: [signalSourcesLogic, ['hasNoSources', 'isClusteringRunning']],
     }),
 
     actions({
@@ -168,7 +170,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         setSearchQuery: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadReports()
@@ -204,6 +206,15 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 lemonToast.error(errorMessage)
             }
         },
+        loadSourceConfigsSuccess: () => {
+            clearInterval(cache.clusteringPollInterval)
+            if (values.isClusteringRunning) {
+                cache.clusteringPollInterval = setInterval(() => {
+                    actions.loadSourceConfigs()
+                    actions.loadReports()
+                }, CLUSTERING_POLL_INTERVAL_MS)
+            }
+        },
         runSessionAnalysis: async () => {
             try {
                 await api.signalReports.analyzeSessions()
@@ -220,9 +231,12 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         },
     })),
 
-    events(({ actions }) => ({
+    events(({ actions, cache }) => ({
         afterMount: () => {
             actions.loadReports()
+        },
+        beforeUnmount: () => {
+            clearInterval(cache.clusteringPollInterval)
         },
     })),
 

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -27,6 +27,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
 
     connect({
         values: [signalSourcesLogic, ['hasNoSources', 'isClusteringRunning']],
+        actions: [signalSourcesLogic, ['loadSourceConfigs']],
     }),
 
     actions({

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -10,7 +10,13 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { RecordingUniversalFilters } from '~/types'
 
 import type { signalSourcesLogicType } from './signalSourcesLogicType'
-import { SignalSourceConfig, SignalSourceProduct, SignalSourceType, ToggleSignalSourceParams } from './types'
+import {
+    SignalSourceConfig,
+    SignalSourceConfigStatus,
+    SignalSourceProduct,
+    SignalSourceType,
+    ToggleSignalSourceParams,
+} from './types'
 
 export const signalSourcesLogic = kea<signalSourcesLogicType>([
     path(['scenes', 'inbox', 'signalSourcesLogic']),
@@ -84,6 +90,7 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         config: {},
                         created_at: new Date().toISOString(),
                         updated_at: new Date().toISOString(),
+                        status: null,
                     },
                 ]
             },
@@ -99,6 +106,10 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         c.source_product === SignalSourceProduct.SESSION_REPLAY &&
                         c.source_type === SignalSourceType.SESSION_ANALYSIS_CLUSTER
                 ) ?? null,
+        ],
+        isClusteringRunning: [
+            (s) => [s.sessionAnalysisConfig],
+            (config: SignalSourceConfig | null): boolean => config?.status === SignalSourceConfigStatus.RUNNING,
         ],
         enabledSourcesCount: [
             (s) => [s.sourceConfigs],

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -40,6 +40,7 @@ export interface SignalSourceConfig {
     config: Record<string, any>
     created_at: string
     updated_at: string
+    status: SignalSourceConfigStatus | null
 }
 
 export enum SignalSourceProduct {
@@ -57,4 +58,10 @@ export interface ToggleSignalSourceParams {
     sourceType: SignalSourceType
     enabled: boolean
     config?: Record<string, any>
+}
+
+export enum SignalSourceConfigStatus {
+    RUNNING = 'running',
+    COMPLETED = 'completed',
+    FAILED = 'failed',
 }

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -7,7 +7,7 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-from posthog.temporal.ai.video_segment_clustering.models import GetSessionsToPrimeResult
+from posthog.temporal.ai.video_segment_clustering.models import EmitSignalsResult, GetSessionsToPrimeResult
 from posthog.temporal.common.base import PostHogWorkflow
 
 with workflow.unsafe.imports_passed_through():
@@ -50,6 +50,9 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: ClusteringWorkflowInputs) -> EmitSignalsResult | None:
         """Execute the video segment clustering workflow for a single team."""
+        return await self._run_pipeline(inputs)
+
+    async def _run_pipeline(self, inputs: ClusteringWorkflowInputs) -> EmitSignalsResult | None:
         # Step 1: Prime the document_embeddings table with analysis of latest sessions
         prime_info = None
         if inputs.skip_priming:

--- a/posthog/temporal/ai/video_segment_clustering/constants.py
+++ b/posthog/temporal/ai/video_segment_clustering/constants.py
@@ -1,6 +1,13 @@
 """Configuration constants for video segment clustering workflow."""
 
 from datetime import timedelta
+from uuid import UUID
+
+
+def clustering_workflow_id(team_id: int, config_id: UUID | str) -> str:
+    """Shared workflow ID for conflict resolution between initial trigger and coordinator."""
+    return f"video-segment-clustering-team-{team_id}-config-{config_id}"
+
 
 # What period to consider in clustering run, and how often to run it on schedule
 DEFAULT_LOOKBACK_WINDOW = timedelta(days=7)

--- a/posthog/temporal/ai/video_segment_clustering/coordinator_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/coordinator_workflow.py
@@ -13,12 +13,13 @@ from typing import Any
 import structlog
 import temporalio
 import posthoganalytics
+import temporalio.exceptions
 from temporalio import activity, workflow
-from temporalio.common import RetryPolicy
+from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.workflow import ChildWorkflowHandle
 
 from posthog.temporal.ai.video_segment_clustering.clustering_workflow import VideoSegmentClusteringWorkflow
-from posthog.temporal.ai.video_segment_clustering.constants import DEFAULT_LOOKBACK_WINDOW
+from posthog.temporal.ai.video_segment_clustering.constants import DEFAULT_LOOKBACK_WINDOW, clustering_workflow_id
 from posthog.temporal.ai.video_segment_clustering.models import ClusteringWorkflowInputs, EmitSignalsResult
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.logger import get_logger
@@ -50,7 +51,7 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: VideoSegmentClusteringCoordinatorInputs) -> dict[str, Any]:
-        enabled_team_ids: list[int] = await workflow.execute_activity(
+        enabled_configs: list[tuple[int, str]] = await workflow.execute_activity(
             get_proactive_tasks_enabled_team_ids_activity,
             start_to_close_timeout=timedelta(seconds=60),
             retry_policy=RetryPolicy(
@@ -60,7 +61,7 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
             ),
         )
 
-        if not enabled_team_ids:
+        if not enabled_configs:
             workflow.logger.debug("No teams with proactive tasks enabled")
             return {
                 "teams_processed": 0,
@@ -69,30 +70,31 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
                 "total_signals_emitted": 0,
             }
 
-        workflow.logger.debug(f"Processing {len(enabled_team_ids)} teams with proactive tasks enabled")
+        workflow.logger.debug(f"Processing {len(enabled_configs)} configs with proactive tasks enabled")
 
         # Track results
         total_signals_emitted = 0
         failed_teams: set[int] = set()
         successful_teams: set[int] = set()
 
-        # Process teams in batches for controlled parallelism
-        for batch_start in range(0, len(enabled_team_ids), DEFAULT_MAX_CONCURRENT_TEAMS):
-            batch = enabled_team_ids[batch_start : batch_start + DEFAULT_MAX_CONCURRENT_TEAMS]
+        # Process configs in batches for controlled parallelism
+        for batch_start in range(0, len(enabled_configs), DEFAULT_MAX_CONCURRENT_TEAMS):
+            batch = enabled_configs[batch_start : batch_start + DEFAULT_MAX_CONCURRENT_TEAMS]
 
             # Start all workflows in batch concurrently
             workflow_handles: dict[
                 int, ChildWorkflowHandle[VideoSegmentClusteringWorkflow, EmitSignalsResult | None]
             ] = {}
-            for team_id in batch:
+            for team_id, config_id in batch:
                 try:
-                    handle = await temporalio.workflow.start_child_workflow(
+                    handle = await workflow.start_child_workflow(
                         VideoSegmentClusteringWorkflow.run,
                         ClusteringWorkflowInputs(
                             team_id=team_id,
                             lookback_hours=inputs.lookback_hours,
                         ),
-                        id=f"video-segment-clustering-team-{team_id}-{temporalio.workflow.now().isoformat()}",
+                        id=clustering_workflow_id(team_id, config_id),
+                        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                         # Clustering is fast, but priming session summaries takes a while due to video export.
                         # However, 3h should comfortably allow exporting even long sessions, thanks to optimization like
                         # ignoring inactivity or playback speedup. If this is not enough, then we need to optimize export further.
@@ -103,9 +105,11 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
                             maximum_interval=timedelta(minutes=5),
                             backoff_coefficient=2.0,
                         ),
-                        parent_close_policy=temporalio.workflow.ParentClosePolicy.REQUEST_CANCEL,  # Terminate but softly
+                        parent_close_policy=workflow.ParentClosePolicy.REQUEST_CANCEL,  # Terminate but softly
                     )
                     workflow_handles[team_id] = handle
+                except temporalio.exceptions.WorkflowAlreadyStartedError:
+                    continue
                 except Exception:
                     workflow.logger.exception(f"Failed to start video segment clustering for team {team_id}")
                     posthoganalytics.capture_exception(properties={"team_id": team_id})
@@ -124,7 +128,7 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
                     failed_teams.add(team_id)
 
         return {
-            "teams_processed": len(enabled_team_ids),
+            "teams_processed": len(enabled_configs),
             "teams_succeeded": len(successful_teams),
             "teams_failed": len(failed_teams),
             "failed_team_ids": list(failed_teams),
@@ -133,12 +137,12 @@ class VideoSegmentClusteringCoordinatorWorkflow(PostHogWorkflow):
 
 
 @activity.defn
-async def get_proactive_tasks_enabled_team_ids_activity() -> list[int]:
-    enabled_team_ids: list[int] = []
+async def get_proactive_tasks_enabled_team_ids_activity() -> list[tuple[int, str]]:
+    enabled_configs: list[tuple[int, str]] = []
     async for config in SignalSourceConfig.objects.filter(
         source_product=SignalSourceConfig.SourceProduct.SESSION_REPLAY,
         source_type=SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER,
         enabled=True,
-    ).only("team_id"):
-        enabled_team_ids.append(config.team_id)
-    return enabled_team_ids
+    ).only("team_id", "id"):
+        enabled_configs.append((config.team_id, str(config.id)))
+    return enabled_configs

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -1,11 +1,22 @@
 import json
+import logging
 
+from asgiref.sync import async_to_sync
 from rest_framework import serializers
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.temporal.ai.video_segment_clustering.constants import clustering_workflow_id
+from posthog.temporal.common.client import sync_connect
 
 from .models import SignalReport, SignalReportArtefact, SignalSourceConfig
 
+logger = logging.getLogger(__name__)
+
 
 class SignalSourceConfigSerializer(serializers.ModelSerializer):
+    status = serializers.SerializerMethodField()
+
     class Meta:
         model = SignalSourceConfig
         fields = [
@@ -16,8 +27,36 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
             "config",
             "created_at",
             "updated_at",
+            "status",
         ]
-        read_only_fields = ["id", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at", "status"]
+
+    def get_status(self, obj: SignalSourceConfig) -> str | None:
+        if obj.source_type != SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER:
+            return None
+        workflow_id = clustering_workflow_id(obj.team_id, obj.id)
+        try:
+            client = sync_connect()
+            handle = client.get_workflow_handle(workflow_id)
+            desc = async_to_sync(handle.describe)()
+            status = desc.status
+            if status == WorkflowExecutionStatus.RUNNING:
+                return "running"
+            if status == WorkflowExecutionStatus.COMPLETED:
+                return "completed"
+            if status in (
+                WorkflowExecutionStatus.FAILED,
+                WorkflowExecutionStatus.TERMINATED,
+                WorkflowExecutionStatus.CANCELED,
+                WorkflowExecutionStatus.TIMED_OUT,
+            ):
+                return "failed"
+            return None
+        except RPCError as e:
+            if e.status == RPCStatusCode.NOT_FOUND:
+                return None
+            logger.warning("Failed to fetch clustering workflow status: %s", e)
+            return None
 
     def validate(self, attrs: dict) -> dict:
         source_product = attrs.get("source_product", getattr(self.instance, "source_product", None))

--- a/products/signals/backend/test/test_signal_source_config_api.py
+++ b/products/signals/backend/test/test_signal_source_config_api.py
@@ -21,7 +21,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         response = self.client.post(
             self._url(),
             data={
-                "source_type": "session_analysis",
+                "source_product": "session_replay",
+                "source_type": "session_analysis_cluster",
                 "enabled": True,
                 "config": {"recording_filters": {"duration_min": 5}},
             },
@@ -29,7 +30,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         )
         data = response.json()
         assert response.status_code == status.HTTP_201_CREATED, data
-        assert data["source_type"] == "session_analysis"
+        assert data["source_product"] == "session_replay"
+        assert data["source_type"] == "session_analysis_cluster"
         assert data["enabled"] is True
         assert data["config"] == {"recording_filters": {"duration_min": 5}}
         assert SignalSourceConfig.objects.filter(id=data["id"], team=self.team).exists()
@@ -37,7 +39,7 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_create_source_config_sets_created_by(self):
         response = self.client.post(
             self._url(),
-            data={"source_type": "session_analysis"},
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster"},
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -47,7 +49,7 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_create_source_config_defaults(self):
         response = self.client.post(
             self._url(),
-            data={"source_type": "session_analysis"},
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster"},
             format="json",
         )
         data = response.json()
@@ -58,7 +60,7 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_create_source_config_invalid_source_type(self):
         response = self.client.post(
             self._url(),
-            data={"source_type": "nonexistent_type"},
+            data={"source_product": "session_replay", "source_type": "nonexistent_type"},
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -67,12 +69,13 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_create_duplicate_source_type_per_team_rejected(self):
         SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.post(
             self._url(),
-            data={"source_type": "session_analysis"},
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster"},
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -81,16 +84,18 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_same_source_type_allowed_on_different_teams(self):
         SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         SignalSourceConfig.objects.create(
             team=other_team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
-        assert SignalSourceConfig.objects.filter(source_type="session_analysis").count() == 2
+        assert SignalSourceConfig.objects.filter(source_type="session_analysis_cluster").count() == 2
 
     # --- Config validation ---
 
@@ -104,7 +109,7 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_create_config_validation(self, _name, config, expected_status):
         response = self.client.post(
             self._url(),
-            data={"source_type": "session_analysis", "config": config},
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster", "config": config},
             format="json",
         )
         assert response.status_code == expected_status, response.json()
@@ -114,25 +119,28 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_list_source_configs(self):
         SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.get(self._url())
         data = response.json()
         assert response.status_code == status.HTTP_200_OK
         assert len(data["results"]) == 1
-        assert data["results"][0]["source_type"] == "session_analysis"
+        assert data["results"][0]["source_type"] == "session_analysis_cluster"
 
     def test_list_excludes_other_teams(self):
         SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         SignalSourceConfig.objects.create(
             team=other_team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
 
@@ -145,7 +153,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_retrieve_source_config(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             config={"recording_filters": {"duration_min": 10}},
             created_by=self.user,
         )
@@ -153,14 +162,15 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         data = response.json()
         assert response.status_code == status.HTTP_200_OK
         assert data["id"] == str(config.id)
-        assert data["source_type"] == "session_analysis"
+        assert data["source_type"] == "session_analysis_cluster"
         assert data["config"] == {"recording_filters": {"duration_min": 10}}
 
     def test_retrieve_other_teams_config_forbidden(self):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         config = SignalSourceConfig.objects.create(
             team=other_team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.get(self._url(str(config.id)))
@@ -170,7 +180,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         config = SignalSourceConfig.objects.create(
             team=other_team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.patch(
@@ -185,7 +196,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_update_enabled(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             enabled=True,
             created_by=self.user,
         )
@@ -202,7 +214,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_update_config(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             config={},
             created_by=self.user,
         )
@@ -217,7 +230,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_update_config_recording_filters_not_dict_rejected(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             config={},
             created_by=self.user,
         )
@@ -232,7 +246,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_update_source_type_is_not_writable(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.patch(
@@ -244,13 +259,14 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         # but the value is validated
         config.refresh_from_db()
         # Should either be rejected or keep original value
-        assert config.source_type == "session_analysis" or response.status_code == status.HTTP_400_BAD_REQUEST
+        assert config.source_type == "session_analysis_cluster" or response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_delete_other_teams_config_forbidden(self):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         config = SignalSourceConfig.objects.create(
             team=other_team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         response = self.client.delete(self._url(str(config.id)))
@@ -262,7 +278,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_delete_source_config(self):
         config = SignalSourceConfig.objects.create(
             team=self.team,
-            source_type="session_analysis",
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
             created_by=self.user,
         )
         config_id = str(config.id)
@@ -275,7 +292,7 @@ class TestSignalSourceConfigAPI(APIBaseTest):
     def test_read_only_fields_in_response(self):
         response = self.client.post(
             self._url(),
-            data={"source_type": "session_analysis"},
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster"},
             format="json",
         )
         data = response.json()

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from temporalio.common import RetryPolicy, WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
 from posthog.schema import EmbeddingModelName
 
@@ -26,6 +27,9 @@ from posthog.api.embedding_worker import emit_embedding_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.permissions import APIScopePermission
+from posthog.temporal.ai.video_segment_clustering.constants import clustering_workflow_id
+from posthog.temporal.ai.video_segment_clustering.models import ClusteringWorkflowInputs
+from posthog.temporal.common.client import sync_connect
 
 from products.signals.backend.api import emit_signal
 from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalSourceConfig
@@ -85,11 +89,31 @@ class SignalSourceConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         try:
-            serializer.save(team_id=self.team_id, created_by=self.request.user)
+            instance = serializer.save(team_id=self.team_id, created_by=self.request.user)
         except IntegrityError:
             raise serializers.ValidationError(
                 {"source_product": "A configuration for this source product and type already exists for this team."}
             )
+
+        if instance.source_type == SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER and instance.enabled:
+            self._trigger_initial_clustering(instance)
+
+    def _trigger_initial_clustering(self, config: SignalSourceConfig) -> None:
+        """Fire-and-forget the clustering workflow."""
+        try:
+            client = sync_connect()
+            async_to_sync(client.start_workflow)(  # type: ignore
+                "video-segment-clustering",  # type: ignore
+                ClusteringWorkflowInputs(team_id=self.team_id),  # type: ignore
+                id=clustering_workflow_id(self.team_id, config.id),
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+            logger.info(f"Started initial clustering workflow for team {self.team_id}")
+        except Exception:
+            logger.exception(f"Failed to start initial clustering workflow for team {self.team_id}")
 
     def perform_update(self, serializer):
         try:

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -38,6 +38,8 @@ export interface SignalSourceConfigApi {
     config?: unknown
     readonly created_at: string
     readonly updated_at: string
+    /** @nullable */
+    readonly status: string | null
 }
 
 export interface PaginatedSignalSourceConfigListApi {


### PR DESCRIPTION
## Problem

Currently when the PostHog Session Replay signal source is enabled, you have to wait up to an hour (for hour:00) for analysis to even start. Not a great starting experience. 

<img width="527" height="518" alt="Screenshot 2026-02-24 at 13 39 56" src="https://github.com/user-attachments/assets/f0e95154-e9ed-4d90-bb07-f65219e8df55" />

## Changes

This adds immediate kickoff of initial session clustering for the team when the Session Replay source is added.
Via the new `status` field on SignalSourceConfig, we surface the status of that run in the UI.

## How did you test this code?

Ran locally.

## Publish to changelog?

No, flagged.