### PR TITLE
feat(gateway): user cost throttles

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -26,7 +26,7 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
 DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
     "twig": UserCostLimit(
         burst_limit_usd=100.0,
-        burst_window_seconds=86400,
+        burst_window_seconds=18000,
         sustained_limit_usd=1000.0,
         sustained_window_seconds=2592000,
     ),

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -174,7 +174,7 @@ class UserCostBurstThrottle(_UserCostThrottleBase):
     scope = "user_cost_burst"
 
     def _get_limit_exceeded_detail(self) -> str:
-        return "User daily rate limit exceeded"
+        return "User burst rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._require_config(context)
@@ -186,7 +186,7 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
     scope = "user_cost_sustained"
 
     def _get_limit_exceeded_detail(self) -> str:
-        return "User monthly rate limit exceeded"
+        return "User sustained rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._require_config(context)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
 import structlog
 from redis.asyncio import Redis
 
 from llm_gateway.config import get_settings
+
+if TYPE_CHECKING:
+    from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
 from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
 
@@ -145,6 +149,12 @@ class _UserCostThrottleBase(CostThrottle):
     def _has_config(self, context: ThrottleContext) -> bool:
         return context.product in get_settings().user_cost_limits
 
+    def _require_config(self, context: ThrottleContext) -> UserCostLimit:
+        config = get_settings().user_cost_limits.get(context.product)
+        if not config:
+            raise RuntimeError(f"No user_cost_limits config for product '{context.product}' — guard check missed")
+        return config
+
     async def allow_request(self, context: ThrottleContext) -> ThrottleResult:
         if not context.end_user_id or not self._has_config(context):
             return ThrottleResult.allow()
@@ -167,10 +177,7 @@ class UserCostBurstThrottle(_UserCostThrottleBase):
         return "User daily rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
-        settings = get_settings()
-        config = settings.user_cost_limits.get(context.product)
-        if not config:
-            return 0.0, 1
+        config = self._require_config(context)
         team_mult = self._get_team_multiplier(context)
         return config.burst_limit_usd * team_mult, config.burst_window_seconds
 
@@ -182,9 +189,6 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         return "User monthly rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
-        settings = get_settings()
-        config = settings.user_cost_limits.get(context.product)
-        if not config:
-            return 0.0, 1
+        config = self._require_config(context)
         team_mult = self._get_team_multiplier(context)
         return config.sustained_limit_usd * team_mult, config.sustained_window_seconds

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -134,8 +134,12 @@ class _UserCostThrottleBase(CostThrottle):
     - OAuth: end_user_id is the token holder (set at context creation)
     - Personal API key: end_user_id is the 'user' param from the request (set in callback)
 
-    Skipped when: no end_user_id, product not in user_cost_limits config, or limits disabled.
+    If no end_user_id is set, user rate limiting is skipped.
+    If a product is not in user_cost_limits config, user rate limiting is skipped but a warning
+    is logged — add the product to LLM_GATEWAY_USER_COST_LIMITS to enable per-user throttling.
     """
+
+    _warned_products: set[str] = set()
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
         if not context.end_user_id:
@@ -147,7 +151,15 @@ class _UserCostThrottleBase(CostThrottle):
         return f"{base}:tm{team_mult}"
 
     def _has_config(self, context: ThrottleContext) -> bool:
-        return context.product in get_settings().user_cost_limits
+        has = context.product in get_settings().user_cost_limits
+        if not has and context.end_user_id and context.product not in self._warned_products:
+            self._warned_products.add(context.product)
+            logger.warning(
+                "user_cost_limits_missing_product",
+                product=context.product,
+                message=f"No user_cost_limits config for product '{context.product}' — per-user throttling skipped",
+            )
+        return has
 
     def _require_config(self, context: ThrottleContext) -> UserCostLimit:
         config = get_settings().user_cost_limits.get(context.product)

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -8,7 +8,11 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import Throttle
 
@@ -22,7 +26,8 @@ def create_test_app(
 
     default_throttles: list[Throttle] = [
         ProductCostThrottle(redis=None),
-        UserCostThrottle(redis=None),
+        UserCostBurstThrottle(redis=None),
+        UserCostSustainedThrottle(redis=None),
     ]
 
     @asynccontextmanager

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -76,8 +76,7 @@ class TestUserCostLimitConfig:
         assert twig.sustained_limit_usd == 500.0
         get_settings.cache_clear()
 
-    def test_empty_string_returns_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_USER_COST_LIMITS", "")
+    def test_unset_env_returns_defaults(self) -> None:
         get_settings.cache_clear()
         settings = get_settings()
         assert "twig" in settings.user_cost_limits

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -162,7 +162,7 @@ class TestUserCostBurstThrottle:
         result = await throttle.allow_request(context)
         assert result.allowed is False
         assert result.scope == "user_cost_burst"
-        assert result.detail == "User daily rate limit exceeded"
+        assert result.detail == "User burst rate limit exceeded"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -247,7 +247,7 @@ class TestUserCostSustainedThrottle:
         result = await throttle.allow_request(context)
         assert result.allowed is False
         assert result.scope == "user_cost_sustained"
-        assert result.detail == "User monthly rate limit exceeded"
+        assert result.detail == "User sustained rate limit exceeded"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -640,6 +640,46 @@ class TestUnconfiguredProductsNotLimitedPerUser:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
+    async def test_logs_warning_for_unconfigured_product_with_end_user(self, capsys: pytest.CaptureFixture[str]) -> None:
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, _UserCostThrottleBase
+
+        _UserCostThrottleBase._warned_products = set()
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="wizard")
+
+        await throttle.allow_request(context)
+        captured = capsys.readouterr()
+        assert "user_cost_limits_missing_product" in captured.out
+        assert "wizard" in captured.out
+
+        await throttle.allow_request(context)
+        captured2 = capsys.readouterr()
+        assert "user_cost_limits_missing_product" not in captured2.out
+
+        _UserCostThrottleBase._warned_products = set()
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_unconfigured_product_without_end_user(self, capsys: pytest.CaptureFixture[str]) -> None:
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, _UserCostThrottleBase
+
+        _UserCostThrottleBase._warned_products = set()
+
+        throttle = UserCostBurstThrottle(redis=None)
+        user = make_user(auth_method="personal_api_key")
+        context = make_context(user=user, product="wizard", end_user_id=None)
+
+        await throttle.allow_request(context)
+        captured = capsys.readouterr()
+        assert "user_cost_limits_missing_product" not in captured.out
+
+        _UserCostThrottleBase._warned_products = set()
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
     async def test_dynamically_adding_product_config_enables_limits(self, monkeypatch: pytest.MonkeyPatch) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -640,7 +640,9 @@ class TestUnconfiguredProductsNotLimitedPerUser:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_logs_warning_for_unconfigured_product_with_end_user(self, capsys: pytest.CaptureFixture[str]) -> None:
+    async def test_logs_warning_for_unconfigured_product_with_end_user(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, _UserCostThrottleBase
 
@@ -662,7 +664,9 @@ class TestUnconfiguredProductsNotLimitedPerUser:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_no_warning_for_unconfigured_product_without_end_user(self, capsys: pytest.CaptureFixture[str]) -> None:
+    async def test_no_warning_for_unconfigured_product_without_end_user(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, _UserCostThrottleBase
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -59,7 +59,7 @@ class TestUserCostLimitConfig:
         assert "twig" in settings.user_cost_limits
         twig = settings.user_cost_limits["twig"]
         assert twig.burst_limit_usd == 100.0
-        assert twig.burst_window_seconds == 86400
+        assert twig.burst_window_seconds == 18000
         assert twig.sustained_limit_usd == 1000.0
         assert twig.sustained_window_seconds == 2592000
         get_settings.cache_clear()
@@ -389,7 +389,7 @@ class TestRetryAfterHeader:
         result = await throttle.allow_request(context)
 
         assert result.allowed is False
-        assert result.retry_after == 86400
+        assert result.retry_after == 18000
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -4,7 +4,11 @@ import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import get_settings
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import (
     Throttle,
@@ -135,9 +139,10 @@ class TestThrottleRunner:
     @pytest.mark.asyncio
     async def test_composite_cost_throttle_order(self) -> None:
         product_throttle = ProductCostThrottle(redis=None)
-        user_throttle = UserCostThrottle(redis=None)
+        burst_throttle = UserCostBurstThrottle(redis=None)
+        sustained_throttle = UserCostSustainedThrottle(redis=None)
 
-        runner = ThrottleRunner(throttles=[product_throttle, user_throttle])
+        runner = ThrottleRunner(throttles=[product_throttle, burst_throttle, sustained_throttle])
 
         user = make_user(auth_method="personal_api_key")
         context = make_context(user=user, product="llm_gateway")


### PR DESCRIPTION
## Problem

We want to have sensible rate limits per user on Twig usage.

## Changes

- Add burst + sustained limits for twig based on cost
