### PR TITLE
fix(KEA): Kea exceptions

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
@@ -103,7 +103,7 @@ export function EmptyState({
                 {displaySuggestions && (
                     <div className="flex flex-col items-end gap-2">
                         <LemonButton
-                            onClick={loadSuggestions}
+                            onClick={() => loadSuggestions()}
                             disabled={suggestionsLoading}
                             type="secondary"
                             icon={<IconRefresh />}

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -273,7 +273,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     loaders(({ values, props }) => ({
         suggestions: {
             __default: [] as SuggestedDomain[],
-            loadSuggestions: async () => {
+            loadSuggestions: async (_, breakpoint) => {
                 const query = hogql`
                     select properties.$current_url, count()
                     from events
@@ -290,6 +290,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
                     scene: currentScene,
                     productKey: 'platform_and_support',
                 })
+                breakpoint()
                 const result = response.results as [string, number][]
 
                 if (result && result.length === 0) {

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -273,7 +273,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     loaders(({ values, props }) => ({
         suggestions: {
             __default: [] as SuggestedDomain[],
-            loadSuggestions: async (_, breakpoint) => {
+            loadSuggestions: async (_: void, breakpoint) => {
                 const query = hogql`
                     select properties.$current_url, count()
                     from events

--- a/frontend/src/lib/utils/kea-logic-builders.ts
+++ b/frontend/src/lib/utils/kea-logic-builders.ts
@@ -8,7 +8,7 @@ export function permanentlyMount(): (logic: BuiltLogic) => void {
         afterMount(() => {
             if (!logic.cache._permanentMount) {
                 logic.cache._permanentMount = true
-                logic.wrapper.mount()
+                logic.mount()
             }
         })(logic)
     }

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -130,7 +130,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
     path(['data-warehouse', 'editor', 'sqlEditorLogic']),
     props({} as SqlEditorLogicProps),
     tabAwareScene(),
-    connect(() => ({
+    connect((props: SqlEditorLogicProps) => ({
         values: [
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueries', 'dataWarehouseSavedQueryMapById'],
@@ -161,7 +161,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             ['fixErrors', 'fixErrorsSuccess', 'fixErrorsFailure'],
             draftsLogic,
             ['saveAsDraft', 'deleteDraft', 'saveAsDraftSuccess', 'deleteDraftSuccess'],
-            endpointLogic,
+            endpointLogic({ tabId: props.tabId }),
             ['setIsUpdateMode', 'setSelectedEndpointName'],
         ],
     })),

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -314,7 +314,16 @@ export const insightDataLogic = kea<insightDataLogicType>([
         },
     })),
     propsChanged(({ actions, props, values }) => {
-        if (props.cachedInsight?.query && !objectsEqual(props.cachedInsight.query, values.query)) {
+        if (!props.cachedInsight?.query) {
+            return
+        }
+        try {
+            if (!objectsEqual(props.cachedInsight.query, values.query)) {
+                actions.setQuery(props.cachedInsight.query)
+            }
+        } catch {
+            // values.query can throw if the logic's state isn't in the store yet
+            // (e.g. when InsightCard rebuilds the logic during navigation)
             actions.setQuery(props.cachedInsight.query)
         }
     }),

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -162,7 +162,8 @@ function PlayerWrapper({
         totalFiltersCount,
         nextSessionRecording,
     } = useValues(sessionRecordingsPlaylistLogic)
-    const { setFilters, resetFilters, setSelectedRecordingId } = useActions(sessionRecordingsPlaylistLogic)
+    const { setFilters, resetFilters, setSelectedRecordingId, loadAllRecordings } =
+        useActions(sessionRecordingsPlaylistLogic)
 
     const { isFiltersExpanded } = useValues(playlistFiltersLogic)
 
@@ -196,8 +197,8 @@ function PlayerWrapper({
                     matchingEventsMatchType={matchingEventsMatchType}
                     autoPlay={props.autoPlay}
                     onRecordingDeleted={() => {
-                        sessionRecordingsPlaylistLogic.actions.loadAllRecordings()
-                        sessionRecordingsPlaylistLogic.actions.setSelectedRecordingId(null)
+                        loadAllRecordings()
+                        setSelectedRecordingId(null)
                     }}
                     pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
                     setPinned={


### PR DESCRIPTION
## Problem
We get these KEA exceptions
<img width="1270" height="683" alt="Screenshot 2026-02-20 at 16 50 31" src="https://github.com/user-attachments/assets/ec31e39e-81aa-4f19-99c1-224f610e5e5e" />
6624a

Reproduced:
https://github.com/user-attachments/assets/d6588ee3-716e-493a-9daf-8e8cc7c4cce4
https://github.com/user-attachments/assets/d2f744d9-67a5-439f-89be-262b0e3
https://github.com/user-attachments/assets/faeb9387-f7e5-41f5-9aa3-9cebfff6f9cb


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
  - Fix permanentlyMount() calling logic.wrapper.mount() which rebuilds keyed logics with undefined key -> use logic.mount() to mount the existing instance directly                                            
  - Fix sqlEditorLogic connecting to endpointLogic without passing required tabId props
  - Add missing breakpoint() call in authorizedUrlListLogic.loadSuggestions to prevent accessing unmounted logic state after async API call
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
See videos.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
