### PR TITLE
fix(session-recording): fix pagination bug in encryption migration command

### DIFF
--- a/posthog/management/commands/migrate_session_recording_encryption.py
+++ b/posthog/management/commands/migrate_session_recording_encryption.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
                 sample_size = min(int(len(target_ids) * percentage / 100), len(target_ids))
                 if seed is not None:
                     random.seed(seed)
-                target_ids = random.sample(target_ids, sample_size)
+                target_ids = random.sample(target_ids, sample_size) if sample_size > 0 else []
 
             total_teams_migrated = 0
 


### PR DESCRIPTION
## Summary
- The `migrate_session_recording_encryption` management command used Django's `Paginator` (OFFSET-based) while mutating the queryset via `.exclude(session_recording_encryption=True)`. Each batch update shifted the queryset, causing every other batch to be skipped — updating exactly half the intended teams.
- Fix by materializing target IDs upfront and batching over the list. Also switches from `bulk_update` (loads objects) to `QuerySet.update()` (single SQL UPDATE per batch).

## Test plan
- [x] Verified bug: dry run reported 28,398 teams, wet run only updated 14,200 (exactly half)
- [ ] Run fixed command with `--dry-run` and verify count matches wet run