### PR TITLE
fix: add edit mode URL parameter to feature flag editor

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { useState } from 'react'
 
 import { IconLock, IconPlusSmall, IconTrash } from '@posthog/icons'
@@ -54,7 +54,6 @@ import { BulkDeleteResultsModal } from './BulkDeleteResultsModal'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
 import { FeatureFlagFiltersSection } from './FeatureFlagFilters'
 import { OverlayForNewFeatureFlagMenu } from './NewFeatureFlagMenu'
-import { featureFlagLogic } from './featureFlagLogic'
 import { FLAGS_PER_PAGE, FeatureFlagsTab, featureFlagsLogic } from './featureFlagsLogic'
 import { flagSelectionLogic } from './flagSelectionLogic'
 
@@ -238,13 +237,7 @@ function FeatureFlagRowActions({ featureFlag }: { featureFlag: FeatureFlagType }
                                             ? "You don't have permission to edit this feature flag."
                                             : null
                                     }
-                                    onClick={() => {
-                                        if (featureFlag.id) {
-                                            featureFlagLogic({ id: featureFlag.id }).mount()
-                                            featureFlagLogic({ id: featureFlag.id }).actions.editFeatureFlag(true)
-                                            router.actions.push(urls.featureFlag(featureFlag.id))
-                                        }
-                                    }}
+                                    to={combineUrl(urls.featureFlag(featureFlag.id), { edit: true }).url}
                                 >
                                     Edit
                                 </LemonButton>

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1862,8 +1862,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             // If the URL was pushed (user clicked on a link), reset the scene's data.
             // This avoids resetting form fields if you click back/forward.
             if (method === 'PUSH') {
-                // Reset editing state when navigating to prevent it from persisting across flags
-                actions.editFeatureFlag(false)
+                // Set editing state based on URL parameter, or reset to prevent persisting across flags
+                actions.editFeatureFlag(searchParams.edit === true || searchParams.edit === 'true')
 
                 if (props.id) {
                     // When there is sourceId, we load the feature flag (for duplicating)


### PR DESCRIPTION
## Problem

When editing a feature flag, the edit state was managed entirely through component logic that would mount and trigger actions. This approach doesn't persist the editing state when navigating directly via URL, making it impossible to link directly to a feature flag in edit mode.

## Changes

- Import `combineUrl` from `kea-router` to construct URLs with query parameters
- Replace the onClick handler in the Edit button with a `to` prop that navigates to the feature flag URL with `edit=true` query parameter
- Remove the manual logic mounting and action dispatching from the Edit button click handler
- Update `featureFlagLogic` to read the `edit` URL parameter and set the editing state accordingly when navigating via PUSH (link click)
- Remove the unused `featureFlagLogic` import from FeatureFlags.tsx

This allows the edit mode to be:
1. Triggered by clicking the Edit button (via URL parameter)
2. Preserved when navigating directly to a feature flag with `?edit=true`
3. Reset when navigating to a feature flag without the parameter

https://claude.ai/code/session_0139qXjLHAPYupZ5KvwFNPx7