### PR TITLE
feat: Parse HeartbeatDetails in backfill batch export

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -108,6 +108,7 @@ class UpdateBatchExportBackfillInputs:
     estimated_records_count: int | None = None
     status: str | None = None
     finished: bool = False
+    latest_error: str | None = None
 
 
 @temporalio.activity.defn
@@ -166,9 +167,9 @@ async def update_batch_export_backfill_model(inputs: UpdateBatchExportBackfillIn
 
     if inputs.finished:
         if backfill.status in (BatchExportBackfill.Status.FAILED, BatchExportBackfill.Status.FAILED_RETRYABLE):
-            logger.error("Batch export backfill failed")
+            logger.error("Batch export backfill failed: %s", inputs.latest_error or "Unknown error")
         elif backfill.status == BatchExportBackfill.Status.CANCELLED:
-            logger.warning("Batch export backfill was cancelled.")
+            logger.warning("Batch export backfill was canceled")
         else:
             logger.info(
                 "Successfully finished backfilling batches in range %s - %s",

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -932,10 +932,12 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             else:
                 update_inputs.status = BatchExportBackfill.Status.FAILED
 
+            update_inputs.latest_error = str(e.cause)
             raise
 
         except Exception:
             update_inputs.status = BatchExportBackfill.Status.FAILED
+            update_inputs.latest_error = "An unexpected error has occurred"
             raise
 
         finally:

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -45,12 +45,25 @@ class TemporalScheduleNotFoundError(Exception):
         super().__init__(f"The Temporal Schedule {schedule_id} was not found (maybe it was deleted?)")
 
 
+class HeartbeatDetailsParseError(Exception):
+    def __init__(self, reason: str):
+        super().__init__(f"Failed to parse heartbeat details: {reason}")
+
+
 class HeartbeatDetails(typing.NamedTuple):
     """Details sent over in a Temporal Activity heartbeat."""
 
     schedule_id: str
     workflow_id: str
     last_batch_data_interval_end: str
+
+    @classmethod
+    def from_details(cls, details: collections.abc.Sequence[typing.Any]) -> typing.Self:
+        """Parse from activity details, raise non-retryable error if it fails."""
+        try:
+            return cls(*details)
+        except Exception as e:
+            raise HeartbeatDetailsParseError(str(e)) from e
 
 
 @dataclasses.dataclass
@@ -603,7 +616,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
         if details:
             # If we receive details from a previous run, it means we were restarted for some reason.
             # Let's not double-backfill and instead wait for any outstanding runs.
-            last_activity_details = HeartbeatDetails(*details)
+            last_activity_details = HeartbeatDetails.from_details(details)
             logger.info(
                 "Heartbeat details received",
                 backfill_run_id=last_activity_details.workflow_id,
@@ -907,7 +920,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
                 retry_policy=temporalio.common.RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=60),
-                    non_retryable_error_types=["TemporalScheduleNotFoundError"],
+                    non_retryable_error_types=["TemporalScheduleNotFoundError", "HeartbeatDetailsParseError"],
                 ),
                 start_to_close_timeout=start_to_close_timeout,
                 heartbeat_timeout=dt.timedelta(seconds=30),

--- a/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
+++ b/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
@@ -1,6 +1,7 @@
 import uuid
 import asyncio
 import datetime as dt
+import dataclasses
 from zoneinfo import ZoneInfo
 
 import pytest

--- a/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
+++ b/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
@@ -31,6 +31,7 @@ from products.batch_exports.backend.temporal.backfill_batch_export import (
     BackfillBatchExportInputs,
     BackfillBatchExportWorkflow,
     BackfillScheduleInputs,
+    HeartbeatDetailsParseError,
     _get_backfill_info_for_events,
     _get_backfill_info_for_persons,
     backfill_range,
@@ -1781,3 +1782,38 @@ class TestGetBackfillInfoForPersons:
 
         assert earliest_start is None
         assert record_count == 0
+
+
+@pytest.mark.parametrize(
+    "corrupted_details",
+    [
+        ("", "", "", ""),  # one extra item should fail parsing
+        ("", ""),  # one less item should fail parsing
+    ],
+)
+async def test_backfill_schedule_activity_fails_with_corrupted_details(
+    activity_environment,
+    temporal_worker,
+    temporal_client,
+    temporal_schedule_hourly,
+    corrupted_details,
+):
+    """Test backfill_schedule activity fails when details are corrupted."""
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 5, 0, 0, tzinfo=dt.UTC)
+    backfill_id = str(uuid.uuid4())
+
+    desc = await temporal_schedule_hourly.describe()
+    inputs = BackfillScheduleInputs(
+        schedule_id=desc.id,
+        start_at=start_at.isoformat(),
+        end_at=end_at.isoformat(),
+        start_delay=0.1,
+        frequency_seconds=desc.schedule.spec.intervals[0].every.total_seconds(),
+        backfill_id=backfill_id,
+    )
+
+    activity_environment.info = dataclasses.replace(activity_environment.info, heartbeat_details=corrupted_details)
+
+    with pytest.raises(HeartbeatDetailsParseError):
+        await activity_environment.run(backfill_schedule, inputs)


### PR DESCRIPTION
## Problem

`HeartbeatDetails` in backfill batch export can be invalid. This is a problem specially because the error raised is retryable.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Introduce a `from_details` class method which can be used to parse activity heartbeat details into `HeartbeatDetails`. For now, this only controls that the number of parameters is correct, eventually more validation logic could be added to the parsing function.

Also, made the error raised when parsing fails non retryable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a new unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
