### PR TITLE
feat(posthog-ai): Add capturing of dashboard/insight creation events from posthog ai

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -25,7 +25,7 @@ from posthog.schema import (
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.models.dashboard_tile import Text
 
-from ee.hogai.artifacts.types import ModelArtifactResult, StateArtifactResult
+from ee.hogai.artifacts.types import ModelArtifactResult, StateArtifactResult, VisualizationWithSourceResult
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.tool_errors import MaxToolAccessDeniedError, MaxToolFatalError, MaxToolRetryableError
@@ -931,10 +931,9 @@ class TestUpsertDashboardTool(BaseTest):
             name="New Insight",
             description="From state",
         )
-        state_result = StateArtifactResult(content=state_content)
+        state_result: VisualizationWithSourceResult = StateArtifactResult(content=state_content)
 
         tool = self._create_tool()
-        tool._context_manager.artifacts.aget_visualizations = AsyncMock(return_value=[state_result])
 
         action = CreateDashboardToolArgs(
             insight_ids=["state-id"],
@@ -942,7 +941,10 @@ class TestUpsertDashboardTool(BaseTest):
             description="Test",
         )
 
-        await tool._arun_impl(action)
+        with patch.object(
+            tool._context_manager.artifacts, "aget_visualizations", new=AsyncMock(return_value=[state_result])
+        ):
+            await tool._arun_impl(action)
 
         insight_created_calls = [c for c in mock_report.call_args_list if c[0][1] == "insight created"]
         self.assertEqual(len(insight_created_calls), 1)

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -25,7 +25,7 @@ from posthog.schema import (
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.models.dashboard_tile import Text
 
-from ee.hogai.artifacts.types import ModelArtifactResult
+from ee.hogai.artifacts.types import ModelArtifactResult, StateArtifactResult
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.tool_errors import MaxToolAccessDeniedError, MaxToolFatalError, MaxToolRetryableError
@@ -885,6 +885,85 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertEqual(text_tiles[0].text_id, text.id)
         self.assertEqual(len(insight_tiles), 1)
         self.assertEqual(insight_tiles[0].insight_id, new_insight.id)
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_reports_dashboard_created(self, mock_report):
+        insight = await self._create_insight("Test Insight")
+        tool = self._create_tool()
+
+        action = CreateDashboardToolArgs(
+            insight_ids=[insight.short_id],
+            name="Reported Dashboard",
+            description="Test",
+        )
+
+        await tool._arun_impl(action)
+
+        dashboard_created_calls = [c for c in mock_report.call_args_list if c[0][1] == "dashboard created"]
+        self.assertEqual(len(dashboard_created_calls), 1)
+        self.assertEqual(dashboard_created_calls[0][0][0], self.user)
+        self.assertEqual(dashboard_created_calls[0][0][2]["source"], "posthog_ai")
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_update_dashboard_reports_dashboard_updated(self, mock_report):
+        dashboard = await Dashboard.objects.acreate(team=self.team, name="Existing", created_by=self.user)
+        insight = await self._create_insight("Test Insight")
+        await DashboardTile.objects.acreate(dashboard=dashboard, insight=insight, layouts={})
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            name="Updated",
+        )
+
+        await tool._arun_impl(action)
+
+        dashboard_updated_calls = [c for c in mock_report.call_args_list if c[0][1] == "dashboard updated"]
+        self.assertEqual(len(dashboard_updated_calls), 1)
+        self.assertEqual(dashboard_updated_calls[0][0][0], self.user)
+        self.assertEqual(dashboard_updated_calls[0][0][2]["source"], "posthog_ai")
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_reports_insight_created_for_new_insights(self, mock_report):
+        state_query = TrendsQuery(series=[EventsNode(name="$pageview")])
+        state_content = VisualizationArtifactContent(
+            query=state_query,
+            name="New Insight",
+            description="From state",
+        )
+        state_result = StateArtifactResult(content=state_content)
+
+        tool = self._create_tool()
+        tool._context_manager.artifacts.aget_visualizations = AsyncMock(return_value=[state_result])
+
+        action = CreateDashboardToolArgs(
+            insight_ids=["state-id"],
+            name="Dashboard with New Insights",
+            description="Test",
+        )
+
+        await tool._arun_impl(action)
+
+        insight_created_calls = [c for c in mock_report.call_args_list if c[0][1] == "insight created"]
+        self.assertEqual(len(insight_created_calls), 1)
+        self.assertEqual(insight_created_calls[0][0][2]["source"], "posthog_ai")
+        self.assertIn("insight_id", insight_created_calls[0][0][2])
+
+    @patch("ee.hogai.tools.upsert_dashboard.tool.report_user_action")
+    async def test_create_dashboard_does_not_report_insight_created_for_existing_insights(self, mock_report):
+        insight = await self._create_insight("Existing Insight")
+        tool = self._create_tool()
+
+        action = CreateDashboardToolArgs(
+            insight_ids=[insight.short_id],
+            name="Dashboard with Existing",
+            description="Test",
+        )
+
+        await tool._arun_impl(action)
+
+        insight_created_calls = [c for c in mock_report.call_args_list if c[0][1] == "insight created"]
+        self.assertEqual(len(insight_created_calls), 0)
 
 
 class TestGetDashboardAndSortedTiles(BaseTest):

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import DataTableNode, HogQLQuery, InsightVizNode, QuerySchemaRoot
 
+from posthog.event_usage import report_user_action
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.sync import database_sync_to_async
 from posthog.utils import pluralize
@@ -150,6 +151,8 @@ class UpsertDashboardTool(MaxTool):
             return CREATE_NO_INSIGHTS_PROMPT, None
 
         dashboard = await self._create_dashboard_with_tiles(action.name, action.description, insights)
+        await self._report_dashboard_action(dashboard, "dashboard created")
+        await self._report_new_insights(artifacts, insights)
         output = await self._format_dashboard_output(dashboard, insights)
 
         return output, {"dashboard_id": dashboard.id}
@@ -171,10 +174,15 @@ class UpsertDashboardTool(MaxTool):
             insight_ids,
             artifacts,
         )
+        await self._report_dashboard_action(dashboard, "dashboard updated")
 
         # Re-fetch sorted tiles to get the latest state
         sorted_tiles = await self._get_dashboard_sorted_tiles(dashboard)
         insights = [tile.insight for tile in sorted_tiles if tile.insight is not None]
+
+        if artifacts:
+            await self._report_new_insights(artifacts, insights)
+
         output = await self._format_dashboard_output(dashboard, insights)
 
         return output, {"dashboard_id": dashboard.id}
@@ -212,6 +220,32 @@ class UpsertDashboardTool(MaxTool):
                 resolved.append(insight)
 
         return resolved
+
+    async def _report_dashboard_action(self, dashboard: Dashboard, event: str) -> None:
+        await database_sync_to_async(report_user_action)(
+            self._user,
+            event,
+            {
+                **await database_sync_to_async(dashboard.get_analytics_metadata)(),
+                "source": "posthog_ai",
+            },
+            team=self._team,
+        )
+
+    async def _report_new_insights(
+        self, artifacts: list[VisualizationWithSourceResult], insights: list[Insight]
+    ) -> None:
+        for artifact, insight in zip(artifacts, insights):
+            if not isinstance(artifact, ModelArtifactResult):
+                await database_sync_to_async(report_user_action)(
+                    self._user,
+                    "insight created",
+                    {
+                        "insight_id": insight.short_id,
+                        "source": "posthog_ai",
+                    },
+                    team=self._team,
+                )
 
     def _create_resolved_insights(self, results: list[Insight]) -> list[Insight]:
         """

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -145,14 +145,15 @@ class UpsertDashboardTool(MaxTool):
         if missing_ids:
             raise MaxToolRetryableError(format_prompt_string(MISSING_INSIGHT_IDS_PROMPT, missing_ids=missing_ids))
 
-        insights = self._resolve_insights(cast(list[VisualizationWithSourceResult], artifacts))
+        validated_artifacts = cast(list[VisualizationWithSourceResult], artifacts)
+        insights = self._resolve_insights(validated_artifacts)
 
         if not insights:
             return CREATE_NO_INSIGHTS_PROMPT, None
 
         dashboard = await self._create_dashboard_with_tiles(action.name, action.description, insights)
         await self._report_dashboard_action(dashboard, "dashboard created")
-        await self._report_new_insights(artifacts, insights)
+        await self._report_new_insights(validated_artifacts, insights)
         output = await self._format_dashboard_output(dashboard, insights)
 
         return output, {"dashboard_id": dashboard.id}
@@ -167,7 +168,7 @@ class UpsertDashboardTool(MaxTool):
         insight_ids = action.insight_ids or []
         artifacts = await self._get_visualization_artifacts(insight_ids) if insight_ids else []
 
-        dashboard = await self._update_dashboard_with_tiles(
+        dashboard, resolved_insights = await self._update_dashboard_with_tiles(
             dashboard,
             action.name,
             action.description,
@@ -176,12 +177,12 @@ class UpsertDashboardTool(MaxTool):
         )
         await self._report_dashboard_action(dashboard, "dashboard updated")
 
+        if artifacts:
+            await self._report_new_insights(cast(list[VisualizationWithSourceResult], artifacts), resolved_insights)
+
         # Re-fetch sorted tiles to get the latest state
         sorted_tiles = await self._get_dashboard_sorted_tiles(dashboard)
         insights = [tile.insight for tile in sorted_tiles if tile.insight is not None]
-
-        if artifacts:
-            await self._report_new_insights(artifacts, insights)
 
         output = await self._format_dashboard_output(dashboard, insights)
 
@@ -282,7 +283,7 @@ class UpsertDashboardTool(MaxTool):
         description: str | None,
         insight_ids: list[str],
         artifacts: list[VisualizationWithSourceResult],
-    ) -> Dashboard:
+    ) -> tuple[Dashboard, list[Insight]]:
         """Update dashboard tiles based on provided insight IDs.
 
         Args:
@@ -291,6 +292,10 @@ class UpsertDashboardTool(MaxTool):
             description: New dashboard description (if provided)
             insight_ids: Ordered list of insight IDs for the dashboard
             artifacts: Resolved visualization artifacts matching insight_ids order
+
+        Returns:
+            Tuple of (dashboard, resolved_insights) where resolved_insights
+            corresponds 1:1 with artifacts in the same order.
         """
         if name is not None:
             dashboard.name = name
@@ -300,7 +305,7 @@ class UpsertDashboardTool(MaxTool):
             dashboard.save(update_fields=["name", "description"])
 
         if not insight_ids:
-            return dashboard
+            return dashboard, []
 
         # 1. Get all existing tiles including soft deleted
         all_tiles = list(
@@ -385,7 +390,7 @@ class UpsertDashboardTool(MaxTool):
             tile.save(update_fields=["layouts", "deleted"])
             xs_y += 5
 
-        return dashboard
+        return dashboard, resolved_insights
 
     async def _format_dashboard_output(
         self,

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import DataTableNode, HogQLQuery, InsightVizNode, QuerySchemaRoot
 
-from posthog.event_usage import report_user_action
+from posthog.event_usage import EventSource, report_user_action
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.sync import database_sync_to_async
 from posthog.utils import pluralize
@@ -228,7 +228,7 @@ class UpsertDashboardTool(MaxTool):
             event,
             {
                 **await database_sync_to_async(dashboard.get_analytics_metadata)(),
-                "source": "posthog_ai",
+                "source": EventSource.POSTHOG_AI,
             },
             team=self._team,
         )
@@ -243,7 +243,7 @@ class UpsertDashboardTool(MaxTool):
                     "insight created",
                     {
                         "insight_id": insight.short_id,
-                        "source": "posthog_ai",
+                        "source": EventSource.POSTHOG_AI,
                     },
                     team=self._team,
                 )

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -37,7 +37,7 @@ from posthog.approvals.mixins import ApprovalHandlingMixin
 from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, TemporaryTokenAuthentication
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX, FlagRequestType
 from posthog.date_util import thirty_days_ago
-from posthog.event_usage import get_event_source, report_user_action
+from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.exceptions import Conflict
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.dashboard_templates import add_enriched_insights_to_feature_flag_dashboard
@@ -1047,7 +1047,7 @@ class FeatureFlagSerializer(
 
         analytics_metadata = instance.get_analytics_metadata()
         analytics_metadata["creation_context"] = creation_context
-        analytics_metadata["source"] = get_event_source(request)
+        analytics_metadata.update(get_request_analytics_properties(request))
         report_user_action(request.user, "feature flag created", analytics_metadata)
 
         return instance
@@ -1211,7 +1211,11 @@ class FeatureFlagSerializer(
         if old_key != instance.key:
             _update_feature_flag_dashboard(instance, old_key)
 
-        report_user_action(request.user, "feature flag updated", instance.get_analytics_metadata())
+        report_user_action(
+            request.user,
+            "feature flag updated",
+            {**instance.get_analytics_metadata(), **get_request_analytics_properties(request)},
+        )
 
         # If flag is using encrypted payloads, replace them with redacted string or unencrypted value
         # if the request was made with a personal API key

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -34,15 +34,10 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSet
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, action
 from posthog.approvals.decorators import approval_gate
 from posthog.approvals.mixins import ApprovalHandlingMixin
-from posthog.auth import (
-    PersonalAPIKeyAuthentication,
-    ProjectSecretAPIKeyAuthentication,
-    SessionAuthentication,
-    TemporaryTokenAuthentication,
-)
+from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, TemporaryTokenAuthentication
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX, FlagRequestType
 from posthog.date_util import thirty_days_ago
-from posthog.event_usage import report_user_action
+from posthog.event_usage import get_event_source, report_user_action
 from posthog.exceptions import Conflict
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.dashboard_templates import add_enriched_insights_to_feature_flag_dashboard
@@ -1052,11 +1047,7 @@ class FeatureFlagSerializer(
 
         analytics_metadata = instance.get_analytics_metadata()
         analytics_metadata["creation_context"] = creation_context
-        # SessionAuthentication is used for standard browser-based web UI requests.
-        # All other authentication methods (API keys, OAuth tokens, toolbar tokens, etc.)
-        # are classified as "api" for analytics purposes.
-        is_web_auth = isinstance(request.successful_authenticator, SessionAuthentication)
-        analytics_metadata["source"] = "web" if is_web_auth else "api"
+        analytics_metadata["source"] = get_event_source(request)
         report_user_action(request.user, "feature flag created", analytics_metadata)
 
         return instance

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -878,8 +878,10 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 "is_shared": False,
                 "item_count": 6,
                 "pinned": False,
+                "source": "web",
                 "tags_count": 0,
                 "template_key": "DEFAULT_APP",
+                "was_impersonated": False,
             },
         )
 
@@ -1558,8 +1560,10 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 "is_shared": False,
                 "item_count": 1,
                 "pinned": False,
+                "source": "web",
                 "tags_count": 0,
                 "template_key": valid_template["template_name"],
+                "was_impersonated": False,
             },
         )
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -528,6 +528,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "payload_count": 0,
                 "creation_context": "feature_flags",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -564,6 +567,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "payload_count": 0,
                 "creation_context": "feature_flags",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -622,6 +628,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "payload_count": 0,
                 "creation_context": "feature_flags",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -659,6 +668,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "payload_count": 0,
                 "creation_context": "feature_flags",
                 "source": "api",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -854,6 +866,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "payload_count": 0,
                 "creation_context": "feature_flags",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -1155,6 +1170,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "created_at": datetime.fromisoformat("2021-08-25T22:09:14.252000+00:00"),
                 "aggregating_by_groups": False,
                 "payload_count": 0,
+                "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 
@@ -1893,6 +1912,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "created_at": datetime.fromisoformat("2021-08-25T22:09:14.252000+00:00"),
                 "aggregating_by_groups": False,
                 "payload_count": 0,
+                "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -202,6 +202,8 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     "insight_id": response_1.json()["short_id"],
                     "$current_url": "https://posthog.com/my-referer",
                     "$session_id": "my-session-id",
+                    "source": "web",
+                    "was_impersonated": False,
                 },
                 groups=ANY,
             )
@@ -237,6 +239,8 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     "insight_id": insight_short_id,
                     "$current_url": "https://posthog.com/my-referer",
                     "$session_id": "my-session-id",
+                    "source": "web",
+                    "was_impersonated": False,
                 },
                 groups=ANY,
             )

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -123,6 +123,9 @@ class TestSurvey(APIBaseTest):
                 "payload_count": 0,
                 "creation_context": "surveys",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -73,6 +73,9 @@ class TestWebExperiment(APIBaseTest):
                 "payload_count": 0,
                 "creation_context": "web_experiments",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -2,6 +2,7 @@
 Module to centralize event reporting on the server-side.
 """
 
+from enum import StrEnum
 from typing import Optional
 
 import posthoganalytics
@@ -258,16 +259,24 @@ def report_user_organization_membership_level_changed(
     )
 
 
-def get_event_source(request) -> str:
+class EventSource(StrEnum):
+    WEB = "web"
+    API = "api"
+    POSTHOG_AI = "posthog_ai"
+    TERRAFORM = "terraform"
+    MCP = "mcp"
+
+
+def get_event_source(request) -> EventSource:
     """Determine the source of an API request for analytics."""
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     if "posthog/terraform-provider" in user_agent:
-        return "terraform"
+        return EventSource.TERRAFORM
     if "posthog/mcp-server" in user_agent:
-        return "mcp"
+        return EventSource.MCP
     if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):
-        return "web"
-    return "api"
+        return EventSource.WEB
+    return EventSource.API
 
 
 def get_request_analytics_properties(request) -> dict[str, str | bool | None]:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -5,6 +5,7 @@ Module to centralize event reporting on the server-side.
 from typing import Optional
 
 import posthoganalytics
+from rest_framework.authentication import SessionAuthentication
 
 from posthog.models import Organization, User
 from posthog.models.activity_logging.model_activity import is_impersonated_session
@@ -259,8 +260,6 @@ def report_user_organization_membership_level_changed(
 
 def get_event_source(request) -> str:
     """Determine the source of an API request for analytics."""
-    from rest_framework.authentication import SessionAuthentication
-
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     if "posthog/terraform-provider" in user_agent:
         return "terraform"

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -256,6 +256,18 @@ def report_user_organization_membership_level_changed(
     )
 
 
+def get_event_source(request) -> str:
+    """Determine the source of an API request for analytics."""
+    from rest_framework.authentication import SessionAuthentication
+
+    user_agent = request.META.get("HTTP_USER_AGENT", "")
+    if "posthog/terraform-provider" in user_agent:
+        return "terraform"
+    if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):
+        return "web"
+    return "api"
+
+
 def report_user_action(user: User, event: str, properties: Optional[dict] = None, team: Optional[Team] = None):
     if not user.distinct_id:
         return

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -7,6 +7,7 @@ from typing import Optional
 import posthoganalytics
 
 from posthog.models import Organization, User
+from posthog.models.activity_logging.model_activity import is_impersonated_session
 from posthog.models.team import Team
 from posthog.settings import SITE_URL
 from posthog.utils import get_instance_realm
@@ -266,6 +267,16 @@ def get_event_source(request) -> str:
     if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):
         return "web"
     return "api"
+
+
+def get_request_analytics_properties(request) -> dict[str, str | bool | None]:
+    """Extract standard analytics properties from a request."""
+    return {
+        "source": get_event_source(request),
+        "$current_url": request.headers.get("Referer"),
+        "$session_id": request.headers.get("X-Posthog-Session-Id"),
+        "was_impersonated": is_impersonated_session(request),
+    }
 
 
 def report_user_action(user: User, event: str, properties: Optional[dict] = None, team: Optional[Team] = None):

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -263,6 +263,8 @@ def get_event_source(request) -> str:
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     if "posthog/terraform-provider" in user_agent:
         return "terraform"
+    if "posthog/mcp-server" in user_agent:
+        return "mcp"
     if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):
         return "web"
     return "api"

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -653,6 +653,9 @@ class TestEarlyAccessFeature(APIBaseTest):
                 "payload_count": 0,
                 "creation_context": "early_access_features",
                 "source": "web",
+                "$current_url": None,
+                "$session_id": None,
+                "was_impersonated": False,
             },
         )
 

--- a/products/feature_flags/backend/max_tools.py
+++ b/products/feature_flags/backend/max_tools.py
@@ -251,6 +251,8 @@ class CreateFeatureFlagTool(MaxTool):
                 successful_authenticator=None,
                 session={},
                 data=serializer_data,
+                META={},
+                headers={},
             )
             team = self._team
             context = {

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -114,6 +114,9 @@ class TestGetSandboxImageReferenceIntegration:
     def setup_method(self):
         _get_sandbox_image_reference.cache_clear()
 
+    @pytest.mark.xfail(
+        reason="Flaky: depends on GHCR availability. Remove this mark when we've figured out a less flaky approach"
+    )
     def test_resolves_digest_from_ghcr(self):
         result = _get_sandbox_image_reference()
 

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -145,6 +145,7 @@ export class ApiClient {
         return {
             Authorization: `Bearer ${this.config.apiToken}`,
             'Content-Type': 'application/json',
+            'User-Agent': 'posthog/mcp-server',
         }
     }
 

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { USER_AGENT } from '@/lib/constants'
 import { ErrorCode } from '@/lib/errors'
 import { getSearchParamsFromRecord } from '@/lib/utils.js'
 import {
@@ -56,7 +57,6 @@ import { type Project, ProjectSchema } from '@/schema/projects'
 import type { ExperimentCreateSchema } from '@/schema/tool-inputs'
 import { isShortId } from '@/tools/insights/utils'
 
-import packageJson from '../../package.json'
 import type { ActionResponse, CreateActionInput, ListActionsInput, UpdateActionInput } from '../schema/actions.js'
 import { ActionResponseSchema } from '../schema/actions.js'
 import type {
@@ -146,7 +146,7 @@ export class ApiClient {
         return {
             Authorization: `Bearer ${this.config.apiToken}`,
             'Content-Type': 'application/json',
-            'User-Agent': `posthog/mcp-server; version: ${packageJson.version}`,
+            'User-Agent': USER_AGENT,
         }
     }
 

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -56,6 +56,7 @@ import { type Project, ProjectSchema } from '@/schema/projects'
 import type { ExperimentCreateSchema } from '@/schema/tool-inputs'
 import { isShortId } from '@/tools/insights/utils'
 
+import packageJson from '../../package.json'
 import type { ActionResponse, CreateActionInput, ListActionsInput, UpdateActionInput } from '../schema/actions.js'
 import { ActionResponseSchema } from '../schema/actions.js'
 import type {
@@ -145,7 +146,7 @@ export class ApiClient {
         return {
             Authorization: `Bearer ${this.config.apiToken}`,
             'Content-Type': 'application/json',
-            'User-Agent': 'posthog/mcp-server',
+            'User-Agent': `posthog/mcp-server; version: ${packageJson.version}`,
         }
     }
 

--- a/services/mcp/src/api/fetcher.ts
+++ b/services/mcp/src/api/fetcher.ts
@@ -1,4 +1,5 @@
-import packageJson from '../../package.json'
+import { USER_AGENT } from '@/lib/constants'
+
 import type { ApiConfig } from './client'
 import type { createApiClient } from './generated'
 import { globalRateLimiter } from './rate-limiter'
@@ -17,7 +18,7 @@ export const buildApiFetcher: (config: ApiConfig) => Parameters<typeof createApi
 
                 const headers = new Headers()
                 headers.set('Authorization', `Bearer ${config.apiToken}`)
-                headers.set('User-Agent', `posthog/mcp-server; version: ${packageJson.version}`)
+                headers.set('User-Agent', USER_AGENT)
 
                 // Handle query parameters
                 if (input.urlSearchParams) {

--- a/services/mcp/src/api/fetcher.ts
+++ b/services/mcp/src/api/fetcher.ts
@@ -1,3 +1,4 @@
+import packageJson from '../../package.json'
 import type { ApiConfig } from './client'
 import type { createApiClient } from './generated'
 import { globalRateLimiter } from './rate-limiter'
@@ -16,7 +17,7 @@ export const buildApiFetcher: (config: ApiConfig) => Parameters<typeof createApi
 
                 const headers = new Headers()
                 headers.set('Authorization', `Bearer ${config.apiToken}`)
-                headers.set('User-Agent', 'posthog/mcp-server')
+                headers.set('User-Agent', `posthog/mcp-server; version: ${packageJson.version}`)
 
                 // Handle query parameters
                 if (input.urlSearchParams) {

--- a/services/mcp/src/api/fetcher.ts
+++ b/services/mcp/src/api/fetcher.ts
@@ -16,6 +16,7 @@ export const buildApiFetcher: (config: ApiConfig) => Parameters<typeof createApi
 
                 const headers = new Headers()
                 headers.set('Authorization', `Bearer ${config.apiToken}`)
+                headers.set('User-Agent', 'posthog/mcp-server')
 
                 // Handle query parameters
                 if (input.urlSearchParams) {

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -2,6 +2,10 @@ import { env } from 'cloudflare:workers'
 
 import type { CloudRegion } from '@/tools/types'
 
+import packageJson from '../../package.json'
+
+export const USER_AGENT = `posthog/mcp-server; version: ${packageJson.version}`
+
 // Region-specific PostHog API base URLs
 export const POSTHOG_US_BASE_URL = 'https://us.posthog.com'
 export const POSTHOG_EU_BASE_URL = 'https://eu.posthog.com'

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -33,6 +33,7 @@ describe('ApiClient', () => {
         expect(headers).toEqual({
             Authorization: 'Bearer test-token-123',
             'Content-Type': 'application/json',
+            'User-Agent': expect.stringMatching(/^posthog\/mcp-server; version: \d+\.\d+\.\d+$/),
         })
     })
 })

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { ApiClient } from '@/api/client'
+import { USER_AGENT } from '@/lib/constants'
 
 describe('ApiClient', () => {
     it('should create ApiClient with required config', () => {
@@ -33,7 +34,7 @@ describe('ApiClient', () => {
         expect(headers).toEqual({
             Authorization: 'Bearer test-token-123',
             'Content-Type': 'application/json',
-            'User-Agent': expect.stringMatching(/^posthog\/mcp-server; version: \d+\.\d+\.\d+$/),
+            'User-Agent': USER_AGENT,
         })
     })
 })


### PR DESCRIPTION
## Problem

Posthog-ai was bypassing `report_user_action()`, which meant we were not getting e.g. `dashboard created` events.

## Changes

I went down a bit of a rabbit-hole.

This PR adds these events to the posthog AI tool calls. It also pulls some feature-flag-specific logic into a shared utility, so that we can detect the difference between web and API traffic. I've also made it able to detect terraform traffic too.

I created `get_request_analytics_properties` which includes the properties can be pulled out of the request, so we can re-use it across the app.

I also made sure that the MCP uses a specific user agent, so that we can detect when insights are created from that, instead.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
