### PR TITLE
feat: add ingestion pipeline and lane labels

### DIFF
--- a/nodejs/src/api/router.ts
+++ b/nodejs/src/api/router.ts
@@ -3,10 +3,25 @@ import express, { Request, Response } from 'ultimate-express'
 
 import { corsMiddleware } from '~/api/middleware/cors'
 import { createInternalApiAuthMiddleware } from '~/api/middleware/internal-api-auth'
-import { HealthCheckResultError, PluginServerService } from '~/types'
+import { HealthCheckResultError, PluginServerService, PluginsServerConfig } from '~/types'
 import { logger } from '~/utils/logger'
 
 prometheus.collectDefaultMetrics()
+
+export function initializePrometheusLabels(
+    config: Pick<PluginsServerConfig, 'INGESTION_PIPELINE' | 'INGESTION_LANE'>
+): void {
+    const labels: Record<string, string> = {}
+    if (config.INGESTION_PIPELINE) {
+        labels['ingestion_pipeline'] = config.INGESTION_PIPELINE
+    }
+    if (config.INGESTION_LANE) {
+        labels['ingestion_lane'] = config.INGESTION_LANE
+    }
+    if (Object.keys(labels).length > 0) {
+        prometheus.register.setDefaultLabels(labels)
+    }
+}
 
 export interface SetupExpressAppOptions {
     internalApiSecret?: string

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -104,6 +104,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         BASE_DIR: '..',
         TASK_TIMEOUT: 30,
         TASKS_PER_WORKER: 10,
+        INGESTION_PIPELINE: null,
+        INGESTION_LANE: null,
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
         INGESTION_OVERFLOW_ENABLED: false,

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -67,6 +67,8 @@ export type IngestionConsumerHub = HogTransformerHub &
         | 'groupTypeManager'
         // EventSchemaEnforcementManager
         | 'postgres'
+        // Prometheus / TopHog labels
+        | 'INGESTION_PIPELINE'
     >
 
 const latestOffsetTimestampGauge = new Gauge({
@@ -210,8 +212,8 @@ export class IngestionConsumer {
         this.topHog = new TopHog({
             kafkaProducer: this.kafkaProducer!,
             topic: KAFKA_CLICKHOUSE_TOPHOG,
-            pipeline: 'analytics',
-            lane: this.hub.INGESTION_LANE ?? 'main',
+            pipeline: this.hub.INGESTION_PIPELINE ?? 'unknown',
+            lane: this.hub.INGESTION_LANE ?? 'unknown',
         })
         this.topHog.start()
 

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -4,7 +4,7 @@ import * as schedule from 'node-schedule'
 import { Counter } from 'prom-client'
 import express from 'ultimate-express'
 
-import { setupCommonRoutes, setupExpressApp } from './api/router'
+import { initializePrometheusLabels, setupCommonRoutes, setupExpressApp } from './api/router'
 import { getPluginServerCapabilities } from './capabilities'
 import { CdpApi } from './cdp/cdp-api'
 import { CdpBatchHogFlowRequestsConsumer } from './cdp/consumers/cdp-batch-hogflow.consumer'
@@ -94,6 +94,7 @@ export class PluginServer {
         const startupTimer = new Date()
         this.setupListeners()
         this.nodeInstrumentation.setupThreadPerformanceInterval()
+        initializePrometheusLabels(this.config)
 
         const capabilities = getPluginServerCapabilities(this.config)
         const hub = (this.hub = await createHub(this.config))

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -215,7 +215,7 @@ export type IngestionLane = 'main' | 'overflow' | 'historical' | 'async'
 
 export type IngestionConsumerConfig = {
     /** The lane this consumer is processing (e.g. main, overflow, historical, async) */
-    INGESTION_LANE?: IngestionLane
+    INGESTION_LANE: IngestionLane | null
 
     // Kafka consumer config
     INGESTION_CONSUMER_GROUP_ID: string
@@ -476,6 +476,7 @@ export interface PluginsServerConfig
     /** Comma-separated list of capability groups for local dev: cdp_workflows, realtime_cohorts, session_replay, logs, feature_flags */
     NODEJS_CAPABILITY_GROUPS: string | null
     PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE: string | null // TODO: shouldn't be a string probably
+    INGESTION_PIPELINE: string | null
     PLUGIN_LOAD_SEQUENTIALLY: boolean // could help with reducing memory usage spikes on startup
     /** Label of the PostHog Cloud environment. Null if not running PostHog Cloud. @example 'US' */
     CLOUD_DEPLOYMENT: string | null


### PR DESCRIPTION
## Problem

We want to use `INGESTION_PIPELINE` and `INGESTION_LANE` for ingestion metrics.

## Changes

- Wires up both env variables
- Sets up Prometheus default labels if the vars are set
- Sets the labels in tophog

## How did you test this code?

Will monitor on prod.