### PR TITLE
fix(llma): fix traces pagination

### DIFF
--- a/posthog/hogql_queries/ai/test/__snapshots__/test_traces_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_traces_query_runner.ambr
@@ -11,7 +11,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -76,7 +76,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -141,7 +141,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'org:acme')))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -206,7 +206,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'org:widgets')))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -271,7 +271,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_1`, 'project:alpha')))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -336,7 +336,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC')))), equals(events.`$group_0`, 'nonexistent')))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -363,7 +363,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 5)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -428,7 +428,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 10)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -493,7 +493,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-16 00:10:59', 'UTC'))))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 15)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -558,7 +558,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -623,7 +623,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'baz'), 0)))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -688,7 +688,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'barz'), 0)))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -715,7 +715,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), 'runnable'), 0)))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -780,7 +780,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -845,7 +845,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), ''), 1), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC')))), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), 'runnable'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0))))
      GROUP BY trace_id
-     ORDER BY max(toTimeZone(events.timestamp, 'UTC')) DESC
+     ORDER BY min(toTimeZone(events.timestamp, 'UTC')) DESC
      LIMIT 101)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,


### PR DESCRIPTION
## Problem
AI traces pagination was producing overlapping results when traces contained multiple events. The subquery was ordering trace IDs by `max(timestamp) DESC` while the main query ordered by `min(timestamp) DESC` (first_timestamp), causing trace positions to shift between pages and breaking offset-based pagination.

## Changes
- Changed the subquery ordering from `max(toTimeZone(events.timestamp, 'UTC')) DESC` to `min(toTimeZone(events.timestamp, 'UTC')) DESC` to match the main query's `ORDER BY first_timestamp DESC`
- Updated test snapshots to reflect the corrected query structure
- Added comprehensive regression test with multi-event traces to verify pagination works correctly

## How did you test this code?
Added a regression test `test_pagination_with_multi_event_traces` that creates 5 traces with 2 events each, where the min and max timestamps produce reversed orderings. The test verifies that:
- Page 1 returns the correct traces in the right order
- Page 2 returns the remaining traces without overlap
- No trace ID appears on both pages

The test demonstrates the fix by showing traces are consistently ordered by their earliest timestamp across paginated requests.

## Publish to changelog?
No