### PR TITLE
feat: Link to GitHub issues from ErrorBoundary

### DIFF
--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -55,7 +55,7 @@ function LinkedIssueDisplay({
                 <p className="text-muted text-xs mb-2">
                     We use{' '}
                     <Link to={docsLink} target="_blank" className="text-link">
-                        PostHog Error tracking
+                        PostHog Error Tracking
                     </Link>{' '}
                     to group errors into issues. This can take a moment while we fingerprint the error.
                 </p>

--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -59,7 +59,13 @@ function LinkedIssueDisplay({
                     </Link>{' '}
                     to group errors into issues. This can take a moment while we fingerprint the error.
                 </p>
-                <LemonButton type="secondary" size="small" onClick={onEmailEngineer} className="mt-1">
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={onEmailEngineer}
+                    className="mt-1"
+                    data-ph-capture-attribute-error-boundary-interaction="email-engineer-polling"
+                >
                     Email an engineer
                 </LemonButton>
             </div>
@@ -70,7 +76,12 @@ function LinkedIssueDisplay({
         return (
             <div className="my-3 p-3 rounded border space-y-3">
                 <p className="text-muted text-sm mb-2">No public issue found for this error.</p>
-                <LemonButton type="secondary" size="small" onClick={onEmailEngineer}>
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={onEmailEngineer}
+                    data-ph-capture-attribute-error-boundary-interaction="email-engineer-timed-out"
+                >
                     Email an engineer
                 </LemonButton>
             </div>
@@ -88,12 +99,18 @@ function LinkedIssueDisplay({
                     targetBlank
                     tooltip="Track this issue on GitHub. Add any extra context about what you were doing when the crash happened in the issue comments!"
                     icon={<img src={ICONS.github} className="w-4 h-4 rounded-sm" />}
+                    data-ph-capture-attribute-error-boundary-interaction="track-github"
                 >
                     Track via GitHub
                 </LemonButton>
             ))}
             <span className="text-muted text-sm">or</span>
-            <LemonButton type="secondary" size="small" onClick={onEmailEngineer}>
+            <LemonButton
+                type="secondary"
+                size="small"
+                onClick={onEmailEngineer}
+                data-ph-capture-attribute-error-boundary-interaction="email-engineer-linked-issue"
+            >
                 Email an engineer
             </LemonButton>
         </div>
@@ -105,7 +122,10 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
     const { openSupportForm } = useActions(supportLogic)
     const showLinkedIssue = useFeatureFlag('ERROR_BOUNDARY_ISSUE_LINK', 'test')
 
-    const additionalProperties = { ...exceptionProps }
+    const additionalProperties: ErrorBoundaryProps['exceptionProps'] = {
+        ...exceptionProps,
+        is_error_boundary_error: true,
+    }
 
     if (currentTeamId !== undefined) {
         additionalProperties.team_id = currentTeamId
@@ -182,6 +202,7 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                                         onClick={emailEngineer}
                                         targetBlank
                                         className="mt-2"
+                                        data-ph-capture-attribute-error-boundary-interaction="email-engineer-control"
                                     >
                                         Email an engineer
                                     </LemonButton>

--- a/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
+++ b/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
@@ -1,0 +1,77 @@
+import { actions, events, kea, key, listeners, path, props, reducers } from 'kea'
+
+import api from 'lib/api'
+import { retryWithBackoff } from 'lib/utils'
+
+import type { errorBoundaryLinkedIssueLogicType } from './errorBoundaryLinkedIssueLogicType'
+
+export interface ErrorTrackingExternalUrl {
+    url: string
+    kind: string
+}
+
+export interface ErrorTrackingLookupByEventResponse {
+    external_urls: ErrorTrackingExternalUrl[]
+}
+
+export interface ErrorBoundaryLinkedIssueLogicProps {
+    eventUuid: string
+    timestamp: string
+}
+
+// Poll 6 times, up to ~30 seconds, for an issue to be created for the given event UUID.
+// If no issue is found after that, we give up and stop polling.
+// Processing p95 is ~6 seconds in Grafana at time of writing this, so we should poll 4 times
+// in most cases.
+const MAX_POLL_ATTEMPTS = 6
+const INITIAL_DELAY_MS = 1000
+const BACKOFF_MULTIPLIER = 2
+
+export const errorBoundaryLinkedIssueLogic = kea<errorBoundaryLinkedIssueLogicType>([
+    path((key) => ['layout', 'ErrorBoundary', 'errorBoundaryLinkedIssueLogic', key]),
+    props({} as ErrorBoundaryLinkedIssueLogicProps),
+    key((props) => props.eventUuid),
+
+    actions({
+        startPolling: true,
+        setExternalUrls: (externalUrls: ErrorTrackingExternalUrl[]) => ({ externalUrls }),
+        setTimedOut: true,
+    }),
+
+    reducers({
+        externalUrls: [[] as ErrorTrackingExternalUrl[], { setExternalUrls: (_, { externalUrls }) => externalUrls }],
+        polling: [
+            true,
+            {
+                setExternalUrls: () => false,
+                setTimedOut: () => false,
+            },
+        ],
+        timedOut: [false, { setTimedOut: () => true }],
+    }),
+
+    listeners(({ actions, props }) => ({
+        startPolling: async () => {
+            try {
+                const result = await retryWithBackoff(
+                    () => api.errorTracking.getGitHubIssueUrlsForEventUuid(props.eventUuid, props.timestamp),
+                    {
+                        maxAttempts: MAX_POLL_ATTEMPTS,
+                        initialDelayMs: INITIAL_DELAY_MS,
+                        backoffMultiplier: BACKOFF_MULTIPLIER,
+                        shouldRetry: (e: unknown) => (e as any)?.status === 404,
+                    }
+                )
+                actions.setExternalUrls(result.external_urls)
+            } catch {
+                actions.setTimedOut()
+            }
+        },
+    })),
+
+    events(({ actions }) => ({
+        afterMount: () => {
+            actions.startPolling()
+        },
+    })),
+])

--- a/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
+++ b/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
@@ -52,7 +52,7 @@ export const errorBoundaryLinkedIssueLogic = kea<errorBoundaryLinkedIssueLogicTy
     }),
 
     listeners(({ actions, props }) => ({
-        startPolling: async () => {
+        startPolling: async (_, breakpoint) => {
             try {
                 const result = await retryWithBackoff(
                     () => api.errorTracking.getGitHubIssueUrlsForEventUuid(props.eventUuid, props.timestamp),
@@ -63,6 +63,7 @@ export const errorBoundaryLinkedIssueLogic = kea<errorBoundaryLinkedIssueLogicTy
                         shouldRetry: (e: unknown) => (e as any)?.status === 404,
                     }
                 )
+                breakpoint()
                 actions.setExternalUrls(result.external_urls)
                 posthog.capture('error_boundary_issue_lookup_completed', {
                     error_boundary_exception_id: props.eventUuid,

--- a/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
+++ b/frontend/src/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic.ts
@@ -1,4 +1,5 @@
 import { actions, events, kea, key, listeners, path, props, reducers } from 'kea'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { retryWithBackoff } from 'lib/utils'
@@ -63,8 +64,17 @@ export const errorBoundaryLinkedIssueLogic = kea<errorBoundaryLinkedIssueLogicTy
                     }
                 )
                 actions.setExternalUrls(result.external_urls)
+                posthog.capture('error_boundary_issue_lookup_completed', {
+                    error_boundary_exception_id: props.eventUuid,
+                    error_boundary_linked_issue_result: 'found_issue',
+                    error_boundary_linked_issues: result.external_urls,
+                })
             } catch {
                 actions.setTimedOut()
+                posthog.capture('error_boundary_issue_lookup_completed', {
+                    error_boundary_exception_id: props.eventUuid,
+                    error_boundary_linked_issue_result: 'timed_out',
+                })
             }
         },
     })),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,6 +18,7 @@ import { SessionSummaryContent } from 'scenes/session-recordings/player/player-m
 import { LINK_PAGE_SIZE, SURVEY_PAGE_SIZE } from 'scenes/surveys/constants'
 
 import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
+import { ErrorTrackingLookupByEventResponse } from '~/layout/ErrorBoundary/errorBoundaryLinkedIssueLogic'
 import { Variable } from '~/queries/nodes/DataVisualization/types'
 import {
     AnyResponseType,
@@ -1190,6 +1191,10 @@ export class ApiRequest {
 
     public errorTrackingIssue(id: ErrorTrackingIssue['id'], teamId?: TeamType['id']): ApiRequest {
         return this.errorTrackingIssues(teamId).addPathComponent(id)
+    }
+
+    public errorTrackingIssueLookupByEvent(teamId?: TeamType['id']): ApiRequest {
+        return this.errorTrackingIssues(teamId).addPathComponent('lookup_by_event')
     }
 
     public errorTrackingIssueMerge(into: ErrorTrackingIssue['id']): ApiRequest {
@@ -3489,6 +3494,16 @@ const api = {
     errorTracking: {
         async getIssue(id: ErrorTrackingIssue['id'], fingerprint?: string): Promise<ErrorTrackingRelationalIssue> {
             return await new ApiRequest().errorTrackingIssue(id).withQueryString(toParams({ fingerprint })).get()
+        },
+
+        async getGitHubIssueUrlsForEventUuid(
+            eventUuid: string,
+            timestamp: string
+        ): Promise<ErrorTrackingLookupByEventResponse> {
+            return await new ApiRequest()
+                .errorTrackingIssueLookupByEvent()
+                .withQueryString(toParams({ event_uuid: eventUuid, timestamp, kind: 'github' }))
+                .get()
         },
 
         async updateIssue(

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -191,6 +191,7 @@ export const FEATURE_FLAGS = {
     CALENDAR_HEATMAP_INSIGHT: 'calendar-heatmap-insight', // owner: @jabahamondes #team-web-analytics
     COOKIELESS_SERVER_HASH_MODE_SETTING: 'cookieless-server-hash-mode-setting', // owner: #team-web-analytics
     CSP_REPORTING: 'mexicspo', // owner @pauldambra @lricoy @robbiec
+    ERROR_BOUNDARY_ISSUE_LINK: 'error-boundary-issue-link', // owner: @luke-belton #team-support
     ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking
     EXPERIMENT_INTERVAL_TIMESERIES: 'experiments-interval-timeseries', // owner: @jurajmajerik #team-experiments
     /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -903,6 +903,20 @@ export const errorTrackingIssuesBulkCreate = async (
     })
 }
 
+export const getErrorTrackingIssuesLookupByEventRetrieveUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/error_tracking/issues/lookup_by_event/`
+}
+
+export const errorTrackingIssuesLookupByEventRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getErrorTrackingIssuesLookupByEventRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getErrorTrackingIssuesValuesRetrieveUrl = (projectId: string) => {
     return `/api/environments/${projectId}/error_tracking/issues/values/`
 }


### PR DESCRIPTION
## Problem

In support we sometimes have customers writing in about exceptions they've seen in the UI. Often the result is us creating/pointing them towards a GitHub issue to track. It would be better to automate this loop.

## Changes

Issue fingerprinting is async, so we poll a new API endpoint to lookup the external (GitHub) issue tracking link for a given event (exception) UUID. Polling is on a backoff loop - I expect/hope it should normally return a result within ~10 seconds of the exception happening but we keep trying up to 6 attempts which is around 30 seconds.

Always show an 'email an engineer' button regardless of whether a GitHub issue is found. I've styled the GitHub issue button as a primary button to promote this as the preferred way for users to interact with the error boundary.

This is behind a feature flag because I'd like to run an experiment:
- does it decrease the number of support tickets when errors see the error boundary?
- do we see more community interaction on the GitHub issues (tbc how we do this, but GitHub is now a data warehouse source...)?
- does it help at all with our prioritisation of user facing issues? Even just tracking error boundary exceptions more closely is an improvement

https://posthog.slack.com/archives/C075D3C5HST/p1771585259882079

**Current (flag off/`control`):**

<img width="893" height="570" alt="CleanShot 2026-02-20 at 11 38 11" src="https://github.com/user-attachments/assets/24323910-e6bb-4c08-b694-441dd05ccd52" />

**New (flag=`test`):**

Not found:
<img width="1277" height="565" alt="CleanShot 2026-02-20 at 11 33 52" src="https://github.com/user-attachments/assets/fff49fb2-df44-4430-b7a8-926eaec3bf82" />

Issue found:
<img width="1311" height="552" alt="CleanShot 2026-02-20 at 11 33 26" src="https://github.com/user-attachments/assets/620a06c4-cd29-496d-8c55-18a35e160712" />

Loading:
<img width="1292" height="617" alt="CleanShot 2026-02-20 at 11 33 21" src="https://github.com/user-attachments/assets/76c05694-6c72-491a-aff3-9dceab8ed48b" />

## How did you test this code?

Tested locally + unit tests to cover the backend. Behind a flag so I can validate in production too.

## Publish to changelog?

No