### PR TITLE
fix(mcp-generation): mcp versions in yaml config

### DIFF
--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -111,6 +111,7 @@ tools:
             destructive: false
             idempotent: true
         list: true
+        mcp_version: 1
         title: List error tracking issues
         description: >
             List all error tracking issues in the project. Returns issues with status, volume, first/last seen
@@ -127,6 +128,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        mcp_version: 1
         title: Get error tracking issue
         description: >
             Get a specific error tracking issue by ID. Returns full issue details including status, description, volume,

--- a/services/mcp/definitions/actions.yaml
+++ b/services/mcp/definitions/actions.yaml
@@ -19,6 +19,7 @@ tools:
             idempotent: true
         enrich_url: '{id}'
         list: true
+        mcp_version: 1
         title: Get all actions
         description: >
             Get all actions in the project. Actions are reusable event definitions that can combine multiple trigger
@@ -57,6 +58,7 @@ tools:
             destructive: false
             idempotent: true
         enrich_url: '{id}'
+        mcp_version: 1
         title: Get action
         description: >
             Get a specific action by ID. Returns the action configuration including all steps and their trigger

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6,7 +6,7 @@
         "summary": "Get all actions",
         "title": "Get all actions",
         "required_scopes": ["action:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -36,7 +36,7 @@
         "summary": "Get action",
         "title": "Get action",
         "required_scopes": ["action:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -81,7 +81,7 @@
         "summary": "List error tracking issues",
         "title": "List error tracking issues",
         "required_scopes": ["error_tracking:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -96,7 +96,7 @@
         "summary": "Get error tracking issue",
         "title": "Get error tracking issue",
         "required_scopes": ["error_tracking:read"],
-        "new_mcp": true,
+        "new_mcp": false,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -464,7 +464,7 @@ function generateDefinitionsJson(
                 summary: toolConfig.title || opDescription.split('.')[0] || name,
                 title: toolConfig.title || resolved.operation.summary || name,
                 required_scopes: toolConfig.scopes,
-                new_mcp: true,
+                new_mcp: toolConfig.mcp_version !== undefined ? toolConfig.mcp_version >= 2 : true,
                 annotations: {
                     destructiveHint: toolConfig.annotations.destructive,
                     idempotentHint: toolConfig.annotations.idempotent,

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -27,6 +27,7 @@ export const ToolConfigSchema = z
         exclude_params: z.array(z.string()).optional(),
         include_params: z.array(z.string()).optional(),
         param_overrides: z.record(z.object({ description: z.string().optional() }).strict()).optional(),
+        mcp_version: z.number().int().positive().optional(),
     })
     .strict()
 


### PR DESCRIPTION
## Problem

The MCP server has two versions:
- v1 that uses tools for retrieval (list/read).
- v2 that uses SQL for retrieval (no list/read tools).

## Changes

- Added the version to manifests.

## How did you test this code?

Manual testing