### PR TITLE
fix(docker): use unit 1.34.2 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,11 +187,62 @@ RUN apt-get update && \
 #
 # ---------------------------------------------------------
 #
-# NOTE: v1.32 is running bullseye, v1.33 is running bookworm
-FROM unit:1.33.0-python3.12
+# NOTE: v1.32 is running bullseye, v1.33+ is running bookworm
+FROM unit:1.34.2-python3.12
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1
+ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
+
+# Build Unit from source at 1.35.0 to ensure the Django 5 ASGI fix is present even when Docker tags lag upstream releases.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "build-essential" \
+    "git" \
+    "libpcre2-dev" \
+    "zlib1g-dev" \
+    && \
+    git clone https://github.com/nginx/unit.git /tmp/unit && \
+    cd /tmp/unit && \
+    git checkout "$UNIT_GIT_REF" && \
+    NCPU="$(getconf _NPROCESSORS_ONLN)" && \
+    DEB_HOST_MULTIARCH="$(gcc -print-multiarch)" && \
+    ./configure \
+        --prefix=/usr \
+        --statedir=/var/lib/unit \
+        --control=unix:/var/run/control.unit.sock \
+        --runstatedir=/var/run \
+        --pid=/var/run/unit.pid \
+        --logdir=/var/log \
+        --log=/var/log/unit.log \
+        --tmpdir=/var/tmp \
+        --user=unit \
+        --group=unit \
+        --openssl \
+        --libdir="/usr/lib/$DEB_HOST_MULTIARCH" \
+        --modulesdir=/usr/lib/unit/modules && \
+    make -j "$NCPU" unitd && \
+    install -pm755 build/sbin/unitd /usr/sbin/unitd && \
+    make clean && \
+    ./configure \
+        --prefix=/usr \
+        --statedir=/var/lib/unit \
+        --control=unix:/var/run/control.unit.sock \
+        --runstatedir=/var/run \
+        --pid=/var/run/unit.pid \
+        --logdir=/var/log \
+        --log=/var/log/unit.log \
+        --tmpdir=/var/tmp \
+        --user=unit \
+        --group=unit \
+        --openssl \
+        --libdir="/usr/lib/$DEB_HOST_MULTIARCH" \
+        --modulesdir=/usr/lib/unit/modules && \
+    ./configure python --config=/usr/local/bin/python3-config && \
+    make -j "$NCPU" python3-install && \
+    rm -rf /tmp/unit && \
+    apt-get purge -y --auto-remove "build-essential" "git" "libpcre2-dev" "zlib1g-dev" && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install OS runtime dependencies.
 # Note: please add in this stage runtime dependences only!


### PR DESCRIPTION
### Motivation
- Use a newer `unit` runtime base to address feedback while keeping the explicit source-build pin so the Django 5 ASGI compatibility fix remains present in the final image.

### Description
- Update `Dockerfile` to change the note and `FROM` line to `unit:1.34.2-python3.12` and preserve the existing `ARG UNIT_GIT_REF` and source-build/install steps that pin Unit to the upstream 1.35.0 commit.

### Testing
- Ran `git diff --check` which completed cleanly and returned no issues.
- Verified the `unit:1.34.2-python3.12` tag exists on Docker Hub using `curl` against the Hub API which returned the tag metadata successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988b59e0ec832e93efadef33bdc0fc)