### PR TITLE
User rate limit message naming

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -174,7 +174,7 @@ class UserCostBurstThrottle(_UserCostThrottleBase):
     scope = "user_cost_burst"
 
     def _get_limit_exceeded_detail(self) -> str:
-        return "User daily rate limit exceeded"
+        return "User burst rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._require_config(context)
@@ -186,7 +186,7 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
     scope = "user_cost_sustained"
 
     def _get_limit_exceeded_detail(self) -> str:
-        return "User monthly rate limit exceeded"
+        return "User sustained rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._require_config(context)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
 import structlog
 from redis.asyncio import Redis
 
 from llm_gateway.config import get_settings
+
+if TYPE_CHECKING:
+    from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
 from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
 
@@ -145,6 +149,12 @@ class _UserCostThrottleBase(CostThrottle):
     def _has_config(self, context: ThrottleContext) -> bool:
         return context.product in get_settings().user_cost_limits
 
+    def _require_config(self, context: ThrottleContext) -> UserCostLimit:
+        config = get_settings().user_cost_limits.get(context.product)
+        if not config:
+            raise RuntimeError(f"No user_cost_limits config for product '{context.product}' — guard check missed")
+        return config
+
     async def allow_request(self, context: ThrottleContext) -> ThrottleResult:
         if not context.end_user_id or not self._has_config(context):
             return ThrottleResult.allow()
@@ -167,10 +177,7 @@ class UserCostBurstThrottle(_UserCostThrottleBase):
         return "User daily rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
-        settings = get_settings()
-        config = settings.user_cost_limits.get(context.product)
-        if not config:
-            return 0.0, 1
+        config = self._require_config(context)
         team_mult = self._get_team_multiplier(context)
         return config.burst_limit_usd * team_mult, config.burst_window_seconds
 
@@ -182,9 +189,6 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         return "User monthly rate limit exceeded"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
-        settings = get_settings()
-        config = settings.user_cost_limits.get(context.product)
-        if not config:
-            return 0.0, 1
+        config = self._require_config(context)
         team_mult = self._get_team_multiplier(context)
         return config.sustained_limit_usd * team_mult, config.sustained_window_seconds

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -8,7 +8,11 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import Throttle
 
@@ -22,7 +26,8 @@ def create_test_app(
 
     default_throttles: list[Throttle] = [
         ProductCostThrottle(redis=None),
-        UserCostThrottle(redis=None),
+        UserCostBurstThrottle(redis=None),
+        UserCostSustainedThrottle(redis=None),
     ]
 
     @asynccontextmanager

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -76,8 +76,7 @@ class TestUserCostLimitConfig:
         assert twig.sustained_limit_usd == 500.0
         get_settings.cache_clear()
 
-    def test_empty_string_returns_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_USER_COST_LIMITS", "")
+    def test_unset_env_returns_defaults(self) -> None:
         get_settings.cache_clear()
         settings = get_settings()
         assert "twig" in settings.user_cost_limits

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -162,7 +162,7 @@ class TestUserCostBurstThrottle:
         result = await throttle.allow_request(context)
         assert result.allowed is False
         assert result.scope == "user_cost_burst"
-        assert result.detail == "User daily rate limit exceeded"
+        assert result.detail == "User burst rate limit exceeded"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -247,7 +247,7 @@ class TestUserCostSustainedThrottle:
         result = await throttle.allow_request(context)
         assert result.allowed is False
         assert result.scope == "user_cost_sustained"
-        assert result.detail == "User monthly rate limit exceeded"
+        assert result.detail == "User sustained rate limit exceeded"
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -4,7 +4,11 @@ import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import get_settings
-from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle, UserCostThrottle
+from llm_gateway.rate_limiting.cost_throttles import (
+    ProductCostThrottle,
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import (
     Throttle,
@@ -135,9 +139,10 @@ class TestThrottleRunner:
     @pytest.mark.asyncio
     async def test_composite_cost_throttle_order(self) -> None:
         product_throttle = ProductCostThrottle(redis=None)
-        user_throttle = UserCostThrottle(redis=None)
+        burst_throttle = UserCostBurstThrottle(redis=None)
+        sustained_throttle = UserCostSustainedThrottle(redis=None)
 
-        runner = ThrottleRunner(throttles=[product_throttle, user_throttle])
+        runner = ThrottleRunner(throttles=[product_throttle, burst_throttle, sustained_throttle])
 
         user = make_user(auth_method="personal_api_key")
         context = make_context(user=user, product="llm_gateway")


### PR DESCRIPTION
## Problem

The existing user cost throttle messages ("User daily rate limit exceeded", "User monthly rate limit exceeded") are inaccurate as the underlying throttle windows are configurable and not strictly tied to a day or month. This can cause confusion for users.

## Changes

- Renamed the `UserCostBurstThrottle` message from "User daily rate limit exceeded" to "User burst rate limit exceeded".
- Renamed the `UserCostSustainedThrottle` message from "User monthly rate limit exceeded" to "User sustained rate limit exceeded".
- Updated corresponding test assertions in `test_cost_throttles.py`.

## How did you test this code?

All existing unit tests were run and passed.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D09AS56P2FJ/p1771761567954099?thread_ts=1771761567.954099&cid=D09AS56P2FJ)

<p><a href="https://cursor.com/agents?id=bc-0144582b-8f25-5997-9723-758766ae3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0144582b-8f25-5997-9723-758766ae3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

