### PR TITLE
fix(signals): add ai_product property to signals tracking events

### DIFF
--- a/ee/hogai/session_summaries/tracking.py
+++ b/ee/hogai/session_summaries/tracking.py
@@ -23,6 +23,7 @@ def capture_session_summary_timing(
     if not user_distinct_id:
         return
     properties: dict = {
+        "ai_product": "signals",
         "session_id": session_id,
         "timing_type": timing_type,
         "duration_seconds": duration_seconds,
@@ -56,6 +57,7 @@ def capture_session_summary_started(
         distinct_id=user.distinct_id,
         event="session summary started",
         properties={
+            "ai_product": "signals",
             "tracking_id": tracking_id,
             "summary_source": summary_source,
             "summary_type": summary_type,
@@ -87,6 +89,7 @@ def capture_session_summary_generated(
     if not user.distinct_id:
         return
     properties: dict = {
+        "ai_product": "signals",
         "tracking_id": tracking_id,
         "summary_source": summary_source,
         "summary_type": summary_type,

--- a/posthog/temporal/data_imports/workflow_activities/emit_signals.py
+++ b/posthog/temporal/data_imports/workflow_activities/emit_signals.py
@@ -239,6 +239,7 @@ async def _summarize_description(
             posthoganalytics.capture_exception(
                 e,
                 properties={
+                    "ai_product": "signals",
                     "tag": "data_warehouse_signals_import",
                     "error_type": "summarization_failed",
                     "source_type": output.source_type,
@@ -356,6 +357,7 @@ async def _check_actionability(
             posthoganalytics.capture_exception(
                 e,
                 properties={
+                    "ai_product": "signals",
                     "tag": "data_warehouse_signals_import",
                     "error_type": "actionability_check_failed",
                     "source_type": output.source_type,


### PR DESCRIPTION
## Problem

The `ai_product` field is missing on summarization LLMA events, so the dashboard doesn't populate.

## Changes

Added `"ai_product": "signals"` property to all tracking event captures in:
- Session summary tracking events (`capture_session_summary_timing`, `capture_session_summary_started`, `capture_session_summary_generated`)
- Data warehouse signals import error tracking (`_summarize_description`, `_check_actionability`)

This ensures consistent product categorization across all signals-related analytics events.

## How did you test this code?

No testing needed - this is a straightforward property addition to existing tracking calls. The changes are purely additive and don't modify any logic or behavior.

## Publish to changelog?

no
