### PR TITLE
feat(clickhouse): add kill switch for cluster overload protection

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -139,6 +139,13 @@ def schedule_warming_for_teams_task():
     so even though we might pick all insights for a team to recalculate,
     only the stale ones (determined by `staleness_threshold_map`) get recalculated.
     """
+    from posthog.clickhouse.client.execute import KillSwitchLevel, get_kill_switch_level
+
+    kill_switch_level = get_kill_switch_level()
+    if kill_switch_level != KillSwitchLevel.OFF:
+        logger.info("kill_switch_on_skipping_cache_warming", level=kill_switch_level)
+        return
+
     team_ids = largest_teams(limit=10)
     threshold = datetime.now(UTC) - LAST_VIEWED_THRESHOLD
 

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -95,14 +95,12 @@ _KILL_SWITCH_SETTINGS: dict[KillSwitchLevel, dict[str, int]] = {
         "max_execution_time": 30,
         "max_threads": 45,
         "max_bytes_to_read": 5_000_000_000_000,  # 5TB
-        "max_result_rows": 1_000_000,
     },
     KillSwitchLevel.FULL: {
         "max_execution_time": 15,
         "max_memory_usage": 30_000_000_000,  # 30GB
         "max_threads": 30,
         "max_bytes_to_read": 1_000_000_000_000,  # 1TB
-        "max_result_rows": 100_000,
     },
 }
 

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -1,9 +1,11 @@
+import time
 import types
 import logging
 import threading
 import traceback
 from collections.abc import Sequence
 from contextlib import contextmanager
+from enum import StrEnum
 from functools import lru_cache
 from time import perf_counter
 from typing import Any, Optional, Union
@@ -72,6 +74,52 @@ CLICKHOUSE_SUPPORTED_JOIN_ALGORITHMS = [
 ]
 
 is_invalid_algorithm = lambda algo: algo not in CLICKHOUSE_SUPPORTED_JOIN_ALGORITHMS
+
+
+class KillSwitchLevel(StrEnum):
+    OFF = "off"
+    LIGHT = "light"
+    FULL = "full"
+
+
+_KILL_SWITCH_EXEMPT_USERS = frozenset(
+    {
+        ClickHouseUser.BATCH_EXPORT,
+        ClickHouseUser.MIGRATIONS,
+        ClickHouseUser.OPS,
+    }
+)
+
+_KILL_SWITCH_SETTINGS: dict[KillSwitchLevel, dict[str, int]] = {
+    KillSwitchLevel.LIGHT: {
+        "max_execution_time": 30,
+        "max_threads": 45,
+        "max_bytes_to_read": 5_000_000_000_000,  # 5TB
+        "max_result_rows": 1_000_000,
+    },
+    KillSwitchLevel.FULL: {
+        "max_execution_time": 15,
+        "max_memory_usage": 30_000_000_000,  # 30GB
+        "max_threads": 30,
+        "max_bytes_to_read": 1_000_000_000_000,  # 1TB
+        "max_result_rows": 100_000,
+    },
+}
+
+
+def get_kill_switch_level() -> KillSwitchLevel:
+    return _get_kill_switch_level(round(time.time() / 60))
+
+
+@lru_cache(maxsize=1)
+def _get_kill_switch_level(_ttl: int) -> KillSwitchLevel:
+    from posthog.models.instance_setting import get_instance_setting
+
+    value = get_instance_setting("CLICKHOUSE_KILL_SWITCH")
+    try:
+        return KillSwitchLevel(value)
+    except ValueError:
+        return KillSwitchLevel.OFF
 
 
 @lru_cache(maxsize=1)
@@ -212,6 +260,12 @@ def sync_execute(
         **CLICKHOUSE_PER_TEAM_QUERY_SETTINGS.get(str(team_id), {}),
         **(settings or {}),
     }
+
+    kill_switch_level = KillSwitchLevel.OFF if TEST else get_kill_switch_level()
+    if kill_switch_level != KillSwitchLevel.OFF and ch_user not in _KILL_SWITCH_EXEMPT_USERS:
+        overrides = _KILL_SWITCH_SETTINGS[kill_switch_level]
+        core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
+
     tags.query_settings = core_settings
     query_type = tags.query_type or "Other"
     if ch_user == ClickHouseUser.DEFAULT:
@@ -263,7 +317,10 @@ def sync_execute(
         # these disruptions
         settings["use_hedged_requests"] = "0"
     elif workload == Workload.ONLINE and ch_user == ClickHouseUser.APP:
-        settings["use_hedged_requests"] = "1"
+        if kill_switch_level != KillSwitchLevel.OFF:
+            settings["use_hedged_requests"] = "0"
+        else:
+            settings["use_hedged_requests"] = "1"
     start_time = perf_counter()
 
     try:

--- a/posthog/clickhouse/test/test_kill_switch.py
+++ b/posthog/clickhouse/test/test_kill_switch.py
@@ -1,0 +1,202 @@
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client.connection import ClickHouseUser, Workload
+from posthog.clickhouse.client.execute import (
+    _KILL_SWITCH_EXEMPT_USERS,
+    _KILL_SWITCH_SETTINGS,
+    KillSwitchLevel,
+    _get_kill_switch_level,
+    default_settings,
+    get_kill_switch_level,
+)
+
+
+class TestGetKillSwitchLevel:
+    @parameterized.expand(
+        [
+            ("off", "off", KillSwitchLevel.OFF),
+            ("light", "light", KillSwitchLevel.LIGHT),
+            ("full", "full", KillSwitchLevel.FULL),
+            ("invalid_string", "garbage", KillSwitchLevel.OFF),
+            ("empty_string", "", KillSwitchLevel.OFF),
+            ("bool_false", False, KillSwitchLevel.OFF),
+        ]
+    )
+    def test_returns_normalized_level(self, _name: str, raw_value: object, expected: KillSwitchLevel):
+        _get_kill_switch_level.cache_clear()
+        with patch("posthog.models.instance_setting.get_instance_setting", return_value=raw_value):
+            assert get_kill_switch_level() == expected
+        _get_kill_switch_level.cache_clear()
+
+    def test_caches_across_same_ttl(self):
+        _get_kill_switch_level.cache_clear()
+        mock = MagicMock(return_value="off")
+        with patch("posthog.models.instance_setting.get_instance_setting", mock):
+            _get_kill_switch_level(42)
+            _get_kill_switch_level(42)
+            assert mock.call_count == 1
+        _get_kill_switch_level.cache_clear()
+
+
+class TestKillSwitchExemptUsers:
+    @parameterized.expand(
+        [
+            ("batch_export", ClickHouseUser.BATCH_EXPORT),
+            ("migrations", ClickHouseUser.MIGRATIONS),
+            ("ops", ClickHouseUser.OPS),
+        ]
+    )
+    def test_exempt_users(self, _name: str, user: ClickHouseUser):
+        assert user in _KILL_SWITCH_EXEMPT_USERS
+
+    @parameterized.expand(
+        [
+            ("app", ClickHouseUser.APP),
+            ("api", ClickHouseUser.API),
+            ("default", ClickHouseUser.DEFAULT),
+            ("cache_warmup", ClickHouseUser.CACHE_WARMUP),
+            ("max_ai", ClickHouseUser.MAX_AI),
+            ("endpoints", ClickHouseUser.ENDPOINTS),
+        ]
+    )
+    def test_non_exempt_users(self, _name: str, user: ClickHouseUser):
+        assert user not in _KILL_SWITCH_EXEMPT_USERS
+
+
+class TestKillSwitchResourceLimits:
+    @parameterized.expand(
+        [
+            ("light_caps_execution_time", KillSwitchLevel.LIGHT, {"max_execution_time": 300}, 30),
+            ("light_keeps_lower_execution_time", KillSwitchLevel.LIGHT, {"max_execution_time": 10}, 10),
+            ("full_caps_execution_time", KillSwitchLevel.FULL, {"max_execution_time": 300}, 15),
+            ("full_keeps_lower_execution_time", KillSwitchLevel.FULL, {"max_execution_time": 5}, 5),
+        ]
+    )
+    def test_min_capping_preserves_lower_existing_value(
+        self, _name: str, level: KillSwitchLevel, existing: dict, expected_time: int
+    ):
+        core_settings = {**default_settings(), **existing}
+        overrides = _KILL_SWITCH_SETTINGS[level]
+        core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
+
+        assert core_settings["max_execution_time"] == expected_time
+
+    @parameterized.expand(
+        [
+            ("light_applies", KillSwitchLevel.LIGHT, ClickHouseUser.APP, True),
+            ("full_applies", KillSwitchLevel.FULL, ClickHouseUser.API, True),
+            ("off_no_change", KillSwitchLevel.OFF, ClickHouseUser.APP, False),
+            ("batch_export_exempt", KillSwitchLevel.FULL, ClickHouseUser.BATCH_EXPORT, False),
+            ("migrations_exempt", KillSwitchLevel.FULL, ClickHouseUser.MIGRATIONS, False),
+            ("ops_exempt", KillSwitchLevel.LIGHT, ClickHouseUser.OPS, False),
+        ]
+    )
+    def test_limits_applied_based_on_level_and_user(
+        self, _name: str, level: KillSwitchLevel, ch_user: ClickHouseUser, should_apply: bool
+    ):
+        core_settings = {**default_settings()}
+
+        if level != KillSwitchLevel.OFF and ch_user not in _KILL_SWITCH_EXEMPT_USERS:
+            overrides = _KILL_SWITCH_SETTINGS[level]
+            core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
+
+        if should_apply:
+            overrides = _KILL_SWITCH_SETTINGS[level]
+            for key, value in overrides.items():
+                assert core_settings[key] == value
+        else:
+            assert "max_result_rows" not in core_settings
+
+    def test_light_does_not_set_max_memory_usage(self):
+        core_settings = {**default_settings()}
+        overrides = _KILL_SWITCH_SETTINGS[KillSwitchLevel.LIGHT]
+        core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
+
+        assert "max_memory_usage" not in core_settings
+
+    def test_full_sets_max_memory_usage(self):
+        core_settings = {**default_settings()}
+        overrides = _KILL_SWITCH_SETTINGS[KillSwitchLevel.FULL]
+        core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
+
+        assert core_settings["max_memory_usage"] == 30_000_000_000
+
+
+class TestKillSwitchHedgedRequests:
+    @parameterized.expand(
+        [
+            ("off_enabled", KillSwitchLevel.OFF, "1"),
+            ("light_disabled", KillSwitchLevel.LIGHT, "0"),
+            ("full_disabled", KillSwitchLevel.FULL, "0"),
+        ]
+    )
+    def test_hedged_requests_for_online_app(self, _name: str, level: KillSwitchLevel, expected: str):
+        settings: dict = {}
+        workload = Workload.ONLINE
+        ch_user = ClickHouseUser.APP
+
+        if workload == Workload.OFFLINE:
+            settings["use_hedged_requests"] = "0"
+        elif workload == Workload.ONLINE and ch_user == ClickHouseUser.APP:
+            if level != KillSwitchLevel.OFF:
+                settings["use_hedged_requests"] = "0"
+            else:
+                settings["use_hedged_requests"] = "1"
+
+        assert settings["use_hedged_requests"] == expected
+
+
+class TestKillSwitchConcurrencyReduction:
+    @parameterized.expand(
+        [
+            ("light_20_to_10", KillSwitchLevel.LIGHT, 20, 10),
+            ("light_6_to_3", KillSwitchLevel.LIGHT, 6, 3),
+            ("light_3_to_1", KillSwitchLevel.LIGHT, 3, 1),
+            ("light_2_to_1", KillSwitchLevel.LIGHT, 2, 1),
+            ("light_1_to_1", KillSwitchLevel.LIGHT, 1, 1),
+            ("full_20_to_5", KillSwitchLevel.FULL, 20, 5),
+            ("full_6_to_1", KillSwitchLevel.FULL, 6, 1),
+            ("full_3_to_1", KillSwitchLevel.FULL, 3, 1),
+            ("full_2_to_1", KillSwitchLevel.FULL, 2, 1),
+            ("full_1_to_1", KillSwitchLevel.FULL, 1, 1),
+        ]
+    )
+    def test_concurrency_reduction(self, _name: str, level: KillSwitchLevel, original: int, expected: int):
+        if level == KillSwitchLevel.LIGHT:
+            result = max(1, original // 2)
+        elif level == KillSwitchLevel.FULL:
+            result = max(1, original // 4)
+        else:
+            result = original
+        assert result == expected
+
+
+class TestKillSwitchCacheWarming:
+    @parameterized.expand(
+        [
+            ("light", KillSwitchLevel.LIGHT),
+            ("full", KillSwitchLevel.FULL),
+        ]
+    )
+    @patch("posthog.caching.warming.logger")
+    def test_cache_warming_skipped(self, _name: str, level: KillSwitchLevel, mock_logger: MagicMock):
+        with patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=level):
+            from posthog.caching.warming import schedule_warming_for_teams_task
+
+            schedule_warming_for_teams_task()
+
+            mock_logger.info.assert_called_with("kill_switch_on_skipping_cache_warming", level=level)
+
+    @patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=KillSwitchLevel.OFF)
+    @patch("posthog.caching.warming.largest_teams", return_value=[])
+    def test_cache_warming_proceeds_when_off(self, mock_largest: MagicMock, _mock_ks: MagicMock):
+        from posthog.caching.warming import schedule_warming_for_teams_task
+
+        try:
+            schedule_warming_for_teams_task()
+        except Exception:
+            pass
+
+        mock_largest.assert_called_once()

--- a/posthog/clickhouse/test/test_kill_switch.py
+++ b/posthog/clickhouse/test/test_kill_switch.py
@@ -2,9 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
-from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute import (
-    _KILL_SWITCH_EXEMPT_USERS,
     _KILL_SWITCH_SETTINGS,
     KillSwitchLevel,
     _get_kill_switch_level,
@@ -19,9 +17,7 @@ class TestGetKillSwitchLevel:
             ("off", "off", KillSwitchLevel.OFF),
             ("light", "light", KillSwitchLevel.LIGHT),
             ("full", "full", KillSwitchLevel.FULL),
-            ("invalid_string", "garbage", KillSwitchLevel.OFF),
-            ("empty_string", "", KillSwitchLevel.OFF),
-            ("bool_false", False, KillSwitchLevel.OFF),
+            ("invalid_falls_back_to_off", "garbage", KillSwitchLevel.OFF),
         ]
     )
     def test_returns_normalized_level(self, _name: str, raw_value: object, expected: KillSwitchLevel):
@@ -40,74 +36,19 @@ class TestGetKillSwitchLevel:
         _get_kill_switch_level.cache_clear()
 
 
-class TestKillSwitchExemptUsers:
-    @parameterized.expand(
-        [
-            ("batch_export", ClickHouseUser.BATCH_EXPORT),
-            ("migrations", ClickHouseUser.MIGRATIONS),
-            ("ops", ClickHouseUser.OPS),
-        ]
-    )
-    def test_exempt_users(self, _name: str, user: ClickHouseUser):
-        assert user in _KILL_SWITCH_EXEMPT_USERS
-
-    @parameterized.expand(
-        [
-            ("app", ClickHouseUser.APP),
-            ("api", ClickHouseUser.API),
-            ("default", ClickHouseUser.DEFAULT),
-            ("cache_warmup", ClickHouseUser.CACHE_WARMUP),
-            ("max_ai", ClickHouseUser.MAX_AI),
-            ("endpoints", ClickHouseUser.ENDPOINTS),
-        ]
-    )
-    def test_non_exempt_users(self, _name: str, user: ClickHouseUser):
-        assert user not in _KILL_SWITCH_EXEMPT_USERS
-
-
 class TestKillSwitchResourceLimits:
     @parameterized.expand(
         [
-            ("light_caps_execution_time", KillSwitchLevel.LIGHT, {"max_execution_time": 300}, 30),
-            ("light_keeps_lower_execution_time", KillSwitchLevel.LIGHT, {"max_execution_time": 10}, 10),
-            ("full_caps_execution_time", KillSwitchLevel.FULL, {"max_execution_time": 300}, 15),
-            ("full_keeps_lower_execution_time", KillSwitchLevel.FULL, {"max_execution_time": 5}, 5),
+            ("existing_higher_gets_capped", {"max_execution_time": 300}, 15),
+            ("existing_lower_is_preserved", {"max_execution_time": 5}, 5),
         ]
     )
-    def test_min_capping_preserves_lower_existing_value(
-        self, _name: str, level: KillSwitchLevel, existing: dict, expected_time: int
-    ):
+    def test_min_capping(self, _name: str, existing: dict, expected_time: int):
         core_settings = {**default_settings(), **existing}
-        overrides = _KILL_SWITCH_SETTINGS[level]
+        overrides = _KILL_SWITCH_SETTINGS[KillSwitchLevel.FULL]
         core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
 
         assert core_settings["max_execution_time"] == expected_time
-
-    @parameterized.expand(
-        [
-            ("light_applies", KillSwitchLevel.LIGHT, ClickHouseUser.APP, True),
-            ("full_applies", KillSwitchLevel.FULL, ClickHouseUser.API, True),
-            ("off_no_change", KillSwitchLevel.OFF, ClickHouseUser.APP, False),
-            ("batch_export_exempt", KillSwitchLevel.FULL, ClickHouseUser.BATCH_EXPORT, False),
-            ("migrations_exempt", KillSwitchLevel.FULL, ClickHouseUser.MIGRATIONS, False),
-            ("ops_exempt", KillSwitchLevel.LIGHT, ClickHouseUser.OPS, False),
-        ]
-    )
-    def test_limits_applied_based_on_level_and_user(
-        self, _name: str, level: KillSwitchLevel, ch_user: ClickHouseUser, should_apply: bool
-    ):
-        core_settings = {**default_settings()}
-
-        if level != KillSwitchLevel.OFF and ch_user not in _KILL_SWITCH_EXEMPT_USERS:
-            overrides = _KILL_SWITCH_SETTINGS[level]
-            core_settings.update({k: min(core_settings.get(k, v), v) for k, v in overrides.items()})
-
-        if should_apply:
-            overrides = _KILL_SWITCH_SETTINGS[level]
-            for key, value in overrides.items():
-                assert core_settings[key] == value
-        else:
-            assert "max_result_rows" not in core_settings
 
     def test_light_does_not_set_max_memory_usage(self):
         core_settings = {**default_settings()}
@@ -124,43 +65,12 @@ class TestKillSwitchResourceLimits:
         assert core_settings["max_memory_usage"] == 30_000_000_000
 
 
-class TestKillSwitchHedgedRequests:
-    @parameterized.expand(
-        [
-            ("off_enabled", KillSwitchLevel.OFF, "1"),
-            ("light_disabled", KillSwitchLevel.LIGHT, "0"),
-            ("full_disabled", KillSwitchLevel.FULL, "0"),
-        ]
-    )
-    def test_hedged_requests_for_online_app(self, _name: str, level: KillSwitchLevel, expected: str):
-        settings: dict = {}
-        workload = Workload.ONLINE
-        ch_user = ClickHouseUser.APP
-
-        if workload == Workload.OFFLINE:
-            settings["use_hedged_requests"] = "0"
-        elif workload == Workload.ONLINE and ch_user == ClickHouseUser.APP:
-            if level != KillSwitchLevel.OFF:
-                settings["use_hedged_requests"] = "0"
-            else:
-                settings["use_hedged_requests"] = "1"
-
-        assert settings["use_hedged_requests"] == expected
-
-
 class TestKillSwitchConcurrencyReduction:
     @parameterized.expand(
         [
-            ("light_20_to_10", KillSwitchLevel.LIGHT, 20, 10),
-            ("light_6_to_3", KillSwitchLevel.LIGHT, 6, 3),
-            ("light_3_to_1", KillSwitchLevel.LIGHT, 3, 1),
-            ("light_2_to_1", KillSwitchLevel.LIGHT, 2, 1),
-            ("light_1_to_1", KillSwitchLevel.LIGHT, 1, 1),
-            ("full_20_to_5", KillSwitchLevel.FULL, 20, 5),
-            ("full_6_to_1", KillSwitchLevel.FULL, 6, 1),
-            ("full_3_to_1", KillSwitchLevel.FULL, 3, 1),
-            ("full_2_to_1", KillSwitchLevel.FULL, 2, 1),
-            ("full_1_to_1", KillSwitchLevel.FULL, 1, 1),
+            ("light_halves", KillSwitchLevel.LIGHT, 20, 10),
+            ("full_quarters", KillSwitchLevel.FULL, 20, 5),
+            ("full_floors_to_1", KillSwitchLevel.FULL, 2, 1),
         ]
     )
     def test_concurrency_reduction(self, _name: str, level: KillSwitchLevel, original: int, expected: int):

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -165,6 +165,11 @@ CONSTANCE_CONFIG = {
         "Whether rate limiting is enabled",
         bool,
     ),
+    "CLICKHOUSE_KILL_SWITCH": (
+        get_from_env("CLICKHOUSE_KILL_SWITCH", "off"),
+        "ClickHouse overload protection. Values: 'off', 'light' (reduce resources, shed background work), 'full' (aggressive caps on everything).",
+        str,
+    ),
     "RATE_LIMITING_ALLOW_LIST_TEAMS": (
         get_from_env("RATE_LIMITING_ALLOW_LIST_TEAMS", ""),
         "Whether teams are on an allow list to bypass rate limiting. Comma separated list of team-ids",
@@ -223,6 +228,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS",
     "RATE_LIMIT_ENABLED",
     "RATE_LIMITING_ALLOW_LIST_TEAMS",
+    "CLICKHOUSE_KILL_SWITCH",
     "REDIRECT_APP_TO_US",
     "WEB_ANALYTICS_WARMING_DAYS",
     "WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT",


### PR DESCRIPTION
Three-level dynamic setting (off/light/full) that tightens ClickHouse query resource limits, reduces concurrency, disables hedged requests, and sheds background work (cache warming) during cluster overload.

Exempt: batch exports, migrations, ops queries.

