### PR TITLE
fix(llma): remove trace query fallback for feedback view

### DIFF
--- a/products/llm_analytics/frontend/feedback-view/FeedbackViewDisplay.tsx
+++ b/products/llm_analytics/frontend/feedback-view/FeedbackViewDisplay.tsx
@@ -7,6 +7,7 @@ import { urls } from 'scenes/urls'
 
 import { SurveyEventProperties } from '~/types'
 
+import { llmAnalyticsTraceDataLogic } from '../llmAnalyticsTraceDataLogic'
 import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
 import { feedbackViewLogic } from './feedbackViewLogic'
 import { SurveyResponseCard } from './survey-responses/SurveyResponseCard'
@@ -15,9 +16,11 @@ import { FeedbackSurveyWizard } from './wizard/FeedbackSurveyWizard'
 
 export function FeedbackViewDisplay(): JSX.Element {
     const traceLogic = useMountedLogic(llmAnalyticsTraceLogic)
+    const traceDataLogic = useMountedLogic(llmAnalyticsTraceDataLogic)
     const { traceId } = useValues(traceLogic)
+    const { trace } = useValues(traceDataLogic)
     const { surveyEvents, surveyEventsLoading, surveys, surveysLoading, hasLoadingError } = useValues(
-        feedbackViewLogic({ traceId })
+        feedbackViewLogic({ traceId, traceCreatedAt: trace?.createdAt ?? null })
     )
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)

--- a/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
@@ -1,5 +1,6 @@
-import { afterMount, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
+import { afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
@@ -72,6 +73,10 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
         ],
     }),
     selectors({
+        traceCreatedAt: [
+            (_, props) => [props.traceCreatedAt],
+            (traceCreatedAt: string | null): string | null => traceCreatedAt,
+        ],
         surveyIds: [
             (s) => [s.surveyEvents],
             (surveyEvents): string[] => {
@@ -94,18 +99,15 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
             actions.loadSurveys()
         },
     })),
+    subscriptions(({ actions, values }) => ({
+        traceCreatedAt: (traceCreatedAt: string | null) => {
+            if (traceCreatedAt && values.surveyEvents === null && !values.surveyEventsLoading) {
+                actions.loadSurveyEvents(traceCreatedAt)
+            }
+        },
+    })),
     afterMount(({ actions, values, props }) => {
         if (props.traceCreatedAt && values.surveyEvents === null && !values.surveyEventsLoading) {
-            actions.loadSurveyEvents(props.traceCreatedAt)
-        }
-    }),
-    propsChanged(({ actions, values, props }, oldProps) => {
-        if (
-            props.traceCreatedAt &&
-            props.traceCreatedAt !== oldProps.traceCreatedAt &&
-            values.surveyEvents === null &&
-            !values.surveyEventsLoading
-        ) {
             actions.loadSurveyEvents(props.traceCreatedAt)
         }
     }),

--- a/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
@@ -1,28 +1,24 @@
-import { afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
-import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+import { LLMTraceEvent } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
 import { Survey, SurveyEventProperties } from '~/types'
 
-import { llmAnalyticsTraceDataLogic } from '../llmAnalyticsTraceDataLogic'
 import type { feedbackViewLogicType } from './feedbackViewLogicType'
 
 export interface FeedbackViewLogicProps {
     traceId: string
+    traceCreatedAt: string | null
 }
 
 export const feedbackViewLogic = kea<feedbackViewLogicType>([
     path(['scenes', 'llm-analytics', 'feedbackViewLogic']),
     props({} as FeedbackViewLogicProps),
     key((props) => props.traceId),
-    connect({
-        values: [llmAnalyticsTraceDataLogic, ['trace']],
-    }),
     loaders(({ props, values }) => ({
         surveyEvents: [
             null as LLMTraceEvent[] | null,
@@ -98,17 +94,9 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
             actions.loadSurveys()
         },
     })),
-    subscriptions(({ actions, values }) => ({
-        trace: (trace: LLMTrace | undefined) => {
-            if (trace?.createdAt && values.surveyEvents === null && !values.surveyEventsLoading) {
-                actions.loadSurveyEvents(trace.createdAt)
-            }
-        },
-    })),
-    afterMount(({ actions, values }) => {
-        const trace = values.trace
-        if (trace?.createdAt && values.surveyEvents === null && !values.surveyEventsLoading) {
-            actions.loadSurveyEvents(trace.createdAt)
+    afterMount(({ actions, values, props }) => {
+        if (props.traceCreatedAt && values.surveyEvents === null && !values.surveyEventsLoading) {
+            actions.loadSurveyEvents(props.traceCreatedAt)
         }
     }),
 ])

--- a/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { afterMount, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -96,6 +96,16 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
     })),
     afterMount(({ actions, values, props }) => {
         if (props.traceCreatedAt && values.surveyEvents === null && !values.surveyEventsLoading) {
+            actions.loadSurveyEvents(props.traceCreatedAt)
+        }
+    }),
+    propsChanged(({ actions, values, props }, oldProps) => {
+        if (
+            props.traceCreatedAt &&
+            props.traceCreatedAt !== oldProps.traceCreatedAt &&
+            values.surveyEvents === null &&
+            !values.surveyEventsLoading
+        ) {
             actions.loadSurveyEvents(props.traceCreatedAt)
         }
     }),

--- a/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
@@ -12,8 +12,6 @@ import {
     DataTableNode,
     LLMTrace,
     LLMTraceEvent,
-    NodeKind,
-    TraceQuery,
     TraceQueryResponse,
 } from '~/queries/schema/schema-general'
 import { InsightLogicProps } from '~/types'
@@ -32,22 +30,13 @@ import { formatLLMUsage, getEventType, isLLMEvent, normalizeMessages } from './u
 
 export interface TraceDataLogicProps {
     traceId: string
-    query?: DataTableNode | null
+    query: DataTableNode
     cachedResults?: AnyResponseType | null
     searchQuery: string
     tabId?: string
 }
 
 function getDataNodeLogicProps({ traceId, query, cachedResults, tabId }: TraceDataLogicProps): DataNodeLogicProps {
-    const fallbackTraceQuery: TraceQuery = {
-        kind: NodeKind.TraceQuery,
-        traceId,
-        // Match trace logic defaults so we still fetch data if query is briefly undefined.
-        dateRange: {
-            date_from: dayjs.utc().subtract(1, 'year').startOf('day').toISOString(),
-        },
-    }
-
     const tabScope = tabId ?? 'default'
     const scopedTraceId = `${traceId}:${tabScope}`
     const insightProps: InsightLogicProps<DataTableNode> = {
@@ -56,7 +45,7 @@ function getDataNodeLogicProps({ traceId, query, cachedResults, tabId }: TraceDa
     }
     const vizKey = insightVizDataNodeKey(insightProps)
     const dataNodeLogicProps: DataNodeLogicProps = {
-        query: query?.source ?? fallbackTraceQuery,
+        query: query.source,
         key: vizKey,
         dataNodeCollectionId: scopedTraceId,
         cachedResults: cachedResults || undefined,


### PR DESCRIPTION
## Problem

The feedback tab in LLM analytics was still coupled to trace-data loading in a way that could mask query wiring issues.
Additionally, `llmAnalyticsTraceDataLogic` had a fallback trace query path that could hide missing/undefined query state instead of failing fast.

## Changes

- Updated `FeedbackViewDisplay` to read `traceCreatedAt` from mounted `llmAnalyticsTraceDataLogic` and pass explicit props into `feedbackViewLogic`.
- Simplified `feedbackViewLogic` by removing cross-logic `connect/subscriptions` to trace data and loading survey events from `traceCreatedAt` props on mount.
- Removed fallback query construction in `llmAnalyticsTraceDataLogic` and now require/use `query.source` directly.
- Made `TraceDataLogicProps.query` required.

## How did you test this code?

- Confirmed the strict `query.source` path does not break in the current trace scene flow (manual verification while reproducing the original feedback-tab issue).
- Did not run a full repo TypeScript/test suite because of unrelated existing workspace failures.

## Publish to changelog?

no
