### PR TITLE
feat(flags): feature flags uses personhog for person data access

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3182,6 +3182,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
+ "async-trait",
  "axum 0.7.9",
  "axum-client-ip",
  "base64 0.22.1",
@@ -3217,6 +3218,7 @@ dependencies = [
  "opentelemetry_sdk 0.22.1",
  "pbkdf2",
  "percent-encoding",
+ "personhog-proto",
  "petgraph 0.6.5",
  "rand 0.8.5",
  "rayon",
@@ -3236,6 +3238,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
+ "tonic 0.12.3",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 axum-client-ip = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
@@ -63,6 +64,8 @@ tracing-opentelemetry = { workspace = true }
 tokio-retry = "0.3"
 serde-pickle = { version = "1.1.1" }
 semver = "1.0.27"
+personhog-proto = { path = "../personhog-proto" }
+tonic = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -520,10 +520,19 @@ impl IntoResponse for FlagError {
             }
             FlagError::PersonhogError { ref code, ref message } => {
                 tracing::error!("Personhog service error ({}): {}", code, message);
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Person data service is currently unavailable. Please try again later.".to_string(),
-                )
+                match code {
+                    tonic::Code::Unavailable
+                    | tonic::Code::DeadlineExceeded
+                    | tonic::Code::ResourceExhausted
+                    | tonic::Code::Aborted => (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Person data service is currently unavailable. Please try again later.".to_string(),
+                    ),
+                    _ => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "An internal error occurred while fetching person data. Please try again later.".to_string(),
+                    ),
+                }
             }
             FlagError::CookielessError(err) => {
                 match err {

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -180,8 +180,14 @@ impl FlagError {
             // Data parsing errors (500) - internal errors, not service unavailability
             FlagError::DataParsingErrorWithContext(_) => ("flag_data_parsing_error", 500),
 
-            // Personhog gRPC errors (503) - transient, service may recover
-            FlagError::PersonhogError { .. } => ("personhog_error", 503),
+            // Personhog gRPC errors - transient codes get 503, bug/data codes get 500
+            FlagError::PersonhogError { code, .. } => match code {
+                tonic::Code::Unavailable
+                | tonic::Code::DeadlineExceeded
+                | tonic::Code::ResourceExhausted
+                | tonic::Code::Aborted => ("personhog_error", 503),
+                _ => ("personhog_error", 500),
+            },
 
             // Service unavailable errors (503) - transient issues, retry may help
             FlagError::RedisUnavailable => ("redis_unavailable", 503),
@@ -318,8 +324,15 @@ impl FlagError {
             | FlagError::CacheMiss
             | FlagError::PersonNotFound
             | FlagError::PropertiesNotInCache
-            | FlagError::StaticCohortMatchesNotCached
-            | FlagError::PersonhogError { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::StaticCohortMatchesNotCached => StatusCode::SERVICE_UNAVAILABLE,
+
+            FlagError::PersonhogError { ref code, .. } => match code {
+                tonic::Code::Unavailable
+                | tonic::Code::DeadlineExceeded
+                | tonic::Code::ResourceExhausted
+                | tonic::Code::Aborted => StatusCode::SERVICE_UNAVAILABLE,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -800,6 +813,40 @@ mod tests {
         assert_eq!(FlagError::PersonNotFound.status_code(), 503);
         assert_eq!(FlagError::PropertiesNotInCache.status_code(), 503);
         assert_eq!(FlagError::StaticCohortMatchesNotCached.status_code(), 503);
+
+        // Personhog errors: transient gRPC codes -> 503, bug/data codes -> 500
+        assert_eq!(
+            FlagError::PersonhogError {
+                code: tonic::Code::Unavailable,
+                message: "test".into()
+            }
+            .status_code(),
+            503
+        );
+        assert_eq!(
+            FlagError::PersonhogError {
+                code: tonic::Code::DeadlineExceeded,
+                message: "test".into()
+            }
+            .status_code(),
+            503
+        );
+        assert_eq!(
+            FlagError::PersonhogError {
+                code: tonic::Code::Internal,
+                message: "test".into()
+            }
+            .status_code(),
+            500
+        );
+        assert_eq!(
+            FlagError::PersonhogError {
+                code: tonic::Code::InvalidArgument,
+                message: "test".into()
+            }
+            .status_code(),
+            500
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -125,8 +125,11 @@ pub enum FlagError {
     DataParsingError,
     #[error("Parallel batch evaluation task panicked")]
     BatchEvaluationPanicked,
-    #[error("Personhog service error: {0}")]
-    PersonhogError(String),
+    #[error("Personhog service error ({code}): {message}")]
+    PersonhogError {
+        code: tonic::Code,
+        message: String,
+    },
     #[error(transparent)]
     CookielessError(#[from] CookielessManagerError),
 }
@@ -181,7 +184,7 @@ impl FlagError {
             FlagError::DataParsingErrorWithContext(_) => ("flag_data_parsing_error", 500),
 
             // Personhog gRPC errors (503) - transient, service may recover
-            FlagError::PersonhogError(_) => ("personhog_error", 503),
+            FlagError::PersonhogError { .. } => ("personhog_error", 503),
 
             // Service unavailable errors (503) - transient issues, retry may help
             FlagError::RedisUnavailable => ("redis_unavailable", 503),
@@ -319,7 +322,7 @@ impl FlagError {
             | FlagError::PersonNotFound
             | FlagError::PropertiesNotInCache
             | FlagError::StaticCohortMatchesNotCached
-            | FlagError::PersonhogError(_) => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::PersonhogError { .. } => StatusCode::SERVICE_UNAVAILABLE,
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -505,8 +508,8 @@ impl IntoResponse for FlagError {
                 tracing::error!("Parallel batch evaluation task panicked");
                 (StatusCode::INTERNAL_SERVER_ERROR, "An internal error occurred during flag evaluation. Please try again later.".to_string())
             }
-            FlagError::PersonhogError(ref msg) => {
-                tracing::error!("Personhog service error: {}", msg);
+            FlagError::PersonhogError { ref code, ref message } => {
+                tracing::error!("Personhog service error ({}): {}", code, message);
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "Person data service is currently unavailable. Please try again later.".to_string(),
@@ -743,7 +746,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
-            FlagError::PersonhogError("test".to_string()),
+            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
             CookielessManagerError::MissingProperty("test".to_string()).into(), // CookielessError
         ];
 
@@ -853,7 +856,7 @@ mod tests {
             FlagError::PersonNotFound,
             FlagError::PropertiesNotInCache,
             FlagError::StaticCohortMatchesNotCached,
-            FlagError::PersonhogError("test".to_string()),
+            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
             FlagError::ClientFacing(ClientFacingError::ServiceUnavailable),
         ];
 
@@ -942,7 +945,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
-            FlagError::PersonhogError("test".to_string()),
+            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
             CookielessManagerError::MissingProperty("test".to_string()).into(),
         ];
 

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -125,6 +125,8 @@ pub enum FlagError {
     DataParsingError,
     #[error("Parallel batch evaluation task panicked")]
     BatchEvaluationPanicked,
+    #[error("Personhog service error: {0}")]
+    PersonhogError(String),
     #[error(transparent)]
     CookielessError(#[from] CookielessManagerError),
 }
@@ -177,6 +179,9 @@ impl FlagError {
 
             // Data parsing errors (500) - internal errors, not service unavailability
             FlagError::DataParsingErrorWithContext(_) => ("flag_data_parsing_error", 500),
+
+            // Personhog gRPC errors (503) - transient, service may recover
+            FlagError::PersonhogError(_) => ("personhog_error", 503),
 
             // Service unavailable errors (503) - transient issues, retry may help
             FlagError::RedisUnavailable => ("redis_unavailable", 503),
@@ -313,7 +318,8 @@ impl FlagError {
             | FlagError::CacheMiss
             | FlagError::PersonNotFound
             | FlagError::PropertiesNotInCache
-            | FlagError::StaticCohortMatchesNotCached => StatusCode::SERVICE_UNAVAILABLE,
+            | FlagError::StaticCohortMatchesNotCached
+            | FlagError::PersonhogError(_) => StatusCode::SERVICE_UNAVAILABLE,
 
             FlagError::CookielessError(
                 CookielessManagerError::HashError(_)
@@ -498,6 +504,13 @@ impl IntoResponse for FlagError {
             FlagError::BatchEvaluationPanicked => {
                 tracing::error!("Parallel batch evaluation task panicked");
                 (StatusCode::INTERNAL_SERVER_ERROR, "An internal error occurred during flag evaluation. Please try again later.".to_string())
+            }
+            FlagError::PersonhogError(ref msg) => {
+                tracing::error!("Personhog service error: {}", msg);
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Person data service is currently unavailable. Please try again later.".to_string(),
+                )
             }
             FlagError::CookielessError(err) => {
                 match err {
@@ -730,6 +743,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::PersonhogError("test".to_string()),
             CookielessManagerError::MissingProperty("test".to_string()).into(), // CookielessError
         ];
 
@@ -839,6 +853,7 @@ mod tests {
             FlagError::PersonNotFound,
             FlagError::PropertiesNotInCache,
             FlagError::StaticCohortMatchesNotCached,
+            FlagError::PersonhogError("test".to_string()),
             FlagError::ClientFacing(ClientFacingError::ServiceUnavailable),
         ];
 
@@ -927,6 +942,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::PersonhogError("test".to_string()),
             CookielessManagerError::MissingProperty("test".to_string()).into(),
         ];
 

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -126,10 +126,7 @@ pub enum FlagError {
     #[error("Parallel batch evaluation task panicked")]
     BatchEvaluationPanicked,
     #[error("Personhog service error ({code}): {message}")]
-    PersonhogError {
-        code: tonic::Code,
-        message: String,
-    },
+    PersonhogError { code: tonic::Code, message: String },
     #[error(transparent)]
     CookielessError(#[from] CookielessManagerError),
 }
@@ -746,7 +743,10 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
-            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
+            FlagError::PersonhogError {
+                code: tonic::Code::Unavailable,
+                message: "test".to_string(),
+            },
             CookielessManagerError::MissingProperty("test".to_string()).into(), // CookielessError
         ];
 
@@ -856,7 +856,10 @@ mod tests {
             FlagError::PersonNotFound,
             FlagError::PropertiesNotInCache,
             FlagError::StaticCohortMatchesNotCached,
-            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
+            FlagError::PersonhogError {
+                code: tonic::Code::Unavailable,
+                message: "test".to_string(),
+            },
             FlagError::ClientFacing(ClientFacingError::ServiceUnavailable),
         ];
 
@@ -945,7 +948,10 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
-            FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "test".to_string() },
+            FlagError::PersonhogError {
+                code: tonic::Code::Unavailable,
+                message: "test".to_string(),
+            },
             CookielessManagerError::MissingProperty("test".to_string()).into(),
         ];
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -486,11 +486,20 @@ pub struct Config {
     #[envconfig(from = "SKIP_WRITES", default = "false")]
     pub skip_writes: FlexBool,
 
-    // Explicit core count for thread pool sizing. Overrides available_parallelism()
-    // which reads the CFS quota (K8s CPU limit), not the CPU request.
-    // 0 = auto (use available_parallelism).
     #[envconfig(from = "THREAD_POOL_CORES", default = "0")]
     pub thread_pool_cores: usize,
+    // Personhog gRPC client configuration
+    // When enabled, person-related data (properties, cohorts, groups, hash key overrides)
+    // is fetched via the personhog-router gRPC service instead of direct SQL queries
+    #[envconfig(from = "USE_PERSONHOG", default = "false")]
+    pub use_personhog: FlexBool,
+
+    #[envconfig(from = "PERSONHOG_URL", default = "http://localhost:50052")]
+    pub personhog_url: String,
+
+    // Timeout for personhog gRPC requests in milliseconds
+    #[envconfig(from = "PERSONHOG_TIMEOUT_MS", default = "3000")]
+    pub personhog_timeout_ms: u64,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -682,6 +691,9 @@ impl Config {
             max_concurrent_batch_evals: 0,
             skip_writes: FlexBool(false),
             thread_pool_cores: 0,
+            use_personhog: FlexBool(false),
+            personhog_url: "http://localhost:50052".to_string(),
+            personhog_timeout_ms: 3000,
         }
     }
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -500,6 +500,18 @@ pub struct Config {
     // Timeout for personhog gRPC requests in milliseconds
     #[envconfig(from = "PERSONHOG_TIMEOUT_MS", default = "3000")]
     pub personhog_timeout_ms: u64,
+
+    // Timeout for establishing a connection to personhog in milliseconds
+    #[envconfig(from = "PERSONHOG_CONNECT_TIMEOUT_MS", default = "5000")]
+    pub personhog_connect_timeout_ms: u64,
+
+    // Interval between HTTP/2 keep-alive pings in seconds
+    #[envconfig(from = "PERSONHOG_KEEP_ALIVE_INTERVAL_SECS", default = "10")]
+    pub personhog_keep_alive_interval_secs: u64,
+
+    // Timeout waiting for a keep-alive ping response in seconds
+    #[envconfig(from = "PERSONHOG_KEEP_ALIVE_TIMEOUT_SECS", default = "20")]
+    pub personhog_keep_alive_timeout_secs: u64,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -694,6 +706,9 @@ impl Config {
             use_personhog: FlexBool(false),
             personhog_url: "http://localhost:50052".to_string(),
             personhog_timeout_ms: 3000,
+            personhog_connect_timeout_ms: 5000,
+            personhog_keep_alive_interval_secs: 10,
+            personhog_keep_alive_timeout_secs: 20,
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -255,7 +255,6 @@ impl FlagSnapshot {
 }
 
 impl FeatureFlagMatcher {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         distinct_id: String,
         device_id: Option<String>,
@@ -264,7 +263,6 @@ impl FeatureFlagMatcher {
         cohort_cache: Arc<CohortCacheManager>,
         group_type_mapping_cache: Option<GroupTypeMappingCache>,
         groups: Option<HashMap<String, Value>>,
-        personhog_client: Option<Arc<dyn PersonhogFetcher>>,
     ) -> Self {
         FeatureFlagMatcher {
             distinct_id,
@@ -279,7 +277,7 @@ impl FeatureFlagMatcher {
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
             skip_writes: false,
-            personhog_client,
+            personhog_client: None,
         }
     }
 
@@ -295,6 +293,11 @@ impl FeatureFlagMatcher {
 
     pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
         self.skip_writes = skip_writes;
+        self
+    }
+
+    pub fn with_personhog_client(mut self, client: Arc<dyn PersonhogFetcher>) -> Self {
+        self.personhog_client = Some(client);
         self
     }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1977,7 +1977,14 @@ impl FeatureFlagMatcher {
         flags_have_experience_continuity_enabled: bool,
         hash_key_override: Option<String>,
     ) -> (Option<HashMap<String, String>>, bool) {
-        let hash_key_timer = common_metrics::timing_guard(FLAG_HASH_KEY_PROCESSING_TIME, &[]);
+        let source = if self.personhog_client.is_some() {
+            "personhog"
+        } else {
+            "sql"
+        };
+        let hash_key_labels = [("source".to_string(), source.to_string())];
+        let hash_key_timer =
+            common_metrics::timing_guard(FLAG_HASH_KEY_PROCESSING_TIME, &hash_key_labels);
         let (hash_key_overrides, flag_hash_key_override_error) =
             if flags_have_experience_continuity_enabled {
                 common_metrics::inc(FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, &[], 1);

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -230,7 +230,7 @@ pub struct FeatureFlagMatcher {
     /// When true, skip all writes to PostgreSQL and Redis.
     skip_writes: bool,
     /// Optional personhog gRPC client for fetching person data
-    pub personhog_client: Option<Arc<dyn PersonhogFetcher>>,
+    personhog_client: Option<Arc<dyn PersonhogFetcher>>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -27,6 +27,7 @@ use crate::metrics::consts::{
     FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
     PROPERTY_CACHE_MISSES_COUNTER,
 };
+use crate::personhog_client::PersonhogFetcher;
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
 use crate::utils::graph_utils::{
@@ -228,6 +229,8 @@ pub struct FeatureFlagMatcher {
     rayon_dispatcher: Option<RayonDispatcher>,
     /// When true, skip all writes to PostgreSQL and Redis.
     skip_writes: bool,
+    /// Optional personhog gRPC client for fetching person data
+    pub personhog_client: Option<Arc<dyn PersonhogFetcher>>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -261,6 +264,7 @@ impl FeatureFlagMatcher {
         cohort_cache: Arc<CohortCacheManager>,
         group_type_mapping_cache: Option<GroupTypeMappingCache>,
         groups: Option<HashMap<String, Value>>,
+        personhog_client: Option<Arc<dyn PersonhogFetcher>>,
     ) -> Self {
         FeatureFlagMatcher {
             distinct_id,
@@ -275,6 +279,7 @@ impl FeatureFlagMatcher {
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
             skip_writes: false,
+            personhog_client,
         }
     }
 
@@ -474,6 +479,7 @@ impl FeatureFlagMatcher {
             self.team_id,
             self.distinct_id.clone(),
             hash_key.clone(),
+            self.personhog_client.as_deref(),
         )
         .await
         {
@@ -508,6 +514,7 @@ impl FeatureFlagMatcher {
                     self.team_id,
                     target_distinct_ids.clone(),
                     hash_key.clone(),
+                    self.personhog_client.as_deref(),
                 )
                 .await
                 {
@@ -545,6 +552,7 @@ impl FeatureFlagMatcher {
             database_for_reading,
             self.team_id,
             target_distinct_ids,
+            self.personhog_client.as_deref(),
         )
         .await
         {
@@ -1824,6 +1832,7 @@ impl FeatureFlagMatcher {
             &group_data.type_indexes,
             &group_data.keys,
             static_cohort_ids,
+            self.personhog_client.as_deref(),
         )
         .await
         {
@@ -1985,6 +1994,7 @@ impl FeatureFlagMatcher {
                             self.router.get_persons_reader().clone(),
                             self.team_id,
                             vec![self.distinct_id.clone()],
+                            self.personhog_client.as_deref(),
                         )
                         .await
                         {

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -556,6 +556,7 @@ impl FeatureFlagMatcher {
             self.team_id,
             target_distinct_ids,
             self.personhog_client.as_deref(),
+            writing_hash_key_override,
         )
         .await
         {
@@ -2005,6 +2006,7 @@ impl FeatureFlagMatcher {
                             self.team_id,
                             vec![self.distinct_id.clone()],
                             self.personhog_client.as_deref(),
+                            false,
                         )
                         .await
                         {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -725,19 +725,37 @@ pub async fn get_feature_flag_hash_key_overrides(
     team_id: TeamId,
     distinct_id_and_hash_key_override: Vec<String>,
     personhog_client: Option<&dyn PersonhogFetcher>,
+    strong_consistency: bool,
 ) -> Result<HashMap<String, String>, FlagError> {
     // Track hash key override lookups for testing
     #[cfg(test)]
     increment_hash_key_override_lookup_count();
 
-    // Retries are handled at the personhog-router service level; the tonic channel
-    // also handles transport reconnection automatically via connect_lazy + keepalives.
     if let Some(client) = personhog_client {
         let timer = common_metrics::timing_guard(FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, &[]);
         let result = client
-            .get_hash_key_override_context(team_id, distinct_id_and_hash_key_override)
+            .get_hash_key_override_context(
+                team_id,
+                distinct_id_and_hash_key_override,
+                strong_consistency,
+            )
             .await;
         timer.fin();
+        if let Ok(ref overrides) = result {
+            let result_label = if overrides.is_empty() {
+                "empty"
+            } else {
+                "has_overrides"
+            };
+            common_metrics::inc(
+                FLAG_HASH_KEY_QUERY_RESULT,
+                &[
+                    ("result".to_string(), result_label.to_string()),
+                    ("source".to_string(), "personhog".to_string()),
+                ],
+                1,
+            );
+        }
         return result;
     }
 
@@ -891,7 +909,10 @@ async fn try_get_feature_flag_hash_key_overrides(
     };
     common_metrics::inc(
         FLAG_HASH_KEY_QUERY_RESULT,
-        &[("result".to_string(), result_label.to_string())],
+        &[
+            ("result".to_string(), result_label.to_string()),
+            ("source".to_string(), "sql".to_string()),
+        ],
         1,
     );
 
@@ -1586,9 +1607,9 @@ async fn should_write_hash_key_override_via_personhog(
 ) -> Result<bool, FlagError> {
     let distinct_ids = vec![distinct_id, hash_key_override];
 
-    // Step 1: Get existing overrides via personhog
+    // Step 1: Get existing overrides via personhog (eventual consistency is fine for this check)
     let existing_overrides = client
-        .get_hash_key_override_context(team_id, distinct_ids)
+        .get_hash_key_override_context(team_id, distinct_ids, false)
         .await?;
 
     // Step 2: Get active EEC flags from non-persons DB
@@ -2774,6 +2795,7 @@ mod tests {
                 team_id,
                 vec!["user1".to_string()],
                 Some(&mock),
+                false,
             )
             .await
             .unwrap();

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -35,6 +35,7 @@ use crate::{
         FLAG_PERSONHOG_COHORT_QUERY_TIME, FLAG_PERSONHOG_GROUP_QUERY_TIME,
         FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, FLAG_PERSONHOG_PERSON_QUERY_TIME,
         FLAG_PERSONHOG_UPSERT_TIME, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
+        FLAG_PROPERTIES_FETCH_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -177,7 +178,9 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<(), FlagError> {
     if let Some(client) = personhog_client {
-        return fetch_properties_via_personhog(
+        let labels = [("source".to_string(), "personhog".to_string())];
+        let timer = common_metrics::timing_guard(FLAG_PROPERTIES_FETCH_TIME, &labels);
+        let result = fetch_properties_via_personhog(
             flag_evaluation_state,
             client,
             distinct_id,
@@ -187,7 +190,14 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             static_cohort_ids,
         )
         .await;
+        timer
+            .label("outcome", if result.is_ok() { "success" } else { "error" })
+            .fin();
+        return result;
     }
+    let sql_labels = [("source".to_string(), "sql".to_string())];
+    let sql_fetch_timer = common_metrics::timing_guard(FLAG_PROPERTIES_FETCH_TIME, &sql_labels);
+
     // Add the test-specific counter increment
     #[cfg(test)]
     increment_fetch_calls_count();
@@ -239,6 +249,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
                 "Failed to acquire database connection"
             );
 
+            sql_fetch_timer.label("outcome", "error").fin();
             return Err(FlagError::from(e));
         }
     };
@@ -446,6 +457,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         group_processing_timer.fin();
     }
 
+    sql_fetch_timer.label("outcome", "success").fin();
     Ok(())
 }
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -31,10 +31,10 @@ use crate::{
     metrics::consts::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
         FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
-        FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME, FLAG_PERSONHOG_COHORT_QUERY_TIME,
-        FLAG_PERSONHOG_GROUP_QUERY_TIME, FLAG_PERSONHOG_HASH_KEY_QUERY_TIME,
-        FLAG_PERSONHOG_PERSON_QUERY_TIME, FLAG_PERSONHOG_UPSERT_TIME,
+        FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER,
+        FLAG_PERSONHOG_COHORT_QUERY_TIME, FLAG_PERSONHOG_GROUP_QUERY_TIME,
+        FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, FLAG_PERSONHOG_PERSON_QUERY_TIME,
+        FLAG_PERSONHOG_UPSERT_TIME, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -462,8 +462,7 @@ async fn fetch_properties_via_personhog(
     static_cohort_ids: Vec<CohortId>,
 ) -> Result<(), FlagError> {
     let person_query_start = Instant::now();
-    let person_timer =
-        common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
+    let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
     let person = client
         .get_person_by_distinct_id(team_id, &distinct_id)
         .await?;
@@ -483,8 +482,7 @@ async fn fetch_properties_via_personhog(
 
         if !static_cohort_ids.is_empty() {
             let cohort_start = Instant::now();
-            let cohort_timer =
-                common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
+            let cohort_timer = common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
             let cohort_results = client
                 .check_cohort_membership(person_id, &static_cohort_ids)
                 .await?;
@@ -518,8 +516,7 @@ async fn fetch_properties_via_personhog(
             .collect();
 
         let group_start = Instant::now();
-        let group_timer =
-            common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
+        let group_timer = common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
         let group_properties = client.get_groups(team_id, group_identifiers).await?;
         group_timer.fin();
         let group_duration = group_start.elapsed();
@@ -928,24 +925,21 @@ pub async fn set_feature_flag_hash_key_overrides(
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<bool, FlagError> {
     if let Some(client) = personhog_client {
-        let first_distinct_id = distinct_ids.first().ok_or_else(|| {
-            FlagError::PersonhogError {
+        let first_distinct_id = distinct_ids
+            .first()
+            .ok_or_else(|| FlagError::PersonhogError {
                 code: tonic::Code::InvalidArgument,
                 message: "distinct_ids must not be empty".to_string(),
-            }
-        })?;
+            })?;
 
         let person_start = Instant::now();
-        let person_timer =
-            common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
+        let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
         let person = client
             .get_person_by_distinct_id(team_id, first_distinct_id)
             .await?
-            .ok_or_else(|| {
-                FlagError::PersonhogError {
-                    code: tonic::Code::NotFound,
-                    message: format!("Person not found for distinct_id {first_distinct_id}"),
-                }
+            .ok_or_else(|| FlagError::PersonhogError {
+                code: tonic::Code::NotFound,
+                message: format!("Person not found for distinct_id {first_distinct_id}"),
             })?;
         person_timer.fin();
         info!(
@@ -2874,10 +2868,7 @@ mod tests {
             let team_id = team.id;
 
             // Mock returns no existing overrides
-            let mock = MockPersonhogClient::new().with_hash_key_overrides(
-                team_id,
-                HashMap::new(),
-            );
+            let mock = MockPersonhogClient::new().with_hash_key_overrides(team_id, HashMap::new());
 
             // Insert an active EEC flag
             let flag_row = FeatureFlagRow {
@@ -2919,8 +2910,7 @@ mod tests {
             // Mock returns an existing override for the flag
             let mut existing = HashMap::new();
             existing.insert("eec_flag".to_string(), "existing_hash".to_string());
-            let mock =
-                MockPersonhogClient::new().with_hash_key_overrides(team_id, existing);
+            let mock = MockPersonhogClient::new().with_hash_key_overrides(team_id, existing);
 
             // Insert an active EEC flag
             let flag_row = FeatureFlagRow {
@@ -2959,7 +2949,7 @@ mod tests {
             let distinct_id = "error_user";
 
             let mock = MockPersonhogClient::new()
-                .with_error(FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "service unavailable".to_string() });
+                .with_error(tonic::Code::Unavailable, "service unavailable");
 
             let mut state = FlagEvaluationState::default();
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -32,7 +32,9 @@ use crate::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
         FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
         FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME,
+        FLAG_PERSON_QUERY_TIME, FLAG_PERSONHOG_COHORT_QUERY_TIME,
+        FLAG_PERSONHOG_GROUP_QUERY_TIME, FLAG_PERSONHOG_HASH_KEY_QUERY_TIME,
+        FLAG_PERSONHOG_PERSON_QUERY_TIME, FLAG_PERSONHOG_UPSERT_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -444,6 +446,12 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
 
 /// Fetches person, cohort, and group properties via the personhog gRPC service
 /// instead of direct SQL queries.
+#[instrument(skip_all, fields(
+    team_id = %team_id,
+    distinct_id = %distinct_id,
+    cohort_ids = ?static_cohort_ids,
+    group_type_indexes = ?group_type_indexes,
+))]
 async fn fetch_properties_via_personhog(
     flag_evaluation_state: &mut FlagEvaluationState,
     client: &dyn PersonhogFetcher,
@@ -453,10 +461,19 @@ async fn fetch_properties_via_personhog(
     group_keys: &HashSet<String>,
     static_cohort_ids: Vec<CohortId>,
 ) -> Result<(), FlagError> {
-    // Fetch person by distinct_id
+    let person_query_start = Instant::now();
+    let person_timer =
+        common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
     let person = client
         .get_person_by_distinct_id(team_id, &distinct_id)
         .await?;
+    person_timer.fin();
+    let person_query_duration = person_query_start.elapsed();
+    info!(
+        duration_ms = person_query_duration.as_millis(),
+        "Personhog person query completed"
+    );
+
     let (person_id, person_props) = person
         .map(|p| (Some(p.id), Some(p.properties)))
         .unwrap_or((None, None));
@@ -465,9 +482,20 @@ async fn fetch_properties_via_personhog(
         flag_evaluation_state.set_person_id(person_id);
 
         if !static_cohort_ids.is_empty() {
+            let cohort_start = Instant::now();
+            let cohort_timer =
+                common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
             let cohort_results = client
                 .check_cohort_membership(person_id, &static_cohort_ids)
                 .await?;
+            cohort_timer.fin();
+            let cohort_duration = cohort_start.elapsed();
+            info!(
+                duration_ms = cohort_duration.as_millis(),
+                person_id = person_id,
+                cohort_count = static_cohort_ids.len(),
+                "Personhog cohort query completed"
+            );
             flag_evaluation_state.set_static_cohort_matches(cohort_results);
         } else {
             flag_evaluation_state.set_static_cohort_matches(HashMap::new());
@@ -483,14 +511,24 @@ async fn fetch_properties_via_personhog(
     all_person_properties.insert("distinct_id".to_string(), Value::String(distinct_id));
     flag_evaluation_state.set_person_properties(all_person_properties);
 
-    // Fetch group properties if needed
     if !group_type_indexes.is_empty() {
         let group_identifiers: Vec<(GroupTypeIndex, String)> = group_type_indexes
             .iter()
             .flat_map(|idx| group_keys.iter().map(move |key| (*idx, key.clone())))
             .collect();
 
+        let group_start = Instant::now();
+        let group_timer =
+            common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
         let group_properties = client.get_groups(team_id, group_identifiers).await?;
+        group_timer.fin();
+        let group_duration = group_start.elapsed();
+        info!(
+            duration_ms = group_duration.as_millis(),
+            group_type_count = group_type_indexes.len(),
+            group_key_count = group_keys.len(),
+            "Personhog group query completed"
+        );
         for (group_type_index, properties) in group_properties {
             flag_evaluation_state.set_group_properties(group_type_index, properties);
         }
@@ -670,9 +708,17 @@ pub async fn get_feature_flag_hash_key_overrides(
     increment_hash_key_override_lookup_count();
 
     if let Some(client) = personhog_client {
-        return client
+        let start = Instant::now();
+        let timer = common_metrics::timing_guard(FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, &[]);
+        let result = client
             .get_hash_key_override_context(team_id, distinct_id_and_hash_key_override)
             .await;
+        timer.fin();
+        info!(
+            duration_ms = start.elapsed().as_millis(),
+            "Personhog hash key override query completed"
+        );
+        return result;
     }
 
     let retry_strategy = ExponentialBackoff::from_millis(50)
@@ -832,6 +878,43 @@ async fn try_get_feature_flag_hash_key_overrides(
     Ok(feature_flag_hash_key_overrides)
 }
 
+/// Fetches the keys of active feature flags with ensure_experience_continuity enabled.
+async fn get_active_eec_flag_keys(
+    router: &PostgresRouter,
+    team_id: TeamId,
+    operation: &str,
+) -> Result<Vec<String>, FlagError> {
+    let flags_query = r#"
+        SELECT key FROM posthog_featureflag flag
+        JOIN posthog_team team ON flag.team_id = team.id
+        WHERE team.id = $1
+            AND flag.ensure_experience_continuity = TRUE
+            AND flag.active = TRUE
+            AND flag.deleted = FALSE
+    "#;
+
+    let mut conn = get_connection_with_metrics(
+        router.get_non_persons_reader(),
+        "non_persons_reader",
+        operation,
+    )
+    .await
+    .map_err(FlagError::from)?;
+
+    let rows = sqlx::query(flags_query)
+        .bind(team_id)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| {
+            FlagError::DatabaseError(
+                e,
+                Some(format!("Failed to fetch EEC flags for {operation}")),
+            )
+        })?;
+
+    Ok(rows.iter().map(|row| row.get("key")).collect())
+}
+
 /// Sets feature flag hash key overrides for a list of distinct IDs.
 ///
 /// This function creates hash key overrides for all active feature flags that have
@@ -845,56 +928,48 @@ pub async fn set_feature_flag_hash_key_overrides(
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<bool, FlagError> {
     if let Some(client) = personhog_client {
-        // When using personhog, we need to resolve person_id and feature_flag_keys.
-        // Get person from first distinct_id
+        let first_distinct_id = distinct_ids.first().ok_or_else(|| {
+            FlagError::PersonhogError {
+                code: tonic::Code::InvalidArgument,
+                message: "distinct_ids must not be empty".to_string(),
+            }
+        })?;
+
+        let person_start = Instant::now();
+        let person_timer =
+            common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
         let person = client
-            .get_person_by_distinct_id(team_id, &distinct_ids[0])
+            .get_person_by_distinct_id(team_id, first_distinct_id)
             .await?
             .ok_or_else(|| {
-                FlagError::PersonhogError(format!(
-                    "Person not found for distinct_id {}",
-                    distinct_ids[0]
-                ))
+                FlagError::PersonhogError {
+                    code: tonic::Code::NotFound,
+                    message: format!("Person not found for distinct_id {first_distinct_id}"),
+                }
             })?;
+        person_timer.fin();
+        info!(
+            duration_ms = person_start.elapsed().as_millis(),
+            "Personhog person query for hash key overrides completed"
+        );
 
-        // Get active flags with ensure_experience_continuity from non-persons DB
-        let mut non_persons_conn = get_connection_with_metrics(
-            router.get_non_persons_reader(),
-            "non_persons_reader",
-            "set_hash_key_overrides_personhog",
-        )
-        .await
-        .map_err(FlagError::from)?;
-
-        let flags_query = r#"
-            SELECT key FROM posthog_featureflag flag
-            JOIN posthog_team team ON flag.team_id = team.id
-            WHERE team.id = $1
-                AND flag.ensure_experience_continuity = TRUE
-                AND flag.active = TRUE
-                AND flag.deleted = FALSE
-        "#;
-
-        let flag_rows = sqlx::query(flags_query)
-            .bind(team_id)
-            .fetch_all(&mut *non_persons_conn)
-            .await
-            .map_err(|e| {
-                FlagError::DatabaseError(
-                    e,
-                    Some("Failed to fetch flags for personhog upsert".to_string()),
-                )
-            })?;
-
-        let feature_flag_keys: Vec<String> = flag_rows.iter().map(|row| row.get("key")).collect();
+        let feature_flag_keys =
+            get_active_eec_flag_keys(router, team_id, "set_hash_key_overrides_personhog").await?;
 
         if feature_flag_keys.is_empty() {
             return Ok(false);
         }
 
+        let upsert_start = Instant::now();
+        let upsert_timer = common_metrics::timing_guard(FLAG_PERSONHOG_UPSERT_TIME, &[]);
         client
             .upsert_hash_key_overrides(team_id, person.id, feature_flag_keys, hash_key_override)
             .await?;
+        upsert_timer.fin();
+        info!(
+            duration_ms = upsert_start.elapsed().as_millis(),
+            "Personhog hash key upsert completed"
+        );
 
         return Ok(true);
     }
@@ -1525,32 +1600,11 @@ async fn should_write_hash_key_override_via_personhog(
         .await?;
 
     // Step 2: Get active EEC flags from non-persons DB
-    let flags_query = r#"
-        SELECT key FROM posthog_featureflag flag
-        JOIN posthog_team team ON flag.team_id = team.id
-        WHERE team.id = $1
-            AND flag.ensure_experience_continuity = TRUE
-            AND flag.active = TRUE
-            AND flag.deleted = FALSE
-    "#;
-
-    let mut non_persons_conn = get_connection_with_metrics(
-        router.get_non_persons_reader(),
-        "non_persons_reader",
-        "should_write_check_personhog",
-    )
-    .await
-    .map_err(FlagError::from)?;
-
-    let flag_rows = sqlx::query(flags_query)
-        .bind(team_id)
-        .fetch_all(&mut *non_persons_conn)
-        .await
-        .map_err(|e| FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string())))?;
+    let flag_keys =
+        get_active_eec_flag_keys(router, team_id, "should_write_check_personhog").await?;
 
     // Step 3: Check if any EEC flag is missing an override
-    for row in flag_rows {
-        let flag_key: String = row.get("key");
+    for flag_key in flag_keys {
         if !existing_overrides.contains_key(&flag_key) {
             return Ok(true);
         }
@@ -2787,12 +2841,125 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_set_hash_key_overrides_no_eec_flags_returns_false() {
+            let context = TestContext::new(None).await;
+            let team = context.insert_new_team(None).await.unwrap();
+            let team_id = team.id;
+            let person_id: PersonId = 100;
+            let distinct_id = "no_eec_user";
+
+            let person = make_test_person(person_id, team_id);
+            let mock = MockPersonhogClient::new().with_person(team_id, distinct_id, Some(person));
+
+            // No EEC flags inserted — query should return empty
+            let router = context.create_postgres_router();
+            let result = set_feature_flag_hash_key_overrides(
+                &router,
+                team_id,
+                vec![distinct_id.to_string()],
+                "anon_hash".to_string(),
+                Some(&mock),
+            )
+            .await
+            .unwrap();
+
+            assert!(!result);
+            assert!(mock.get_upsert_calls().is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_should_write_override_via_personhog_returns_true_when_missing() {
+            let context = TestContext::new(None).await;
+            let team = context.insert_new_team(None).await.unwrap();
+            let team_id = team.id;
+
+            // Mock returns no existing overrides
+            let mock = MockPersonhogClient::new().with_hash_key_overrides(
+                team_id,
+                HashMap::new(),
+            );
+
+            // Insert an active EEC flag
+            let flag_row = FeatureFlagRow {
+                id: 70001,
+                team_id,
+                name: Some("EEC Flag".to_string()),
+                key: "eec_flag".to_string(),
+                filters: json!({"groups": [{"rollout_percentage": 50}]}),
+                deleted: false,
+                active: true,
+                ensure_experience_continuity: Some(true),
+                version: Some(1),
+                evaluation_runtime: None,
+                evaluation_tags: None,
+                bucketing_identifier: None,
+            };
+            context.insert_flag(team_id, Some(flag_row)).await.unwrap();
+
+            let router = context.create_postgres_router();
+            let result = should_write_hash_key_override(
+                &router,
+                team_id,
+                "user_a".to_string(),
+                "anon_hash".to_string(),
+                Some(&mock),
+            )
+            .await
+            .unwrap();
+
+            assert!(result);
+        }
+
+        #[tokio::test]
+        async fn test_should_write_override_via_personhog_returns_false_when_all_exist() {
+            let context = TestContext::new(None).await;
+            let team = context.insert_new_team(None).await.unwrap();
+            let team_id = team.id;
+
+            // Mock returns an existing override for the flag
+            let mut existing = HashMap::new();
+            existing.insert("eec_flag".to_string(), "existing_hash".to_string());
+            let mock =
+                MockPersonhogClient::new().with_hash_key_overrides(team_id, existing);
+
+            // Insert an active EEC flag
+            let flag_row = FeatureFlagRow {
+                id: 70002,
+                team_id,
+                name: Some("EEC Flag".to_string()),
+                key: "eec_flag".to_string(),
+                filters: json!({"groups": [{"rollout_percentage": 50}]}),
+                deleted: false,
+                active: true,
+                ensure_experience_continuity: Some(true),
+                version: Some(1),
+                evaluation_runtime: None,
+                evaluation_tags: None,
+                bucketing_identifier: None,
+            };
+            context.insert_flag(team_id, Some(flag_row)).await.unwrap();
+
+            let router = context.create_postgres_router();
+            let result = should_write_hash_key_override(
+                &router,
+                team_id,
+                "user_a".to_string(),
+                "anon_hash".to_string(),
+                Some(&mock),
+            )
+            .await
+            .unwrap();
+
+            assert!(!result);
+        }
+
+        #[tokio::test]
         async fn test_personhog_error_propagation() {
             let team_id: TeamId = 1;
             let distinct_id = "error_user";
 
             let mock = MockPersonhogClient::new()
-                .with_error(FlagError::PersonhogError("service unavailable".to_string()));
+                .with_error(FlagError::PersonhogError { code: tonic::Code::Unavailable, message: "service unavailable".to_string() });
 
             let mut state = FlagEvaluationState::default();
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -903,23 +903,6 @@ pub async fn set_feature_flag_hash_key_overrides(
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<bool, FlagError> {
     if let Some(client) = personhog_client {
-        let first_distinct_id = distinct_ids
-            .first()
-            .ok_or_else(|| FlagError::PersonhogError {
-                code: tonic::Code::InvalidArgument,
-                message: "distinct_ids must not be empty".to_string(),
-            })?;
-
-        let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
-        let person = client
-            .get_person_by_distinct_id(team_id, first_distinct_id)
-            .await?
-            .ok_or_else(|| FlagError::PersonhogError {
-                code: tonic::Code::NotFound,
-                message: format!("Person not found for distinct_id {first_distinct_id}"),
-            })?;
-        person_timer.fin();
-
         let feature_flag_keys =
             get_active_eec_flag_keys(router, team_id, "set_hash_key_overrides_personhog").await?;
 
@@ -929,7 +912,7 @@ pub async fn set_feature_flag_hash_key_overrides(
 
         let upsert_timer = common_metrics::timing_guard(FLAG_PERSONHOG_UPSERT_TIME, &[]);
         client
-            .upsert_hash_key_overrides(team_id, person.id, feature_flag_keys, hash_key_override)
+            .upsert_hash_key_overrides(team_id, distinct_ids, feature_flag_keys, hash_key_override)
             .await?;
         upsert_timer.fin();
 
@@ -2795,9 +2778,9 @@ mod tests {
 
             let calls = mock.get_upsert_calls();
             assert_eq!(calls.len(), 1);
-            let (call_team_id, call_person_id, call_keys, call_hash) = &calls[0];
+            let (call_team_id, call_distinct_ids, call_keys, call_hash) = &calls[0];
             assert_eq!(*call_team_id, team_id);
-            assert_eq!(*call_person_id, person_id);
+            assert_eq!(call_distinct_ids, &vec![distinct_id.to_string()]);
             assert_eq!(call_keys, &vec!["eec_flag".to_string()]);
             assert_eq!(call_hash, "anon_hash");
         }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -461,17 +461,11 @@ async fn fetch_properties_via_personhog(
     group_keys: &HashSet<String>,
     static_cohort_ids: Vec<CohortId>,
 ) -> Result<(), FlagError> {
-    let person_query_start = Instant::now();
     let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
     let person = client
         .get_person_by_distinct_id(team_id, &distinct_id)
         .await?;
     person_timer.fin();
-    let person_query_duration = person_query_start.elapsed();
-    info!(
-        duration_ms = person_query_duration.as_millis(),
-        "Personhog person query completed"
-    );
 
     let (person_id, person_props) = person
         .map(|p| (Some(p.id), Some(p.properties)))
@@ -481,19 +475,11 @@ async fn fetch_properties_via_personhog(
         flag_evaluation_state.set_person_id(person_id);
 
         if !static_cohort_ids.is_empty() {
-            let cohort_start = Instant::now();
             let cohort_timer = common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
             let cohort_results = client
                 .check_cohort_membership(person_id, &static_cohort_ids)
                 .await?;
             cohort_timer.fin();
-            let cohort_duration = cohort_start.elapsed();
-            info!(
-                duration_ms = cohort_duration.as_millis(),
-                person_id = person_id,
-                cohort_count = static_cohort_ids.len(),
-                "Personhog cohort query completed"
-            );
             flag_evaluation_state.set_static_cohort_matches(cohort_results);
         } else {
             flag_evaluation_state.set_static_cohort_matches(HashMap::new());
@@ -515,17 +501,9 @@ async fn fetch_properties_via_personhog(
             .flat_map(|idx| group_keys.iter().map(move |key| (*idx, key.clone())))
             .collect();
 
-        let group_start = Instant::now();
         let group_timer = common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
         let group_properties = client.get_groups(team_id, group_identifiers).await?;
         group_timer.fin();
-        let group_duration = group_start.elapsed();
-        info!(
-            duration_ms = group_duration.as_millis(),
-            group_type_count = group_type_indexes.len(),
-            group_key_count = group_keys.len(),
-            "Personhog group query completed"
-        );
         for (group_type_index, properties) in group_properties {
             flag_evaluation_state.set_group_properties(group_type_index, properties);
         }
@@ -705,16 +683,11 @@ pub async fn get_feature_flag_hash_key_overrides(
     increment_hash_key_override_lookup_count();
 
     if let Some(client) = personhog_client {
-        let start = Instant::now();
         let timer = common_metrics::timing_guard(FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, &[]);
         let result = client
             .get_hash_key_override_context(team_id, distinct_id_and_hash_key_override)
             .await;
         timer.fin();
-        info!(
-            duration_ms = start.elapsed().as_millis(),
-            "Personhog hash key override query completed"
-        );
         return result;
     }
 
@@ -932,7 +905,6 @@ pub async fn set_feature_flag_hash_key_overrides(
                 message: "distinct_ids must not be empty".to_string(),
             })?;
 
-        let person_start = Instant::now();
         let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
         let person = client
             .get_person_by_distinct_id(team_id, first_distinct_id)
@@ -942,10 +914,6 @@ pub async fn set_feature_flag_hash_key_overrides(
                 message: format!("Person not found for distinct_id {first_distinct_id}"),
             })?;
         person_timer.fin();
-        info!(
-            duration_ms = person_start.elapsed().as_millis(),
-            "Personhog person query for hash key overrides completed"
-        );
 
         let feature_flag_keys =
             get_active_eec_flag_keys(router, team_id, "set_hash_key_overrides_personhog").await?;
@@ -954,16 +922,11 @@ pub async fn set_feature_flag_hash_key_overrides(
             return Ok(false);
         }
 
-        let upsert_start = Instant::now();
         let upsert_timer = common_metrics::timing_guard(FLAG_PERSONHOG_UPSERT_TIME, &[]);
         client
             .upsert_hash_key_overrides(team_id, person.id, feature_flag_keys, hash_key_override)
             .await?;
         upsert_timer.fin();
-        info!(
-            duration_ms = upsert_start.elapsed().as_millis(),
-            "Personhog hash key upsert completed"
-        );
 
         return Ok(true);
     }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -178,6 +178,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<(), FlagError> {
     if let Some(client) = personhog_client {
+        with_canonical_log(|log| log.property_data_source = Some("personhog"));
         let labels = [("source".to_string(), "personhog".to_string())];
         let timer = common_metrics::timing_guard(FLAG_PROPERTIES_FETCH_TIME, &labels);
         let result = fetch_properties_via_personhog(
@@ -195,6 +196,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             .fin();
         return result;
     }
+    with_canonical_log(|log| log.property_data_source = Some("sql"));
     let sql_labels = [("source".to_string(), "sql".to_string())];
     let sql_fetch_timer = common_metrics::timing_guard(FLAG_PROPERTIES_FETCH_TIME, &sql_labels);
 
@@ -485,11 +487,16 @@ async fn fetch_properties_via_personhog(
         .collect();
 
     let person_fut = async {
+        let start = Instant::now();
         let timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
         let result = client
             .get_person_by_distinct_id(team_id, &distinct_id)
             .await;
         timer.fin();
+        with_canonical_log(|log| {
+            log.person_queries += 1;
+            log.person_query_time_ms += start.elapsed().as_millis() as u64;
+        });
         result
     };
 
@@ -497,9 +504,14 @@ async fn fetch_properties_via_personhog(
         if group_identifiers.is_empty() {
             return Ok(HashMap::new());
         }
+        let start = Instant::now();
         let timer = common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
         let result = client.get_groups(team_id, group_identifiers).await;
         timer.fin();
+        with_canonical_log(|log| {
+            log.group_queries += 1;
+            log.group_query_time_ms += start.elapsed().as_millis() as u64;
+        });
         result
     };
 
@@ -516,11 +528,16 @@ async fn fetch_properties_via_personhog(
 
         // Cohort check depends on person_id so it must run after person lookup
         if !static_cohort_ids.is_empty() {
+            let cohort_start = Instant::now();
             let cohort_timer = common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
             let cohort_results = client
                 .check_cohort_membership(person_id, &static_cohort_ids)
                 .await?;
             cohort_timer.fin();
+            with_canonical_log(|log| {
+                log.static_cohort_queries += 1;
+                log.cohort_query_time_ms += cohort_start.elapsed().as_millis() as u64;
+            });
             flag_evaluation_state.set_static_cohort_matches(cohort_results);
         } else {
             flag_evaluation_state.set_static_cohort_matches(HashMap::new());

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -701,6 +701,8 @@ pub async fn get_feature_flag_hash_key_overrides(
     #[cfg(test)]
     increment_hash_key_override_lookup_count();
 
+    // Retries are handled at the personhog-router service level; the tonic channel
+    // also handles transport reconnection automatically via connect_lazy + keepalives.
     if let Some(client) = personhog_client {
         let timer = common_metrics::timing_guard(FLAG_PERSONHOG_HASH_KEY_QUERY_TIME, &[]);
         let result = client
@@ -916,6 +918,8 @@ pub async fn set_feature_flag_hash_key_overrides(
     hash_key_override: String,
     personhog_client: Option<&dyn PersonhogFetcher>,
 ) -> Result<bool, FlagError> {
+    // Retries are handled at the personhog-router service level; the tonic channel
+    // also handles transport reconnection automatically via connect_lazy + keepalives.
     if let Some(client) = personhog_client {
         let feature_flag_keys =
             get_active_eec_flag_keys(router, team_id, "set_hash_key_overrides_personhog").await?;

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -359,17 +359,12 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     }
 
     // if we have person properties, set them
-    let mut all_person_properties: HashMap<String, Value> = if let Some(person_props) = person_props
-    {
-        person_props
-            .as_object()
-            .unwrap_or(&serde_json::Map::new())
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    } else {
-        HashMap::new()
-    };
+    let mut all_person_properties: HashMap<String, Value> =
+        if let Some(Value::Object(props)) = person_props {
+            props.into_iter().collect()
+        } else {
+            HashMap::new()
+        };
 
     // Always add distinct_id to person properties to match Python implementation
     // This allows flags to filter on distinct_id even when no other person properties exist
@@ -479,17 +474,12 @@ async fn fetch_properties_via_personhog(
         }
     }
 
-    let mut all_person_properties: HashMap<String, Value> = if let Some(person_props) = person_props
-    {
-        person_props
-            .as_object()
-            .unwrap_or(&serde_json::Map::new())
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    } else {
-        HashMap::new()
-    };
+    let mut all_person_properties: HashMap<String, Value> =
+        if let Some(Value::Object(props)) = person_props {
+            props.into_iter().collect()
+        } else {
+            HashMap::new()
+        };
     all_person_properties.insert("distinct_id".to_string(), Value::String(distinct_id));
     flag_evaluation_state.set_person_properties(all_person_properties);
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -466,11 +466,34 @@ async fn fetch_properties_via_personhog(
     group_keys: &HashSet<String>,
     static_cohort_ids: Vec<CohortId>,
 ) -> Result<(), FlagError> {
-    let person_timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
-    let person = client
-        .get_person_by_distinct_id(team_id, &distinct_id)
-        .await?;
-    person_timer.fin();
+    // Person lookup and group fetch are independent — run them concurrently
+    let group_identifiers: Vec<(GroupTypeIndex, String)> = group_type_indexes
+        .iter()
+        .flat_map(|idx| group_keys.iter().map(move |key| (*idx, key.clone())))
+        .collect();
+
+    let person_fut = async {
+        let timer = common_metrics::timing_guard(FLAG_PERSONHOG_PERSON_QUERY_TIME, &[]);
+        let result = client
+            .get_person_by_distinct_id(team_id, &distinct_id)
+            .await;
+        timer.fin();
+        result
+    };
+
+    let group_fut = async {
+        if group_identifiers.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let timer = common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
+        let result = client.get_groups(team_id, group_identifiers).await;
+        timer.fin();
+        result
+    };
+
+    let (person_result, group_result) = tokio::join!(person_fut, group_fut);
+    let person = person_result?;
+    let group_properties = group_result?;
 
     let (person_id, person_props) = person
         .map(|p| (Some(p.id), Some(p.properties)))
@@ -479,6 +502,7 @@ async fn fetch_properties_via_personhog(
     if let Some(person_id) = person_id {
         flag_evaluation_state.set_person_id(person_id);
 
+        // Cohort check depends on person_id so it must run after person lookup
         if !static_cohort_ids.is_empty() {
             let cohort_timer = common_metrics::timing_guard(FLAG_PERSONHOG_COHORT_QUERY_TIME, &[]);
             let cohort_results = client
@@ -500,18 +524,8 @@ async fn fetch_properties_via_personhog(
     all_person_properties.insert("distinct_id".to_string(), Value::String(distinct_id));
     flag_evaluation_state.set_person_properties(all_person_properties);
 
-    if !group_type_indexes.is_empty() {
-        let group_identifiers: Vec<(GroupTypeIndex, String)> = group_type_indexes
-            .iter()
-            .flat_map(|idx| group_keys.iter().map(move |key| (*idx, key.clone())))
-            .collect();
-
-        let group_timer = common_metrics::timing_guard(FLAG_PERSONHOG_GROUP_QUERY_TIME, &[]);
-        let group_properties = client.get_groups(team_id, group_identifiers).await?;
-        group_timer.fin();
-        for (group_type_index, properties) in group_properties {
-            flag_evaluation_state.set_group_properties(group_type_index, properties);
-        }
+    for (group_type_index, properties) in group_properties {
+        flag_evaluation_state.set_group_properties(group_type_index, properties);
     }
 
     Ok(())

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -2743,6 +2743,16 @@ mod tests {
             let groups = state.get_group_properties();
             let org = groups.get(&0).unwrap();
             assert_eq!(org.get("name"), Some(&json!("PostHog")));
+
+            let cohort_calls = mock.get_cohort_calls();
+            assert_eq!(cohort_calls.len(), 1);
+            assert_eq!(cohort_calls[0].0, person_id);
+            assert_eq!(cohort_calls[0].1, vec![100, 200]);
+
+            let group_calls = mock.get_group_calls();
+            assert_eq!(group_calls.len(), 1);
+            assert_eq!(group_calls[0].0, team_id);
+            assert_eq!(group_calls[0].1, vec![(0, "org_key".to_string())]);
         }
 
         #[tokio::test]
@@ -2774,6 +2784,9 @@ mod tests {
                 Some(&json!("unknown_user"))
             );
             assert_eq!(person_props.len(), 1);
+
+            assert!(mock.get_cohort_calls().is_empty());
+            assert!(mock.get_group_calls().is_empty());
         }
 
         #[tokio::test]
@@ -2802,6 +2815,11 @@ mod tests {
 
             assert_eq!(result.get("flag_1"), Some(&"hash_a".to_string()));
             assert_eq!(result.get("flag_2"), Some(&"hash_b".to_string()));
+
+            let hash_calls = mock.get_hash_key_context_calls();
+            assert_eq!(hash_calls.len(), 1);
+            assert_eq!(hash_calls[0].0, team_id);
+            assert_eq!(hash_calls[0].1, vec!["user1".to_string()]);
         }
 
         #[tokio::test]
@@ -2919,6 +2937,14 @@ mod tests {
             .unwrap();
 
             assert!(result);
+
+            let hash_calls = mock.get_hash_key_context_calls();
+            assert_eq!(hash_calls.len(), 1);
+            assert_eq!(hash_calls[0].0, team_id);
+            assert_eq!(
+                hash_calls[0].1,
+                vec!["user_a".to_string(), "anon_hash".to_string()]
+            );
         }
 
         #[tokio::test]
@@ -2961,6 +2987,14 @@ mod tests {
             .unwrap();
 
             assert!(!result);
+
+            let hash_calls = mock.get_hash_key_context_calls();
+            assert_eq!(hash_calls.len(), 1);
+            assert_eq!(hash_calls[0].0, team_id);
+            assert_eq!(
+                hash_calls[0].1,
+                vec!["user_a".to_string(), "anon_hash".to_string()]
+            );
         }
 
         #[tokio::test]

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -361,12 +361,17 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     }
 
     // if we have person properties, set them
-    let mut all_person_properties: HashMap<String, Value> =
-        if let Some(Value::Object(props)) = person_props {
-            props.into_iter().collect()
-        } else {
-            HashMap::new()
-        };
+    let mut all_person_properties: HashMap<String, Value> = if let Some(person_props) = person_props
+    {
+        person_props
+            .as_object()
+            .unwrap_or(&serde_json::Map::new())
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    } else {
+        HashMap::new()
+    };
 
     // Always add distinct_id to person properties to match Python implementation
     // This allows flags to filter on distinct_id even when no other person properties exist

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -94,6 +94,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -115,6 +116,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -136,6 +138,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -199,6 +202,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -289,6 +293,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             Some(groups),
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -373,6 +378,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -540,6 +546,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
@@ -699,6 +706,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -831,6 +839,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -1003,6 +1012,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
@@ -1105,6 +1115,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             Some(groups),
+            None, // personhog_client
         );
         let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
         assert!(variant.is_some(), "No variant was selected");
@@ -1141,6 +1152,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
+            None, // personhog_client
         );
 
         let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
@@ -1192,6 +1204,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         let (is_match, reason) = matcher
             .is_condition_match(&flag, &condition, &HashMap::new(), None, &None)
@@ -1251,6 +1264,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         matcher
             .flag_evaluation_state
@@ -1359,6 +1373,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         reset_fetch_calls_count();
@@ -1439,6 +1454,7 @@ mod tests {
                     cohort_cache_clone,
                     None,
                     None,
+                    None, // personhog_client
                 );
                 matcher.get_match(&flag_clone, None, None, &None).unwrap()
             }));
@@ -1521,6 +1537,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -1571,6 +1588,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1618,6 +1636,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1672,6 +1691,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let mut control_count = 0;
@@ -1750,6 +1770,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1814,6 +1835,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1860,6 +1882,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let (is_match, reason) = matcher
@@ -1940,6 +1963,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -2173,6 +2197,7 @@ mod tests {
                 cohort_cache.clone(),
                 None,
                 None,
+                None, // personhog_client
             );
 
             matcher
@@ -2288,6 +2313,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let mut matcher_example_id = FeatureFlagMatcher::new(
@@ -2298,6 +2324,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let mut matcher_another_id = FeatureFlagMatcher::new(
@@ -2308,6 +2335,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher_test_id
@@ -2428,6 +2456,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -2539,6 +2568,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let mut matcher_example_id = FeatureFlagMatcher::new(
@@ -2549,6 +2579,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let mut matcher_another_id = FeatureFlagMatcher::new(
@@ -2559,6 +2590,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher_test_id
@@ -2690,6 +2722,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -2786,6 +2819,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -2882,6 +2916,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -2999,6 +3034,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -3095,6 +3131,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -3191,6 +3228,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -3279,6 +3317,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -3362,6 +3401,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -3460,6 +3500,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -3534,6 +3575,7 @@ mod tests {
             team.id,
             vec![distinct_id.clone()],
             "hash_key_continuity".to_string(),
+            None,
         )
         .await
         .unwrap();
@@ -3551,6 +3593,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -3644,6 +3687,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None, false)
         .await;
@@ -3755,6 +3799,7 @@ mod tests {
             team.id,
             vec![distinct_id.clone()],
             "hash_key_mixed".to_string(),
+            None,
         )
         .await
         .unwrap();
@@ -3772,6 +3817,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -3879,6 +3925,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4110,6 +4157,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4134,6 +4182,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher2
@@ -4250,6 +4299,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4273,6 +4323,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4296,6 +4347,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4391,6 +4443,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4457,6 +4510,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher
@@ -4529,6 +4583,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_numeric),
+            None, // personhog_client
         );
 
         matcher_numeric
@@ -4549,6 +4604,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_string),
+            None, // personhog_client
         );
 
         matcher_string
@@ -4581,6 +4637,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_float),
+            None, // personhog_client
         );
 
         matcher_float
@@ -4602,6 +4659,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_bool),
+            None, // personhog_client
         );
 
         matcher_bool
@@ -4746,6 +4804,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4771,6 +4830,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4796,6 +4856,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4869,6 +4930,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         matcher
@@ -4926,6 +4988,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -4947,6 +5010,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         matcher_same_device
             .prepare_flag_evaluation_state(&[&flag])
@@ -4970,6 +5034,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         matcher_low
             .prepare_flag_evaluation_state(&[&flag])
@@ -5003,6 +5068,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -5024,6 +5090,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         matcher_high
             .prepare_flag_evaluation_state(&[&flag])
@@ -5059,6 +5126,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -5080,6 +5148,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
         matcher_low
             .prepare_flag_evaluation_state(&[&flag])
@@ -5200,6 +5269,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -5246,6 +5316,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result2 = matcher2
@@ -5281,6 +5352,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result3 = matcher3
@@ -5318,6 +5390,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let result4 = matcher4
@@ -5472,6 +5545,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
+            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -5517,6 +5591,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
+            None, // personhog_client
         );
 
         let result2 = matcher2
@@ -5558,6 +5633,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
+            None, // personhog_client
         );
 
         let result3 = matcher3
@@ -5595,6 +5671,7 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
+            None, // personhog_client
         );
 
         let result4 = matcher4
@@ -5636,6 +5713,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             Some(groups),
+            None, // personhog_client
         );
 
         let result5 = matcher5
@@ -5741,6 +5819,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         // Pass email as a property override to avoid database lookup
@@ -5771,6 +5850,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         );
 
         let mut other_properties = HashMap::new();
@@ -5816,6 +5896,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         // Create flags: one with experience continuity enabled, one without
@@ -5941,6 +6022,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -6022,6 +6104,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher
@@ -6123,6 +6206,7 @@ mod tests {
             cohort_cache,
             None,
             None,
+            None, // personhog_client
         );
 
         let result = matcher
@@ -6207,6 +6291,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6297,6 +6382,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6400,6 +6486,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6508,6 +6595,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6600,6 +6688,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6732,6 +6821,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6868,6 +6958,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7010,6 +7101,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7110,6 +7202,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7219,6 +7312,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7321,6 +7415,7 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
+            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -94,7 +94,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -116,7 +115,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -138,7 +136,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -202,7 +199,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -293,7 +289,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             Some(groups),
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -378,7 +373,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -546,7 +540,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
@@ -706,7 +699,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -839,7 +831,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -1012,7 +1003,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
@@ -1115,7 +1105,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             Some(groups),
-            None, // personhog_client
         );
         let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
         assert!(variant.is_some(), "No variant was selected");
@@ -1152,7 +1141,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
-            None, // personhog_client
         );
 
         let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
@@ -1204,7 +1192,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         let (is_match, reason) = matcher
             .is_condition_match(&flag, &condition, &HashMap::new(), None, &None)
@@ -1264,7 +1251,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         matcher
             .flag_evaluation_state
@@ -1373,7 +1359,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         reset_fetch_calls_count();
@@ -1454,7 +1439,6 @@ mod tests {
                     cohort_cache_clone,
                     None,
                     None,
-                    None, // personhog_client
                 );
                 matcher.get_match(&flag_clone, None, None, &None).unwrap()
             }));
@@ -1537,7 +1521,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -1588,7 +1571,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1636,7 +1618,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1691,7 +1672,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let mut control_count = 0;
@@ -1770,7 +1750,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1835,7 +1814,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -1882,7 +1860,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let (is_match, reason) = matcher
@@ -1963,7 +1940,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -2197,7 +2173,6 @@ mod tests {
                 cohort_cache.clone(),
                 None,
                 None,
-                None, // personhog_client
             );
 
             matcher
@@ -2313,7 +2288,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let mut matcher_example_id = FeatureFlagMatcher::new(
@@ -2324,7 +2298,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let mut matcher_another_id = FeatureFlagMatcher::new(
@@ -2335,7 +2308,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher_test_id
@@ -2456,7 +2428,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -2568,7 +2539,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let mut matcher_example_id = FeatureFlagMatcher::new(
@@ -2579,7 +2549,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let mut matcher_another_id = FeatureFlagMatcher::new(
@@ -2590,7 +2559,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher_test_id
@@ -2722,7 +2690,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -2819,7 +2786,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -2916,7 +2882,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -3034,7 +2999,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -3131,7 +3095,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -3228,7 +3191,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -3317,7 +3279,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -3401,7 +3362,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -3500,7 +3460,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -3593,7 +3552,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -3687,7 +3645,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None, false)
         .await;
@@ -3817,7 +3774,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -3925,7 +3881,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4157,7 +4112,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4182,7 +4136,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher2
@@ -4299,7 +4252,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4323,7 +4275,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4347,7 +4298,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
@@ -4443,7 +4393,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4510,7 +4459,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher
@@ -4583,7 +4531,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_numeric),
-            None, // personhog_client
         );
 
         matcher_numeric
@@ -4604,7 +4551,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_string),
-            None, // personhog_client
         );
 
         matcher_string
@@ -4637,7 +4583,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_float),
-            None, // personhog_client
         );
 
         matcher_float
@@ -4659,7 +4604,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups_bool),
-            None, // personhog_client
         );
 
         matcher_bool
@@ -4804,7 +4748,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4830,7 +4773,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4856,7 +4798,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4930,7 +4871,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         matcher
@@ -4988,7 +4928,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -5010,7 +4949,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         matcher_same_device
             .prepare_flag_evaluation_state(&[&flag])
@@ -5034,7 +4972,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         matcher_low
             .prepare_flag_evaluation_state(&[&flag])
@@ -5068,7 +5005,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -5090,7 +5026,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         matcher_high
             .prepare_flag_evaluation_state(&[&flag])
@@ -5126,7 +5061,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
         matcher
             .prepare_flag_evaluation_state(&[&flag])
@@ -5148,7 +5082,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
         matcher_low
             .prepare_flag_evaluation_state(&[&flag])
@@ -5269,7 +5202,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -5316,7 +5248,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result2 = matcher2
@@ -5352,7 +5283,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result3 = matcher3
@@ -5390,7 +5320,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let result4 = matcher4
@@ -5545,7 +5474,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
-            None, // personhog_client
         );
 
         let flags = FeatureFlagList {
@@ -5591,7 +5519,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
-            None, // personhog_client
         );
 
         let result2 = matcher2
@@ -5633,7 +5560,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
-            None, // personhog_client
         );
 
         let result3 = matcher3
@@ -5671,7 +5597,6 @@ mod tests {
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
             Some(groups.clone()),
-            None, // personhog_client
         );
 
         let result4 = matcher4
@@ -5713,7 +5638,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             Some(groups),
-            None, // personhog_client
         );
 
         let result5 = matcher5
@@ -5819,7 +5743,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         // Pass email as a property override to avoid database lookup
@@ -5850,7 +5773,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         );
 
         let mut other_properties = HashMap::new();
@@ -5896,7 +5818,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         // Create flags: one with experience continuity enabled, one without
@@ -6022,7 +5943,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
@@ -6104,7 +6024,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher
@@ -6206,7 +6125,6 @@ mod tests {
             cohort_cache,
             None,
             None,
-            None, // personhog_client
         );
 
         let result = matcher
@@ -6291,7 +6209,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6382,7 +6299,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6486,7 +6402,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6595,7 +6510,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6688,7 +6602,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6821,7 +6734,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -6958,7 +6870,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7101,7 +7012,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7202,7 +7112,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7312,7 +7221,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,
@@ -7415,7 +7323,6 @@ mod tests {
             cohort_cache.clone(),
             None,
             None,
-            None, // personhog_client
         )
         .evaluate_all_feature_flags(
             flags,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -171,6 +171,8 @@ pub struct FlagsCanonicalLogLine {
     pub person_properties_not_cached: bool,
     /// True if group properties were not found in evaluation state cache.
     pub group_properties_not_cached: bool,
+    /// Which data source was used for person/group property fetches: "sql" or "personhog".
+    pub property_data_source: Option<&'static str>,
     pub cohorts_evaluated: usize,
     pub flags_errored: usize,
     /// Number of errors encountered during dependency graph construction.
@@ -230,6 +232,7 @@ impl Default for FlagsCanonicalLogLine {
             property_cache_misses: 0,
             person_properties_not_cached: false,
             group_properties_not_cached: false,
+            property_data_source: None,
             cohorts_evaluated: 0,
             flags_errored: 0,
             dependency_graph_errors: 0,
@@ -289,6 +292,7 @@ impl FlagsCanonicalLogLine {
             property_cache_misses = self.property_cache_misses,
             person_properties_not_cached = self.person_properties_not_cached,
             group_properties_not_cached = self.group_properties_not_cached,
+            property_data_source = self.property_data_source,
             cohorts_evaluated = self.cohorts_evaluated,
             flags_errored = self.flags_errored,
             dependency_graph_errors = self.dependency_graph_errors,

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -30,6 +30,7 @@ pub async fn evaluate_feature_flags(
         context.cohort_cache,
         Some(group_type_mapping_cache),
         context.groups,
+        context.personhog_client,
     )
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
     .with_rayon_dispatcher(context.rayon_dispatcher)

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -30,11 +30,14 @@ pub async fn evaluate_feature_flags(
         context.cohort_cache,
         Some(group_type_mapping_cache),
         context.groups,
-        context.personhog_client,
     )
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
     .with_rayon_dispatcher(context.rayon_dispatcher)
     .with_skip_writes(context.skip_writes);
+
+    if let Some(client) = context.personhog_client {
+        matcher = matcher.with_personhog_client(client);
+    }
 
     matcher
         .evaluate_all_feature_flags(

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -264,6 +264,7 @@ pub async fn evaluate_for_request(
         parallel_eval_threshold: state.config.parallel_eval_threshold,
         rayon_dispatcher: state.rayon_dispatcher.clone(),
         skip_writes: *state.config.skip_writes,
+        personhog_client: state.personhog_client.clone(),
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -194,6 +194,7 @@ async fn test_evaluate_feature_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -288,6 +289,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -696,6 +698,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -803,6 +806,7 @@ async fn test_evaluate_feature_flags_details() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -962,6 +966,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -1056,6 +1061,7 @@ async fn test_long_distinct_id() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
 
     let request_id = Uuid::new_v4();
@@ -1575,6 +1581,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
     let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4()).await;
 
@@ -1598,6 +1605,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 1,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        personhog_client: None,
     };
     let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4()).await;
 

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -8,8 +8,7 @@ use uuid::Uuid;
 use crate::{
     api::types::FlagsQueryParams, cohorts::cohort_cache_manager::CohortCacheManager,
     flags::flag_models::FeatureFlagList, personhog_client::PersonhogFetcher,
-    rayon_dispatcher::RayonDispatcher, router,
-    utils::user_agent::UserAgentInfo,
+    rayon_dispatcher::RayonDispatcher, router, utils::user_agent::UserAgentInfo,
 };
 
 pub struct RequestContext {

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 
 use crate::{
     api::types::FlagsQueryParams, cohorts::cohort_cache_manager::CohortCacheManager,
-    flags::flag_models::FeatureFlagList, rayon_dispatcher::RayonDispatcher, router,
+    flags::flag_models::FeatureFlagList, personhog_client::PersonhogFetcher,
+    rayon_dispatcher::RayonDispatcher, router,
     utils::user_agent::UserAgentInfo,
 };
 
@@ -67,6 +68,8 @@ pub struct FeatureFlagEvaluationContext {
     pub rayon_dispatcher: RayonDispatcher,
     /// When true, skip all writes to PostgreSQL and Redis.
     pub skip_writes: bool,
+    /// Optional personhog gRPC client for fetching person data
+    pub personhog_client: Option<Arc<dyn PersonhogFetcher>>,
 }
 
 /// SDK type classification based on user-agent parsing.

--- a/rust/feature-flags/src/lib.rs
+++ b/rust/feature-flags/src/lib.rs
@@ -9,6 +9,7 @@ pub mod db_monitor;
 pub mod flags;
 pub mod handler;
 pub mod metrics;
+pub mod personhog_client;
 pub mod properties;
 pub mod rayon_dispatcher;
 pub mod router;

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -48,6 +48,13 @@ pub const FLAG_PERSONHOG_GROUP_QUERY_TIME: &str = "flags_personhog_group_query_t
 pub const FLAG_PERSONHOG_HASH_KEY_QUERY_TIME: &str = "flags_personhog_hash_key_query_time";
 pub const FLAG_PERSONHOG_UPSERT_TIME: &str = "flags_personhog_upsert_time";
 
+// Personhog error counter — labels: method (rpc name), grpc_code (tonic status code)
+pub const FLAG_PERSONHOG_ERRORS_COUNTER: &str = "flags_personhog_errors_total";
+
+// Unified property-fetch histogram — labels: source=sql|personhog
+// Wraps the entire property-fetch operation (person + cohort + groups) for apples-to-apples comparison
+pub const FLAG_PROPERTIES_FETCH_TIME: &str = "flags_properties_fetch_time";
+
 // Flag request kludges (to see how often we have to massage our request data to be able to parse it)
 pub const FLAG_REQUEST_KLUDGE_COUNTER: &str = "flags_request_kludge_total";
 

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -41,6 +41,13 @@ pub const FLAG_GROUP_QUERY_TIME: &str = "flags_group_query_time";
 pub const FLAG_GROUP_PROCESSING_TIME: &str = "flags_group_processing_time";
 pub const FLAG_DB_CONNECTION_TIME: &str = "flags_db_connection_time";
 
+// Personhog gRPC timing (mirrors SQL timing constants for A/B comparison)
+pub const FLAG_PERSONHOG_PERSON_QUERY_TIME: &str = "flags_personhog_person_query_time";
+pub const FLAG_PERSONHOG_COHORT_QUERY_TIME: &str = "flags_personhog_cohort_query_time";
+pub const FLAG_PERSONHOG_GROUP_QUERY_TIME: &str = "flags_personhog_group_query_time";
+pub const FLAG_PERSONHOG_HASH_KEY_QUERY_TIME: &str = "flags_personhog_hash_key_query_time";
+pub const FLAG_PERSONHOG_UPSERT_TIME: &str = "flags_personhog_upsert_time";
+
 // Flag request kludges (to see how often we have to massage our request data to be able to parse it)
 pub const FLAG_REQUEST_KLUDGE_COUNTER: &str = "flags_request_kludge_total";
 

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -1,0 +1,446 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common_types::{Person, PersonId, TeamId};
+use personhog_proto::personhog::service::v1::person_hog_service_client::PersonHogServiceClient;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, GetGroupsRequest, GetHashKeyOverrideContextRequest,
+    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideInput,
+    UpsertHashKeyOverridesRequest,
+};
+use serde_json::Value;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::api::errors::FlagError;
+use crate::cohorts::cohort_models::CohortId;
+use crate::flags::flag_group_type_mapping::GroupTypeIndex;
+
+/// Abstraction over person/group data fetching from the personhog service.
+///
+/// Production code uses `PersonhogClient` (gRPC). Tests inject `MockPersonhogClient`
+/// so we can exercise the personhog code paths without a running personhog-router.
+#[async_trait]
+pub trait PersonhogFetcher: Send + Sync {
+    async fn get_person_by_distinct_id(
+        &self,
+        team_id: TeamId,
+        distinct_id: &str,
+    ) -> Result<Option<Person>, FlagError>;
+
+    async fn check_cohort_membership(
+        &self,
+        person_id: PersonId,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, FlagError>;
+
+    async fn get_groups(
+        &self,
+        team_id: TeamId,
+        group_identifiers: Vec<(GroupTypeIndex, String)>,
+    ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError>;
+
+    async fn get_hash_key_override_context(
+        &self,
+        team_id: TeamId,
+        distinct_ids: Vec<String>,
+    ) -> Result<HashMap<String, String>, FlagError>;
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        team_id: TeamId,
+        person_id: PersonId,
+        feature_flag_keys: Vec<String>,
+        hash_key: String,
+    ) -> Result<(), FlagError>;
+}
+
+#[derive(Clone)]
+pub struct PersonhogClient {
+    client: PersonHogServiceClient<Channel>,
+}
+
+impl PersonhogClient {
+    pub fn new(url: &str, timeout_ms: u64) -> Result<Self, FlagError> {
+        let channel = Channel::from_shared(url.to_string())
+            .map_err(|e| FlagError::PersonhogError(format!("Invalid personhog URL: {e}")))?
+            .timeout(Duration::from_millis(timeout_ms))
+            .connect_lazy();
+
+        Ok(Self {
+            client: PersonHogServiceClient::new(channel),
+        })
+    }
+}
+
+#[async_trait]
+impl PersonhogFetcher for PersonhogClient {
+    async fn get_person_by_distinct_id(
+        &self,
+        team_id: TeamId,
+        distinct_id: &str,
+    ) -> Result<Option<Person>, FlagError> {
+        let request = Request::new(GetPersonByDistinctIdRequest {
+            team_id: team_id as i64,
+            distinct_id: distinct_id.to_string(),
+            read_options: None,
+        });
+
+        let response = self
+            .client
+            .clone()
+            .get_person_by_distinct_id(request)
+            .await
+            .map_err(|s| FlagError::PersonhogError(format!("GetPersonByDistinctId failed: {s}")))?;
+
+        let proto_person = match response.into_inner().person {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        let properties: Value = serde_json::from_slice(&proto_person.properties).map_err(|e| {
+            FlagError::DataParsingErrorWithContext(format!(
+                "Failed to parse person properties from personhog: {e}"
+            ))
+        })?;
+
+        Ok(Some(Person {
+            id: proto_person.id,
+            team_id: proto_person.team_id as i32,
+            uuid: proto_person
+                .uuid
+                .parse()
+                .unwrap_or_else(|_| uuid::Uuid::nil()),
+            properties,
+            is_identified: proto_person.is_identified,
+            is_user_id: if proto_person.is_user_id {
+                Some(1)
+            } else {
+                None
+            },
+            version: Some(proto_person.version),
+            created_at: chrono::DateTime::from_timestamp(proto_person.created_at, 0)
+                .unwrap_or_default(),
+        }))
+    }
+
+    async fn check_cohort_membership(
+        &self,
+        person_id: PersonId,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, FlagError> {
+        let request = Request::new(CheckCohortMembershipRequest {
+            person_id,
+            cohort_ids: cohort_ids.iter().map(|id| *id as i64).collect(),
+            read_options: None,
+        });
+
+        let response = self
+            .client
+            .clone()
+            .check_cohort_membership(request)
+            .await
+            .map_err(|s| FlagError::PersonhogError(format!("CheckCohortMembership failed: {s}")))?;
+
+        let memberships = response
+            .into_inner()
+            .memberships
+            .into_iter()
+            .map(|m| (m.cohort_id as CohortId, m.is_member))
+            .collect();
+
+        Ok(memberships)
+    }
+
+    async fn get_groups(
+        &self,
+        team_id: TeamId,
+        group_identifiers: Vec<(GroupTypeIndex, String)>,
+    ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError> {
+        let identifiers = group_identifiers
+            .into_iter()
+            .map(|(idx, key)| GroupIdentifier {
+                group_type_index: idx,
+                group_key: key,
+            })
+            .collect();
+
+        let request = Request::new(GetGroupsRequest {
+            team_id: team_id as i64,
+            group_identifiers: identifiers,
+            read_options: None,
+        });
+
+        let response = self
+            .client
+            .clone()
+            .get_groups(request)
+            .await
+            .map_err(|s| FlagError::PersonhogError(format!("GetGroups failed: {s}")))?;
+
+        let mut result = HashMap::new();
+        for group in response.into_inner().groups {
+            let properties: Value =
+                serde_json::from_slice(&group.group_properties).map_err(|e| {
+                    FlagError::DataParsingErrorWithContext(format!(
+                        "Failed to parse group properties from personhog: {e}"
+                    ))
+                })?;
+
+            if let Value::Object(props) = properties {
+                let properties_map = props.into_iter().collect();
+                result.insert(group.group_type_index, properties_map);
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn get_hash_key_override_context(
+        &self,
+        team_id: TeamId,
+        distinct_ids: Vec<String>,
+    ) -> Result<HashMap<String, String>, FlagError> {
+        let request = Request::new(GetHashKeyOverrideContextRequest {
+            team_id: team_id as i64,
+            distinct_ids: distinct_ids.clone(),
+            check_person_exists: false,
+            read_options: None,
+        });
+
+        let response = self
+            .client
+            .clone()
+            .get_hash_key_override_context(request)
+            .await
+            .map_err(|s| {
+                FlagError::PersonhogError(format!("GetHashKeyOverrideContext failed: {s}"))
+            })?;
+
+        let mut overrides = HashMap::new();
+
+        // Process results: priority is based on distinct_id order (first = highest priority)
+        // We process in reverse so highest priority (first distinct_id) writes last
+        let results = response.into_inner().results;
+        for context in results.iter().rev() {
+            for hash_override in &context.overrides {
+                overrides.insert(
+                    hash_override.feature_flag_key.clone(),
+                    hash_override.hash_key.clone(),
+                );
+            }
+        }
+
+        // Now process in forward order so the first distinct_id's overrides take precedence
+        for context in &results {
+            if !distinct_ids.is_empty() && context.distinct_id == distinct_ids[0] {
+                for hash_override in &context.overrides {
+                    overrides.insert(
+                        hash_override.feature_flag_key.clone(),
+                        hash_override.hash_key.clone(),
+                    );
+                }
+            }
+        }
+
+        Ok(overrides)
+    }
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        team_id: TeamId,
+        person_id: PersonId,
+        feature_flag_keys: Vec<String>,
+        hash_key: String,
+    ) -> Result<(), FlagError> {
+        let overrides = feature_flag_keys
+            .into_iter()
+            .map(|key| HashKeyOverrideInput {
+                person_id,
+                feature_flag_key: key,
+            })
+            .collect();
+
+        let request = Request::new(UpsertHashKeyOverridesRequest {
+            team_id: team_id as i64,
+            overrides,
+            hash_key,
+        });
+
+        self.client
+            .clone()
+            .upsert_hash_key_overrides(request)
+            .await
+            .map_err(|s| {
+                FlagError::PersonhogError(format!("UpsertHashKeyOverrides failed: {s}"))
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    type UpsertCall = (TeamId, PersonId, Vec<String>, String);
+
+    pub struct MockPersonhogClient {
+        person_responses: HashMap<(TeamId, String), Option<Person>>,
+        cohort_responses: HashMap<PersonId, HashMap<CohortId, bool>>,
+        group_responses: HashMap<TeamId, HashMap<GroupTypeIndex, HashMap<String, Value>>>,
+        hash_key_override_responses: HashMap<TeamId, HashMap<String, String>>,
+        upsert_calls: Arc<Mutex<Vec<UpsertCall>>>,
+        error: Option<FlagError>,
+    }
+
+    impl Default for MockPersonhogClient {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl MockPersonhogClient {
+        pub fn new() -> Self {
+            Self {
+                person_responses: HashMap::new(),
+                cohort_responses: HashMap::new(),
+                group_responses: HashMap::new(),
+                hash_key_override_responses: HashMap::new(),
+                upsert_calls: Arc::new(Mutex::new(Vec::new())),
+                error: None,
+            }
+        }
+
+        pub fn with_person(
+            mut self,
+            team_id: TeamId,
+            distinct_id: &str,
+            person: Option<Person>,
+        ) -> Self {
+            self.person_responses
+                .insert((team_id, distinct_id.to_string()), person);
+            self
+        }
+
+        pub fn with_cohort_membership(
+            mut self,
+            person_id: PersonId,
+            memberships: HashMap<CohortId, bool>,
+        ) -> Self {
+            self.cohort_responses.insert(person_id, memberships);
+            self
+        }
+
+        pub fn with_groups(
+            mut self,
+            team_id: TeamId,
+            groups: HashMap<GroupTypeIndex, HashMap<String, Value>>,
+        ) -> Self {
+            self.group_responses.insert(team_id, groups);
+            self
+        }
+
+        pub fn with_hash_key_overrides(
+            mut self,
+            team_id: TeamId,
+            overrides: HashMap<String, String>,
+        ) -> Self {
+            self.hash_key_override_responses.insert(team_id, overrides);
+            self
+        }
+
+        pub fn with_error(mut self, error: FlagError) -> Self {
+            self.error = Some(error);
+            self
+        }
+
+        pub fn get_upsert_calls(&self) -> Vec<UpsertCall> {
+            self.upsert_calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PersonhogFetcher for MockPersonhogClient {
+        async fn get_person_by_distinct_id(
+            &self,
+            team_id: TeamId,
+            distinct_id: &str,
+        ) -> Result<Option<Person>, FlagError> {
+            if let Some(ref error) = self.error {
+                return Err(FlagError::PersonhogError(error.to_string()));
+            }
+            Ok(self
+                .person_responses
+                .get(&(team_id, distinct_id.to_string()))
+                .cloned()
+                .unwrap_or(None))
+        }
+
+        async fn check_cohort_membership(
+            &self,
+            person_id: PersonId,
+            _cohort_ids: &[CohortId],
+        ) -> Result<HashMap<CohortId, bool>, FlagError> {
+            if let Some(ref error) = self.error {
+                return Err(FlagError::PersonhogError(error.to_string()));
+            }
+            Ok(self
+                .cohort_responses
+                .get(&person_id)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        async fn get_groups(
+            &self,
+            team_id: TeamId,
+            _group_identifiers: Vec<(GroupTypeIndex, String)>,
+        ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError> {
+            if let Some(ref error) = self.error {
+                return Err(FlagError::PersonhogError(error.to_string()));
+            }
+            Ok(self
+                .group_responses
+                .get(&team_id)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        async fn get_hash_key_override_context(
+            &self,
+            team_id: TeamId,
+            _distinct_ids: Vec<String>,
+        ) -> Result<HashMap<String, String>, FlagError> {
+            if let Some(ref error) = self.error {
+                return Err(FlagError::PersonhogError(error.to_string()));
+            }
+            Ok(self
+                .hash_key_override_responses
+                .get(&team_id)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        async fn upsert_hash_key_overrides(
+            &self,
+            team_id: TeamId,
+            person_id: PersonId,
+            feature_flag_keys: Vec<String>,
+            hash_key: String,
+        ) -> Result<(), FlagError> {
+            if let Some(ref error) = self.error {
+                return Err(FlagError::PersonhogError(error.to_string()));
+            }
+            self.upsert_calls.lock().unwrap().push((
+                team_id,
+                person_id,
+                feature_flag_keys,
+                hash_key,
+            ));
+            Ok(())
+        }
+    }
+}

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -11,8 +11,8 @@ use personhog_proto::personhog::types::v1::{
 };
 use serde_json::Value;
 use tonic::transport::Channel;
-use tracing::warn;
 use tonic::Request;
+use tracing::warn;
 
 use crate::api::errors::FlagError;
 use crate::cohorts::cohort_models::CohortId;

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -6,7 +6,7 @@ use common_types::{Person, PersonId, TeamId};
 use personhog_proto::personhog::service::v1::person_hog_service_client::PersonHogServiceClient;
 use personhog_proto::personhog::types::v1::{
     CheckCohortMembershipRequest, GetGroupsRequest, GetHashKeyOverrideContextRequest,
-    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideContext, HashKeyOverrideInput,
+    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideContext,
     UpsertHashKeyOverridesRequest,
 };
 use serde_json::Value;
@@ -51,7 +51,7 @@ pub trait PersonhogFetcher: Send + Sync {
     async fn upsert_hash_key_overrides(
         &self,
         team_id: TeamId,
-        person_id: PersonId,
+        distinct_ids: Vec<String>,
         feature_flag_keys: Vec<String>,
         hash_key: String,
     ) -> Result<(), FlagError>;
@@ -255,22 +255,15 @@ impl PersonhogFetcher for PersonhogClient {
     async fn upsert_hash_key_overrides(
         &self,
         team_id: TeamId,
-        person_id: PersonId,
+        distinct_ids: Vec<String>,
         feature_flag_keys: Vec<String>,
         hash_key: String,
     ) -> Result<(), FlagError> {
-        let overrides = feature_flag_keys
-            .into_iter()
-            .map(|key| HashKeyOverrideInput {
-                person_id,
-                feature_flag_key: key,
-            })
-            .collect();
-
         let request = Request::new(UpsertHashKeyOverridesRequest {
             team_id: team_id as i64,
-            overrides,
+            distinct_ids,
             hash_key,
+            feature_flag_keys,
         });
 
         self.client
@@ -327,7 +320,7 @@ pub mod mock {
     use super::*;
     use std::sync::{Arc, Mutex};
 
-    type UpsertCall = (TeamId, PersonId, Vec<String>, String);
+    type UpsertCall = (TeamId, Vec<String>, Vec<String>, String);
 
     pub struct MockPersonhogClient {
         person_responses: HashMap<(TeamId, String), Option<Person>>,
@@ -481,7 +474,7 @@ pub mod mock {
         async fn upsert_hash_key_overrides(
             &self,
             team_id: TeamId,
-            person_id: PersonId,
+            distinct_ids: Vec<String>,
             feature_flag_keys: Vec<String>,
             hash_key: String,
         ) -> Result<(), FlagError> {
@@ -493,7 +486,7 @@ pub mod mock {
             }
             self.upsert_calls.lock().unwrap().push((
                 team_id,
-                person_id,
+                distinct_ids,
                 feature_flag_keys,
                 hash_key,
             ));

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use common_types::{Person, PersonId, TeamId};
 use personhog_proto::personhog::service::v1::person_hog_service_client::PersonHogServiceClient;
 use personhog_proto::personhog::types::v1::{
-    CheckCohortMembershipRequest, GetGroupsRequest, GetHashKeyOverrideContextRequest,
-    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideContext,
-    UpsertHashKeyOverridesRequest,
+    CheckCohortMembershipRequest, ConsistencyLevel, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetPersonByDistinctIdRequest, GroupIdentifier,
+    HashKeyOverrideContext, ReadOptions, UpsertHashKeyOverridesRequest,
 };
 use serde_json::Value;
 use tonic::transport::Channel;
@@ -47,6 +47,7 @@ pub trait PersonhogFetcher: Send + Sync {
         &self,
         team_id: TeamId,
         distinct_ids: Vec<String>,
+        strong_consistency: bool,
     ) -> Result<HashMap<String, String>, FlagError>;
 
     async fn upsert_hash_key_overrides(
@@ -254,14 +255,23 @@ impl PersonhogFetcher for PersonhogClient {
         &self,
         team_id: TeamId,
         distinct_ids: Vec<String>,
+        strong_consistency: bool,
     ) -> Result<HashMap<String, String>, FlagError> {
         let first_distinct_id = distinct_ids.first().cloned();
+
+        let read_options = if strong_consistency {
+            Some(ReadOptions {
+                consistency: ConsistencyLevel::Strong as i32,
+            })
+        } else {
+            None
+        };
 
         let request = Request::new(GetHashKeyOverrideContextRequest {
             team_id: team_id as i64,
             distinct_ids,
             check_person_exists: false,
-            read_options: None,
+            read_options,
         });
 
         let response = self
@@ -538,6 +548,7 @@ pub mod mock {
             &self,
             team_id: TeamId,
             distinct_ids: Vec<String>,
+            _strong_consistency: bool,
         ) -> Result<HashMap<String, String>, FlagError> {
             if let Some((code, message)) = &self.error {
                 return Err(FlagError::PersonhogError {

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -17,6 +17,7 @@ use tracing::warn;
 use crate::api::errors::FlagError;
 use crate::cohorts::cohort_models::CohortId;
 use crate::flags::flag_group_type_mapping::GroupTypeIndex;
+use crate::metrics::consts::FLAG_PERSONHOG_ERRORS_COUNTER;
 
 /// Abstraction over person/group data fetching from the personhog service.
 ///
@@ -105,9 +106,19 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_person_by_distinct_id(request)
             .await
-            .map_err(|s| FlagError::PersonhogError {
-                code: s.code(),
-                message: format!("GetPersonByDistinctId failed: {}", s.message()),
+            .map_err(|s| {
+                common_metrics::inc(
+                    FLAG_PERSONHOG_ERRORS_COUNTER,
+                    &[
+                        ("method".to_string(), "GetPersonByDistinctId".to_string()),
+                        ("grpc_code".to_string(), format!("{:?}", s.code())),
+                    ],
+                    1,
+                );
+                FlagError::PersonhogError {
+                    code: s.code(),
+                    message: format!("GetPersonByDistinctId failed: {}", s.message()),
+                }
             })?;
 
         let proto_person = match response.into_inner().person {
@@ -162,9 +173,19 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .check_cohort_membership(request)
             .await
-            .map_err(|s| FlagError::PersonhogError {
-                code: s.code(),
-                message: format!("CheckCohortMembership failed: {}", s.message()),
+            .map_err(|s| {
+                common_metrics::inc(
+                    FLAG_PERSONHOG_ERRORS_COUNTER,
+                    &[
+                        ("method".to_string(), "CheckCohortMembership".to_string()),
+                        ("grpc_code".to_string(), format!("{:?}", s.code())),
+                    ],
+                    1,
+                );
+                FlagError::PersonhogError {
+                    code: s.code(),
+                    message: format!("CheckCohortMembership failed: {}", s.message()),
+                }
             })?;
 
         let memberships = response
@@ -197,6 +218,14 @@ impl PersonhogFetcher for PersonhogClient {
         });
 
         let response = self.client.clone().get_groups(request).await.map_err(|s| {
+            common_metrics::inc(
+                FLAG_PERSONHOG_ERRORS_COUNTER,
+                &[
+                    ("method".to_string(), "GetGroups".to_string()),
+                    ("grpc_code".to_string(), format!("{:?}", s.code())),
+                ],
+                1,
+            );
             FlagError::PersonhogError {
                 code: s.code(),
                 message: format!("GetGroups failed: {}", s.message()),
@@ -240,9 +269,22 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_hash_key_override_context(request)
             .await
-            .map_err(|s| FlagError::PersonhogError {
-                code: s.code(),
-                message: format!("GetHashKeyOverrideContext failed: {}", s.message()),
+            .map_err(|s| {
+                common_metrics::inc(
+                    FLAG_PERSONHOG_ERRORS_COUNTER,
+                    &[
+                        (
+                            "method".to_string(),
+                            "GetHashKeyOverrideContext".to_string(),
+                        ),
+                        ("grpc_code".to_string(), format!("{:?}", s.code())),
+                    ],
+                    1,
+                );
+                FlagError::PersonhogError {
+                    code: s.code(),
+                    message: format!("GetHashKeyOverrideContext failed: {}", s.message()),
+                }
             })?;
 
         let results = response.into_inner().results;
@@ -270,9 +312,19 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .upsert_hash_key_overrides(request)
             .await
-            .map_err(|s| FlagError::PersonhogError {
-                code: s.code(),
-                message: format!("UpsertHashKeyOverrides failed: {}", s.message()),
+            .map_err(|s| {
+                common_metrics::inc(
+                    FLAG_PERSONHOG_ERRORS_COUNTER,
+                    &[
+                        ("method".to_string(), "UpsertHashKeyOverrides".to_string()),
+                        ("grpc_code".to_string(), format!("{:?}", s.code())),
+                    ],
+                    1,
+                );
+                FlagError::PersonhogError {
+                    code: s.code(),
+                    message: format!("UpsertHashKeyOverrides failed: {}", s.message()),
+                }
             })?;
 
         Ok(())

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -11,6 +11,7 @@ use personhog_proto::personhog::types::v1::{
 };
 use serde_json::Value;
 use tonic::transport::Channel;
+use tracing::warn;
 use tonic::Request;
 
 use crate::api::errors::FlagError;
@@ -108,10 +109,15 @@ impl PersonhogFetcher for PersonhogClient {
         Ok(Some(Person {
             id: proto_person.id,
             team_id: proto_person.team_id as i32,
-            uuid: proto_person
-                .uuid
-                .parse()
-                .unwrap_or_else(|_| uuid::Uuid::nil()),
+            uuid: proto_person.uuid.parse().unwrap_or_else(|e| {
+                warn!(
+                    person_id = proto_person.id,
+                    raw_uuid = proto_person.uuid,
+                    error = %e,
+                    "Failed to parse person UUID from personhog, falling back to nil"
+                );
+                uuid::Uuid::nil()
+            }),
             properties,
             is_identified: proto_person.is_identified,
             is_user_id: if proto_person.is_user_id {
@@ -220,8 +226,8 @@ impl PersonhogFetcher for PersonhogClient {
 
         let mut overrides = HashMap::new();
 
-        // Process results: priority is based on distinct_id order (first = highest priority)
-        // We process in reverse so highest priority (first distinct_id) writes last
+        // Priority is based on distinct_id order (first = highest priority)
+        // Process all results in reverse so later entries get overwritten
         let results = response.into_inner().results;
         for context in results.iter().rev() {
             for hash_override in &context.overrides {
@@ -232,10 +238,10 @@ impl PersonhogFetcher for PersonhogClient {
             }
         }
 
-        // Now process in forward order so the first distinct_id's overrides take precedence
-        for context in &results {
-            if !distinct_ids.is_empty() && context.distinct_id == distinct_ids[0] {
-                for hash_override in &context.overrides {
+        // Now process first distinct_id to ensure its overrides take precedence
+        if !distinct_ids.is_empty() {
+            if let Some(first_context) = results.iter().find(|c| c.distinct_id == distinct_ids[0]) {
+                for hash_override in &first_context.overrides {
                     overrides.insert(
                         hash_override.feature_flag_key.clone(),
                         hash_override.hash_key.clone(),

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -71,7 +71,10 @@ impl PersonhogClient {
         keep_alive_timeout_secs: u64,
     ) -> Result<Self, FlagError> {
         let channel = Channel::from_shared(url.to_string())
-            .map_err(|e| FlagError::PersonhogError { code: tonic::Code::InvalidArgument, message: format!("Invalid personhog URL: {e}") })?
+            .map_err(|e| FlagError::PersonhogError {
+                code: tonic::Code::InvalidArgument,
+                message: format!("Invalid personhog URL: {e}"),
+            })?
             .timeout(Duration::from_millis(timeout_ms))
             .connect_timeout(Duration::from_millis(connect_timeout_ms))
             .http2_keep_alive_interval(Duration::from_secs(keep_alive_interval_secs))
@@ -102,7 +105,10 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_person_by_distinct_id(request)
             .await
-            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetPersonByDistinctId failed: {}", s.message()) })?;
+            .map_err(|s| FlagError::PersonhogError {
+                code: s.code(),
+                message: format!("GetPersonByDistinctId failed: {}", s.message()),
+            })?;
 
         let proto_person = match response.into_inner().person {
             Some(p) => p,
@@ -156,7 +162,10 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .check_cohort_membership(request)
             .await
-            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("CheckCohortMembership failed: {}", s.message()) })?;
+            .map_err(|s| FlagError::PersonhogError {
+                code: s.code(),
+                message: format!("CheckCohortMembership failed: {}", s.message()),
+            })?;
 
         let memberships = response
             .into_inner()
@@ -187,12 +196,12 @@ impl PersonhogFetcher for PersonhogClient {
             read_options: None,
         });
 
-        let response = self
-            .client
-            .clone()
-            .get_groups(request)
-            .await
-            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetGroups failed: {}", s.message()) })?;
+        let response = self.client.clone().get_groups(request).await.map_err(|s| {
+            FlagError::PersonhogError {
+                code: s.code(),
+                message: format!("GetGroups failed: {}", s.message()),
+            }
+        })?;
 
         let mut result = HashMap::new();
         for group in response.into_inner().groups {
@@ -231,7 +240,10 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_hash_key_override_context(request)
             .await
-            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetHashKeyOverrideContext failed: {}", s.message()) })?;
+            .map_err(|s| FlagError::PersonhogError {
+                code: s.code(),
+                message: format!("GetHashKeyOverrideContext failed: {}", s.message()),
+            })?;
 
         let results = response.into_inner().results;
         Ok(merge_hash_key_overrides(
@@ -265,7 +277,10 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .upsert_hash_key_overrides(request)
             .await
-            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("UpsertHashKeyOverrides failed: {}", s.message()) })?;
+            .map_err(|s| FlagError::PersonhogError {
+                code: s.code(),
+                message: format!("UpsertHashKeyOverrides failed: {}", s.message()),
+            })?;
 
         Ok(())
     }
@@ -293,8 +308,8 @@ fn merge_hash_key_overrides(
         }
     }
 
-    if let Some(primary_context) = primary_distinct_id
-        .and_then(|id| results.iter().find(|c| c.distinct_id == id))
+    if let Some(primary_context) =
+        primary_distinct_id.and_then(|id| results.iter().find(|c| c.distinct_id == id))
     {
         for hash_override in &primary_context.overrides {
             overrides.insert(
@@ -320,7 +335,7 @@ pub mod mock {
         group_responses: HashMap<TeamId, HashMap<GroupTypeIndex, HashMap<String, Value>>>,
         hash_key_override_responses: HashMap<TeamId, HashMap<String, String>>,
         upsert_calls: Arc<Mutex<Vec<UpsertCall>>>,
-        error: Option<FlagError>,
+        error: Option<(tonic::Code, String)>,
     }
 
     impl Default for MockPersonhogClient {
@@ -379,8 +394,8 @@ pub mod mock {
             self
         }
 
-        pub fn with_error(mut self, error: FlagError) -> Self {
-            self.error = Some(error);
+        pub fn with_error(mut self, code: tonic::Code, message: impl Into<String>) -> Self {
+            self.error = Some((code, message.into()));
             self
         }
 
@@ -396,8 +411,11 @@ pub mod mock {
             team_id: TeamId,
             distinct_id: &str,
         ) -> Result<Option<Person>, FlagError> {
-            if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
+            if let Some((code, message)) = &self.error {
+                return Err(FlagError::PersonhogError {
+                    code: *code,
+                    message: message.clone(),
+                });
             }
             Ok(self
                 .person_responses
@@ -411,8 +429,11 @@ pub mod mock {
             person_id: PersonId,
             _cohort_ids: &[CohortId],
         ) -> Result<HashMap<CohortId, bool>, FlagError> {
-            if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
+            if let Some((code, message)) = &self.error {
+                return Err(FlagError::PersonhogError {
+                    code: *code,
+                    message: message.clone(),
+                });
             }
             Ok(self
                 .cohort_responses
@@ -426,8 +447,11 @@ pub mod mock {
             team_id: TeamId,
             _group_identifiers: Vec<(GroupTypeIndex, String)>,
         ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError> {
-            if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
+            if let Some((code, message)) = &self.error {
+                return Err(FlagError::PersonhogError {
+                    code: *code,
+                    message: message.clone(),
+                });
             }
             Ok(self
                 .group_responses
@@ -441,8 +465,11 @@ pub mod mock {
             team_id: TeamId,
             _distinct_ids: Vec<String>,
         ) -> Result<HashMap<String, String>, FlagError> {
-            if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
+            if let Some((code, message)) = &self.error {
+                return Err(FlagError::PersonhogError {
+                    code: *code,
+                    message: message.clone(),
+                });
             }
             Ok(self
                 .hash_key_override_responses
@@ -458,8 +485,11 @@ pub mod mock {
             feature_flag_keys: Vec<String>,
             hash_key: String,
         ) -> Result<(), FlagError> {
-            if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
+            if let Some((code, message)) = &self.error {
+                return Err(FlagError::PersonhogError {
+                    code: *code,
+                    message: message.clone(),
+                });
             }
             self.upsert_calls.lock().unwrap().push((
                 team_id,
@@ -477,10 +507,7 @@ mod tests {
     use super::*;
     use personhog_proto::personhog::types::v1::HashKeyOverride;
 
-    fn make_context(
-        distinct_id: &str,
-        overrides: Vec<(&str, &str)>,
-    ) -> HashKeyOverrideContext {
+    fn make_context(distinct_id: &str, overrides: Vec<(&str, &str)>) -> HashKeyOverrideContext {
         HashKeyOverrideContext {
             person_id: 0,
             distinct_id: distinct_id.to_string(),

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -6,7 +6,7 @@ use common_types::{Person, PersonId, TeamId};
 use personhog_proto::personhog::service::v1::person_hog_service_client::PersonHogServiceClient;
 use personhog_proto::personhog::types::v1::{
     CheckCohortMembershipRequest, GetGroupsRequest, GetHashKeyOverrideContextRequest,
-    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideInput,
+    GetPersonByDistinctIdRequest, GroupIdentifier, HashKeyOverrideContext, HashKeyOverrideInput,
     UpsertHashKeyOverridesRequest,
 };
 use serde_json::Value;
@@ -63,10 +63,19 @@ pub struct PersonhogClient {
 }
 
 impl PersonhogClient {
-    pub fn new(url: &str, timeout_ms: u64) -> Result<Self, FlagError> {
+    pub fn new(
+        url: &str,
+        timeout_ms: u64,
+        connect_timeout_ms: u64,
+        keep_alive_interval_secs: u64,
+        keep_alive_timeout_secs: u64,
+    ) -> Result<Self, FlagError> {
         let channel = Channel::from_shared(url.to_string())
-            .map_err(|e| FlagError::PersonhogError(format!("Invalid personhog URL: {e}")))?
+            .map_err(|e| FlagError::PersonhogError { code: tonic::Code::InvalidArgument, message: format!("Invalid personhog URL: {e}") })?
             .timeout(Duration::from_millis(timeout_ms))
+            .connect_timeout(Duration::from_millis(connect_timeout_ms))
+            .http2_keep_alive_interval(Duration::from_secs(keep_alive_interval_secs))
+            .keep_alive_timeout(Duration::from_secs(keep_alive_timeout_secs))
             .connect_lazy();
 
         Ok(Self {
@@ -93,7 +102,7 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_person_by_distinct_id(request)
             .await
-            .map_err(|s| FlagError::PersonhogError(format!("GetPersonByDistinctId failed: {s}")))?;
+            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetPersonByDistinctId failed: {}", s.message()) })?;
 
         let proto_person = match response.into_inner().person {
             Some(p) => p,
@@ -147,7 +156,7 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .check_cohort_membership(request)
             .await
-            .map_err(|s| FlagError::PersonhogError(format!("CheckCohortMembership failed: {s}")))?;
+            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("CheckCohortMembership failed: {}", s.message()) })?;
 
         let memberships = response
             .into_inner()
@@ -183,7 +192,7 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_groups(request)
             .await
-            .map_err(|s| FlagError::PersonhogError(format!("GetGroups failed: {s}")))?;
+            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetGroups failed: {}", s.message()) })?;
 
         let mut result = HashMap::new();
         for group in response.into_inner().groups {
@@ -208,9 +217,11 @@ impl PersonhogFetcher for PersonhogClient {
         team_id: TeamId,
         distinct_ids: Vec<String>,
     ) -> Result<HashMap<String, String>, FlagError> {
+        let first_distinct_id = distinct_ids.first().cloned();
+
         let request = Request::new(GetHashKeyOverrideContextRequest {
             team_id: team_id as i64,
-            distinct_ids: distinct_ids.clone(),
+            distinct_ids,
             check_person_exists: false,
             read_options: None,
         });
@@ -220,37 +231,13 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .get_hash_key_override_context(request)
             .await
-            .map_err(|s| {
-                FlagError::PersonhogError(format!("GetHashKeyOverrideContext failed: {s}"))
-            })?;
+            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("GetHashKeyOverrideContext failed: {}", s.message()) })?;
 
-        let mut overrides = HashMap::new();
-
-        // Priority is based on distinct_id order (first = highest priority)
-        // Process all results in reverse so later entries get overwritten
         let results = response.into_inner().results;
-        for context in results.iter().rev() {
-            for hash_override in &context.overrides {
-                overrides.insert(
-                    hash_override.feature_flag_key.clone(),
-                    hash_override.hash_key.clone(),
-                );
-            }
-        }
-
-        // Now process first distinct_id to ensure its overrides take precedence
-        if !distinct_ids.is_empty() {
-            if let Some(first_context) = results.iter().find(|c| c.distinct_id == distinct_ids[0]) {
-                for hash_override in &first_context.overrides {
-                    overrides.insert(
-                        hash_override.feature_flag_key.clone(),
-                        hash_override.hash_key.clone(),
-                    );
-                }
-            }
-        }
-
-        Ok(overrides)
+        Ok(merge_hash_key_overrides(
+            &results,
+            first_distinct_id.as_deref(),
+        ))
     }
 
     async fn upsert_hash_key_overrides(
@@ -278,12 +265,46 @@ impl PersonhogFetcher for PersonhogClient {
             .clone()
             .upsert_hash_key_overrides(request)
             .await
-            .map_err(|s| {
-                FlagError::PersonhogError(format!("UpsertHashKeyOverrides failed: {s}"))
-            })?;
+            .map_err(|s| FlagError::PersonhogError { code: s.code(), message: format!("UpsertHashKeyOverrides failed: {}", s.message()) })?;
 
         Ok(())
     }
+}
+
+/// Merges hash key override results, giving priority to the first distinct_id.
+///
+/// Results from the server may arrive in any order. All overrides are collected,
+/// but `primary_distinct_id`'s entries are applied last so they win on conflict.
+fn merge_hash_key_overrides(
+    results: &[HashKeyOverrideContext],
+    primary_distinct_id: Option<&str>,
+) -> HashMap<String, String> {
+    let mut overrides = HashMap::new();
+
+    for context in results.iter() {
+        if primary_distinct_id.is_some_and(|id| id == context.distinct_id) {
+            continue;
+        }
+        for hash_override in &context.overrides {
+            overrides.insert(
+                hash_override.feature_flag_key.clone(),
+                hash_override.hash_key.clone(),
+            );
+        }
+    }
+
+    if let Some(primary_context) = primary_distinct_id
+        .and_then(|id| results.iter().find(|c| c.distinct_id == id))
+    {
+        for hash_override in &primary_context.overrides {
+            overrides.insert(
+                hash_override.feature_flag_key.clone(),
+                hash_override.hash_key.clone(),
+            );
+        }
+    }
+
+    overrides
 }
 
 #[cfg(test)]
@@ -376,7 +397,7 @@ pub mod mock {
             distinct_id: &str,
         ) -> Result<Option<Person>, FlagError> {
             if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError(error.to_string()));
+                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
             }
             Ok(self
                 .person_responses
@@ -391,7 +412,7 @@ pub mod mock {
             _cohort_ids: &[CohortId],
         ) -> Result<HashMap<CohortId, bool>, FlagError> {
             if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError(error.to_string()));
+                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
             }
             Ok(self
                 .cohort_responses
@@ -406,7 +427,7 @@ pub mod mock {
             _group_identifiers: Vec<(GroupTypeIndex, String)>,
         ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError> {
             if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError(error.to_string()));
+                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
             }
             Ok(self
                 .group_responses
@@ -421,7 +442,7 @@ pub mod mock {
             _distinct_ids: Vec<String>,
         ) -> Result<HashMap<String, String>, FlagError> {
             if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError(error.to_string()));
+                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
             }
             Ok(self
                 .hash_key_override_responses
@@ -438,7 +459,7 @@ pub mod mock {
             hash_key: String,
         ) -> Result<(), FlagError> {
             if let Some(ref error) = self.error {
-                return Err(FlagError::PersonhogError(error.to_string()));
+                return Err(FlagError::PersonhogError { code: tonic::Code::Internal, message: error.to_string() });
             }
             self.upsert_calls.lock().unwrap().push((
                 team_id,
@@ -448,5 +469,89 @@ pub mod mock {
             ));
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use personhog_proto::personhog::types::v1::HashKeyOverride;
+
+    fn make_context(
+        distinct_id: &str,
+        overrides: Vec<(&str, &str)>,
+    ) -> HashKeyOverrideContext {
+        HashKeyOverrideContext {
+            person_id: 0,
+            distinct_id: distinct_id.to_string(),
+            overrides: overrides
+                .into_iter()
+                .map(|(key, val)| HashKeyOverride {
+                    feature_flag_key: key.to_string(),
+                    hash_key: val.to_string(),
+                })
+                .collect(),
+            existing_feature_flag_keys: vec![],
+        }
+    }
+
+    #[test]
+    fn test_merge_primary_distinct_id_wins_on_conflict() {
+        let results = vec![
+            make_context("user_b", vec![("flag_1", "hash_b")]),
+            make_context("user_a", vec![("flag_1", "hash_a")]),
+        ];
+
+        let overrides = merge_hash_key_overrides(&results, Some("user_a"));
+        assert_eq!(overrides.get("flag_1").unwrap(), "hash_a");
+    }
+
+    #[test]
+    fn test_merge_non_conflicting_overrides_from_all_distinct_ids() {
+        let results = vec![
+            make_context("user_a", vec![("flag_1", "hash_a")]),
+            make_context("user_b", vec![("flag_2", "hash_b")]),
+        ];
+
+        let overrides = merge_hash_key_overrides(&results, Some("user_a"));
+        assert_eq!(overrides.get("flag_1").unwrap(), "hash_a");
+        assert_eq!(overrides.get("flag_2").unwrap(), "hash_b");
+    }
+
+    #[test]
+    fn test_merge_works_regardless_of_result_order() {
+        // primary comes first in results
+        let results_primary_first = vec![
+            make_context("user_a", vec![("flag_1", "hash_a")]),
+            make_context("user_b", vec![("flag_1", "hash_b")]),
+        ];
+        // primary comes last in results
+        let results_primary_last = vec![
+            make_context("user_b", vec![("flag_1", "hash_b")]),
+            make_context("user_a", vec![("flag_1", "hash_a")]),
+        ];
+
+        let overrides_first = merge_hash_key_overrides(&results_primary_first, Some("user_a"));
+        let overrides_last = merge_hash_key_overrides(&results_primary_last, Some("user_a"));
+        assert_eq!(overrides_first, overrides_last);
+        assert_eq!(overrides_first.get("flag_1").unwrap(), "hash_a");
+    }
+
+    #[test]
+    fn test_merge_with_no_primary_distinct_id() {
+        let results = vec![
+            make_context("user_a", vec![("flag_1", "hash_a")]),
+            make_context("user_b", vec![("flag_1", "hash_b")]),
+        ];
+
+        // Without a primary, last writer wins (iteration order)
+        let overrides = merge_hash_key_overrides(&results, None);
+        assert_eq!(overrides.get("flag_1").unwrap(), "hash_b");
+    }
+
+    #[test]
+    fn test_merge_with_empty_results() {
+        let overrides = merge_hash_key_overrides(&[], Some("user_a"));
+        assert!(overrides.is_empty());
     }
 }

--- a/rust/feature-flags/src/personhog_client.rs
+++ b/rust/feature-flags/src/personhog_client.rs
@@ -320,6 +320,9 @@ pub mod mock {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    type CohortCall = (PersonId, Vec<CohortId>);
+    type GroupCall = (TeamId, Vec<(GroupTypeIndex, String)>);
+    type HashKeyContextCall = (TeamId, Vec<String>);
     type UpsertCall = (TeamId, Vec<String>, Vec<String>, String);
 
     pub struct MockPersonhogClient {
@@ -327,6 +330,9 @@ pub mod mock {
         cohort_responses: HashMap<PersonId, HashMap<CohortId, bool>>,
         group_responses: HashMap<TeamId, HashMap<GroupTypeIndex, HashMap<String, Value>>>,
         hash_key_override_responses: HashMap<TeamId, HashMap<String, String>>,
+        cohort_calls: Arc<Mutex<Vec<CohortCall>>>,
+        group_calls: Arc<Mutex<Vec<GroupCall>>>,
+        hash_key_context_calls: Arc<Mutex<Vec<HashKeyContextCall>>>,
         upsert_calls: Arc<Mutex<Vec<UpsertCall>>>,
         error: Option<(tonic::Code, String)>,
     }
@@ -344,6 +350,9 @@ pub mod mock {
                 cohort_responses: HashMap::new(),
                 group_responses: HashMap::new(),
                 hash_key_override_responses: HashMap::new(),
+                cohort_calls: Arc::new(Mutex::new(Vec::new())),
+                group_calls: Arc::new(Mutex::new(Vec::new())),
+                hash_key_context_calls: Arc::new(Mutex::new(Vec::new())),
                 upsert_calls: Arc::new(Mutex::new(Vec::new())),
                 error: None,
             }
@@ -392,6 +401,18 @@ pub mod mock {
             self
         }
 
+        pub fn get_cohort_calls(&self) -> Vec<CohortCall> {
+            self.cohort_calls.lock().unwrap().clone()
+        }
+
+        pub fn get_group_calls(&self) -> Vec<GroupCall> {
+            self.group_calls.lock().unwrap().clone()
+        }
+
+        pub fn get_hash_key_context_calls(&self) -> Vec<HashKeyContextCall> {
+            self.hash_key_context_calls.lock().unwrap().clone()
+        }
+
         pub fn get_upsert_calls(&self) -> Vec<UpsertCall> {
             self.upsert_calls.lock().unwrap().clone()
         }
@@ -420,7 +441,7 @@ pub mod mock {
         async fn check_cohort_membership(
             &self,
             person_id: PersonId,
-            _cohort_ids: &[CohortId],
+            cohort_ids: &[CohortId],
         ) -> Result<HashMap<CohortId, bool>, FlagError> {
             if let Some((code, message)) = &self.error {
                 return Err(FlagError::PersonhogError {
@@ -428,6 +449,10 @@ pub mod mock {
                     message: message.clone(),
                 });
             }
+            self.cohort_calls
+                .lock()
+                .unwrap()
+                .push((person_id, cohort_ids.to_vec()));
             Ok(self
                 .cohort_responses
                 .get(&person_id)
@@ -438,7 +463,7 @@ pub mod mock {
         async fn get_groups(
             &self,
             team_id: TeamId,
-            _group_identifiers: Vec<(GroupTypeIndex, String)>,
+            group_identifiers: Vec<(GroupTypeIndex, String)>,
         ) -> Result<HashMap<GroupTypeIndex, HashMap<String, Value>>, FlagError> {
             if let Some((code, message)) = &self.error {
                 return Err(FlagError::PersonhogError {
@@ -446,6 +471,10 @@ pub mod mock {
                     message: message.clone(),
                 });
             }
+            self.group_calls
+                .lock()
+                .unwrap()
+                .push((team_id, group_identifiers));
             Ok(self
                 .group_responses
                 .get(&team_id)
@@ -456,7 +485,7 @@ pub mod mock {
         async fn get_hash_key_override_context(
             &self,
             team_id: TeamId,
-            _distinct_ids: Vec<String>,
+            distinct_ids: Vec<String>,
         ) -> Result<HashMap<String, String>, FlagError> {
             if let Some((code, message)) = &self.error {
                 return Err(FlagError::PersonhogError {
@@ -464,6 +493,10 @@ pub mod mock {
                     message: message.clone(),
                 });
             }
+            self.hash_key_context_calls
+                .lock()
+                .unwrap()
+                .push((team_id, distinct_ids));
             Ok(self
                 .hash_key_override_responses
                 .get(&team_id)

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -38,6 +38,7 @@ use crate::{
         consts::{FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER},
         utils::team_id_label_filter,
     },
+    personhog_client::PersonhogFetcher,
     rayon_dispatcher::RayonDispatcher,
 };
 
@@ -76,6 +77,9 @@ pub struct State {
     pub config_hypercache_reader: Arc<HyperCacheReader>,
     /// Bounds concurrent large-batch dispatches to the Rayon pool
     pub rayon_dispatcher: RayonDispatcher,
+    /// Optional personhog gRPC client for fetching person data via the personhog-router
+    /// instead of direct SQL queries. Controlled by USE_PERSONHOG env var.
+    pub personhog_client: Option<Arc<dyn PersonhogFetcher>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -94,6 +98,7 @@ pub fn router(
     team_hypercache_reader: Arc<HyperCacheReader>,
     config_hypercache_reader: Arc<HyperCacheReader>,
     rayon_dispatcher: RayonDispatcher,
+    personhog_client: Option<Arc<dyn PersonhogFetcher>>,
     config: Config,
 ) -> Router {
     // Initialize flag definitions rate limiter with default and custom team rates
@@ -159,6 +164,7 @@ pub fn router(
         team_hypercache_reader,
         config_hypercache_reader,
         rayon_dispatcher,
+        personhog_client,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -336,7 +336,13 @@ pub async fn serve<F>(
     }
 
     let personhog_client: Option<Arc<dyn PersonhogFetcher>> = if *config.use_personhog {
-        match PersonhogClient::new(&config.personhog_url, config.personhog_timeout_ms) {
+        match PersonhogClient::new(
+            &config.personhog_url,
+            config.personhog_timeout_ms,
+            config.personhog_connect_timeout_ms,
+            config.personhog_keep_alive_interval_secs,
+            config.personhog_keep_alive_timeout_secs,
+        ) {
             Ok(client) => {
                 tracing::info!(
                     url = %config.personhog_url,

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -8,6 +8,7 @@ use crate::cohorts::cohort_cache_manager::CohortCacheManager;
 use crate::config::Config;
 use crate::database_pools::DatabasePools;
 use crate::db_monitor::DatabasePoolMonitor;
+use crate::personhog_client::{PersonhogClient, PersonhogFetcher};
 use crate::rayon_dispatcher::RayonDispatcher;
 use crate::router;
 use crate::tokio_monitor::TokioRuntimeMonitor;
@@ -334,6 +335,30 @@ pub async fn serve<F>(
         );
     }
 
+    let personhog_client: Option<Arc<dyn PersonhogFetcher>> = if *config.use_personhog {
+        match PersonhogClient::new(&config.personhog_url, config.personhog_timeout_ms) {
+            Ok(client) => {
+                tracing::info!(
+                    url = %config.personhog_url,
+                    timeout_ms = config.personhog_timeout_ms,
+                    "Personhog gRPC client enabled"
+                );
+                Some(Arc::new(client))
+            }
+            Err(e) => {
+                tracing::error!(
+                    url = %config.personhog_url,
+                    error = %e,
+                    "Failed to create personhog client, falling back to SQL"
+                );
+                None
+            }
+        }
+    } else {
+        tracing::info!("Personhog gRPC client disabled (USE_PERSONHOG=false)");
+        None
+    };
+
     let app = router::router(
         redis_client,
         dedicated_redis_client,
@@ -349,6 +374,7 @@ pub async fn serve<F>(
         team_hypercache_reader,
         config_hypercache_reader,
         rayon_dispatcher,
+        personhog_client,
         config,
     );
 

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1052,6 +1052,7 @@ impl TestContext {
             self.persons_reader.clone(),
             team_id,
             distinct_ids,
+            None,
         )
         .await
     }

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1053,6 +1053,7 @@ impl TestContext {
             team_id,
             distinct_ids,
             None,
+            false,
         )
         .await
     }

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -328,6 +328,7 @@ impl ServerHandle {
                 team_hypercache_reader,
                 config_hypercache_reader,
                 RayonDispatcher::new(2),
+                None, // personhog_client
                 config,
             );
 

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -125,7 +125,7 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
+            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None, None)
         }
         .get_match(&flags[0], None, None, &None)
         .unwrap();
@@ -1223,7 +1223,7 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
+            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None, None)
         }
         .get_match(&flags[0], None, None, &None)
         .unwrap();

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -125,7 +125,7 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None, None)
+            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
         .get_match(&flags[0], None, None, &None)
         .unwrap();
@@ -1223,7 +1223,7 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None, None)
+            FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
         .get_match(&flags[0], None, None, &None)
         .unwrap();


### PR DESCRIPTION
## Problem

The feature-flags Rust service currently queries the persons database directly via SQL
for all person, group, and cohort data needed during flag evaluation.
We want to migrate these reads and writes to go through the personhog gRPC service instead,
which owns the persons data domain and will eventually replace direct DB access.

## Changes

### Personhog client (`personhog_client.rs` — new file)

- Adds a `PersonhogClient` that wraps the personhog-router gRPC service, providing 5 methods:
  - `get_person_by_distinct_id` — person lookup + properties
  - `check_cohort_membership` — static cohort membership checks
  - `get_groups` — group properties by type index
  - `get_hash_key_override_context` — read hash key overrides for experience continuity
  - `upsert_hash_key_overrides` — write hash key overrides for experience continuity
- Defines a `PersonhogFetcher` trait abstracting these methods so tests can inject a mock
  without a running personhog cluster
- Includes `MockPersonhogClient` (behind `#[cfg(test)]`) with builder methods for test setup

### Feature flag evaluation integration

- `fetch_and_locally_cache_all_relevant_properties` — when `personhog_client` is `Some`,
  fetches person properties, cohort membership, and group properties via personhog
  instead of SQL
- `get_feature_flag_hash_key_overrides` — reads hash key overrides via personhog when available
- `set_feature_flag_hash_key_overrides` — writes hash key overrides via personhog when available
- `should_write_hash_key_override` — added personhog branch that checks existing overrides
  via gRPC instead of querying the persons database directly

### Configuration

- `USE_PERSONHOG` env var (default `false`) controls whether the gRPC client is initialized
- `PERSONHOG_URL` env var (default `http://localhost:50052`) points at personhog-router
- `PERSONHOG_TIMEOUT_MS` env var (default `3000`) configures gRPC request timeout

### Type plumbing

- When personhog is disabled, all code paths fall back to the existing SQL queries unchanged

### Tests

- 5 new tests using `MockPersonhogClient` that exercise the personhog code paths:
  - Person property fetch + cohort membership + group properties via personhog
  - Person-not-found handling
  - Hash key override reads via personhog
  - Hash key override writes via personhog (verifies correct upsert calls)
  - Error propagation from personhog errors

## How did you test this code?

- **Unit tests**: `cargo test -p feature-flags test_personhog` — all 5 mock-based tests pass
- **Lints**: `cargo fmt`, `cargo clippy`, `cargo check` all clean
- **Local dev integration testing**: ran personhog-replica + personhog-router + feature-flags
  locally with `USE_PERSONHOG=true`, then:
  - Evaluated flags via cURL for a known distinct ID and confirmed person property filters
    matched correctly through personhog
  - Evaluated flags for a second distinct ID belonging to the same person and confirmed
    identical results
  - Evaluated flags for an unknown user and confirmed rollout-percentage-only flags
    still returned correctly
  - Tested the EEC write path by passing `$anon_distinct_id` and confirmed
    `upsert_hash_key_overrides` was called via personhog
- **UI testing**: created a feature flag with a person property filter in the PostHog UI,
  toggled it on, and confirmed it evaluated correctly for the logged-in user via the
  JS SDK's `/flags` call

