### PR TITLE
feat: open support tickets in different posthog tabs

### DIFF
--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -7,6 +7,7 @@ import { LemonBadge, LemonButton, LemonCheckbox, LemonDropdown, LemonTable, Lemo
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { TZLabel } from 'lib/components/TZLabel'
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { stripMarkdown } from 'lib/utils/stripMarkdown'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -193,9 +194,25 @@ export function SupportTicketsScene(): JSX.Element {
                             ? () => setCurrentPage(currentPage + 1)
                             : undefined,
                 }}
-                onRow={(ticket) => ({
-                    onClick: () => push(urls.supportTicketDetail(ticket.id)),
-                })}
+                onRow={(ticket) => {
+                    const ticketUrl = urls.supportTicketDetail(ticket.id)
+                    return {
+                        onClick: (e: React.MouseEvent) => {
+                            if (e.metaKey || e.ctrlKey) {
+                                window.open(ticketUrl, '_blank')
+                            } else {
+                                push(ticketUrl)
+                            }
+                        },
+                        onAuxClick: (e: React.MouseEvent) => {
+                            if (e.button === 1) {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                newInternalTab(ticketUrl)
+                            }
+                        },
+                    }
+                }}
                 rowClassName={(ticket) =>
                     clsx({
                         'bg-primary-alt-highlight': ticket.unread_team_count > 0,

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -199,7 +199,9 @@ export function SupportTicketsScene(): JSX.Element {
                     return {
                         onClick: (e: React.MouseEvent) => {
                             if (e.metaKey || e.ctrlKey) {
-                                window.open(ticketUrl, '_blank')
+                                e.preventDefault()
+                                e.stopPropagation()
+                                newInternalTab(ticketUrl)
                             } else {
                                 push(ticketUrl)
                             }


### PR DESCRIPTION
## Problem

Often you need to open multiple tickets in posthog

## Changes

Let's allow that

<img width="580" height="180" alt="Screenshot 2026-02-23 at 14 37 05" src="https://github.com/user-attachments/assets/2db22b41-1c45-4eab-b6fe-053e00ddceab" />

