### PR TITLE
fix(llma): restore cluster icon and datasets tab title

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -360,16 +360,18 @@ export const productConfiguration: Record<string, any> = {
     },
     LLMAnalyticsDatasets: {
         projectBased: true,
-        name: 'LLM analytics datasets',
+        name: 'Datasets',
         description: 'Manage datasets for testing and evaluation.',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_datasets',
     },
     LLMAnalyticsDataset: {
         projectBased: true,
         name: 'LLM analytics dataset',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_datasets',
     },
     LLMAnalyticsEvaluations: {
         projectBased: true,
@@ -378,6 +380,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'LLMAnalytics',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/evaluations',
+        iconType: 'llm_evaluations',
     },
     LLMAnalyticsEvaluation: {
         projectBased: true,
@@ -385,6 +388,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'LLMAnalytics',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_evaluations',
     },
     LLMAnalyticsEvaluationTemplates: {
         projectBased: true,
@@ -392,6 +396,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'LLMAnalytics',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_evaluations',
     },
     LLMAnalyticsPrompts: {
         projectBased: true,
@@ -399,12 +404,14 @@ export const productConfiguration: Record<string, any> = {
         description: 'Track and manage your LLM prompts.',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/prompts',
+        iconType: 'llm_prompts',
     },
     LLMAnalyticsPrompt: {
         projectBased: true,
         name: 'LLM analytics prompt',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_prompts',
     },
     LLMAnalyticsClusters: {
         projectBased: true,
@@ -412,12 +419,14 @@ export const productConfiguration: Record<string, any> = {
         description: 'Discover patterns and clusters in your LLM usage.',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/clusters',
+        iconType: 'llm_clusters',
     },
     LLMAnalyticsCluster: {
         projectBased: true,
         name: 'LLM analytics cluster',
         layout: 'app-container',
         defaultDocsPath: '/docs/llm-analytics/installation',
+        iconType: 'llm_clusters',
     },
     Logs: {
         projectBased: true,

--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.test.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.test.ts
@@ -399,6 +399,7 @@ describe('clusterDetailLogic', () => {
                 expect(breadcrumbs).toHaveLength(3)
                 expect(breadcrumbs[0].name).toBe('Clusters')
                 expect(breadcrumbs[2].name).toBe('Test Cluster')
+                expect(breadcrumbs[2].iconType).toBe('llm_clusters')
             })
 
             it('uses default cluster name when cluster has no title', async () => {

--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
@@ -301,6 +301,7 @@ export const clusterDetailLogic = kea<clusterDetailLogicType>([
                     key: 'LLMAnalyticsClusters',
                     name: 'Clusters',
                     path: urls.llmAnalyticsClusters(),
+                    iconType: 'llm_clusters',
                 },
                 {
                     key: 'LLMAnalyticsClustersRun',
@@ -308,10 +309,12 @@ export const clusterDetailLogic = kea<clusterDetailLogicType>([
                         ? dayjs(runId.split('_')[1] || runId).format('MMM D, YYYY')
                         : 'Run',
                     path: urls.llmAnalyticsClusters(runId),
+                    iconType: 'llm_clusters',
                 },
                 {
                     key: 'LLMAnalyticsCluster',
                     name: cluster?.title || 'Cluster',
+                    iconType: 'llm_clusters',
                 },
             ],
         ],

--- a/products/llm_analytics/frontend/clusters/clustersLogic.test.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.test.ts
@@ -224,6 +224,19 @@ describe('clustersLogic', () => {
     })
 
     describe('selectors', () => {
+        describe('breadcrumbs', () => {
+            it('returns clusters breadcrumb with icon type', () => {
+                expect(logic.values.breadcrumbs).toEqual([
+                    {
+                        key: 'LLMAnalyticsClusters',
+                        name: 'Clusters',
+                        path: '/llm-analytics/clusters',
+                        iconType: 'llm_clusters',
+                    },
+                ])
+            })
+        })
+
         const mockCluster1: Cluster = {
             cluster_id: 0,
             size: 10,

--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -254,6 +254,7 @@ export const clustersLogic = kea<clustersLogicType>([
                     key: 'LLMAnalyticsClusters',
                     name: 'Clusters',
                     path: urls.llmAnalyticsClusters(),
+                    iconType: 'llm_clusters',
                 },
             ],
         ],

--- a/products/llm_analytics/manifest.tsx
+++ b/products/llm_analytics/manifest.tsx
@@ -50,10 +50,11 @@ export const manifest: ProductManifest = {
         LLMAnalyticsDatasets: {
             import: () => import('./frontend/datasets/LLMAnalyticsDatasetsScene'),
             projectBased: true,
-            name: 'LLM analytics datasets',
+            name: 'Datasets',
             description: 'Manage datasets for testing and evaluation.',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_datasets',
         },
         LLMAnalyticsDataset: {
             import: () => import('./frontend/datasets/LLMAnalyticsDatasetScene'),
@@ -61,6 +62,7 @@ export const manifest: ProductManifest = {
             name: 'LLM analytics dataset',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_datasets',
         },
         LLMAnalyticsEvaluations: {
             import: () => import('./frontend/evaluations/LLMAnalyticsEvaluationsScene'),
@@ -70,6 +72,7 @@ export const manifest: ProductManifest = {
             activityScope: 'LLMAnalytics',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/evaluations',
+            iconType: 'llm_evaluations',
         },
         LLMAnalyticsEvaluation: {
             import: () => import('./frontend/evaluations/LLMAnalyticsEvaluation'),
@@ -78,6 +81,7 @@ export const manifest: ProductManifest = {
             activityScope: 'LLMAnalytics',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_evaluations',
         },
         LLMAnalyticsEvaluationTemplates: {
             import: () => import('./frontend/evaluations/EvaluationTemplates'),
@@ -86,6 +90,7 @@ export const manifest: ProductManifest = {
             activityScope: 'LLMAnalytics',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_evaluations',
         },
         LLMAnalyticsPrompts: {
             import: () => import('./frontend/prompts/LLMPromptsScene'),
@@ -94,6 +99,7 @@ export const manifest: ProductManifest = {
             description: 'Track and manage your LLM prompts.',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/prompts',
+            iconType: 'llm_prompts',
         },
         LLMAnalyticsPrompt: {
             import: () => import('./frontend/prompts/LLMPromptScene'),
@@ -101,6 +107,7 @@ export const manifest: ProductManifest = {
             name: 'LLM analytics prompt',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_prompts',
         },
         LLMAnalyticsClusters: {
             import: () => import('./frontend/clusters/LLMAnalyticsClustersScene'),
@@ -109,6 +116,7 @@ export const manifest: ProductManifest = {
             description: 'Discover patterns and clusters in your LLM usage.',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/clusters',
+            iconType: 'llm_clusters',
         },
         LLMAnalyticsCluster: {
             import: () => import('./frontend/clusters/LLMAnalyticsClusterScene'),
@@ -116,6 +124,7 @@ export const manifest: ProductManifest = {
             name: 'LLM analytics cluster',
             layout: 'app-container',
             defaultDocsPath: '/docs/llm-analytics/installation',
+            iconType: 'llm_clusters',
         },
     },
     routes: {


### PR DESCRIPTION
## Problem

Users navigating to the Clusters, Evaluations, Datasets, and Prompts pages in LLM analytics had inconsistent tab metadata.
Clusters, Evaluations, and Prompts did not consistently show an icon in the tab, and Datasets showed the verbose scene name (`LLM analytics datasets`) instead of `Datasets`.

## Changes

<img width="1418" height="270" alt="image" src="https://github.com/user-attachments/assets/5dbe5160-ee81-4d79-8499-23ac7ebf02eb" />

- Added explicit `iconType` values in the LLM analytics manifest for:
  - Clusters (`LLMAnalyticsClusters`, `LLMAnalyticsCluster`)
  - Datasets (`LLMAnalyticsDatasets`, `LLMAnalyticsDataset`)
  - Evaluations (`LLMAnalyticsEvaluations`, `LLMAnalyticsEvaluation`, `LLMAnalyticsEvaluationTemplates`)
  - Prompts (`LLMAnalyticsPrompts`, `LLMAnalyticsPrompt`)
- Updated `LLMAnalyticsDatasets` scene name to `Datasets` so the tab title is concise.
- Added `iconType: 'llm_clusters'` to clusters breadcrumbs in:
  - `clustersLogic`
  - `clusterDetailLogic`
- Regenerated `frontend/src/products.tsx` via `build:products`.
- Added/updated cluster breadcrumb tests to assert icon behavior.

## How did you test this code?

- Ran:
  - `pnpm --filter=@posthog/frontend jest products/llm_analytics/frontend/clusters/clustersLogic.test.ts products/llm_analytics/frontend/clusters/clusterDetailLogic.test.ts`
- Result: 2 test suites passed, 52 tests passed.
- Also regenerated products successfully with `pnpm --filter=@posthog/frontend run build:products`.

## Publish to changelog?

no
