### PR TITLE
fix: Use a different key than workflow_id

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -133,7 +133,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
             try:
                 logger.info(
-                    "Waiting for pending workflow",
+                    "Waiting for pending backfill run",
                     backfill_run_id=heartbeater.details.workflow_id,
                     schedule_id=heartbeater.details.schedule_id,
                     last_batch_data_interval_end=heartbeater.details.last_batch_data_interval_end,
@@ -141,7 +141,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
                 await workflow_handle.result()
             except temporalio.client.WorkflowFailureError:
-                logger.exception("Pending workflow failed", backfill_run_id=heartbeater.details.workflow_id)
+                logger.exception("Pending backfill run failed", backfill_run_id=heartbeater.details.workflow_id)
                 # TODO: Handle failures here instead of in the batch export.
                 await asyncio.sleep(inputs.start_delay)
 
@@ -216,7 +216,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             try:
                 await workflow_handle.result()
             except temporalio.client.WorkflowFailureError:
-                logger.exception("Workflow run failed", backfill_run_id=heartbeater.details.workflow_id)
+                logger.exception("Backfill run failed", backfill_run_id=heartbeater.details.workflow_id)
                 # `WorkflowFailureError` includes cancellations, terminations, timeouts, and errors.
                 # Common errors should be handled by the workflow itself (i.e. by retrying an activity).
                 # We briefly sleep to allow heartbeating to potentially receive a cancellation request.

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -118,7 +118,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             last_activity_details = HeartbeatDetails(*details)
             logger.info(
                 "Heartbeat details received",
-                workflow_id=last_activity_details.workflow_id,
+                backfill_run_id=last_activity_details.workflow_id,
                 schedule_id=last_activity_details.schedule_id,
                 last_batch_data_interval_end=last_activity_details.last_batch_data_interval_end,
             )
@@ -134,14 +134,14 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             try:
                 logger.info(
                     "Waiting for pending workflow",
-                    workflow_id=heartbeater.details.workflow_id,
+                    backfill_run_id=heartbeater.details.workflow_id,
                     schedule_id=heartbeater.details.schedule_id,
                     last_batch_data_interval_end=heartbeater.details.last_batch_data_interval_end,
                 )
 
                 await workflow_handle.result()
             except temporalio.client.WorkflowFailureError:
-                logger.exception("Pending workflow failed", workflow_id=heartbeater.details.workflow_id)
+                logger.exception("Pending workflow failed", backfill_run_id=heartbeater.details.workflow_id)
                 # TODO: Handle failures here instead of in the batch export.
                 await asyncio.sleep(inputs.start_delay)
 
@@ -191,7 +191,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
             try:
                 workflow_id = f"{description.id}-{backfill_end_at:%Y-%m-%dT%H:%M:%S}Z"
-                logger.info("Starting backfill run", workflow_id=workflow_id)
+                logger.info("Starting backfill run", backfill_run_id=workflow_id)
                 workflow_handle = await client.start_workflow(
                     schedule_action.workflow,
                     *args,
@@ -216,7 +216,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             try:
                 await workflow_handle.result()
             except temporalio.client.WorkflowFailureError:
-                logger.exception("Workflow run failed", workflow_id=heartbeater.details.workflow_id)
+                logger.exception("Workflow run failed", backfill_run_id=heartbeater.details.workflow_id)
                 # `WorkflowFailureError` includes cancellations, terminations, timeouts, and errors.
                 # Common errors should be handled by the workflow itself (i.e. by retrying an activity).
                 # We briefly sleep to allow heartbeating to potentially receive a cancellation request.


### PR DESCRIPTION
## Problem

When adding logs to backfills, I overrode the `workflow_id` key with the value for the currently running backfill run (what a mouthful). This makes filtering logs a bit awkward, as one must look for a different global filter than just the backfill workflow id. 

So let's use a different key.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use `backfill_run_id` instead of `workflow_id` for the current backfill run, so that the top level `workflow_id` can be the backfill workflow itself.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
