### PR TITLE
fix(alerts): centralise transient ClickHouse errors and add retries

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -872,3 +872,6 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     1003: ErrorCodeMeta("SSH_EXCEPTION"),
     1004: ErrorCodeMeta("STARTUP_SCRIPTS_ERROR"),
 }
+# Transient ClickHouse infrastructure errors that are safe to retry.
+# Use this in celery autoretry_for and except clauses instead of listing errors individually.
+CH_TRANSIENT_ERRORS = (CHQueryErrorTooManySimultaneousQueries, CHQueryErrorCannotScheduleTask, CHQueryErrorS3Error)

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -872,6 +872,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     1003: ErrorCodeMeta("SSH_EXCEPTION"),
     1004: ErrorCodeMeta("STARTUP_SCRIPTS_ERROR"),
 }
+
 # Transient ClickHouse infrastructure errors that are safe to retry.
-# Use this in celery autoretry_for and except clauses instead of listing errors individually.
+# This can be used in things like celery `autoretry_for` to increase resiliency.
 CH_TRANSIENT_ERRORS = (CHQueryErrorTooManySimultaneousQueries, CHQueryErrorCannotScheduleTask, CHQueryErrorS3Error)

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -11,6 +11,7 @@ import structlog
 from celery import shared_task
 from celery.canvas import chain
 from dateutil.relativedelta import relativedelta
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.schema import AlertCalculationInterval, AlertState, TrendsQuery
 
@@ -180,10 +181,6 @@ def check_alerts_task() -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.ALERTS.value,
-    autoretry_for=CH_TRANSIENT_ERRORS,
-    retry_backoff=1,
-    retry_backoff_max=10,
-    max_retries=3,
     expires=60 * 60,
 )
 # @limit_concurrency(5)  Concurrency controlled by CeleryQueue.ALERTS for now
@@ -192,6 +189,17 @@ def check_alert_task(alert_id: str) -> None:
         check_alert(alert_id, capture_ph_event)
 
 
+@retry(
+    retry=retry_if_exception_type(CH_TRANSIENT_ERRORS),
+    stop=stop_after_attempt(4),
+    wait=wait_exponential_jitter(initial=1, max=10),
+    before_sleep=lambda rs: logger.info(
+        "check_alert.retrying",
+        attempt=rs.attempt_number,
+        error=str(rs.outcome.exception()) if rs.outcome else None,
+    ),
+    reraise=True,
+)
 def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwargs: None) -> None:
     try:
         alert = AlertConfiguration.objects.select_related("insight").get(id=alert_id, enabled=True)
@@ -320,7 +328,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         value = alert_evaluation_result.value
         breaches = alert_evaluation_result.breaches
     except CH_TRANSIENT_ERRORS:
-        # Re-raise so Celery retries the full task via autoretry_for
+        # Re-raise so we retry the full flow
         raise
     except Exception as err:
         error_message = f"Alert id = {alert.id}, failed to evaluate"

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -15,7 +15,7 @@ from dateutil.relativedelta import relativedelta
 from posthog.schema import AlertCalculationInterval, AlertState, TrendsQuery
 
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.errors import CHQueryErrorTooManySimultaneousQueries
+from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
 from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck
@@ -180,7 +180,7 @@ def check_alerts_task() -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.ALERTS.value,
-    autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),
+    autoretry_for=CH_TRANSIENT_ERRORS,
     retry_backoff=1,
     retry_backoff_max=10,
     max_retries=3,
@@ -319,9 +319,8 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         alert_evaluation_result = check_alert_for_insight(alert)
         value = alert_evaluation_result.value
         breaches = alert_evaluation_result.breaches
-    except CHQueryErrorTooManySimultaneousQueries:
-        # error on our side so we raise
-        # as celery task can be retried according to config
+    except CH_TRANSIENT_ERRORS:
+        # transient infra errors — re-raise so celery retries according to config
         raise
     except Exception as err:
         error_message = f"Alert id = {alert.id}, failed to evaluate"

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -320,7 +320,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         value = alert_evaluation_result.value
         breaches = alert_evaluation_result.breaches
     except CH_TRANSIENT_ERRORS:
-        # transient infra errors — re-raise so celery retries according to config
+        # Re-raise so Celery retries the full task via autoretry_for
         raise
     except Exception as err:
         error_message = f"Alert id = {alert.id}, failed to evaluate"

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -20,7 +20,7 @@ from posthog.schema import (
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.caching.fetch_from_cache import InsightResult
-from posthog.errors import CHQueryErrorCannotScheduleTask
+from posthog.errors import CHQueryErrorCannotScheduleTask, CHQueryErrorS3Error, CHQueryErrorTooManySimultaneousQueries
 from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
@@ -851,18 +851,33 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         else:
             assert alert_check.calculated_value == 0
 
-    def test_ch_cannot_schedule_task_raises_for_retry(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    @parameterized.expand(
+        [
+            ("cannot_schedule", CHQueryErrorCannotScheduleTask),
+            ("too_many_queries", CHQueryErrorTooManySimultaneousQueries),
+            ("s3_error", CHQueryErrorS3Error),
+        ]
+    )
+    def test_transient_ch_errors_propagate_for_celery_retry(
+        self,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        _name: str,
+        error_class: type[Exception],
     ) -> None:
         self.set_thresholds(lower=1)
 
         with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
+            mock_calculate.side_effect = error_class("transient failure")
 
-            with pytest.raises(CHQueryErrorCannotScheduleTask):
+            with pytest.raises(error_class):
                 check_alert(self.alert["id"])
 
         assert mock_send_errors.call_count == 0
+
+        # No ERRORED alert check created — the error propagates for Celery to retry
+        alert_checks = AlertCheck.objects.filter(alert_configuration=self.alert["id"])
+        assert alert_checks.count() == 0
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -884,6 +884,9 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_send_notifications_for_breaches.call_count == 1
         assert mock_send_errors.call_count == 0
 
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.FIRING
+
     @parameterized.expand(
         [
             ("cannot_schedule", CHQueryErrorCannotScheduleTask),
@@ -910,9 +913,8 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         # 4 attempts (1 initial + 3 retries)
         assert mock_calculate.call_count == 4
-
+        assert mock_send_notifications_for_breaches.call_count == 0
         assert mock_send_errors.call_count == 0
-
         # No ERRORED alert check — the error propagates after exhausting retries
         alert_checks = AlertCheck.objects.filter(alert_configuration=self.alert["id"])
         assert alert_checks.count() == 0

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -858,12 +858,47 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             ("s3_error", CHQueryErrorS3Error),
         ]
     )
-    def test_transient_ch_errors_propagate_for_celery_retry(
+    @patch("posthog.tasks.alerts.checks.wait_exponential_jitter", return_value=lambda rs: 0)
+    def test_transient_ch_errors_retry_and_succeed(
         self,
-        mock_send_notifications_for_breaches: MagicMock,
-        mock_send_errors: MagicMock,
         _name: str,
         error_class: type[Exception],
+        _mock_wait: MagicMock,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+    ) -> None:
+        self.set_thresholds(lower=1)
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.side_effect = [
+                error_class("transient failure"),
+                error_class("transient failure"),
+                InsightResult(result=[], last_refresh=None, cache_key=None, is_cached=False, timezone=None),
+            ]
+
+            check_alert(self.alert["id"])
+
+        assert mock_calculate.call_count == 3
+
+        # Alert evaluated successfully after retries — breach notification sent (value 0 < lower 1)
+        assert mock_send_notifications_for_breaches.call_count == 1
+        assert mock_send_errors.call_count == 0
+
+    @parameterized.expand(
+        [
+            ("cannot_schedule", CHQueryErrorCannotScheduleTask),
+            ("too_many_queries", CHQueryErrorTooManySimultaneousQueries),
+            ("s3_error", CHQueryErrorS3Error),
+        ]
+    )
+    @patch("posthog.tasks.alerts.checks.wait_exponential_jitter", return_value=lambda rs: 0)
+    def test_transient_ch_errors_exhaust_retries(
+        self,
+        _name: str,
+        error_class: type[Exception],
+        _mock_wait: MagicMock,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
     ) -> None:
         self.set_thresholds(lower=1)
 
@@ -873,9 +908,12 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             with pytest.raises(error_class):
                 check_alert(self.alert["id"])
 
+        # 4 attempts (1 initial + 3 retries)
+        assert mock_calculate.call_count == 4
+
         assert mock_send_errors.call_count == 0
 
-        # No ERRORED alert check created — the error propagates for Celery to retry
+        # No ERRORED alert check — the error propagates after exhausting retries
         alert_checks = AlertCheck.objects.filter(alert_configuration=self.alert["id"])
         assert alert_checks.count() == 0
 

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -851,6 +851,19 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         else:
             assert alert_check.calculated_value == 0
 
+    def test_ch_cannot_schedule_task_raises_for_retry(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=1)
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
+
+            with pytest.raises(CHQueryErrorCannotScheduleTask):
+                check_alert(self.alert["id"])
+
+        assert mock_send_errors.call_count == 0
+
 
 @freeze_time("2024-06-02T08:55:00.000Z")
 class TestAlertSubscriptionOrgMembership(APIBaseTest):
@@ -921,19 +934,6 @@ class TestAlertSubscriptionOrgMembership(APIBaseTest):
         email = mocked_email_messages[0]
         assert len(email.to) == 1
         assert email.to[0]["recipient"] == "user1@posthog.com"
-
-    def test_ch_cannot_schedule_task_raises_for_retry(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self.set_thresholds(lower=1)
-
-        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
-
-            with pytest.raises(CHQueryErrorCannotScheduleTask):
-                check_alert(self.alert["id"])
-
-        assert mock_send_errors.call_count == 0
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create
 from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
+from tenacity import wait_none
 
 from posthog.schema import (
     AlertConditionType,
@@ -858,12 +859,11 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             ("s3_error", CHQueryErrorS3Error),
         ]
     )
-    @patch("posthog.tasks.alerts.checks.wait_exponential_jitter", return_value=lambda rs: 0)
+    @patch.object(check_alert.retry, "wait", wait_none())  # type: ignore[attr-defined]
     def test_transient_ch_errors_retry_and_succeed(
         self,
         _name: str,
         error_class: type[Exception],
-        _mock_wait: MagicMock,
         mock_send_notifications_for_breaches: MagicMock,
         mock_send_errors: MagicMock,
     ) -> None:
@@ -880,11 +880,10 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_calculate.call_count == 3
 
-        # Alert evaluated successfully after retries — breach notification sent (value 0 < lower 1)
+        # Alert evaluated successfully after retries
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
         assert mock_send_notifications_for_breaches.call_count == 1
         assert mock_send_errors.call_count == 0
-
-        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
         assert alert_check.state == AlertState.FIRING
 
     @parameterized.expand(
@@ -894,12 +893,11 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             ("s3_error", CHQueryErrorS3Error),
         ]
     )
-    @patch("posthog.tasks.alerts.checks.wait_exponential_jitter", return_value=lambda rs: 0)
+    @patch.object(check_alert.retry, "wait", wait_none())  # type: ignore[attr-defined]
     def test_transient_ch_errors_exhaust_retries(
         self,
         _name: str,
         error_class: type[Exception],
-        _mock_wait: MagicMock,
         mock_send_notifications_for_breaches: MagicMock,
         mock_send_errors: MagicMock,
     ) -> None:
@@ -915,9 +913,13 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert mock_calculate.call_count == 4
         assert mock_send_notifications_for_breaches.call_count == 0
         assert mock_send_errors.call_count == 0
-        # No ERRORED alert check — the error propagates after exhausting retries
+        # No ERRORED alert check; this so that it will be picked up at the next cycle
         alert_checks = AlertCheck.objects.filter(alert_configuration=self.alert["id"])
         assert alert_checks.count() == 0
+
+        # is_calculating cleared by the finally block so alert doesn't get stuck
+        alert = AlertConfiguration.objects.get(pk=self.alert["id"])
+        assert alert.is_calculating is False
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -19,6 +19,7 @@ from posthog.schema import (
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.caching.fetch_from_cache import InsightResult
+from posthog.errors import CHQueryErrorCannotScheduleTask
 from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
@@ -991,3 +992,18 @@ class TestGetSubscribedUsersEmails(APIBaseTest):
 
         emails = self.alert.get_subscribed_users_emails()
         assert emails == []
+
+    def test_ch_cannot_schedule_task_raises_for_retry(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=1)
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
+
+            import pytest
+
+            with pytest.raises(CHQueryErrorCannotScheduleTask):
+                check_alert(self.alert["id"])
+
+        assert mock_send_errors.call_count == 0

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import pytest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
 from unittest.mock import MagicMock, patch
@@ -921,6 +922,19 @@ class TestAlertSubscriptionOrgMembership(APIBaseTest):
         assert len(email.to) == 1
         assert email.to[0]["recipient"] == "user1@posthog.com"
 
+    def test_ch_cannot_schedule_task_raises_for_retry(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        self.set_thresholds(lower=1)
+
+        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
+
+            with pytest.raises(CHQueryErrorCannotScheduleTask):
+                check_alert(self.alert["id"])
+
+        assert mock_send_errors.call_count == 0
+
 
 @freeze_time("2024-06-02T08:55:00.000Z")
 class TestGetSubscribedUsersEmails(APIBaseTest):
@@ -992,18 +1006,3 @@ class TestGetSubscribedUsersEmails(APIBaseTest):
 
         emails = self.alert.get_subscribed_users_emails()
         assert emails == []
-
-    def test_ch_cannot_schedule_task_raises_for_retry(
-        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
-    ) -> None:
-        self.set_thresholds(lower=1)
-
-        with patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.side_effect = CHQueryErrorCannotScheduleTask("cannot schedule")
-
-            import pytest
-
-            with pytest.raises(CHQueryErrorCannotScheduleTask):
-                check_alert(self.alert["id"])
-
-        assert mock_send_errors.call_count == 0

--- a/posthog/tasks/exports/failure_handler.py
+++ b/posthog/tasks/exports/failure_handler.py
@@ -15,6 +15,7 @@ from posthog.hogql.errors import (
 
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.errors import (
+    CH_TRANSIENT_ERRORS,
     CHQueryErrorCannotParseUuid,
     CHQueryErrorIllegalAggregation,
     CHQueryErrorIllegalTypeOfArgument,
@@ -22,9 +23,7 @@ from posthog.errors import (
     CHQueryErrorNoCommonType,
     CHQueryErrorNotAnAggregate,
     CHQueryErrorNumberOfArgumentsDoesntMatch,
-    CHQueryErrorS3Error,
     CHQueryErrorTooManyBytes,
-    CHQueryErrorTooManySimultaneousQueries,
     CHQueryErrorTypeMismatch,
     CHQueryErrorUnknownFunction,
     CHQueryErrorUnknownIdentifier,
@@ -73,8 +72,7 @@ class ExcelColumnLimitExceeded(Exception):
 
 
 EXCEPTIONS_TO_RETRY = (
-    CHQueryErrorS3Error,
-    CHQueryErrorTooManySimultaneousQueries,
+    *CH_TRANSIENT_ERRORS,
     OperationalError,
     ProtocolError,
     ConcurrencyLimitExceeded,


### PR DESCRIPTION
## Problem

Alert checks can fail due to transient ClickHouse errors that should be retried rather than treated as permanent failures. Additionally, the codebase had multiple locations tracking their own lists of transient errors to retry, creating duplication and inconsistency.

## Changes

- Added `CH_TRANSIENT_ERRORS` tuple in `posthog/errors.py` containing `CHQueryErrorTooManySimultaneousQueries`, `CHQueryErrorCannotScheduleTask`, and `CHQueryErrorS3Error`
- Replaced Celery's `autoretry_for` mechanism in alert tasks with tenacity's `@retry` decorator for more flexible retry configuration
- Updated alert checking to use `CH_TRANSIENT_ERRORS` instead of only handling `CHQueryErrorTooManySimultaneousQueries`
- Modified export failure handler to use the centralized `CH_TRANSIENT_ERRORS` tuple
- Added logging for retry attempts with attempt number and error details

## How did you test this code?

:white_check_mark: Added unit tests `test_transient_ch_errors_retry_and_succeed` and `test_transient_ch_errors_exhaust_retries` that verify all three transient error types properly trigger retry behavior.

## Publish to changelog?

No