### PR TITLE
feat: save draft state in support when move between tabs

### DIFF
--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -24,6 +24,14 @@ export interface ChatViewProps {
     unreadCustomerCount?: number
     /** Whether to show delivery status on team messages */
     showDeliveryStatus?: boolean
+    /** Draft content to restore (for tab persistence) */
+    draftContent?: JSONContent | null
+    /** Called when draft content changes */
+    onDraftChange?: (content: JSONContent | null) => void
+    /** Whether the private note checkbox is checked */
+    isPrivate?: boolean
+    /** Called when private checkbox changes */
+    onPrivateChange?: (isPrivate: boolean) => void
 }
 
 export function ChatView({
@@ -40,6 +48,10 @@ export function ChatView({
     showPrivateOption = false,
     unreadCustomerCount,
     showDeliveryStatus = false,
+    draftContent,
+    onDraftChange,
+    isPrivate,
+    onPrivateChange,
 }: ChatViewProps): JSX.Element {
     const listMinHeight = minHeight ?? '400px'
     const listMaxHeight = maxHeight ?? '600px'
@@ -64,6 +76,10 @@ export function ChatView({
                     onSendMessage={onSendMessage}
                     messageSending={messageSending}
                     showPrivateOption={showPrivateOption}
+                    draftContent={draftContent}
+                    onDraftChange={onDraftChange}
+                    isPrivate={isPrivate}
+                    onPrivateChange={onPrivateChange}
                 />
             </div>
         </LemonCard>

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { JSONContent } from '@tiptap/core'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { IconLock } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
@@ -42,6 +42,10 @@ export function MessageInput({
     const [isUploading, setIsUploading] = useState(false)
     const [localIsPrivate, setLocalIsPrivate] = useState(false)
     const editorRef = useRef<RichContentEditorType | null>(null)
+
+    useEffect(() => {
+        setIsEmpty(!draftContent)
+    }, [draftContent])
 
     // Support controlled or uncontrolled isPrivate
     const isPrivate = controlledIsPrivate ?? localIsPrivate

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -16,6 +16,14 @@ export interface MessageInputProps {
     minRows?: number
     /** Whether to show the "Send as private" checkbox */
     showPrivateOption?: boolean
+    /** Draft content to restore (from parent logic for tab persistence) */
+    draftContent?: JSONContent | null
+    /** Called when draft content changes */
+    onDraftChange?: (content: JSONContent | null) => void
+    /** Whether the private note checkbox is checked (from parent logic for tab persistence) */
+    isPrivate?: boolean
+    /** Called when private checkbox changes */
+    onPrivateChange?: (isPrivate: boolean) => void
 }
 
 export function MessageInput({
@@ -25,11 +33,19 @@ export function MessageInput({
     buttonText = 'Send',
     minRows = 3,
     showPrivateOption = false,
+    draftContent,
+    onDraftChange,
+    isPrivate: controlledIsPrivate,
+    onPrivateChange,
 }: MessageInputProps): JSX.Element {
-    const [isEmpty, setIsEmpty] = useState(true)
+    const [isEmpty, setIsEmpty] = useState(!draftContent)
     const [isUploading, setIsUploading] = useState(false)
-    const [isPrivate, setIsPrivate] = useState(false)
+    const [localIsPrivate, setLocalIsPrivate] = useState(false)
     const editorRef = useRef<RichContentEditorType | null>(null)
+
+    // Support controlled or uncontrolled isPrivate
+    const isPrivate = controlledIsPrivate ?? localIsPrivate
+    const setIsPrivate = onPrivateChange ?? setLocalIsPrivate
 
     const handleSubmit = (): void => {
         if (editorRef.current && !isEmpty) {
@@ -38,18 +54,35 @@ export function MessageInput({
             onSendMessage(content, richContent, isPrivate, () => {
                 editorRef.current?.clear()
                 setIsEmpty(true)
+                onDraftChange?.(null)
+                if (onPrivateChange) {
+                    onPrivateChange(false)
+                } else {
+                    setLocalIsPrivate(false)
+                }
             })
+        }
+    }
+
+    const handleUpdate = (empty: boolean): void => {
+        setIsEmpty(empty)
+        if (onDraftChange && editorRef.current) {
+            onDraftChange(empty ? null : editorRef.current.getJSON())
         }
     }
 
     return (
         <div>
             <SupportEditor
+                initialContent={draftContent}
                 placeholder={placeholder}
                 onCreate={(editor) => {
                     editorRef.current = editor
+                    if (draftContent) {
+                        setIsEmpty(false)
+                    }
                 }}
-                onUpdate={(empty) => setIsEmpty(empty)}
+                onUpdate={handleUpdate}
                 onPressCmdEnter={handleSubmit}
                 onUploadingChange={setIsUploading}
                 disabled={messageSending}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -52,8 +52,19 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         exceptionsQuery,
         chatPanelWidth,
         hasUnsavedChanges,
+        draftContent,
+        draftIsPrivate,
     } = useValues(logic)
-    const { setStatus, setPriority, setAssignee, sendMessage, updateTicket, loadOlderMessages } = useActions(logic)
+    const {
+        setStatus,
+        setPriority,
+        setAssignee,
+        sendMessage,
+        updateTicket,
+        loadOlderMessages,
+        setDraftContent,
+        setDraftIsPrivate,
+    } = useActions(logic)
 
     const chatPanelRef = useRef<HTMLDivElement>(null)
 
@@ -124,6 +135,10 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         showPrivateOption
                         unreadCustomerCount={ticket?.unread_customer_count}
                         showDeliveryStatus={ticket?.channel_source === 'widget'}
+                        draftContent={draftContent}
+                        onDraftChange={setDraftContent}
+                        isPrivate={draftIsPrivate}
+                        onPrivateChange={setDraftIsPrivate}
                     />
                     <div className="hidden lg:block">
                         <Resizer {...resizerLogicProps} />

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1,3 +1,4 @@
+import { JSONContent } from '@tiptap/core'
 import { actions, afterMount, beforeUnmount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
@@ -127,6 +128,10 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         // Session context actions
         loadPerson: true,
         loadPreviousTickets: true,
+
+        // Draft message state (persists across tab switches)
+        setDraftContent: (content: JSONContent | null) => ({ content }),
+        setDraftIsPrivate: (isPrivate: boolean) => ({ isPrivate }),
     }),
     loaders(({ values, props }) => ({
         person: [
@@ -264,6 +269,18 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             {
                 sendMessage: () => true,
                 setMessageSending: (_, { sending }) => sending,
+            },
+        ],
+        draftContent: [
+            null as JSONContent | null,
+            {
+                setDraftContent: (_, { content }) => content,
+            },
+        ],
+        draftIsPrivate: [
+            false,
+            {
+                setDraftIsPrivate: (_, { isPrivate }) => isPrivate,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

If you start typing a response in Support ticket but then open another PostHog tab - the message is lost.

## Changes

Let's save the state

![ezgif-6c8ce382507db93c](https://github.com/user-attachments/assets/8ab872b8-bfb3-4af6-a8e6-968acb639ab9)
