### PR TITLE
fix(data-modeling): Fix column case sensitivity failure in materialize_view_activity after deltalake 1.4.0 upgrade

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -443,14 +443,13 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
                 )
             else:
                 await logger.adebug(
-                    f"Writing batch to delta table: index={index} mode=append schema_mode=merge batch_row_count={batch.num_rows}"
+                    f"Writing batch to delta table: index={index} mode=append batch_row_count={batch.num_rows}"
                 )
                 await asyncio.to_thread(
                     deltalake.write_deltalake,
                     table_or_uri=table_uri,
                     data=batch,
                     mode="append",
-                    schema_mode="merge",
                     storage_options=storage_options,
                 )
             if index == 0:

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -523,10 +523,8 @@ async def materialize_model(
                 )
 
             mode: typing.Literal["error", "append", "overwrite", "ignore"] = "append"
-            schema_mode: typing.Literal["merge", "overwrite"] | None = None
             if index == 0:
                 mode = "overwrite"
-                schema_mode = "overwrite"
 
             await logger.adebug(
                 f"Writing batch to delta table. index={index}. mode={mode}. batch_row_count={batch.num_rows}"
@@ -538,7 +536,6 @@ async def materialize_model(
                 storage_options=storage_options,
                 data=batch,
                 mode=mode,
-                schema_mode=schema_mode,
             )
             write_duration = (dt.datetime.now() - write_start).total_seconds()
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -515,28 +515,32 @@ async def materialize_model(
             batch = _transform_unsupported_decimals(batch)
             batch = _transform_date_and_datetimes(batch, ch_types)
 
-            if delta_table is None:
-                delta_table = deltalake.DeltaTable.create(
-                    table_uri=table_uri,
-                    schema=batch.schema,
-                    storage_options=storage_options,
+            if index == 0:
+                await logger.adebug(
+                    f"Writing batch to delta table. index={index}. mode=overwrite. schema_mode=overwrite. batch_row_count={batch.num_rows}"
                 )
 
-            mode: typing.Literal["error", "append", "overwrite", "ignore"] = "append"
-            if index == 0:
-                mode = "overwrite"
+                write_start = dt.datetime.now()
+                deltalake.write_deltalake(
+                    table_or_uri=table_uri,
+                    storage_options=storage_options,
+                    data=batch,
+                    mode="overwrite",
+                    schema_mode="overwrite",
+                )
+                delta_table = deltalake.DeltaTable(table_uri, storage_options=storage_options)
+            else:
+                await logger.adebug(
+                    f"Writing batch to delta table. index={index}. mode=append. batch_row_count={batch.num_rows}"
+                )
 
-            await logger.adebug(
-                f"Writing batch to delta table. index={index}. mode={mode}. batch_row_count={batch.num_rows}"
-            )
-
-            write_start = dt.datetime.now()
-            deltalake.write_deltalake(
-                table_or_uri=delta_table,
-                storage_options=storage_options,
-                data=batch,
-                mode=mode,
-            )
+                write_start = dt.datetime.now()
+                deltalake.write_deltalake(
+                    table_or_uri=delta_table,  # type: ignore[call-overload]
+                    storage_options=storage_options,
+                    data=batch,
+                    mode="append",
+                )
             write_duration = (dt.datetime.now() - write_start).total_seconds()
 
             row_count = row_count + batch.num_rows

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -1,3 +1,4 @@
+import os
 import re
 import uuid
 import asyncio
@@ -1125,6 +1126,66 @@ async def test_run_workflow_triggers_ducklake_copy_child(monkeypatch):
     assert len(child_ducklake_workflow_runs) == 1
     assert child_ducklake_workflow_runs[0]["team_id"] == 1
     assert child_ducklake_workflow_runs[0]["models"][0]["model_label"] == model_label
+
+
+async def test_dlt_direct_naming(ateam, bucket_name, minio_client, pageview_events):
+    """Test that setting SCHEMA__NAMING=direct preserves original column casing when materializing models."""
+    # Query with CamelCase and PascalCase column names, not snake_case
+    query = """\
+    select
+      event as Event,
+      if(distinct_id != '0', distinct_id, null) as DistinctId,
+      timestamp as TimeStamp,
+      'example' as CamelCaseColumn
+    from events
+    where event = '$pageview'
+    """
+    saved_query = await DataWarehouseSavedQuery.objects.acreate(
+        team=ateam,
+        name="camel_case_model",
+        query={"query": query, "kind": "HogQLQuery"},
+    )
+
+    # Make sure we have pageview events for the query to work with
+    events, _ = pageview_events
+
+    with (
+        override_settings(
+            BUCKET_URL=f"s3://{bucket_name}",
+            DATAWAREHOUSE_LOCAL_ACCESS_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            DATAWAREHOUSE_LOCAL_ACCESS_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            DATAWAREHOUSE_LOCAL_BUCKET_REGION="us-east-1",
+            DATAWAREHOUSE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        unittest.mock.patch.dict(os.environ, {"SCHEMA__NAMING": "direct"}, clear=True),
+    ):
+        job = await database_sync_to_async(DataModelingJob.objects.create)(
+            team=ateam,
+            status=DataModelingJob.Status.RUNNING,
+            workflow_id="test_workflow",
+        )
+
+        # Check that SCHEMA__NAMING is set to direct in the environment
+        assert os.environ.get("SCHEMA__NAMING") == "direct", "SCHEMA__NAMING should be 'direct'"
+
+        key, delta_table, job_id = await materialize_model(
+            saved_query.id.hex,
+            ateam,
+            saved_query,
+            job,
+            unittest.mock.AsyncMock(),
+        )
+
+    await database_sync_to_async(saved_query.refresh_from_db)()
+    assert saved_query.is_materialized is True
+
+    # Check that the column names maintain their original casing
+    table_columns = delta_table.to_pyarrow_table().column_names
+    # Verify the original capitalization is preserved
+    assert "Event" in table_columns, "Column 'Event' should maintain its original capitalization"
+    assert "DistinctId" in table_columns, "Column 'DistinctId' should maintain its original capitalization"
+    assert "TimeStamp" in table_columns, "Column 'TimeStamp' should maintain its original capitalization"
+    assert "CamelCaseColumn" in table_columns, "Column 'CamelCaseColumn' should maintain its original capitalization"
 
 
 async def test_materialize_model_with_decimal256_fix(ateam, bucket_name, minio_client):


### PR DESCRIPTION
## Problem

After the deltalake upgrade to 1.4.0 (#45956), materialized view jobs that produce more than one batch (>100MB) fail when the HogQL query has mixed-case column names (e.g., `Event`, `DistinctId`).

The root cause: `schema_mode="merge"` in `write_deltalake()` triggers deltalake 1.4.0's new DataFusion logical plan path, which lowercases identifiers via `enable_ident_normalization`. The schema reconciliation  then does a case-sensitive comparison between the lowercased identifiers and the original-casing stored schema, causing a mismatch (see [delta-io/delta-rs#4097](https://github.com/delta-io/delta-rs/issues/4097))

## Changes

~- Removed `schema_mode="merge"` from the append path in `materialize_view_activity`. Since all batches come from the same ClickHouse query, the schema is identical across batches — no schema merge/evolution is needed. This matches how `run_workflow.py::materialize_model` already handles appends (with `schema_mode=None`).~

edit: - rather than creating an empty DeltaTable, and then using it to overwrite and append for first and other batches respectively, we just write the first batch, and then use the DeltaTable to append - reusing the pattern from v2 backend

- Restored `test_dlt_direct_naming` which was deleted in #45956. This test materializes a model with CamelCase column names and asserts the original casing is preserved in the output delta table.

## How did you test this code?

- Test pass

## Publish to changelog?
NO