### PR TITLE
fix: Separate tracking stuff from Heartbeater

### DIFF
--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -112,7 +112,7 @@ class LivenessHeartbeater(Heartbeater):
     """Like ``Heartbeater``, but includes additional liveness tracking."""
 
     def __init__(self, details: tuple[typing.Any, ...] = (), factor: int = 120):
-        super().__init__(details)
+        super().__init__(details, factor)
         self.tracker = get_liveness_tracker()
 
     async def _heartbeat_forever(self, delay):

--- a/posthog/temporal/data_imports/workflow_activities/emit_signals.py
+++ b/posthog/temporal/data_imports/workflow_activities/emit_signals.py
@@ -20,7 +20,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
 from posthog.temporal.data_imports.signals import SignalEmitter, SignalSourceTableConfig, get_signal_config
 from posthog.temporal.data_imports.signals.registry import SignalEmitterOutput
 

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -14,7 +14,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.sync import database_sync_to_async_pool
-from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.shutdown import ShutdownMonitor
 from posthog.temporal.data_imports.pipelines.common.extract import (


### PR DESCRIPTION
## Problem

Heartbeater is used by most or all Temporal workflows. Not all of them need liveness tracking, nor they need to pay for the overhead of threadsafety, nor they expect their details to include an additional item.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Introduce a new class `LivenessHeartbeater`, which adds tracking information to every heartbeat.
* Use the new class in data warehouse workflows, which are the only ones that I can tell that use the `report_heartbeat_timeout` function here: https://github.com/PostHog/posthog/blob/c8ca8ac466e5b75197addb9990a9f25461aee87c/posthog/temporal/data_imports/workflow_activities/import_data_sync.py#L83. Everyone else doesn't need this at the moment.

Also, some minor stuff:
* Use sync methods for logger calls. Structlog async variants pay an overhead. This is wasteful given that we immediately sleep afterwards and the log call itself is trivial.
* Global lookups are also expensive. Assign `get_liveness_tracker` once instead of calling it on every heartbeat call.
* Use the `exception` method to automatically capture exception context rather than manually including it in logs. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
