### PR TITLE
fix(cdp): ipv6 validation 

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -129,6 +129,42 @@ describe('SesWebhookHandler', () => {
         expect(result.metrics).toEqual([])
     })
 
+    it('rejects SubscriptionConfirmation with non-SNS SubscribeURL', async () => {
+        const snsEnvelope = {
+            Type: 'SubscriptionConfirmation',
+            MessageId: 'sns-msg-1',
+            Token: 'token-123',
+            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
+            Message: JSON.stringify({
+                SubscribeURL: 'https://evil.lhr.life/latest/meta-data/iam/security-credentials/role',
+            }),
+            Timestamp: '2025-10-03T12:10:00Z',
+            SignatureVersion: '1',
+            Signature: 'fake',
+            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        }
+        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        expect(result.status).toBe(403)
+    })
+
+    it('rejects SubscriptionConfirmation with HTTP SubscribeURL', async () => {
+        const snsEnvelope = {
+            Type: 'SubscriptionConfirmation',
+            MessageId: 'sns-msg-1',
+            Token: 'token-123',
+            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
+            Message: JSON.stringify({
+                SubscribeURL: 'http://sns.us-east-1.amazonaws.com/subscribe',
+            }),
+            Timestamp: '2025-10-03T12:10:00Z',
+            SignatureVersion: '1',
+            Signature: 'fake',
+            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        }
+        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        expect(result.status).toBe(403)
+    })
+
     it('parses an SNS envelope Notification event', async () => {
         const snsEnvelope = {
             Type: 'Notification',

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -129,6 +129,28 @@ describe('SesWebhookHandler', () => {
         expect(result.metrics).toEqual([])
     })
 
+    it('confirms SubscriptionConfirmation with valid SNS SubscribeURL', async () => {
+        const fetchSpy = jest.spyOn(handler as any, 'fetchText').mockResolvedValue('')
+        const snsEnvelope = {
+            Type: 'SubscriptionConfirmation',
+            MessageId: 'sns-msg-1',
+            Token: 'token-123',
+            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
+            Message: JSON.stringify({
+                SubscribeURL:
+                    'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:123456789012:ses-topic&Token=token-123',
+            }),
+            Timestamp: '2025-10-03T12:10:00Z',
+            SignatureVersion: '1',
+            Signature: 'fake',
+            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        }
+        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        expect(result.status).toBe(200)
+        expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('https://sns.us-east-1.amazonaws.com/'))
+        fetchSpy.mockRestore()
+    })
+
     it('rejects SubscriptionConfirmation with non-SNS SubscribeURL', async () => {
         const snsEnvelope = {
             Type: 'SubscriptionConfirmation',

--- a/nodejs/src/utils/request.test.ts
+++ b/nodejs/src/utils/request.test.ts
@@ -100,6 +100,7 @@ describe('fetch', () => {
         ])('should block IPv6-mapped IPv4 addresses: %s (%s)', async (ip) => {
             jest.mocked(dns.lookup).mockResolvedValue([{ address: ip, family: 6 }] as any)
 
+            // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
             await expect(fetch(`http://example.com`)).rejects.toThrow(new SecureRequestError(`Hostname is not allowed`))
         })
     })

--- a/nodejs/src/utils/request.test.ts
+++ b/nodejs/src/utils/request.test.ts
@@ -90,6 +90,18 @@ describe('fetch', () => {
             // nosemgrep: typescript.react.security.react-insecure-request.react-insecure-request
             await expect(fetch(`http://example.com`)).rejects.toThrow(new SecureRequestError(`Hostname is not allowed`))
         })
+
+        it.each([
+            ['::ffff:169.254.169.254', 'IPv6-mapped IMDS'],
+            ['::ffff:127.0.0.1', 'IPv6-mapped loopback'],
+            ['::ffff:10.0.0.1', 'IPv6-mapped private'],
+            ['::ffff:192.168.1.1', 'IPv6-mapped private'],
+            ['::ffff:0.0.0.0', 'IPv6-mapped this network'],
+        ])('should block IPv6-mapped IPv4 addresses: %s (%s)', async (ip) => {
+            jest.mocked(dns.lookup).mockResolvedValue([{ address: ip, family: 6 }] as any)
+
+            await expect(fetch(`http://example.com`)).rejects.toThrow(new SecureRequestError(`Hostname is not allowed`))
+        })
     })
 
     describe('parallel requests execution', () => {


### PR DESCRIPTION
### Summary                                                                            
                                                                                     
  - Improve IPv6 handling in outbound request validation                             
  - Tighten URL validation in SES webhook subscription confirmation flow             
                                                                                     
### Context                                                                            

We have safeguards that prevent our services from making requests to internal/private addresses. During a routine review we found two gaps:             

  1. IP addresses can be written in different formats. We were checking the common format but not an alternative notation that represents the same addresses differently. Now we check both.
  2. Our email webhook handler validates one type of AWS callback URL but wasn't validating another similar one. Now both are validated consistently.

 ### Tests

  - Added tests for the alternative IP address format
  - Added tests for the webhook URL validation
  - Existing tests continue to pass