### PR TITLE
fix(phai): prevent context chips from overlapping send button

### DIFF
--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -250,7 +250,7 @@ export function ContextTags({ size = 'default' }: { size?: 'small' | 'default' }
         return null
     }
 
-    return <div className="flex flex-wrap gap-1 flex-1 min-w-0 overflow-hidden">{allTags}</div>
+    return <>{allTags}</>
 }
 
 export function ContextToolInfoTags({ size = 'default' }: { size?: 'small' | 'default' }): JSX.Element | null {

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -347,7 +347,9 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         <div className="flex items-start gap-1 h-full mt-1 mr-1">{topActions}</div>
                                     </div>
                                 ) : (
-                                    <ContextDisplay size={contextDisplaySize} />
+                                    <div className="pr-12">
+                                        <ContextDisplay size={contextDisplaySize} />
+                                    </div>
                                 )}
                             </div>
                         )}

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -340,16 +340,15 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                         </SlashCommandAutocomplete>
 
                         {!isSharedThread && (
-                            <div className="pb-2">
+                            <div className="pb-2 pr-12">
                                 {!isThreadVisible ? (
                                     <div className="flex items-start justify-between">
                                         <ContextDisplay size={contextDisplaySize} />
+
                                         <div className="flex items-start gap-1 h-full mt-1 mr-1">{topActions}</div>
                                     </div>
                                 ) : (
-                                    <div className="pr-12">
-                                        <ContextDisplay size={contextDisplaySize} />
-                                    </div>
+                                    <ContextDisplay size={contextDisplaySize} />
                                 )}
                             </div>
                         )}


### PR DESCRIPTION
## Problem

Add right padding to the context display wrapper when in thread view
to reserve space for the absolutely positioned send/stop button.

Slack thread: https://posthog.slack.com/archives/C06NZEZ7V3Q/p1771607168324689?thread_ts=1771581886.015179&cid=C06NZEZ7V3Q

https://claude.ai/code/session_01VaDREYwdrDaitn5PkaxtHh



**Before**

![Screenshot 2026-02-25 at 11.23.38.png](https://app.graphite.com/user-attachments/assets/4d55c47d-3fb3-400e-b0c6-868b8cb8243e.png)

**After**

![Screenshot 2026-02-25 at 11.22.08.png](https://app.graphite.com/user-attachments/assets/2cdd26f3-70eb-4001-89dc-49688d621a28.png)





## Changes

- Added padding
- Fixed wrapping of elements