### PR TITLE
chore(session-replay): make parse step team aware

### DIFF
--- a/nodejs/src/ingestion/session_replay/team-filter-step.ts
+++ b/nodejs/src/ingestion/session_replay/team-filter-step.ts
@@ -1,13 +1,13 @@
-import { ParsedMessageData } from '../../session-recording/kafka/types'
 import { TeamForReplay } from '../../session-recording/teams/types'
 import { TeamService } from '../../session-replay/shared/teams/team-service'
+import { EventHeaders } from '../../types'
 import { dlq, drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export type TeamTokenResolver = Pick<TeamService, 'getTeamByToken' | 'getRetentionPeriodByTeamId'>
 
 export interface TeamFilterStepInput {
-    parsedMessage: ParsedMessageData
+    headers: EventHeaders
 }
 
 export interface TeamFilterStepOutput {
@@ -27,9 +27,9 @@ export function createTeamFilterStep<T extends TeamFilterStepInput>(
     teamService: TeamTokenResolver
 ): ProcessingStep<T, T & TeamFilterStepOutput> {
     return async function teamFilterStep(input) {
-        const { parsedMessage } = input
+        const { headers } = input
 
-        const token = parsedMessage.token
+        const token = headers.token
         if (!token) {
             // DLQ: Capture should always add a token header. Missing token indicates a bug.
             return dlq('no_token_in_header')


### PR DESCRIPTION
## Problem

because parse messages isn't team aware, ingestion warnings will be filtered out.

## Changes

make the parse message step team aware, apply team filtering first.

## How did you test this code?

unit tests

## Publish to changelog?

no
