### PR TITLE
fix(toolbar): scroll depth canvas tooltip text color for accessibility

### DIFF
--- a/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/ScrollDepthCanvas.tsx
@@ -62,7 +62,7 @@ export function ScrollDepthMouseCanvas({
             <div className="border-b border-default w-full opacity-75" />
             <div
                 className={clsx(
-                    'bg-default whitespace-nowrap text-white rounded p-2 font-semibold opacity-75 hover:opacity-100 transition-all',
+                    'bg-default whitespace-nowrap text-primary-inverse rounded p-2 font-semibold opacity-75 hover:opacity-100 transition-all',
                     !shiftPressed ? 'pointer-events-auto' : 'pointer-events-none'
                 )}
             >


### PR DESCRIPTION
## Problem

The scroll depth canvas tooltip was using hardcoded white text (`text-white`) which may not have sufficient contrast against the default background color in all theme contexts, affecting readability and accessibility.

## Changes

Updated the tooltip text color in `ScrollDepthMouseCanvas` from `text-white` to `text-primary-inverse`, which is the semantic color token that ensures proper contrast and respects the current theme settings.

- Changed `text-white` to `text-primary-inverse` in the tooltip className

## How did you test this code?

Verified that the tooltip renders correctly with the new color token and maintains proper contrast in both light and dark theme modes.

## Publish to changelog?

No

https://claude.ai/code/session_01H7jxnZDr775pCtoxUhD9QN