### PR TITLE
chore(err): quick cymbal fixes

### DIFF
--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -93,6 +93,9 @@ pub struct Config {
     #[envconfig(default = "symbolsets")]
     pub ss_prefix: String,
 
+    #[envconfig(default = "600")]
+    pub issue_cache_ttl_seconds: u64,
+
     #[envconfig(default = "100000")]
     pub frame_cache_size: u64,
 

--- a/rust/cymbal/src/stages/linking/issue.rs
+++ b/rust/cymbal/src/stages/linking/issue.rs
@@ -150,7 +150,7 @@ async fn resolve_issue(
     if !was_created {
         txn.rollback().await?;
         // Replace the attempt issue with the existing one
-        issue = Issue::load(&mut *conn, team_id, issue_override.id)
+        issue = Issue::load(&mut *conn, team_id, issue_override.issue_id)
             .await?
             .unwrap_or(issue);
 

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -46,7 +46,9 @@ impl Stage for LinkingStage {
 impl From<&Arc<AppContext>> for LinkingStage {
     fn from(ctx: &Arc<AppContext>) -> Self {
         let issue_cache = CacheBuilder::new(1000)
-            .time_to_live(std::time::Duration::from_secs(ctx.config.issue_cache_ttl_seconds))
+            .time_to_live(std::time::Duration::from_secs(
+                ctx.config.issue_cache_ttl_seconds,
+            ))
             .build();
         Self {
             app_context: ctx.clone(),

--- a/rust/cymbal/src/stages/linking/mod.rs
+++ b/rust/cymbal/src/stages/linking/mod.rs
@@ -45,7 +45,9 @@ impl Stage for LinkingStage {
 
 impl From<&Arc<AppContext>> for LinkingStage {
     fn from(ctx: &Arc<AppContext>) -> Self {
-        let issue_cache = CacheBuilder::new(1000).build();
+        let issue_cache = CacheBuilder::new(1000)
+            .time_to_live(std::time::Duration::from_secs(ctx.config.issue_cache_ttl_seconds))
+            .build();
         Self {
             app_context: ctx.clone(),
             issue_cache,

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -97,11 +97,13 @@ impl LocalSymbolResolver {
         assert!(!resolved.is_empty()); // If this ever happens, we've got a data-dropping bug, and want to crash
 
         let (set, release) = if let Some(set_ref) = frame.symbol_set_ref() {
-            let (set, release) = tokio::try_join!(
-                SymbolSetRecord::load(&self.pool, raw_id.team_id, &set_ref),
-                ReleaseRecord::for_symbol_set_ref(&self.pool, &set_ref, raw_id.team_id),
-            )?;
-            (set, release)
+            let set_fut = SymbolSetRecord::load(&self.pool, raw_id.team_id, &set_ref);
+            let release_fut = async {
+                ReleaseRecord::for_symbol_set_ref(&self.pool, &set_ref, raw_id.team_id)
+                    .await
+                    .map_err(UnhandledError::from)
+            };
+            tokio::try_join!(set_fut, release_fut)?
         } else {
             (None, None)
         };

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -97,17 +97,17 @@ impl LocalSymbolResolver {
         assert!(!resolved.is_empty()); // If this ever happens, we've got a data-dropping bug, and want to crash
 
         let (set, release) = if let Some(set_ref) = frame.symbol_set_ref() {
-            // TODO - should be a join
-            (
-                SymbolSetRecord::load(&self.pool, raw_id.team_id, &set_ref).await?,
-                ReleaseRecord::for_symbol_set_ref(&self.pool, &set_ref, raw_id.team_id).await?,
-            )
+            let (set, release) = tokio::try_join!(
+                SymbolSetRecord::load(&self.pool, raw_id.team_id, &set_ref),
+                ReleaseRecord::for_symbol_set_ref(&self.pool, &set_ref, raw_id.team_id),
+            )?;
+            (set, release)
         } else {
             (None, None)
         };
 
         let mut records = Vec::new();
-        let mut resolved = resolved.clone();
+        let mut resolved = resolved;
         for r_frame in resolved.iter_mut() {
             r_frame.release = release.clone(); // Enrich with release information
 

--- a/rust/cymbal/src/symbol_store/concurrency.rs
+++ b/rust/cymbal/src/symbol_store/concurrency.rs
@@ -38,6 +38,7 @@ impl<P> AtMostOne<P> {
     pub async fn acquire(&self, key: impl ToString) -> OwnedMutexGuard<()> {
         let key = key.to_string();
         let mut state = self.limiters.lock().await;
+        state.retain(|_, v| v.strong_count() > 0);
         let limiter = state.entry(key).or_default();
 
         if let Some(lock) = limiter.upgrade() {


### PR DESCRIPTION
## Changes

- add issue cache ttl to take suppression that happens on the UI
- fetch symbol set and record in parallel
- fix memory leak on AtMostOne cache