### PR TITLE
chore(llma): Scatter plot explanation tooltip

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown, IconChevronRight, IconFilter, IconGear } from '@posthog/icons'
+import { IconChevronDown, IconChevronRight, IconFilter, IconGear, IconQuestion } from '@posthog/icons'
 import { LemonButton, LemonSegmentedButton, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -231,6 +231,39 @@ export function ClustersView(): JSX.Element {
                     {isScatterPlotExpanded && (
                         <div className="border-t p-4">
                             <ClusterScatterPlot traceSummaries={traceSummaries} />
+                            <div className="flex items-center justify-between mt-2">
+                                <span className="text-xs text-muted">Drag to zoom &middot; Double-click to reset</span>
+                                <Tooltip
+                                    title={
+                                        <div className="space-y-1.5">
+                                            <p className="font-semibold mb-0">WTH (What The Hog) is this?</p>
+                                            <p className="mb-0">
+                                                Each dot is a{' '}
+                                                {clusteringLevel === 'generation' ? 'generation' : 'trace'}. We crunched
+                                                them through embeddings and squished them into 2D so similar ones land
+                                                near each other.
+                                            </p>
+                                            <p className="mb-0">
+                                                Clusters of dots = groups of{' '}
+                                                {clusteringLevel === 'generation' ? 'generations' : 'conversations'}{' '}
+                                                that your LLM handled in a similar way. Outliers are the loners that
+                                                didn't fit any group.
+                                            </p>
+                                            <p className="mb-0">Click any dot to drill into that specific trace.</p>
+                                        </div>
+                                    }
+                                    placement="left"
+                                    docLink="https://posthog.com/docs/llm-analytics/clusters"
+                                >
+                                    <span
+                                        className="inline-flex items-center gap-1 text-xs text-muted hover:text-default cursor-pointer transition-colors"
+                                        data-attr="clusters-scatter-plot-wth"
+                                    >
+                                        <IconQuestion className="text-sm" />
+                                        WTH is this?
+                                    </span>
+                                </Tooltip>
+                            </div>
                         </div>
                     )}
                 </div>

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -251,7 +251,7 @@ export function ClustersView(): JSX.Element {
                                                 didn't fit any group.
 
                                             </p>
-                                            <p className="mb-0">Click any dot to drill into that specific trace.</p>
+                                            <p className="mb-0">Click any dot to drill into that specific {clusteringLevel === 'generation' ? 'generation' : 'trace'}.</p>
                                         </div>
                                     }
                                     placement="left"

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -238,6 +238,7 @@ export function ClustersView(): JSX.Element {
                                         <div className="space-y-1.5">
                                             <p className="font-semibold mb-0">WTH (What The Hog) is this?</p>
                                             <p className="mb-0">
+
                                                 Each dot is a{' '}
                                                 {clusteringLevel === 'generation' ? 'generation' : 'trace'}. We crunched
                                                 them through embeddings and squished them into 2D so similar ones land
@@ -245,9 +246,10 @@ export function ClustersView(): JSX.Element {
                                             </p>
                                             <p className="mb-0">
                                                 Clusters of dots = groups of{' '}
-                                                {clusteringLevel === 'generation' ? 'generations' : 'conversations'}{' '}
+                                                {clusteringLevel === 'generation' ? 'generations' : 'traces'}{' '}
                                                 that your LLM handled in a similar way. Outliers are the loners that
                                                 didn't fit any group.
+
                                             </p>
                                             <p className="mb-0">Click any dot to drill into that specific trace.</p>
                                         </div>

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -238,7 +238,6 @@ export function ClustersView(): JSX.Element {
                                         <div className="space-y-1.5">
                                             <p className="font-semibold mb-0">WTH (What The Hog) is this?</p>
                                             <p className="mb-0">
-
                                                 Each dot is a{' '}
                                                 {clusteringLevel === 'generation' ? 'generation' : 'trace'}. We crunched
                                                 them through embeddings and squished them into 2D so similar ones land
@@ -246,12 +245,14 @@ export function ClustersView(): JSX.Element {
                                             </p>
                                             <p className="mb-0">
                                                 Clusters of dots = groups of{' '}
-                                                {clusteringLevel === 'generation' ? 'generations' : 'traces'}{' '}
-                                                that your LLM handled in a similar way. Outliers are the loners that
-                                                didn't fit any group.
-
+                                                {clusteringLevel === 'generation' ? 'generations' : 'traces'} that your
+                                                LLM handled in a similar way. Outliers are the loners that didn't fit
+                                                any group.
                                             </p>
-                                            <p className="mb-0">Click any dot to drill into that specific {clusteringLevel === 'generation' ? 'generation' : 'trace'}.</p>
+                                            <p className="mb-0">
+                                                Click any dot to drill into that specific{' '}
+                                                {clusteringLevel === 'generation' ? 'generation' : 'trace'}.
+                                            </p>
                                         </div>
                                     }
                                     placement="left"


### PR DESCRIPTION
## Problem

Users sometimes struggle to understand the LLM analytics scatter plot in the Clusters tab. This change addresses the need for an accessible, on-demand explanation of the scatter plot's meaning and how to interpret it, without distracting users who are already familiar with the feature.

## Changes

- Added a subtle "WTH is this?" (What The Hog) tooltip to the bottom-right corner of the expanded scatter plot in LLM analytics clusters.
- The tooltip provides an "Explain Like I'm 5" (ELI5) overview of the scatter plot, detailing what dots, proximity, clusters, and outliers represent.
- Includes a direct link to the relevant PostHog documentation for more in-depth information.
- Added a "Drag to zoom · Double-click to reset" hint to improve chart interaction usability.

<img width="1367" height="764" alt="image" src="https://github.com/user-attachments/assets/aa9985dc-9bd7-4f8e-a868-ee705b83afd0" />

## How did you test this code?

- Verified TypeScript compilation.
- Ensured linting and formatting rules were applied.
- Manually confirmed the tooltip's appearance, content, and documentation link functionality within the UI.

## Publish to changelog?

No

---
<p><a href="https://cursor.com/agents?id=bc-ab24e730-080f-4989-95cc-f0bbd59b53ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab24e730-080f-4989-95cc-f0bbd59b53ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

