### PR TITLE
chore: track dropped frames for all sessions

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -16,8 +16,7 @@ const shouldDefer = (): boolean => {
 const shouldTrackFramerate = (loadedInstance: PostHogInterface): boolean => {
     return (
         !!window.POSTHOG_APP_CONTEXT?.preflight?.is_debug ||
-        (!!loadedInstance.getFeatureFlag(FEATURE_FLAGS.TRACK_REACT_FRAMERATE) &&
-            sampleOnProperty(loadedInstance.get_session_id(), 0.5))
+        !!loadedInstance.getFeatureFlag(FEATURE_FLAGS.TRACK_REACT_FRAMERATE)
     )
 }
 


### PR DESCRIPTION
let's track dropped frames for all sessions so we don't accidentally get skewed metrics