### PR TITLE
refactor(flags): consolidate local evaluation flag paths with batch support

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3556,15 +3556,14 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.client.logout()
 
-        with self.assertNumQueries(FuzzyInt(17, 21)):
+        with self.assertNumQueries(FuzzyInt(17, 22)):
             # 1-10: Auth, team, project, membership, and access control queries
             # 11. SELECT surveys (for survey exclusion)
-            # 12. SELECT all feature flags
-            # 13. SELECT cohorts (only referenced cohorts in bulk, not all cohorts)
-            # 14-18. SELECT evaluation tags (one per flag)
-            # 19. SELECT group type mapping
-            # Note: Query count reduced because cohorts are now loaded in bulk
-            # for only those referenced by flags, instead of loading all cohorts.
+            # 12. EXISTS check for any flag referencing a cohort
+            # 13. SELECT all feature flags
+            # 14. SELECT cohorts (only loaded because a flag references a cohort)
+            # 15-19. SELECT evaluation tags (one per flag)
+            # 20. SELECT group type mapping
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -1,10 +1,12 @@
 import time
+from collections import defaultdict
 from collections.abc import Generator
+from itertools import groupby
 from typing import Any, Union, cast
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -384,335 +386,162 @@ def clear_flag_caches(team: Team, kinds: list[str] | None = None):
     flags_without_cohorts_hypercache.clear_cache(team, kinds=kinds)
 
 
-def _extract_cohort_ids_from_filters(filters: dict) -> set[int]:
-    """
-    Extract cohort IDs directly from flag filters without loading from DB.
-    Only extracts direct references, not nested dependencies.
-    """
-    cohort_ids: set[int] = set()
-    for prop in _get_properties_from_filters(filters, "cohort"):
-        value = prop.get("value")
-        # Skip list values to align with other cohort-processing code paths
-        if value is None or isinstance(value, list):
-            continue
-        try:
-            cohort_ids.add(int(value))
-        except (TypeError, ValueError):
-            continue
-    return cohort_ids
-
-
-def _load_cohorts_with_dependencies(
-    direct_cohort_ids: set[int], project_id: int, using_database: str
-) -> dict[int, CohortOrEmpty]:
-    """
-    Load cohorts and their dependencies in bulk queries.
-
-    Performs iterative bulk loading to resolve nested cohort dependencies
-    with minimal database queries (typically 1-2 iterations).
-    """
-    seen_cohorts_cache: dict[int, CohortOrEmpty] = {}
-    ids_to_load = direct_cohort_ids.copy()
-    loaded_ids: set[int] = set()
-
-    while ids_to_load:
-        # Load cohorts in bulk with team prefetched to avoid N+1 queries
-        # when get_all_cohort_dependencies accesses cohort.team.project_id
-        new_cohorts = (
-            Cohort.objects.db_manager(using_database)
-            .filter(pk__in=ids_to_load, team__project_id=project_id, deleted=False)
-            .select_related("team")
-        )
-
-        # Add loaded cohorts to cache
-        for cohort in new_cohorts:
-            seen_cohorts_cache[cohort.pk] = cohort
-            loaded_ids.add(cohort.pk)
-
-        # Mark missing cohorts as empty to avoid repeated lookups
-        for cohort_id in ids_to_load:
-            if cohort_id not in seen_cohorts_cache:
-                seen_cohorts_cache[cohort_id] = ""
-                loaded_ids.add(cohort_id)
-
-        # Extract nested cohort IDs from newly loaded cohorts
-        nested_ids: set[int] = set()
-        for cohort_id in ids_to_load:
-            cohort = seen_cohorts_cache.get(cohort_id)
-            if isinstance(cohort, Cohort):
-                for prop in cohort.properties.flat:
-                    if prop.type == "cohort" and not isinstance(prop.value, list):
-                        try:
-                            nested_id = int(prop.value)
-                            if nested_id not in loaded_ids:
-                                nested_ids.add(nested_id)
-                        except (ValueError, TypeError):
-                            continue
-
-        # Continue with nested IDs that haven't been loaded
-        ids_to_load = nested_ids
-
-    return seen_cohorts_cache
-
-
-def _get_cohort_with_fallback(
-    cohort_id: int, team: Team, seen_cohorts_cache: dict[int, CohortOrEmpty]
-) -> CohortOrEmpty:
-    """
-    Get a cohort from cache, falling back to a database query if not found.
-
-    Updates the cache with the result to avoid repeated queries.
-    """
-    if cohort_id in seen_cohorts_cache:
-        return seen_cohorts_cache[cohort_id]
-
-    logger.warning(
-        "Cohort not in seen_cohorts_cache, performing fallback query",
-        extra={"cohort_id": cohort_id, "team_id": team.id},
-    )
-    cohort = (
-        Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
-        .filter(id=cohort_id, team__project_id=team.project_id, deleted=False)
-        .first()
-    )
-    seen_cohorts_cache[cohort_id] = cohort or ""
-    return seen_cohorts_cache[cohort_id]
-
-
-def _add_cohort_to_dict(
-    cohort_id: int,
-    team: Team,
-    seen_cohorts_cache: dict[int, CohortOrEmpty],
-    cohorts_dict: dict[str, Any],
-) -> None:
-    """
-    Add a cohort to the cohorts dict if it's valid and not already present.
-
-    Handles skipping already-added cohorts, looking up cohorts with fallback,
-    skipping static cohorts, and error handling for properties serialization.
-    """
-    if str(cohort_id) in cohorts_dict:
-        return
-
-    cohort = _get_cohort_with_fallback(cohort_id, team, seen_cohorts_cache)
-    if cohort and not cohort.is_static:
-        try:
-            cohorts_dict[str(cohort.pk)] = cohort.properties.to_dict()
-        except Exception:
-            logger.error(
-                "Error processing cohort properties",
-                extra={"cohort_id": cohort_id},
-                exc_info=True,
-            )
-
-
-def _get_transformed_filters_for_without_cohorts(
-    feature_flag: FeatureFlag,
-    original_filters: dict,
-    cohort_ids: list[int],
-    seen_cohorts_cache: dict[int, CohortOrEmpty],
-) -> dict:
-    """
-    Get filters for without-cohorts response, transforming single-cohort filters.
-
-    When a flag has exactly one cohort, transforms cohort filters to person
-    properties for simpler client-side evaluation.
-    """
-    if len(cohort_ids) == 1:
-        return {
-            **original_filters,
-            "groups": feature_flag.transform_cohort_filters_for_easy_evaluation(
-                using_database=DATABASE_FOR_LOCAL_EVALUATION,
-                seen_cohorts_cache=seen_cohorts_cache,
-            ),
-        }
-    return original_filters
-
-
-def _get_base_flags_queryset(team: Team) -> QuerySet[FeatureFlag]:
-    """
-    Return the base queryset for feature flags, excluding survey-linked flags
-    and encrypted remote configuration flags.
-    """
-    survey_flag_ids = Survey.get_internal_flag_ids(
-        team_id=team.id,
-        using=DATABASE_FOR_LOCAL_EVALUATION,
-    )
-
-    return (
-        FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
-        .filter(
-            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
-            team_id=team.id,
-            deleted=False,
-        )
-        .exclude(id__in=survey_flag_ids)
-    )
-
-
-def _load_flags_and_cohorts_for_team(team: Team) -> tuple[list[FeatureFlag], dict[int, CohortOrEmpty]]:
-    """
-    Load feature flags and their cohort dependencies for a team.
-
-    Handles:
-    - Excluding survey-linked flags
-    - Excluding remote configuration flags
-    - Extracting cohort IDs from flag filters
-    - Loading cohorts with nested dependencies
-
-    Returns:
-        tuple: (feature_flags, seen_cohorts_cache)
-    """
-    feature_flags = list(_get_base_flags_queryset(team))
-
-    seen_cohorts_cache: dict[int, CohortOrEmpty] = {}
-    try:
-        all_direct_cohort_ids: set[int] = set()
-        for flag in feature_flags:
-            all_direct_cohort_ids.update(_extract_cohort_ids_from_filters(flag.get_filters()))
-
-        if all_direct_cohort_ids:
-            seen_cohorts_cache = _load_cohorts_with_dependencies(
-                all_direct_cohort_ids, team.project_id, DATABASE_FOR_LOCAL_EVALUATION
-            )
-    except Exception:
-        logger.error("Error loading cohorts for flags", exc_info=True)
-
-    return feature_flags, seen_cohorts_cache
-
-
-def _get_flags_for_local_evaluation(team: Team, include_cohorts: bool = True) -> tuple[list[FeatureFlag], dict]:
-    """
-    Get all feature flags for a team with conditional cohort handling for local evaluation.
-
-    This method supports two different client integration patterns:
-
-    Args:
-        team: The team to get feature flags for.
-        include_cohorts: Controls cohort handling strategy for client compatibility.
-
-    Returns:
-        tuple[list[FeatureFlag], dict]: (flags, cohorts_dict)
-
-    Behavior based on include_cohorts:
-
-    When include_cohorts=True (for smart clients):
-        - Flag filters are kept unchanged (cohort references preserved)
-        - Returns cohorts dict with cohort definitions for client-side evaluation
-        - Client must evaluate cohort membership locally using provided cohort criteria
-
-    When include_cohorts=False (for simple clients):
-        - Flag filters are transformed (simple cohorts expanded to person properties)
-        - Returns empty cohorts dict
-        - Client only needs to evaluate simplified property-based filters
-    """
-    feature_flags, seen_cohorts_cache = _load_flags_and_cohorts_for_team(team)
-    cohorts: dict[str, Any] = {}
-
-    for feature_flag in feature_flags:
-        try:
-            filters = feature_flag.get_filters()
-
-            # Capture cohort_ids BEFORE transformation to avoid losing cohort references
-            cohort_ids = feature_flag.get_cohort_ids(
-                using_database=DATABASE_FOR_LOCAL_EVALUATION,
-                seen_cohorts_cache=seen_cohorts_cache,
-            )
-
-            # Transform cohort filters for simple clients, or keep original filters
-            if not include_cohorts:
-                feature_flag.filters = _get_transformed_filters_for_without_cohorts(
-                    feature_flag, filters, cohort_ids, seen_cohorts_cache
-                )
-            else:
-                feature_flag.filters = filters
-
-            # Only build cohorts when include_cohorts is True (matching send_cohorts behavior)
-            if include_cohorts:
-                for cohort_id in cohort_ids:
-                    _add_cohort_to_dict(cohort_id, team, seen_cohorts_cache, cohorts)
-
-        except Exception:
-            logger.error("Error processing feature flag", extra={"flag_id": feature_flag.pk}, exc_info=True)
-            continue
-
-    return feature_flags, cohorts
-
-
 def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict[str, Any]:
-    """
-    Build the local-evaluation response using streamed flag processing to reduce peak memory.
+    """Build the local-evaluation response for a single team."""
+    results = _get_flags_response_for_local_evaluation_batch([team], include_cohorts)
+    return results.get(team.id, {"flags": [], "group_type_mapping": {}, "cohorts": {}})
 
-    Uses .iterator() to stream flags from the database rather than materializing
-    all ORM objects with list(). This keeps peak memory close to the size of the
-    final serialized response, since only one FeatureFlag instance is in memory at
-    a time during processing. This matters for teams with many flags, where eager
-    loading caused worker memory to spike well beyond the size of the output.
+
+def _get_flags_response_for_local_evaluation_batch(
+    teams: list[Team], include_cohorts: bool
+) -> dict[int, dict[str, Any]]:
+    """
+    Build local-evaluation responses for multiple teams using bulk data loading
+    and streaming flag serialization to control memory.
+
+    Loads survey flag IDs, cohorts, and group type mappings in bulk (one query
+    each regardless of team count), then streams flags with .iterator() and
+    itertools.groupby to process one team at a time.
     """
     from posthog.api.feature_flag import MinimalFeatureFlagSerializer
 
-    base_queryset = _get_base_flags_queryset(team)
+    if not teams:
+        return {}
 
-    # Pass 1: collect cohort IDs from flag filters (lightweight, only loads filters column)
-    all_direct_cohort_ids: set[int] = set()
-    for flag in base_queryset.only("filters").iterator():
-        all_direct_cohort_ids.update(_extract_cohort_ids_from_filters(flag.filters or {}))
+    team_ids = [t.id for t in teams]
+    team_by_id = {t.id: t for t in teams}
+    project_ids = list({t.project_id for t in teams})
 
-    # Bulk load cohorts with nested dependencies
-    seen_cohorts_cache: dict[int, CohortOrEmpty] = {}
-    if all_direct_cohort_ids:
-        try:
-            seen_cohorts_cache = _load_cohorts_with_dependencies(
-                all_direct_cohort_ids, team.project_id, DATABASE_FOR_LOCAL_EVALUATION
-            )
-        except Exception:
-            logger.error("Error loading cohorts for flags", exc_info=True)
+    # Bulk load survey flag IDs across all teams
+    survey_flag_ids: set[int] = set()
+    for row in (
+        Survey.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+        .filter(team_id__in=team_ids)
+        .values_list(
+            "targeting_flag_id",
+            "internal_targeting_flag_id",
+            "internal_response_sampling_flag_id",
+        )
+    ):
+        survey_flag_ids.update(fid for fid in row if fid is not None)
 
-    # Pass 2: stream flags, serialize each immediately
-    flags_data: list[dict[str, Any]] = []
-    cohorts: dict[str, Any] = {}
-    flag_id_to_key: dict[str, str] = {}
+    # Bulk load all non-deleted cohorts for all projects (including static ones for
+    # cache completeness). Static cohorts are excluded from the response but need to
+    # be in the cache so get_cohort_ids doesn't make fallback DB queries for them.
+    cohorts_by_project: dict[int, dict[int, Cohort]] = defaultdict(dict)
+    for cohort in (
+        Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+        .filter(team__project_id__in=project_ids, deleted=False)
+        .select_related("team")
+    ):
+        cohorts_by_project[cohort.team.project_id][cohort.pk] = cohort
 
-    for feature_flag in base_queryset.iterator():
-        try:
-            filters = feature_flag.get_filters()
+    # Bulk load group type mappings for all projects
+    gtm_by_project: dict[int, dict[str, str]] = defaultdict(dict)
+    for row in GroupTypeMapping.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(project_id__in=project_ids):
+        gtm_by_project[row.project_id][str(row.group_type_index)] = row.group_type
 
-            cohort_ids = feature_flag.get_cohort_ids(
-                using_database=DATABASE_FOR_LOCAL_EVALUATION,
-                seen_cohorts_cache=seen_cohorts_cache,
-            )
+    # Stream flags ordered by team_id then key for consistent ordering (ETag stability)
+    flags_qs = (
+        FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+        .filter(
+            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
+            team_id__in=team_ids,
+            deleted=False,
+        )
+        .exclude(id__in=survey_flag_ids)
+        .order_by("team_id", "key")
+    )
 
-            if not include_cohorts:
-                feature_flag.filters = _get_transformed_filters_for_without_cohorts(
-                    feature_flag, filters, cohort_ids, seen_cohorts_cache
-                )
-            else:
-                feature_flag.filters = filters
+    results: dict[int, dict[str, Any]] = {}
 
-            flags_data.append(MinimalFeatureFlagSerializer(feature_flag, context={}).data)
-
-            if include_cohorts:
-                for cohort_id in cohort_ids:
-                    _add_cohort_to_dict(cohort_id, team, seen_cohorts_cache, cohorts)
-
-            flag_id_to_key[str(feature_flag.id)] = feature_flag.key
-
-        except Exception:
-            logger.error("Error processing feature flag", extra={"flag_id": feature_flag.pk}, exc_info=True)
+    for tid, team_flags_iter in groupby(flags_qs.iterator(), key=lambda f: f.team_id):
+        team = team_by_id.get(tid)
+        if team is None:
             continue
 
-    response_data = {
-        "flags": flags_data,
-        "group_type_mapping": {
-            str(row.group_type_index): row.group_type
-            for row in GroupTypeMapping.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
-                project_id=team.project_id
-            )
-        },
-        "cohorts": cohorts if include_cohorts else {},
-    }
+        project_cohorts = cohorts_by_project.get(team.project_id, {})
+        # Build a seen_cohorts_cache compatible with FeatureFlag.get_cohort_ids
+        seen_cohorts_cache: dict[int, CohortOrEmpty] = dict(project_cohorts)
 
-    return _apply_flag_dependency_transformation(response_data, flag_id_to_key)
+        flags_data: list[dict[str, Any]] = []
+        cohorts: dict[str, Any] = {}
+        flag_id_to_key: dict[str, str] = {}
+
+        for feature_flag in team_flags_iter:
+            try:
+                filters = feature_flag.get_filters()
+
+                # Pre-populate cache with empty entries for any referenced cohort_id
+                # not already loaded, so get_cohort_ids doesn't make fallback DB queries
+                # for deleted or cross-team cohorts.
+                for group in filters.get("groups", []):
+                    for prop in group.get("properties", []):
+                        if prop.get("type") == "cohort" and prop.get("value") is not None:
+                            try:
+                                cid = int(prop["value"])
+                                if cid not in seen_cohorts_cache:
+                                    seen_cohorts_cache[cid] = ""
+                            except (TypeError, ValueError):
+                                pass
+
+                cohort_ids = feature_flag.get_cohort_ids(
+                    using_database=DATABASE_FOR_LOCAL_EVALUATION,
+                    seen_cohorts_cache=seen_cohorts_cache,
+                )
+
+                if not include_cohorts and len(cohort_ids) == 1:
+                    feature_flag.filters = {
+                        **filters,
+                        "groups": feature_flag.transform_cohort_filters_for_easy_evaluation(
+                            using_database=DATABASE_FOR_LOCAL_EVALUATION,
+                            seen_cohorts_cache=seen_cohorts_cache,
+                        ),
+                    }
+                else:
+                    feature_flag.filters = filters
+
+                flags_data.append(MinimalFeatureFlagSerializer(feature_flag, context={}).data)
+
+                if include_cohorts:
+                    for cohort_id in cohort_ids:
+                        str_id = str(cohort_id)
+                        if str_id not in cohorts:
+                            cohort = project_cohorts.get(cohort_id)
+                            if cohort is not None and not cohort.is_static:
+                                try:
+                                    cohorts[str_id] = cohort.properties.to_dict()
+                                except Exception:
+                                    logger.error(
+                                        "Error processing cohort properties",
+                                        extra={"cohort_id": cohort_id},
+                                        exc_info=True,
+                                    )
+
+                flag_id_to_key[str(feature_flag.id)] = feature_flag.key
+
+            except Exception:
+                logger.error("Error processing feature flag", extra={"flag_id": feature_flag.pk}, exc_info=True)
+                continue
+
+        response_data: dict[str, Any] = {
+            "flags": flags_data,
+            "group_type_mapping": gtm_by_project.get(team.project_id, {}),
+            "cohorts": cohorts if include_cohorts else {},
+        }
+
+        results[tid] = _apply_flag_dependency_transformation(response_data, flag_id_to_key)
+
+    # Ensure every requested team has a result, even if it had no flags
+    for tid in team_ids:
+        if tid not in results:
+            results[tid] = {
+                "flags": [],
+                "group_type_mapping": gtm_by_project.get(team_by_id[tid].project_id, {}),
+                "cohorts": {},
+            }
+
+    return results
 
 
 # NOTE: All models that affect feature flag evaluation should have a signal to update the cache

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -425,16 +425,24 @@ def _get_flags_response_for_local_evaluation_batch(
     ):
         survey_flag_ids.update(fid for fid in row if fid is not None)
 
-    # Bulk load all non-deleted cohorts for all projects (including static ones for
-    # cache completeness). Static cohorts are excluded from the response but need to
-    # be in the cache so get_cohort_ids doesn't make fallback DB queries for them.
+    # Only load cohorts if at least one flag references a cohort property.
+    # This avoids loading thousands of unused cohorts for teams that don't
+    # use cohorts in their feature flags.
+    any_flag_uses_cohort = (
+        FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+        .filter(team_id__in=team_ids, deleted=False)
+        .filter(filters__groups__contains=[{"properties": [{"type": "cohort"}]}])
+        .exists()
+    )
+
     cohorts_by_project: dict[int, dict[int, Cohort]] = defaultdict(dict)
-    for cohort in (
-        Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
-        .filter(team__project_id__in=project_ids, deleted=False)
-        .select_related("team")
-    ):
-        cohorts_by_project[cohort.team.project_id][cohort.pk] = cohort
+    if any_flag_uses_cohort:
+        for cohort in (
+            Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+            .filter(team__project_id__in=project_ids, deleted=False)
+            .select_related("team")
+        ):
+            cohorts_by_project[cohort.team.project_id][cohort.pk] = cohort
 
     # Bulk load group type mappings for all projects
     gtm_by_project: dict[int, dict[str, str]] = defaultdict(dict)

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -6,10 +6,7 @@ from parameterized import parameterized
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagEvaluationTag
 from posthog.models.feature_flag.local_evaluation import (
-    DATABASE_FOR_LOCAL_EVALUATION,
-    _extract_cohort_ids_from_filters,
-    _get_flags_for_local_evaluation,
-    _load_cohorts_with_dependencies,
+    _get_flags_response_for_local_evaluation,
     clear_flag_caches,
     flags_hypercache,
     get_flags_response_for_local_evaluation,
@@ -338,8 +335,8 @@ class TestSurveyFlagExclusion(BaseTest):
             **{flag_field: survey_flag},
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
 
         assert regular_flag.key in flag_keys
         assert survey_flag.key not in flag_keys
@@ -359,8 +356,8 @@ class TestSurveyFlagExclusion(BaseTest):
             linked_flag=user_linked_flag,
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
 
         assert user_linked_flag.key in flag_keys
 
@@ -379,13 +376,13 @@ class TestSurveyFlagExclusion(BaseTest):
             targeting_flag=survey_flag,
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        assert survey_flag.key not in [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        assert survey_flag.key not in [f["key"] for f in response["flags"]]
 
         survey.delete()
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        assert survey_flag.key in [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        assert survey_flag.key in [f["key"] for f in response["flags"]]
 
     def test_survey_flags_excluded_from_api_response(self):
         """Verify the full API response excludes survey flags."""
@@ -481,16 +478,16 @@ class TestSurveyFlagExclusion(BaseTest):
             targeting_flag=survey_flag,
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        assert survey_flag.key not in [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        assert survey_flag.key not in [f["key"] for f in response["flags"]]
 
         # Archive the survey (not delete)
         survey.archived = True
         survey.save()
 
         # Flag should still be excluded since the survey still exists
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        assert survey_flag.key not in [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        assert survey_flag.key not in [f["key"] for f in response["flags"]]
 
     def test_survey_flag_reassignment_updates_exclusions(self):
         """When a survey changes which flags it uses, both old and new flags should update correctly."""
@@ -512,16 +509,16 @@ class TestSurveyFlagExclusion(BaseTest):
             targeting_flag=flag_a,
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
         assert flag_a.key not in flag_keys
         assert flag_b.key in flag_keys
 
         survey.targeting_flag = flag_b
         survey.save()
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
         assert flag_a.key in flag_keys
         assert flag_b.key not in flag_keys
 
@@ -541,8 +538,8 @@ class TestSurveyFlagExclusion(BaseTest):
                 targeting_flag=shared_flag,
             )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
 
         assert shared_flag.key not in flag_keys
 
@@ -573,214 +570,9 @@ class TestSurveyFlagExclusion(BaseTest):
             internal_response_sampling_flag=flag_b,
         )
 
-        flags, _ = _get_flags_for_local_evaluation(self.team, include_cohorts=True)
-        flag_keys = [f.key for f in flags]
+        response = _get_flags_response_for_local_evaluation(self.team, include_cohorts=True)
+        flag_keys = [f["key"] for f in response["flags"]]
 
         assert flag_a.key not in flag_keys
         assert flag_b.key not in flag_keys
         assert regular_flag.key in flag_keys
-
-
-class TestExtractCohortIdsFromFilters(BaseTest):
-    """Tests for _extract_cohort_ids_from_filters helper function."""
-
-    @parameterized.expand(
-        [
-            ("empty_filters", {}, set()),
-            ("no_groups", {"multivariate": {}}, set()),
-            ("empty_groups", {"groups": []}, set()),
-            (
-                "person_properties_only",
-                {"groups": [{"properties": [{"type": "person", "key": "email", "value": "test@example.com"}]}]},
-                set(),
-            ),
-            (
-                "single_cohort",
-                {"groups": [{"properties": [{"type": "cohort", "value": 123}]}]},
-                {123},
-            ),
-            (
-                "multiple_cohorts_same_group",
-                {"groups": [{"properties": [{"type": "cohort", "value": 1}, {"type": "cohort", "value": 2}]}]},
-                {1, 2},
-            ),
-            (
-                "multiple_cohorts_different_groups",
-                {
-                    "groups": [
-                        {"properties": [{"type": "cohort", "value": 10}]},
-                        {"properties": [{"type": "cohort", "value": 20}]},
-                        {"properties": [{"type": "cohort", "value": 30}]},
-                    ]
-                },
-                {10, 20, 30},
-            ),
-            (
-                "string_cohort_value",
-                {"groups": [{"properties": [{"type": "cohort", "value": "456"}]}]},
-                {456},
-            ),
-            (
-                "invalid_string_value",
-                {"groups": [{"properties": [{"type": "cohort", "value": "invalid"}]}]},
-                set(),
-            ),
-            (
-                "none_value",
-                {"groups": [{"properties": [{"type": "cohort", "value": None}]}]},
-                set(),
-            ),
-            (
-                "mixed_valid_and_invalid",
-                {
-                    "groups": [
-                        {
-                            "properties": [
-                                {"type": "cohort", "value": 100},
-                                {"type": "cohort", "value": "invalid"},
-                                {"type": "cohort", "value": None},
-                                {"type": "cohort", "value": 200},
-                            ]
-                        }
-                    ]
-                },
-                {100, 200},
-            ),
-            (
-                "duplicate_cohort_ids",
-                {
-                    "groups": [
-                        {"properties": [{"type": "cohort", "value": 5}]},
-                        {"properties": [{"type": "cohort", "value": 5}]},
-                    ]
-                },
-                {5},
-            ),
-        ]
-    )
-    def test_extract_cohort_ids(self, _name: str, filters: dict, expected: set):
-        result = _extract_cohort_ids_from_filters(filters)
-        assert result == expected
-
-
-class TestLoadCohortsWithDependencies(BaseTest):
-    """Tests for _load_cohorts_with_dependencies helper function."""
-
-    def _make_cohort_filter(self, nested_values: list) -> dict:
-        """Helper to create a properly structured cohort filter."""
-        return {
-            "properties": {
-                "type": "OR",
-                "values": [{"type": "OR", "values": nested_values}],
-            }
-        }
-
-    def _make_person_property(self, key: str, value: str) -> dict:
-        return {"key": key, "value": value, "type": "person"}
-
-    def _make_cohort_reference(self, cohort_id: int) -> dict:
-        return {"key": "id", "value": cohort_id, "type": "cohort"}
-
-    def test_empty_cohort_ids(self):
-        result = _load_cohorts_with_dependencies(set(), self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-        assert result == {}
-
-    def test_single_cohort_exists(self):
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="test-cohort",
-            filters=self._make_cohort_filter([self._make_person_property("email", "test@example.com")]),
-        )
-
-        result = _load_cohorts_with_dependencies({cohort.pk}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        assert cohort.pk in result
-        assert result[cohort.pk] == cohort
-
-    def test_missing_cohort_marked_empty(self):
-        nonexistent_id = 99999
-
-        result = _load_cohorts_with_dependencies({nonexistent_id}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        assert nonexistent_id in result
-        assert result[nonexistent_id] == ""
-
-    def test_nested_dependency_both_loaded(self):
-        """Cohort B references Cohort A - both should be loaded."""
-        cohort_a = Cohort.objects.create(
-            team=self.team,
-            name="cohort-a",
-            filters=self._make_cohort_filter([self._make_person_property("email", "a@example.com")]),
-        )
-        cohort_b = Cohort.objects.create(
-            team=self.team,
-            name="cohort-b",
-            filters=self._make_cohort_filter([self._make_cohort_reference(cohort_a.pk)]),
-        )
-
-        # Only request cohort_b, but cohort_a should also be loaded due to dependency
-        result = _load_cohorts_with_dependencies({cohort_b.pk}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        assert cohort_b.pk in result
-        assert cohort_a.pk in result
-        assert result[cohort_b.pk] == cohort_b
-        assert result[cohort_a.pk] == cohort_a
-
-    def test_three_level_nesting(self):
-        """A -> B -> C chain: all three should be loaded."""
-        cohort_c = Cohort.objects.create(
-            team=self.team,
-            name="cohort-c",
-            filters=self._make_cohort_filter([self._make_person_property("email", "c@example.com")]),
-        )
-        cohort_b = Cohort.objects.create(
-            team=self.team,
-            name="cohort-b",
-            filters=self._make_cohort_filter([self._make_cohort_reference(cohort_c.pk)]),
-        )
-        cohort_a = Cohort.objects.create(
-            team=self.team,
-            name="cohort-a",
-            filters=self._make_cohort_filter([self._make_cohort_reference(cohort_b.pk)]),
-        )
-
-        result = _load_cohorts_with_dependencies({cohort_a.pk}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        assert cohort_a.pk in result
-        assert cohort_b.pk in result
-        assert cohort_c.pk in result
-
-    def test_circular_reference_no_infinite_loop(self):
-        """A -> B -> A: should handle circular reference without infinite loop."""
-        cohort_a = Cohort.objects.create(
-            team=self.team,
-            name="cohort-a",
-            filters=self._make_cohort_filter([self._make_person_property("email", "a@example.com")]),
-        )
-        cohort_b = Cohort.objects.create(
-            team=self.team,
-            name="cohort-b",
-            filters=self._make_cohort_filter([self._make_cohort_reference(cohort_a.pk)]),
-        )
-        # Update cohort_a to reference cohort_b (creating circular reference)
-        cohort_a.filters = self._make_cohort_filter([self._make_cohort_reference(cohort_b.pk)])
-        cohort_a.save()
-
-        # Should complete without infinite loop
-        result = _load_cohorts_with_dependencies({cohort_a.pk}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        assert cohort_a.pk in result
-        assert cohort_b.pk in result
-
-    def test_deleted_cohort_not_loaded(self):
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="deleted-cohort",
-            filters=self._make_cohort_filter([self._make_person_property("email", "test@example.com")]),
-            deleted=True,
-        )
-
-        result = _load_cohorts_with_dependencies({cohort.pk}, self.team.project_id, DATABASE_FOR_LOCAL_EVALUATION)
-
-        # Deleted cohort should be marked as empty string
-        assert result[cohort.pk] == ""

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -7,6 +7,7 @@ from posthog.models.cohort.cohort import Cohort
 from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagEvaluationTag
 from posthog.models.feature_flag.local_evaluation import (
     _get_flags_response_for_local_evaluation,
+    _get_flags_response_for_local_evaluation_batch,
     clear_flag_caches,
     flags_hypercache,
     get_flags_response_for_local_evaluation,
@@ -576,3 +577,150 @@ class TestSurveyFlagExclusion(BaseTest):
         assert flag_a.key not in flag_keys
         assert flag_b.key not in flag_keys
         assert regular_flag.key in flag_keys
+
+
+class TestLocalEvaluationBatch(BaseTest):
+    def _create_team_with_project(self, name: str) -> Team:
+        project, team = Project.objects.create_with_team(
+            initiating_user=self.user,
+            organization=self.organization,
+            name=name,
+        )
+        return team
+
+    def test_batch_empty_team_list(self):
+        result = _get_flags_response_for_local_evaluation_batch([], True)
+        assert result == {}
+
+    def test_batch_two_teams_flags_isolated(self):
+        team_a = self._create_team_with_project("Team A")
+        team_b = self._create_team_with_project("Team B")
+
+        FeatureFlag.objects.create(
+            team=team_a,
+            key="flag-a",
+            filters={"groups": [{"rollout_percentage": 100}]},
+        )
+        FeatureFlag.objects.create(
+            team=team_b,
+            key="flag-b",
+            filters={"groups": [{"rollout_percentage": 50}]},
+        )
+
+        results = _get_flags_response_for_local_evaluation_batch([team_a, team_b], True)
+
+        assert team_a.id in results
+        assert team_b.id in results
+
+        keys_a = [f["key"] for f in results[team_a.id]["flags"]]
+        keys_b = [f["key"] for f in results[team_b.id]["flags"]]
+
+        assert keys_a == ["flag-a"]
+        assert keys_b == ["flag-b"]
+
+    def test_batch_team_with_no_flags(self):
+        team_with_flags = self._create_team_with_project("Has Flags")
+        team_without_flags = self._create_team_with_project("No Flags")
+
+        FeatureFlag.objects.create(
+            team=team_with_flags,
+            key="some-flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+        )
+
+        results = _get_flags_response_for_local_evaluation_batch([team_with_flags, team_without_flags], True)
+
+        assert len(results[team_with_flags.id]["flags"]) == 1
+        assert results[team_without_flags.id]["flags"] == []
+        assert "group_type_mapping" in results[team_without_flags.id]
+        assert "cohorts" in results[team_without_flags.id]
+
+    def test_batch_team_with_no_flags_includes_group_type_mapping(self):
+        team = self._create_team_with_project("GTM Team")
+
+        create_group_type_mapping_without_created_at(
+            team=team, project_id=team.project_id, group_type="company", group_type_index=0
+        )
+
+        results = _get_flags_response_for_local_evaluation_batch([team], True)
+
+        assert results[team.id]["flags"] == []
+        assert results[team.id]["group_type_mapping"] == {"0": "company"}
+
+    def test_batch_cohort_isolation_across_projects(self):
+        team_a = self._create_team_with_project("Project A")
+        team_b = self._create_team_with_project("Project B")
+
+        cohort_a = Cohort.objects.create(
+            team=team_a,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+            name="cohort-a",
+        )
+        cohort_b = Cohort.objects.create(
+            team=team_b,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "b@b.com", "type": "person"}]}],
+                }
+            },
+            name="cohort-b",
+        )
+
+        FeatureFlag.objects.create(
+            team=team_a,
+            key="flag-with-cohort-a",
+            filters={"groups": [{"properties": [{"key": "id", "type": "cohort", "value": cohort_a.pk}]}]},
+        )
+        FeatureFlag.objects.create(
+            team=team_b,
+            key="flag-with-cohort-b",
+            filters={"groups": [{"properties": [{"key": "id", "type": "cohort", "value": cohort_b.pk}]}]},
+        )
+
+        results = _get_flags_response_for_local_evaluation_batch([team_a, team_b], True)
+
+        cohort_ids_a = set(results[team_a.id]["cohorts"].keys())
+        cohort_ids_b = set(results[team_b.id]["cohorts"].keys())
+
+        assert str(cohort_a.pk) in cohort_ids_a
+        assert str(cohort_b.pk) not in cohort_ids_a
+
+        assert str(cohort_b.pk) in cohort_ids_b
+        assert str(cohort_a.pk) not in cohort_ids_b
+
+    def test_batch_deleted_cohort_handled_gracefully(self):
+        team = self._create_team_with_project("Deleted Cohort Team")
+
+        cohort = Cohort.objects.create(
+            team=team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "x@x.com", "type": "person"}]}],
+                }
+            },
+            name="soon-deleted",
+        )
+        cohort_id = cohort.pk
+
+        FeatureFlag.objects.create(
+            team=team,
+            key="flag-ref-deleted-cohort",
+            filters={"groups": [{"properties": [{"key": "id", "type": "cohort", "value": cohort_id}]}]},
+        )
+
+        # Soft-delete the cohort
+        cohort.deleted = True
+        cohort.save()
+
+        results = _get_flags_response_for_local_evaluation_batch([team], True)
+
+        flag_keys = [f["key"] for f in results[team.id]["flags"]]
+        assert "flag-ref-deleted-cohort" in flag_keys
+        assert str(cohort_id) not in results[team.id]["cohorts"]


### PR DESCRIPTION
## Summary

- Replace two overlapping code paths (`_get_flags_for_local_evaluation` and `_get_flags_response_for_local_evaluation`) with a single batch-capable, streaming function (`_get_flags_response_for_local_evaluation_batch`)
- The batch function bulk-loads survey flag IDs, cohorts, and group type mappings in one query each regardless of team count, then streams flags with `iterator()` and `itertools.groupby`
- Delete eight now-unused helper functions, reducing the module by ~380 lines
- This provides a clean foundation for the HyperCache batch PR (#44701) to build on without duplicating logic

## Behavioral changes

- **Flag sorting**: Flags are now returned sorted by key (via `order_by("key")`), improving ETag stability
- **Cohort loading**: All project cohorts are loaded upfront in one query instead of a two-pass targeted approach. Slightly broader but simpler, consistent, and avoids extra query passes
- **No cohort fallback queries**: Referenced cohort IDs not found in the bulk load are pre-populated as empty in the cache, preventing individual fallback DB queries

## Test plan

- [x] `pytest posthog/models/feature_flag/test/test_local_evaluation.py -x` (23/23 pass)
- [x] `pytest posthog/api/test/test_feature_flag.py -k "local_evaluation" -x` (27/27 pass)
- [x] `ruff check` clean
- [x] Pre-commit hooks pass