### PR TITLE
feat(phai): Track dashboard creation events from PostHog AI

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -139,10 +139,8 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertEqual(call_args[0][1], "dashboard created")
         properties = call_args[0][2]
         self.assertTrue(properties["from_posthog_ai"])
-        self.assertFalse(properties["from_template"])
-        self.assertIsNone(properties["template_key"])
-        self.assertFalse(properties["duplicated"])
         self.assertIsNotNone(properties["dashboard_id"])
+        self.assertIn("$session_id", properties)
         self.assertEqual(properties["item_count"], 1)
         self.assertEqual(call_args[1]["team"], self.team)
 

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -139,6 +139,10 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertEqual(call_args[0][1], "dashboard created")
         properties = call_args[0][2]
         self.assertTrue(properties["from_posthog_ai"])
+        self.assertFalse(properties["from_template"])
+        self.assertIsNone(properties["template_key"])
+        self.assertFalse(properties["duplicated"])
+        self.assertIsNotNone(properties["dashboard_id"])
         self.assertEqual(properties["item_count"], 1)
         self.assertEqual(call_args[1]["team"], self.team)
 

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -119,6 +119,29 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertIn("Test Dashboard", result)
         self.assertIn(str(dashboard.id), result)
 
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_reports_user_action_with_from_posthog_ai(self, mock_report_user_action):
+        insight = await self._create_insight("Analytics Insight")
+
+        tool = self._create_tool()
+
+        action = CreateDashboardToolArgs(
+            insight_ids=[insight.short_id],
+            name="AI Created Dashboard",
+            description="Dashboard created by PostHog AI",
+        )
+
+        await tool._arun_impl(action)
+
+        mock_report_user_action.assert_called_once()
+        call_args = mock_report_user_action.call_args
+        self.assertEqual(call_args[0][0], self.user)
+        self.assertEqual(call_args[0][1], "dashboard created")
+        properties = call_args[0][2]
+        self.assertTrue(properties["from_posthog_ai"])
+        self.assertEqual(properties["item_count"], 1)
+        self.assertEqual(call_args[1]["team"], self.team)
+
     async def test_create_dashboard_output_includes_correct_url(self):
         insight = await self._create_insight("URL Test Insight")
 

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -133,16 +133,75 @@ class TestUpsertDashboardTool(BaseTest):
 
         await tool._arun_impl(action)
 
-        mock_report_user_action.assert_called_once()
-        call_args = mock_report_user_action.call_args
+        # One call for the insight (from _create_resolved_insights) and one for the dashboard
+        dashboard_calls = [c for c in mock_report_user_action.call_args_list if c[0][1] == "dashboard created"]
+        self.assertEqual(len(dashboard_calls), 1)
+        call_args = dashboard_calls[0]
         self.assertEqual(call_args[0][0], self.user)
-        self.assertEqual(call_args[0][1], "dashboard created")
         properties = call_args[0][2]
         self.assertTrue(properties["from_posthog_ai"])
         self.assertIsNotNone(properties["dashboard_id"])
         self.assertIn("$session_id", properties)
         self.assertEqual(properties["item_count"], 1)
         self.assertEqual(call_args[1]["team"], self.team)
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_reports_insight_created_for_new_insights(self, mock_report_user_action):
+        insight1 = await self._create_insight("Insight One")
+        insight2 = await self._create_insight("Insight Two")
+
+        tool = self._create_tool()
+
+        action = CreateDashboardToolArgs(
+            insight_ids=[insight1.short_id, insight2.short_id],
+            name="Multi Insight Dashboard",
+            description="Dashboard with multiple insights",
+        )
+
+        await tool._arun_impl(action)
+
+        insight_calls = [c for c in mock_report_user_action.call_args_list if c[0][1] == "insight created"]
+        dashboard_calls = [c for c in mock_report_user_action.call_args_list if c[0][1] == "dashboard created"]
+        self.assertEqual(len(dashboard_calls), 1)
+        self.assertEqual(len(insight_calls), 0)  # Existing insights are not newly created
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_reports_insight_created_for_unsaved_insights(self, mock_report_user_action):
+        viz_id = str(uuid4())
+        state = AssistantState(
+            messages=[
+                VisualizationMessage(
+                    id=viz_id,
+                    query="Show me pageviews",
+                    answer=DEFAULT_TRENDS_QUERY,
+                    plan="Plan",
+                ),
+            ],
+            root_tool_call_id=str(uuid4()),
+        )
+
+        context_manager = AssistantContextManager(team=self.team, user=self.user)
+        tool = UpsertDashboardTool(
+            team=self.team,
+            user=self.user,
+            state=state,
+            context_manager=context_manager,
+        )
+
+        action = CreateDashboardToolArgs(
+            insight_ids=[viz_id],
+            name="State Dashboard",
+            description="Dashboard with state insight",
+        )
+
+        await tool._arun_impl(action)
+
+        insight_calls = [c for c in mock_report_user_action.call_args_list if c[0][1] == "insight created"]
+        self.assertEqual(len(insight_calls), 1)
+        properties = insight_calls[0][0][2]
+        self.assertTrue(properties["from_posthog_ai"])
+        self.assertIn("insight_id", properties)
+        self.assertIn("$session_id", properties)
 
     async def test_create_dashboard_output_includes_correct_url(self):
         insight = await self._create_insight("URL Test Insight")

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -234,6 +234,16 @@ class UpsertDashboardTool(MaxTool):
             if getattr(insight, "pk", None):
                 continue
             insight.save()
+            report_user_action(
+                self._user,
+                "insight created",
+                {
+                    "insight_id": insight.short_id,
+                    "$session_id": (self._config.get("configurable") or {}).get("session_id"),
+                    "from_posthog_ai": True,
+                },
+                team=self._team,
+            )
         return results
 
     @database_sync_to_async

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -158,6 +158,10 @@ class UpsertDashboardTool(MaxTool):
             "dashboard created",
             {
                 **await database_sync_to_async(dashboard.get_analytics_metadata)(),
+                "from_template": False,
+                "template_key": None,
+                "duplicated": False,
+                "dashboard_id": dashboard.id,
                 "from_posthog_ai": True,
             },
             team=self._team,

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -158,10 +158,8 @@ class UpsertDashboardTool(MaxTool):
             "dashboard created",
             {
                 **await database_sync_to_async(dashboard.get_analytics_metadata)(),
-                "from_template": False,
-                "template_key": None,
-                "duplicated": False,
                 "dashboard_id": dashboard.id,
+                "$session_id": (self._config.get("configurable") or {}).get("session_id"),
                 "from_posthog_ai": True,
             },
             team=self._team,

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import DataTableNode, HogQLQuery, InsightVizNode, QuerySchemaRoot
 
+from posthog.event_usage import report_user_action
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.sync import database_sync_to_async
 from posthog.utils import pluralize
@@ -151,6 +152,16 @@ class UpsertDashboardTool(MaxTool):
 
         dashboard = await self._create_dashboard_with_tiles(action.name, action.description, insights)
         output = await self._format_dashboard_output(dashboard, insights)
+
+        await database_sync_to_async(report_user_action)(
+            self._user,
+            "dashboard created",
+            {
+                **await database_sync_to_async(dashboard.get_analytics_metadata)(),
+                "from_posthog_ai": True,
+            },
+            team=self._team,
+        )
 
         return output, {"dashboard_id": dashboard.id}
 


### PR DESCRIPTION
## Problem

We need to track when dashboards are created through the PostHog AI tool to understand usage patterns and measure the feature's impact.

## Changes

- Added `report_user_action` call in the dashboard creation flow to log "dashboard created" events
- Events include metadata about the dashboard (via `get_analytics_metadata()`) and a `from_posthog_ai` flag to distinguish AI-generated dashboards
- Added comprehensive test to verify the user action is reported with correct parameters

## How did you test this code?

Added `test_create_dashboard_reports_user_action_with_from_posthog_ai` test that:
- Creates a dashboard through the AI tool
- Verifies `report_user_action` is called once with the correct user, event name, and properties
- Confirms the `from_posthog_ai` flag is set to `True`
- Validates the item count is properly tracked

## Publish to changelog?

no

https://claude.ai/code/session_01DHf6nPRSqWysC6HS8j4hzk