### PR TITLE
fix(alerts): auto-disable permanently broken alerts and notify via email

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -543,8 +543,6 @@ posthog/tasks/alerts/checks.py:0: error: Item "None" of "Any | None" has no attr
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | None" is not indexable  [index]
-posthog/tasks/alerts/trends.py:0: error: Unsupported right operand type for in ("Any | None")  [operator]
-posthog/tasks/alerts/trends.py:0: error: Value of type "Any | None" is not indexable  [index]
 posthog/tasks/email.py:0: error: Argument "email" to "add_recipient" of "EmailMessage" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/tasks/email.py:0: error: Incompatible types in assignment (expression has type "Team | None", variable has type "Team")  [assignment]
 posthog/tasks/email.py:0: error: Item "None" of "User | None" has no attribute "first_name"  [union-attr]

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -278,8 +278,12 @@ class AlertSerializer(serializers.ModelSerializer):
         condition = attrs.get("condition", self.instance.condition if self.instance else None)
         config = attrs.get("config", self.instance.config if self.instance else None)
         insight = attrs.get("insight") or (self.instance.insight if self.instance else None)
+        if insight is None:
+            raise ValidationError({"insight": ["Insight is required."]})
         with upgrade_query(insight):
             query = insight.query
+            if query is None:
+                raise ValidationError({"insight": ["Insight has no valid query."]})
 
         threshold_config = None
         if "threshold" in attrs and isinstance(attrs["threshold"], dict):

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -21,6 +21,8 @@ from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.alert import AlertCheck, AlertConfiguration, AlertSubscription, Threshold
 from posthog.models.signals import model_activity_signal, mutable_receiver
+from posthog.schema_migrations.upgrade_manager import upgrade_query
+from posthog.tasks.alerts.utils import validate_alert_config
 from posthog.utils import relative_date_parse
 
 
@@ -272,6 +274,23 @@ class AlertSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         if attrs.get("insight") and attrs["insight"].team.id != self.context["team_id"]:
             raise ValidationError({"insight": ["This insight does not belong to your team."]})
+
+        condition = attrs.get("condition", self.instance.condition if self.instance else None)
+        config = attrs.get("config", self.instance.config if self.instance else None)
+        insight = attrs.get("insight") or (self.instance.insight if self.instance else None)
+        with upgrade_query(insight):
+            query = insight.query
+
+        threshold_config = None
+        if "threshold" in attrs and isinstance(attrs["threshold"], dict):
+            threshold_config = attrs["threshold"].get("configuration")
+        elif self.instance and self.instance.threshold:
+            threshold_config = self.instance.threshold.configuration
+
+        try:
+            validate_alert_config(query, condition, config, threshold_config)
+        except ValueError as e:
+            raise ValidationError(str(e))
 
         # only validate alert count when creating a new alert
         if self.context["request"].method != "POST":

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -41,6 +41,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "name": "alert name",
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
@@ -50,7 +51,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
 
         expected_alert_json = {
             "calculation_interval": "daily",
-            "condition": {},
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "created_at": mock.ANY,
             "created_by": mock.ANY,
             "enabled": True,
@@ -119,6 +120,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
@@ -146,6 +148,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
                 "subscribed_users": [
                     self.user.id,
                 ],
+                "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
                 "config": {"type": "TrendsAlertConfig", "series_index": 0},
                 "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
                 "name": "alert name",
@@ -165,6 +168,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
@@ -196,6 +200,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         creation_request = {
             "insight": self.insight["id"],
             "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
@@ -242,6 +247,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
@@ -311,6 +317,44 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             **overrides,
         }
         response = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert expected_error_fragment in str(response.content).lower()
+
+    @parameterized.expand(
+        [
+            (
+                "invalid_condition_via_patch",
+                {"condition": {"type": "bogus"}},
+                "invalid condition",
+            ),
+            (
+                "missing_config_type_via_patch",
+                {"config": {"series_index": 0}},
+                "unsupported alert config type",
+            ),
+            (
+                "absolute_with_percentage_threshold_via_patch",
+                {
+                    "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+                    "threshold": {"configuration": {"type": InsightThresholdType.PERCENTAGE, "bounds": {}}},
+                },
+                "absolute value alerts require an absolute threshold",
+            ),
+        ]
+    )
+    def test_patch_alert_rejects_invalid_config(self, _name, overrides, expected_error_fragment):
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "alert name",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        assert "id" in alert, alert
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert['id']}", overrides)
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert expected_error_fragment in str(response.content).lower()
 
@@ -385,6 +429,7 @@ class TestAlertAPIKeyAccess(APIBaseTest):
                 "insight": self.insight["id"],
                 "subscribed_users": [self.user.id],
                 "name": "New Alert",
+                "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
                 "config": {"type": "TrendsAlertConfig", "series_index": 0},
                 "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             },

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -8,7 +8,7 @@ from unittest import mock
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.schema import AlertState, InsightThresholdType
+from posthog.schema import AlertConditionType, AlertState, InsightThresholdType
 
 from posthog.models import AlertConfiguration
 from posthog.models.alert import AlertCheck
@@ -119,6 +119,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
         }
@@ -145,6 +146,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
                 "subscribed_users": [
                     self.user.id,
                 ],
+                "config": {"type": "TrendsAlertConfig", "series_index": 0},
                 "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
                 "name": "alert name",
             }
@@ -163,6 +165,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
         }
@@ -193,6 +196,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         creation_request = {
             "insight": self.insight["id"],
             "subscribed_users": [self.user.id],
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
         }
@@ -238,6 +242,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             "subscribed_users": [
                 self.user.id,
             ],
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             "name": "alert name",
             "state": AlertState.FIRING,
@@ -261,6 +266,53 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         # should also create a new alert check with resolution
         check = AlertCheck.objects.filter(alert_configuration=firing_alert.id).latest("created_at")
         assert check.state == AlertState.SNOOZED
+
+    @parameterized.expand(
+        [
+            (
+                "invalid_condition",
+                {"condition": {"type": "bogus"}, "config": {"type": "TrendsAlertConfig", "series_index": 0}},
+                "invalid condition",
+            ),
+            (
+                "missing_config_type",
+                {"condition": {"type": AlertConditionType.ABSOLUTE_VALUE}, "config": {"series_index": 0}},
+                "unsupported alert config type",
+            ),
+            (
+                "relative_condition_on_pie_chart",
+                {
+                    "condition": {"type": AlertConditionType.RELATIVE_INCREASE},
+                    "config": {"type": "TrendsAlertConfig", "series_index": 0},
+                },
+                "not compatible with non time series",
+            ),
+            (
+                "absolute_with_percentage_threshold",
+                {
+                    "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+                    "config": {"type": "TrendsAlertConfig", "series_index": 0},
+                    "threshold": {"configuration": {"type": InsightThresholdType.PERCENTAGE, "bounds": {}}},
+                },
+                "absolute value alerts require an absolute threshold",
+            ),
+        ]
+    )
+    def test_create_alert_rejects_invalid_config(self, _name, overrides, expected_error_fragment):
+        pie_insight_data = deepcopy(self.default_insight_data)
+        pie_insight_data["query"]["trendsFilter"]["display"] = "ActionsPie"
+        pie_insight = self.client.post(f"/api/projects/{self.team.id}/insights", data=pie_insight_data).json()
+
+        creation_request = {
+            "insight": pie_insight["id"],
+            "subscribed_users": [self.user.id],
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "alert name",
+            **overrides,
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert expected_error_fragment in str(response.content).lower()
 
 
 class TestAlertAPIKeyAccess(APIBaseTest):
@@ -333,6 +385,7 @@ class TestAlertAPIKeyAccess(APIBaseTest):
                 "insight": self.insight["id"],
                 "subscribed_users": [self.user.id],
                 "name": "New Alert",
+                "config": {"type": "TrendsAlertConfig", "series_index": 0},
                 "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
             },
             HTTP_AUTHORIZATION=f"Bearer {api_key}",

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -29,8 +29,10 @@ from posthog.tasks.alerts.utils import (
     calculation_interval_to_order,
     next_check_time,
     send_notifications_for_breaches,
+    send_notifications_for_disabled,
     send_notifications_for_errors,
     skip_because_of_weekend,
+    validate_alert_config,
 )
 from posthog.tasks.utils import CeleryQueue
 from posthog.utils import get_from_dict_or_attr
@@ -251,6 +253,15 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
             alert.snoozed_until = None
             alert.state = AlertState.NOT_FIRING
 
+    try:
+        insight = alert.insight
+        with upgrade_query(insight):
+            threshold_config = alert.threshold.configuration if alert.threshold else None
+            validate_alert_config(insight.query, alert.condition, alert.config, threshold_config)
+    except ValueError as e:
+        _disable_invalid_alert(alert, str(e))
+        return
+
     # we will attempt to check alert
     logger.info("check_alert", alert_id=alert.id)
     alert.last_checked_at = datetime.now(UTC)
@@ -378,6 +389,28 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         # so we raise again as @transaction.atomic decorator won't commit db updates
         # TODO: later should have a way just to retry notification mechanism
         raise
+
+
+def _disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
+    logger.warning("check_alert.auto_disabling", alert_id=alert.id, reason=reason)
+    AlertConfiguration.objects.filter(pk=alert.pk).update(
+        enabled=False,
+        state=AlertState.ERRORED,
+        last_checked_at=datetime.now(UTC),
+    )
+    alert.refresh_from_db()
+
+    targets_to_notify = alert.get_subscribed_users_emails()
+    AlertCheck.objects.create(
+        alert_configuration=alert,
+        calculated_value=None,
+        condition=alert.condition,
+        targets_notified={"users": targets_to_notify} if targets_to_notify else {},
+        state=AlertState.ERRORED,
+        error={"message": reason},
+    )
+    if targets_to_notify:
+        send_notifications_for_disabled(alert, reason)
 
 
 def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -256,6 +256,8 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
     try:
         insight = alert.insight
         with upgrade_query(insight):
+            if insight.query is None:
+                raise ValueError("Alert's insight has no valid query")
             threshold_config = alert.threshold.configuration if alert.threshold else None
             validate_alert_config(insight.query, alert.condition, alert.config, threshold_config)
     except ValueError as e:
@@ -410,7 +412,7 @@ def _disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
         error={"message": reason},
     )
     if targets_to_notify:
-        send_notifications_for_disabled(alert, reason)
+        send_notifications_for_disabled(alert, reason, targets_to_notify)
 
 
 def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -950,7 +950,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         alert.refresh_from_db()
         assert alert.enabled is False
-        assert alert.state == AlertState.ERRORED
+        assert alert.state == AlertState.ERRORED  # type: ignore[unreachable]
         assert mock_send_disabled.call_count == 1
         assert mock_send_notifications_for_breaches.call_count == 0
 

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -921,6 +921,70 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         alert = AlertConfiguration.objects.get(pk=self.alert["id"])
         assert alert.is_calculating is False
 
+    @parameterized.expand(
+        [
+            ("invalid_condition", {"condition": {}}, "invalid condition"),
+            ("missing_config_type", {"config": {"series_index": 0}}, "Unsupported alert config type"),
+            ("relative_on_non_time_series", {"condition": {"type": "relative_increase"}}, "not compatible"),
+        ]
+    )
+    @patch("posthog.tasks.alerts.checks.send_notifications_for_disabled")
+    def test_invalid_config_auto_disables_alert(
+        self,
+        _name: str,
+        field_overrides: dict,
+        expected_error_fragment: str,
+        mock_send_disabled: MagicMock,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+    ) -> None:
+        alert = AlertConfiguration.objects.get(pk=self.alert["id"])
+        assert alert.enabled is True
+        assert alert.state != AlertState.ERRORED
+
+        for field, value in field_overrides.items():
+            setattr(alert, field, value)
+        alert.save()
+
+        check_alert(self.alert["id"])
+
+        alert.refresh_from_db()
+        assert alert.enabled is False
+        assert alert.state == AlertState.ERRORED
+        assert mock_send_disabled.call_count == 1
+        assert mock_send_notifications_for_breaches.call_count == 0
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.ERRORED
+        assert alert_check.calculated_value is None
+        assert alert_check.condition == alert.condition
+        assert alert_check.targets_notified == {"users": ["user1@posthog.com"]}
+        assert expected_error_fragment in alert_check.error["message"]
+
+    @patch("posthog.tasks.alerts.checks.send_notifications_for_disabled")
+    def test_auto_disable_with_no_subscribers_sets_targets_notified_to_none(
+        self,
+        mock_send_disabled: MagicMock,
+        mock_send_notifications_for_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+    ) -> None:
+        alert = AlertConfiguration.objects.get(pk=self.alert["id"])
+        alert.condition = {}
+        alert.save()
+        AlertSubscription.objects.filter(alert_configuration=alert).delete()
+
+        check_alert(self.alert["id"])
+
+        alert.refresh_from_db()
+        assert alert.enabled is False
+        assert alert.state == AlertState.ERRORED
+        assert mock_send_disabled.call_count == 0
+        assert mock_send_notifications_for_breaches.call_count == 0
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=self.alert["id"]).latest("created_at")
+        assert alert_check.state == AlertState.ERRORED
+        assert alert_check.targets_notified == {}
+
 
 @freeze_time("2024-06-02T08:55:00.000Z")
 class TestAlertSubscriptionOrgMembership(APIBaseTest):

--- a/posthog/tasks/alerts/test/test_validate_alert_config.py
+++ b/posthog/tasks/alerts/test/test_validate_alert_config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from parameterized import parameterized
@@ -5,16 +7,16 @@ from parameterized import parameterized
 from posthog.tasks.alerts.utils import validate_alert_config
 
 
-def _base_condition(type="absolute_value"):
+def _base_condition(type: str = "absolute_value") -> dict[str, Any]:
     return {"type": type}
 
 
-def _base_config(series_index=0):
+def _base_config(series_index: int = 0) -> dict[str, Any]:
     return {"type": "TrendsAlertConfig", "series_index": series_index}
 
 
-def _base_query(series_count=1, display=None):
-    query = {
+def _base_query(series_count: int = 1, display: str | None = None) -> dict[str, Any]:
+    query: dict[str, Any] = {
         "kind": "TrendsQuery",
         "series": [{"kind": "EventsNode", "event": f"$event_{i}"} for i in range(series_count)],
     }
@@ -23,8 +25,8 @@ def _base_query(series_count=1, display=None):
     return query
 
 
-def _base_threshold(type="absolute", bounds=None):
-    config = {"type": type}
+def _base_threshold(type: str = "absolute", bounds: dict[str, Any] | None = None) -> dict[str, Any]:
+    config: dict[str, Any] = {"type": type}
     if bounds is not None:
         config["bounds"] = bounds
     return config
@@ -48,6 +50,22 @@ class TestValidateAlertConfig:
                 _base_config(),
                 _base_threshold(),
                 None,
+            ),
+            (
+                "none_condition",
+                _base_query(),
+                None,
+                _base_config(),
+                None,
+                "Alert has invalid condition: None",
+            ),
+            (
+                "empty_condition",
+                _base_query(),
+                {},
+                _base_config(),
+                None,
+                "Alert has invalid condition",
             ),
             (
                 "invalid_condition_type",
@@ -183,7 +201,15 @@ class TestValidateAlertConfig:
             ),
         ]
     )
-    def test_validate_alert_config(self, _name, query, condition, config, threshold_config, expected_error_fragment):
+    def test_validate_alert_config(
+        self,
+        _name: str,
+        query: dict[str, Any],
+        condition: dict[str, Any] | None,
+        config: dict[str, Any] | None,
+        threshold_config: dict[str, Any] | None,
+        expected_error_fragment: str | None,
+    ) -> None:
         if expected_error_fragment is None:
             validate_alert_config(query, condition, config, threshold_config)
         else:

--- a/posthog/tasks/alerts/test/test_validate_alert_config.py
+++ b/posthog/tasks/alerts/test/test_validate_alert_config.py
@@ -1,0 +1,191 @@
+import pytest
+
+from parameterized import parameterized
+
+from posthog.tasks.alerts.utils import validate_alert_config
+
+
+def _base_condition(type="absolute_value"):
+    return {"type": type}
+
+
+def _base_config(series_index=0):
+    return {"type": "TrendsAlertConfig", "series_index": series_index}
+
+
+def _base_query(series_count=1, display=None):
+    query = {
+        "kind": "TrendsQuery",
+        "series": [{"kind": "EventsNode", "event": f"$event_{i}"} for i in range(series_count)],
+    }
+    if display:
+        query["trendsFilter"] = {"display": display}
+    return query
+
+
+def _base_threshold(type="absolute", bounds=None):
+    config = {"type": type}
+    if bounds is not None:
+        config["bounds"] = bounds
+    return config
+
+
+class TestValidateAlertConfig:
+    @parameterized.expand(
+        [
+            (
+                "valid_absolute_config",
+                _base_query(),
+                _base_condition(),
+                _base_config(),
+                _base_threshold(),
+                None,
+            ),
+            (
+                "valid_relative_increase",
+                _base_query(display="ActionsLineGraph"),
+                _base_condition("relative_increase"),
+                _base_config(),
+                _base_threshold(),
+                None,
+            ),
+            (
+                "invalid_condition_type",
+                _base_query(),
+                {"type": "bogus"},
+                _base_config(),
+                None,
+                "Alert has invalid condition",
+            ),
+            (
+                "missing_config",
+                _base_query(),
+                _base_condition(),
+                None,
+                None,
+                "Unsupported alert config type: None",
+            ),
+            (
+                "missing_config_type",
+                _base_query(),
+                _base_condition(),
+                {"series_index": 0},
+                None,
+                "Unsupported alert config type",
+            ),
+            (
+                "invalid_config_schema",
+                _base_query(),
+                _base_condition(),
+                {"type": "TrendsAlertConfig"},
+                None,
+                "Alert has invalid TrendsAlertConfig",
+            ),
+            (
+                "unsupported_query_kind",
+                {"kind": "FunnelsQuery", "series": []},
+                _base_condition(),
+                _base_config(),
+                None,
+                "query kind 'FunnelsQuery' is not supported",
+            ),
+            (
+                "wrapper_node_unwrapped",
+                {"kind": "InsightVizNode", "source": _base_query()},
+                _base_condition(),
+                _base_config(),
+                _base_threshold(),
+                None,
+            ),
+            (
+                "relative_on_pie",
+                _base_query(display="ActionsPie"),
+                _base_condition("relative_increase"),
+                _base_config(),
+                None,
+                "not compatible with non time series",
+            ),
+            (
+                "relative_on_bold_number",
+                _base_query(display="BoldNumber"),
+                _base_condition("relative_decrease"),
+                _base_config(),
+                None,
+                "not compatible with non time series",
+            ),
+            (
+                "absolute_with_percentage_threshold",
+                _base_query(),
+                _base_condition("absolute_value"),
+                _base_config(),
+                _base_threshold("percentage"),
+                "Absolute value alerts require an absolute threshold, but a percentage threshold was configured",
+            ),
+            (
+                "check_ongoing_no_upper_absolute",
+                _base_query(),
+                _base_condition("absolute_value"),
+                {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
+                _base_threshold("absolute", {"lower": 0}),
+                "check_ongoing_interval is only supported .* when upper threshold is specified",
+            ),
+            (
+                "check_ongoing_no_upper_relative",
+                _base_query(display="ActionsLineGraph"),
+                _base_condition("relative_increase"),
+                {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
+                _base_threshold("absolute", {"lower": 0}),
+                "check_ongoing_interval is only supported .* when upper threshold is specified",
+            ),
+            (
+                "series_index_out_of_range",
+                _base_query(series_count=1),
+                _base_condition(),
+                _base_config(series_index=5),
+                None,
+                r"series_index 5 is out of range \(query has 1 series\)",
+            ),
+            (
+                "series_index_valid_with_formulas",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "formulaNodes": [
+                            {"formula": "A"},
+                            {"formula": "A*2"},
+                        ],
+                    },
+                },
+                _base_condition(),
+                _base_config(series_index=1),
+                _base_threshold(),
+                None,
+            ),
+            (
+                "series_index_out_of_range_with_formulas",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "formulaNodes": [
+                            {"formula": "A"},
+                            {"formula": "A*2"},
+                        ],
+                    },
+                },
+                _base_condition(),
+                _base_config(series_index=2),
+                None,
+                r"series_index 2 is out of range \(query has 2 series\)",
+            ),
+        ]
+    )
+    def test_validate_alert_config(self, _name, query, condition, config, threshold_config, expected_error_fragment):
+        if expected_error_fragment is None:
+            validate_alert_config(query, condition, config, threshold_config)
+        else:
+            with pytest.raises(ValueError, match=expected_error_fragment):
+                validate_alert_config(query, condition, config, threshold_config)

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -15,7 +15,7 @@ from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.caching.fetch_from_cache import InsightResult
 from posthog.models import AlertConfiguration, Insight
-from posthog.tasks.alerts.utils import NON_TIME_SERIES_DISPLAY_TYPES, AlertEvaluationResult
+from posthog.tasks.alerts.utils import AlertEvaluationResult, is_non_time_series_trend
 
 
 # TODO: move the TrendResult UI type to schema.ts and use that instead
@@ -71,12 +71,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
     But in some cases (when check_current_interval = True) like value > X or value inc > X, we can check the value for the current interval and alert right away if threshold is breached.
     So then we check current interval value first and alert if threshold breached, otherwise fallback and process previous interval.
     """
-
-    if "type" in alert.config and alert.config["type"] == "TrendsAlertConfig":
-        config = TrendsAlertConfig.model_validate(alert.config)
-    else:
-        raise ValueError(f"Unsupported alert config type: {alert.config}")
-
+    config = TrendsAlertConfig.model_validate(alert.config)
     condition = AlertCondition.model_validate(alert.condition)
     threshold = InsightThreshold.model_validate(alert.threshold.configuration) if alert.threshold else None
 
@@ -86,7 +81,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
     has_breakdown = query.breakdownFilter and (
         (query.breakdownFilter.breakdown and query.breakdownFilter.breakdown_type) or query.breakdownFilter.breakdowns
     )
-    is_non_time_series = _is_non_time_series_trend(query)
+    is_non_time_series = is_non_time_series_trend(query)
     check_current_interval = config.check_ongoing_interval
 
     # Do not use cache hourly trends alerts.
@@ -98,9 +93,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
 
     match condition.type:
         case AlertConditionType.ABSOLUTE_VALUE:
-            if threshold.type != InsightThresholdType.ABSOLUTE:
-                raise ValueError(f"Absolute threshold not configured for alert condition ABSOLUTE_VALUE")
-
             if is_non_time_series:
                 # for non time series, it's an aggregated value for full interval
                 # so we need to compute full insight
@@ -124,12 +116,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 calculation_result, alert, threshold.bounds, threshold.type, condition, interval
             ):
                 return no_result_evaluation
-
-            if check_current_interval and threshold.bounds.upper is None:
-                # checking for value > X so we can also check current interval value
-                raise ValueError(
-                    f"check_ongoing_interval is only supported for alert condition ABSOLUTE_VALUE when upper threshold is specified"
-                )
 
             if has_breakdown:
                 # for breakdowns, we need to check all values in calculation_result.result
@@ -195,9 +181,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                     )
                     return AlertEvaluationResult(value=prev_interval_value, breaches=breaches)
         case AlertConditionType.RELATIVE_INCREASE:
-            if is_non_time_series:
-                raise ValueError(f"Relative alerts not supported for non time series trends")
-
             # to measure relative increase, we can't alert until current interval has completed
             # as to check increase less than X, we need interval to complete
             # so we need to compute the trend values for last 3 intervals
@@ -231,13 +214,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             # and increase will be the evaluated value of that result
             increase = None
             breaches = []
-
-            if check_current_interval and threshold.bounds.upper is None:
-                # checking for value increased > X so we can also check current interval value
-                # as can alert right away if current interval value - previous interval value > upper threshold
-                raise ValueError(
-                    f"check_ongoing_interval is only supported for alert condition RELATIVE_INCREASE when upper threshold is specified"
-                )
 
             for result in results_to_evaluate:
                 current_interval_value = _pick_interval_value_from_trend_result(query, result, 0)
@@ -304,9 +280,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             return AlertEvaluationResult(value=(increase if not has_breakdown else None), breaches=[])
 
         case AlertConditionType.RELATIVE_DECREASE:
-            if is_non_time_series:
-                raise ValueError(f"Relative alerts not supported for non time series trends")
-
             # to measure relative decrease, we can't alert until current interval has completed
             # as to check decrease more than X, we need interval to complete
             # so we need to compute the trend values for last 3 intervals
@@ -377,10 +350,6 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             raise NotImplementedError(f"Unsupported alert condition type: {condition.type}")
 
 
-def _is_non_time_series_trend(query: TrendsQuery) -> bool:
-    return bool(query.trendsFilter and query.trendsFilter.display in NON_TIME_SERIES_DISPLAY_TYPES)
-
-
 def _date_range_override_for_intervals(query: TrendsQuery, last_x_intervals: int = 1) -> Optional[dict]:
     """
     Resulting filter overrides don't set 'date_to' so we always get value for current interval.
@@ -414,7 +383,7 @@ def _pick_interval_value_from_trend_result(query: TrendsQuery, result: TrendResu
     """
     assert interval_to_pick <= 0
 
-    if _is_non_time_series_trend(query):
+    if is_non_time_series_trend(query):
         # only one value in result
         return result["aggregated_value"]
 

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -300,7 +300,7 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     # message.send()
 
 
-def send_notifications_for_disabled(alert: AlertConfiguration, reason: str) -> None:
+def send_notifications_for_disabled(alert: AlertConfiguration, reason: str, targets: list[str]) -> None:
     logger.info("Sending alert disabled notification", alert_id=alert.id, reason=reason)
 
     subject = f"PostHog alert {alert.name} has been disabled"
@@ -319,7 +319,7 @@ def send_notifications_for_disabled(alert: AlertConfiguration, reason: str) -> N
             "alert_error": reason,
         },
     )
-    for target in alert.get_subscribed_users_emails():
+    for target in targets:
         message.add_recipient(email=target)
 
     message.send()

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -7,12 +7,23 @@ import pytz
 import structlog
 from dateutil.relativedelta import MO, relativedelta
 
-from posthog.schema import AlertCalculationInterval, ChartDisplayType, NodeKind
+from posthog.schema import (
+    AlertCalculationInterval,
+    AlertCondition,
+    AlertConditionType,
+    ChartDisplayType,
+    InsightThreshold,
+    InsightThresholdType,
+    NodeKind,
+    TrendsAlertConfig,
+    TrendsQuery,
+)
 
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 from posthog.email import EmailMessage
 from posthog.exceptions_capture import capture_exception
 from posthog.models import AlertConfiguration
+from posthog.utils import get_from_dict_or_attr
 
 logger = structlog.get_logger(__name__)
 
@@ -32,6 +43,80 @@ NON_TIME_SERIES_DISPLAY_TYPES = {
     ChartDisplayType.ACTIONS_TABLE,
     ChartDisplayType.WORLD_MAP,
 }
+
+
+def is_non_time_series_trend(query: TrendsQuery) -> bool:
+    display = query.trendsFilter.display if query.trendsFilter else None
+    return display in NON_TIME_SERIES_DISPLAY_TYPES
+
+
+def validate_alert_config(
+    query: dict,
+    condition: dict | None,
+    config: dict | None,
+    threshold_config: dict | None = None,
+) -> None:
+    """Validate alert configuration dicts. Raises ValueError on failure."""
+    try:
+        parsed_condition = AlertCondition.model_validate(condition)
+    except Exception:
+        raise ValueError(f"Alert has invalid condition: {condition}")
+
+    if not config or not isinstance(config, dict) or config.get("type") != "TrendsAlertConfig":
+        raise ValueError(f"Unsupported alert config type: {config}")
+    try:
+        parsed_config = TrendsAlertConfig.model_validate(config)
+    except Exception:
+        raise ValueError(f"Alert has invalid TrendsAlertConfig: {config}")
+
+    kind = get_from_dict_or_attr(query, "kind")
+    if kind in WRAPPER_NODE_KINDS:
+        query = get_from_dict_or_attr(query, "source")
+        kind = get_from_dict_or_attr(query, "kind")
+
+    if kind != NodeKind.TRENDS_QUERY:
+        raise ValueError(f"Alert's insight query kind '{kind}' is not supported (only TrendsQuery)")
+
+    try:
+        trends_query = TrendsQuery.model_validate(query)
+    except Exception as e:
+        raise ValueError(f"Alert's insight has an invalid TrendsQuery: {e}")
+
+    if parsed_condition.type in (
+        AlertConditionType.RELATIVE_INCREASE,
+        AlertConditionType.RELATIVE_DECREASE,
+    ) and is_non_time_series_trend(trends_query):
+        raise ValueError(
+            f"Relative alert condition '{parsed_condition.type}' is not compatible with non time series trends"
+        )
+
+    formula_nodes = trends_query.trendsFilter.formulaNodes if trends_query.trendsFilter else None
+    result_count = len(formula_nodes) if formula_nodes else len(trends_query.series)
+    if parsed_config.series_index >= result_count:
+        raise ValueError(f"series_index {parsed_config.series_index} is out of range (query has {result_count} series)")
+
+    if threshold_config is not None:
+        try:
+            threshold = InsightThreshold.model_validate(threshold_config)
+        except Exception:
+            raise ValueError(f"Alert has invalid threshold configuration: {threshold_config}")
+
+        if (
+            parsed_condition.type == AlertConditionType.ABSOLUTE_VALUE
+            and threshold.type != InsightThresholdType.ABSOLUTE
+        ):
+            raise ValueError(
+                "Absolute value alerts require an absolute threshold, but a percentage threshold was configured"
+            )
+
+        if parsed_config.check_ongoing_interval and parsed_condition.type in (
+            AlertConditionType.ABSOLUTE_VALUE,
+            AlertConditionType.RELATIVE_INCREASE,
+        ):
+            if not threshold.bounds or threshold.bounds.upper is None:
+                raise ValueError(
+                    f"check_ongoing_interval is only supported for alert condition {parsed_condition.type} when upper threshold is specified"
+                )
 
 
 def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> int:
@@ -213,3 +298,28 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     #     message.add_recipient(email=target)
 
     # message.send()
+
+
+def send_notifications_for_disabled(alert: AlertConfiguration, reason: str) -> None:
+    logger.info("Sending alert disabled notification", alert_id=alert.id, reason=reason)
+
+    subject = f"PostHog alert {alert.name} has been disabled"
+    campaign_key = f"alert-disabled-notification-{alert.id}-{timezone.now().timestamp()}"
+    insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
+    alert_url = f"{insight_url}?alert_id={alert.id}"
+    message = EmailMessage(
+        campaign_key=campaign_key,
+        subject=subject,
+        template_name="alert_disabled",
+        template_context={
+            "alert_url": alert_url,
+            "alert_name": alert.name,
+            "insight_url": insight_url,
+            "insight_name": alert.insight.name,
+            "alert_error": reason,
+        },
+    )
+    for target in alert.get_subscribed_users_emails():
+        message.add_recipient(email=target)
+
+    message.send()

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,0 +1,13 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+    <p>
+        The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a
+            href="{% absolute_uri insight_url %}">{{ insight_name }}</a> has been <strong>automatically disabled</strong> because its configuration is no longer valid:
+    </p>
+    <p><i>{{ alert_error }}</i></p>
+    <p>
+        To resume monitoring, fix the issue above and re-enable the alert.
+    </p>
+    <div class="mb mt text-center">
+        <a class="button" href="{% absolute_uri alert_url %}">Manage alert</a>
+    </div>
+{% endblock %}{% load posthog_filters %}

--- a/posthog/test/activity_log_utils.py
+++ b/posthog/test/activity_log_utils.py
@@ -606,6 +606,7 @@ class ActivityLogTestHelper(APILicensedTest):
         data = {
             "name": name,
             "insight": insight["id"],
+            "condition": {"type": "absolute_value"},
             "config": {"type": "TrendsAlertConfig", "series_index": 0},
             "threshold": {"configuration": {"type": "absolute", "bounds": {"lower": 100, "upper": 1000}}},
             "enabled": True,

--- a/posthog/test/activity_logging/test_alert_activity_logging.py
+++ b/posthog/test/activity_logging/test_alert_activity_logging.py
@@ -54,7 +54,7 @@ class TestAlertActivityLogging(ActivityLogTestHelper):
             name="Alert with relative threshold",
             insight=insight["id"],
             threshold={"configuration": {"type": "percentage", "bounds": {"lower": 10, "upper": 90}}},
-            condition={"type": "relative_previous_period"},
+            condition={"type": "relative_increase"},
         )
 
         log1 = ActivityLog.objects.filter(
@@ -67,7 +67,7 @@ class TestAlertActivityLogging(ActivityLogTestHelper):
         alert2 = self.create_alert_configuration(
             name="Alert with series index",
             insight=insight["id"],
-            config={"type": "TrendsAlertConfig", "series_index": 1},
+            config={"type": "TrendsAlertConfig", "series_index": 0},
         )
 
         log2 = ActivityLog.objects.filter(


### PR DESCRIPTION
## Problem

There are 2 problems that this PR is solving:

1. The validation logic within the API differs from the validation logic used at "check time" for the alerts, making it possible to configure alerts that never run and always error out.
2. Invalid alerts are continuously checked, even though (without code changes), we know that they will never succeed (e.g. a "drift problem").

The PR solves this by:

1. Centralizing the validation logic, and moving certain "low-level" validation pieces to a central location that can be used during both API and "check time".
    1. This does result in the fact that alerts without a condition will now error (due to which I updated the tests as some of the existing cases are not valid alert spec), this seemed fine as at check time, these alerts would fail immediately either way, so I'd rather inform users upfront.
2. Once an alert has been deemed invalid at check time, we will also mark it as errored and disable it. Additionally we will send an email to the subscribed users informing that their alert is disabled, asking them to fix it in order to re-enable it again.

This will prevent "incorrectly configured / legacy" alerts from firing continuously and therefore incurring a penalty on our alert success criteria. These alerts are likely in this state due to historical reasons, invalid API requests or code changes without updating the existing models. The list of these configuration errors is roughly as following:

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## ![CleanShot 2026-03-04 at 09.10.39.png](https://app.graphite.com/user-attachments/assets/f8bf420d-5032-4353-acfc-459b2105fb95.png)

[Link](https://us.posthog.com/project/2/ai?chat=8fac7a63-2c46-40fc-9a32-25f8a41d72bd)

Finally, [this insight](https://us.posthog.com/project/2/insights/1Shhxk4j) shows the amount of unique users and alerts that would be impacted by disabling it (as they have invalid configurations), based on data from the last 30 days.

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Added centralized `validate_alert_config` function in `posthog/tasks/alerts/utils.py` that validates alert configurations consistently across API and check time
- Enhanced API validation in `posthog/api/alert.py` to use the centralized validation logic during alert creation and updates
- Modified alert checking logic in `posthog/tasks/alerts/checks.py` to automatically disable invalid alerts and send notifications
- Created email template `alert_disabled.html` for notifying users when alerts are automatically disabled
- Added comprehensive test coverage for validation scenarios and error handling
- Fixed mypy type checking issues in the alerts module

## How did you test this code?

:white_check_mark: Alerts can still be created through the UI

![CleanShot 2026-03-04 at 09.16.31.png](https://app.graphite.com/user-attachments/assets/7fa77d5a-3a0a-4e2d-8d7d-17b235805316.png)



![CleanShot 2026-03-04 at 09.16.16.png](https://app.graphite.com/user-attachments/assets/03a819e8-7446-47f5-8a12-1092f3304f4a.png)

:white_check_mark: Exceptions do not "leak" information and correctly surface the error

![CleanShot 2026-03-04 at 09.26.16.png](https://app.graphite.com/user-attachments/assets/cb9c8730-a86e-499a-9f9e-285501a6361f.png)

 ✅ Newly added tests are passing in the CI, including parameterized tests for various invalid configurations

:white_check_mark:Triggering the email flow locally by corrupting an alert configuration and running the check process:

```python
from django.conf import settings
# Ensure we print the email to the stdout
settings.EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

from unittest.mock import patch
from posthog.email import EmailMessage

orig_send = EmailMessage.send
# Don't send emails over celery but send it over stdout
patched = lambda self, **kw: orig_send(self, send_async=False)
patch.object(EmailMessage, "send", patched).start()

from posthog.models.alert import AlertConfiguration, AlertCheck

# Corrupt our test alert
a = AlertConfiguration.objects.get(id="019c9e59-d36c-0000-54cd-7ab8f8934410")
a.condition = {}
a.next_check_at = None
a.is_calculating = False
a.enabled = True
a.save()
print("corrupted")

from posthog.tasks.alerts.checks import check_alert

check_alert(str(a.id))

a.refresh_from_db()
print(f"enabled={a.enabled} state={a.state}")

c = AlertCheck.objects.filter(alert_configuration_id=a.id).order_by("-created_at").first()
if c:
  print(f"check state={c.state} error={c.error}")
else:
  print("no check")
```

Running the above through a minified (to avoid indentation issues):

```bash
flox activate -- bash -c "source .venv/bin/activate && python manage.py shell -c \"from django.conf import settings; settings.EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'; from unittest.mock import patch; from posthog.email import EmailMessage; orig_send = EmailMessage.send; patched = lambda self,  **kw: orig_send(self, send_async=False); patch.object(EmailMessage, 'send', patched).start(); from posthog.models.alert import AlertConfiguration, AlertCheck; a = AlertConfiguration.objects.get(id='019c9e59-d36c-0000-54cd-7ab8f8934410'); a.condition = {}; a.next_check_at = None; a.is_calculating = False; a.enabled = True; a.save(); print('corrupted'); from posthog.tasks.alerts.checks import check_alert; check_alert(str(a.id)); a.refresh_from_db(); print(f'enabled={a.enabled} state={a.state}'); c = AlertCheck.objects.filter(alert_configuration_id=a.id).order_by('-created_at').first(); print(f'check state={c.state} error={c.error}') if c else print('no check')\""
```

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

Results in the following:

![CleanShot 2026-03-02 at 16.17.32@2x.png](https://app.graphite.com/user-attachments/assets/4a14e10b-15e3-43fb-93e3-2b5a6704e257.png)

![CleanShot 2026-03-02 at 16.19.43@2x.png](https://app.graphite.com/user-attachments/assets/fe5f5e0c-8f25-4350-8858-9caa382115a5.png)

_(Condition =_ `{}` _due to how we "broke" the alert, see the script above)_

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

Yes

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->