### PR TITLE
chore: Update PR template with agent-specific testing guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,7 @@
 
 <!-- Briefly describe the steps you took. -->
 <!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
-
-<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->
+<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 


### PR DESCRIPTION
## Problem

The pull request template needed to be updated to provide clearer guidance for AI agents contributing code, ensuring they don't claim to have performed manual testing they cannot actually complete.

## Changes

Updated the pull request template to replace the documentation reminder with specific instructions for AI agents, clarifying that they should not include manual tasks they haven't completed and can identify themselves as agents who have only performed code-based unit/integration tests.

## How did you test this code?

This is a documentation change to the pull request template. The modification was verified by reviewing the template content to ensure the new guidance is clear and appropriate for both human contributors and AI agents.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No - this is an internal template change that doesn't affect the product functionality.