### PR TITLE
feat(insights): Correct docs links for inline events

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -222,6 +222,9 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         excludedProperties,
         allowNonCapturedEvents,
         hogQLGlobals,
+        inlineEventsDocLink: isTrendsFilter(filters)
+            ? 'https://posthog.com/docs/product-analytics/trends/overview#combine-events-inline'
+            : 'https://posthog.com/docs/product-analytics/funnels#combine-events-inline',
     }
 
     const reachedLimit: boolean = Boolean(entitiesLimit && localFilters.length >= entitiesLimit)

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -184,6 +184,8 @@ export interface ActionFilterRowProps {
     filtersLeftPadding?: boolean
     /** Doc link to show in the tooltip of the New Filter button */
     addFilterDocLink?: string
+    /** Doc link to show in the tooltip of the Combine events button */
+    inlineEventsDocLink?: string
     /** Allow adding non-captured events */
     allowNonCapturedEvents?: boolean
     hogQLGlobals?: Record<string, any>
@@ -225,6 +227,7 @@ export function ActionFilterRow({
     excludedProperties,
     allowNonCapturedEvents,
     hogQLGlobals,
+    inlineEventsDocLink,
 }: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties' | 'allowNonCapturedEvents'>): JSX.Element {
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
     const effectiveActionsTaxonomicGroupTypes = showQuickFilters
@@ -562,7 +565,7 @@ export function ActionFilterRow({
                 })
             }}
             tooltip="Combine events"
-            tooltipDocLink="https://posthog.com/docs/product-analytics/trends/overview#combine-events-inline"
+            tooltipDocLink={inlineEventsDocLink}
         />
     )
 


### PR DESCRIPTION
## Problem
I've added docs for the inline events in funnels. Now, we need to point to trends or funnels docs depending on the insight type.

## Changes

Set correct docs links for trends and funnel insights

## How did you test this code?

Manually


## Publish to changelog?

No