### PR TITLE
fix(insights): make Refresh button more discoverable with accent background

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -46,7 +46,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
                     >
                         <Link
                             onClick={() => loadData(shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')}
-                            className={disabledReason ? 'opacity-50' : ''}
+                            className={`bg-[var(--color-accent)] text-white rounded px-1.5 py-0.5 no-underline hover:text-white ${disabledReason ? 'opacity-50' : ''}`}
                             disabledReason={canBypassRefreshDisabled ? '' : disabledReason}
                         >
                             Refresh


### PR DESCRIPTION
## Summary
- Styled the insight Refresh button with an accent (orange) background and white text so it stands out from the surrounding "Computed X ago" text
- Previously it was a plain text link that blended in, making it easy to miss

Before:
<img width="1452" height="828" alt="Screenshot 2026-02-22 at 5 44 53 PM" src="https://github.com/user-attachments/assets/2cc83941-7b9f-4ee8-aa49-3d50707e8753" />

After:
<img width="1453" height="830" alt="Screenshot 2026-02-22 at 5 45 14 PM" src="https://github.com/user-attachments/assets/b426686c-d34a-4f6e-b2c6-1ef1f855d8f3" />

## Test plan
- [x] Load a saved insight — verify the Refresh button has an orange background with white text
- [x] Click Refresh — verify it still triggers a data reload
- [x] Check disabled state (refresh within cooldown) — verify the button shows at 50% opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)