### PR TITLE
fix(signals): Increase ClickHouse timeout for session recording fetch

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
@@ -117,6 +117,8 @@ _BASELINE_HAVING_PREDICATES: list[RecordingPropertyFilter] = [
     ),
 ]
 
+_DEFAULT_FILTER_TEST_ACCOUNTS = False  # Summarize all sessions (it's also faster to skip this filter)
+
 
 def _fetch_recent_session_ids(team: Team, lookback_hours: int) -> list[str]:
     """Fetch session IDs of recordings that ended within the lookback period.
@@ -135,7 +137,7 @@ def _fetch_recent_session_ids(team: Team, lookback_hours: int) -> list[str]:
         query = RecordingsQuery(
             filter_test_accounts=user_defined_query.filter_test_accounts
             if user_defined_query.filter_test_accounts is not None
-            else True,
+            else _DEFAULT_FILTER_TEST_ACCOUNTS,
             date_from=f"-{lookback_hours}h",
             limit=MAX_SESSIONS_TO_PRIME_EMBEDDINGS,
             having_predicates=_BASELINE_HAVING_PREDICATES + (user_defined_query.having_predicates or []),
@@ -147,7 +149,7 @@ def _fetch_recent_session_ids(team: Team, lookback_hours: int) -> list[str]:
         )
     else:
         query = RecordingsQuery(
-            filter_test_accounts=True,
+            filter_test_accounts=_DEFAULT_FILTER_TEST_ACCOUNTS,
             date_from=f"-{lookback_hours}h",
             limit=MAX_SESSIONS_TO_PRIME_EMBEDDINGS,
             having_predicates=_BASELINE_HAVING_PREDICATES,

--- a/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
@@ -14,6 +14,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
 from posthog.session_recordings.playlist_counters import convert_filters_to_recordings_query
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
+from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai.video_segment_clustering.models import (
     GetSessionsToPrimeResult,
@@ -153,6 +154,10 @@ def _fetch_recent_session_ids(team: Team, lookback_hours: int) -> list[str]:
         )
 
     with tags_context(product=Product.SESSION_SUMMARY):
-        result = SessionRecordingListFromQuery(team=team, query=query).run()
+        result = SessionRecordingListFromQuery(
+            team=team,
+            query=query,
+            max_execution_time=HOGQL_INCREASED_MAX_EXECUTION_TIME,
+        ).run()
 
     return [recording["session_id"] for recording in result.results]

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -74,7 +74,9 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
                         lookback_hours=inputs.lookback_hours,
                     )
                 ],
-                start_to_close_timeout=timedelta(seconds=300),
+                start_to_close_timeout=timedelta(
+                    seconds=660
+                ),  # Should exceed HOGQL_INCREASED_MAX_EXECUTION_TIME (600s)
                 retry_policy=RetryPolicy(
                     maximum_attempts=3,
                     initial_interval=timedelta(seconds=1),


### PR DESCRIPTION
## Problem

SessionRecordingListFromQuery was hitting the 60s default max_execution_time when fetching sessions to prime embeddings for video segment clustering. The query can take longer, possibly due to cohort filters (not sure yet). Example behind login: [https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/video-segment-clustering-team-2-2026-02-23T14%3A00%3A10.177360%2B00%3A00/019c8acc-e6d8-7b3f-86b6-7d0f4768e445/history](link)

## Changes

Add optional `max_execution_time` param to `SessionRecordingListFromQuery`. Then, use `HOGQL_INCREASED_MAX_EXECUTION_TIME` (600s) in the video clustering activity. Updating `start_to_close_timeout` as well.

_Also_, in the interest of making filtering lightweight, skipping internal users filtering by default.

Should fix timeout failures in `get_sessions_to_prime_activity`.