### PR TITLE
docs(insights): Improve the docs for the query of the Insights

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -309,22 +309,7 @@ class InsightBasicSerializer(
         return [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
 
 
-@extend_schema_field(
-    {
-        "type": "object",
-        "example": {
-            "kind": "InsightVizNode",
-            "source": {
-                "kind": "TrendsQuery",
-                "series": [
-                    {"kind": "EventsNode", "math": "total", "name": "$pageview", "event": "$pageview", "version": 1}
-                ],
-                "version": 1,
-            },
-            "version": 1,
-        },
-    }
-)
+@extend_schema_field(schema.InsightVizNode)  # type: ignore[arg-type]
 class QueryFieldSerializer(serializers.Serializer):
     def to_representation(self, value):
         return self.parent._query_variables_mapping(value)  # type: ignore

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -314,7 +314,12 @@ class InsightBasicSerializer(
 
 
 class _InsightQuerySchema(RootModel):
-    """Schema-only model for OpenAPI documentation of the insight query field."""
+    """The query definition for this insight. The `kind` field determines the query type:
+    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+    - `DataVisualizationNode` — SQL insights using HogQL
+    - `DataTableNode` — raw data tables
+    - `HogQuery` — Hog language queries
+    """
 
     root: schema.InsightVizNode | schema.DataTableNode | schema.DataVisualizationNode | schema.HogQuery = PydanticField(
         discriminator="kind"


### PR DESCRIPTION
## Problem

The insight API serializer was using an inline schema definition for the query field instead of referencing the centralized schema definition. The result is that the Swagger docs were very difficult to interpret as you only had the example to go off (especially for systematically generated Swagger clients).  

Also see: https://posthoghelp.zendesk.com/agent/tickets/49285 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52869)

## Changes

_This is a doc only change_

- Introduce a `_InsightQuerySchema` model which holds the available schemas for the query field inside the `insights`. The result is that the typehinting in Swagger is now a lot clearer and it's easier to systematically infer what the available options are. 
    - I wasn't able to find a clear source of truth so I've based the list of available types on the list defined here: https://github.com/PostHog/posthog/blob/bedef2bef5b10cb20ce4366a19550c97267ea459/frontend/src/scenes/insights/insightDataLogic.tsx#L175-L201 
     
## How did you test this code?

Verified that the API schema documentation generates correctly with the new fields:

**Before:**

![CleanShot 2026-02-20 at 09.52.09.png](https://app.graphite.com/user-attachments/assets/16cb44a8-59c9-4226-93f6-c295ddc5cf73.png)

**After:**

![CleanShot 2026-02-20 at 10.10.58.png](https://app.graphite.com/user-attachments/assets/38f974fc-de2f-4250-b5c5-5d35bce9b7a4.png)

## Publish to changelog?

No