### PR TITLE
fix: prevent payload edits from triggering blast radius and fix condition truncation

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -96,14 +96,12 @@ function ConditionHeader({
             : null
 
     return (
-        <div className="flex items-center justify-between w-full">
-            <div className="flex items-center gap-2">
-                <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5">{index + 1}</span>
-                <span className="text-sm truncate max-w-[300px]" title={summary}>
-                    {summary}
-                </span>
+        <div className="flex items-start justify-between w-full gap-2">
+            <div className="flex items-start gap-2 min-w-0">
+                <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">{index + 1}</span>
+                <span className="text-sm break-all">{summary}</span>
             </div>
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1 shrink-0">
                 <span className="text-sm text-muted mr-2">
                     ({rollout}%{group.variant && ` · ${group.variant}`}
                     {actualUserCount !== null &&

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -605,7 +605,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         ],
     }),
     propsChanged(({ props, values, actions }) => {
-        if (!objectsEqual(props.filters, values.filters)) {
+        // Compare only the fields that affect release conditions and blast radius,
+        // excluding payloads which don't affect targeting
+        const { payloads: _newPayloads, ...newRelevant } = props.filters
+        const { payloads: _oldPayloads, ...oldRelevant } = values.filters
+        if (!objectsEqual(newRelevant, oldRelevant)) {
             actions.setFilters(props.filters)
         }
     }),


### PR DESCRIPTION
## Summary
- Payload edits no longer trigger `user_blast_radius` API calls. The `propsChanged` hook now excludes `payloads` from the filter comparison since they don't affect targeting.
- Collapsed condition rows now wrap long values (like UUIDs) instead of truncating them with an ellipsis.