### PR TITLE
feat(capture): update rate limiter histogram metrics and bucket scheme

### DIFF
--- a/rust/common/limiters/src/global_rate_limiter.rs
+++ b/rust/common/limiters/src/global_rate_limiter.rs
@@ -16,8 +16,8 @@ const GLOBAL_RATE_LIMITER_EVAL_COUNTER: &str = "global_rate_limiter_eval_counts_
 const GLOBAL_RATE_LIMITER_CACHE_COUNTER: &str = "global_rate_limiter_cache_counts_total";
 const GLOBAL_RATE_LIMITER_RECORDS_COUNTER: &str = "global_rate_limiter_records_total";
 const GLOBAL_RATE_LIMITER_ERROR_COUNTER: &str = "global_rate_limiter_error_total";
-const GLOBAL_RATE_LIMITER_BATCH_WRITE_HISTOGRAM: &str = "global_rate_limiter_batch_write_seconds";
-const GLOBAL_RATE_LIMITER_BATCH_READ_HISTOGRAM: &str = "global_rate_limiter_batch_read_seconds";
+const GLOBAL_RATE_LIMITER_BATCH_WRITE_HISTOGRAM: &str = "global_rate_limiter_batch_write_ms";
+const GLOBAL_RATE_LIMITER_BATCH_READ_HISTOGRAM: &str = "global_rate_limiter_batch_read_ms";
 
 /// Trait for global rate limiting
 #[async_trait]
@@ -506,7 +506,7 @@ impl GlobalRateLimiterImpl {
                     GLOBAL_RATE_LIMITER_BATCH_READ_HISTOGRAM,
                     "redis_idx" => redis_idx_str.clone(),
                 )
-                .record(read_start.elapsed().as_millis() as f64);
+                .record(read_start.elapsed().as_micros() as f64 / 1000.0);
                 counts
             }
             Ok(Err(e)) => {
@@ -659,7 +659,7 @@ impl GlobalRateLimiterImpl {
                                 GLOBAL_RATE_LIMITER_BATCH_WRITE_HISTOGRAM,
                                 "redis_idx" => redis_idx_str.clone(),
                             )
-                            .record(write_batch_start.elapsed().as_millis() as f64);
+                            .record(write_batch_start.elapsed().as_micros() as f64 / 1000.0);
                         }
                         Ok(Err(e)) => {
                             metrics::counter!(


### PR DESCRIPTION
## Problem
Didn't set up buckets in `capture` for the global rate limiter histogram metrics
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix limiter metric naming and output granularity
* Add bucket scheme for the same to `capture` metrics collection cfg
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; mirror smoke test and dashboard updates once landed
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
