### PR TITLE
fix(notebooks): clear local content on conflict so reload shows latest version

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -365,6 +365,7 @@ export const notebookLogic = kea<notebookLogicType>([
                         return response
                     } catch (error: any) {
                         if (error.code === 'conflict') {
+                            actions.clearLocalContent()
                             actions.showConflictWarning()
                             return null
                         }


### PR DESCRIPTION
## Problem

When two users edit the same notebook concurrently, the conflict warning appears correctly but clicking "Reload to see the latest content" does **not** show the other user's version.

[LOOM](https://www.loom.com/share/4d96d96d9999480a81d9572851032c51)

## Changes

Clear `localContent` when a 409 conflict is caught so that after reload the editor falls through to the server content.

## How did you test this code?

Manually