### PR TITLE
fix(agents): shell escaping commands

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -493,12 +493,13 @@ class DockerSandbox:
         )
 
         target_path = f"/tmp/workspace/repos/{org}/{repo}"
+        org_path = f"/tmp/workspace/repos/{org}"
 
         clone_command = (
-            f"rm -rf {target_path} && "
-            f"mkdir -p /tmp/workspace/repos/{org} && "
-            f"cd /tmp/workspace/repos/{org} && "
-            f"git clone {repo_url} {repo}"
+            f"rm -rf {shlex.quote(target_path)} && "
+            f"mkdir -p {shlex.quote(org_path)} && "
+            f"cd {shlex.quote(org_path)} && "
+            f"git clone {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id}")
@@ -515,7 +516,7 @@ class DockerSandbox:
         org, repo = repository.lower().split("/")
         repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
-        result = self.execute(f"cd {repo_path} && git status --porcelain")
+        result = self.execute(f"cd {shlex.quote(repo_path)} && git status --porcelain")
         is_clean = not result.stdout.strip()
 
         return is_clean, result.stdout
@@ -557,8 +558,8 @@ class DockerSandbox:
 
         command = (
             f"cd /scripts && "
-            f"nohup npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {repo_path} "
-            f"--taskId {task_id} --runId {run_id} --mode {mode} "
+            f"nohup npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)} "
             f"> /tmp/agent-server.log 2>&1 &"
         )
 

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -377,12 +377,13 @@ class ModalSandbox:
         )
 
         target_path = f"/tmp/workspace/repos/{org}/{repo}"
+        org_path = f"/tmp/workspace/repos/{org}"
 
         clone_command = (
-            f"rm -rf {target_path} && "
-            f"mkdir -p /tmp/workspace/repos/{org} && "
-            f"cd /tmp/workspace/repos/{org} && "
-            f"git clone {repo_url} {repo}"
+            f"rm -rf {shlex.quote(target_path)} && "
+            f"mkdir -p {shlex.quote(org_path)} && "
+            f"cd {shlex.quote(org_path)} && "
+            f"git clone {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id}")
@@ -399,7 +400,7 @@ class ModalSandbox:
         org, repo = repository.lower().split("/")
         repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
-        result = self.execute(f"cd {repo_path} && git status --porcelain")
+        result = self.execute(f"cd {shlex.quote(repo_path)} && git status --porcelain")
         is_clean = not result.stdout.strip()
 
         return is_clean, result.stdout
@@ -438,8 +439,8 @@ class ModalSandbox:
 
         command = (
             f"cd /scripts && "
-            f"nohup npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {repo_path} "
-            f"--taskId {task_id} --runId {run_id} --mode {mode} "
+            f"nohup npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)} "
             f"> /tmp/agent-server.log 2>&1 &"
         )
 

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -287,7 +287,6 @@ class TestModalSandboxCommandEscaping:
         sandbox.config = SandboxConfig(name="test")
         sandbox._sandbox = MagicMock()
         sandbox._sandbox_url = None
-        sandbox._host_port = 8080
 
         with patch.object(sandbox, "is_running", return_value=True):
             with patch.object(sandbox, "execute") as mock_execute:

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -172,11 +172,13 @@ class TestModalSandboxAgentServer:
 
         start_call = mock_sandbox.execute.call_args_list[0]
         command = start_call[0][0]
+        import shlex
+
         assert f"--port {AGENT_SERVER_PORT}" in command
-        assert "--repositoryPath /tmp/workspace/repos/posthog/posthog" in command
-        assert "--taskId task-123" in command
-        assert "--runId run-456" in command
-        assert "--mode background" in command
+        assert f"--repositoryPath {shlex.quote('/tmp/workspace/repos/posthog/posthog')}" in command
+        assert f"--taskId {shlex.quote('task-123')}" in command
+        assert f"--runId {shlex.quote('run-456')}" in command
+        assert f"--mode {shlex.quote('background')}" in command
 
     def test_start_agent_server_raises_when_not_running(self, mock_sandbox: Any):
         mock_sandbox._sandbox.poll.return_value = 0
@@ -232,3 +234,73 @@ class TestModalSandboxAgentServer:
         assert result is True
         assert mock_sandbox.execute.call_count == 3
         assert mock_sleep.call_count == 2
+
+
+class TestModalSandboxCommandEscaping:
+    @pytest.mark.parametrize(
+        "repository",
+        [
+            "PostHog/posthog",
+            "org/repo-name",
+            "org/repo; echo hacked",
+            "org/repo$(whoami)",
+            "org'/repo",
+            "org/repo`id`",
+        ],
+    )
+    def test_clone_repository_command_escaping(self, repository):
+        import shlex
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        sandbox.id = "sb-123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._sandbox = MagicMock()
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                sandbox.clone_repository(repository, github_token="test-token")
+                command = mock_execute.call_args[0][0]
+
+                org, repo = repository.lower().split("/")
+                target_path = f"/tmp/workspace/repos/{org}/{repo}"
+                org_path = f"/tmp/workspace/repos/{org}"
+
+                assert shlex.quote(target_path) in command
+                assert shlex.quote(org_path) in command
+                assert shlex.quote(repo) in command
+
+    @pytest.mark.parametrize(
+        "repository,task_id,run_id,mode",
+        [
+            ("PostHog/posthog", "task-123", "run-456", "background"),
+            ("org/repo; echo hacked", "task-123", "run-456", "background"),
+            ("PostHog/posthog", "task; echo hacked", "run-456", "background"),
+            ("PostHog/posthog", "task-123", "run$(whoami)", "background"),
+            ("PostHog/posthog", "task-123", "run-456", "mode`id`"),
+        ],
+    )
+    def test_start_agent_server_command_escaping(self, repository, task_id, run_id, mode):
+        import shlex
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        sandbox.id = "sb-123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._sandbox = MagicMock()
+        sandbox._sandbox_url = None
+        sandbox._host_port = 8080
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                mock_execute.return_value = MagicMock(exit_code=0)
+                with patch.object(sandbox, "_wait_for_health_check", return_value=True):
+                    sandbox.start_agent_server(repository, task_id, run_id, mode)
+
+                command = mock_execute.call_args_list[0][0][0]
+
+                org, repo = repository.lower().split("/")
+                repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+
+                assert shlex.quote(repo_path) in command
+                assert shlex.quote(task_id) in command
+                assert shlex.quote(run_id) in command
+                assert shlex.quote(mode) in command


### PR DESCRIPTION
## Problem

This PR addresses shell command injection in the sandbox environments (`DockerSandbox` and `ModalSandbox`). The original PR (#47091) was stale and no longer applied due to codebase changes. This update ensures that user-controlled inputs passed to shell commands are properly escaped.

Closes #47091

## Changes

- Applied `shlex.quote()` to all user-controlled values in shell commands within `products/tasks/backend/services/docker_sandbox.py` and `products/tasks/backend/services/modal_sandbox.py`.
- Specifically targeted inputs for `clone_repository`, `is_git_clean`, and `start_agent_server`.
- Added new parameterized tests for both `DockerSandbox` and `ModalSandbox` to cover various shell injection attempts (e.g., command injection, command substitution, quote injection, backtick substitution).
- Updated existing tests to assert that `shlex.quote()` is correctly applied to command arguments.

