### PR TITLE
chore(llma): remove beta tag from trace summary tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -1085,14 +1085,7 @@ const EventContent = React.memo(
                                     ? [
                                           {
                                               key: TraceViewMode.Summary,
-                                              label: (
-                                                  <>
-                                                      Summary{' '}
-                                                      <LemonTag className="ml-1" type="completion">
-                                                          Beta
-                                                      </LemonTag>
-                                                  </>
-                                              ),
+                                              label: 'Summary',
                                               'data-attr': 'llma-trace-summary-tab',
                                               content: (
                                                   <SummaryViewDisplay


### PR DESCRIPTION
## Summary
- Removes the "Beta" `LemonTag` from the Summary tab in the LLM analytics trace view

## Test plan
- [ ] Open an LLM analytics trace that shows the Summary tab
- [ ] Verify the tab label reads "Summary" without a beta badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)