### PR TITLE
fix(ci): unset GITHUB_TOKEN extraheader before OpenAPI type push

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -767,6 +767,10 @@ jobs:
                   # Disable auto-merge before pushing to prevent unreviewed code from merging
                   gh pr merge --disable-auto "$PR_NUMBER" || echo "Auto-merge was not enabled"
 
+                  # Remove GITHUB_TOKEN extraheader set by actions/checkout — it overrides
+                  # URL-embedded credentials and causes the push to use GITHUB_TOKEN instead
+                  # of the app token. GITHUB_TOKEN commits don't trigger CI; app token ones do.
+                  git config --unset-all http.https://github.com/.extraheader || true
                   git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
**Problem:** auto-updating OpenAPI types broke merging — the commit landed but required checks never started.

**Root cause:** `actions/checkout` (in `check-migrations`) runs without a `token:` param, so git gets configured with a `GITHUB_TOKEN`-based `http.https://github.com/.extraheader`. That extraheader takes precedence over URL-embedded credentials, so the later `git remote set-url origin "https://x-access-token:${APP_TOKEN}@..."` has no effect — the push still uses `GITHUB_TOKEN`. GitHub blocks `GITHUB_TOKEN` pushes from triggering CI runs to prevent loops, so required checks never start on the auto-committed types.

**Fix:** unset the extraheader before setting the remote URL so the app token actually gets used for the push.

This matches how the snapshot commit jobs handle the same problem — they pass `token:` to `actions/checkout` to set the extraheader to the app token from the start (same net result, different approach). The existing comment in those jobs — `# Use GitHub app token so Actions run after commiting updated snapshots` — documents exactly this behavior.