### PR TITLE
feat: Add host to all temporal logger contexts

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -27,6 +27,7 @@ automatically included.
 import ssl
 import sys
 import json
+import socket
 import typing
 import asyncio
 import functools
@@ -445,6 +446,8 @@ def merge_temporal_context(
 
         for k, v in ctx.items():
             event_dict.setdefault(k, v)
+
+    event_dict.setdefault("worker", socket.gethostname())
 
     return event_dict
 

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -440,14 +440,14 @@ def merge_temporal_context(
 
         for k, v in ctx.items():
             event_dict.setdefault(k, v)
+            event_dict.setdefault("worker", socket.gethostname())
 
     elif temporalio.workflow.in_workflow():
         ctx = get_temporal_workflow_context()
 
         for k, v in ctx.items():
             event_dict.setdefault(k, v)
-
-    event_dict.setdefault("worker", socket.gethostname())
+            event_dict.setdefault("worker", socket.gethostname())
 
     return event_dict
 

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -3,6 +3,7 @@ import json
 import time
 import uuid
 import random
+import socket
 import asyncio
 import datetime as dt
 import operator
@@ -429,6 +430,7 @@ async def test_logger_binds_activity_context(
             assert info_dict["workflow_namespace"] == activity_environment.info.workflow_namespace
             assert info_dict["workflow_type"] == activity_environment.info.workflow_type
             assert info_dict["workflow_run_id"] == activity_environment.info.workflow_run_id
+            assert info_dict["worker"] == socket.gethostname()
 
 
 @freezegun.freeze_time("2023-11-02 10:00:00.123123")


### PR DESCRIPTION
## Problem

The host is the Temporal worker where an activity or workflow is running. Its always useful to have this information in the log context.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add the host where an activity or workflow is running to the logger context under the "worker" key.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
