### PR TITLE
fix: clean up gemini uploaded files

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -8,6 +8,7 @@ from posthog.temporal.ai.research_agent import ResearchAgentWorkflow, process_re
 from posthog.temporal.ai.session_summary.activities import (
     analyze_video_segment_activity,
     capture_timing_activity,
+    cleanup_gemini_file_activity,
     consolidate_video_segments_activity,
     embed_and_store_segments_activity,
     prep_session_video_asset_activity,
@@ -118,6 +119,7 @@ SIGNALS_ACTIVITIES = [
     analyze_video_segment_activity,
     embed_and_store_segments_activity,
     store_video_session_summary_activity,
+    cleanup_gemini_file_activity,
     consolidate_video_segments_activity,
     capture_timing_activity,
     get_sessions_to_prime_activity,

--- a/posthog/temporal/ai/session_summary/activities/__init__.py
+++ b/posthog/temporal/ai/session_summary/activities/__init__.py
@@ -4,6 +4,7 @@ from .a3_analyze_video_segment import analyze_video_segment_activity
 from .a4_consolidate_video_segments import consolidate_video_segments_activity
 from .a5_embed_and_store_segments import embed_and_store_segments_activity
 from .a6_store_video_session_summary import store_video_session_summary_activity
+from .a7_cleanup_gemini_file import cleanup_gemini_file_activity
 from .capture_timing import CaptureTimingInputs, capture_timing_activity
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "consolidate_video_segments_activity",
     "embed_and_store_segments_activity",
     "store_video_session_summary_activity",
+    "cleanup_gemini_file_activity",
     "capture_timing_activity",
 ]

--- a/posthog/temporal/ai/session_summary/activities/a2_upload_video_to_gemini.py
+++ b/posthog/temporal/ai/session_summary/activities/a2_upload_video_to_gemini.py
@@ -121,6 +121,7 @@ async def upload_video_to_gemini_activity(
 
             uploaded_video = UploadedVideo(
                 file_uri=uploaded_file.uri,
+                gemini_file_name=uploaded_file.name,
                 mime_type=uploaded_file.mime_type or MOMENT_VIDEO_EXPORT_FORMAT,
                 duration=duration,
             )

--- a/posthog/temporal/ai/session_summary/activities/a7_cleanup_gemini_file.py
+++ b/posthog/temporal/ai/session_summary/activities/a7_cleanup_gemini_file.py
@@ -1,0 +1,34 @@
+"""
+Activity 7 of the video-based summarization workflow:
+Delete the uploaded video file from Gemini to free storage quota.
+"""
+
+from django.conf import settings
+
+import structlog
+import temporalio
+from asgiref.sync import sync_to_async
+from google.genai import Client as RawGenAIClient
+
+logger = structlog.get_logger(__name__)
+
+
+@temporalio.activity.defn
+async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -> None:
+    """Delete an uploaded file from Gemini. Best-effort: logs failures but never raises."""
+    try:
+        raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
+        await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=gemini_file_name)
+        logger.info(
+            f"Deleted Gemini file {gemini_file_name} for session {session_id}",
+            gemini_file_name=gemini_file_name,
+            session_id=session_id,
+            signals_type="session-summaries",
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to delete Gemini file {gemini_file_name} for session {session_id}",
+            gemini_file_name=gemini_file_name,
+            session_id=session_id,
+            signals_type="session-summaries",
+        )

--- a/posthog/temporal/ai/session_summary/types/video.py
+++ b/posthog/temporal/ai/session_summary/types/video.py
@@ -36,6 +36,7 @@ class UploadedVideo(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     file_uri: str
+    gemini_file_name: str = Field(description="Gemini file identifier for deletion (e.g. 'files/abc123')")
     mime_type: str
     duration: int = Field(description="Duration in seconds")
 

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -61,6 +61,7 @@ class TestAITemporalModuleIntegrity:
             "consolidate_video_segments_activity",
             "embed_and_store_segments_activity",
             "store_video_session_summary_activity",
+            "cleanup_gemini_file_activity",
             "capture_timing_activity",
             "get_sessions_to_prime_activity",
             "fetch_segments_activity",


### PR DESCRIPTION
## Problem

we don't delete files after uploading to gemini

they have a 48hr ttl, BUT we are capped at 20gb total

more details here: https://posthog.slack.com/archives/C09KTRWD3HD/p1771653050547899

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds automatic cleanup as the last step in the session summarizer

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

i'm gonna be so real, this is 100% claude

but i did validate & mitigate the issue (see slack thread)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->