### PR TITLE
chore(flags): remove rollout_percentage from hogai

### DIFF
--- a/ee/hogai/context/feature_flag/context.py
+++ b/ee/hogai/context/feature_flag/context.py
@@ -6,7 +6,6 @@ from .prompts import (
     FEATURE_FLAG_CONTEXT_TEMPLATE,
     FEATURE_FLAG_NOT_FOUND_TEMPLATE,
     FEATURE_FLAG_RELEASE_CONDITIONS_TEMPLATE,
-    FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE,
     FEATURE_FLAG_VARIANTS_TEMPLATE,
 )
 
@@ -47,12 +46,6 @@ class FeatureFlagContext:
     @database_sync_to_async
     def format_feature_flag(self, flag: FeatureFlag) -> str:
         """Format feature flag data for AI consumption."""
-        rollout_percentage_section = ""
-        if flag.rollout_percentage is not None:
-            rollout_percentage_section = FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE.format(
-                rollout_percentage=flag.rollout_percentage
-            )
-
         variants_section = ""
         release_conditions_section = ""
 
@@ -89,7 +82,6 @@ class FeatureFlagContext:
             flag_name=flag.name or "No description",
             flag_active=flag.active,
             flag_created_at=flag.created_at.isoformat() if flag.created_at else "Unknown",
-            rollout_percentage_section=rollout_percentage_section,
             variants_section=variants_section,
             release_conditions_section=release_conditions_section,
         ).strip()

--- a/ee/hogai/context/feature_flag/prompts.py
+++ b/ee/hogai/context/feature_flag/prompts.py
@@ -5,13 +5,8 @@ FEATURE_FLAG_CONTEXT_TEMPLATE = """
 **Name/Description:** {flag_name}
 **Active:** {flag_active}
 **Created:** {flag_created_at}
-{rollout_percentage_section}
 {variants_section}
 {release_conditions_section}
-""".strip()
-
-FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE = """
-**Rollout Percentage:** {rollout_percentage}%
 """.strip()
 
 FEATURE_FLAG_VARIANTS_TEMPLATE = """


### PR DESCRIPTION
This removes the the redundant `rollout_percentage` section from HogAI feature flag context. It reads from the model column which is NULL for all modern flags. The per-group rollout percentage is already shown in the release conditions section.
  
PR 3 of issue https://github.com/PostHog/posthog/issues/47640