### PR TITLE
fix(docker): build Unit 1.35.0 ourselves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,11 +188,50 @@ RUN apt-get update && \
 #
 # ---------------------------------------------------------
 #
-# NOTE: v1.32 is running bullseye, v1.33 is running bookworm
-FROM unit:1.33.0-python3.12
+# NOTE: v1.32 is running bullseye, v1.33+ is running bookworm
+FROM unit:1.34.2-python3.12
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1
+ARG UNIT_GIT_TAG=1.35.0
+ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
+
+# Build Unit from the upstream 1.35.0 release ref to ensure the Django 5 ASGI fix is present even when Docker tags lag.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "build-essential" \
+    "git" \
+    "libpcre2-dev" \
+    "zlib1g-dev" \
+    && \
+    git clone --depth 1 --branch "$UNIT_GIT_TAG" https://github.com/nginx/unit.git /tmp/unit && \
+    cd /tmp/unit && \
+    test "$(git rev-parse HEAD)" = "$UNIT_GIT_REF" && \
+    NCPU="$(getconf _NPROCESSORS_ONLN)" && \
+    DEB_HOST_MULTIARCH="$(gcc -print-multiarch)" && \
+    CONFIGURE_ARGS="--prefix=/usr \
+        --statedir=/var/lib/unit \
+        --control=unix:/var/run/control.unit.sock \
+        --runstatedir=/var/run \
+        --pid=/var/run/unit.pid \
+        --logdir=/var/log \
+        --log=/var/log/unit.log \
+        --tmpdir=/var/tmp \
+        --user=unit \
+        --group=unit \
+        --openssl \
+        --libdir=/usr/lib/$DEB_HOST_MULTIARCH \
+        --modulesdir=/usr/lib/unit/modules" && \
+    ./configure $CONFIGURE_ARGS && \
+    make -j "$NCPU" unitd && \
+    install -pm755 build/sbin/unitd /usr/sbin/unitd && \
+    make clean && \
+    ./configure $CONFIGURE_ARGS && \
+    ./configure python --config=/usr/local/bin/python3-config && \
+    make -j "$NCPU" python3-install && \
+    rm -rf /tmp/unit && \
+    apt-get purge -y --auto-remove "build-essential" "git" "libpcre2-dev" "zlib1g-dev" && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install OS runtime dependencies.
 # Note: please add in this stage runtime dependences only!

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,8 +245,8 @@ RUN apt-get update && \
     "libxmlsec1-dev=1.2.37-2" \
     "libxml2" \
     "ffmpeg=7:5.1.8-0+deb12u1" \
-    "libssl-dev=3.0.18-1~deb12u2" \
-    "libssl3=3.0.18-1~deb12u2" \
+    "libssl-dev=3.0.19-1~deb12u2" \
+    "libssl3=3.0.19-1~deb12u2" \
     "libjemalloc2" \
     && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Motivation

- Ensure production images include the Django 5 ASGI compatibility fix from Unit, even if Docker Hub tags lag upstream releases.
- Reduce CI/network overhead by avoiding a full-history clone of the Unit repository.
- Improve maintainability by removing duplicated ./configure flag blocks.

Description

- Keep the runtime base image on unit:1.34.2-python3.12.
- Build Unit from upstream source using:
- Use a shallow clone (--depth 1 --branch "$UNIT_GIT_TAG") to fetch only the required release ref.
- Verify reproducibility by asserting the checked-out HEAD matches UNIT_GIT_REF.
- Deduplicate configure options by defining a shared CONFIGURE_ARGS string and reusing it for both configure invocations (unitd and Python module).



------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988b59e0ec832e93efadef33bdc0fc)