### PR TITLE
fix(posthog-js): remove `__preview_remote_config` from our snippet

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -137,8 +137,6 @@ export function loadPostHogJS(): void {
                 blockSelector: '.ph-replay-block',
             },
             person_profiles: 'always',
-            __preview_remote_config: true,
-            __preview_flags_v2: true,
             __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
             __preview_disable_xhr_credentials: true,
             external_scripts_inject_target: 'head',


### PR DESCRIPTION
## Problem

I removed `__preview_remote_config` from the posthog-js config [here](https://github.com/PostHog/posthog-js/pull/2895/changes), but I didn't remove that field from the way that we load posthog-js in our app snippet, which mean that auto-bumping the snippet for the posthog app failed (context: https://posthog.slack.com/archives/C02E3BKC78F/p1771607686878919)

## Changes

- remove `__preview_remote_config` since it's unused
- I'm also removing `__preview_flags_v2` since everything uses `/flags` now and that config field is functionally useless
omment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->