### PR TITLE
feat: add some events to weekly digest

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1455,7 +1455,8 @@ def send_error_tracking_weekly_digest_for_team(
     daily_counts = get_daily_exception_counts(team_id)
     crash_free = get_crash_free_sessions(team)
 
-    date_suffix = timezone.now().strftime("%Y-%W")
+    # TODO: restore to "%Y-%W" after testing (currently allows one email per hour)
+    date_suffix = timezone.now().strftime("%Y-%W-%d-%H")
     error_tracking_url = f"{settings.SITE_URL}/project/{team_id}/error_tracking?utm_source=error_tracking_weekly_digest"
     ingestion_failures_url = build_ingestion_failures_url(team_id)
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1456,7 +1456,7 @@ def send_error_tracking_weekly_digest_for_team(
     crash_free = get_crash_free_sessions(team)
 
     date_suffix = timezone.now().strftime("%Y-%W")
-    error_tracking_url = f"{settings.SITE_URL}/project/{team_id}/error_tracking"
+    error_tracking_url = f"{settings.SITE_URL}/project/{team_id}/error_tracking?utm_source=error_tracking_weekly_digest"
     ingestion_failures_url = build_ingestion_failures_url(team_id)
 
     for membership in memberships_to_email:
@@ -1476,6 +1476,7 @@ def send_error_tracking_weekly_digest_for_team(
                 "error_tracking_url": error_tracking_url,
                 "ingestion_failures_url": ingestion_failures_url,
                 "contact_support_url": "https://posthog.com/support",
+                "feedback_survey_url": f"https://us.posthog.com/external_surveys/019c7fd6-7cfa-0000-2b03-a8e5d4c03743?distinct_id={membership.user.distinct_id}",
             },
         )
         message.add_user_recipient(membership.user)

--- a/posthog/tasks/test/preview_error_tracking_digest.py
+++ b/posthog/tasks/test/preview_error_tracking_digest.py
@@ -42,7 +42,7 @@ html = template.render(
                     {"height_percent": 75},
                     {"height_percent": 80},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/abc",
+                "url": "https://us.posthog.com/project/2/error_tracking/abc?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "def",
@@ -58,7 +58,7 @@ html = template.render(
                     {"height_percent": 70},
                     {"height_percent": 50},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/def",
+                "url": "https://us.posthog.com/project/2/error_tracking/def?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "ghi",
@@ -74,7 +74,7 @@ html = template.render(
                     {"height_percent": 55},
                     {"height_percent": 40},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/ghi",
+                "url": "https://us.posthog.com/project/2/error_tracking/ghi?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "jkl",
@@ -90,7 +90,7 @@ html = template.render(
                     {"height_percent": 80},
                     {"height_percent": 60},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/jkl",
+                "url": "https://us.posthog.com/project/2/error_tracking/jkl?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "mno",
@@ -106,7 +106,7 @@ html = template.render(
                     {"height_percent": 100},
                     {"height_percent": 85},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/mno",
+                "url": "https://us.posthog.com/project/2/error_tracking/mno?utm_source=error_tracking_weekly_digest",
             },
         ],
         "new_issues": [
@@ -124,7 +124,7 @@ html = template.render(
                     {"height_percent": 100},
                     {"height_percent": 85},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/new1",
+                "url": "https://us.posthog.com/project/2/error_tracking/new1?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "new2",
@@ -140,7 +140,7 @@ html = template.render(
                     {"height_percent": 100},
                     {"height_percent": 70},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/new2",
+                "url": "https://us.posthog.com/project/2/error_tracking/new2?utm_source=error_tracking_weekly_digest",
             },
             {
                 "id": "new3",
@@ -156,7 +156,7 @@ html = template.render(
                     {"height_percent": 100},
                     {"height_percent": 45},
                 ],
-                "url": "https://us.posthog.com/project/2/error_tracking/new3",
+                "url": "https://us.posthog.com/project/2/error_tracking/new3?utm_source=error_tracking_weekly_digest",
             },
         ],
         "crash_free": {
@@ -164,9 +164,10 @@ html = template.render(
             "crash_sessions": 3421,
             "crash_free_rate": 98.80,
         },
-        "error_tracking_url": "https://us.posthog.com/project/2/error_tracking",
+        "error_tracking_url": "https://us.posthog.com/project/2/error_tracking?utm_source=error_tracking_weekly_digest",
         "ingestion_failures_url": "https://us.posthog.com/project/2/activity/explore",
         "contact_support_url": "https://posthog.com/support",
+        "feedback_survey_url": "https://us.posthog.com/external_surveys/019c7fd6-7cfa-0000-2b03-a8e5d4c03743?distinct_id=test@posthog.com",
     }
 )
 

--- a/posthog/templates/email/error_tracking_weekly_digest.html
+++ b/posthog/templates/email/error_tracking_weekly_digest.html
@@ -172,6 +172,9 @@
 <div style="margin-bottom: 16px; text-align: center;">
     <a href="{{ error_tracking_url }}" style="display: inline-block; padding: 10px 24px; background-color: #f54e00; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 0.9em;">Open error tracking</a>
 </div>
+<div style="margin-bottom: 16px; text-align: center;">
+    <a href="{{ feedback_survey_url }}" target="_blank" style="color: #6b7280; font-size: 0.85em; text-decoration: underline;">Share feedback on this digest</a>
+</div>
 {% endblock %}
 
 {% block footer %}

--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -230,7 +230,7 @@ def _build_issues_list(results: list, issues_by_id: dict, team: Team) -> list[di
                 "description": issue.description if issue else None,
                 "occurrence_count": occurrence_count,
                 "sparkline": sparkline,
-                "url": f"{settings.SITE_URL}/project/{team.pk}/error_tracking/{issue_id}",
+                "url": f"{settings.SITE_URL}/project/{team.pk}/error_tracking/{issue_id}?utm_source=error_tracking_weekly_digest",
             }
         )
     return issues

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -66,7 +66,11 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     const { updateAssignee, updateStatus, updateName } = useActions(errorTrackingIssueSceneLogic)
 
     useEffect(() => {
-        posthog.capture('error_tracking_issue_viewed', { issue_id: issueId })
+        const utmSource = new URLSearchParams(window.location.search).get('utm_source')
+        posthog.capture('error_tracking_issue_viewed', {
+            issue_id: issueId,
+            ...(utmSource ? { utm_source: utmSource } : {}),
+        })
     }, [issueId])
 
     return (

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -57,6 +57,7 @@ export function ErrorTrackingScene(): JSX.Element {
     const hasIssueCorrelation = useFeatureFlag('ERROR_TRACKING_ISSUE_CORRELATION')
 
     useOnMountEffect(() => {
+        const utmSource = new URLSearchParams(window.location.search).get('utm_source')
         api.hogFunctions
             .list({
                 types: ['internal_destination'],
@@ -66,6 +67,7 @@ export function ErrorTrackingScene(): JSX.Element {
                 posthog.capture('error_tracking_issues_list_viewed', {
                     active_tab: activeTab,
                     alert_destination_count: res.results.length,
+                    ...(utmSource ? { utm_source: utmSource } : {}),
                 })
             })
     })


### PR DESCRIPTION
- adds utm source tracking in issue viewed and issues list viewed,
- links to survey to give feedback on this email,
- adjusts campaign key to let us send emails more often than 1 per week for debug purposes.