### PR TITLE
fix(session-recording): add load_all mode to fix JSON export with snapshot store

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-store/types.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-store/types.ts
@@ -13,7 +13,7 @@ export interface SourceEntry {
 
 export interface LoadBatch {
     sourceIndices: number[]
-    reason: 'seek_target' | 'seek_backward' | 'seek_gap_fill' | 'buffer_ahead'
+    reason: 'seek_target' | 'seek_backward' | 'seek_gap_fill' | 'buffer_ahead' | 'load_all'
 }
 
 export interface SourceLoadingState {
@@ -22,4 +22,4 @@ export interface SourceLoadingState {
     state: 'unloaded' | 'loaded'
 }
 
-export type Mode = { kind: 'buffer_ahead' } | { kind: 'seek'; targetTimestamp: number }
+export type Mode = { kind: 'buffer_ahead' } | { kind: 'seek'; targetTimestamp: number } | { kind: 'load_all' }


### PR DESCRIPTION
## Summary

- Fixes JSON export timing out when the `REPLAY_SNAPSHOT_STORE` feature flag is enabled
- The `LoadingScheduler`'s `buffer_ahead` mode only loads 30 sources ahead of the playback position, so for longer recordings `fullyLoaded` never becomes true and the export times out after 30 seconds
- Adds a `load_all` scheduler mode that loads all unloaded sources regardless of playback position, activated when export starts

## Test plan

- [x] New unit tests for `load_all` mode in `LoadingScheduler.test.ts`
- [x] All existing LoadingScheduler, integration, and snapshotDataLogic tests pass
- [ ] Manual: enable `REPLAY_SNAPSHOT_STORE` flag, open a recording with >30 sources, export to JSON — should complete without timeout