### PR TITLE
Fix #48399: Managed reverse proxy status sometimes doesn't update from "

### DIFF
--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -604,24 +604,6 @@ class CreateManagedProxyWorkflow(PostHogWorkflow):
                 ),
             )
 
-        except ActivityError as e:
-            if (
-                hasattr(e, "cause")
-                and e.cause
-                and hasattr(e.cause, "type")
-                and e.cause.type != "RecordDeletedException"
-            ):
-                raise
-
-            logger.info(
-                "Record was deleted before completing provisioning for id %s (%s)",
-                inputs.proxy_record_id,
-                inputs.domain,
-            )
-
-            # if the record has been deleted don't error the workflow, just ignore
-            return
-
         except Exception as e:
             logger.info(
                 "Exception caught during workflow run: %s (%s)",


### PR DESCRIPTION
Fixes #48399

## Summary
This PR fixes: Managed reverse proxy status sometimes doesn't update from "Issuing" status

## Changes
```
posthog/temporal/proxy_service/create.py | 18 ------------------
 1 file changed, 18 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).