### PR TITLE
chore(ff): skip write flag

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -539,6 +539,7 @@ impl ThreadCounts {
             rayon_threads,
         }
     }
+}
 
 impl Config {
     const MAX_RESPONSE_TIMEOUT_MS: u64 = 30_000; // 30 seconds

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -479,6 +479,12 @@ pub struct Config {
     // 0 = auto (derived from rayon thread count).
     #[envconfig(from = "MAX_CONCURRENT_BATCH_EVALS", default = "0")]
     pub max_concurrent_batch_evals: usize,
+
+    // When true, skip all writes to PostgreSQL and Redis.
+    // Used to safely deploy and test the personhog migration path
+    // without risking any data mutations.
+    #[envconfig(from = "SKIP_WRITES", default = "false")]
+    pub skip_writes: FlexBool,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -533,7 +539,6 @@ impl ThreadCounts {
             rayon_threads,
         }
     }
-}
 
 impl Config {
     const MAX_RESPONSE_TIMEOUT_MS: u64 = 30_000; // 30 seconds
@@ -654,6 +659,7 @@ impl Config {
             optimize_experience_continuity_lookups: FlexBool(true),
             parallel_eval_threshold: 100,
             max_concurrent_batch_evals: 0,
+            skip_writes: FlexBool(false),
         }
     }
 
@@ -794,6 +800,7 @@ mod tests {
         assert_eq!(config.new_analytics_capture_endpoint, "/i/v0/e/");
         assert_eq!(config.debug, FlexBool(false));
         assert!(!config.flags_session_replay_quota_check);
+        assert_eq!(config.skip_writes, FlexBool(false));
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -225,6 +225,8 @@ pub struct FeatureFlagMatcher {
     /// Dispatcher for bounded-concurrency Rayon batch evaluation.
     /// `None` in tests that don't exercise the parallel path.
     rayon_dispatcher: Option<RayonDispatcher>,
+    /// When true, skip all writes to PostgreSQL and Redis.
+    skip_writes: bool,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -271,6 +273,7 @@ impl FeatureFlagMatcher {
             flag_evaluation_state: FlagEvaluationState::default(),
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
+            skip_writes: false,
         }
     }
 
@@ -281,6 +284,11 @@ impl FeatureFlagMatcher {
 
     pub fn with_rayon_dispatcher(mut self, dispatcher: RayonDispatcher) -> Self {
         self.rayon_dispatcher = Some(dispatcher);
+        self
+    }
+
+    pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
+        self.skip_writes = skip_writes;
         self
     }
 
@@ -486,24 +494,32 @@ impl FeatureFlagMatcher {
         let mut writing_hash_key_override = false;
 
         if should_write {
-            if let Err(e) = set_feature_flag_hash_key_overrides(
-                // NB: this is the only method that writes to the database
-                &self.router,
-                self.team_id,
-                target_distinct_ids.clone(),
-                hash_key.clone(),
-            )
-            .await
-            {
-                error!("Failed to set feature flag hash key overrides for team {} distinct_id {} hash_key {}: {:?}", self.team_id, self.distinct_id, hash_key, e);
-                inc(
-                    FLAG_EVALUATION_ERROR_COUNTER,
-                    &[("reason".to_string(), e.evaluation_error_code())],
-                    1,
+            if self.skip_writes {
+                tracing::info!(
+                    team_id = self.team_id,
+                    distinct_id = %self.distinct_id,
+                    "SKIP_WRITES: skipping hash key override write to PostgreSQL"
                 );
-                return (None, true);
+            } else {
+                if let Err(e) = set_feature_flag_hash_key_overrides(
+                    // NB: this is the only method that writes to the database
+                    &self.router,
+                    self.team_id,
+                    target_distinct_ids.clone(),
+                    hash_key.clone(),
+                )
+                .await
+                {
+                    error!("Failed to set feature flag hash key overrides for team {} distinct_id {} hash_key {}: {:?}", self.team_id, self.distinct_id, hash_key, e);
+                    inc(
+                        FLAG_EVALUATION_ERROR_COUNTER,
+                        &[("reason".to_string(), e.evaluation_error_code())],
+                        1,
+                    );
+                    return (None, true);
+                }
+                writing_hash_key_override = true;
             }
-            writing_hash_key_override = true;
         }
 
         inc(

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -495,7 +495,7 @@ impl FeatureFlagMatcher {
 
         if should_write {
             if self.skip_writes {
-                tracing::info!(
+                tracing::debug!(
                     team_id = self.team_id,
                     distinct_id = %self.distinct_id,
                     "SKIP_WRITES: skipping hash key override write to PostgreSQL"

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -49,6 +49,10 @@ pub async fn record_usage(
     team_id: i32,
     library: Library,
 ) {
+    if *context.state.config.skip_writes {
+        return;
+    }
+
     let has_billable_flags = contains_billable_flags(filtered_flags);
 
     if has_billable_flags {

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -32,7 +32,8 @@ pub async fn evaluate_feature_flags(
         context.groups,
     )
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
-    .with_rayon_dispatcher(context.rayon_dispatcher);
+    .with_rayon_dispatcher(context.rayon_dispatcher)
+    .with_skip_writes(context.skip_writes);
 
     matcher
         .evaluate_all_feature_flags(

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -263,6 +263,7 @@ pub async fn evaluate_for_request(
             .0,
         parallel_eval_threshold: state.config.parallel_eval_threshold,
         rayon_dispatcher: state.rayon_dispatcher.clone(),
+        skip_writes: *state.config.skip_writes,
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1574,6 +1574,7 @@ async fn test_parallel_path_matches_sequential_results() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
     let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4()).await;
 
@@ -1596,6 +1597,7 @@ async fn test_parallel_path_matches_sequential_results() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 1,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
     let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4()).await;
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -193,6 +193,7 @@ async fn test_evaluate_feature_flags() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -286,6 +287,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -693,6 +695,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -799,6 +802,7 @@ async fn test_evaluate_feature_flags_details() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -957,6 +961,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -1050,6 +1055,7 @@ async fn test_long_distinct_id() {
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -65,6 +65,8 @@ pub struct FeatureFlagEvaluationContext {
     pub parallel_eval_threshold: usize,
     /// Dispatcher for bounded-concurrency Rayon batch evaluation.
     pub rayon_dispatcher: RayonDispatcher,
+    /// When true, skip all writes to PostgreSQL and Redis.
+    pub skip_writes: bool,
 }
 
 /// SDK type classification based on user-agent parsing.

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -307,6 +307,13 @@ pub async fn serve<F>(
             }
         };
 
+    if *config.skip_writes {
+        tracing::warn!(
+            "SKIP_WRITES is enabled: all writes to PostgreSQL and Redis are disabled. \
+             This instance is running in read-only mode for safe performance testing."
+        );
+    }
+
     // Warn about deprecated environment variables
     if std::env::var("TEAM_CACHE_TTL_SECONDS").is_ok() {
         tracing::warn!(

--- a/rust/feature-flags/tests/test_skip_writes.rs
+++ b/rust/feature-flags/tests/test_skip_writes.rs
@@ -104,11 +104,12 @@ async fn test_skip_writes_prevents_hash_key_override_write() -> Result<()> {
 
     // Step 4: Verify the posthog_featureflaghashkeyoverride table has no rows for this team
     let mut conn = context.get_persons_connection().await?;
-    let row_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM posthog_featureflaghashkeyoverride WHERE team_id = $1")
-            .bind(team.id)
-            .fetch_one(&mut *conn)
-            .await?;
+    let row_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM posthog_featureflaghashkeyoverride WHERE team_id = $1",
+    )
+    .bind(team.id)
+    .fetch_one(&mut *conn)
+    .await?;
 
     assert_eq!(
         row_count, 0,

--- a/rust/feature-flags/tests/test_skip_writes.rs
+++ b/rust/feature-flags/tests/test_skip_writes.rs
@@ -1,0 +1,176 @@
+use anyhow::Result;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+pub mod common;
+use crate::common::ServerHandle;
+use feature_flags::config::{FlexBool, DEFAULT_TEST_CONFIG};
+use feature_flags::flags::flag_models::FeatureFlagRow;
+use feature_flags::utils::test_utils::TestContext;
+
+#[tokio::test]
+async fn test_skip_writes_prevents_hash_key_override_write() -> Result<()> {
+    // With SKIP_WRITES=true, sending $anon_distinct_id should NOT persist a hash key override.
+    // A subsequent request without $anon_distinct_id should fall back to the distinct_id,
+    // meaning the override was never written.
+
+    let context = TestContext::new(None).await;
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
+
+    let flag_row = FeatureFlagRow {
+        id: 200,
+        team_id: team.id,
+        name: Some("Skip Writes EEC Flag".to_string()),
+        key: "skip-writes-eec-flag".to_string(),
+        filters: json!({
+            "groups": [{"rollout_percentage": 50}]
+        }),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: Some(true),
+        version: Some(1),
+        evaluation_runtime: None,
+        evaluation_tags: None,
+        bucketing_identifier: None,
+    };
+    context.insert_flag(team.id, Some(flag_row)).await?;
+
+    let user_id = "false_eval_user";
+    context
+        .insert_person(
+            team.id,
+            user_id.to_string(),
+            Some(json!({"email": "false_eval_user@example.com"})),
+        )
+        .await?;
+
+    let mut config = DEFAULT_TEST_CONFIG.clone();
+    config.skip_writes = FlexBool(true);
+    let server = ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![],
+        vec![(team.api_token.clone(), team.id)],
+    )
+    .await;
+
+    // Step 1: Verify the user evaluates to false without override
+    let initial_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+    });
+
+    let initial_res = server
+        .send_flags_request(initial_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(initial_res.status(), StatusCode::OK);
+    let initial_json = initial_res.json::<Value>().await?;
+    let initial_value = initial_json["flags"]["skip-writes-eec-flag"]["enabled"].clone();
+
+    // Step 2: Send a request WITH $anon_distinct_id (would normally write the override)
+    let anon_id = "true_eval_user";
+    let override_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+        "$anon_distinct_id": anon_id,
+    });
+
+    let override_res = server
+        .send_flags_request(override_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(override_res.status(), StatusCode::OK);
+
+    // Step 3: Send request WITHOUT $anon_distinct_id again.
+    // If the write was skipped, we should get the same result as Step 1
+    // (the override should not have been persisted).
+    let final_payload = json!({
+        "token": team.api_token,
+        "distinct_id": user_id,
+    });
+
+    let final_res = server
+        .send_flags_request(final_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(final_res.status(), StatusCode::OK);
+    let final_json = final_res.json::<Value>().await?;
+
+    assert_eq!(
+        final_json["flags"]["skip-writes-eec-flag"]["enabled"], initial_value,
+        "With SKIP_WRITES=true, the hash key override should not have been persisted. \
+         The final evaluation should match the initial evaluation (no override in DB)."
+    );
+
+    // Step 4: Verify the posthog_featureflaghashkeyoverride table has no rows for this team
+    let mut conn = context.get_persons_connection().await?;
+    let row_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM posthog_featureflaghashkeyoverride WHERE team_id = $1")
+            .bind(team.id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    assert_eq!(
+        row_count, 0,
+        "No hash key overrides should be written when SKIP_WRITES=true"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_writes_still_evaluates_flags_correctly() -> Result<()> {
+    // SKIP_WRITES should not affect flag evaluation results - only writes.
+
+    let context = TestContext::new(None).await;
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
+
+    let flag_row = FeatureFlagRow {
+        id: 201,
+        team_id: team.id,
+        name: Some("Simple Flag".to_string()),
+        key: "simple-flag".to_string(),
+        filters: json!({
+            "groups": [{"rollout_percentage": 100}]
+        }),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: Some(false),
+        version: Some(1),
+        evaluation_runtime: None,
+        evaluation_tags: None,
+        bucketing_identifier: None,
+    };
+    context.insert_flag(team.id, Some(flag_row)).await?;
+
+    let mut config = DEFAULT_TEST_CONFIG.clone();
+    config.skip_writes = FlexBool(true);
+    let server = ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![],
+        vec![(team.api_token.clone(), team.id)],
+    )
+    .await;
+
+    let payload = json!({
+        "token": team.api_token,
+        "distinct_id": "test_user",
+    });
+
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let json_response = res.json::<Value>().await?;
+
+    assert_eq!(
+        json_response["flags"]["simple-flag"]["enabled"],
+        json!(true),
+        "A 100% rollout flag should still evaluate to true with SKIP_WRITES enabled"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

The ingestion team is looking to fence off access to the persons DB behind a persons API (personhog). In order to test the performance of switching feature flags from querying the datbase directly to making requests to that service, before any migration happens, it would be great if we could mirror some production traffic towards an ff deployment that uses the new personhog client.

To support testing with mirrored production traffic, the `feature-flags` service requires a `SKIP_WRITES` mode to ensure the mirrored service doesn't make any writes to databases/only serves read requests to get an idea of the performance differences.


## Changes

- Added `skip_writes: FlexBool` config field (env `SKIP_WRITES`, default `false`) and updated `default_test_config()`
- Log a `warn!` at startup when `skip_writes` is enabled
- Threaded `skip_writes` through `FeatureFlagEvaluationContext` → `FeatureFlagMatcher` via the existing config/context/builder pattern
- Guarded the PostgreSQL hash key override write in `process_hash_key_override()` — logs and skips when true, reads for existing overrides still execute
- Guarded the Redis billing counter write in `record_usage()` (`/flags` handler) — early return when true
- Guarded the Redis billing counter write in `flags_definitions()` (`/flags/definitions` handler) — conditional skip when true
- Added integration test verifying no rows written to `posthog_featureflaghashkeyoverride` when `SKIP_WRITES=true`
- Added integration test verifying flag evaluation still returns correct results when `SKIP_WRITES=true`


## How did you test this code?

Unit tests:
- a unit test confirming the writer pool aliases to readers and doesn't attempt to connect to the writer URL

Integration test:
- test that we skip persisting hash key override to DB when SKIP_WRITES is true
- test that we evalute flags correctly when SKIP_WRITES is true
