### PR TITLE
feat(replay): add filtering support to kiosk mode

### DIFF
--- a/frontend/src/scenes/session-recordings/kiosk/KioskPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskPlayer.tsx
@@ -18,7 +18,7 @@ const INACTIVITY_TIMEOUT_MS = 3000
 
 export function KioskPlayer(): JSX.Element | null {
     const { currentRecordingId, currentRecording } = useValues(sessionRecordingsKioskLogic)
-    const { advanceToNextRecording } = useActions(sessionRecordingsKioskLogic)
+    const { advanceToNextRecording, resetPlayback } = useActions(sessionRecordingsKioskLogic)
     const [isActive, setIsActive] = useState(false)
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -36,6 +36,11 @@ export function KioskPlayer(): JSX.Element | null {
 
     useEventListener('mousemove', handleActivity)
     useEventListener('mousedown', handleActivity)
+    useEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            handleClose()
+        }
+    })
 
     useEffect(() => {
         return () => {
@@ -46,6 +51,7 @@ export function KioskPlayer(): JSX.Element | null {
     }, [])
 
     const handleClose = (): void => {
+        resetPlayback()
         router.actions.push(urls.replay())
     }
 

--- a/frontend/src/scenes/session-recordings/kiosk/KioskSetup.scss
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskSetup.scss
@@ -1,0 +1,39 @@
+.KioskSetup {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    &__card {
+        width: 100%;
+        max-width: 420px;
+        padding: 2rem;
+        background: var(--color-bg-3000-light);
+        border-radius: 0.75rem;
+
+        h2 {
+            margin: 0 0 0.25rem;
+            font-size: 1.25rem;
+            color: var(--text-3000-light);
+        }
+    }
+
+    &__description {
+        margin: 0 0 1.5rem;
+        font-size: 0.875rem;
+        color: var(--muted-3000-light);
+    }
+
+    &__field {
+        margin-bottom: 1rem;
+
+        label {
+            display: block;
+            margin-bottom: 0.25rem;
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: var(--text-3000-light);
+        }
+    }
+}

--- a/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/KioskSetup.tsx
@@ -1,0 +1,83 @@
+import './KioskSetup.scss'
+
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconPlay } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
+
+import { sessionRecordingsKioskLogic } from './sessionRecordingsKioskLogic'
+
+const DATE_RANGE_OPTIONS = [
+    { value: '-1h', label: 'Last hour' },
+    { value: '-24h', label: 'Last 24 hours' },
+    { value: '-7d', label: 'Last 7 days' },
+    { value: '-30d', label: 'Last 30 days' },
+    { value: '-90d', label: 'Last 90 days' },
+]
+
+export function KioskSetup(): JSX.Element {
+    const { filters } = useValues(sessionRecordingsKioskLogic)
+    const { setFilters, startPlayback } = useActions(sessionRecordingsKioskLogic)
+
+    const [visitedPage, setVisitedPage] = useState(filters.visitedPage || '')
+    const [dateFrom, setDateFrom] = useState(filters.dateFrom || '-30d')
+    const [minDurationSeconds, setMinDurationSeconds] = useState(filters.minDurationSeconds)
+
+    const handleStart = (): void => {
+        setFilters({ visitedPage: visitedPage.trim() || null, dateFrom, minDurationSeconds })
+        startPlayback()
+    }
+
+    return (
+        <div className="KioskSetup">
+            <div className="KioskSetup__card">
+                <h2>Kiosk mode</h2>
+                <p className="KioskSetup__description">
+                    Auto-play session recordings on a loop. Optionally filter which recordings to show.
+                </p>
+
+                <div className="KioskSetup__field">
+                    <label htmlFor="kiosk-visited-page">Pages visited (contains)</label>
+                    <LemonInput
+                        id="kiosk-visited-page"
+                        value={visitedPage}
+                        onChange={setVisitedPage}
+                        placeholder="e.g. /welcome (leave empty for all)"
+                        fullWidth
+                        onPressEnter={handleStart}
+                        autoFocus
+                    />
+                </div>
+
+                <div className="KioskSetup__field">
+                    <label htmlFor="kiosk-date-range">Date range</label>
+                    <LemonSelect
+                        id="kiosk-date-range"
+                        value={dateFrom}
+                        onChange={(value) => setDateFrom(value)}
+                        options={DATE_RANGE_OPTIONS}
+                        fullWidth
+                    />
+                </div>
+
+                <div className="KioskSetup__field">
+                    <label htmlFor="kiosk-min-duration">Minimum active duration (seconds)</label>
+                    <LemonInput
+                        id="kiosk-min-duration"
+                        type="number"
+                        min={0}
+                        value={minDurationSeconds}
+                        onChange={(val) => setMinDurationSeconds(Number(val) || 0)}
+                        fullWidth
+                        onPressEnter={handleStart}
+                    />
+                </div>
+
+                <LemonButton type="primary" fullWidth size="large" icon={<IconPlay />} onClick={handleStart}>
+                    Start kiosk
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/session-recordings/kiosk/SessionRecordingsKiosk.scss
+++ b/frontend/src/scenes/session-recordings/kiosk/SessionRecordingsKiosk.scss
@@ -7,7 +7,8 @@
     background: black;
 
     &--loading,
-    &--empty {
+    &--empty,
+    &--setup {
         display: flex;
         align-items: center;
         justify-content: center;

--- a/frontend/src/scenes/session-recordings/kiosk/SessionRecordingsKiosk.tsx
+++ b/frontend/src/scenes/session-recordings/kiosk/SessionRecordingsKiosk.tsx
@@ -1,12 +1,13 @@
 import './SessionRecordingsKiosk.scss'
 
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
-import { Link } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { KioskPlayer } from './KioskPlayer'
+import { KioskSetup } from './KioskSetup'
 import { sessionRecordingsKioskLogic } from './sessionRecordingsKioskLogic'
 
 export const scene: SceneExport = {
@@ -15,7 +16,16 @@ export const scene: SceneExport = {
 }
 
 export function SessionRecordingsKiosk(): JSX.Element {
-    const { recordingsLoading, hasRecordings } = useValues(sessionRecordingsKioskLogic)
+    const { isConfigured, recordingsLoading, hasRecordings } = useValues(sessionRecordingsKioskLogic)
+    const { resetPlayback } = useActions(sessionRecordingsKioskLogic)
+
+    if (!isConfigured) {
+        return (
+            <div className="SessionRecordingsKiosk SessionRecordingsKiosk--setup">
+                <KioskSetup />
+            </div>
+        )
+    }
 
     if (recordingsLoading) {
         return (
@@ -29,11 +39,11 @@ export function SessionRecordingsKiosk(): JSX.Element {
         return (
             <div className="SessionRecordingsKiosk SessionRecordingsKiosk--empty">
                 <div className="SessionRecordingsKiosk__message">
-                    <h2>No recordings available</h2>
-                    <p>There are no unplayed session recordings to display.</p>
-                    <p>
-                        <Link to="/replay">Go to Session replay</Link>
-                    </p>
+                    <h2>No recordings found</h2>
+                    <p>No recordings matched your filters. Try adjusting the date range or page filter.</p>
+                    <LemonButton type="secondary" onClick={resetPlayback}>
+                        Back to setup
+                    </LemonButton>
                 </div>
             </div>
         )
@@ -45,5 +55,3 @@ export function SessionRecordingsKiosk(): JSX.Element {
         </div>
     )
 }
-
-export default SessionRecordingsKiosk


### PR DESCRIPTION
## Summary

- Adds a setup screen before kiosk playback where users can configure filters (visited page, date range, minimum active duration)
- Supports URL query params (`?visited_page=/welcome&date_from=-7d&min_duration=10&play=1`) for bookmarkable kiosk URLs
- Always filters out test accounts
- Continuous unattended playback: soft API re-fetch every 10 recordings, loops existing recordings if nothing new, hard page reload every 50 recordings to free memory
- Escape key exits kiosk mode
- Empty state offers "Back to setup" instead of being a dead end
- Retries on network failure after 5s delay

## Test plan

- [ ] Visit `/replay/kiosk` — verify setup screen appears with filter inputs
- [ ] Enter a visited page filter, click Start — verify only matching recordings play
- [ ] Start without any filters — verify latest recordings play (same as before)
- [ ] Verify URL params update: `?play=1&visited_page=...&date_from=...&min_duration=...`
- [ ] Navigate directly to a URL with `?play=1` — verify playback starts automatically
- [ ] Press Escape during playback — verify redirect to `/replay`
- [ ] Enter filters that match no recordings — verify "No recordings found" with "Back to setup" button
- [ ] Let playback run through 10+ recordings — verify soft refresh fetches new recordings from API
- [ ] Clear the min duration input field — verify it defaults to 0, no NaN