### PR TITLE
feat(dagster): further narrow step 1 windowed person reconciliation job query

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -517,21 +517,21 @@ def get_affected_person_ids_from_clickhouse(
     bug_window_end: str,
 ) -> list[str]:
     """
-    Query ClickHouse for distinct person_ids who had property-setting events in the bug window.
+    Query ClickHouse for person_ids whose events in the bug window produce property
+    diffs when compared against current person state.
 
-    This is the first step of the batched windowed query flow:
-    1. get_affected_person_ids_from_clickhouse() - identify affected persons (bounded)
-    2. For each batch of persons: run windowed event queries filtered to that batch
-    3. compare_raw_updates_with_person_state() to filter to actual diffs
+    Uses the same aggregation + person-state comparison structure as the
+    non-windowed query (get_person_property_updates_from_clickhouse) but:
+    - Bounded by bug_window_end (not now()) to keep the scan lightweight
+    - Returns only person_ids (no full diff data)
 
-    The query is bounded by bug_window_end to limit the set of affected persons,
-    even though the actual event property aggregation will extend to now() to
-    capture all property updates for those persons.
+    This means only persons whose bug-window event aggregation actually differs
+    from their current person properties are returned, dramatically reducing the
+    set compared to a simple event-presence check.
 
-    The query filters out FILTERED_PERSON_UPDATE_PROPERTIES using arrayExists
-    so that persons whose events only set high-frequency SDK properties (like
-    $browser, $os, $current_url) are excluded. This keeps the detected set
-    close to the set that will actually have diffs after comparison.
+    Possible false positives (acceptable): a person whose bug-window aggregation
+    shows a diff that disappears when events up to now() are included. These are
+    filtered out by the downstream windowed comparison step.
 
     Args:
         team_id: Team ID to query
@@ -542,7 +542,7 @@ def get_affected_person_ids_from_clickhouse(
         List of person_id strings (UUIDs) affected in the bug window
     """
     query = """
-    -- CTE 1: Get all overrides for the team
+    -- CTE 1: Get all overrides for the team (no filtering)
     WITH overrides AS (
         SELECT
             argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -551,34 +551,118 @@ def get_affected_person_ids_from_clickhouse(
         WHERE equals(person_distinct_id_overrides.team_id, %(team_id)s)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)
+    ),
+    -- CTE 2: Extract properties from events, grouped by RESOLVED person_id (after overrides)
+    event_properties_raw AS (
+        SELECT
+            person_id,
+            arrayMap(x -> x.1, arrayFilter(x -> x.4 = 'set', grouped_props)) AS set_keys,
+            arrayMap(x -> x.2, arrayFilter(x -> x.4 = 'set', grouped_props)) AS set_values,
+            arrayMap(x -> x.1, arrayFilter(x -> x.4 = 'set_once', grouped_props)) AS set_once_keys,
+            arrayMap(x -> x.1, arrayFilter(x -> x.4 = 'unset', grouped_props)) AS unset_keys
+        FROM (
+            SELECT
+                person_id,
+                groupArray(tuple(key, value, kv_timestamp, prop_type)) AS grouped_props
+            FROM (
+                SELECT
+                    if(notEmpty(o.distinct_id), o.person_id, e.person_id) AS person_id,
+                    kv_tuple.2 AS key,
+                    kv_tuple.1 AS prop_type,
+                    if(kv_tuple.1 = 'set',
+                        argMaxIf(kv_tuple.3, e.timestamp, kv_tuple.3 IS NOT NULL AND kv_tuple.3 != ''),
+                        argMinIf(kv_tuple.3, e.timestamp, kv_tuple.3 IS NOT NULL AND kv_tuple.3 != '')
+                    ) AS value,
+                    if(kv_tuple.1 = 'set_once', min(e.timestamp), max(e.timestamp)) AS kv_timestamp
+                FROM events e
+                LEFT JOIN overrides o ON e.distinct_id = o.distinct_id
+                ARRAY JOIN
+                    arrayConcat(
+                        arrayFilter(x -> x.3 IS NOT NULL AND x.3 != '' AND x.3 != 'null' AND x.2 NOT IN %(filtered_properties)s,
+                            arrayMap(x -> tuple('set', x.1, toString(x.2)),
+                                arrayFilter(x -> x.2 IS NOT NULL, JSONExtractKeysAndValuesRaw(e.properties, '$set'))
+                            )
+                        ),
+                        arrayFilter(x -> x.3 IS NOT NULL AND x.3 != '' AND x.3 != 'null' AND x.2 NOT IN %(filtered_properties)s,
+                            arrayMap(x -> tuple('set_once', x.1, toString(x.2)),
+                                arrayFilter(x -> x.2 IS NOT NULL, JSONExtractKeysAndValuesRaw(e.properties, '$set_once'))
+                            )
+                        ),
+                        arrayFilter(x -> x.2 NOT IN %(filtered_properties)s,
+                            arrayMap(x -> tuple('unset', JSON_VALUE(x, '$'), ''),
+                                JSONExtractArrayRaw(e.properties, '$unset')
+                            )
+                        )
+                    ) AS kv_tuple
+                WHERE e.team_id = %(team_id)s
+                  AND e.timestamp >= %(bug_window_start)s
+                  AND e.timestamp < %(bug_window_end)s
+                  AND (JSONExtractString(e.properties, '$set') != '' OR JSONExtractString(e.properties, '$set_once') != '' OR notEmpty(JSONExtractArrayRaw(e.properties, '$unset')))
+                GROUP BY if(notEmpty(o.distinct_id), o.person_id, e.person_id), kv_tuple.2, kv_tuple.1
+            )
+            GROUP BY person_id
+        )
+    ),
+    -- CTE 3: Filter to only persons with non-empty property sets
+    event_properties_flat AS (
+        SELECT *
+        FROM event_properties_raw
+        WHERE length(set_keys) > 0 OR length(set_once_keys) > 0 OR length(unset_keys) > 0
+    ),
+    -- CTE 4: Get person properties only for affected persons
+    person_props AS (
+        SELECT
+            id,
+            argMax(properties, version) as person_properties
+        FROM person
+        WHERE team_id = %(team_id)s
+          AND id IN (SELECT person_id FROM event_properties_flat)
+        GROUP BY id
+        HAVING argMax(is_deleted, version) = 0
     )
-    -- Get distinct resolved person_ids with property-setting events in the bug window
-    SELECT DISTINCT
-        if(notEmpty(o.distinct_id), o.person_id, e.person_id) AS person_id
-    FROM events e
-    LEFT JOIN overrides o ON e.distinct_id = o.distinct_id
-    WHERE e.team_id = %(team_id)s
-      AND e.timestamp >= %(bug_window_start)s
-      AND e.timestamp < %(bug_window_end)s
-      AND (
-        arrayExists(
-            x -> x.1 NOT IN %(filtered_properties)s,
-            JSONExtractKeysAndValuesRaw(e.properties, '$set')
-        )
-        OR arrayExists(
-            x -> x.1 NOT IN %(filtered_properties)s,
-            JSONExtractKeysAndValuesRaw(e.properties, '$set_once')
-        )
-        OR arrayExists(
-            x -> JSON_VALUE(x, '$') NOT IN %(filtered_properties)s,
-            JSONExtractArrayRaw(e.properties, '$unset')
-        )
-      )
-    ORDER BY person_id
+    -- Return only person_ids that have actual diffs against current state
+    SELECT ep.person_id
+    FROM event_properties_flat ep
+    INNER JOIN (
+        SELECT
+            id,
+            person_properties,
+            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(person_properties)) AS keys2,
+            arrayMap(x -> toString(x.2), JSONExtractKeysAndValuesRaw(person_properties)) AS vals2
+        FROM person_props
+    ) AS p ON p.id = ep.person_id
+    WHERE
+        -- $set: key exists in person AND value differs
+        length(arrayFilter(
+            i -> (
+                indexOf(p.keys2, ep.set_keys[i]) > 0
+                AND ep.set_values[i] != p.vals2[indexOf(p.keys2, ep.set_keys[i])]
+            ),
+            arrayEnumerate(ep.set_keys)
+        )) > 0
+        -- $set_once: key does NOT exist in person
+        OR length(arrayFilter(
+            i -> indexOf(p.keys2, ep.set_once_keys[i]) = 0,
+            arrayEnumerate(ep.set_once_keys)
+        )) > 0
+        -- $unset: key EXISTS in person
+        OR length(arrayFilter(
+            i -> indexOf(p.keys2, ep.unset_keys[i]) > 0,
+            arrayEnumerate(ep.unset_keys)
+        )) > 0
+    ORDER BY ep.person_id
     SETTINGS
         readonly=2,
-        max_execution_time=600,
-        allow_experimental_analyzer=1
+        max_execution_time=1200,
+        allow_experimental_object_type=1,
+        format_csv_allow_double_quotes=0,
+        max_ast_elements=4000000,
+        max_expanded_ast_elements=4000000,
+        allow_experimental_analyzer=1,
+        transform_null_in=1,
+        optimize_min_equality_disjunction_chain_length=4294967295,
+        allow_experimental_join_condition=1,
+        use_hive_partitioning=0
     """
 
     params = {

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -2223,7 +2223,11 @@ class TestGetPersonPropertyUpdatesWindowed:
 
 
 class TestGetAffectedPersonIdsFromClickhouse:
-    """Test the get_affected_person_ids_from_clickhouse function."""
+    """Test the get_affected_person_ids_from_clickhouse function.
+
+    This query aggregates event properties within the bug window, compares against
+    current person state, and returns only person_ids with actual diffs.
+    """
 
     @patch("posthog.dags.person_property_reconciliation.sync_execute")
     def test_returns_person_ids_in_bug_window(self, mock_sync_execute):
@@ -5155,7 +5159,7 @@ class TestClickHouseQueryIntegration:
         whose events only set FILTERED_PERSON_UPDATE_PROPERTIES ($browser, $os, etc.).
 
         Person A: events with ONLY filtered properties -> excluded
-        Person B: events with at least one non-filtered property -> included
+        Person B: events with at least one non-filtered property that differs from person state -> included
         """
         team_id = 99980
         person_a = UUID("aaaa0000-0000-0000-0000-000000000001")
@@ -5183,7 +5187,7 @@ class TestClickHouseQueryIntegration:
                     }
                 ),
             ),
-            # Person B: has a non-filtered property
+            # Person B: has a non-filtered property with a value that differs from person state
             (
                 team_id,
                 "real_update_user",
@@ -5193,7 +5197,7 @@ class TestClickHouseQueryIntegration:
                     {
                         "$set": {
                             "$browser": "Firefox",
-                            "email": "user@example.com",
+                            "email": "new@example.com",
                         },
                     }
                 ),
@@ -5209,18 +5213,36 @@ class TestClickHouseQueryIntegration:
 
         cluster.any_host(insert_events).result()
 
+        person_data = [
+            (team_id, person_a, json.dumps({"$browser": "Safari"}), 1, now - timedelta(hours=4)),
+            (team_id, person_b, json.dumps({"email": "old@example.com"}), 1, now - timedelta(hours=4)),
+        ]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
         affected_ids = get_affected_person_ids_from_clickhouse(
             team_id=team_id,
             bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
             bug_window_end=bug_window_end.strftime("%Y-%m-%d %H:%M:%S"),
         )
 
-        assert str(person_b) in affected_ids, "Person with non-filtered property should be detected"
+        assert str(person_b) in affected_ids, "Person with non-filtered property diff should be detected"
         assert str(person_a) not in affected_ids, "Person with only filtered properties should be excluded"
 
     def test_affected_person_ids_includes_set_once_and_unset_with_non_filtered_keys(self, cluster: ClickhouseCluster):
         """
-        Integration test: detection covers $set_once and $unset with non-filtered keys.
+        Integration test: detection covers $set_once and $unset with non-filtered keys
+        that produce actual diffs against person state.
+
+        person_set_once: $set_once for key not on person -> included
+        person_unset: $unset for key that exists on person -> included
         """
         team_id = 99981
         person_set_once = UUID("cccc0000-0000-0000-0000-000000000001")
@@ -5256,6 +5278,22 @@ class TestClickHouseQueryIntegration:
 
         cluster.any_host(insert_events).result()
 
+        person_data = [
+            # person_set_once: does NOT have "initial_campaign" -> $set_once will produce a diff
+            (team_id, person_set_once, json.dumps({"name": "Alice"}), 1, now - timedelta(hours=4)),
+            # person_unset: HAS "email" -> $unset will produce a diff
+            (team_id, person_unset, json.dumps({"email": "remove@example.com"}), 1, now - timedelta(hours=4)),
+        ]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
         affected_ids = get_affected_person_ids_from_clickhouse(
             team_id=team_id,
             bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
@@ -5264,6 +5302,93 @@ class TestClickHouseQueryIntegration:
 
         assert str(person_set_once) in affected_ids, "$set_once with non-filtered key should be detected"
         assert str(person_unset) in affected_ids, "$unset with non-filtered key should be detected"
+
+    def test_affected_person_ids_excludes_persons_whose_properties_already_match(self, cluster: ClickhouseCluster):
+        """
+        Integration test: persons whose events set non-filtered properties to values
+        that already match the current person state should NOT be returned.
+
+        This is the core fix for the 100x over-selection bug: the old query returned
+        anyone with property-setting events, the new query compares against person
+        state and only returns persons with actual diffs.
+
+        person_match: $set email to same value already on person -> excluded
+        person_diff: $set email to different value -> included
+        person_set_once_exists: $set_once for key already on person -> excluded
+        person_unset_missing: $unset for key NOT on person -> excluded
+        """
+        team_id = 99983
+        person_match = UUID("ff000000-0000-0000-0000-000000000001")
+        person_diff = UUID("ff000000-0000-0000-0000-000000000002")
+        person_set_once_exists = UUID("ff000000-0000-0000-0000-000000000003")
+        person_unset_missing = UUID("ff000000-0000-0000-0000-000000000004")
+        now = datetime.now().replace(microsecond=0)
+        bug_window_start = now - timedelta(hours=3)
+        bug_window_end = now - timedelta(hours=1)
+        event_ts = now - timedelta(hours=2)
+
+        events = [
+            # person_match: $set email to value that already matches person state
+            (team_id, "match_user", person_match, event_ts, json.dumps({"$set": {"email": "same@example.com"}})),
+            # person_diff: $set email to different value
+            (team_id, "diff_user", person_diff, event_ts, json.dumps({"$set": {"email": "new@example.com"}})),
+            # person_set_once_exists: $set_once for key already on person (no-op)
+            (
+                team_id,
+                "set_once_exists_user",
+                person_set_once_exists,
+                event_ts,
+                json.dumps({"$set_once": {"signup_source": "google"}}),
+            ),
+            # person_unset_missing: $unset for key not on person (no-op)
+            (
+                team_id,
+                "unset_missing_user",
+                person_unset_missing,
+                event_ts,
+                json.dumps({"$unset": ["nonexistent_key"]}),
+            ),
+        ]
+
+        def insert_events(client: Client) -> None:
+            client.execute(
+                """INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp, properties)
+                VALUES""",
+                events,
+            )
+
+        cluster.any_host(insert_events).result()
+
+        person_data = [
+            # person_match: email already matches the event value
+            (team_id, person_match, json.dumps({"email": "same@example.com"}), 1, now - timedelta(hours=4)),
+            # person_diff: email differs from event value
+            (team_id, person_diff, json.dumps({"email": "old@example.com"}), 1, now - timedelta(hours=4)),
+            # person_set_once_exists: already has the key -> $set_once is a no-op
+            (team_id, person_set_once_exists, json.dumps({"signup_source": "facebook"}), 1, now - timedelta(hours=4)),
+            # person_unset_missing: does NOT have the key -> $unset is a no-op
+            (team_id, person_unset_missing, json.dumps({"name": "Alice"}), 1, now - timedelta(hours=4)),
+        ]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
+        affected_ids = get_affected_person_ids_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+            bug_window_end=bug_window_end.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        assert str(person_diff) in affected_ids, "$set with different value should be detected"
+        assert str(person_match) not in affected_ids, "$set with matching value should be excluded"
+        assert str(person_set_once_exists) not in affected_ids, "$set_once for existing key should be excluded"
+        assert str(person_unset_missing) not in affected_ids, "$unset for missing key should be excluded"
 
     def test_windowed_query_produces_same_result_as_single_query(self, cluster: ClickhouseCluster):
         """
@@ -5428,11 +5553,13 @@ class TestClickHouseQueryIntegration:
         - Events with both filtered and non-filtered properties
         - Events spread across multiple time windows
         - A person with ONLY filtered-property events (should be excluded by both)
+        - A person with non-filtered properties that MATCH current state (no diff, excluded by both)
         - $set, $set_once, and $unset operations
         """
         team_id = 99982
         person_real = UUID("eeee0000-0000-0000-0000-000000000001")
         person_filtered_only = UUID("eeee0000-0000-0000-0000-000000000002")
+        person_no_diff = UUID("eeee0000-0000-0000-0000-000000000003")
         now = datetime.now().replace(microsecond=0)
         bug_window_start = now - timedelta(hours=6)
         bug_window_end = now - timedelta(minutes=5)
@@ -5499,6 +5626,21 @@ class TestClickHouseQueryIntegration:
                     }
                 ),
             ),
+            # Person with non-filtered properties that already match person state (no diff).
+            # This is the exact scenario causing 100x over-selection in production:
+            # the old affected persons query returned these, the new one should not.
+            (
+                team_id,
+                "no_diff_user",
+                person_no_diff,
+                bug_window_start + timedelta(hours=2),
+                json.dumps(
+                    {
+                        "$set": {"plan": "enterprise", "company": "Acme Corp"},
+                        "$set_once": {"signup_source": "organic"},
+                    }
+                ),
+            ),
         ]
 
         def insert_events(client: Client) -> None:
@@ -5522,6 +5664,14 @@ class TestClickHouseQueryIntegration:
                 team_id,
                 person_filtered_only,
                 json.dumps({"$browser": "Safari", "$os": "Linux"}),
+                1,
+                now - timedelta(hours=7),
+            ),
+            # person_no_diff: properties already match what the events would set
+            (
+                team_id,
+                person_no_diff,
+                json.dumps({"plan": "enterprise", "company": "Acme Corp", "signup_source": "organic"}),
                 1,
                 now - timedelta(hours=7),
             ),
@@ -5556,7 +5706,7 @@ class TestClickHouseQueryIntegration:
         ):
             batched_results.extend(batch)
 
-        # Both should return exactly one person (the real one, not the filtered-only one)
+        # Both should return exactly one person (the real one, not the others)
         assert len(single_results) == 1, f"single query returned {len(single_results)}, expected 1"
         assert len(batched_results) == 1, f"batched windowed returned {len(batched_results)}, expected 1"
 
@@ -5566,9 +5716,12 @@ class TestClickHouseQueryIntegration:
         # Same person_id
         assert single_diff.person_id == batched_diff.person_id == str(person_real)
 
-        # Filtered-only person must not appear
+        # No-diff and filtered-only persons must not appear in either mode
         result_person_ids = {r.person_id for r in single_results} | {r.person_id for r in batched_results}
         assert str(person_filtered_only) not in result_person_ids
+        assert str(person_no_diff) not in result_person_ids, (
+            "Person whose properties already match event values should be excluded by both modes"
+        )
 
         # Same keys in each diff category
         assert set(single_diff.set_updates.keys()) == set(batched_diff.set_updates.keys()), (


### PR DESCRIPTION
## Problem
After parity-testing the last round of changes to windowed persons reconciliation query, I found another source of extra work in the logs.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Improve step 1 person filtering query again
* Update test suite to exercise this better, including integration/parity tests
* Update job docs/comments to ensure latest behavior is documented
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; another smoke test parity dry run on team 2 (windowed and non) will be run after this lands in Dagster Cloud
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
