### PR TITLE
fix(tests): use freeze_time in test_period_not_final to fix flakiness

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -545,8 +545,9 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(0, friday["reached_from_step_count"])
         self.assertEqual(0, friday["conversion_rate"])
 
+    @freeze_time("2021-05-02 12:00:00")
     def test_period_not_final(self):
-        now = datetime.now()
+        now = datetime(2021, 5, 2, 12, 0, 0)
 
         journeys_for(
             {
@@ -564,8 +565,8 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
             "funnel_viz_type": "trends",
             "display": TRENDS_LINEAR,
             "interval": "day",
-            "date_from": (now - timedelta(1)).strftime(FORMAT_TIME),
-            "date_to": now.strftime(FORMAT_TIME_DAY_END),
+            "date_from": "2021-05-01 00:00:00",
+            "date_to": "2021-05-02 23:59:59",
             "funnel_window_days": 1,
             "events": [
                 {"id": "step one", "order": 0},
@@ -585,7 +586,7 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day["conversion_rate"], 0)
         self.assertEqual(
             day["timestamp"].replace(tzinfo=ZoneInfo("UTC")),
-            (datetime(now.year, now.month, now.day) - timedelta(1)).replace(tzinfo=ZoneInfo("UTC")),
+            datetime(2021, 5, 1, tzinfo=ZoneInfo("UTC")),
         )
 
         day = results[1]  # today
@@ -594,7 +595,7 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day["conversion_rate"], 100)
         self.assertEqual(
             day["timestamp"].replace(tzinfo=ZoneInfo("UTC")),
-            datetime(now.year, now.month, now.day).replace(tzinfo=ZoneInfo("UTC")),
+            datetime(2021, 5, 2, tzinfo=ZoneInfo("UTC")),
         )
 
     def test_two_runs_by_single_user_in_one_period(self):


### PR DESCRIPTION
## Summary

- Fix flaky `test_period_not_final` in both legacy and HogQL funnel trends test suites
- The test used `datetime.now()` which fails when CI runs near midnight UTC, causing events to land in a different day bucket than expected
- Replace with `@freeze_time` and fixed timestamps to make the test deterministic

## Test plan

- [ ] Verify both `test_period_not_final` tests pass in CI regardless of time of day