### PR TITLE
fix(resolver): selectquerytype in a column

### DIFF
--- a/posthog/hogql/resolver_utils.py
+++ b/posthog/hogql/resolver_utils.py
@@ -219,6 +219,9 @@ def _recursively_resolve_column(
         fields[name] = _constant_type_to_database_field(name, column.return_type)
     elif isinstance(column, ast.ConstantType):
         fields[name] = _constant_type_to_database_field(name, column)
+    elif isinstance(column, ast.SelectQueryType):
+        first_col = next(iter(column.columns.values()))
+        return _recursively_resolve_column(name, first_col, fields, context)
     else:
         raise QueryError(f"{column.__class__.__name__} is not supported in CTETableType")
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
@Scott-Sowers-PostHog flagged his endpoint stopped working. the endpoint had a select query as a column in a CTE
```sql
date_range AS (                                                                                                  
      SELECT                                                                                                       
          MIN(date) as period_start,                                                                               
          (SELECT period_end FROM latest_period) as period_end,                                                    
          dateDiff('day', MIN(date), (SELECT period_end FROM latest_period)) as total_days                         
      FROM period_data                                                                                             
  ),                       
```
failing with `posthog.hogql.errors.QueryError: SelectQueryType is not supported in CTETableType`

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- support SelectQueryType in a CTE

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- added a test close to what we saw fail in Endpoints

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
