### PR TITLE
fix(alerts): treat empty query results as zero instead of erroring

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -563,7 +563,6 @@ posthog/tasks/alerts/checks.py:0: error: Item "None" of "Any | None" has no attr
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
-posthog/tasks/alerts/trends.py:0: error: Argument 1 to "extend" of "list" has incompatible type "Any | None"; expected "Iterable[TrendResult]"  [arg-type]
 posthog/tasks/alerts/trends.py:0: error: Unsupported right operand type for in ("Any | None")  [operator]
 posthog/tasks/alerts/trends.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/email.py:0: error: Argument "email" to "add_recipient" of "EmailMessage" has incompatible type "str | None"; expected "str"  [arg-type]

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -691,29 +691,37 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_send_errors.call_count == 0
         assert AlertCheck.objects.filter(alert_configuration=self.alert["id"]).count() == 0
 
-    def test_empty_results_returns_value_zero_not_error(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self.set_thresholds(lower=0, upper=100)
-
+    def _check_alert_with_empty_results(self) -> None:
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
             from posthog.caching.fetch_from_cache import InsightResult
 
             mock_calculate.return_value = InsightResult(
-                result=[],
-                last_refresh=None,
-                cache_key=None,
-                is_cached=False,
-                timezone=None,
+                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
             )
-
             check_alert(self.alert["id"])
 
+    def test_empty_results_within_bounds_does_not_fire(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=0, upper=100)
+        self._check_alert_with_empty_results()
+
         assert mock_send_notifications_for_breaches.call_count == 0
-        assert mock_send_errors.call_count == 0
 
         alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
         assert alert_check.state == AlertState.NOT_FIRING
+        assert alert_check.calculated_value == 0
+
+    def test_empty_results_below_threshold_fires(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=1)
+        self._check_alert_with_empty_results()
+
+        assert mock_send_notifications_for_breaches.call_count == 1
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.FIRING
         assert alert_check.calculated_value == 0
 
 

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -691,6 +691,31 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_send_errors.call_count == 0
         assert AlertCheck.objects.filter(alert_configuration=self.alert["id"]).count() == 0
 
+    def test_empty_results_returns_value_zero_not_error(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=0, upper=100)
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            from posthog.caching.fetch_from_cache import InsightResult
+
+            mock_calculate.return_value = InsightResult(
+                result=[],
+                last_refresh=None,
+                cache_key=None,
+                is_cached=False,
+                timezone=None,
+            )
+
+            check_alert(self.alert["id"])
+
+        assert mock_send_notifications_for_breaches.call_count == 0
+        assert mock_send_errors.call_count == 0
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.NOT_FIRING
+        assert alert_check.calculated_value == 0
+
 
 @freeze_time("2024-06-02T08:55:00.000Z")
 class TestAlertSubscriptionOrgMembership(APIBaseTest):

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -244,6 +244,25 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_send_notifications_for_breaches.call_count == 0
 
+    def test_send_error_while_calculating(
+        self, _mock_send_notifications_for_breaches: MagicMock, mock_send_notifications_for_errors: MagicMock
+    ) -> None:
+        with patch(
+            "posthog.tasks.alerts.trends.calculate_for_query_based_insight"
+        ) as mock_calculate_for_query_based_insight:
+            mock_calculate_for_query_based_insight.side_effect = Exception("Some error")
+
+            with freeze_time("2024-06-02T09:00:00.000Z"):
+                check_alert(self.alert["id"])
+                assert mock_send_notifications_for_errors.call_count == 1
+
+                latest_alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest(
+                    "created_at"
+                )
+
+                error_message = latest_alert_check.error["message"]
+                assert "Some error" in error_message
+
     def test_error_while_calculating_on_alert_in_firing_state(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_notifications_for_errors: MagicMock
     ) -> None:

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 
 from posthog.schema import (
+    AlertConditionType,
     AlertState,
     ChartDisplayType,
     EventsNode,
@@ -17,6 +18,7 @@ from posthog.schema import (
 )
 
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.caching.fetch_from_cache import InsightResult
 from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
@@ -701,19 +703,46 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_send_errors.call_count == 0
         assert AlertCheck.objects.filter(alert_configuration=self.alert["id"]).count() == 0
 
-    def _check_alert_with_mock_result(self, result: Any) -> None:
-        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            from posthog.caching.fetch_from_cache import InsightResult
-
-            mock_calculate.return_value = InsightResult(
-                result=result, last_refresh=None, cache_key=None, is_cached=False, timezone=None
-            )
-            check_alert(self.alert["id"])
-
     @parameterized.expand(
         [
-            ("within_bounds", 0, 100, AlertState.NOT_FIRING),
-            ("below_lower", 1, None, AlertState.FIRING),
+            ("absolute_within_bounds", AlertConditionType.ABSOLUTE_VALUE, False, 0, 100, AlertState.NOT_FIRING, 0),
+            ("absolute_below_lower", AlertConditionType.ABSOLUTE_VALUE, False, 1, None, AlertState.FIRING, 1),
+            (
+                "relative_increase_within_bounds",
+                AlertConditionType.RELATIVE_INCREASE,
+                True,
+                None,
+                1,
+                AlertState.NOT_FIRING,
+                0,
+            ),
+            (
+                "relative_increase_below_lower",
+                AlertConditionType.RELATIVE_INCREASE,
+                True,
+                1,
+                None,
+                AlertState.FIRING,
+                1,
+            ),
+            (
+                "relative_decrease_within_bounds",
+                AlertConditionType.RELATIVE_DECREASE,
+                True,
+                None,
+                1,
+                AlertState.NOT_FIRING,
+                0,
+            ),
+            (
+                "relative_decrease_below_lower",
+                AlertConditionType.RELATIVE_DECREASE,
+                True,
+                1,
+                None,
+                AlertState.FIRING,
+                1,
+            ),
         ]
     )
     def test_empty_results_treated_as_zero(
@@ -721,24 +750,52 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         mock_send_notifications_for_breaches: MagicMock,
         mock_send_errors: MagicMock,
         _name: str,
-        lower: Optional[int],
-        upper: Optional[int],
-        expected_state: str,
+        condition_type: AlertConditionType,
+        time_series: bool,
+        lower: Optional[float],
+        upper: Optional[float],
+        expected_state: AlertState,
+        expected_breach_count: int,
     ) -> None:
-        self.set_thresholds(lower=lower, upper=upper)
-        self._check_alert_with_mock_result([])
+        query_dict = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            trendsFilter=TrendsFilter(
+                display=ChartDisplayType.ACTIONS_LINE_GRAPH if time_series else ChartDisplayType.BOLD_NUMBER,
+            ),
+            interval=IntervalType.WEEK,
+        ).model_dump()
+        insight = self.dashboard_api.create_insight(data={"name": "insight", "query": query_dict})[1]
+        alert = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            data={
+                "name": "test alert",
+                "insight": insight["id"],
+                "subscribed_users": [self.user.id],
+                "calculation_interval": "daily",
+                "config": {"type": "TrendsAlertConfig", "series_index": 0},
+                "condition": {"type": condition_type},
+                "threshold": {"configuration": {"type": "absolute", "bounds": {"lower": lower, "upper": upper}}},
+            },
+        ).json()
 
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = InsightResult(
+                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
+            )
+            check_alert(alert["id"])
+
+        assert mock_send_notifications_for_breaches.call_count == expected_breach_count
         assert mock_send_errors.call_count == 0
 
-        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
         assert alert_check.state == expected_state
         assert alert_check.calculated_value == 0
 
     @parameterized.expand(
         [
-            ("absolute_value", "absolute_value", False),
-            ("relative_increase", "relative_increase", True),
-            ("relative_decrease", "relative_decrease", True),
+            ("absolute value", AlertConditionType.ABSOLUTE_VALUE, False),
+            ("relative increase", AlertConditionType.RELATIVE_INCREASE, True),
+            ("relative decrease", AlertConditionType.RELATIVE_DECREASE, True),
         ]
     )
     def test_none_result_produces_errored_state(
@@ -754,7 +811,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             trendsFilter=TrendsFilter(
                 display=ChartDisplayType.ACTIONS_LINE_GRAPH if time_series else ChartDisplayType.BOLD_NUMBER,
             ),
-            interval=IntervalType.WEEK if time_series else None,
+            interval=IntervalType.WEEK,
         ).model_dump()
         insight = self.dashboard_api.create_insight(data={"name": "insight", "query": query_dict})[1]
         alert = self.client.post(
@@ -771,8 +828,6 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         ).json()
 
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            from posthog.caching.fetch_from_cache import InsightResult
-
             mock_calculate.return_value = InsightResult(
                 result=None, last_refresh=None, cache_key=None, is_cached=False, timezone=None
             )

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
@@ -691,12 +691,12 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_send_errors.call_count == 0
         assert AlertCheck.objects.filter(alert_configuration=self.alert["id"]).count() == 0
 
-    def _check_alert_with_empty_results(self) -> None:
+    def _check_alert_with_mock_result(self, result: Any) -> None:
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
             from posthog.caching.fetch_from_cache import InsightResult
 
             mock_calculate.return_value = InsightResult(
-                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
+                result=result, last_refresh=None, cache_key=None, is_cached=False, timezone=None
             )
             check_alert(self.alert["id"])
 
@@ -704,7 +704,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
     ) -> None:
         self.set_thresholds(lower=0, upper=100)
-        self._check_alert_with_empty_results()
+        self._check_alert_with_mock_result([])
 
         assert mock_send_notifications_for_breaches.call_count == 0
 
@@ -716,13 +716,26 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
     ) -> None:
         self.set_thresholds(lower=1)
-        self._check_alert_with_empty_results()
+        self._check_alert_with_mock_result([])
 
         assert mock_send_notifications_for_breaches.call_count == 1
 
         alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
         assert alert_check.state == AlertState.FIRING
         assert alert_check.calculated_value == 0
+
+    def test_none_result_produces_errored_state(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=0, upper=100)
+        self._check_alert_with_mock_result(None)
+
+        assert mock_send_notifications_for_breaches.call_count == 0
+        assert mock_send_errors.call_count == 1
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.ERRORED
+        assert alert_check.error is not None
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -705,47 +705,100 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     @parameterized.expand(
         [
-            ("absolute_within_bounds", AlertConditionType.ABSOLUTE_VALUE, False, 0, 100, AlertState.NOT_FIRING, 0),
-            ("absolute_below_lower", AlertConditionType.ABSOLUTE_VALUE, False, 1, None, AlertState.FIRING, 1),
+            # result=[] treated as zero, threshold check still applies
             (
-                "relative_increase_within_bounds",
+                "absolute_empty_within_bounds",
+                AlertConditionType.ABSOLUTE_VALUE,
+                False,
+                0,
+                100,
+                [],
+                AlertState.NOT_FIRING,
+                0,
+                0,
+            ),
+            (
+                "absolute_empty_below_lower",
+                AlertConditionType.ABSOLUTE_VALUE,
+                False,
+                1,
+                None,
+                [],
+                AlertState.FIRING,
+                1,
+                0,
+            ),
+            (
+                "relative_increase_empty_within_bounds",
                 AlertConditionType.RELATIVE_INCREASE,
                 True,
                 None,
                 1,
+                [],
                 AlertState.NOT_FIRING,
+                0,
                 0,
             ),
             (
-                "relative_increase_below_lower",
+                "relative_increase_empty_below_lower",
                 AlertConditionType.RELATIVE_INCREASE,
                 True,
                 1,
                 None,
+                [],
                 AlertState.FIRING,
                 1,
-            ),
-            (
-                "relative_decrease_within_bounds",
-                AlertConditionType.RELATIVE_DECREASE,
-                True,
-                None,
-                1,
-                AlertState.NOT_FIRING,
                 0,
             ),
             (
-                "relative_decrease_below_lower",
+                "relative_decrease_empty_within_bounds",
+                AlertConditionType.RELATIVE_DECREASE,
+                True,
+                None,
+                1,
+                [],
+                AlertState.NOT_FIRING,
+                0,
+                0,
+            ),
+            (
+                "relative_decrease_empty_below_lower",
                 AlertConditionType.RELATIVE_DECREASE,
                 True,
                 1,
                 None,
+                [],
                 AlertState.FIRING,
+                1,
+                0,
+            ),
+            # result=None produces errored state
+            ("absolute_none_errored", AlertConditionType.ABSOLUTE_VALUE, False, 0, 100, None, AlertState.ERRORED, 0, 1),
+            (
+                "relative_increase_none_errored",
+                AlertConditionType.RELATIVE_INCREASE,
+                True,
+                0,
+                100,
+                None,
+                AlertState.ERRORED,
+                0,
+                1,
+            ),
+            (
+                "relative_decrease_none_errored",
+                AlertConditionType.RELATIVE_DECREASE,
+                True,
+                0,
+                100,
+                None,
+                AlertState.ERRORED,
+                0,
                 1,
             ),
         ]
     )
-    def test_empty_results_treated_as_zero(
+    def test_empty_or_none_insight_results(
         self,
         mock_send_notifications_for_breaches: MagicMock,
         mock_send_errors: MagicMock,
@@ -754,8 +807,10 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         time_series: bool,
         lower: Optional[float],
         upper: Optional[float],
+        result: Optional[list],
         expected_state: AlertState,
         expected_breach_count: int,
+        expected_error_count: int,
     ) -> None:
         query_dict = TrendsQuery(
             series=[EventsNode(event="$pageview")],
@@ -780,65 +835,19 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
             mock_calculate.return_value = InsightResult(
-                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
+                result=result, last_refresh=None, cache_key=None, is_cached=False, timezone=None
             )
             check_alert(alert["id"])
 
         assert mock_send_notifications_for_breaches.call_count == expected_breach_count
-        assert mock_send_errors.call_count == 0
+        assert mock_send_errors.call_count == expected_error_count
 
         alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
         assert alert_check.state == expected_state
-        assert alert_check.calculated_value == 0
-
-    @parameterized.expand(
-        [
-            ("absolute value", AlertConditionType.ABSOLUTE_VALUE, False),
-            ("relative increase", AlertConditionType.RELATIVE_INCREASE, True),
-            ("relative decrease", AlertConditionType.RELATIVE_DECREASE, True),
-        ]
-    )
-    def test_none_result_produces_errored_state(
-        self,
-        mock_send_notifications_for_breaches: MagicMock,
-        mock_send_errors: MagicMock,
-        _name: str,
-        condition_type: str,
-        time_series: bool,
-    ) -> None:
-        query_dict = TrendsQuery(
-            series=[EventsNode(event="$pageview")],
-            trendsFilter=TrendsFilter(
-                display=ChartDisplayType.ACTIONS_LINE_GRAPH if time_series else ChartDisplayType.BOLD_NUMBER,
-            ),
-            interval=IntervalType.WEEK,
-        ).model_dump()
-        insight = self.dashboard_api.create_insight(data={"name": "insight", "query": query_dict})[1]
-        alert = self.client.post(
-            f"/api/projects/{self.team.id}/alerts",
-            data={
-                "name": "test alert",
-                "insight": insight["id"],
-                "subscribed_users": [self.user.id],
-                "calculation_interval": "daily",
-                "config": {"type": "TrendsAlertConfig", "series_index": 0},
-                "condition": {"type": condition_type},
-                "threshold": {"configuration": {"type": "absolute", "bounds": {"lower": 0, "upper": 100}}},
-            },
-        ).json()
-
-        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = InsightResult(
-                result=None, last_refresh=None, cache_key=None, is_cached=False, timezone=None
-            )
-            check_alert(alert["id"])
-
-        assert mock_send_notifications_for_breaches.call_count == 0
-        assert mock_send_errors.call_count == 1
-
-        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
-        assert alert_check.state == AlertState.ERRORED
-        assert alert_check.error is not None
+        if expected_error_count > 0:
+            assert alert_check.error is not None
+        else:
+            assert alert_check.calculated_value == 0
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -4,7 +4,17 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
 from unittest.mock import MagicMock, patch
 
-from posthog.schema import AlertState, ChartDisplayType, EventsNode, TrendsFilter, TrendsFormulaNode, TrendsQuery
+from parameterized import parameterized
+
+from posthog.schema import (
+    AlertState,
+    ChartDisplayType,
+    EventsNode,
+    IntervalType,
+    TrendsFilter,
+    TrendsFormulaNode,
+    TrendsQuery,
+)
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.models import AlertConfiguration, User
@@ -233,25 +243,6 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         check_alert(self.alert["id"])
 
         assert mock_send_notifications_for_breaches.call_count == 0
-
-    def test_send_error_while_calculating(
-        self, _mock_send_notifications_for_breaches: MagicMock, mock_send_notifications_for_errors: MagicMock
-    ) -> None:
-        with patch(
-            "posthog.tasks.alerts.trends.calculate_for_query_based_insight"
-        ) as mock_calculate_for_query_based_insight:
-            mock_calculate_for_query_based_insight.side_effect = Exception("Some error")
-
-            with freeze_time("2024-06-02T09:00:00.000Z"):
-                check_alert(self.alert["id"])
-                assert mock_send_notifications_for_errors.call_count == 1
-
-                latest_alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest(
-                    "created_at"
-                )
-
-                error_message = latest_alert_check.error["message"]
-                assert "Some error" in error_message
 
     def test_error_while_calculating_on_alert_in_firing_state(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_notifications_for_errors: MagicMock
@@ -700,40 +691,78 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             )
             check_alert(self.alert["id"])
 
-    def test_empty_results_within_bounds_does_not_fire(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    @parameterized.expand(
+        [
+            ("within_bounds", 0, 100, AlertState.NOT_FIRING),
+            ("below_lower", 1, None, AlertState.FIRING),
+        ]
+    )
+    def test_empty_results_treated_as_zero(
+        self,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        _name: str,
+        lower: Optional[int],
+        upper: Optional[int],
+        expected_state: str,
     ) -> None:
-        self.set_thresholds(lower=0, upper=100)
+        self.set_thresholds(lower=lower, upper=upper)
         self._check_alert_with_mock_result([])
 
-        assert mock_send_notifications_for_breaches.call_count == 0
+        assert mock_send_errors.call_count == 0
 
         alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
-        assert alert_check.state == AlertState.NOT_FIRING
+        assert alert_check.state == expected_state
         assert alert_check.calculated_value == 0
 
-    def test_empty_results_below_threshold_fires(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self.set_thresholds(lower=1)
-        self._check_alert_with_mock_result([])
-
-        assert mock_send_notifications_for_breaches.call_count == 1
-
-        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
-        assert alert_check.state == AlertState.FIRING
-        assert alert_check.calculated_value == 0
-
+    @parameterized.expand(
+        [
+            ("absolute_value", "absolute_value", False),
+            ("relative_increase", "relative_increase", True),
+            ("relative_decrease", "relative_decrease", True),
+        ]
+    )
     def test_none_result_produces_errored_state(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+        self,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        _name: str,
+        condition_type: str,
+        time_series: bool,
     ) -> None:
-        self.set_thresholds(lower=0, upper=100)
-        self._check_alert_with_mock_result(None)
+        query_dict = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            trendsFilter=TrendsFilter(
+                display=ChartDisplayType.ACTIONS_LINE_GRAPH if time_series else ChartDisplayType.BOLD_NUMBER,
+            ),
+            interval=IntervalType.WEEK if time_series else None,
+        ).model_dump()
+        insight = self.dashboard_api.create_insight(data={"name": "insight", "query": query_dict})[1]
+        alert = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            data={
+                "name": "test alert",
+                "insight": insight["id"],
+                "subscribed_users": [self.user.id],
+                "calculation_interval": "daily",
+                "config": {"type": "TrendsAlertConfig", "series_index": 0},
+                "condition": {"type": condition_type},
+                "threshold": {"configuration": {"type": "absolute", "bounds": {"lower": 0, "upper": 100}}},
+            },
+        ).json()
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            from posthog.caching.fetch_from_cache import InsightResult
+
+            mock_calculate.return_value = InsightResult(
+                result=None, last_refresh=None, cache_key=None, is_cached=False, timezone=None
+            )
+            check_alert(alert["id"])
 
         assert mock_send_notifications_for_breaches.call_count == 0
         assert mock_send_errors.call_count == 1
 
-        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
         assert alert_check.state == AlertState.ERRORED
         assert alert_check.error is not None
 

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytz
 import dateutil
 import dateutil.relativedelta
+from parameterized import parameterized
 
 from posthog.schema import (
     AlertCalculationInterval,
@@ -2110,16 +2111,22 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
 
             mock_send_breaches.assert_called_once()
 
-    def _check_empty_results_does_not_fire(
-        self, condition_type: AlertConditionType, mock_send_breaches: MagicMock
-    ) -> None:
+    def _check_empty_results(
+        self,
+        condition_type: AlertConditionType,
+        mock_send_breaches: MagicMock,
+        *,
+        lower: Optional[float] = None,
+        upper: Optional[float] = None,
+    ) -> AlertCheck:
         insight = self.create_time_series_trend_insight(interval=IntervalType.WEEK)
         alert = self.create_alert(
             insight,
             series_index=0,
             condition_type=condition_type,
             threshold_type=InsightThresholdType.ABSOLUTE,
-            upper=1,
+            lower=lower,
+            upper=upper,
         )
 
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
@@ -2130,17 +2137,42 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
             )
             check_alert(alert["id"])
 
-        assert mock_send_breaches.call_count == 0
-        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
-        assert alert_check.state == AlertState.NOT_FIRING
+        return AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+
+    @parameterized.expand(
+        [
+            (
+                "relative_increase_within_bounds",
+                AlertConditionType.RELATIVE_INCREASE,
+                None,
+                1,
+                AlertState.NOT_FIRING,
+                0,
+            ),
+            (
+                "relative_decrease_within_bounds",
+                AlertConditionType.RELATIVE_DECREASE,
+                None,
+                1,
+                AlertState.NOT_FIRING,
+                0,
+            ),
+            ("relative_increase_below_threshold", AlertConditionType.RELATIVE_INCREASE, 1, None, AlertState.FIRING, 1),
+            ("relative_decrease_below_threshold", AlertConditionType.RELATIVE_DECREASE, 1, None, AlertState.FIRING, 1),
+        ]
+    )
+    def test_empty_results_threshold_check(
+        self,
+        _name: str,
+        condition_type: AlertConditionType,
+        lower: Optional[float],
+        upper: Optional[float],
+        expected_state: AlertState,
+        expected_breach_count: int,
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+    ) -> None:
+        alert_check = self._check_empty_results(condition_type, mock_send_breaches, lower=lower, upper=upper)
+        assert mock_send_breaches.call_count == expected_breach_count
+        assert alert_check.state == expected_state
         assert alert_check.calculated_value == 0
-
-    def test_empty_results_does_not_fire_for_relative_increase(
-        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self._check_empty_results_does_not_fire(AlertConditionType.RELATIVE_INCREASE, mock_send_breaches)
-
-    def test_empty_results_does_not_fire_for_relative_decrease(
-        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self._check_empty_results_does_not_fire(AlertConditionType.RELATIVE_DECREASE, mock_send_breaches)

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -7,7 +7,6 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytz
 import dateutil
 import dateutil.relativedelta
-from parameterized import parameterized
 
 from posthog.schema import (
     AlertCalculationInterval,
@@ -2110,69 +2109,3 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
             assert alert_check.state == AlertState.FIRING
 
             mock_send_breaches.assert_called_once()
-
-    def _check_empty_results(
-        self,
-        condition_type: AlertConditionType,
-        mock_send_breaches: MagicMock,
-        *,
-        lower: Optional[float] = None,
-        upper: Optional[float] = None,
-    ) -> AlertCheck:
-        insight = self.create_time_series_trend_insight(interval=IntervalType.WEEK)
-        alert = self.create_alert(
-            insight,
-            series_index=0,
-            condition_type=condition_type,
-            threshold_type=InsightThresholdType.ABSOLUTE,
-            lower=lower,
-            upper=upper,
-        )
-
-        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            from posthog.caching.fetch_from_cache import InsightResult
-
-            mock_calculate.return_value = InsightResult(
-                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
-            )
-            check_alert(alert["id"])
-
-        return AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
-
-    @parameterized.expand(
-        [
-            (
-                "relative_increase_within_bounds",
-                AlertConditionType.RELATIVE_INCREASE,
-                None,
-                1,
-                AlertState.NOT_FIRING,
-                0,
-            ),
-            (
-                "relative_decrease_within_bounds",
-                AlertConditionType.RELATIVE_DECREASE,
-                None,
-                1,
-                AlertState.NOT_FIRING,
-                0,
-            ),
-            ("relative_increase_below_threshold", AlertConditionType.RELATIVE_INCREASE, 1, None, AlertState.FIRING, 1),
-            ("relative_decrease_below_threshold", AlertConditionType.RELATIVE_DECREASE, 1, None, AlertState.FIRING, 1),
-        ]
-    )
-    def test_empty_results_threshold_check(
-        self,
-        _name: str,
-        condition_type: AlertConditionType,
-        lower: Optional[float],
-        upper: Optional[float],
-        expected_state: AlertState,
-        expected_breach_count: int,
-        mock_send_breaches: MagicMock,
-        mock_send_errors: MagicMock,
-    ) -> None:
-        alert_check = self._check_empty_results(condition_type, mock_send_breaches, lower=lower, upper=upper)
-        assert mock_send_breaches.call_count == expected_breach_count
-        assert alert_check.state == expected_state
-        assert alert_check.calculated_value == 0

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -2109,3 +2109,38 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
             assert alert_check.state == AlertState.FIRING
 
             mock_send_breaches.assert_called_once()
+
+    def _check_empty_results_does_not_fire(
+        self, condition_type: AlertConditionType, mock_send_breaches: MagicMock
+    ) -> None:
+        insight = self.create_time_series_trend_insight(interval=IntervalType.WEEK)
+        alert = self.create_alert(
+            insight,
+            series_index=0,
+            condition_type=condition_type,
+            threshold_type=InsightThresholdType.ABSOLUTE,
+            upper=1,
+        )
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            from posthog.caching.fetch_from_cache import InsightResult
+
+            mock_calculate.return_value = InsightResult(
+                result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None
+            )
+            check_alert(alert["id"])
+
+        assert mock_send_breaches.call_count == 0
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.NOT_FIRING
+        assert alert_check.calculated_value == 0
+
+    def test_empty_results_does_not_fire_for_relative_increase(
+        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self._check_empty_results_does_not_fire(AlertConditionType.RELATIVE_INCREASE, mock_send_breaches)
+
+    def test_empty_results_does_not_fire_for_relative_decrease(
+        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self._check_empty_results_does_not_fire(AlertConditionType.RELATIVE_DECREASE, mock_send_breaches)

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -189,7 +189,8 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                return AlertEvaluationResult(value=0, breaches=[])
+                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
+                return AlertEvaluationResult(value=0, breaches=breaches)
 
             results_to_evaluate: list[TrendResult] = []
 
@@ -203,7 +204,8 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 results_to_evaluate.append(selected_series_result)
 
             if not results_to_evaluate:
-                return AlertEvaluationResult(value=0, breaches=[])
+                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
+                return AlertEvaluationResult(value=0, breaches=breaches)
 
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result
@@ -299,7 +301,8 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                return AlertEvaluationResult(value=0, breaches=[])
+                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
+                return AlertEvaluationResult(value=0, breaches=breaches)
 
             results_to_evaluate = []
 

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -97,7 +97,8 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                return AlertEvaluationResult(value=0, breaches=[])
+                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, None, "")
+                return AlertEvaluationResult(value=0, breaches=breaches)
 
             interval = query.interval if not is_non_time_series else None
 
@@ -186,6 +187,9 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 user=None,
                 filters_override=filters_overrides,
             )
+
+            if not calculation_result.result:
+                return AlertEvaluationResult(value=0, breaches=[])
 
             results_to_evaluate: list[TrendResult] = []
 

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -203,10 +203,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 selected_series_result = _pick_series_result(config, calculation_result)
                 results_to_evaluate.append(selected_series_result)
 
-            if not results_to_evaluate:
-                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
-                return AlertEvaluationResult(value=0, breaches=breaches)
-
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result
             increase = None

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -97,7 +97,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, None, "")
+                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, None, "empty result")
                 return AlertEvaluationResult(value=0, breaches=breaches)
 
             interval = query.interval if not is_non_time_series else None
@@ -189,7 +189,9 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
+                breaches = _breach_messages(
+                    threshold.bounds, 0, threshold.type, condition.type, query.interval, "empty result"
+                )
                 return AlertEvaluationResult(value=0, breaches=breaches)
 
             results_to_evaluate: list[TrendResult] = []
@@ -297,7 +299,9 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, query.interval, "")
+                breaches = _breach_messages(
+                    threshold.bounds, 0, threshold.type, condition.type, query.interval, "empty result"
+                )
                 return AlertEvaluationResult(value=0, breaches=breaches)
 
             results_to_evaluate = []

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -38,6 +38,27 @@ class TrendResult(TypedDict):
     filter: dict
 
 
+def _is_empty_query_result(
+    calculation_result: InsightResult,
+    alert: AlertConfiguration,
+    threshold: InsightThreshold,
+    condition: AlertCondition,
+    interval_type: IntervalType | None,
+) -> AlertEvaluationResult | None:
+    # is None -> Indicates that the query layer swallowed a legitimate error, in this case we still want
+    # to raise an exception to avoid mis-fires of the alert.
+    if calculation_result.result is None:
+        raise RuntimeError(f"No results found for insight with alert id = {alert.id}")
+
+    # For other "empty" cases we assume that they had no legitimate results and as a result will treat it as a 0 value
+    # in terms of alerting. See: https://github.com/PostHog/posthog/pull/48701
+    if not calculation_result.result:
+        breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, interval_type, "empty result")
+        return AlertEvaluationResult(value=0, breaches=breaches)
+
+    return None
+
+
 def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: TrendsQuery) -> AlertEvaluationResult:
     """
     Calculates insight value for the needed time periods and compares it with the threshold.
@@ -96,11 +117,12 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 filters_override=filters_override,
             )
 
-            if not calculation_result.result:
-                breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, None, "empty result")
-                return AlertEvaluationResult(value=0, breaches=breaches)
-
             interval = query.interval if not is_non_time_series else None
+
+            if no_result_evaluation := _is_empty_query_result(
+                calculation_result, alert, threshold, condition, interval
+            ):
+                return no_result_evaluation
 
             if check_current_interval and threshold.bounds.upper is None:
                 # checking for value > X so we can also check current interval value
@@ -188,11 +210,10 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 filters_override=filters_overrides,
             )
 
-            if not calculation_result.result:
-                breaches = _breach_messages(
-                    threshold.bounds, 0, threshold.type, condition.type, query.interval, "empty result"
-                )
-                return AlertEvaluationResult(value=0, breaches=breaches)
+            if no_result_evaluation := _is_empty_query_result(
+                calculation_result, alert, threshold, condition, query.interval
+            ):
+                return no_result_evaluation
 
             results_to_evaluate: list[TrendResult] = []
 
@@ -298,11 +319,10 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 filters_override=filters_overrides,
             )
 
-            if not calculation_result.result:
-                breaches = _breach_messages(
-                    threshold.bounds, 0, threshold.type, condition.type, query.interval, "empty result"
-                )
-                return AlertEvaluationResult(value=0, breaches=breaches)
+            if no_result_evaluation := _is_empty_query_result(
+                calculation_result, alert, threshold, condition, query.interval
+            ):
+                return no_result_evaluation
 
             results_to_evaluate = []
 

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -97,7 +97,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if not calculation_result.result:
-                raise RuntimeError(f"No results found for insight with alert id = {alert.id}")
+                return AlertEvaluationResult(value=0, breaches=[])
 
             interval = query.interval if not is_non_time_series else None
 
@@ -199,7 +199,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 results_to_evaluate.append(selected_series_result)
 
             if not results_to_evaluate:
-                raise RuntimeError(f"No results found for insight with alert id = {alert.id}")
+                return AlertEvaluationResult(value=0, breaches=[])
 
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result
@@ -294,6 +294,9 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 filters_override=filters_overrides,
             )
 
+            if not calculation_result.result:
+                return AlertEvaluationResult(value=0, breaches=[])
+
             results_to_evaluate = []
 
             if has_breakdown:
@@ -304,9 +307,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 # for non breakdowns, we pick the series (config.series_index) from calculation_result.result
                 selected_series_result = _pick_series_result(config, calculation_result)
                 results_to_evaluate.append(selected_series_result)
-
-                # for non breakdowns, we pick the series (config.series_index) from calculation_result.result
-                selected_series_result = _pick_series_result(config, calculation_result)
 
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -41,7 +41,8 @@ class TrendResult(TypedDict):
 def _is_empty_query_result(
     calculation_result: InsightResult,
     alert: AlertConfiguration,
-    threshold: InsightThreshold,
+    bounds: InsightsThresholdBounds,
+    threshold_type: InsightThresholdType,
     condition: AlertCondition,
     interval_type: IntervalType | None,
 ) -> AlertEvaluationResult | None:
@@ -53,7 +54,7 @@ def _is_empty_query_result(
     # For other "empty" cases we assume that they had no legitimate results and as a result will treat it as a 0 value
     # in terms of alerting. See: https://github.com/PostHog/posthog/pull/48701
     if not calculation_result.result:
-        breaches = _breach_messages(threshold.bounds, 0, threshold.type, condition.type, interval_type, "empty result")
+        breaches = _breach_messages(bounds, 0, threshold_type, condition.type, interval_type, "empty result")
         return AlertEvaluationResult(value=0, breaches=breaches)
 
     return None
@@ -120,7 +121,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             interval = query.interval if not is_non_time_series else None
 
             if no_result_evaluation := _is_empty_query_result(
-                calculation_result, alert, threshold, condition, interval
+                calculation_result, alert, threshold.bounds, threshold.type, condition, interval
             ):
                 return no_result_evaluation
 
@@ -132,7 +133,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
 
             if has_breakdown:
                 # for breakdowns, we need to check all values in calculation_result.result
-                breakdown_results = calculation_result.result
+                breakdown_results = cast(list[TrendResult], calculation_result.result)
 
                 for breakdown_result in breakdown_results:
                     if check_current_interval or is_non_time_series:
@@ -211,7 +212,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if no_result_evaluation := _is_empty_query_result(
-                calculation_result, alert, threshold, condition, query.interval
+                calculation_result, alert, threshold.bounds, threshold.type, condition, query.interval
             ):
                 return no_result_evaluation
 
@@ -320,7 +321,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             )
 
             if no_result_evaluation := _is_empty_query_result(
-                calculation_result, alert, threshold, condition, query.interval
+                calculation_result, alert, threshold.bounds, threshold.type, condition, query.interval
             ):
                 return no_result_evaluation
 
@@ -328,7 +329,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
 
             if has_breakdown:
                 # for breakdowns, we need to check all values in calculation_result.result
-                breakdown_results = calculation_result.result
+                breakdown_results = cast(list[TrendResult], calculation_result.result)
                 results_to_evaluate.extend(breakdown_results)
             else:
                 # for non breakdowns, we pick the series (config.series_index) from calculation_result.result


### PR DESCRIPTION
## Problem

Alert checks were failing with runtime errors when insights returned empty results, causing unnecessary error notifications and preventing proper alert state tracking.

This results in about 75% of the failed alert checks ([insight](https://us.posthog.com/project/2/insights/US61ntVv?dashboard=636477&variables_override=%7B%7D&filters_override=%7B%7D&tile_filters_override=%7B%7D)):

![CleanShot 2026-02-23 at 13.00.35.png](https://app.graphite.com/user-attachments/assets/67ac5aeb-5406-4c49-83d2-b708cea58ad1.png)

The idea behind this change is that insights that have 0 results should still be valid candidates (e.g. cases where you want to be notified if something goes to 0 for example), thus as a result, I would propose to remove the thrown exception and instead handle the empty results as an actual state.

A live example of such a case can be found here: https://us.posthog.com/project/2/insights/d7Eyq2dj albeit that the alert does not trigger (as it checks > 5), it clealry shows the recent failure due to the (legitimate) absence of data. 

Please note that this only affects a small subset of our insights / alerts (also see the metabase links below) due to the fact that "empty" insights without a breakdown do not run into this case:

> Without a breakdown, the trends SQL generates the full date array upfront via _get_date_subqueries — an arrayMap over range(0, dateDiff(...)) that produces every time bucket
  regardless of whether any events exist. The per-bucket values then get filled via arraySum/arrayMap which defaults to 0 for missing data. So you always get back a series
  like:
>
>  [{"data": [0, 0, 0, 0, 0, 0, 0, 0], "label": "Formula (A-A)", ...}]
>
>  That's a non-empty list with one item — not result is False, and the code proceeds normally with value=0.
>
>  With a breakdown, the query does GROUP BY breakdown_value. The breakdown values come from the actual event data. If there are zero matching events, there are no breakdown
  values to group by, so ClickHouse returns zero rows. build_series_response iterates over zero rows, produces nothing, and the final result is:
>
>  []
>
>  That's an empty list — not result is True, and on master that hit the old not calculation_result.result check.
>
>  In short: without breakdown, the date-fill creates the structure even with no data. With breakdown, no data means no breakdown groups means no structure at all.
>
> [Code location](https://github.com/PostHog/posthog/blob/b0dae56053048e40b3a2e2576031f8715cb535af/posthog/hogql_queries/insights/trends/trends_query_builder.py#L315)
> (©️ Claude)

## Changes

- Modified trends alert checking to return a value of 0 instead of raising a `RuntimeError` when calculation results are empty
- Added proper handling for empty results in all code paths within the trends alert checker
- Removed duplicate series result selection code that was unreachable

## How did you test this code?

✅ Alerts now trigger if an insight reached 0 (note: Had to add a breakdown here in order to trigger the condition as otherwise it will not enter the check due to earlier termination)

This also confirms that the impact is quite limited, and explains the numbers found by the queries below (as the insights need to have breakdowns to trigger in which case it can return an empty `[]` as result, without a breakdown it would return a valid series like `[0,0,0,0...]`, which does not trigger the exception).

<img width="1060" height="1136" alt="CleanShot 2026-02-27 at 10 30 01" src="https://github.com/user-attachments/assets/e61969d0-9e43-40e7-a2e3-2e3fe67c90be" />
<img width="1431" height="765" alt="CleanShot 2026-02-27 at 10 44 38" src="https://github.com/user-attachments/assets/92689516-d735-4353-a8e7-19e293fdd753" />


**Running the above with the code from master results in:**
<img width="1411" height="1808" alt="CleanShot 2026-02-27 at 10 40 57" src="https://github.com/user-attachments/assets/7526f7da-bb11-41bc-9751-58ac2cd7a540" />


✅ Did a multi step impact assessment:

- 1️⃣ : Fetch all `alert_ids` which have triggered the failing event in the last `60d`:

```sql
SELECT  
    JSONExtractString(properties, 'alert_id') AS alert_id  
FROM events  
WHERE  
    event = 'alert check failed'  
    AND timestamp >= now() - INTERVAL 60 DAY  
    AND JSONExtractString(properties, 'traceback') LIKE '%No results found for insight%'  
    AND JSONExtractString(properties, 'alert_id') != ''  
GROUP BY alert_id  
```

- 2️⃣ : With those alert ID's query for the alert configuration and investigate which alerts would start to fire if we are to treat 0 as a valid case. 

```sql
WITH affected_alerts AS (
      SELECT
          ac.id,
          ac.name,
          ac.team_id,
          ac.state,
          ac.enabled,
          ac.condition->>'type' AS condition_type,
          ac.calculation_interval,
          t.configuration->'bounds'->>'lower' AS lower_bound,
          t.configuration->'bounds'->>'upper' AS upper_bound,
          t.id IS NOT NULL AS has_threshold,
          CASE
              WHEN (
                  (t.configuration->'bounds'->>'lower' IS NOT NULL AND 0 <
  (t.configuration->'bounds'->>'lower')::float)
                  OR
                  (t.configuration->'bounds'->>'upper' IS NOT NULL AND 0 >
  (t.configuration->'bounds'->>'upper')::float)
              ) THEN 'would_fire'
              ELSE 'would_not_fire'
          END AS new_behavior
      FROM posthog_alertconfiguration ac
      LEFT JOIN posthog_threshold t ON ac.threshold_id = t.id
      WHERE ac.id::text IN (
          -- ID's from step 1
      )
  ),


  -- Per-team summary for the detail section
  team_summary AS (
      SELECT
          a.team_id,
          o.name AS org_name,
          t.name AS team_name,
          COUNT(*) AS total_alerts,
          COUNT(*) FILTER (WHERE a.new_behavior = 'would_fire' AND a.enabled) AS would_fire_enabled,
          COUNT(*) FILTER (WHERE a.new_behavior = 'would_fire') AS would_fire_total,
          COUNT(*) FILTER (WHERE a.new_behavior = 'would_not_fire') AS would_not_fire,
          string_agg(DISTINCT a.condition_type, ', ') AS condition_types
      FROM affected_alerts a
      JOIN posthog_team t ON t.id = a.team_id
      JOIN posthog_organization o ON o.id = t.organization_id
      GROUP BY a.team_id, o.name, t.name
  )

  -- Part 1: Summary stats
  SELECT 'SUMMARY' AS section, 'Total affected alerts' AS metric, COUNT(*)::text AS value FROM affected_alerts
  UNION ALL SELECT 'SUMMARY', 'Enabled', COUNT(*) FILTER (WHERE enabled)::text FROM affected_alerts
  UNION ALL SELECT 'SUMMARY', 'Disabled', COUNT(*) FILTER (WHERE NOT enabled)::text FROM affected_alerts
  UNION ALL SELECT 'SUMMARY', 'Currently in Errored state', COUNT(*) FILTER (WHERE state = 'Errored')::text
  FROM affected_alerts

  -- Part 2: By condition type
  UNION ALL SELECT 'CONDITION TYPE', condition_type, COUNT(*)::text FROM affected_alerts GROUP BY
  condition_type

  -- Part 3: Behavior change
  UNION ALL SELECT 'BEHAVIOR', 'Would fire (0 breaches threshold)', COUNT(*) FILTER (WHERE new_behavior =
  'would_fire')::text FROM affected_alerts
  UNION ALL SELECT 'BEHAVIOR', 'Would fire + enabled', COUNT(*) FILTER (WHERE new_behavior = 'would_fire' AND
  enabled)::text FROM affected_alerts
  UNION ALL SELECT 'BEHAVIOR', 'Would NOT fire', COUNT(*) FILTER (WHERE new_behavior = 'would_not_fire')::text
  FROM affected_alerts

  -- Part 4: By interval
  UNION ALL SELECT 'INTERVAL', COALESCE(calculation_interval, 'NULL'), COUNT(*)::text FROM affected_alerts
  GROUP BY calculation_interval

  -- Part 5: Threshold config
  UNION ALL SELECT 'THRESHOLD', 'Has threshold', COUNT(*) FILTER (WHERE has_threshold)::text FROM
  affected_alerts
  UNION ALL SELECT 'THRESHOLD', 'No threshold', COUNT(*) FILTER (WHERE NOT has_threshold)::text FROM
  affected_alerts
  UNION ALL SELECT 'THRESHOLD', 'Lower bound only', COUNT(*) FILTER (WHERE lower_bound IS NOT NULL AND
  upper_bound IS NULL)::text FROM affected_alerts
  UNION ALL SELECT 'THRESHOLD', 'Upper bound only', COUNT(*) FILTER (WHERE lower_bound IS NULL AND upper_bound
  IS NOT NULL)::text FROM affected_alerts
  UNION ALL SELECT 'THRESHOLD', 'Both bounds', COUNT(*) FILTER (WHERE lower_bound IS NOT NULL AND upper_bound
  IS NOT NULL)::text FROM affected_alerts

  -- Part 6: Blast radius
  UNION ALL SELECT 'BLAST RADIUS', 'Distinct teams (all affected)', COUNT(DISTINCT team_id)::text FROM
  affected_alerts
  UNION ALL SELECT 'BLAST RADIUS', 'Distinct teams (would fire + enabled)', COUNT(DISTINCT team_id)::text FROM
  affected_alerts WHERE new_behavior = 'would_fire' AND enabled
  UNION ALL SELECT 'BLAST RADIUS', 'Subscribed users (would fire + enabled)', (
      SELECT COUNT(DISTINCT asub.user_id)::text
      FROM posthog_alertsubscription asub
      WHERE asub.alert_configuration_id IN (SELECT id FROM affected_alerts WHERE new_behavior = 'would_fire'
  AND enabled)
        AND asub.subscribed = true
  )

  -- Part 7: Per-team breakdown (sorted by most would-fire alerts)
  UNION ALL SELECT 'TEAM DETAIL', org_name || ' / ' || team_name || ' (team ' || team_id || ')',
      would_fire_enabled || ' would fire (enabled) / ' || total_alerts || ' total, types: ' || condition_types
  FROM team_summary
  WHERE would_fire_enabled > 0
  ORDER BY section, metric;
```

- [US results](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6IldJVEggYWZmZWN0ZWRfYWxlcnRzIEFTIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFjLmlkLFxuICAgICAgICAgIGFjLm5hbWUsXG4gICAgICAgICAgYWMudGVhbV9pZCxcbiAgICAgICAgICBhYy5zdGF0ZSxcbiAgICAgICAgICBhYy5lbmFibGVkLFxuICAgICAgICAgIGFjLmNvbmRpdGlvbi0-Pid0eXBlJyBBUyBjb25kaXRpb25fdHlwZSxcbiAgICAgICAgICBhYy5jYWxjdWxhdGlvbl9pbnRlcnZhbCxcbiAgICAgICAgICB0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J2xvd2VyJyBBUyBsb3dlcl9ib3VuZCxcbiAgICAgICAgICB0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J3VwcGVyJyBBUyB1cHBlcl9ib3VuZCxcbiAgICAgICAgICB0LmlkIElTIE5PVCBOVUxMIEFTIGhhc190aHJlc2hvbGQsXG4gICAgICAgICAgQ0FTRVxuICAgICAgICAgICAgICBXSEVOIChcbiAgICAgICAgICAgICAgICAgICh0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J2xvd2VyJyBJUyBOT1QgTlVMTCBBTkQgMCA8XG4gICh0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J2xvd2VyJyk6OmZsb2F0KVxuICAgICAgICAgICAgICAgICAgT1JcbiAgICAgICAgICAgICAgICAgICh0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J3VwcGVyJyBJUyBOT1QgTlVMTCBBTkQgMCA-XG4gICh0LmNvbmZpZ3VyYXRpb24tPidib3VuZHMnLT4-J3VwcGVyJyk6OmZsb2F0KVxuICAgICAgICAgICAgICApIFRIRU4gJ3dvdWxkX2ZpcmUnXG4gICAgICAgICAgICAgIEVMU0UgJ3dvdWxkX25vdF9maXJlJ1xuICAgICAgICAgIEVORCBBUyBuZXdfYmVoYXZpb3JcbiAgICAgIEZST00gcG9zdGhvZ19hbGVydGNvbmZpZ3VyYXRpb24gYWNcbiAgICAgIExFRlQgSk9JTiBwb3N0aG9nX3RocmVzaG9sZCB0IE9OIGFjLnRocmVzaG9sZF9pZCA9IHQuaWRcbiAgICAgIFdIRVJFIGFjLmlkOjp0ZXh0IElOIChcbiAgICAgICAgICAnMDE5OWMzMjgtNWYwZC0wMDAwLTRhMDItMGQyNTgyZWI3NTljJywnMDE5MzkyOTctNTFjZS0wMDAwLTZhZDktNzRmMjg2ZTA4YWMzJyxcbiAgICAgICAgICAnMDE5OTI4ZjktMWMxNi0wMDAwLTE3YTEtNDUxMmFjNzE0NzA2JywnMDE5NTEwYzAtYmNmMi0wMDAwLWVhMGEtZmU4NzEwZjliYjlhJyxcbiAgICAgICAgICAnMDE5YzJlNWEtNDYxNC0wMDAwLWJkN2EtZmIzYTg5NmM4N2IxJywnMDE5YjRhZDctNWY0Ny0wMDAwLTgwYjUtOTNlNTQxNzBiMDk0JyxcbiAgICAgICAgICAnMDE5YzFkZDgtZDlkMi0wMDAwLWI0NTctZDJjMGZkODE4Y2ZlJywnMDE5OGFkNDAtMjM1MS0wMDAwLTYzNDUtYTUyZGY1YzczYTUxJyxcbiAgICAgICAgICAnMDE5YjMwZWQtNzhhNy0wMDAwLTVmZGMtMWI0OTA3MWQ4NmRhJywnMDE5YWU5ZWUtZGZkNi0wMDAwLTM5ZTEtZDkzNjA1YmEzMmFjJyxcbiAgICAgICAgICAnMDE5Mzc5ZTctZTFlMy0wMDAwLTk2YTgtZDVhNTU2NjIyMzA0JywnMDE5YmUxYzAtYTRkYy0wMDAwLWU4ZGItNzdhMTJmZTU5ZjllJyxcbiAgICAgICAgICAnMDE5YWNkYzktZTJjYS0wMDAwLThmYzYtMzRkNGVhZjBkNWFiJywnMDE5Yzc2ZDItNDc0ZS0wMDAwLTBkYWQtOTJhM2E5YjRhMGEyJyxcbiAgICAgICAgICAnMDE5NmU5N2QtOGYzNS0wMDAwLWM4NzEtYTFlYjM1MmI2MzY0JywnMDE5OGIzYWItODNiYS0wMDAwLTM1ODItZmM2ODk4NTIxNzYzJyxcbiAgICAgICAgICAnMDE5NTMyOTMtMTUzZi0wMDAwLTY3NzAtYmQxNGJjYjgwMDJmJywnMDE5OWRlMjktNDk5Yi0wMDAwLWNjNjUtNDFjNmViYTRiYjQzJyxcbiAgICAgICAgICAnMDE5NmEyNjEtNDU4Mi0wMDAwLWU0MDUtMzA4MDZhMjcwZmNlJywnMDE5YzJlNTYtZmYyOS0wMDAwLTk3YjYtY2VhMWViZjkzZmIwJyxcbiAgICAgICAgICAnMDE5NmZlMGQtOGViNS0wMDAwLWZhZjgtMmM2YmE2ZGY4ZjE3JywnMDE5M2Q5M2QtYzc4NS0wMDAwLThiMWUtNmI4MThjYWMwODQ5JyxcbiAgICAgICAgICAnMDE5OTExM2QtM2FmMS0wMDAwLWNhMGMtOGY4ZTY2ZjJmYzZiJywnMDE5YzM0NjEtOWRkOS0wMDAwLWY2YTMtYmIwMTA0MDkyYWUwJyxcbiAgICAgICAgICAnMDE5YTU5MTMtODMzNi0wMDAwLTUzNjQtNDNlZmU3ZjZkNjk1JywnMDE5YTU5ZjktOGU2MS0wMDAwLWVkMGMtNmY3NzRjOTgzNmI4JyxcbiAgICAgICAgICAnMDE5YTAyYTItMmM4Yi0wMDAwLTNkN2ItNjViM2UyZGM1ZTczJywnMDE5OGE5ZGItZWYwOC0wMDAwLTMwZGYtM2YyODk0M2VlMWVkJyxcbiAgICAgICAgICAnMDE5Yjk3YzItNDM0Ny0wMDAwLWQ4NWQtN2I0MTQyMjg0OWQwJywnMDE5ODc4NDYtOTNmMy0wMDAwLWZmNjAtYzYxYmUyMmQxZTA5JyxcbiAgICAgICAgICAnMDE5YWZlNjctZWZjMC0wMDAwLTQ0NzUtOGUwZjBiYjA4OGMzJywnMDE5OGViMjktYjg0Mi0wMDAwLTNjOTctMjgzMzNmZjUxNDg1JyxcbiAgICAgICAgICAnMDE5ODk3NjItOTM4NC0wMDAwLTc0NWMtMTEwOTlmYjY5NDljJywnMDE5YzQzYTQtZTA2My0wMDAwLWEwODQtMmQ1MjcxY2ZjMGY5JyxcbiAgICAgICAgICAnMDE5ODVjYWEtOTExYy0wMDAwLTlhODEtN2E5ODdiN2JmMjg2JywnMDE5NjY4ODktYThkYS0wMDAwLWZlNjktMWQ4Nzc2NTc3MjhiJyxcbiAgICAgICAgICAnMDE5YmJkZGUtZTAyOC0wMDAwLTdhM2YtMjFiOTU0NTM1ZWFjJywnMDE5YzJlNWItMWI1OS0wMDAwLTM4ZWItMjdmNDc3NTUxYmRlJyxcbiAgICAgICAgICAnMDE5NzQ2OGYtMWRjNS0wMDAwLTQ5ZTYtNTk1NjQyOWEwODViJywnMDE5YWZjOWMtZjVhZS0wMDAwLWUyNTYtOGUyNmIxMDZmODZjJyxcbiAgICAgICAgICAnMDE5YWE2NTUtYzg4Ni0wMDAwLTY4MTgtOTdlNzBhNTMzNTc3JywnMDE5OWM1OTUtNWNhMS0wMDAwLTlkOTEtN2UzYzhjNGVkMmY2JyxcbiAgICAgICAgICAnMDE5YmQ0MDYtM2ViYS0wMDAwLWY3NmMtNDkzMGU5YTBjZjc3JywnMDE5YmQ0MWQtZWZjOS0wMDAwLWRkZWQtZjBmMzZkM2U5NzgyJyxcbiAgICAgICAgICAnMDE5YTRmYmMtNDQxOC0wMDAwLWMzODEtNzlhYTI1MTI0MGZiJywnMDE5NTQ5NTQtYjIxNC0wMDAwLWU3YTUtMzgwZDVhYTA3M2IwJyxcbiAgICAgICAgICAnMDE5NzEzYTgtZGVjOS0wMDAwLWNmMGUtMTZiN2NlNThjY2I0JywnMDE5NTM3NjYtM2FkYS0wMDAwLTQwNzktMThjNjY4YmZhNDViJyxcbiAgICAgICAgICAnMDE5MzZiN2UtNjI1NC0wMDAwLWFhNjYtZDEzYTUzZWMxNDk3JywnMDE5NGY0ZDEtZGVkYS0wMDAwLTEzNzAtZDQ1MzJiZjdjZmExJyxcbiAgICAgICAgICAnMDE5YzgyNzItOTgyZi0wMDAwLTMxNDMtYWExYWMzYjlmY2RmJywnMDE5YjRiN2UtMDE2YS0wMDAwLWNjMzctYmM0ZjJhM2M5YmQyJyxcbiAgICAgICAgICAnMDE5OTM4ZWQtODYwMy0wMDAwLTU4OWYtMzE1ZGI3OTRmOTgwJywnMDE5YzVkMTItMDAxMS0wMDAwLWVkMGQtNTA0NGZmN2M0Y2ZkJyxcbiAgICAgICAgICAnMDE5OTBhNzItYTRkNC0wMDAwLTBiYWQtNjU4OGJjNWI2MmI4JywnMDE5NjE1ZGEtZmVkNC0wMDAwLTExOTYtMzI2YTA5ZTUzYTJjJyxcbiAgICAgICAgICAnMDE5YzBmZTUtMDUyNC0wMDAwLTdkN2EtOGY4OGJjZjM1YjY2JywnMDE5YWI5M2MtN2RkZC0wMDAwLWY4NjQtMjQxOTk0ZWZjMWQwJyxcbiAgICAgICAgICAnMDE5YTZjNjEtNDNhYS0wMDAwLTkwYWItODZlMjczYmQ0N2IzJywnMDE5NjM0ZDItMTY4Yi0wMDAwLTA5NzYtNzU4MjU1ODA0MTAyJyxcbiAgICAgICAgICAnMDE5OWMzMjItMDY0MC0wMDAwLTVhYzMtNzU5OWQyMWU3NjA2JywnMDE5YTZlNWEtMjNmOS0wMDAwLTI2N2YtYmUyMzA4ZGY0MjRjJyxcbiAgICAgICAgICAnMDE5Yjk3ZDUtNGRlMS0wMDAwLTk0ZWQtMTIzY2E0YmYwNDE1JywnMDE5YjI4MjUtYWYxZS0wMDAwLWQyZDctYzkwZGMzOTI5ODg3JyxcbiAgICAgICAgICAnMDE5MmQzYzQtOTBiYi0wMDAwLWJiNzktMmQ3NGFkOWJiYzRiJywnMDE5Nzk0ZjYtOWQ2Yi0wMDAwLTY4YjUtMDIwY2IyOGY0YmIzJyxcbiAgICAgICAgICAnMDE5N2NjMGEtZDIxOS0wMDAwLWE0NzEtM2IxM2FlNThkNGVjJywnMDE5OTBhZTgtNTgxYi0wMDAwLTZiMjQtZWE5NDBjODhhYzRmJyxcbiAgICAgICAgICAnMDE5MzhkMzItMTVjMy0wMDAwLTlhMzAtMGNmY2M3ZDQyMjIwJywnMDE5YmExNDQtY2Q0YS0wMDAwLTVlNDMtNWI3OTk1OTVkZjdmJyxcbiAgICAgICAgICAnMDE5YWIxOTktZTdjZi0wMDAwLTZjZTktMTdmYmIxNjNkM2RmJywnMDE5YmU3MDctMTY0Ny0wMDAwLTU3YTktZWY0OGMyNWFmMTgzJyxcbiAgICAgICAgICAnMDE5ODE2YjUtYjM3MS0wMDAwLWQyM2YtNGY1OGNkMGNhOWRjJywnMDE5Yjk3YTItMDUzYi0wMDAwLTU0ZTMtMjkyOWU5YmVlODA1JyxcbiAgICAgICAgICAnMDE5OTM0YmYtNDk4OS0wMDAwLTI5ZTUtZDZiNjIwNTY0MmM1JywnMDE5N2E2YTMtNDNiMS0wMDAwLThkN2UtZjU5MmQ0Y2U2ZWNhJyxcbiAgICAgICAgICAnMDE5YjkyZGMtODIwNy0wMDAwLTMwZDktYThmNDdiYjlmYWYzJywnMDE5NzI4YzQtZDc5Yy0wMDAwLTc3MDctZDFkODkxODFjNTZlJyxcbiAgICAgICAgICAnMDE5YTE1YmUtZWUzNS0wMDAwLWI5MzQtZTdkMjU5ZTBhYmU0JywnMDE5YTJiZjItOTk0Ny0wMDAwLWI3MmQtNWY4YjJmMWY0ZDYzJyxcbiAgICAgICAgICAnMDE5YTZlMDUtNDBiMC0wMDAwLTY0YjEtNzVlM2Y5ZWRlMWRiJywnMDE5NTEwNGEtOGFiMy0wMDAwLWU2MzctZWQ1ZGQxYmZiOGExJyxcbiAgICAgICAgICAnMDE5OTc0MDEtZDg0NC0wMDAwLWIwZGYtNzBjY2FlNzg4ZTQ0JywnMDE5NDcyZTktZDNkZC0wMDAwLTZkMDItZmJjMGNkYjZkMmJmJyxcbiAgICAgICAgICAnMDE5YzdkMGQtMmQ4OS0wMDAwLTBkYWUtZWEwZmZjMjJmZDJmJywnMDE5NTkxZWYtMzRmYy0wMDAwLWIxMjUtNjliN2NhMmZhM2FkJyxcbiAgICAgICAgICAnMDE5OWNkYzctOTczYi0wMDAwLTYxMGItZDA1ZmM2ZDY2MmE5JywnMDE5YzQyNDUtYjMzZS0wMDAwLTE1YmMtZTRmZjUzZWIxMDZlJyxcbiAgICAgICAgICAnMDE5YzE1ZjYtZGU4ZC0wMDAwLWZkMmUtZDViMTM3NGQwYzhlJywnMDE5OWMyYzYtYjZmMi0wMDAwLTM3MjgtNTVjMTQwYjcwYmZlJyxcbiAgICAgICAgICAnMDE5YzBiMWItZTYyNS0wMDAwLTA2YzktZGRmMWUwM2U0NDdlJywnMDE5YjgyZDItYWViMC0wMDAwLWIzZGMtZjIwMjc1NDE3YzVkJyxcbiAgICAgICAgICAnMDE5NTZkNDAtNWU0OS0wMDAwLWQ5MjQtNDM2N2NhNjEyMDNmJywnMDE5YWVmYzEtYTZkNi0wMDAwLTZkYTItZGEzNDU5ZDFkNjRiJyxcbiAgICAgICAgICAnMDE5YmRmYTYtNGU0NC0wMDAwLWExZTEtNTE3Yjg4MDg5NWNiJywnMDE5OTMzMjctZWYwYy0wMDAwLTQ4MjYtOWI2Y2MyZGMwNGIwJyxcbiAgICAgICAgICAnMDE5OWU3YzgtYTg0Zi0wMDAwLTZjZDQtYjkzZWNlNGEzZGYxJywnMDE5OTU4YWYtM2JmZC0wMDAwLTlmN2YtNjM4NzRlZTllOWFhJyxcbiAgICAgICAgICAnMDE5N2NjMGMtMDhmMy0wMDAwLTU3NTctYWJhN2EyMjlmNjU2JywnMDE5NmQ5ODItOGEzMC0wMDAwLTY1YmQtMDAwMWZiYjYxMmYyJyxcbiAgICAgICAgICAnMDE5NTBjMjMtMDQ3Ny0wMDAwLTY2YmQtNWI3YjYzZDkwY2YyJywnMDE5YzgxNGMtODIwYS0wMDAwLWVlMTEtMGYwYzg3YTkzZmY5JyxcbiAgICAgICAgICAnMDE5ODc4MzEtMDEwZi0wMDAwLTU5MjYtZGI4YTI3OTdmOGJjJywnMDE5M2JmNWEtZTVkNy0wMDAwLWNjN2QtYTdlMmI1MGU5NGUyJyxcbiAgICAgICAgICAnMDE5NTAxNTItZjAxYy0wMDAwLWIzNGQtNDZjNmY2YTdkMGZhJywnMDE5NTMwMjMtNmI5ZS0wMDAwLTFhY2UtOGM1MzQ5M2FlNTk5JyxcbiAgICAgICAgICAnMDE5YzAxZjMtZGIzZS0wMDAwLTBjMWEtMTk1YzJmZmM1MDQ5JywnMDE5OWUzYzktNzMzYy0wMDAwLWNjYjctN2Q2ZmU1N2Y3MzgyJyxcbiAgICAgICAgICAnMDE5NzM3OTYtYjEyZC0wMDAwLWI4YTEtYzk5NDVmZmI2ZDRkJywnMDE5YjA1ODAtMTlkOS0wMDAwLTY0NTQtMWVhZGViMmE0YWI3JyxcbiAgICAgICAgICAnMDE5NTQzNzEtYTk0Yy0wMDAwLWQzNTItOTQ0YjE0MjhmNjRhJywnMDE5YzI0MWMtZWI3Ni0wMDAwLTkwNjctYWE0MDU2YTQyOWI0JyxcbiAgICAgICAgICAnMDE5OTk0MzEtNzRmZS0wMDAwLTMyODMtY2ZiZjJhMWEwYmE2JywnMDE5YzQyOGUtNDlkNC0wMDAwLTgzOWItNzI1OTcwMWNkM2Q3JyxcbiAgICAgICAgICAnMDE5YjZmYzgtNzA4ZS0wMDAwLWQzMjctYWU4ZDg5ZjFmZDVmJywnMDE5NmIwZjEtNDRhMy0wMDAwLWUzNjQtMDZlOGZlYzJhMmMxJyxcbiAgICAgICAgICAnMDE5NTE3YjYtMWE4Yy0wMDAwLWYyMjgtYWJjZjUxZTc0YjUzJywnMDE5NGI5MTctM2M0Zi0wMDAwLWVjZTgtMThjODQyNzhkOTFjJyxcbiAgICAgICAgICAnMDE5MzhkNjEtZTdhOS0wMDAwLWQ0YzUtYzc5MmM5ZDEwZmMwJywnMDE5YWQ2YjEtYTAwMy0wMDAwLWI5YjYtZDk1ZjhmNGM3MDBmJyxcbiAgICAgICAgICAnMDE5YzY3ZTEtYzRjYi0wMDAwLWYxMDgtY2RjYjQzOTBlZTQ1JywnMDE5MzhkNmEtNGVkMy0wMDAwLTExNzUtNDUzMTEyNTRkZDA4JyxcbiAgICAgICAgICAnMDE5YjMwZTctYjY4Yy0wMDAwLTI4MzMtMTI2MjIzYTQxMjU2JywnMDE5NjgxNjItMWQ4Ny0wMDAwLWM1NDgtOTA0ZDVkNGU0NWE5JyxcbiAgICAgICAgICAnMDE5OGRkYzAtZTQ5OC0wMDAwLTY1NzYtZGFjNzRlYzk3MzIyJywnMDE5YWNlZGItMWIyZS0wMDAwLTY4YzgtMmY1YjZkMzI0MTg0JyxcbiAgICAgICAgICAnMDE5YmZkMjMtZDQzZS0wMDAwLWViZjYtNzNhMmRmMTgxZTg4JywnMDE5YWUzODctOGQ0Zi0wMDAwLTk0NGYtMWUzZjRkNWFhY2MwJyxcbiAgICAgICAgICAnMDE5OTQ0NGEtMTE0Ni0wMDAwLWZmZjUtOWY3N2M4NjQwYzkwJywnMDE5YjM1ZTgtZmUwNy0wMDAwLTE1YjUtNDgzMzVmODEwOTRmJyxcbiAgICAgICAgICAnMDE5YTc4Y2QtNjdlYi0wMDAwLWU3ODUtODhhYjI4OTMyMDMwJywnMDE5YzRkMGQtMTZiNy0wMDAwLTViMzYtOTRlYWIzZWU5M2ZlJyxcbiAgICAgICAgICAnMDE5OTNlODQtYzUwYS0wMDAwLTcwMDItNDA0NjhkYTgwMTI2JywnMDE5NDgzZjYtODUxNy0wMDAwLWIwMjMtYTIwMTg1YWM4OTg4JyxcbiAgICAgICAgICAnMDE5YzAxZmItMGZlNC0wMDAwLTY2YjEtZGQ3YWEwMDlkY2I1JywnMDE5YmJlNTAtYjhmMy0wMDAwLTMxNzktNjJiOWMxMGMxMmM1JyxcbiAgICAgICAgICAnMDE5YTUyYzgtOTk0Zi0wMDAwLWM0ZTMtM2EzNmJkNjk3NzgzJywnMDE5YzRlYmYtODA3MS0wMDAwLTRjMTUtZTIxNjhmYTNkMGZmJyxcbiAgICAgICAgICAnMDE5YmFhMjYtOTQxZS0wMDAwLTk1YmYtMTg2OTYxMDg3MWQ3JywnMDE5YmZiZWEtM2UxOC0wMDAwLTdhZmUtNjg0MWU2M2Q4ZWQ3JyxcbiAgICAgICAgICAnMDE5Yzg3NzctM2E4MC0wMDAwLTY1MTMtZmFkODYxNjdkMTRlJywnMDE5OTM0MjItZTE4Ni0wMDAwLWEwZjEtN2RmMTc4NzRiOTE5JyxcbiAgICAgICAgICAnMDE5NGFjOTUtMmUyMi0wMDAwLTgwMjUtOTkwYjAwOGJjMzU2JywnMDE5NT)
- [EU results](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJXSVRIIGFmZmVjdGVkX2FsZXJ0cyBBUyAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhYy5pZCxcbiAgICAgICAgICBhYy5uYW1lLFxuICAgICAgICAgIGFjLnRlYW1faWQsXG4gICAgICAgICAgYWMuc3RhdGUsXG4gICAgICAgICAgYWMuZW5hYmxlZCxcbiAgICAgICAgICBhYy5jb25kaXRpb24tPj4ndHlwZScgQVMgY29uZGl0aW9uX3R5cGUsXG4gICAgICAgICAgYWMuY2FsY3VsYXRpb25faW50ZXJ2YWwsXG4gICAgICAgICAgdC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pidsb3dlcicgQVMgbG93ZXJfYm91bmQsXG4gICAgICAgICAgdC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pid1cHBlcicgQVMgdXBwZXJfYm91bmQsXG4gICAgICAgICAgdC5pZCBJUyBOT1QgTlVMTCBBUyBoYXNfdGhyZXNob2xkLFxuICAgICAgICAgIENBU0VcbiAgICAgICAgICAgICAgV0hFTiAoXG4gICAgICAgICAgICAgICAgICAodC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pidsb3dlcicgSVMgTk9UIE5VTEwgQU5EIDAgPFxuICAodC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pidsb3dlcicpOjpmbG9hdClcbiAgICAgICAgICAgICAgICAgIE9SXG4gICAgICAgICAgICAgICAgICAodC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pid1cHBlcicgSVMgTk9UIE5VTEwgQU5EIDAgPlxuICAodC5jb25maWd1cmF0aW9uLT4nYm91bmRzJy0-Pid1cHBlcicpOjpmbG9hdClcbiAgICAgICAgICAgICAgKSBUSEVOICd3b3VsZF9maXJlJ1xuICAgICAgICAgICAgICBFTFNFICd3b3VsZF9ub3RfZmlyZSdcbiAgICAgICAgICBFTkQgQVMgbmV3X2JlaGF2aW9yXG4gICAgICBGUk9NIHBvc3Rob2dfYWxlcnRjb25maWd1cmF0aW9uIGFjXG4gICAgICBMRUZUIEpPSU4gcG9zdGhvZ190aHJlc2hvbGQgdCBPTiBhYy50aHJlc2hvbGRfaWQgPSB0LmlkXG4gICAgICBXSEVSRSBhYy5pZDo6dGV4dCBJTiAoXG4gICAgICAgICAgJzAxOTljMzI4LTVmMGQtMDAwMC00YTAyLTBkMjU4MmViNzU5YycsJzAxOTM5Mjk3LTUxY2UtMDAwMC02YWQ5LTc0ZjI4NmUwOGFjMycsXG4gICAgICAgICAgJzAxOTkyOGY5LTFjMTYtMDAwMC0xN2ExLTQ1MTJhYzcxNDcwNicsJzAxOTUxMGMwLWJjZjItMDAwMC1lYTBhLWZlODcxMGY5YmI5YScsXG4gICAgICAgICAgJzAxOWMyZTVhLTQ2MTQtMDAwMC1iZDdhLWZiM2E4OTZjODdiMScsJzAxOWI0YWQ3LTVmNDctMDAwMC04MGI1LTkzZTU0MTcwYjA5NCcsXG4gICAgICAgICAgJzAxOWMxZGQ4LWQ5ZDItMDAwMC1iNDU3LWQyYzBmZDgxOGNmZScsJzAxOThhZDQwLTIzNTEtMDAwMC02MzQ1LWE1MmRmNWM3M2E1MScsXG4gICAgICAgICAgJzAxOWIzMGVkLTc4YTctMDAwMC01ZmRjLTFiNDkwNzFkODZkYScsJzAxOWFlOWVlLWRmZDYtMDAwMC0zOWUxLWQ5MzYwNWJhMzJhYycsXG4gICAgICAgICAgJzAxOTM3OWU3LWUxZTMtMDAwMC05NmE4LWQ1YTU1NjYyMjMwNCcsJzAxOWJlMWMwLWE0ZGMtMDAwMC1lOGRiLTc3YTEyZmU1OWY5ZScsXG4gICAgICAgICAgJzAxOWFjZGM5LWUyY2EtMDAwMC04ZmM2LTM0ZDRlYWYwZDVhYicsJzAxOWM3NmQyLTQ3NGUtMDAwMC0wZGFkLTkyYTNhOWI0YTBhMicsXG4gICAgICAgICAgJzAxOTZlOTdkLThmMzUtMDAwMC1jODcxLWExZWIzNTJiNjM2NCcsJzAxOThiM2FiLTgzYmEtMDAwMC0zNTgyLWZjNjg5ODUyMTc2MycsXG4gICAgICAgICAgJzAxOTUzMjkzLTE1M2YtMDAwMC02NzcwLWJkMTRiY2I4MDAyZicsJzAxOTlkZTI5LTQ5OWItMDAwMC1jYzY1LTQxYzZlYmE0YmI0MycsXG4gICAgICAgICAgJzAxOTZhMjYxLTQ1ODItMDAwMC1lNDA1LTMwODA2YTI3MGZjZScsJzAxOWMyZTU2LWZmMjktMDAwMC05N2I2LWNlYTFlYmY5M2ZiMCcsXG4gICAgICAgICAgJzAxOTZmZTBkLThlYjUtMDAwMC1mYWY4LTJjNmJhNmRmOGYxNycsJzAxOTNkOTNkLWM3ODUtMDAwMC04YjFlLTZiODE4Y2FjMDg0OScsXG4gICAgICAgICAgJzAxOTkxMTNkLTNhZjEtMDAwMC1jYTBjLThmOGU2NmYyZmM2YicsJzAxOWMzNDYxLTlkZDktMDAwMC1mNmEzLWJiMDEwNDA5MmFlMCcsXG4gICAgICAgICAgJzAxOWE1OTEzLTgzMzYtMDAwMC01MzY0LTQzZWZlN2Y2ZDY5NScsJzAxOWE1OWY5LThlNjEtMDAwMC1lZDBjLTZmNzc0Yzk4MzZiOCcsXG4gICAgICAgICAgJzAxOWEwMmEyLTJjOGItMDAwMC0zZDdiLTY1YjNlMmRjNWU3MycsJzAxOThhOWRiLWVmMDgtMDAwMC0zMGRmLTNmMjg5NDNlZTFlZCcsXG4gICAgICAgICAgJzAxOWI5N2MyLTQzNDctMDAwMC1kODVkLTdiNDE0MjI4NDlkMCcsJzAxOTg3ODQ2LTkzZjMtMDAwMC1mZjYwLWM2MWJlMjJkMWUwOScsXG4gICAgICAgICAgJzAxOWFmZTY3LWVmYzAtMDAwMC00NDc1LThlMGYwYmIwODhjMycsJzAxOThlYjI5LWI4NDItMDAwMC0zYzk3LTI4MzMzZmY1MTQ4NScsXG4gICAgICAgICAgJzAxOTg5NzYyLTkzODQtMDAwMC03NDVjLTExMDk5ZmI2OTQ5YycsJzAxOWM0M2E0LWUwNjMtMDAwMC1hMDg0LTJkNTI3MWNmYzBmOScsXG4gICAgICAgICAgJzAxOTg1Y2FhLTkxMWMtMDAwMC05YTgxLTdhOTg3YjdiZjI4NicsJzAxOTY2ODg5LWE4ZGEtMDAwMC1mZTY5LTFkODc3NjU3NzI4YicsXG4gICAgICAgICAgJzAxOWJiZGRlLWUwMjgtMDAwMC03YTNmLTIxYjk1NDUzNWVhYycsJzAxOWMyZTViLTFiNTktMDAwMC0zOGViLTI3ZjQ3NzU1MWJkZScsXG4gICAgICAgICAgJzAxOTc0NjhmLTFkYzUtMDAwMC00OWU2LTU5NTY0MjlhMDg1YicsJzAxOWFmYzljLWY1YWUtMDAwMC1lMjU2LThlMjZiMTA2Zjg2YycsXG4gICAgICAgICAgJzAxOWFhNjU1LWM4ODYtMDAwMC02ODE4LTk3ZTcwYTUzMzU3NycsJzAxOTljNTk1LTVjYTEtMDAwMC05ZDkxLTdlM2M4YzRlZDJmNicsXG4gICAgICAgICAgJzAxOWJkNDA2LTNlYmEtMDAwMC1mNzZjLTQ5MzBlOWEwY2Y3NycsJzAxOWJkNDFkLWVmYzktMDAwMC1kZGVkLWYwZjM2ZDNlOTc4MicsXG4gICAgICAgICAgJzAxOWE0ZmJjLTQ0MTgtMDAwMC1jMzgxLTc5YWEyNTEyNDBmYicsJzAxOTU0OTU0LWIyMTQtMDAwMC1lN2E1LTM4MGQ1YWEwNzNiMCcsXG4gICAgICAgICAgJzAxOTcxM2E4LWRlYzktMDAwMC1jZjBlLTE2YjdjZTU4Y2NiNCcsJzAxOTUzNzY2LTNhZGEtMDAwMC00MDc5LTE4YzY2OGJmYTQ1YicsXG4gICAgICAgICAgJzAxOTM2YjdlLTYyNTQtMDAwMC1hYTY2LWQxM2E1M2VjMTQ5NycsJzAxOTRmNGQxLWRlZGEtMDAwMC0xMzcwLWQ0NTMyYmY3Y2ZhMScsXG4gICAgICAgICAgJzAxOWM4MjcyLTk4MmYtMDAwMC0zMTQzLWFhMWFjM2I5ZmNkZicsJzAxOWI0YjdlLTAxNmEtMDAwMC1jYzM3LWJjNGYyYTNjOWJkMicsXG4gICAgICAgICAgJzAxOTkzOGVkLTg2MDMtMDAwMC01ODlmLTMxNWRiNzk0Zjk4MCcsJzAxOWM1ZDEyLTAwMTEtMDAwMC1lZDBkLTUwNDRmZjdjNGNmZCcsXG4gICAgICAgICAgJzAxOTkwYTcyLWE0ZDQtMDAwMC0wYmFkLTY1ODhiYzViNjJiOCcsJzAxOTYxNWRhLWZlZDQtMDAwMC0xMTk2LTMyNmEwOWU1M2EyYycsXG4gICAgICAgICAgJzAxOWMwZmU1LTA1MjQtMDAwMC03ZDdhLThmODhiY2YzNWI2NicsJzAxOWFiOTNjLTdkZGQtMDAwMC1mODY0LTI0MTk5NGVmYzFkMCcsXG4gICAgICAgICAgJzAxOWE2YzYxLTQzYWEtMDAwMC05MGFiLTg2ZTI3M2JkNDdiMycsJzAxOTYzNGQyLTE2OGItMDAwMC0wOTc2LTc1ODI1NTgwNDEwMicsXG4gICAgICAgICAgJzAxOTljMzIyLTA2NDAtMDAwMC01YWMzLTc1OTlkMjFlNzYwNicsJzAxOWE2ZTVhLTIzZjktMDAwMC0yNjdmLWJlMjMwOGRmNDI0YycsXG4gICAgICAgICAgJzAxOWI5N2Q1LTRkZTEtMDAwMC05NGVkLTEyM2NhNGJmMDQxNScsJzAxOWIyODI1LWFmMWUtMDAwMC1kMmQ3LWM5MGRjMzkyOTg4NycsXG4gICAgICAgICAgJzAxOTJkM2M0LTkwYmItMDAwMC1iYjc5LTJkNzRhZDliYmM0YicsJzAxOTc5NGY2LTlkNmItMDAwMC02OGI1LTAyMGNiMjhmNGJiMycsXG4gICAgICAgICAgJzAxOTdjYzBhLWQyMTktMDAwMC1hNDcxLTNiMTNhZTU4ZDRlYycsJzAxOTkwYWU4LTU4MWItMDAwMC02YjI0LWVhOTQwYzg4YWM0ZicsXG4gICAgICAgICAgJzAxOTM4ZDMyLTE1YzMtMDAwMC05YTMwLTBjZmNjN2Q0MjIyMCcsJzAxOWJhMTQ0LWNkNGEtMDAwMC01ZTQzLTViNzk5NTk1ZGY3ZicsXG4gICAgICAgICAgJzAxOWFiMTk5LWU3Y2YtMDAwMC02Y2U5LTE3ZmJiMTYzZDNkZicsJzAxOWJlNzA3LTE2NDctMDAwMC01N2E5LWVmNDhjMjVhZjE4MycsXG4gICAgICAgICAgJzAxOTgxNmI1LWIzNzEtMDAwMC1kMjNmLTRmNThjZDBjYTlkYycsJzAxOWI5N2EyLTA1M2ItMDAwMC01NGUzLTI5MjllOWJlZTgwNScsXG4gICAgICAgICAgJzAxOTkzNGJmLTQ5ODktMDAwMC0yOWU1LWQ2YjYyMDU2NDJjNScsJzAxOTdhNmEzLTQzYjEtMDAwMC04ZDdlLWY1OTJkNGNlNmVjYScsXG4gICAgICAgICAgJzAxOWI5MmRjLTgyMDctMDAwMC0zMGQ5LWE4ZjQ3YmI5ZmFmMycsJzAxOTcyOGM0LWQ3OWMtMDAwMC03NzA3LWQxZDg5MTgxYzU2ZScsXG4gICAgICAgICAgJzAxOWExNWJlLWVlMzUtMDAwMC1iOTM0LWU3ZDI1OWUwYWJlNCcsJzAxOWEyYmYyLTk5NDctMDAwMC1iNzJkLTVmOGIyZjFmNGQ2MycsXG4gICAgICAgICAgJzAxOWE2ZTA1LTQwYjAtMDAwMC02NGIxLTc1ZTNmOWVkZTFkYicsJzAxOTUxMDRhLThhYjMtMDAwMC1lNjM3LWVkNWRkMWJmYjhhMScsXG4gICAgICAgICAgJzAxOTk3NDAxLWQ4NDQtMDAwMC1iMGRmLTcwY2NhZTc4OGU0NCcsJzAxOTQ3MmU5LWQzZGQtMDAwMC02ZDAyLWZiYzBjZGI2ZDJiZicsXG4gICAgICAgICAgJzAxOWM3ZDBkLTJkODktMDAwMC0wZGFlLWVhMGZmYzIyZmQyZicsJzAxOTU5MWVmLTM0ZmMtMDAwMC1iMTI1LTY5YjdjYTJmYTNhZCcsXG4gICAgICAgICAgJzAxOTljZGM3LTk3M2ItMDAwMC02MTBiLWQwNWZjNmQ2NjJhOScsJzAxOWM0MjQ1LWIzM2UtMDAwMC0xNWJjLWU0ZmY1M2ViMTA2ZScsXG4gICAgICAgICAgJzAxOWMxNWY2LWRlOGQtMDAwMC1mZDJlLWQ1YjEzNzRkMGM4ZScsJzAxOTljMmM2LWI2ZjItMDAwMC0zNzI4LTU1YzE0MGI3MGJmZScsXG4gICAgICAgICAgJzAxOWMwYjFiLWU2MjUtMDAwMC0wNmM5LWRkZjFlMDNlNDQ3ZScsJzAxOWI4MmQyLWFlYjAtMDAwMC1iM2RjLWYyMDI3NTQxN2M1ZCcsXG4gICAgICAgICAgJzAxOTU2ZDQwLTVlNDktMDAwMC1kOTI0LTQzNjdjYTYxMjAzZicsJzAxOWFlZmMxLWE2ZDYtMDAwMC02ZGEyLWRhMzQ1OWQxZDY0YicsXG4gICAgICAgICAgJzAxOWJkZmE2LTRlNDQtMDAwMC1hMWUxLTUxN2I4ODA4OTVjYicsJzAxOTkzMzI3LWVmMGMtMDAwMC00ODI2LTliNmNjMmRjMDRiMCcsXG4gICAgICAgICAgJzAxOTllN2M4LWE4NGYtMDAwMC02Y2Q0LWI5M2VjZTRhM2RmMScsJzAxOTk1OGFmLTNiZmQtMDAwMC05ZjdmLTYzODc0ZWU5ZTlhYScsXG4gICAgICAgICAgJzAxOTdjYzBjLTA4ZjMtMDAwMC01NzU3LWFiYTdhMjI5ZjY1NicsJzAxOTZkOTgyLThhMzAtMDAwMC02NWJkLTAwMDFmYmI2MTJmMicsXG4gICAgICAgICAgJzAxOTUwYzIzLTA0NzctMDAwMC02NmJkLTViN2I2M2Q5MGNmMicsJzAxOWM4MTRjLTgyMGEtMDAwMC1lZTExLTBmMGM4N2E5M2ZmOScsXG4gICAgICAgICAgJzAxOTg3ODMxLTAxMGYtMDAwMC01OTI2LWRiOGEyNzk3ZjhiYycsJzAxOTNiZjVhLWU1ZDctMDAwMC1jYzdkLWE3ZTJiNTBlOTRlMicsXG4gICAgICAgICAgJzAxOTUwMTUyLWYwMWMtMDAwMC1iMzRkLTQ2YzZmNmE3ZDBmYScsJzAxOTUzMDIzLTZiOWUtMDAwMC0xYWNlLThjNTM0OTNhZTU5OScsXG4gICAgICAgICAgJzAxOWMwMWYzLWRiM2UtMDAwMC0wYzFhLTE5NWMyZmZjNTA0OScsJzAxOTllM2M5LTczM2MtMDAwMC1jY2I3LTdkNmZlNTdmNzM4MicsXG4gICAgICAgICAgJzAxOTczNzk2LWIxMmQtMDAwMC1iOGExLWM5OTQ1ZmZiNmQ0ZCcsJzAxOWIwNTgwLTE5ZDktMDAwMC02NDU0LTFlYWRlYjJhNGFiNycsXG4gICAgICAgICAgJzAxOTU0MzcxLWE5NGMtMDAwMC1kMzUyLTk0NGIxNDI4ZjY0YScsJzAxOWMyNDFjLWViNzYtMDAwMC05MDY3LWFhNDA1NmE0MjliNCcsXG4gICAgICAgICAgJzAxOTk5NDMxLTc0ZmUtMDAwMC0zMjgzLWNmYmYyYTFhMGJhNicsJzAxOWM0MjhlLTQ5ZDQtMDAwMC04MzliLTcyNTk3MDFjZDNkNycsXG4gICAgICAgICAgJzAxOWI2ZmM4LTcwOGUtMDAwMC1kMzI3LWFlOGQ4OWYxZmQ1ZicsJzAxOTZiMGYxLTQ0YTMtMDAwMC1lMzY0LTA2ZThmZWMyYTJjMScsXG4gICAgICAgICAgJzAxOTUxN2I2LTFhOGMtMDAwMC1mMjI4LWFiY2Y1MWU3NGI1MycsJzAxOTRiOTE3LTNjNGYtMDAwMC1lY2U4LTE4Yzg0Mjc4ZDkxYycsXG4gICAgICAgICAgJzAxOTM4ZDYxLWU3YTktMDAwMC1kNGM1LWM3OTJjOWQxMGZjMCcsJzAxOWFkNmIxLWEwMDMtMDAwMC1iOWI2LWQ5NWY4ZjRjNzAwZicsXG4gICAgICAgICAgJzAxOWM2N2UxLWM0Y2ItMDAwMC1mMTA4LWNkY2I0MzkwZWU0NScsJzAxOTM4ZDZhLTRlZDMtMDAwMC0xMTc1LTQ1MzExMjU0ZGQwOCcsXG4gICAgICAgICAgJzAxOWIzMGU3LWI2OGMtMDAwMC0yODMzLTEyNjIyM2E0MTI1NicsJzAxOTY4MTYyLTFkODctMDAwMC1jNTQ4LTkwNGQ1ZDRlNDVhOScsXG4gICAgICAgICAgJzAxOThkZGMwLWU0OTgtMDAwMC02NTc2LWRhYzc0ZWM5NzMyMicsJzAxOWFjZWRiLTFiMmUtMDAwMC02OGM4LTJmNWI2ZDMyNDE4NCcsXG4gICAgICAgICAgJzAxOWJmZDIzLWQ0M2UtMDAwMC1lYmY2LTczYTJkZjE4MWU4OCcsJzAxOWFlMzg3LThkNGYtMDAwMC05NDRmLTFlM2Y0ZDVhYWNjMCcsXG4gICAgICAgICAgJzAxOTk0NDRhLTExNDYtMDAwMC1mZmY1LTlmNzdjODY0MGM5MCcsJzAxOWIzNWU4LWZlMDctMDAwMC0xNWI1LTQ4MzM1ZjgxMDk0ZicsXG4gICAgICAgICAgJzAxOWE3OGNkLTY3ZWItMDAwMC1lNzg1LTg4YWIyODkzMjAzMCcsJzAxOWM0ZDBkLTE2YjctMDAwMC01YjM2LTk0ZWFiM2VlOTNmZScsXG4gICAgICAgICAgJzAxOTkzZTg0LWM1MGEtMDAwMC03MDAyLTQwNDY4ZGE4MDEyNicsJzAxOTQ4M2Y2LTg1MTctMDAwMC1iMDIzLWEyMDE4NWFjODk4OCcsXG4gICAgICAgICAgJzAxOWMwMWZiLTBmZTQtMDAwMC02NmIxLWRkN2FhMDA5ZGNiNScsJzAxOWJiZTUwLWI4ZjMtMDAwMC0zMTc5LTYyYjljMTBjMTJjNScsXG4gICAgICAgICAgJzAxOWE1MmM4LTk5NGYtMDAwMC1jNGUzLTNhMzZiZDY5Nzc4MycsJzAxOWM0ZWJmLTgwNzEtMDAwMC00YzE1LWUyMTY4ZmEzZDBmZicsXG4gICAgICAgICAgJzAxOWJhYTI2LTk0MWUtMDAwMC05NWJmLTE4Njk2MTA4NzFkNycsJzAxOWJmYmVhLTNlMTgtMDAwMC03YWZlLTY4NDFlNjNkOGVkNycsXG4gICAgICAgICAgJzAxOWM4Nzc3LTNhODAtMDAwMC02NTEzLWZhZDg2MTY3ZDE0ZScsJzAxOTkzNDIyLWUxODYtMDAwMC1hMGYxLTdkZjE3ODc0YjkxOScsXG4gICAgICAgICAgJzAxOTRhYzk1LTJlMjItMDAwMC04MDI1LTk5MGIwMDhiYzM1NicsJzAxOTUwYzExLTdlMjctMDAwMC)

> [!NOTE] 
> This is a generous approximation as some of these alerts might have failed "a while ago" whilst there was no data in the insight (0 / empty case), but have since received data again. This is fine, rather error on the side of safety here. 
> Additionally, as the alerts can run once per month, we will just look 60 days back so that we're certain that we get all permutations of alerts.

- 3️⃣ : Evaluate results

Based on the results we can see that:

- ~90% of the affected alerts would no longer error out (albeit not fire as the "empty" case is not something those alerts would alert on)
- ~10% of the affected alerts would now correctly fire (informing users their metric is zero, rather than a errorring)
- The number of users which would get alerted is very low
- The insight/alert that would trigger for us in EU is the following: https://eu.posthog.com/project/1/insights/plMkqEh0/alerts?alert_id=0198848d-6ac8-0000-928b-728fb1dbdfe1
    - This is clearly a test alert, but it's a good case to dogfood. 
 - And here is another example (also a test case) which would fire for us in the US: https://us.posthog.com/project/150522/insights/rbGFgu0v
     - As we can see here, this one errors as long as all breakdown values are 0 which should be fixed after this PR is merged, as we then correctly treat them as empty. 

Looking at the exact numbers, they are relatively low compared to the total volume, giving confidence that we could safely release this, with the caveat that we will leave a note in the changelog so people can correlate it back to this update. 

✅ Added new test cases to verify the different alert types firing / ignoring the empty results correctly

## Publish to changelog?

Yes