### PR TITLE
feat(sig): deleting signal reports and signals

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4260,6 +4260,9 @@ const api = {
         async getReportSignals(reportId: string): Promise<{ report: SignalReport | null; signals: SignalNode[] }> {
             return await new ApiRequest().signalReport(reportId).withAction('signals').get()
         },
+        async delete(id: SignalReport['id']): Promise<void> {
+            await new ApiRequest().signalReport(id).delete()
+        },
     },
 
     signalSourceConfigs: {

--- a/frontend/src/scenes/debug/SignalsDebug.tsx
+++ b/frontend/src/scenes/debug/SignalsDebug.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 
 import { useLocalStorage } from 'lib/hooks/useLocalStorage'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 
@@ -33,8 +34,15 @@ export function SignalsDebug(): JSX.Element {
         loaded,
     } = useValues(signalsDebugLogic)
 
-    const { setReportId, loadReportSignals, selectReport, setSelectedSignalId, setHoveredEdge, setMousePos } =
-        useActions(signalsDebugLogic)
+    const {
+        setReportId,
+        loadReportSignals,
+        selectReport,
+        setSelectedSignalId,
+        setHoveredEdge,
+        setMousePos,
+        deleteReport,
+    } = useActions(signalsDebugLogic)
 
     const [simConfig, setSimConfig] = useLocalStorage<SimConfig>('signals-debug-physics', { ...DEFAULT_CONFIG })
 
@@ -107,7 +115,7 @@ export function SignalsDebug(): JSX.Element {
                     {/* Report summary overlay */}
                     {report && (
                         <div
-                            className="absolute top-3 left-3 z-20 flex items-center gap-2 rounded-md bg-surface-primary/80 backdrop-blur text-sm select-none pointer-events-none"
+                            className="absolute top-3 left-3 z-20 flex items-center gap-2 rounded-md bg-surface-primary/80 backdrop-blur text-sm select-none"
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{
                                 border: '1px solid var(--border)',
@@ -125,6 +133,28 @@ export function SignalsDebug(): JSX.Element {
                                 {signals.length} signal{signals.length !== 1 ? 's' : ''} · w
                                 {report.total_weight.toFixed(2)}
                             </span>
+                            <LemonButton
+                                size="xsmall"
+                                type="tertiary"
+                                status="danger"
+                                onClick={() => {
+                                    LemonDialog.open({
+                                        title: 'Delete report?',
+                                        description:
+                                            'This will soft-delete all signals in this report and remove the report. This cannot be undone.',
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            status: 'danger',
+                                            onClick: () => deleteReport(report.id),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                        },
+                                    })
+                                }}
+                            >
+                                Delete
+                            </LemonButton>
                         </div>
                     )}
                     {loading && (

--- a/frontend/src/scenes/debug/signals/signalsDebugLogic.ts
+++ b/frontend/src/scenes/debug/signals/signalsDebugLogic.ts
@@ -23,6 +23,7 @@ export const signalsDebugLogic = kea<signalsDebugLogicType>([
         setReportSearch: (search: string) => ({ search }),
         setStatusFilter: (status: string | null) => ({ status }),
         loadMoreReports: true,
+        deleteReport: (reportId: string) => ({ reportId }),
     }),
 
     loaders(({ values }) => ({
@@ -169,6 +170,21 @@ export const signalsDebugLogic = kea<signalsDebugLogicType>([
     listeners(({ actions, values }) => ({
         selectReport: ({ reportId }) => {
             actions.loadReportSignals(reportId)
+        },
+        deleteReport: async ({ reportId }) => {
+            try {
+                await api.signalReports.delete(reportId)
+                lemonToast.success('Report deleted')
+                // Clear current view if we just deleted the loaded report
+                if (values.reportId === reportId) {
+                    actions.setReportId('')
+                    actions.loadReportSignalsSuccess({ report: null, signals: [] })
+                }
+                actions.loadReports()
+            } catch (e) {
+                lemonToast.error('Failed to delete report')
+                throw e
+            }
         },
         setStatusFilter: () => {
             actions.loadReports()

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -127,6 +127,7 @@ async def fetch_signal_type_examples_activity(input: FetchSignalTypeExamplesInpu
                 )
                 WHERE content != ''
                   AND timestamp >= now() - INTERVAL 1 MONTH
+                  AND NOT JSONExtractBool(metadata, 'deleted')
             )
             GROUP BY source_product, source_type
         """
@@ -320,6 +321,7 @@ async def run_signal_semantic_search_activity(input: RunSignalSemanticSearchInpu
             )
             WHERE JSONExtractString(metadata, 'report_id') != ''
               AND timestamp >= now() - INTERVAL 1 MONTH
+              AND NOT JSONExtractBool(metadata, 'deleted')
             ORDER BY distance ASC
             LIMIT {limit}
         """

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -232,6 +232,7 @@ async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -
                 GROUP BY document_id
             )
             WHERE JSONExtractString(metadata, 'report_id') = {report_id}
+              AND NOT JSONExtractBool(metadata, 'deleted')
             ORDER BY timestamp ASC
         """
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import logging
+from datetime import datetime
 
 from django.conf import settings
 from django.db import IntegrityError
@@ -8,7 +9,7 @@ from django.db.models import Count
 
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import filters, serializers, status, viewsets
+from rest_framework import filters, mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -21,6 +22,7 @@ from posthog.schema import EmbeddingModelName
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.api.embedding_worker import emit_embedding_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.permissions import APIScopePermission
@@ -102,7 +104,7 @@ class SignalSourceConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     list=extend_schema(exclude=True),
     retrieve=extend_schema(exclude=True),
 )
-class SignalReportViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class SignalReportViewSet(TeamAndOrgViewSetMixin, mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = SignalReportSerializer
     authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
     permission_classes = [IsAuthenticated, APIScopePermission]
@@ -168,6 +170,7 @@ class SignalReportViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet)
                 GROUP BY document_id
             )
             WHERE JSONExtractString(metadata, 'report_id') = {report_id}
+              AND NOT JSONExtractBool(metadata, 'deleted')
             ORDER BY timestamp ASC
         """
 
@@ -200,3 +203,65 @@ class SignalReportViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet)
             )
 
         return Response({"report": report_data, "signals": signals_list})
+
+    def destroy(self, request, *args, **kwargs):
+        report = self.get_object()
+        report_id = str(report.id)
+
+        # Fetch all signals for this report from ClickHouse (including already-deleted ones,
+        # so we don't miss any — the query intentionally omits the soft-delete filter)
+        query = """
+            SELECT
+                document_id,
+                content,
+                metadata,
+                toString(timestamp) as timestamp
+            FROM (
+                SELECT
+                    document_id,
+                    argMax(content, inserted_at) as content,
+                    argMax(metadata, inserted_at) as metadata,
+                    argMax(timestamp, inserted_at) as timestamp
+                FROM document_embeddings
+                WHERE model_name = {model_name}
+                  AND product = 'signals'
+                  AND document_type = 'signal'
+                GROUP BY document_id
+            )
+            WHERE JSONExtractString(metadata, 'report_id') = {report_id}
+            ORDER BY timestamp ASC
+        """
+
+        result = execute_hogql_query(
+            query_type="SignalsFetchForReportDelete",
+            query=query,
+            team=self.team,
+            placeholders={
+                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+                "report_id": ast.Constant(value=report_id),
+            },
+        )
+
+        # Emit a soft-delete version of each signal, preserving the original timestamp
+        # so the row lands in the same partition and replaces the original via ReplacingMergeTree
+        for row in result.results or []:
+            document_id, content, metadata_str, timestamp_str = row
+            metadata = json.loads(metadata_str)
+            metadata["deleted"] = True
+
+            emit_embedding_request(
+                content=content,
+                team_id=self.team.pk,
+                product="signals",
+                document_type="signal",
+                rendering="plain",
+                document_id=document_id,
+                models=[m.value for m in EmbeddingModelName],
+                timestamp=datetime.fromisoformat(timestamp_str),
+                metadata=metadata,
+            )
+
+        # Delete the Django model (cascades to artefacts)
+        report.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Adds a soft deletion for signals in clickhouse, and respects that during the grouping phase (so new signals don't get grouped into deleted reports). Also exposes it on the debug ui - I didn't spend any time on polishing that, could be cleaner (we'll probably want bulk actions etc), but for now I think it's fine as-is.