### PR TITLE
fix: return empty 204 from Vercel proxy instead of body with {}

### DIFF
--- a/ee/api/vercel/test/test_vercel_region_proxy_mixin.py
+++ b/ee/api/vercel/test/test_vercel_region_proxy_mixin.py
@@ -419,6 +419,16 @@ class TestVercelRegionProxyMixin(VercelTestBase):
                             self._assert_drf_response(result, expected_super_response)
                             mock_super_dispatch.assert_called_once()
 
+    def test_dispatch_proxy_204_returns_empty_response(self):
+        request = self._create_authenticated_request(self.INVALID_INSTALLATION)
+
+        with self._setup_region_test(self.US_DOMAIN):
+            with self._patch_proxy_to_eu(Response(status=204)) as mock_proxy:
+                result = self.test_viewset.dispatch(request, *[], **{})
+                mock_proxy.assert_called_once()
+                assert result.status_code == 204
+                assert result.content == b""
+
     def test_upsert_new_installation_in_us_region_should_not_404(self):
         factory = RequestFactory()
         request_body = json.dumps(

--- a/ee/api/vercel/test/test_vercel_region_proxy_mixin.py
+++ b/ee/api/vercel/test/test_vercel_region_proxy_mixin.py
@@ -285,6 +285,20 @@ class TestVercelRegionProxyMixin(VercelTestBase):
             assert call_kwargs["headers"]["Host"] == "eu.posthog.com"
 
     @patch("ee.api.vercel.vercel_region_proxy_mixin.requests.request")
+    def test_proxy_204_returns_no_body(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        mock_response.headers = {}
+        mock_request.return_value = mock_response
+        mock_django_request = self._create_mock_request()
+
+        with self._setup_region_test(self.US_DOMAIN):
+            result = self.test_viewset._proxy_to_eu(mock_django_request)
+            assert result.status_code == 204
+            assert result.data is None
+
+    @patch("ee.api.vercel.vercel_region_proxy_mixin.requests.request")
     def test_raises_exception_on_proxy_request_failure(self, mock_request):
         mock_request.side_effect = requests.exceptions.RequestException("Connection failed")
         mock_django_request = self._create_mock_request(headers={})

--- a/ee/api/vercel/vercel_region_proxy_mixin.py
+++ b/ee/api/vercel/vercel_region_proxy_mixin.py
@@ -134,6 +134,9 @@ class VercelRegionProxyMixin:
                 integration="vercel",
             )
 
+            if response.status_code == 204:
+                return Response(status=204)
+
             content_type = response.headers.get("content-type", "")
             if not content_type.startswith(("application/json", "text/")):
                 logger.warning("Unexpected content type from proxy", content_type=content_type)
@@ -193,6 +196,8 @@ class VercelRegionProxyMixin:
             )
             try:
                 drf_response = self._proxy_to_eu(request)
+                if drf_response.status_code == 204:
+                    return HttpResponse(status=204)
                 content = json.dumps(drf_response.data) if drf_response.data else "{}"
                 return HttpResponse(content=content, status=drf_response.status_code, content_type="application/json")
             except exceptions.APIException as e:


### PR DESCRIPTION
## Problem

EU Vercel installations were failing with "An error occurred while creating the Account" despite our API returning 204 success responses.

The proxy in `VercelRegionProxyMixin` was wrapping 204 No Content responses from the EU region with `Response(data={}, status=204)`. Since `{}` is truthy in Python, `dispatch` then serialized it into `HttpResponse(content="{}", status=204, content_type="application/json")` — violating the HTTP spec (204 must have no body) and causing Vercel to reject the response.

US direct responses were unaffected because the viewset returns `Response(status=204)` with no data, which DRF renders correctly.

## Changes

- Short-circuit on 204 in `_proxy_to_eu` to return `Response(status=204)` with no data
- Short-circuit on 204 in `dispatch` to return `HttpResponse(status=204)` with no body
- Added test verifying 204 proxy responses have no body

## How did you test this code?

- New unit test `test_proxy_204_returns_no_body` verifying the fix
- Full Vercel test suite passes (163/163, 2 pre-existing failures in `test_vercel_permission.py` unrelated to this change — confirmed failing on master)
- Manual verification: Will test Vercel EU installation after deploy

## Changelog

No