### PR TITLE
fix(llma): render bracket-prefixed text as plain text instead of empty JSON

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+import { cleanup, render } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+
+import { CompatMessage } from '../types'
+import { LLMMessageDisplay } from './ConversationMessagesDisplay'
+
+describe('LLMMessageDisplay', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it.each([
+        [
+            'bracket-prefixed thinking text',
+            '[Thinking: The user wants to build a todo app.]I will build a clean todo app for you!',
+        ],
+        [
+            'bracket-prefixed tool call text',
+            '[Tool Call: lov-write, Input: {"file_path":"src/pages/Index.tsx","content":"import React"}]',
+        ],
+        [
+            'mixed thinking and tool call text',
+            '[Thinking: Let me help.]Here is the answer.[Tool Call: write, Input: {"path":"index.ts"}]',
+        ],
+    ])('renders %s as plain text instead of empty JSON', (_label, content) => {
+        const message: CompatMessage = { role: 'assistant', content }
+        const { container } = render(
+            <Provider>
+                <LLMMessageDisplay message={message} show minimal />
+            </Provider>
+        )
+        expect(container.textContent).toContain(content)
+    })
+
+    it.each([
+        ['valid JSON object', '{"key": "value"}', 'key'],
+        ['valid JSON array', '[{"role": "assistant", "content": "hello"}]', 'role'],
+        ['truncated JSON object', '{"key": "val', 'key'],
+    ])('renders %s as JSON', (_label, content, expectedSubstring) => {
+        const message: CompatMessage = { role: 'assistant', content }
+        const { container } = render(
+            <Provider>
+                <LLMMessageDisplay message={message} show minimal />
+            </Provider>
+        )
+        expect(container.textContent).toContain(expectedSubstring)
+    })
+})

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -500,6 +500,14 @@ export const LLMMessageDisplay = React.memo(
             if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
                 try {
                     const parsed = typeof content === 'string' ? parsePartialJSON(content) : content
+                    // If the partial parser returned an empty container, the input wasn't
+                    // actually JSON (e.g. "[Thinking: ...]" starts with "[" but is plain text)
+                    const isParsedEmpty =
+                        (Array.isArray(parsed) && parsed.length === 0) ||
+                        (isObject(parsed) && Object.keys(parsed as Record<string, unknown>).length === 0)
+                    if (isParsedEmpty) {
+                        throw new Error('not JSON')
+                    }
                     if (isObject(parsed) && parsed.type === 'image') {
                         return <ImageMessageDisplay message={parsed} />
                     }

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -540,6 +540,16 @@ describe('LLM Analytics utils', () => {
         it('throws on completely invalid input', () => {
             expect(() => parsePartialJSON('not json at all')).toThrow()
         })
+
+        it.each([
+            ['bracket-prefixed text', '[Thinking: The user wants to build a todo app.]I will build it'],
+            ['bracket-prefixed with tool call', '[Tool Call: lov-write, Input: {"file_path":"src/index.tsx"}]'],
+        ])('returns empty array for %s (not actual JSON)', (_label, input) => {
+            // These strings start with "[" so they look like JSON arrays,
+            // but the partial parser can't extract any valid elements
+            const result = parsePartialJSON(input)
+            expect(result).toEqual([])
+        })
     })
 
     describe('looksLikeXml', () => {


### PR DESCRIPTION
## Problem

When assistant output starts with `[` (e.g. `[Thinking: The user wants to build a todo app.]I'll build...`), the conversation view displays an empty `[]` instead of the actual content.

This happens because `renderMessageContent` sees `[` and tries `parsePartialJSON`, which treats it as a JSON array. Since `Thinking:` isn't a valid JSON element, the partial parser returns `[]` (empty array), which gets rendered by the JSON viewer.

## Changes

- After `parsePartialJSON`, check if the result is an empty container (`[]` or `{}`). If so, fall through to text/markdown rendering instead of displaying the empty container.
- Added unit tests documenting the `parsePartialJSON` behavior for bracket-prefixed text.
- Added component tests verifying bracket-prefixed content renders as text, and valid/truncated JSON still renders as JSON.

## Test plan

- [x] `parsePartialJSON` tests pass (9 cases including 2 new)
- [x] `LLMMessageDisplay` component tests pass (6 new cases)
- [x] Manual: check a trace with `[Thinking: ...]` output renders the full text
- [x] Manual: check normal JSON output traces still render correctly