### PR TITLE
fix(endpoints): materialized endpoint execution now uses original hogql query limit

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -892,26 +892,32 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             logger.debug("Failed to analyze variables for materialization", exc_info=True)
             return []
 
-    def _get_original_select_columns(self, query: dict, version: EndpointVersion) -> builtins.list[ast.Expr] | None:
-        """Parse the original HogQL query and return SELECT columns as materialized field references.
+    def _parse_original_hogql_query(
+        self, query: dict, version: EndpointVersion
+    ) -> tuple[builtins.list[ast.Expr] | None, int | None]:
+        """Parse the original HogQL query and extract SELECT columns and LIMIT.
 
-        Returns field references for only the original SELECT expressions (not variable columns).
-        Returns None if parsing fails, so the caller can fall back to SELECT *.
+        Returns (select_columns, limit) where either may be None.
+        select_columns are transformed to materialized field references.
         """
         from products.endpoints.backend.materialization import transform_select_for_materialized_table
 
         query_str = query.get("query")
         if not query_str:
-            return None
+            return None, None
 
         try:
             parsed = parse_select(query_str)
-            if isinstance(parsed, ast.SelectQuery) and parsed.select:
-                return transform_select_for_materialized_table(list(parsed.select), self.team)
+            if isinstance(parsed, ast.SelectQuery):
+                columns = (
+                    transform_select_for_materialized_table(list(parsed.select), self.team) if parsed.select else None
+                )
+                limit = parsed.limit.value if isinstance(parsed.limit, ast.Constant) else None
+                return columns, limit
         except Exception:
-            logger.debug("Failed to parse original query for SELECT columns", exc_info=True)
+            logger.debug("Failed to parse original HogQL query", exc_info=True)
 
-        return None
+        return None, None
 
     # Query types that support user-configurable breakdown filtering
     BREAKDOWN_SUPPORTED_QUERY_TYPES = {"TrendsQuery", "FunnelsQuery", "RetentionQuery"}
@@ -1121,9 +1127,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             query_kind = query.get("kind")
 
             select_columns: list[ast.Expr] = [ast.Field(chain=["*"])]
-            if query_kind == "HogQLQuery" and query.get("variables"):
-                original_select = self._get_original_select_columns(query, version)
-                if original_select:
+            original_limit: int | None = None
+            if query_kind == "HogQLQuery":
+                original_select, original_limit = self._parse_original_hogql_query(query, version)
+                if query.get("variables") and original_select:
                     select_columns = original_select
 
             select_query = ast.SelectQuery(
@@ -1131,8 +1138,15 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 select_from=ast.JoinExpr(table=ast.Field(chain=[saved_query.name])),
             )
 
-            if limit is not None:
-                select_query.limit = ast.Constant(value=limit)
+            effective_limit = None
+            if limit is not None and original_limit is not None:
+                effective_limit = min(limit, original_limit)
+            elif limit is not None:
+                effective_limit = limit
+            elif original_limit is not None:
+                effective_limit = original_limit
+            if effective_limit is not None:
+                select_query.limit = ast.Constant(value=effective_limit)
 
             deprecation_headers: dict[str, str] | None = None
 
@@ -1446,7 +1460,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                         {"error": f"Invalid limit parameter: {limit_param}"},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
-        elif limit <= 0:  # Add validation for body limit
+        elif limit <= 0:
             return Response(
                 {"error": f"Invalid limit parameter: {limit}"},
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
default 101 limit is applied to materialized endpoint execution. so even if there are more results, endpoint UX currently does not allow paginating
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- make sure to use the original query's limit (if there is one) when making a request to a materialized endpoint
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- locally and unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
