### PR TITLE
feat: remove reduntant info

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1459,8 +1459,7 @@ def send_error_tracking_weekly_digest_for_team(
     crash_free = get_crash_free_sessions(team)
     exception_change = compute_week_over_week_change(exception_count, prev_exception_count, higher_is_better=False)
 
-    # TODO: restore to "%Y-%W" after testing (currently allows one email per hour)
-    date_suffix = timezone.now().strftime("%Y-%W-%d-%H")
+    date_suffix = timezone.now().strftime("%Y-%W")
     error_tracking_url = f"{settings.SITE_URL}/project/{team_id}/error_tracking?utm_source=error_tracking_weekly_digest"
     ingestion_failures_url = build_ingestion_failures_url(team_id)
 

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -271,9 +271,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="send HogFunctions daily digest",
     )
 
-    # TODO: restore to crontab(day_of_week="mon", hour="8", minute="30") after testing
     sender.add_periodic_task(
-        crontab(hour="*", minute="0"),
+        crontab(day_of_week="mon", hour="8", minute="30"),
         send_error_tracking_weekly_digest.s(),
         name="send Error Tracking weekly digest",
     )

--- a/posthog/tasks/test/preview_error_tracking_digest.py
+++ b/posthog/tasks/test/preview_error_tracking_digest.py
@@ -168,7 +168,6 @@ html = template.render(
         ],
         "crash_free": {
             "total_sessions": 284532,
-            "crash_sessions": 3421,
             "crash_free_rate": 98.80,
             "crash_free_rate_change": {
                 "percent": 1,
@@ -183,13 +182,6 @@ html = template.render(
                 "color": "#2f7d4f",
                 "text": "Up 12%",
                 "long_text": "Up 12% from previous week",
-            },
-            "crash_sessions_change": {
-                "percent": 8,
-                "direction": "Up",
-                "color": "#a13232",
-                "text": "Up 8%",
-                "long_text": "Up 8% from previous week",
             },
         },
         "error_tracking_url": "https://us.posthog.com/project/2/error_tracking?utm_source=error_tracking_weekly_digest",

--- a/posthog/templates/email/error_tracking_weekly_digest.html
+++ b/posthog/templates/email/error_tracking_weekly_digest.html
@@ -47,13 +47,6 @@
     <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top: 16px; border-top: 1px solid #f3f4f6; padding-top: 16px;">
         <tr>
             <td align="center" style="text-align: center; padding: 8px;">
-                <div style="font-size: 0.8em; color: #6b7280;">Crash free sessions</div>
-                <div style="font-size: 1.5em; font-weight: bold;">{{ crash_free.crash_free_rate }}%</div>
-                {% if crash_free.crash_free_rate_change %}
-                <div style="font-size: 0.75em; color: {{ crash_free.crash_free_rate_change.color }};">{{ crash_free.crash_free_rate_change.text }}</div>
-                {% endif %}
-            </td>
-            <td align="center" style="text-align: center; padding: 8px;">
                 <div style="font-size: 0.8em; color: #6b7280;">Total sessions</div>
                 <div style="font-size: 1.5em; font-weight: bold;">{{ crash_free.total_sessions|compact_number }}</div>
                 {% if crash_free.total_sessions_change %}
@@ -61,10 +54,10 @@
                 {% endif %}
             </td>
             <td align="center" style="text-align: center; padding: 8px;">
-                <div style="font-size: 0.8em; color: #6b7280;">Crashed sessions</div>
-                <div style="font-size: 1.5em; font-weight: bold;">{{ crash_free.crash_sessions|compact_number }}</div>
-                {% if crash_free.crash_sessions_change %}
-                <div style="font-size: 0.75em; color: {{ crash_free.crash_sessions_change.color }};">{{ crash_free.crash_sessions_change.text }}</div>
+                <div style="font-size: 0.8em; color: #6b7280;">Crash free sessions</div>
+                <div style="font-size: 1.5em; font-weight: bold;">{{ crash_free.crash_free_rate }}%</div>
+                {% if crash_free.crash_free_rate_change %}
+                <div style="font-size: 0.75em; color: {{ crash_free.crash_free_rate_change.color }};">{{ crash_free.crash_free_rate_change.text }}</div>
                 {% endif %}
             </td>
         </tr>

--- a/products/error_tracking/backend/test/test_weekly_digest.py
+++ b/products/error_tracking/backend/test/test_weekly_digest.py
@@ -134,7 +134,6 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         result = get_crash_free_sessions(self.team)
 
         assert result["total_sessions"] == 3
-        assert result["crash_sessions"] == 1
         assert result["crash_free_rate"] == 66.67
 
     def test_get_crash_free_sessions_empty_when_no_sessions(self):
@@ -154,10 +153,8 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         result = get_crash_free_sessions(self.team)
 
         assert result["total_sessions"] == 2
-        assert result["crash_sessions"] == 1
         assert result["crash_free_rate"] == 50.0
         assert result["total_sessions_change"] is not None
-        assert result["crash_sessions_change"] is None  # 1 -> 1, no change
 
     def test_get_daily_exception_counts_returns_7_days(self):
         issue = self._create_issue()

--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -84,7 +84,6 @@ def get_crash_free_sessions(team: Team) -> dict:
 
     result: dict = {
         "total_sessions": total_sessions,
-        "crash_sessions": crash_sessions,
         "crash_free_rate": crash_free_rate,
     }
 
@@ -95,9 +94,6 @@ def get_crash_free_sessions(team: Team) -> dict:
     )
     result["total_sessions_change"] = compute_week_over_week_change(
         total_sessions, prev_total_sessions, higher_is_better=True
-    )
-    result["crash_sessions_change"] = compute_week_over_week_change(
-        crash_sessions, prev_crash_sessions, higher_is_better=False
     )
 
     return result


### PR DESCRIPTION
We had redundant info and stats looked strange because you saw great trend in crashed sessions but in reality you just had less sessions:
<img width="570" height="381" alt="image" src="https://github.com/user-attachments/assets/6d8b0b67-9ad1-4ead-876e-f407cba47791" />

Changed that to just display two stats:
<img width="581" height="377" alt="image" src="https://github.com/user-attachments/assets/9975fef9-1c8e-4d2d-ab92-98a77b02db8e" />
