### PR TITLE
feat(flags): tokio runtime monitoring

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [env]
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,4 +1,7 @@
 [build]
+# Unlocks Tokio's unstable RuntimeMetrics API (per-worker poll counts, blocking pool stats, etc.).
+# Used by feature-flags/src/tokio_monitor.rs — no other crate calls unstable APIs.
+# Applies workspace-wide because Cargo doesn't support per-crate config within a workspace.
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,6 +1,3 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
-
 [env]
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -45,6 +45,7 @@ members = [
 
 [workspace.lints.rust]
 # See https://doc.rust-lang.org/stable/rustc/lints/listing/allowed-by-default.html
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 unstable_features = "forbid"
 macro_use_extern_crate = "forbid"
 let_underscore_drop = "deny"

--- a/rust/feature-flags/.cargo/config.toml
+++ b/rust/feature-flags/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]

--- a/rust/feature-flags/.cargo/config.toml
+++ b/rust/feature-flags/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/rust/feature-flags/src/lib.rs
+++ b/rust/feature-flags/src/lib.rs
@@ -14,6 +14,7 @@ pub mod router;
 pub mod server;
 pub mod site_apps;
 pub mod team;
+pub mod tokio_monitor;
 
 // Test modules don't need to be compiled with main binary
 // #[cfg(test)]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -97,3 +97,61 @@ pub const FLAG_BATCH_EVALUATION_COUNTER: &str = "flags_batch_evaluation_total";
 // Histogram of flag counts per batch evaluation
 // Labels: evaluation_type ("sequential" or "parallel")
 pub const FLAG_BATCH_SIZE: &str = "flags_batch_size";
+
+// Tokio runtime metrics
+// These track worker thread utilization to inform thread pool sizing decisions.
+// Sampled periodically by TokioRuntimeMonitor (default: every 15s).
+
+// Fraction of wall-clock time that workers spent executing tasks (gauge, 0.0–1.0).
+// Computed as: sum(worker_busy_duration_delta) / (elapsed * num_workers).
+// < 0.3 means workers are idle 70%+ of the time — room to reduce worker count.
+// > 0.8 means approaching saturation.
+pub const TOKIO_RUNTIME_BUSY_RATIO: &str = "flags_tokio_busy_ratio";
+
+// Number of tasks currently alive (spawned but not yet completed) on the runtime (gauge).
+pub const TOKIO_RUNTIME_ALIVE_TASKS: &str = "flags_tokio_alive_tasks";
+
+// Tasks pending in the runtime's global injection queue (gauge).
+// Sustained values > 0 indicate workers cannot drain tasks fast enough.
+pub const TOKIO_RUNTIME_GLOBAL_QUEUE_DEPTH: &str = "flags_tokio_global_queue_depth";
+
+// Number of configured Tokio worker threads (gauge, constant after startup).
+pub const TOKIO_RUNTIME_NUM_WORKERS: &str = "flags_tokio_num_workers";
+
+// Per-worker local queue depth (gauge). Labels: worker="0", worker="1", etc.
+// High values indicate a specific worker is overloaded.
+pub const TOKIO_WORKER_LOCAL_QUEUE_DEPTH: &str = "flags_tokio_worker_local_queue_depth";
+
+// Per-worker poll count delta over the sampling interval (gauge). Labels: worker.
+// Shows throughput per worker — large imbalances suggest uneven task distribution.
+pub const TOKIO_WORKER_POLL_DELTA: &str = "flags_tokio_worker_poll_delta";
+
+// Per-worker park count delta over the sampling interval (gauge). Labels: worker.
+// A park event means the worker went idle. High park rates indicate light workloads.
+pub const TOKIO_WORKER_PARK_DELTA: &str = "flags_tokio_worker_park_delta";
+
+// Per-worker busy duration over the sampling interval in seconds (gauge). Labels: worker.
+// Used to detect load imbalance across workers.
+pub const TOKIO_WORKER_BUSY_DURATION_DELTA: &str = "flags_tokio_worker_busy_duration_delta_secs";
+
+// Number of threads in the blocking thread pool (gauge).
+pub const TOKIO_BLOCKING_THREADS: &str = "flags_tokio_blocking_threads";
+
+// Idle threads in the blocking thread pool (gauge).
+pub const TOKIO_IDLE_BLOCKING_THREADS: &str = "flags_tokio_idle_blocking_threads";
+
+// Tasks waiting for a blocking thread (gauge).
+// High values indicate spawn_blocking contention.
+pub const TOKIO_BLOCKING_QUEUE_DEPTH: &str = "flags_tokio_blocking_queue_depth";
+
+// Mean poll duration per worker in microseconds (gauge). Labels: worker.
+// Long poll times can indicate blocking or CPU-heavy futures on the Tokio runtime.
+pub const TOKIO_WORKER_MEAN_POLL_TIME_US: &str = "flags_tokio_worker_mean_poll_time_us";
+
+// Times a worker's local queue overflowed to the global queue (gauge, delta). Labels: worker.
+// Non-zero indicates a worker couldn't keep up and had to shed work.
+pub const TOKIO_WORKER_OVERFLOW_DELTA: &str = "flags_tokio_worker_overflow_delta";
+
+// Number of tasks stolen from other workers (gauge, delta). Labels: worker.
+// Active stealing indicates work imbalance being corrected by the scheduler.
+pub const TOKIO_WORKER_STEAL_DELTA: &str = "flags_tokio_worker_steal_delta";

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -9,6 +9,7 @@ use crate::config::Config;
 use crate::database_pools::DatabasePools;
 use crate::db_monitor::DatabasePoolMonitor;
 use crate::router;
+use crate::tokio_monitor::TokioRuntimeMonitor;
 use common_cookieless::CookielessManager;
 use common_geoip::GeoIpClient;
 use common_hypercache::{HyperCacheConfig, HyperCacheReader};
@@ -133,6 +134,12 @@ where
         cohort_cache_clone
             .start_monitoring(cohort_cache_monitor_interval)
             .await;
+    });
+
+    // Start Tokio runtime monitoring
+    let tokio_monitor = TokioRuntimeMonitor::new(&tokio::runtime::Handle::current());
+    tokio::spawn(async move {
+        tokio_monitor.start_monitoring().await;
     });
 
     let feature_flags_billing_limiter = match FeatureFlagsLimiter::new(

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -1,20 +1,18 @@
-use std::time::Duration;
-#[cfg(tokio_unstable)]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use common_metrics::gauge;
 use tokio::runtime::RuntimeMetrics;
 use tokio::time::interval;
 
 use crate::metrics::consts::{
-    TOKIO_RUNTIME_ALIVE_TASKS, TOKIO_RUNTIME_GLOBAL_QUEUE_DEPTH, TOKIO_RUNTIME_NUM_WORKERS,
+    TOKIO_RUNTIME_ALIVE_TASKS, TOKIO_RUNTIME_BUSY_RATIO, TOKIO_RUNTIME_GLOBAL_QUEUE_DEPTH,
+    TOKIO_RUNTIME_NUM_WORKERS, TOKIO_WORKER_BUSY_DURATION_DELTA, TOKIO_WORKER_PARK_DELTA,
 };
 
 #[cfg(tokio_unstable)]
 use crate::metrics::consts::{
     TOKIO_BLOCKING_QUEUE_DEPTH, TOKIO_BLOCKING_THREADS, TOKIO_IDLE_BLOCKING_THREADS,
-    TOKIO_RUNTIME_BUSY_RATIO, TOKIO_WORKER_BUSY_DURATION_DELTA, TOKIO_WORKER_LOCAL_QUEUE_DEPTH,
-    TOKIO_WORKER_MEAN_POLL_TIME_US, TOKIO_WORKER_OVERFLOW_DELTA, TOKIO_WORKER_PARK_DELTA,
+    TOKIO_WORKER_LOCAL_QUEUE_DEPTH, TOKIO_WORKER_MEAN_POLL_TIME_US, TOKIO_WORKER_OVERFLOW_DELTA,
     TOKIO_WORKER_POLL_DELTA, TOKIO_WORKER_STEAL_DELTA,
 };
 
@@ -42,36 +40,33 @@ impl TokioRuntimeMonitor {
 
         gauge(TOKIO_RUNTIME_NUM_WORKERS, &[], num_workers as f64);
 
+        let mut stable_state = WorkerState::new(num_workers, &self.metrics);
+
         #[cfg(tokio_unstable)]
         {
-            let mut state = PerWorkerState::new(num_workers, &self.metrics);
-            self.run_unstable_loop(&mut state).await;
+            let mut unstable_state = UnstableWorkerState::new(num_workers, &self.metrics);
+            self.run_unstable_loop(&mut stable_state, &mut unstable_state)
+                .await;
         }
 
         #[cfg(not(tokio_unstable))]
         {
-            self.run_stable_loop().await;
+            self.run_stable_loop(&mut stable_state).await;
         }
     }
 
     #[cfg(not(tokio_unstable))]
-    async fn run_stable_loop(&self) {
+    async fn run_stable_loop(&self, state: &mut WorkerState) {
         tracing::warn!(
-            "tokio_unstable not enabled — only reporting stable metrics \
-             (alive_tasks, global_queue_depth). Enable with rustflags = [\"--cfg\", \"tokio_unstable\"] \
-             for full worker utilization metrics."
+            "tokio_unstable not enabled — blocking pool and some per-worker metrics \
+             (poll count, steal count, overflow count, local queue depth, mean poll time) \
+             are unavailable. Enable with rustflags = [\"--cfg\", \"tokio_unstable\"] for full metrics."
         );
 
         let mut ticker = interval(SAMPLING_INTERVAL);
-        loop {
-            ticker.tick().await;
-            self.report_stable_metrics();
-        }
-    }
+        // Skip the immediate first tick so the first report comes after a full interval
+        ticker.tick().await;
 
-    #[cfg(tokio_unstable)]
-    async fn run_unstable_loop(&self, state: &mut PerWorkerState) {
-        let mut ticker = interval(SAMPLING_INTERVAL);
         loop {
             ticker.tick().await;
 
@@ -79,12 +74,33 @@ impl TokioRuntimeMonitor {
             let elapsed = now.duration_since(state.last_sample);
             state.last_sample = now;
 
-            self.report_stable_metrics();
-            self.report_unstable_metrics(state, elapsed);
+            self.report_stable_metrics(state, elapsed);
         }
     }
 
-    fn report_stable_metrics(&self) {
+    #[cfg(tokio_unstable)]
+    async fn run_unstable_loop(
+        &self,
+        stable_state: &mut WorkerState,
+        unstable_state: &mut UnstableWorkerState,
+    ) {
+        let mut ticker = interval(SAMPLING_INTERVAL);
+        // Skip the immediate first tick so the first report comes after a full interval
+        ticker.tick().await;
+
+        loop {
+            ticker.tick().await;
+
+            let now = Instant::now();
+            let elapsed = now.duration_since(stable_state.last_sample);
+            stable_state.last_sample = now;
+
+            self.report_stable_metrics(stable_state, elapsed);
+            self.report_unstable_metrics(unstable_state, &stable_state.worker_labels);
+        }
+    }
+
+    fn report_stable_metrics(&self, state: &mut WorkerState, elapsed: Duration) {
         gauge(
             TOKIO_RUNTIME_ALIVE_TASKS,
             &[],
@@ -95,12 +111,48 @@ impl TokioRuntimeMonitor {
             &[],
             self.metrics.global_queue_depth() as f64,
         );
+
+        let num_workers = self.metrics.num_workers();
+        let elapsed_secs = elapsed.as_secs_f64();
+        let mut total_busy_delta = Duration::ZERO;
+
+        for i in 0..num_workers {
+            let label = &state.worker_labels[i];
+
+            // Busy duration (stable API)
+            let busy = self.metrics.worker_total_busy_duration(i);
+            let busy_delta = busy.saturating_sub(state.prev_busy[i]);
+            state.prev_busy[i] = busy;
+            total_busy_delta += busy_delta;
+
+            gauge(
+                TOKIO_WORKER_BUSY_DURATION_DELTA,
+                label,
+                busy_delta.as_secs_f64(),
+            );
+
+            // Park count (stable API)
+            let parks = self.metrics.worker_park_count(i);
+            let park_delta = parks.saturating_sub(state.prev_parks[i]);
+            state.prev_parks[i] = parks;
+            gauge(TOKIO_WORKER_PARK_DELTA, label, park_delta as f64);
+        }
+
+        let busy_ratio = if elapsed_secs > 0.0 && num_workers > 0 {
+            total_busy_delta.as_secs_f64() / (elapsed_secs * num_workers as f64)
+        } else {
+            0.0
+        };
+        gauge(TOKIO_RUNTIME_BUSY_RATIO, &[], busy_ratio);
     }
 
     #[cfg(tokio_unstable)]
-    fn report_unstable_metrics(&self, state: &mut PerWorkerState, elapsed: Duration) {
+    fn report_unstable_metrics(
+        &self,
+        state: &mut UnstableWorkerState,
+        worker_labels: &[[(String, String); 1]],
+    ) {
         let num_workers = self.metrics.num_workers();
-        let elapsed_secs = elapsed.as_secs_f64();
 
         // Blocking pool
         gauge(
@@ -119,35 +171,14 @@ impl TokioRuntimeMonitor {
             self.metrics.blocking_queue_depth() as f64,
         );
 
-        // Per-worker metrics + aggregate busy ratio
-        let mut total_busy_delta = Duration::ZERO;
-
         for i in 0..num_workers {
-            let label = &state.worker_labels[i];
-
-            // Busy duration
-            let busy = self.metrics.worker_total_busy_duration(i);
-            let busy_delta = busy.saturating_sub(state.prev_busy[i]);
-            state.prev_busy[i] = busy;
-            total_busy_delta += busy_delta;
-
-            gauge(
-                TOKIO_WORKER_BUSY_DURATION_DELTA,
-                label,
-                busy_delta.as_secs_f64(),
-            );
+            let label = &worker_labels[i];
 
             // Poll count
             let polls = self.metrics.worker_poll_count(i);
             let poll_delta = polls.saturating_sub(state.prev_polls[i]);
             state.prev_polls[i] = polls;
             gauge(TOKIO_WORKER_POLL_DELTA, label, poll_delta as f64);
-
-            // Park count
-            let parks = self.metrics.worker_park_count(i);
-            let park_delta = parks.saturating_sub(state.prev_parks[i]);
-            state.prev_parks[i] = parks;
-            gauge(TOKIO_WORKER_PARK_DELTA, label, park_delta as f64);
 
             // Steal count
             let steals = self.metrics.worker_steal_count(i);
@@ -173,56 +204,63 @@ impl TokioRuntimeMonitor {
                 self.metrics.worker_mean_poll_time(i).as_micros() as f64,
             );
         }
-
-        // Aggregate busy ratio: total busy time / (elapsed * num_workers)
-        let busy_ratio = if elapsed_secs > 0.0 && num_workers > 0 {
-            total_busy_delta.as_secs_f64() / (elapsed_secs * num_workers as f64)
-        } else {
-            0.0
-        };
-        gauge(TOKIO_RUNTIME_BUSY_RATIO, &[], busy_ratio);
     }
 }
 
-#[cfg(tokio_unstable)]
-struct PerWorkerState {
+struct WorkerState {
     last_sample: Instant,
     worker_labels: Vec<[(String, String); 1]>,
     prev_busy: Vec<Duration>,
-    prev_polls: Vec<u64>,
     prev_parks: Vec<u64>,
-    prev_steals: Vec<u64>,
-    prev_overflows: Vec<u64>,
 }
 
-#[cfg(tokio_unstable)]
-impl PerWorkerState {
+impl WorkerState {
     fn new(num_workers: usize, metrics: &RuntimeMetrics) -> Self {
-        let mut prev_busy = vec![Duration::ZERO; num_workers];
-        let mut prev_polls = vec![0u64; num_workers];
-        let mut prev_parks = vec![0u64; num_workers];
-        let mut prev_steals = vec![0u64; num_workers];
-        let mut prev_overflows = vec![0u64; num_workers];
-
         let worker_labels: Vec<[(String, String); 1]> = (0..num_workers)
             .map(|i| [("worker".to_string(), i.to_string())])
             .collect();
 
+        let mut prev_busy = vec![Duration::ZERO; num_workers];
+        let mut prev_parks = vec![0u64; num_workers];
+
         // Snapshot current values so the first delta is accurate
         for i in 0..num_workers {
             prev_busy[i] = metrics.worker_total_busy_duration(i);
-            prev_polls[i] = metrics.worker_poll_count(i);
             prev_parks[i] = metrics.worker_park_count(i);
-            prev_steals[i] = metrics.worker_steal_count(i);
-            prev_overflows[i] = metrics.worker_overflow_count(i);
         }
 
         Self {
             last_sample: Instant::now(),
             worker_labels,
             prev_busy,
-            prev_polls,
             prev_parks,
+        }
+    }
+}
+
+#[cfg(tokio_unstable)]
+struct UnstableWorkerState {
+    prev_polls: Vec<u64>,
+    prev_steals: Vec<u64>,
+    prev_overflows: Vec<u64>,
+}
+
+#[cfg(tokio_unstable)]
+impl UnstableWorkerState {
+    fn new(num_workers: usize, metrics: &RuntimeMetrics) -> Self {
+        let mut prev_polls = vec![0u64; num_workers];
+        let mut prev_steals = vec![0u64; num_workers];
+        let mut prev_overflows = vec![0u64; num_workers];
+
+        // Snapshot current values so the first delta is accurate
+        for i in 0..num_workers {
+            prev_polls[i] = metrics.worker_poll_count(i);
+            prev_steals[i] = metrics.worker_steal_count(i);
+            prev_overflows[i] = metrics.worker_overflow_count(i);
+        }
+
+        Self {
+            prev_polls,
             prev_steals,
             prev_overflows,
         }
@@ -251,7 +289,9 @@ mod tests {
         );
 
         let monitor = TokioRuntimeMonitor::new(&handle);
-        monitor.report_stable_metrics();
+        let num_workers = handle.metrics().num_workers();
+        let mut state = WorkerState::new(num_workers, &handle.metrics());
+        monitor.report_stable_metrics(&mut state, Duration::from_secs(15));
 
         tx.send(()).ok();
         task.await.ok();
@@ -265,9 +305,10 @@ mod tests {
         let num_workers = metrics.num_workers();
         let monitor = TokioRuntimeMonitor::new(&handle);
 
-        let mut state = PerWorkerState::new(num_workers, &metrics);
-        let polls_before: Vec<u64> = state.prev_polls.clone();
-        let busy_before: Vec<Duration> = state.prev_busy.clone();
+        let mut stable_state = WorkerState::new(num_workers, &metrics);
+        let mut unstable_state = UnstableWorkerState::new(num_workers, &metrics);
+        let polls_before: Vec<u64> = unstable_state.prev_polls.clone();
+        let busy_before: Vec<Duration> = stable_state.prev_busy.clone();
 
         // Spawn real tasks so worker threads register polls
         let mut handles = Vec::new();
@@ -280,10 +321,10 @@ mod tests {
             h.await.ok();
         }
 
-        monitor.report_unstable_metrics(&mut state, Duration::from_secs(15));
+        monitor.report_stable_metrics(&mut stable_state, Duration::from_secs(15));
+        monitor.report_unstable_metrics(&mut unstable_state, &stable_state.worker_labels);
 
-        // report_unstable_metrics updates prev_* to current cumulative values
-        let polls_advanced = state
+        let polls_advanced = unstable_state
             .prev_polls
             .iter()
             .zip(polls_before.iter())
@@ -291,10 +332,10 @@ mod tests {
         assert!(
             polls_advanced,
             "poll counts should advance: before={polls_before:?}, after={:?}",
-            state.prev_polls
+            unstable_state.prev_polls
         );
 
-        let busy_advanced = state
+        let busy_advanced = stable_state
             .prev_busy
             .iter()
             .zip(busy_before.iter())
@@ -302,11 +343,10 @@ mod tests {
         assert!(
             busy_advanced,
             "busy durations should advance: before={busy_before:?}, after={:?}",
-            state.prev_busy
+            stable_state.prev_busy
         );
     }
 
-    #[cfg(tokio_unstable)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn busy_ratio_bounded_with_real_elapsed() {
         let handle = tokio::runtime::Handle::current();

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -171,9 +171,7 @@ impl TokioRuntimeMonitor {
             self.metrics.blocking_queue_depth() as f64,
         );
 
-        for i in 0..num_workers {
-            let label = &worker_labels[i];
-
+        for (i, label) in worker_labels.iter().enumerate().take(num_workers) {
             // Poll count
             let polls = self.metrics.worker_poll_count(i);
             let poll_delta = polls.saturating_sub(state.prev_polls[i]);

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -1,0 +1,274 @@
+use std::time::Duration;
+#[cfg(tokio_unstable)]
+use std::time::Instant;
+
+use common_metrics::gauge;
+use tokio::runtime::RuntimeMetrics;
+use tokio::time::interval;
+
+use crate::metrics::consts::{
+    TOKIO_RUNTIME_ALIVE_TASKS, TOKIO_RUNTIME_GLOBAL_QUEUE_DEPTH, TOKIO_RUNTIME_NUM_WORKERS,
+};
+
+#[cfg(tokio_unstable)]
+use crate::metrics::consts::{
+    TOKIO_BLOCKING_QUEUE_DEPTH, TOKIO_BLOCKING_THREADS, TOKIO_IDLE_BLOCKING_THREADS,
+    TOKIO_RUNTIME_BUSY_RATIO, TOKIO_WORKER_BUSY_DURATION_DELTA, TOKIO_WORKER_LOCAL_QUEUE_DEPTH,
+    TOKIO_WORKER_MEAN_POLL_TIME_US, TOKIO_WORKER_OVERFLOW_DELTA, TOKIO_WORKER_PARK_DELTA,
+    TOKIO_WORKER_POLL_DELTA, TOKIO_WORKER_STEAL_DELTA,
+};
+
+const SAMPLING_INTERVAL: Duration = Duration::from_secs(15);
+
+pub struct TokioRuntimeMonitor {
+    metrics: RuntimeMetrics,
+}
+
+impl TokioRuntimeMonitor {
+    pub fn new(handle: &tokio::runtime::Handle) -> Self {
+        Self {
+            metrics: handle.metrics(),
+        }
+    }
+
+    pub async fn start_monitoring(self) {
+        let num_workers = self.metrics.num_workers();
+
+        tracing::info!(
+            "Starting Tokio runtime monitoring (workers={}, interval={}s)",
+            num_workers,
+            SAMPLING_INTERVAL.as_secs()
+        );
+
+        gauge(TOKIO_RUNTIME_NUM_WORKERS, &[], num_workers as f64);
+
+        #[cfg(tokio_unstable)]
+        {
+            let mut state = PerWorkerState::new(num_workers, &self.metrics);
+            self.run_unstable_loop(&mut state).await;
+        }
+
+        #[cfg(not(tokio_unstable))]
+        {
+            self.run_stable_loop().await;
+        }
+    }
+
+    #[cfg(not(tokio_unstable))]
+    async fn run_stable_loop(&self) {
+        tracing::warn!(
+            "tokio_unstable not enabled — only reporting stable metrics \
+             (alive_tasks, global_queue_depth). Enable with rustflags = [\"--cfg\", \"tokio_unstable\"] \
+             for full worker utilization metrics."
+        );
+
+        let mut ticker = interval(SAMPLING_INTERVAL);
+        loop {
+            ticker.tick().await;
+            self.report_stable_metrics();
+        }
+    }
+
+    #[cfg(tokio_unstable)]
+    async fn run_unstable_loop(&self, state: &mut PerWorkerState) {
+        let mut ticker = interval(SAMPLING_INTERVAL);
+        loop {
+            ticker.tick().await;
+
+            let now = Instant::now();
+            let elapsed = now.duration_since(state.last_sample);
+            state.last_sample = now;
+
+            self.report_stable_metrics();
+            self.report_unstable_metrics(state, elapsed);
+        }
+    }
+
+    fn report_stable_metrics(&self) {
+        gauge(
+            TOKIO_RUNTIME_ALIVE_TASKS,
+            &[],
+            self.metrics.num_alive_tasks() as f64,
+        );
+        gauge(
+            TOKIO_RUNTIME_GLOBAL_QUEUE_DEPTH,
+            &[],
+            self.metrics.global_queue_depth() as f64,
+        );
+    }
+
+    #[cfg(tokio_unstable)]
+    fn report_unstable_metrics(&self, state: &mut PerWorkerState, elapsed: Duration) {
+        let num_workers = self.metrics.num_workers();
+        let elapsed_secs = elapsed.as_secs_f64();
+
+        // Blocking pool
+        gauge(
+            TOKIO_BLOCKING_THREADS,
+            &[],
+            self.metrics.num_blocking_threads() as f64,
+        );
+        gauge(
+            TOKIO_IDLE_BLOCKING_THREADS,
+            &[],
+            self.metrics.num_idle_blocking_threads() as f64,
+        );
+        gauge(
+            TOKIO_BLOCKING_QUEUE_DEPTH,
+            &[],
+            self.metrics.blocking_queue_depth() as f64,
+        );
+
+        // Per-worker metrics + aggregate busy ratio
+        let mut total_busy_delta = Duration::ZERO;
+
+        for i in 0..num_workers {
+            let label = [("worker".to_string(), i.to_string())];
+
+            // Busy duration
+            let busy = self.metrics.worker_total_busy_duration(i);
+            let busy_delta = busy.saturating_sub(state.prev_busy[i]);
+            state.prev_busy[i] = busy;
+            total_busy_delta += busy_delta;
+
+            gauge(
+                TOKIO_WORKER_BUSY_DURATION_DELTA,
+                &label,
+                busy_delta.as_secs_f64(),
+            );
+
+            // Poll count
+            let polls = self.metrics.worker_poll_count(i);
+            let poll_delta = polls.saturating_sub(state.prev_polls[i]);
+            state.prev_polls[i] = polls;
+            gauge(TOKIO_WORKER_POLL_DELTA, &label, poll_delta as f64);
+
+            // Park count
+            let parks = self.metrics.worker_park_count(i);
+            let park_delta = parks.saturating_sub(state.prev_parks[i]);
+            state.prev_parks[i] = parks;
+            gauge(TOKIO_WORKER_PARK_DELTA, &label, park_delta as f64);
+
+            // Steal count
+            let steals = self.metrics.worker_steal_count(i);
+            let steal_delta = steals.saturating_sub(state.prev_steals[i]);
+            state.prev_steals[i] = steals;
+            gauge(TOKIO_WORKER_STEAL_DELTA, &label, steal_delta as f64);
+
+            // Overflow count
+            let overflows = self.metrics.worker_overflow_count(i);
+            let overflow_delta = overflows.saturating_sub(state.prev_overflows[i]);
+            state.prev_overflows[i] = overflows;
+            gauge(TOKIO_WORKER_OVERFLOW_DELTA, &label, overflow_delta as f64);
+
+            // Instantaneous gauges (not deltas)
+            gauge(
+                TOKIO_WORKER_LOCAL_QUEUE_DEPTH,
+                &label,
+                self.metrics.worker_local_queue_depth(i) as f64,
+            );
+            gauge(
+                TOKIO_WORKER_MEAN_POLL_TIME_US,
+                &label,
+                self.metrics.worker_mean_poll_time(i).as_micros() as f64,
+            );
+        }
+
+        // Aggregate busy ratio: total busy time / (elapsed * num_workers)
+        let busy_ratio = if elapsed_secs > 0.0 && num_workers > 0 {
+            total_busy_delta.as_secs_f64() / (elapsed_secs * num_workers as f64)
+        } else {
+            0.0
+        };
+        gauge(TOKIO_RUNTIME_BUSY_RATIO, &[], busy_ratio);
+    }
+}
+
+#[cfg(tokio_unstable)]
+struct PerWorkerState {
+    last_sample: Instant,
+    prev_busy: Vec<Duration>,
+    prev_polls: Vec<u64>,
+    prev_parks: Vec<u64>,
+    prev_steals: Vec<u64>,
+    prev_overflows: Vec<u64>,
+}
+
+#[cfg(tokio_unstable)]
+impl PerWorkerState {
+    fn new(num_workers: usize, metrics: &RuntimeMetrics) -> Self {
+        let mut prev_busy = vec![Duration::ZERO; num_workers];
+        let mut prev_polls = vec![0u64; num_workers];
+        let mut prev_parks = vec![0u64; num_workers];
+        let mut prev_steals = vec![0u64; num_workers];
+        let mut prev_overflows = vec![0u64; num_workers];
+
+        // Snapshot current values so the first delta is accurate
+        for i in 0..num_workers {
+            prev_busy[i] = metrics.worker_total_busy_duration(i);
+            prev_polls[i] = metrics.worker_poll_count(i);
+            prev_parks[i] = metrics.worker_park_count(i);
+            prev_steals[i] = metrics.worker_steal_count(i);
+            prev_overflows[i] = metrics.worker_overflow_count(i);
+        }
+
+        Self {
+            last_sample: Instant::now(),
+            prev_busy,
+            prev_polls,
+            prev_parks,
+            prev_steals,
+            prev_overflows,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn monitor_reports_stable_metrics() {
+        let handle = tokio::runtime::Handle::current();
+        let monitor = TokioRuntimeMonitor::new(&handle);
+
+        // Stable metrics should be callable without panicking
+        monitor.report_stable_metrics();
+    }
+
+    #[cfg(tokio_unstable)]
+    #[tokio::test]
+    async fn monitor_reports_unstable_metrics() {
+        let handle = tokio::runtime::Handle::current();
+        let metrics = handle.metrics();
+        let num_workers = metrics.num_workers();
+        let monitor = TokioRuntimeMonitor::new(&handle);
+
+        let mut state = PerWorkerState::new(num_workers, &metrics);
+
+        // Simulate some work so deltas are non-trivial
+        tokio::task::yield_now().await;
+
+        monitor.report_unstable_metrics(&mut state, Duration::from_secs(15));
+    }
+
+    #[cfg(tokio_unstable)]
+    #[tokio::test]
+    async fn busy_ratio_is_bounded() {
+        let handle = tokio::runtime::Handle::current();
+        let metrics = handle.metrics();
+        let num_workers = metrics.num_workers();
+        let monitor = TokioRuntimeMonitor::new(&handle);
+
+        let mut state = PerWorkerState::new(num_workers, &metrics);
+
+        // Wait briefly so there's a real elapsed duration
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let elapsed = Duration::from_millis(50);
+        monitor.report_unstable_metrics(&mut state, elapsed);
+
+        // The busy_ratio gauge was set — we can't easily read it back from the
+        // metrics crate, but we verified it doesn't panic with real data.
+    }
+}

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -330,8 +330,7 @@ mod tests {
             total_busy_delta += busy_now.saturating_sub(busy_before[i]);
         }
 
-        let ratio =
-            total_busy_delta.as_secs_f64() / (elapsed.as_secs_f64() * num_workers as f64);
+        let ratio = total_busy_delta.as_secs_f64() / (elapsed.as_secs_f64() * num_workers as f64);
         assert!(
             (0.0..=1.0).contains(&ratio),
             "busy ratio should be in [0, 1], got {ratio}"

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -363,8 +363,7 @@ mod tests {
         let elapsed = start.elapsed();
 
         let mut total_busy_delta = Duration::ZERO;
-        for i in 0..num_workers {
-            let busy_now = metrics.worker_total_busy_duration(i);
+        for (i, busy_now) in busy_before.iter().enumerate().take(num_workers) {
             total_busy_delta += busy_now.saturating_sub(busy_before[i]);
         }
 

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -346,9 +346,9 @@ mod tests {
         let elapsed = start.elapsed();
 
         let mut total_busy_delta = Duration::ZERO;
-        for i in 0..num_workers {
+        for (i, &before) in busy_before.iter().enumerate().take(num_workers) {
             let busy_now = metrics.worker_total_busy_duration(i);
-            total_busy_delta += busy_now.saturating_sub(busy_before[i]);
+            total_busy_delta += busy_now.saturating_sub(before);
         }
 
         let ratio = total_busy_delta.as_secs_f64() / (elapsed.as_secs_f64() * num_workers as f64);

--- a/rust/feature-flags/src/tokio_monitor.rs
+++ b/rust/feature-flags/src/tokio_monitor.rs
@@ -43,20 +43,22 @@ impl TokioRuntimeMonitor {
         let mut stable_state = WorkerState::new(num_workers, &self.metrics);
 
         #[cfg(tokio_unstable)]
-        {
-            let mut unstable_state = UnstableWorkerState::new(num_workers, &self.metrics);
-            self.run_unstable_loop(&mut stable_state, &mut unstable_state)
-                .await;
-        }
+        let mut unstable_state = UnstableWorkerState::new(num_workers, &self.metrics);
 
-        #[cfg(not(tokio_unstable))]
-        {
-            self.run_stable_loop(&mut stable_state).await;
-        }
+        self.run_loop(
+            &mut stable_state,
+            #[cfg(tokio_unstable)]
+            &mut unstable_state,
+        )
+        .await;
     }
 
-    #[cfg(not(tokio_unstable))]
-    async fn run_stable_loop(&self, state: &mut WorkerState) {
+    async fn run_loop(
+        &self,
+        stable_state: &mut WorkerState,
+        #[cfg(tokio_unstable)] unstable_state: &mut UnstableWorkerState,
+    ) {
+        #[cfg(not(tokio_unstable))]
         tracing::warn!(
             "tokio_unstable not enabled — blocking pool and some per-worker metrics \
              (poll count, steal count, overflow count, local queue depth, mean poll time) \
@@ -71,31 +73,12 @@ impl TokioRuntimeMonitor {
             ticker.tick().await;
 
             let now = Instant::now();
-            let elapsed = now.duration_since(state.last_sample);
-            state.last_sample = now;
-
-            self.report_stable_metrics(state, elapsed);
-        }
-    }
-
-    #[cfg(tokio_unstable)]
-    async fn run_unstable_loop(
-        &self,
-        stable_state: &mut WorkerState,
-        unstable_state: &mut UnstableWorkerState,
-    ) {
-        let mut ticker = interval(SAMPLING_INTERVAL);
-        // Skip the immediate first tick so the first report comes after a full interval
-        ticker.tick().await;
-
-        loop {
-            ticker.tick().await;
-
-            let now = Instant::now();
             let elapsed = now.duration_since(stable_state.last_sample);
             stable_state.last_sample = now;
 
             self.report_stable_metrics(stable_state, elapsed);
+
+            #[cfg(tokio_unstable)]
             self.report_unstable_metrics(unstable_state, &stable_state.worker_labels);
         }
     }
@@ -363,7 +346,8 @@ mod tests {
         let elapsed = start.elapsed();
 
         let mut total_busy_delta = Duration::ZERO;
-        for (i, busy_now) in busy_before.iter().enumerate().take(num_workers) {
+        for i in 0..num_workers {
+            let busy_now = metrics.worker_total_busy_duration(i);
             total_busy_delta += busy_now.saturating_sub(busy_before[i]);
         }
 


### PR DESCRIPTION
## Problem

We currently have no visibility into how the Tokio runtime behaves under production load in the feature flags service.
When we see elevated p99 latencies or timeouts, we can't distinguish between:
- The runtime being saturated (too few worker threads for the workload)
- The runtime being oversized (wasting memory on idle threads)
- Load imbalance across workers (one thread bottlenecked while others idle)
- Blocking work starving the async thread pool (`spawn_blocking` contention)

Without these signals, thread pool sizing is guesswork. This is going to be pretty helpful for sizing the correct thread pools for the Rayon/Tokio decoupling initiative at #47457.

## Changes

Adds a `TokioRuntimeMonitor` that samples Tokio's `RuntimeMetrics` every 15 seconds
and exports them as Prometheus gauges, all prefixed with `flags_tokio_*`.

### Metrics and what they tell us

**Aggregate runtime health:**
- `flags_tokio_busy_ratio` — fraction of wall-clock time workers spent executing tasks (0.0-1.0).
  Below 0.3 means workers are mostly idle; above 0.8 means approaching saturation.
  This is the single most important metric for right-sizing `worker_threads`.
- `flags_tokio_alive_tasks` — tasks spawned but not yet completed.
  Sustained growth indicates task leaks or backpressure.
- `flags_tokio_global_queue_depth` — tasks waiting in the global injection queue.
  Sustained values > 0 mean workers can't drain tasks fast enough.
- `flags_tokio_num_workers` — configured worker thread count (constant after startup, useful as a dashboard reference).

**Per-worker breakdown** (labeled by `worker="0"`, `worker="1"`, etc.):
- `flags_tokio_worker_poll_delta` — polls per interval per worker.
  Large imbalances across workers indicate uneven task distribution.
- `flags_tokio_worker_busy_duration_delta_secs` — time spent executing tasks per worker per interval.
  Detects hot workers.
- `flags_tokio_worker_park_delta` — times a worker went idle per interval.
  High park rates confirm light workload on that worker.
- `flags_tokio_worker_steal_delta` — tasks stolen from other workers.
  Active stealing means the scheduler is compensating for imbalance.
- `flags_tokio_worker_overflow_delta` — times a worker's local queue overflowed to the global queue.
  Non-zero means a worker couldn't keep up.
- `flags_tokio_worker_local_queue_depth` — instantaneous local queue depth.
- `flags_tokio_worker_mean_poll_time_us` — lifetime mean poll duration.
  Long poll times indicate blocking or CPU-heavy futures on the async runtime.

**Blocking thread pool:**
- `flags_tokio_blocking_threads` / `flags_tokio_idle_blocking_threads` / `flags_tokio_blocking_queue_depth` — tracks `spawn_blocking` pool utilization.
  A non-zero queue depth means blocking work is waiting for a thread.

### - `tokio_unstable` flag

The per-worker and blocking pool metrics require Tokio's unstable `RuntimeMetrics` API,
enabled via the `tokio_unstable` cfg flag.
This flag is set in `rust/.cargo/config.toml` and applies workspace-wide — Cargo does not support
per-crate config files within a workspace
([docs](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure)).

All monitoring code that calls unstable APIs is gated behind `#[cfg(tokio_unstable)]` in `tokio_monitor.rs`.
Without the flag, the monitor gracefully degrades to reporting only `alive_tasks` and `global_queue_depth`.

### Impact on other services in the workspace

`tokio_unstable` is a compile-time flag. It cannot be scoped to a single crate in a Cargo workspace.
Every Rust service that shares this workspace (capture, cymbal, cyclotron, hook-worker, personhog, etc.) is affected.

**Stability**: The flag does **not** change Tokio's stable API or runtime behavior.
`tokio::spawn`, `TcpListener`, `select!`, channels, all of these work identically with or without the flag.
The only thing it does is make additional unstable methods available (e.g. `RuntimeMetrics::worker_poll_count`).

**Performance**: The flag enables atomic counter increments inside Tokio on every task poll, park, and steal.
This adds low single-digit nanoseconds per task poll.
For a service polling millions of tasks per second, this is still under 1% overhead.
No service will see a measurable latency or throughput difference.

**Future breakage**: Unstable Tokio APIs can and do break between minor 1.x releases
(e.g. `JoinSet::join_one` return type changed, `task::Builder::spawn` made fallible).
If Tokio removes or renames an unstable method in a future release,
**only code that calls that method fails to compile**.
Today, the only call sites are in `feature-flags/src/tokio_monitor.rs`.
Services like `capture` or `cymbal` don't call any unstable APIs, so they won't break.
In an emergency, the flag can be removed from `config.toml` and the monitor
gracefully degrades to stable-only metrics.