### PR TITLE
fix(llma): pin libxmlsec1 version in LLM Analytics Dockerfile

### DIFF
--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -8,9 +8,9 @@
 #
 
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
-FROM ghcr.io/astral-sh/uv:0.10.4 AS uv
+FROM ghcr.io/astral-sh/uv:0.10.2 AS uv
 
-FROM python:3.12.12-slim-bookworm
+FROM python:3.12.12-slim-bookworm@sha256:78e702aee4d693e769430f0d7b4f4858d8ea3f1118dc3f57fee3f757d0ca64b1
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # Copy uv
@@ -30,8 +30,8 @@ RUN apt-get update && \
     "build-essential" \
     "git" \
     "libpq-dev" \
-    "libxmlsec1" \
-    "libxmlsec1-dev" \
+    "libxmlsec1=1.2.37-2" \
+    "libxmlsec1-dev=1.2.37-2" \
     "libffi-dev" \
     "zlib1g-dev" \
     "pkg-config" \
@@ -39,7 +39,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies including sentiment ML deps
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-dev --no-install-project --group sentiment --no-binary-package lxml --no-binary-package xmlsec


### PR DESCRIPTION
## Changes

Align `Dockerfile.llm-analytics` with the main `Dockerfile` to fix runtime crashes and improve build reproducibility:

- **Pin `libxmlsec1` to `1.2.37-2`** — fixes `xmlsec.Error: (19, 'xmlsec library version mismatch.')` that crashes Django startup
- **Pin base image with digest** — `python:3.12.12-slim-bookworm@sha256:78e702...` for reproducible builds
- **Match uv version to `0.10.2`** — consistent with main Dockerfile
- **Add version-tagged uv cache ID** — busts build cache when system library versions change

## Problem

The LLM Analytics temporal worker (`temporal-worker-llm-analytics`) fails to start when using the custom `posthog-llm-analytics` ECR image. The `wait-for-migrations` init container crashes with:

```
social_core.backends.saml → onelogin.saml2 → xmlsec
xmlsec.Error: (19, 'xmlsec library version mismatch.')
```

Without version pinning, apt pulls the latest `libxmlsec1` from bookworm repos which doesn't match the Python `xmlsec` package compiled against `1.2.37-2`.

## Test plan

- [x] Add `build-llm-analytics-image` label to trigger the CD workflow
- [ ] Verify the image builds successfully
- [ ] Once merged, trigger `workflow_dispatch` on master to build and deploy
- [ ] Verify dev worker starts without xmlsec errors