### PR TITLE
fix: temporarily increase quota limiting timeout

### DIFF
--- a/posthog/temporal/quota_limiting/run_quota_limiting.py
+++ b/posthog/temporal/quota_limiting/run_quota_limiting.py
@@ -60,7 +60,7 @@ class RunQuotaLimitingWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 run_quota_limiting_all_orgs,
                 RunQuotaLimitingAllOrgsInputs(),
-                start_to_close_timeout=timedelta(minutes=120),
+                start_to_close_timeout=timedelta(hours=12),
                 retry_policy=common.RetryPolicy(
                     maximum_attempts=1,
                 ),


### PR DESCRIPTION
Temporarily increasing timeout further after #48552 while we investigate what's causing this

The issues seemingly started after migrating the temporal billing worker to new namespace, more context here: https://posthog.slack.com/archives/C01MM7VT7MG/p1771586985192939