### PR TITLE
fix: Scope materialization runs state per editor tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -121,21 +121,18 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
 
     const isLineageDependencyViewEnabled = featureFlags[FEATURE_FLAGS.LINEAGE_DEPENDENCY_VIEW]
 
-    const {
-        dataWarehouseSavedQueryMapById,
-        updatingDataWarehouseSavedQuery,
-        initialDataWarehouseSavedQueryLoading,
-        dataModelingJobs,
-        hasMoreJobsToLoad,
-        startingMaterialization,
-    } = useValues(dataWarehouseViewsLogic)
+    const { dataModelingJobs, dataModelingJobsLoading, hasMoreJobsToLoad, startingMaterialization } = useValues(
+        infoTabLogic({ tabId })
+    )
+    const { loadOlderDataModelingJobs, setStartingMaterialization } = useActions(infoTabLogic({ tabId }))
+
+    const { dataWarehouseSavedQueryMapById, updatingDataWarehouseSavedQuery, initialDataWarehouseSavedQueryLoading } =
+        useValues(dataWarehouseViewsLogic)
     const {
         updateDataWarehouseSavedQuery,
-        loadOlderDataModelingJobs,
         cancelDataWarehouseSavedQuery,
         materializeDataWarehouseSavedQuery,
         revertMaterialization,
-        setStartingMaterialization,
     } = useActions(dataWarehouseViewsLogic)
 
     // note: editingView is stale, but dataWarehouseSavedQueryMapById gets updated
@@ -292,7 +289,7 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
                         </div>
                         <LemonTable
                             size="small"
-                            loading={initialDataWarehouseSavedQueryLoading}
+                            loading={dataModelingJobsLoading && !dataModelingJobs?.results?.length}
                             dataSource={dataModelingJobs?.results || []}
                             columns={[
                                 {
@@ -381,7 +378,7 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
                                             center
                                             fullWidth
                                             onClick={() => loadOlderDataModelingJobs()}
-                                            loading={initialDataWarehouseSavedQueryLoading}
+                                            loading={dataModelingJobsLoading}
                                         >
                                             Load older runs
                                         </LemonButton>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
@@ -1,10 +1,18 @@
-import { connect, kea, key, path, props, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
+import api, { PaginatedResponse } from 'lib/api'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
 
+import { DataModelingJob } from '~/types'
+
 import { sqlEditorLogic } from '../sqlEditorLogic'
 import type { infoTabLogicType } from './infoTabLogicType'
+
+const REFRESH_INTERVAL = 10000
+const DEFAULT_JOBS_PAGE_SIZE = 10
 
 export interface InfoTableRow {
     name: string
@@ -25,13 +33,66 @@ export const infoTabLogic = kea<infoTabLogicType>([
     connect((props: InfoTabLogicProps) => ({
         values: [
             sqlEditorLogic({ tabId: props.tabId }),
-            ['metadata'],
+            ['metadata', 'editingView'],
             databaseTableListLogic,
             ['posthogTablesMap', 'dataWarehouseTablesMap'],
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueryMap'],
         ],
     })),
+    actions({
+        setStartingMaterialization: (starting: boolean) => ({ starting }),
+    }),
+    loaders(({ values }) => ({
+        dataModelingJobs: [
+            null as PaginatedResponse<DataModelingJob> | null,
+            {
+                loadDataModelingJobs: async (savedQueryId: string) => {
+                    return await api.dataWarehouseSavedQueries.dataWarehouseDataModelingJobs.list(
+                        savedQueryId,
+                        values.dataModelingJobs?.results.length
+                            ? Math.max(values.dataModelingJobs.results.length, DEFAULT_JOBS_PAGE_SIZE)
+                            : DEFAULT_JOBS_PAGE_SIZE,
+                        0
+                    )
+                },
+                loadOlderDataModelingJobs: async () => {
+                    const nextUrl = values.dataModelingJobs?.next
+
+                    if (!nextUrl) {
+                        return values.dataModelingJobs
+                    }
+
+                    const res = await api.get<PaginatedResponse<DataModelingJob>>(nextUrl)
+                    res.results = [...(values.dataModelingJobs?.results ?? []), ...res.results]
+
+                    return res
+                },
+                resetDataModelingJobs: () => null,
+            },
+        ],
+    })),
+    reducers({
+        startingMaterialization: [
+            false,
+            {
+                setStartingMaterialization: (_, { starting }: { starting: boolean }) => starting,
+                loadDataModelingJobsSuccess: (
+                    state: boolean,
+                    { dataModelingJobs }: { dataModelingJobs: PaginatedResponse<DataModelingJob> | null }
+                ) => {
+                    const currentJobStatus = dataModelingJobs?.results?.[0]?.status
+                    if (
+                        currentJobStatus &&
+                        ['Running', 'Completed', 'Failed', 'Cancelled'].includes(currentJobStatus)
+                    ) {
+                        return false
+                    }
+                    return state
+                },
+            },
+        ],
+    }),
     selectors({
         sourceTableItems: [
             (s) => [s.metadata, s.dataWarehouseSavedQueryMap],
@@ -62,5 +123,27 @@ export const infoTabLogic = kea<infoTabLogicType>([
                 )
             },
         ],
+        hasMoreJobsToLoad: [(s) => [s.dataModelingJobs], (dataModelingJobs) => !!dataModelingJobs?.next],
     }),
+    listeners(({ actions, cache }) => ({
+        loadDataModelingJobsSuccess: ({ payload }) => {
+            cache.disposables.add(() => {
+                const timeoutId = setTimeout(() => {
+                    if (payload) {
+                        actions.loadDataModelingJobs(payload)
+                    }
+                }, REFRESH_INTERVAL)
+                return () => clearTimeout(timeoutId)
+            }, 'dataModelingJobsRefreshTimeout')
+        },
+    })),
+    subscriptions(({ actions, values }) => ({
+        editingView: (editingView) => {
+            if (editingView) {
+                if (values.dataModelingJobs === null) {
+                    actions.loadDataModelingJobs(editingView.id)
+                }
+            }
+        },
+    })),
 ])

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
@@ -68,7 +68,6 @@ export const infoTabLogic = kea<infoTabLogicType>([
 
                     return res
                 },
-                resetDataModelingJobs: () => null,
             },
         ],
     })),

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -139,7 +139,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
     path(['data-warehouse', 'editor', 'sqlEditorLogic']),
     props({ mode: SQLEditorMode.FullScene } as SqlEditorLogicProps),
     tabAwareScene(),
-    connect((props: SqlEditorLogicProps) => ({
+    connect(() => ({
         values: [
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueries', 'dataWarehouseSavedQueryMapById'],
@@ -158,8 +158,6 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 'createDataWarehouseSavedQuerySuccess',
                 'runDataWarehouseSavedQuery',
                 'materializeDataWarehouseSavedQuery',
-                'resetDataModelingJobs',
-                'loadDataModelingJobs',
                 'updateDataWarehouseSavedQuerySuccess',
                 'updateDataWarehouseSavedQueryFailure',
                 'updateDataWarehouseSavedQuery',
@@ -1050,8 +1048,6 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         },
         editingView: (editingView) => {
             if (editingView) {
-                actions.resetDataModelingJobs()
-                actions.loadDataModelingJobs(editingView.id)
                 actions.loadUpstream(editingView.id)
             }
         },

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -139,7 +139,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
     path(['data-warehouse', 'editor', 'sqlEditorLogic']),
     props({ mode: SQLEditorMode.FullScene } as SqlEditorLogicProps),
     tabAwareScene(),
-    connect(() => ({
+    connect((props: SqlEditorLogicProps) => ({
         values: [
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueries', 'dataWarehouseSavedQueryMapById'],


### PR DESCRIPTION
## Problem

I noticed that materialization run info was bleeding across tabs because the logic was global, rather than being scoped per tab.

## Changes

Scope dataModellingJobs per logic, rather than globally.

## How did you test this code?

Verified locally that materialization info is correctly scoped per tab.