### PR TITLE
fix: Change invalid rrweb events handling from DLQ to DROP with warning

### DIFF
--- a/nodejs/src/ingestion/session_replay/parse-message-step.test.ts
+++ b/nodejs/src/ingestion/session_replay/parse-message-step.test.ts
@@ -160,7 +160,7 @@ describe('createParseMessageStep', () => {
         }
     })
 
-    it('should send messages with no valid rrweb events to DLQ', async () => {
+    it('should drop messages with no valid rrweb events with ingestion warning', async () => {
         const step = createParseMessageStep()
         const event = {
             event: '$snapshot_items',
@@ -178,9 +178,14 @@ describe('createParseMessageStep', () => {
 
         const result = await step(input)
 
-        expect(result.type).toBe(PipelineResultType.DLQ)
-        if (result.type === PipelineResultType.DLQ) {
+        expect(result.type).toBe(PipelineResultType.DROP)
+        if (result.type === PipelineResultType.DROP) {
             expect(result.reason).toBe('message_contained_no_valid_rrweb_events')
+            expect(result.warnings).toHaveLength(1)
+            expect(result.warnings[0]).toEqual({
+                type: 'message_contained_no_valid_rrweb_events',
+                details: {},
+            })
         }
     })
 

--- a/nodejs/src/ingestion/session_replay/parse-message-step.ts
+++ b/nodejs/src/ingestion/session_replay/parse-message-step.ts
@@ -133,7 +133,16 @@ export function createParseMessageStep(
 
         const result = getValidEvents($snapshot_items)
         if (!result) {
-            return dlq('message_contained_no_valid_rrweb_events')
+            return drop(
+                'message_contained_no_valid_rrweb_events',
+                [],
+                [
+                    {
+                        type: 'message_contained_no_valid_rrweb_events',
+                        details: {},
+                    },
+                ]
+            )
         }
         const { validEvents, startDateTime, endDateTime } = result
 


### PR DESCRIPTION
## Problem

Messages with no valid rrweb events should be dropped with an ingestion warning rather than sent to the Dead Letter Queue (DLQ). This provides better visibility into data quality issues while avoiding unnecessary DLQ processing.

## Changes

- Modified `parse-message-step.ts` to return a `DROP` result with an ingestion warning instead of a `DLQ` result when no valid rrweb events are found in a message
- The warning includes the reason `message_contained_no_valid_rrweb_events` with empty details
- Updated corresponding test in `parse-message-step.test.ts` to verify the new behavior:
  - Changed assertion from `PipelineResultType.DLQ` to `PipelineResultType.DROP`
  - Added assertions to verify the warning is properly attached to the result
  - Updated test description to reflect the new behavior

## How did you test this code?

The existing unit test has been updated to verify the new behavior. The test confirms that:
1. Messages with no valid rrweb events are dropped (not sent to DLQ)
2. The drop result includes the appropriate reason
3. The drop result includes a warning with the correct type and details

No additional testing needed - the change is covered by the updated unit test.

## Publish to changelog?

no

https://claude.ai/code/session_01J1PqJyYskHCEzUPVMVW1d1