### PR TITLE
fix(signals): Improve resilience of fetch_segments

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -94,7 +94,7 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
                     lookback_hours=inputs.lookback_hours,
                 )
             ],
-            start_to_close_timeout=timedelta(seconds=120),
+            start_to_close_timeout=timedelta(minutes=10),
             retry_policy=RetryPolicy(
                 maximum_attempts=3,
                 initial_interval=timedelta(seconds=1),

--- a/posthog/temporal/ai/video_segment_clustering/data.py
+++ b/posthog/temporal/ai/video_segment_clustering/data.py
@@ -50,7 +50,6 @@ def fetch_video_segment_metadata_rows(team: Team, lookback_hours: int):
                     AND product = {product}
                     AND document_type = {document_type}
                     AND rendering = {rendering}
-                    AND length(embedding) > 0
                 ORDER BY timestamp ASC
                 LIMIT {max_segments_returned}"""
             ),


### PR DESCRIPTION
## Problem

Currently seeing the `fetch_segments` of session analysis time out sometimes: https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/video-segment-clustering-team-2-2026-02-23T08%3A00%3A07.021601%2B00%3A00/019c8983-4386-7ca1-bc19-9231d4e66dd7/history

## Changes

Increased timeout, and making the ClickHouse query lighter (I don't think we really need that embedding check).