### PR TITLE
feat(retention): aggregation mode graph should show values

### DIFF
--- a/frontend/src/scenes/retention/RetentionGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionGraph.tsx
@@ -41,6 +41,8 @@ export function RetentionGraph({ inSharedMode = false }: RetentionGraphProps): J
 
     const selectedInterval = retentionFilter?.selectedInterval ?? null
 
+    const isPercentage = !retentionFilter?.aggregationType || retentionFilter.aggregationType === 'count'
+
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {
         return (
             <p className="w-full m-0 text-center text-sm text-gray-500">
@@ -62,7 +64,7 @@ export function RetentionGraph({ inSharedMode = false }: RetentionGraphProps): J
             // in retention graph, we want the bars side by side so it's easier
             // to see the retention trend change for each cohort
             isStacked={retentionFilter?.display !== ChartDisplayType.ActionsBar}
-            trendsFilter={{ aggregationAxisFormat: 'percentage' } as TrendsFilter}
+            trendsFilter={{ aggregationAxisFormat: isPercentage ? 'percentage' : 'numeric' } as TrendsFilter}
             tooltip={{
                 altTitle: selectedInterval !== null ? `${retentionFilter?.period} ${selectedInterval}` : undefined,
                 renderSeries: function _renderCohortPrefix(value) {
@@ -79,7 +81,7 @@ export function RetentionGraph({ inSharedMode = false }: RetentionGraphProps): J
                 },
                 showHeader: selectedInterval !== null,
                 renderCount: (count) => {
-                    return `${roundToDecimal(count)}%`
+                    return isPercentage ? `${roundToDecimal(count)}%` : `${roundToDecimal(count)}`
                 },
             }}
             onClick={(payload) => {


### PR DESCRIPTION
## Problem
Retention graph always show percentages

## Changes
When in aggregation mode, need to graph the aggregation value instead
<img width="1059" height="680" alt="image" src="https://github.com/user-attachments/assets/cac32a18-5116-4c45-8373-ae7e4780e2ec" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
