### PR TITLE
fix: Correct payment details "hedgehogs" case

### DIFF
--- a/frontend/src/scenes/billing/PaymentEntryModal.tsx
+++ b/frontend/src/scenes/billing/PaymentEntryModal.tsx
@@ -113,7 +113,7 @@ export const PaymentEntryModal = (): JSX.Element => {
                                 alt="Loading animation"
                             />
                         </div>
-                        <p className="text-secondary text-md mt-4">We're contacting the Hedgehogs for approval.</p>
+                        <p className="text-secondary text-md mt-4">We're contacting the hedgehogs for approval.</p>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Problem

The word "Hedgehogs" was incorrectly capitalized in the middle of a phrase within the payment details modal.

## Changes

Corrected the capitalization of "Hedgehogs" to "hedgehogs" in the `PaymentEntryModal.tsx` file.

- Changed "We're contacting the Hedgehogs for approval." → "We're contacting the hedgehogs for approval."

## How did you test this code?

Manually verified the change by navigating to the payment details modal and observing the corrected text.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771556545053659?thread_ts=1771556545.053659&cid=C0ACRAMJUAG)

<p><a href="https://cursor.com/agents?id=bc-7174619b-66ee-5ac7-9c44-54732ab62d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7174619b-66ee-5ac7-9c44-54732ab62d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

