### PR TITLE
chore(playwright): Add to playwright setup utils

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22795,57 +22795,6 @@
             "enum": ["pending", "in_progress", "completed"],
             "type": "string"
         },
-        "PlaywrightWorkspaceSetupData": {
-            "additionalProperties": false,
-            "properties": {
-                "organization_name": {
-                    "type": "string"
-                },
-                "skip_onboarding": {
-                    "type": "boolean"
-                },
-                "use_current_time": {
-                    "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "PlaywrightWorkspaceSetupResult": {
-            "additionalProperties": false,
-            "properties": {
-                "organization_id": {
-                    "type": "string"
-                },
-                "organization_name": {
-                    "type": "string"
-                },
-                "personal_api_key": {
-                    "type": "string"
-                },
-                "team_id": {
-                    "type": "string"
-                },
-                "team_name": {
-                    "type": "string"
-                },
-                "user_email": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "organization_id",
-                "team_id",
-                "organization_name",
-                "team_name",
-                "user_id",
-                "user_email",
-                "personal_api_key"
-            ],
-            "type": "object"
-        },
         "ProductAnalyticsInsightQueryNode": {
             "anyOf": [
                 {
@@ -32151,38 +32100,6 @@
                 "results",
                 "timezone"
             ],
-            "type": "object"
-        },
-        "TestSetupRequest": {
-            "additionalProperties": false,
-            "properties": {
-                "data": {
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "TestSetupResponse": {
-            "additionalProperties": false,
-            "properties": {
-                "available_tests": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "result": {},
-                "success": {
-                    "type": "boolean"
-                },
-                "test_name": {
-                    "type": "string"
-                }
-            },
-            "required": ["success", "test_name"],
             "type": "object"
         },
         "TikTokAdsDefaultSources": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5187,35 +5187,6 @@ export enum InfinityValue {
     NEGATIVE_INFINITY_VALUE = -999999,
 }
 
-// PostHog Playwright Setup Types for Playwright Testing
-export interface TestSetupRequest {
-    data?: Record<string, any>
-}
-
-export interface TestSetupResponse {
-    success: boolean
-    test_name: string
-    result?: any
-    error?: string
-    available_tests?: string[]
-}
-
-export interface PlaywrightWorkspaceSetupData {
-    organization_name?: string
-    use_current_time?: boolean
-    skip_onboarding?: boolean
-}
-
-export interface PlaywrightWorkspaceSetupResult {
-    organization_id: string
-    team_id: string
-    organization_name: string
-    team_name: string
-    user_id: string
-    user_email: string
-    personal_api_key: string
-}
-
 export type UsageMetricFormat = 'numeric' | 'currency'
 
 export type UsageMetricDisplay = 'number' | 'sparkline'

--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -12,13 +12,70 @@
  */
 import { APIRequestContext, Page } from '@playwright/test'
 
-import type {
-    PlaywrightWorkspaceSetupData,
-    PlaywrightWorkspaceSetupResult,
-    TestSetupResponse,
-} from '~/queries/schema/schema-general'
-
 import { LOGIN_PASSWORD } from './playwright-test-core'
+
+export interface TestSetupResponse {
+    success: boolean
+    test_name: string
+    result?: any
+    error?: string
+    available_tests?: string[]
+}
+
+export interface PlaywrightSetupVariable {
+    name: string
+    type: 'String' | 'Number' | 'Boolean' | 'List' | 'Date'
+    default_value?: any
+}
+
+export interface PlaywrightSetupInsight {
+    name: string
+    query: Record<string, any>
+    variable_indexes?: number[]
+}
+
+export interface PlaywrightSetupDashboard {
+    name: string
+    insight_indexes?: number[]
+    filters?: Record<string, any>
+    variable_overrides?: Record<string, any>
+}
+
+export interface PlaywrightWorkspaceSetupData {
+    organization_name?: string
+    use_current_time?: boolean
+    skip_onboarding?: boolean
+    insight_variables?: PlaywrightSetupVariable[]
+    insights?: PlaywrightSetupInsight[]
+    dashboards?: PlaywrightSetupDashboard[]
+}
+
+export interface PlaywrightSetupCreatedVariable {
+    id: string
+    code_name: string
+}
+
+export interface PlaywrightSetupCreatedInsight {
+    id: number
+    short_id: string
+}
+
+export interface PlaywrightSetupCreatedDashboard {
+    id: number
+}
+
+export interface PlaywrightWorkspaceSetupResult {
+    organization_id: string
+    team_id: string
+    organization_name: string
+    team_name: string
+    user_id: string
+    user_email: string
+    personal_api_key: string
+    created_variables?: PlaywrightSetupCreatedVariable[]
+    created_insights?: PlaywrightSetupCreatedInsight[]
+    created_dashboards?: PlaywrightSetupCreatedDashboard[]
+}
 
 export interface PlaywrightSetupOptions {
     /** Custom data to pass to the setup function */
@@ -159,6 +216,3 @@ export async function createTestWorkspace(
     const playwrightSetup = createPlaywrightSetup(request)
     return playwrightSetup.callSetupEndpoint(setupType, { data })
 }
-
-// Re-export types for convenience
-export type { TestSetupResponse, PlaywrightWorkspaceSetupData, PlaywrightWorkspaceSetupResult }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3008,28 +3008,6 @@ class PlanningStepStatus(StrEnum):
     COMPLETED = "completed"
 
 
-class PlaywrightWorkspaceSetupData(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    organization_name: str | None = None
-    skip_onboarding: bool | None = None
-    use_current_time: bool | None = None
-
-
-class PlaywrightWorkspaceSetupResult(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    organization_id: str
-    organization_name: str
-    personal_api_key: str
-    team_id: str
-    team_name: str
-    user_email: str
-    user_id: str
-
-
 class ProductIntentContext(StrEnum):
     ONBOARDING_PRODUCT_SELECTED___PRIMARY = "onboarding product selected - primary"
     ONBOARDING_PRODUCT_SELECTED___SECONDARY = "onboarding product selected - secondary"
@@ -3997,24 +3975,6 @@ class TaxonomicFilterGroupType(StrEnum):
     WORKFLOW_VARIABLES = "workflow_variables"
     SUGGESTED_FILTERS = "suggested_filters"
     EMPTY = "empty"
-
-
-class TestSetupRequest(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    data: dict[str, Any] | None = None
-
-
-class TestSetupResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    available_tests: list[str] | None = None
-    error: str | None = None
-    result: Any | None = None
-    success: bool
-    test_name: str
 
 
 class TikTokAdsDefaultSources(StrEnum):

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -3,19 +3,82 @@
 import secrets
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol, runtime_checkable
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
 
 from django.utils import timezone
 
 from pydantic import BaseModel
 
-from posthog.schema import PlaywrightWorkspaceSetupData, PlaywrightWorkspaceSetupResult
-
 from posthog.constants import AvailableFeature
 from posthog.management.commands.generate_demo_data import Command as GenerateDemoDataCommand
-from posthog.models import PersonalAPIKey, User
+from posthog.models import Dashboard, DashboardTile, Insight, PersonalAPIKey, User
+from posthog.models.insight_variable import InsightVariable
 from posthog.models.personal_api_key import hash_key_value
 from posthog.models.utils import mask_key_value
+
+
+class PlaywrightSetupVariableType(StrEnum):
+    STRING = "String"
+    NUMBER = "Number"
+    BOOLEAN = "Boolean"
+    LIST = "List"
+    DATE = "Date"
+
+
+class PlaywrightSetupVariable(BaseModel):
+    name: str
+    type: PlaywrightSetupVariableType
+    default_value: Any | None = None
+
+
+class PlaywrightSetupInsight(BaseModel):
+    name: str
+    query: dict[str, Any]
+    variable_indexes: list[int] | None = None
+
+
+class PlaywrightSetupDashboard(BaseModel):
+    name: str
+    insight_indexes: list[int] | None = None
+    filters: dict[str, Any] | None = None
+    variable_overrides: dict[str, Any] | None = None
+
+
+class PlaywrightWorkspaceSetupData(BaseModel):
+    organization_name: str | None = None
+    use_current_time: bool | None = None
+    skip_onboarding: bool | None = None
+    insight_variables: list[PlaywrightSetupVariable] | None = None
+    insights: list[PlaywrightSetupInsight] | None = None
+    dashboards: list[PlaywrightSetupDashboard] | None = None
+
+
+class PlaywrightSetupCreatedVariable(BaseModel):
+    id: str
+    code_name: str
+
+
+class PlaywrightSetupCreatedInsight(BaseModel):
+    id: int
+    short_id: str
+
+
+class PlaywrightSetupCreatedDashboard(BaseModel):
+    id: int
+
+
+class PlaywrightWorkspaceSetupResult(BaseModel):
+    organization_id: str
+    team_id: str
+    organization_name: str
+    team_name: str
+    user_id: str
+    user_email: str
+    personal_api_key: str
+    created_variables: list[PlaywrightSetupCreatedVariable] | None = None
+    created_insights: list[PlaywrightSetupCreatedInsight] | None = None
+    created_dashboards: list[PlaywrightSetupCreatedDashboard] | None = None
 
 
 @runtime_checkable
@@ -117,6 +180,10 @@ def create_organization_with_team(data: PlaywrightWorkspaceSetupData) -> Playwri
         }
         team.save()
 
+    created_variables = _create_variables(data, team)
+    created_insights = _create_insights(data, team, user, created_variables)
+    created_dashboards = _create_dashboards(data, team, user, created_variables, created_insights)
+
     return PlaywrightWorkspaceSetupResult(
         organization_id=str(organization.id),
         team_id=str(team.id),
@@ -125,7 +192,100 @@ def create_organization_with_team(data: PlaywrightWorkspaceSetupData) -> Playwri
         user_id=str(user.id),
         user_email=user.email,
         personal_api_key=api_key._value,  # type: ignore
+        created_variables=[
+            PlaywrightSetupCreatedVariable(id=str(v.id), code_name=v.code_name or "") for v in created_variables
+        ]
+        or None,
+        created_insights=[PlaywrightSetupCreatedInsight(id=i.id, short_id=i.short_id) for i in created_insights]
+        or None,
+        created_dashboards=[PlaywrightSetupCreatedDashboard(id=d.id) for d in created_dashboards] or None,
     )
+
+
+def _derive_code_name(name: str) -> str:
+    return "".join(c for c in name if c.isalnum() or c == " " or c == "_").replace(" ", "_").lower()
+
+
+def _create_variables(data: PlaywrightWorkspaceSetupData, team: "Team") -> list[InsightVariable]:  # type: ignore[name-defined] # noqa: F821
+    if not data.insight_variables:
+        return []
+    created: list[InsightVariable] = []
+    for var_spec in data.insight_variables:
+        var = InsightVariable.objects.create(
+            team=team,
+            name=var_spec.name,
+            code_name=_derive_code_name(var_spec.name),
+            type=var_spec.type,
+            default_value=var_spec.default_value,
+        )
+        created.append(var)
+    return created
+
+
+def _create_insights(
+    data: PlaywrightWorkspaceSetupData,
+    team: "Team",  # type: ignore[name-defined] # noqa: F821
+    user: User,
+    created_variables: list[InsightVariable],
+) -> list[Insight]:
+    if not data.insights:
+        return []
+    created: list[Insight] = []
+    for insight_spec in data.insights:
+        query = insight_spec.query
+        if insight_spec.variable_indexes and created_variables:
+            variables_dict: dict[str, dict[str, str]] = {}
+            for idx in insight_spec.variable_indexes:
+                var = created_variables[int(idx)]
+                variables_dict[str(var.id)] = {"code_name": var.code_name or "", "variableId": str(var.id)}
+            if "source" in query:
+                query = {**query, "source": {**query["source"], "variables": variables_dict}}
+        insight = Insight.objects.create(
+            team=team,
+            name=insight_spec.name,
+            query=query,
+            created_by=user,
+        )
+        created.append(insight)
+    return created
+
+
+def _create_dashboards(
+    data: PlaywrightWorkspaceSetupData,
+    team: "Team",  # type: ignore[name-defined] # noqa: F821
+    user: User,
+    created_variables: list[InsightVariable],
+    created_insights: list[Insight],
+) -> list[Dashboard]:
+    if not data.dashboards:
+        return []
+    created: list[Dashboard] = []
+    for dash_spec in data.dashboards:
+        variables = None
+        if dash_spec.variable_overrides and created_variables:
+            variables = {}
+            for idx_str, override_value in dash_spec.variable_overrides.items():
+                var = created_variables[int(idx_str)]
+                variables[str(var.id)] = {
+                    "code_name": var.code_name or "",
+                    "variableId": str(var.id),
+                    "value": override_value,
+                }
+        dashboard = Dashboard.objects.create(
+            team=team,
+            name=dash_spec.name,
+            created_by=user,
+            filters=dash_spec.filters or {},
+            variables=variables or {},
+        )
+        if dash_spec.insight_indexes and created_insights:
+            for idx in dash_spec.insight_indexes:
+                DashboardTile.objects.create(
+                    dashboard=dashboard,
+                    insight=created_insights[int(idx)],
+                )
+        created.append(dashboard)
+    return created
 
 
 @dataclass(frozen=True)

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -86,7 +86,9 @@ class PlaywrightSetupFunction(Protocol):
     def __call__(self, data: BaseModel, /) -> BaseModel: ...
 
 
-def create_organization_with_team(data: PlaywrightWorkspaceSetupData) -> PlaywrightWorkspaceSetupResult:
+def create_organization_with_team(
+    data: PlaywrightWorkspaceSetupData,
+) -> PlaywrightWorkspaceSetupResult:
     """Creates PostHog workspace with organization, team, user, API key, and demo data."""
     org_name = data.organization_name or "Hedgebox Inc."
 
@@ -155,7 +157,11 @@ def create_organization_with_team(data: PlaywrightWorkspaceSetupData) -> Playwri
     api_key, _ = PersonalAPIKey.objects.get_or_create(
         user=user,
         label="Test API Key",
-        defaults={"secure_value": secure_value, "mask_value": mask_value, "scopes": ["*"]},
+        defaults={
+            "secure_value": secure_value,
+            "mask_value": mask_value,
+            "scopes": ["*"],
+        },
     )
     api_key._value = api_key_value  # type: ignore
 
@@ -236,9 +242,15 @@ def _create_insights(
             variables_dict: dict[str, dict[str, str]] = {}
             for idx in insight_spec.variable_indexes:
                 var = created_variables[int(idx)]
-                variables_dict[str(var.id)] = {"code_name": var.code_name or "", "variableId": str(var.id)}
+                variables_dict[str(var.id)] = {
+                    "code_name": var.code_name or "",
+                    "variableId": str(var.id),
+                }
             if "source" in query:
-                query = {**query, "source": {**query["source"], "variables": variables_dict}}
+                query = {
+                    **query,
+                    "source": {**query["source"], "variables": variables_dict},
+                }
         insight = Insight.objects.create(
             team=team,
             name=insight_spec.name,

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -280,6 +280,8 @@ def _create_dashboards(
         )
         if dash_spec.insight_indexes and created_insights:
             for idx in dash_spec.insight_indexes:
+                if int(idx) >= len(created_insights):
+                    continue  # Skip invalid indexes
                 DashboardTile.objects.create(
                     dashboard=dashboard,
                     insight=created_insights[int(idx)],

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -198,12 +198,19 @@ def create_organization_with_team(
         user_id=str(user.id),
         user_email=user.email,
         personal_api_key=api_key._value,  # type: ignore
-        created_variables=[
-            PlaywrightSetupCreatedVariable(id=str(v.id), code_name=v.code_name or "") for v in created_variables
-        ] if created_variables else None,
-        created_insights=[PlaywrightSetupCreatedInsight(id=i.id, short_id=i.short_id) for i in created_insights]
-        if created_insights else None,
-        created_dashboards=[PlaywrightSetupCreatedDashboard(id=d.id) for d in created_dashboards] if created_dashboards else None,
+        created_variables=(
+            [PlaywrightSetupCreatedVariable(id=str(v.id), code_name=v.code_name or "") for v in created_variables]
+            if created_variables
+            else None
+        ),
+        created_insights=(
+            [PlaywrightSetupCreatedInsight(id=i.id, short_id=i.short_id) for i in created_insights]
+            if created_insights
+            else None
+        ),
+        created_dashboards=(
+            [PlaywrightSetupCreatedDashboard(id=d.id) for d in created_dashboards] if created_dashboards else None
+        ),
     )
 
 

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -194,11 +194,10 @@ def create_organization_with_team(data: PlaywrightWorkspaceSetupData) -> Playwri
         personal_api_key=api_key._value,  # type: ignore
         created_variables=[
             PlaywrightSetupCreatedVariable(id=str(v.id), code_name=v.code_name or "") for v in created_variables
-        ]
-        or None,
+        ] if created_variables else None,
         created_insights=[PlaywrightSetupCreatedInsight(id=i.id, short_id=i.short_id) for i in created_insights]
-        or None,
-        created_dashboards=[PlaywrightSetupCreatedDashboard(id=d.id) for d in created_dashboards] or None,
+        if created_insights else None,
+        created_dashboards=[PlaywrightSetupCreatedDashboard(id=d.id) for d in created_dashboards] if created_dashboards else None,
     )
 
 


### PR DESCRIPTION
## Problem
- Want more flexibility in options to setup workspaces for playwright.
- We have playwright test related stuff in our actual production schema


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add `createWorkspace()` support for seeding variables, insights, and dashboards
- Define models and TypeScript interfaces in test infrastructure files instead of the production schema pipeline
- Remove Playwright test types from `schema-general.ts` and `posthog/schema.py`

## How did you test this code?
There's a PR above this in the stack that uses these utils

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

