### PR TITLE
Twig llm rate limits

### DIFF
--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -8,7 +8,11 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import Throttle
 
@@ -22,7 +26,8 @@ def create_test_app(
 
     default_throttles: list[Throttle] = [
         ProductCostThrottle(redis=None),
-        UserCostThrottle(redis=None),
+        UserCostBurstThrottle(redis=None),
+        UserCostSustainedThrottle(redis=None),
     ]
 
     @asynccontextmanager

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -76,8 +76,7 @@ class TestUserCostLimitConfig:
         assert twig.sustained_limit_usd == 500.0
         get_settings.cache_clear()
 
-    def test_empty_string_returns_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_USER_COST_LIMITS", "")
+    def test_unset_env_returns_defaults(self) -> None:
         get_settings.cache_clear()
         settings = get_settings()
         assert "twig" in settings.user_cost_limits

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -4,7 +4,11 @@ import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import get_settings
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import (
     Throttle,
@@ -135,9 +139,10 @@ class TestThrottleRunner:
     @pytest.mark.asyncio
     async def test_composite_cost_throttle_order(self) -> None:
         product_throttle = ProductCostThrottle(redis=None)
-        user_throttle = UserCostThrottle(redis=None)
+        burst_throttle = UserCostBurstThrottle(redis=None)
+        sustained_throttle = UserCostSustainedThrottle(redis=None)
 
-        runner = ThrottleRunner(throttles=[product_throttle, user_throttle])
+        runner = ThrottleRunner(throttles=[product_throttle, burst_throttle, sustained_throttle])
 
         user = make_user(auth_method="personal_api_key")
         context = make_context(user=user, product="llm_gateway")


### PR DESCRIPTION
## Problem

User cost rate limits on the LLM Gateway were disabled and lacked per-product burst/sustained configuration. This prevented setting specific daily and monthly cost limits for products like Twig, which requires a $100/day and $1000/month limit to manage costs effectively.

## Changes

- Replaced the single `UserCostThrottle` with distinct `UserCostBurstThrottle` (daily) and `UserCostSustainedThrottle` (monthly) to support burst/sustained patterns.
- Introduced `user_cost_limits` configuration (via `LLM_GATEWAY_USER_COST_LIMITS` env var) to define per-product cost limits.
- Set default limits for Twig: $100 USD/day (burst) and $1000 USD/month (sustained).
- `user_cost_limits_disabled` now defaults to `false`, enabling limits by default.
- Products not explicitly configured in `user_cost_limits` will not be rate-limited by cost.

## How did you test this code?

- Updated and expanded unit tests in `test_cost_throttles.py` to cover the new burst/sustained throttles, product-specific limits, and the `user_cost_limits_disabled` flag.
- Verified all 477 LLM Gateway tests pass.

## Publish to changelog?

Yes

---
[Slack Thread](https://posthog.slack.com/archives/D09AS56P2FJ/p1771759340619509?thread_ts=1771759340.619509&cid=D09AS56P2FJ)

<p><a href="https://cursor.com/agents?id=bc-9b332c85-3f55-57d6-8f36-a151134a303a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b332c85-3f55-57d6-8f36-a151134a303a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

