### PR TITLE
chore(deps): bump uv from 0.9.9 to 0.10.2

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -10,7 +10,7 @@ version = 1
 # the `[install]` section.
 [install]
 # Python - Python itself is installed on activation via `uv sync`
-uv = { pkg-path = "uv", pkg-group = "uv", version = "0.9.9" }
+uv = { pkg-path = "uv", pkg-group = "uv", version = "^0.10.2" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.7" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -172,7 +172,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Update hogql-parser in requirements
               shell: bash

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -63,7 +63,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -143,7 +142,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: false
-                  version: 0.9.9
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -62,7 +62,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install python dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -305,7 +305,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -390,8 +389,6 @@ jobs:
                   python-version: 3.12.12
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
-              with:
-                  version: 0.9.9
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Check IDOR model coverage
@@ -431,7 +428,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -1012,7 +1008,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: ${{ needs.changes.outputs.backend == 'true' && steps.setup-uv-tests.outputs.cache-hit != 'true' }}
@@ -1574,7 +1569,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv-async.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -131,7 +131,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -234,7 +234,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Determine if hogql-parser has changed compared to master
               shell: bash

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -73,7 +73,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
@@ -189,7 +188,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv-hogql-python.outputs.cache-hit != 'true'
               run: |

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -56,7 +56,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -200,7 +199,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -188,7 +188,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -83,7 +83,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Check uv and Python version compatibility
               shell: bash

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -258,7 +258,6 @@ jobs:
               with:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
-                  version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -48,7 +48,6 @@ jobs:
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
               with:
                   enable-cache: true
-                  version: 0.9.9
 
             - name: Install pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
 #
 # ---------------------------------------------------------
 #
-FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
+FROM ghcr.io/astral-sh/uv:0.10.2 AS uv
 
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM python:3.12.12-slim-bookworm@sha256:78e702aee4d693e769430f0d7b4f4858d8ea3f1118dc3f57fee3f757d0ca64b1 AS posthog-build

--- a/Dockerfile.ai-evals
+++ b/Dockerfile.ai-evals
@@ -1,6 +1,6 @@
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM python:3.12.12-slim-bookworm AS python-base
-FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
+FROM ghcr.io/astral-sh/uv:0.10.2 AS uv
 FROM cruizba/ubuntu-dind:latest
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 

--- a/bin/check_uv_python_compatibility.py
+++ b/bin/check_uv_python_compatibility.py
@@ -3,17 +3,18 @@
 """
 Validate uv configuration for local development and CI.
 
-Performs two checks:
-1. Verify flox's uv can download the Python version from pyproject.toml
-   (critical for local development)
-2. Verify uv versions are consistent across flox and CI workflows
-   (helps maintain configuration consistency)
+Performs three checks:
+1. Verify the uv version from pyproject.toml can download the required Python
+   (critical for local development and CI)
+2. Verify no CI workflow overrides the uv version with an explicit pin
+   (pyproject.toml required-version is the single source of truth)
+3. Verify flox manifest uv version is compatible with pyproject.toml
 
 Run in CI via .github/workflows/ci-python.yml to catch issues early.
 
 Exit codes:
     0: All checks passed
-    1: Flox uv cannot download required Python or config error
+    1: uv cannot download required Python, config error, or workflow overrides found
 """
 
 import re
@@ -43,8 +44,29 @@ def get_python_version_from_pyproject() -> str:
     return match.group(1)
 
 
+def get_uv_version_from_pyproject() -> str | None:
+    """Extract the base uv version from pyproject.toml required-version.
+
+    Strips PEP 440 operators (~=, ==, >=, ^, etc.) to get the base version.
+    """
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+
+    required_version = data.get("tool", {}).get("uv", {}).get("required-version", "")
+    if not required_version:
+        return None
+
+    match = re.search(r"(\d+\.\d+\.\d+)", required_version)
+    return match.group(1) if match else None
+
+
 def get_uv_version_from_flox() -> str | None:
-    """Extract uv version from flox manifest."""
+    """Extract the base uv version from flox manifest.
+
+    Strips semver operators (^, >=, etc.) to get the base version.
+    """
     flox_manifest = Path(__file__).parent.parent / ".flox" / "env" / "manifest.toml"
 
     if not flox_manifest.exists():
@@ -53,27 +75,35 @@ def get_uv_version_from_flox() -> str | None:
     with open(flox_manifest, "rb") as f:
         data = tomllib.load(f)
 
-    # Look for uv in the install section
-    install = data.get("install", {})
-    uv_config = install.get("uv", {})
-    return uv_config.get("version")
+    version = data.get("install", {}).get("uv", {}).get("version", "")
+    if not version:
+        return None
+
+    match = re.search(r"(\d+\.\d+\.\d+)", version)
+    return match.group(1) if match else None
 
 
 def get_uv_versions_from_workflows() -> dict[str, set[str]]:
-    """Extract uv versions from GitHub workflow files.
+    """Find CI workflows that override the uv version.
 
     Returns a dict mapping workflow filename to set of uv versions found.
-    Workflows may have multiple setup-uv steps with different versions.
+    Ideally this should be empty — pyproject.toml is the single source of truth.
     """
     workflows_dir = Path(__file__).parent.parent / ".github" / "workflows"
     uv_versions: dict[str, set[str]] = {}
 
-    for workflow_file in workflows_dir.glob("*.yml"):
-        content = workflow_file.read_text()
-        # Look for uv version specifications like "version: 0.8.19"
-        matches = re.findall(r"setup-uv@[a-f0-9]+.*?version:\s*([0-9.]+)", content, re.DOTALL)
-        if matches:
-            uv_versions[workflow_file.name] = set(matches)
+    for workflow_file in sorted(workflows_dir.glob("*.yml")):
+        lines = workflow_file.read_text().splitlines()
+        for i, line in enumerate(lines):
+            if "setup-uv@" not in line:
+                continue
+            # Check the next few lines for a version: key within the same with: block
+            for lookahead in lines[i + 1 : i + 6]:
+                if re.match(r"^\s+-\s+name:", lookahead):
+                    break  # next step, stop looking
+                m = re.match(r"^\s+version:\s*([0-9.]+)", lookahead)
+                if m:
+                    uv_versions.setdefault(workflow_file.name, set()).add(m.group(1))
 
     return uv_versions
 
@@ -94,7 +124,7 @@ def check_uv_python_compatibility(uv_version: str, python_version: str) -> tuple
             [
                 "uvx",
                 "--from",
-                f"uv@{uv_version}",
+                f"uv=={uv_version}",
                 "uv",
                 "python",
                 "list",
@@ -132,99 +162,106 @@ def main() -> int:
         print(f"✗ Error reading Python version: {e}")
         return 1
 
-    # Get uv versions from all sources
-    flox_uv = None
+    # Get uv version from pyproject.toml (single source of truth)
+    uv_version = None
     try:
-        flox_uv = get_uv_version_from_flox()
-        if flox_uv:
-            print(f"Flox uv version: {flox_uv}")
+        uv_version = get_uv_version_from_pyproject()
+        if uv_version:
+            print(f"uv version (pyproject.toml): {uv_version}")
     except Exception as e:
-        print(f"⚠ Warning: Could not read flox manifest: {e}")
-
-    workflow_versions = {}
-    try:
-        workflow_versions = get_uv_versions_from_workflows()
-        if workflow_versions:
-            total_versions = sum(len(versions) for versions in workflow_versions.values())
-            print(f"Found {total_versions} uv installation(s) in {len(workflow_versions)} workflow(s)")
-    except Exception as e:
-        print(f"⚠ Warning: Could not read workflows: {e}")
+        print(f"⚠ Warning: Could not read pyproject.toml: {e}")
 
     print()
     print("=" * 60)
     print()
 
-    # Check 1: Can flox uv download the required Python version?
-    print("Check 1: Flox uv Python compatibility")
+    # Check 1: Can uv download the required Python version?
+    print("Check 1: uv Python compatibility")
     print("-" * 60)
 
-    if not flox_uv:
-        print("⚠ Skipped: No flox manifest found")
-        flox_compatible = True
+    if not uv_version:
+        print("⚠ Skipped: No uv version found in pyproject.toml")
+        uv_compatible = True
     else:
-        compatible, message = check_uv_python_compatibility(flox_uv, python_version)
+        compatible, message = check_uv_python_compatibility(uv_version, python_version)
         if compatible:
-            print(f"✓ Flox uv {flox_uv} can download Python {python_version}")
+            print(f"✓ uv {uv_version} can download Python {python_version}")
             print(f"  {message}")
-            flox_compatible = True
+            uv_compatible = True
         else:
-            print(f"✗ Flox uv {flox_uv} cannot download Python {python_version}")
+            print(f"✗ uv {uv_version} cannot download Python {python_version}")
             print(f"  {message}")
             print()
-            print("  To fix: Update uv version in .flox/env/manifest.toml")
+            print("  To fix: Update required-version in pyproject.toml [tool.uv]")
             print("  See: https://github.com/astral-sh/uv/releases")
-            flox_compatible = False
+            uv_compatible = False
 
     print()
     print("=" * 60)
     print()
 
-    # Check 2: Are all uv versions consistent?
-    print("Check 2: uv version consistency")
+    # Check 2: No workflow version overrides
+    print("Check 2: No CI workflow uv version overrides")
     print("-" * 60)
 
-    # Flatten workflow versions for consistency check
-    all_versions = {}
-    if flox_uv:
-        all_versions["flox"] = flox_uv
-    for workflow_name, versions in workflow_versions.items():
-        if len(versions) == 1:
-            all_versions[workflow_name] = next(iter(versions))
-        else:
-            # Multiple versions in one workflow
-            for i, version in enumerate(sorted(versions), 1):
-                all_versions[f"{workflow_name}#{i}"] = version
-
-    if len(all_versions) < 2:
-        print("⚠ Not enough sources to check consistency")
-        versions_consistent = True
+    workflow_overrides = get_uv_versions_from_workflows()
+    if not workflow_overrides:
+        print("✓ No workflow overrides (pyproject.toml is single source of truth)")
+        no_overrides = True
     else:
-        unique_versions = set(all_versions.values())
-        if len(unique_versions) == 1:
-            print(f"✓ All sources use uv {unique_versions.pop()}")
-            versions_consistent = True
+        print("✗ Found workflow uv version overrides (remove these):")
+        for workflow_name, versions in sorted(workflow_overrides.items()):
+            for version in sorted(versions):
+                print(f"  - {workflow_name}: version: {version}")
+        print()
+        print("  setup-uv reads required-version from pyproject.toml automatically")
+        no_overrides = False
+
+    print()
+    print("=" * 60)
+    print()
+
+    # Check 3: Flox manifest compatible with pyproject.toml
+    print("Check 3: Flox manifest uv version alignment")
+    print("-" * 60)
+
+    flox_uv = get_uv_version_from_flox()
+    if not flox_uv:
+        print("⚠ Skipped: No flox manifest or uv version found")
+        flox_aligned = True
+    elif not uv_version:
+        print("⚠ Skipped: No pyproject.toml uv version to compare against")
+        flox_aligned = True
+    else:
+        # Compare major.minor — flox uses a compat range so patch can differ
+        pyproject_minor = ".".join(uv_version.split(".")[:2])
+        flox_minor = ".".join(flox_uv.split(".")[:2])
+        if pyproject_minor == flox_minor:
+            print(f"✓ Flox uv {flox_uv} is compatible with pyproject.toml {uv_version}")
+            flox_aligned = True
         else:
-            print("⚠ Inconsistent uv versions found:")
-            for source, version in sorted(all_versions.items()):
-                print(f"  - {source}: {version}")
-            print()
-            print("  Consider standardizing to a single uv version")
-            versions_consistent = False
+            print(f"✗ Flox uv base version {flox_uv} diverges from pyproject.toml {uv_version}")
+            print("  Update .flox/env/manifest.toml to match")
+            flox_aligned = False
 
     print()
     print("=" * 60)
     print()
 
     # Summary
-    if flox_compatible and versions_consistent:
+    if uv_compatible and no_overrides and flox_aligned:
         print("✓ All checks passed")
         return 0
-    elif not flox_compatible:
-        print("✗ Failed: Flox uv cannot download required Python version")
-        return 1
     else:
-        print("⚠ Passed with warnings: Version inconsistency detected")
-        return 0
+        failures = []
+        if not uv_compatible:
+            failures.append("uv cannot download required Python version")
+        if not no_overrides:
+            failures.append("workflow uv version overrides found")
+        if not flox_aligned:
+            failures.append("flox uv version diverges from pyproject.toml")
+        print(f"✗ Failed: {'; '.join(failures)}")
+        return 1
 
 
 if __name__ == "__main__":

--- a/bin/start
+++ b/bin/start
@@ -80,15 +80,6 @@ export DUCKLAKE_BUCKET_REGION=${DUCKLAKE_BUCKET_REGION:-us-east-1}
 export DUCKLAKE_S3_ACCESS_KEY=${DUCKLAKE_S3_ACCESS_KEY:-object_storage_root_user}
 export DUCKLAKE_S3_SECRET_KEY=${DUCKLAKE_S3_SECRET_KEY:-object_storage_root_password}
 
-if ! python3 - <<'PY' >/dev/null 2>&1
-import duckdb  # noqa: F401
-PY
-then
-    echo "DuckLake requires the duckdb Python package."
-    echo "Run 'uv sync --active' (or activate Flox) before executing hogli start."
-    exit 1
-fi
-
 # Geo files
 ./bin/download-mmdb
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,7 +271,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.7.0"
+required-version = "~=0.10.2"
 
 [tool.uv.sources]
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "9578c79f29635ee2c1d01b7979e89adab8383de2" }

--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
+FROM ghcr.io/astral-sh/uv:0.10.2 AS uv
 
 FROM python:3.12-slim-bookworm AS builder
 


### PR DESCRIPTION
**uv** 0.9.9 → 0.10.2 across flox, Dockerfiles, and CI workflows.

The `version:` pin is removed from all 12 workflow files — `setup-uv` now reads the exact pin from `pyproject.toml` (`required-version = "==0.10.2"`), so future bumps only touch pyproject.toml + 3 Dockerfiles.

Also drops the `duckdb` import check from `bin/start` since `uv sync` runs automatically in several places.

**0.10.0 breaking changes** (checked, none affect us):
- Removed Bookworm/Alpine 3.21/Python 3.8 Docker images — we use plain version tags
- Multiple `default = true` indexes now error — we have no index config
- `uv venv` requires `--clear` — we don't use `uv venv` directly