### PR TITLE
fix: prevent horizontal sql editor error msg overflow

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -794,7 +794,11 @@ const ErrorState = ({ responseError, sourceQuery, queryCancelled, response }: an
             <InsightErrorState
                 query={sourceQuery}
                 excludeDetail
-                title={error}
+                title={
+                    <pre className="text-xs bg-danger-highlight p-2 rounded overflow-auto max-h-40 max-w-[80%] mx-auto text-left whitespace-pre-wrap break-words">
+                        {error}
+                    </pre>
+                }
                 excludeActions={queryCancelled} // Don't display fix/debugger buttons if the query was cancelled
                 fixWithAIComponent={
                     <FixErrorButton contentOverride="Fix error with AI" type="primary" source="query-error" />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -516,7 +516,7 @@ export function InsightValidationError({
 }
 
 export interface InsightErrorStateProps {
-    title?: string | null
+    title?: string | JSX.Element | null
     query?: Record<string, any> | Node | null
     queryId?: string | null
     excludeDetail?: boolean


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
big error messages would go crazy
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- put them in a box

before

![image.png](https://app.graphite.com/user-attachments/assets/3a554028-c0a1-48c0-b2db-c06483274988.png)

after

![image.png](https://app.graphite.com/user-attachments/assets/293f70b2-1c88-47ae-a28e-b3d9bb8ed84a.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
nah
<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
