### PR TITLE
fix(llma): increase cluster card color indicator width

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -56,7 +56,7 @@ export function ClusterCard({
             }`}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
-                borderLeftWidth: 3,
+                borderLeftWidth: 5,
                 borderLeftColor: clusterColor,
                 borderLeftStyle: isOutlierCluster ? 'dashed' : 'solid',
             }}


### PR DESCRIPTION
## Summary
- Increase the left border width from 3px to 5px on cluster cards to make the color indicator more visible and easier to distinguish

## Test plan
- [ ] Verify cluster cards in LLM analytics show a thicker, more visible color line

🤖 Generated with [Claude Code](https://claude.com/claude-code)