### PR TITLE
fix(signals): Avoid including multiple cases from a single session into a pattern

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a3_cluster_segments.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a3_cluster_segments.py
@@ -6,6 +6,7 @@ Clustering video segments using iterative K-means, with noise handling.
 import json
 import math
 import asyncio
+from collections import defaultdict
 from dataclasses import dataclass
 
 import numpy as np
@@ -169,7 +170,62 @@ def _perform_clustering(segments: list[VideoSegment]) -> _ClusteringResultWithCe
         # Merge centroids
         centroids.update(noise_result.centroids)
 
+    # Keep at most one segment per session within each cluster
+    result = _deduplicate_sessions_within_clusters(result, segments, centroids)
+
     return _ClusteringResultWithCentroids(result=result, centroids=centroids)
+
+
+def _deduplicate_sessions_within_clusters(
+    result: ClusteringResult,
+    segments: list[VideoSegment],
+    centroids: dict[int, list[float]],
+) -> ClusteringResult:
+    """For each cluster, keep only the segment closest to the centroid per session."""
+    segment_lookup = {s.document_id: s for s in segments}
+    dropped_doc_ids: set[str] = set()
+    # Iterate over all clusters
+    for cluster in result.clusters:
+        centroid = centroids.get(cluster.cluster_id)
+        if centroid is None:
+            continue
+        # Group segments by session_id
+        session_to_doc_ids: dict[str, list[str]] = defaultdict(list)
+        for doc_id in cluster.segment_ids:
+            seg = segment_lookup.get(doc_id)
+            if seg:
+                session_to_doc_ids[seg.session_id].append(doc_id)
+        # For sessions with multiple segments, pick the closest to centroid
+        kept_doc_ids: list[str] = []
+        for _, doc_ids in session_to_doc_ids.items():
+            if len(doc_ids) == 1:
+                # Single segment per session per cluster, keeping it
+                kept_doc_ids.append(doc_ids[0])
+                continue
+            # Multiple segments per session per cluster, picking the closest to centroid
+            centroid_arr = np.array(centroid).reshape(1, -1)
+            embeddings = np.array([segment_lookup[did].embedding for did in doc_ids])
+            distances = cosine_distances(embeddings, centroid_arr).flatten()
+            best_idx = int(np.argmin(distances))
+            kept_doc_ids.append(doc_ids[best_idx])
+            dropped_doc_ids.update(did for i, did in enumerate(doc_ids) if i != best_idx)
+        cluster.segment_ids = kept_doc_ids
+        cluster.size = len(kept_doc_ids)
+    if dropped_doc_ids:
+        # Remove dropped segments
+        result.segment_to_cluster = {
+            doc_id: cid for doc_id, cid in result.segment_to_cluster.items() if doc_id not in dropped_doc_ids
+        }
+        # Mark dropped segments as noise (-1)
+        all_document_ids = [s.document_id for s in segments]
+        result.labels = [result.segment_to_cluster.get(doc_id, -1) for doc_id in all_document_ids]
+        # Add dropped segments to noise
+        result.noise_segment_ids.extend(dropped_doc_ids)
+        logger.debug(
+            "Deduplicated sessions within clusters",
+            segments_dropped=len(dropped_doc_ids),
+        )
+    return result
 
 
 def _estimate_k(n_segments: int, k_multiplier: float = constants.KMEANS_K_MULTIPLIER) -> int:

--- a/posthog/temporal/ai/video_segment_clustering/activities/a5_label_clusters.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a5_label_clusters.py
@@ -150,7 +150,7 @@ async def _calculate_metrics_from_segments(team: Team, segments: list[VideoSegme
 
     return {
         "relevant_user_count": relevant_user_count,
-        "occurrence_count": len(segments),
+        "occurrence_count": len({s.session_id for s in segments}),
         "last_occurrence_at": last_occurrence_at,
     }
 

--- a/posthog/temporal/ai/video_segment_clustering/priority.py
+++ b/posthog/temporal/ai/video_segment_clustering/priority.py
@@ -50,7 +50,7 @@ async def calculate_task_metrics(team: Team, segments: list[VideoSegmentMetadata
 
     return TaskMetrics(
         relevant_user_count=relevant_user_count,
-        occurrence_count=len(segments),
+        occurrence_count=len({s.session_id for s in segments}),
         last_occurrence_at=last_occurrence_at,
     )
 

--- a/posthog/temporal/ai/video_segment_clustering/tests/test_deduplicate_sessions.py
+++ b/posthog/temporal/ai/video_segment_clustering/tests/test_deduplicate_sessions.py
@@ -1,0 +1,105 @@
+from parameterized import parameterized
+
+from posthog.temporal.ai.video_segment_clustering.activities.a3_cluster_segments import (
+    _deduplicate_sessions_within_clusters,
+)
+from posthog.temporal.ai.video_segment_clustering.models import Cluster, ClusteringResult, VideoSegment
+
+
+def _make_segment(document_id: str, session_id: str, embedding: list[float]) -> VideoSegment:
+    return VideoSegment(
+        document_id=document_id,
+        session_id=session_id,
+        start_time="0:00",
+        end_time="0:30",
+        session_start_time="2025-01-01T00:00:00Z",
+        session_end_time="2025-01-01T01:00:00Z",
+        session_duration=3600,
+        session_active_seconds=1800,
+        distinct_id=f"user-{session_id}",
+        content="test content",
+        embedding=embedding,
+    )
+
+
+class TestDeduplicateSessionsWithinClusters:
+    @parameterized.expand(
+        [
+            (
+                "no_duplicates_leaves_cluster_unchanged",
+                # Two segments from different sessions — nothing to dedup
+                [
+                    _make_segment("s1:0:30", "s1", [1.0, 0.0, 0.0]),
+                    _make_segment("s2:0:30", "s2", [0.9, 0.1, 0.0]),
+                ],
+                [Cluster(cluster_id=0, segment_ids=["s1:0:30", "s2:0:30"], size=2)],
+                {0: [1.0, 0.0, 0.0]},
+                # Expected: both segments kept
+                ["s1:0:30", "s2:0:30"],
+                [],
+            ),
+            (
+                "duplicate_session_keeps_closest_to_centroid",
+                # Two segments from same session — seg_a is closer to centroid [1,0,0]
+                [
+                    _make_segment("s1:0:30", "s1", [0.95, 0.05, 0.0]),
+                    _make_segment("s1:30:60", "s1", [0.5, 0.5, 0.0]),
+                ],
+                [Cluster(cluster_id=0, segment_ids=["s1:0:30", "s1:30:60"], size=2)],
+                {0: [1.0, 0.0, 0.0]},
+                # Expected: s1:0:30 kept (closer), s1:30:60 dropped
+                ["s1:0:30"],
+                ["s1:30:60"],
+            ),
+            (
+                "multiple_sessions_deduped_independently",
+                # Session s1 has 2 segments, session s2 has 2 segments
+                [
+                    _make_segment("s1:0:30", "s1", [0.9, 0.1, 0.0]),
+                    _make_segment("s1:30:60", "s1", [0.3, 0.7, 0.0]),
+                    _make_segment("s2:0:30", "s2", [0.8, 0.2, 0.0]),
+                    _make_segment("s2:30:60", "s2", [0.1, 0.9, 0.0]),
+                ],
+                [Cluster(cluster_id=0, segment_ids=["s1:0:30", "s1:30:60", "s2:0:30", "s2:30:60"], size=4)],
+                {0: [1.0, 0.0, 0.0]},
+                # Expected: keep the closest per session (s1:0:30, s2:0:30)
+                ["s1:0:30", "s2:0:30"],
+                ["s1:30:60", "s2:30:60"],
+            ),
+            (
+                "same_session_in_different_clusters_both_kept",
+                # Same session in two different clusters — each cluster keeps one
+                [
+                    _make_segment("s1:0:30", "s1", [1.0, 0.0, 0.0]),
+                    _make_segment("s1:30:60", "s1", [0.0, 1.0, 0.0]),
+                ],
+                [
+                    Cluster(cluster_id=0, segment_ids=["s1:0:30"], size=1),
+                    Cluster(cluster_id=1, segment_ids=["s1:30:60"], size=1),
+                ],
+                {0: [1.0, 0.0, 0.0], 1: [0.0, 1.0, 0.0]},
+                # Expected: both kept, one per cluster
+                ["s1:0:30", "s1:30:60"],
+                [],
+            ),
+        ]
+    )
+    def test_dedup(self, _name, segments, clusters, centroids, expected_kept, expected_dropped):
+        result = ClusteringResult(
+            clusters=clusters,
+            noise_segment_ids=[],
+            labels=[0] * len(segments),
+            segment_to_cluster={doc_id: c.cluster_id for c in clusters for doc_id in c.segment_ids},
+        )
+
+        deduped = _deduplicate_sessions_within_clusters(result, segments, centroids)
+
+        all_kept = [doc_id for c in deduped.clusters for doc_id in c.segment_ids]
+        assert sorted(all_kept) == sorted(expected_kept)
+
+        for doc_id in expected_dropped:
+            assert doc_id not in deduped.segment_to_cluster
+            assert doc_id in deduped.noise_segment_ids
+
+        for cluster in deduped.clusters:
+            assert cluster.size == len(cluster.segment_ids)


### PR DESCRIPTION
## Problem
- Reports include segments from the same sessions, dropping the quality significantly

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- When clustering - keep only the segment from the session that is the closest to the centroid

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
