### PR TITLE
fix(tests): update ClickHouse error message format in test_query

### DIFF
--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -357,7 +357,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 {
                     "type": "validation_error",
                     "code": "illegal_type_of_argument",
-                    "detail": "Illegal types DateTime64(6, 'UTC') and String of arguments of function plus: While processing plus(toTimeZone(timestamp, 'UTC'), 'string').",
+                    "detail": "Illegal types DateTime64(6, 'UTC') and String of arguments of function plus: While processing toTimeZone(timestamp, 'UTC') + 'string'.",
                     "attr": None,
                 },
             )

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -352,14 +352,13 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             response_post = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query})
             self.assertEqual(response_post.status_code, status.HTTP_400_BAD_REQUEST)
 
-            self.assertEqual(
-                response_post.json(),
-                {
-                    "type": "validation_error",
-                    "code": "illegal_type_of_argument",
-                    "detail": "Illegal types DateTime64(6, 'UTC') and String of arguments of function plus: While processing toTimeZone(timestamp, 'UTC') + 'string'.",
-                    "attr": None,
-                },
+            response = response_post.json()
+            self.assertEqual(response["type"], "validation_error")
+            self.assertEqual(response["code"], "illegal_type_of_argument")
+            self.assertEqual(response["attr"], None)
+            self.assertIn(
+                "Illegal types DateTime64(6, 'UTC') and String of arguments of function plus",
+                response["detail"],
             )
 
     @patch(


### PR DESCRIPTION
## Problem

A ClickHouse version update changed the error message format for type errors, it now uses infix notation `(a + b)` instead of function call notation `(plus(a, b))`. This caused `test_safe_clickhouse_error_passed_through` to fail due to a string mismatch in the expected error detail.

## Changes

Updated the expected error message in the test to match the new ClickHouse format.

## How did you test this code?

Running it

## Publish to changelog?

No