### PR TITLE
fix: apply searchTerm filter in logs query runner

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -284,6 +284,14 @@ class LogsQueryRunnerMixin(QueryRunner):
 
         exprs.append(ast.Placeholder(expr=ast.Field(chain=["filters"])))
 
+        if self.query.searchTerm:
+            exprs.append(
+                parse_expr(
+                    "body ILIKE {searchTerm}",
+                    placeholders={"searchTerm": ast.Constant(value=f"%{self.query.searchTerm}%")},
+                )
+            )
+
         if self.query.severityLevels:
             exprs.append(
                 parse_expr(

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -285,12 +285,14 @@ class LogsQueryRunnerMixin(QueryRunner):
         exprs.append(ast.Placeholder(expr=ast.Field(chain=["filters"])))
 
         if self.query.searchTerm:
-            exprs.append(
-                parse_expr(
-                    "body ILIKE {searchTerm}",
-                    placeholders={"searchTerm": ast.Constant(value=f"%{self.query.searchTerm}%")},
-                )
+            search_filter = LogPropertyFilter(
+                key="body",
+                operator=PropertyOperator.ICONTAINS,
+                type=LogPropertyFilterType.LOG,
+                value=self.query.searchTerm,
             )
+            exprs.append(get_lowercase_index_hint(search_filter, team=self.team))
+            exprs.append(property_to_expr(search_filter, team=self.team))
 
         if self.query.severityLevels:
             exprs.append(

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -370,6 +370,7 @@ class TestAttributeFilters(APIBaseTest):
 
         self.assertIn("body", query_str)
         self.assertIn("timeout error", query_str)
+        self.assertIn("indexHint", query_str)
 
     def test_no_search_term_filter(self):
         """Test that omitting searchTerm does not add a body filter"""

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -338,6 +338,70 @@ class TestAttributeFilters(APIBaseTest):
         self.assertIn("resource_fingerprint", query_str)
         self.assertIn("12345678", query_str)
 
+    def test_search_term_filter(self):
+        """Test that searchTerm adds a body ILIKE filter"""
+        query = LogsQuery(
+            dateRange=DateRange(date_from="2024-01-10T00:00:00Z", date_to="2024-01-15T23:59:59Z"),
+            serviceNames=[],
+            severityLevels=[],
+            searchTerm="timeout error",
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+            ),
+            kind="LogsQuery",
+        )
+
+        runner = LogsQueryRunner(query=query, team=self.team)
+        executor = HogQLQueryExecutor(
+            query_type="LogsQuery",
+            query=runner.to_query(),
+            modifiers=runner.modifiers,
+            team=runner.team,
+            workload=Workload.LOGS,
+            timings=runner.timings,
+            limit_context=runner.limit_context,
+            filters=HogQLFilters(dateRange=runner.query.dateRange),
+            settings=runner.settings,
+        )
+        executor.generate_clickhouse_sql()
+        assert executor.clickhouse_prepared_ast is not None
+        query_str = executor.clickhouse_prepared_ast.to_hogql()
+
+        self.assertIn("body", query_str)
+        self.assertIn("timeout error", query_str)
+
+    def test_no_search_term_filter(self):
+        """Test that omitting searchTerm does not add a body filter"""
+        query = LogsQuery(
+            dateRange=DateRange(date_from="2024-01-10T00:00:00Z", date_to="2024-01-15T23:59:59Z"),
+            serviceNames=[],
+            severityLevels=[],
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+            ),
+            kind="LogsQuery",
+        )
+
+        runner = LogsQueryRunner(query=query, team=self.team)
+        executor = HogQLQueryExecutor(
+            query_type="LogsQuery",
+            query=runner.to_query(),
+            modifiers=runner.modifiers,
+            team=runner.team,
+            workload=Workload.LOGS,
+            timings=runner.timings,
+            limit_context=runner.limit_context,
+            filters=HogQLFilters(dateRange=runner.query.dateRange),
+            settings=runner.settings,
+        )
+        executor.generate_clickhouse_sql()
+        assert executor.clickhouse_prepared_ast is not None
+        query_str = executor.clickhouse_prepared_ast.to_hogql()
+
+        self.assertNotIn("ilike(body", query_str.lower())
+
 
 class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
     CLASS_DATA_LEVEL_SETUP = True


### PR DESCRIPTION
## Problem

The `searchTerm` parameter in `LogsQuery` was accepted by the schema and passed through the API, but **never actually used** when building the SQL WHERE clause in `LogsQueryRunnerMixin.where()`. This meant any free-text search on logs (including via the MCP `logs-query` tool) was silently ignored and returned unfiltered results.

## Changes

- Added `body ILIKE '%<searchTerm>%'` filter to the `where()` method in `LogsQueryRunnerMixin` when `searchTerm` is set
- Added unit tests verifying the filter is applied when `searchTerm` is present and omitted when it's not

## How did you test this code?

- Added `test_search_term_filter` — verifies that when `searchTerm` is set, the generated SQL contains a `body` ILIKE filter with the search term
- Added `test_no_search_term_filter` — verifies that when `searchTerm` is omitted, no body ILIKE filter is added
- Ran the full `TestAttributeFilters` suite (8/8 passing)
- Confirmed the bug by using the MCP `logs-query` tool with a `searchTerm` parameter and observing it had no effect on results

🤖 Generated with [Claude Code](https://claude.com/claude-code)