### PR TITLE
feat: add context aware rate limiting to the event/values API

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -178,7 +178,7 @@ class EventViewSet(
         if self.action != "values":
             return super().check_throttles(request_to_check)
 
-        has_event_name = bool(request_to_check.GET.getlist("event_name", None))
+        has_event_name = bool(request_to_check.GET.getlist("event_name", None) and len(request_to_check.GET.getlist("event_name", None)) > 0)
         if has_event_name:
             throttles = [EventValuesBurstThrottle(), EventValuesSustainedThrottle()]
         else:

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -171,23 +171,18 @@ class EventViewSet(
 
     def get_throttles(self):
         if self.action == "values":
-            return []
+            request_obj = getattr(self, "request", None)
+            has_event_name = bool(
+                request_obj
+                and request_obj.GET.getlist("event_name", None)
+                and len(request_obj.GET.getlist("event_name", None)) > 0
+            )
+            if has_event_name:
+                throttle_classes = [EventValuesBurstThrottle, EventValuesSustainedThrottle]
+            else:
+                throttle_classes = [EventValuesNoEventNameBurstThrottle, EventValuesNoEventNameSustainedThrottle]
+            return [throttle_class() for throttle_class in throttle_classes]
         return super().get_throttles()
-
-    def check_throttles(self, request_to_check: request.Request) -> None:
-        if self.action != "values":
-            return super().check_throttles(request_to_check)
-
-        has_event_name = bool(request_to_check.GET.getlist("event_name", None) and len(request_to_check.GET.getlist("event_name", None)) > 0)
-        if has_event_name:
-            throttles = [EventValuesBurstThrottle(), EventValuesSustainedThrottle()]
-        else:
-            throttles = [EventValuesNoEventNameBurstThrottle(), EventValuesNoEventNameSustainedThrottle()]
-
-        durations = []
-        for throttle in throttles:
-            if not throttle.allow_request(request_to_check, self):
-                durations.append(throttle.wait())
         
         if durations:
             self.throttled(request_to_check, max(durations) or 0.0)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -184,9 +184,13 @@ class EventViewSet(
         else:
             throttles = [EventValuesNoEventNameBurstThrottle(), EventValuesNoEventNameSustainedThrottle()]
 
+        durations = []
         for throttle in throttles:
             if not throttle.allow_request(request_to_check, self):
-                self.throttled(request_to_check, throttle.wait() or 0.0)
+                durations.append(throttle.wait())
+        
+        if durations:
+            self.throttled(request_to_check, max(durations) or 0.0)
 
     def _build_next_url(
         self,

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -186,7 +186,7 @@ class EventViewSet(
 
         for throttle in throttles:
             if not throttle.allow_request(request_to_check, self):
-                self.throttled(request_to_check, throttle.wait())
+                self.throttled(request_to_check, throttle.wait() or 0.0)
 
     def _build_next_url(
         self,

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -451,6 +451,15 @@ class EventViewSet(
         event_names = request.GET.getlist("event_name", None)
         has_event_name = bool(event_names and len(event_names) > 0)
         is_personal_api_key = isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication)
+        
+        # Reject personal API key requests without event_name filter
+        if is_personal_api_key and not has_event_name:
+            raise serializers.ValidationError(
+                "The event_name parameter is required when using a personal API key. "
+                "For queries without event filters, please use the Query endpoint instead: "
+                "https://posthog.com/docs/api/query"
+            )
+        
         EVENT_VALUES_COUNTER.labels(
             has_event_name=str(has_event_name),
             auth="personal_api_key" if is_personal_api_key else "app",

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -183,9 +183,6 @@ class EventViewSet(
                 throttle_classes = [EventValuesNoEventNameBurstThrottle, EventValuesNoEventNameSustainedThrottle]
             return [throttle_class() for throttle_class in throttle_classes]
         return super().get_throttles()
-        
-        if durations:
-            self.throttled(request_to_check, max(durations) or 0.0)
 
     def _build_next_url(
         self,

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -451,7 +451,7 @@ class EventViewSet(
         event_names = request.GET.getlist("event_name", None)
         has_event_name = bool(event_names and len(event_names) > 0)
         is_personal_api_key = isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication)
-        
+
         # Reject personal API key requests without event_name filter
         if is_personal_api_key and not has_event_name:
             raise serializers.ValidationError(
@@ -459,7 +459,7 @@ class EventViewSet(
                 "For queries without event filters, please use the Query endpoint instead: "
                 "https://posthog.com/docs/api/query"
             )
-        
+
         EVENT_VALUES_COUNTER.labels(
             has_event_name=str(has_event_name),
             auth="personal_api_key" if is_personal_api_key else "app",

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -45,8 +45,6 @@ from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
     EventValuesBurstThrottle,
-    EventValuesNoEventNameBurstThrottle,
-    EventValuesNoEventNameSustainedThrottle,
     EventValuesSustainedThrottle,
 )
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
@@ -171,17 +169,7 @@ class EventViewSet(
 
     def get_throttles(self):
         if self.action == "values":
-            request_obj = getattr(self, "request", None)
-            has_event_name = bool(
-                request_obj
-                and request_obj.GET.getlist("event_name", None)
-                and len(request_obj.GET.getlist("event_name", None)) > 0
-            )
-            if has_event_name:
-                throttle_classes = [EventValuesBurstThrottle, EventValuesSustainedThrottle]
-            else:
-                throttle_classes = [EventValuesNoEventNameBurstThrottle, EventValuesNoEventNameSustainedThrottle]
-            return [throttle_class() for throttle_class in throttle_classes]
+            return [EventValuesBurstThrottle(), EventValuesSustainedThrottle()]
         return super().get_throttles()
 
     def _build_next_url(

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -486,6 +486,36 @@ class LLMAnalyticsSummarizationDailyThrottle(PersonalApiKeyRateThrottle):
     rate = "500/day"
 
 
+class EventValuesBaseThrottle(SimpleRateThrottle):
+    def get_cache_key(self, request, view):
+        try:
+            team_id = getattr(view, "team_id", None)
+        except KeyError:
+            team_id = None
+        ident = team_id or self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class EventValuesBurstThrottle(EventValuesBaseThrottle):
+    scope = "event_values_burst"
+    rate = "60/minute"
+
+
+class EventValuesSustainedThrottle(EventValuesBaseThrottle):
+    scope = "event_values_sustained"
+    rate = "300/hour"
+
+
+class EventValuesNoEventNameBurstThrottle(EventValuesBaseThrottle):
+    scope = "event_values_no_event_name_burst"
+    rate = "6/minute"
+
+
+class EventValuesNoEventNameSustainedThrottle(EventValuesBaseThrottle):
+    scope = "event_values_no_event_name_sustained"
+    rate = "30/hour"
+
+
 class UserPasswordResetThrottle(UserOrEmailRateThrottle):
     scope = "user_password_reset"
     rate = "6/day"

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -486,34 +486,14 @@ class LLMAnalyticsSummarizationDailyThrottle(PersonalApiKeyRateThrottle):
     rate = "500/day"
 
 
-class EventValuesBaseThrottle(SimpleRateThrottle):
-    def get_cache_key(self, request, view):
-        try:
-            team_id = getattr(view, "team_id", None)
-        except KeyError:
-            team_id = None
-        ident = team_id or self.get_ident(request)
-        return self.cache_format % {"scope": self.scope, "ident": ident}
-
-
-class EventValuesBurstThrottle(EventValuesBaseThrottle):
+class EventValuesBurstThrottle(PersonalApiKeyRateThrottle):
     scope = "event_values_burst"
     rate = "60/minute"
 
 
-class EventValuesSustainedThrottle(EventValuesBaseThrottle):
+class EventValuesSustainedThrottle(PersonalApiKeyRateThrottle):
     scope = "event_values_sustained"
     rate = "300/hour"
-
-
-class EventValuesNoEventNameBurstThrottle(EventValuesBaseThrottle):
-    scope = "event_values_no_event_name_burst"
-    rate = "6/minute"
-
-
-class EventValuesNoEventNameSustainedThrottle(EventValuesBaseThrottle):
-    scope = "event_values_no_event_name_sustained"
-    rate = "30/hour"
 
 
 class UserPasswordResetThrottle(UserOrEmailRateThrottle):


### PR DESCRIPTION
lower rate limits on the event/values API for personal API key  
it is expensive and people should be using the query API  
  
also  
  
don't allow personal API key calls to not specify events  
that's really expensive