### PR TITLE
fix(alerts): Add missing raise for unsupported config type

### DIFF
--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -53,7 +53,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
     if "type" in alert.config and alert.config["type"] == "TrendsAlertConfig":
         config = TrendsAlertConfig.model_validate(alert.config)
     else:
-        ValueError(f"Unsupported alert config type: {alert.config}")
+        raise ValueError(f"Unsupported alert config type: {alert.config}")
 
     condition = AlertCondition.model_validate(alert.condition)
     threshold = InsightThreshold.model_validate(alert.threshold.configuration) if alert.threshold else None


### PR DESCRIPTION
## Problem

The trends alert validation code was creating a `ValueError` exception but not raising it, causing the error to be silently ignored instead of properly handling unsupported alert configuration types.

This results in about 8% of the failed alert checks ([insight](https://us.posthog.com/project/2/insights/US61ntVv?dashboard=636477&variables_override={}&filters_override={}&tile_filters_override={})): 

## ![CleanShot 2026-02-23 at 13.00.35.png](https://app.graphite.com/user-attachments/assets/3ec0fc1b-8636-47fd-b56c-c7dca04cb94c.png)

(note: That after merging this, we will no longer fail on line 68 (`check_current_interval = config.check_ongoing_interval`), but these alerts will still not "succeed", this is due to the fact that the config is invalid (likely outdated / stale config), but we would like to clean up this piece of code nonetheless to have clearer errors.

## Changes

Fixed the missing `raise` keyword before `ValueError` in the trends alert validation logic to ensure unsupported alert config types properly throw an exception. There are other `ValueError` exceptions in this function, proving that we can handle them correctly in upstream function calls. 

In a future PR in this stack, we will also add validation to avoid code getting to this state to begin with. 

## How did you test this code?

:white_check_mark:CI is passing

## Publish to changelog?

No