### PR TITLE
fix(data-warehouse): set SSL enforcement cutoff date to deployment date

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -35,7 +35,7 @@ from posthog.temporal.data_imports.sources.common.sql import Column, Table
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
 
 # Sources created after this date must use SSL/TLS connections
-SSL_REQUIRED_AFTER_DATE = datetime(2025, 2, 17, tzinfo=UTC)
+SSL_REQUIRED_AFTER_DATE = datetime(2026, 2, 18, tzinfo=UTC)
 
 
 class SSLRequiredError(Exception):

--- a/posthog/temporal/tests/data_imports/test_postgres_source.py
+++ b/posthog/temporal/tests/data_imports/test_postgres_source.py
@@ -377,7 +377,7 @@ class TestSSLRequirement:
         assert _get_sslmode(require_ssl=False) == "prefer"
 
     def test_ssl_required_after_date_is_set(self):
-        assert SSL_REQUIRED_AFTER_DATE == dt.datetime(2025, 2, 17, tzinfo=dt.UTC)
+        assert SSL_REQUIRED_AFTER_DATE == dt.datetime(2026, 2, 18, tzinfo=dt.UTC)
 
     def test_ssl_required_error_message(self):
         error = SSLRequiredError("Test error message")


### PR DESCRIPTION
## Problem

PR #46089 introduced SSL/TLS enforcement for Postgres sources, but set the cutoff date to `2025-02-17`

## Changes

  * Fixed SSL enforcement cutoff date from `2025-02-17` to `2026-02-18` to match deployment date
  * Updated corresponding test assertion

## How did you test this code?

Test pass

## Publish to changelog?

NO
