### PR TITLE
fix(ph-ai): research mode suggestions

### DIFF
--- a/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
@@ -11,7 +11,6 @@ import { cn } from 'lib/utils/css-classes'
 
 import { SuggestionGroup, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
-import { checkSuggestionRequiresUserInput, formatSuggestion, stripSuggestionPlaceholders } from '../utils'
 import { InputFormArea } from './InputFormArea'
 import { QuestionInput } from './QuestionInput'
 
@@ -122,9 +121,9 @@ function SuggestionsList(): JSX.Element {
                         return
                     }
 
-                    if (checkSuggestionRequiresUserInput(suggestion.content)) {
+                    if (suggestion.requiresUserInput) {
                         // Content requires to write something to continue
-                        setQuestion(stripSuggestionPlaceholders(suggestion.content))
+                        setQuestion(suggestion.content)
                         focusInput()
                     } else {
                         // Otherwise, just launch the generation
@@ -151,7 +150,7 @@ function SuggestionsList(): JSX.Element {
                             type="tertiary"
                             fullWidth
                         >
-                            <span className="font-normal">{formatSuggestion(suggestion.content)}</span>
+                            <span className="font-normal">{suggestion.content}</span>
                         </LemonButton>
                     </ToggleGroupItem>
                 ))}

--- a/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
@@ -9,7 +9,10 @@ import { cn } from 'lib/utils/css-classes'
 import { MaxMemorySettings } from 'scenes/settings/environment/MaxMemorySettings'
 import { maxSettingsLogic } from 'scenes/settings/environment/maxSettingsLogic'
 
-import { maxLogic } from '../maxLogic'
+import { AgentMode } from '~/queries/schema/schema-assistant-messages'
+
+import { QUESTION_SUGGESTIONS_DATA, RESEARCH_SUGGESTIONS_DATA, maxLogic } from '../maxLogic'
+import { maxThreadLogic } from '../maxThreadLogic'
 import { FloatingSuggestionsDisplay } from './FloatingSuggestionsDisplay'
 import { SidebarQuestionInput } from './SidebarQuestionInput'
 
@@ -20,6 +23,7 @@ export function SidebarQuestionInputWithSuggestions({
 }): JSX.Element {
     const { dataProcessingAccepted, activeSuggestionGroup } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
+    const { agentMode } = useValues(maxThreadLogic)
     const { coreMemory, coreMemoryLoading } = useValues(maxSettingsLogic)
 
     const [settingsModalOpen, setSettingsModalOpen] = useState(false)
@@ -31,7 +35,9 @@ export function SidebarQuestionInputWithSuggestions({
     const tip =
         !coreMemoryLoading && !coreMemory?.text
             ? 'Tip: Run /init to initialize PostHog AI in this project'
-            : 'Try PostHog AI for…'
+            : agentMode === AgentMode.Research
+              ? 'Try PostHog AI Research Mode for…'
+              : 'Try PostHog AI for…'
 
     return (
         <DismissableLayer
@@ -54,6 +60,9 @@ export function SidebarQuestionInputWithSuggestions({
                 <FloatingSuggestionsDisplay
                     type="secondary"
                     dataProcessingAccepted={dataProcessingAccepted}
+                    suggestionsData={
+                        agentMode === AgentMode.Research ? RESEARCH_SUGGESTIONS_DATA : QUESTION_SUGGESTIONS_DATA
+                    }
                     additionalSuggestions={[
                         <LemonButton
                             key="edit-max-memory"

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -57,6 +57,7 @@ export type ThreadMessage = RootAssistantMessage & {
 
 export interface SuggestionItem {
     content: string
+    requiresUserInput?: boolean
 }
 
 export interface SuggestionGroup {
@@ -632,6 +633,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
             },
             {
                 content: 'Calculate a conversion rate for <events or actions>…',
+                requiresUserInput: true,
             },
         ],
         tooltip: 'PostHog AI can generate insights from natural language and tweak existing ones.',
@@ -642,6 +644,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
         suggestions: [
             {
                 content: 'Write an SQL query to…',
+                requiresUserInput: true,
             },
         ],
         url: urls.sqlEditor(),
@@ -653,6 +656,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
         suggestions: [
             {
                 content: 'Find recordings for…',
+                requiresUserInput: true,
             },
         ],
         url: productUrls.replay(),
@@ -664,24 +668,31 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
         suggestions: [
             {
                 content: 'How can I set up the session replay in <a framework or language>…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the feature flags in…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the experiments in…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the data warehouse in…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the error tracking in…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the LLM analytics in…',
+                requiresUserInput: true,
             },
             {
                 content: 'How can I set up the product analytics in…',
+                requiresUserInput: true,
             },
         ],
         tooltip: 'PostHog AI can help you set up PostHog SDKs in your stack.',
@@ -693,15 +704,19 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
         suggestions: [
             {
                 content: 'Create a flag to gradually roll out…',
+                requiresUserInput: true,
             },
             {
                 content: 'Create a flag that starts at 10% rollout for…',
+                requiresUserInput: true,
             },
             {
                 content: 'Create a multivariate flag for…',
+                requiresUserInput: true,
             },
             {
                 content: 'Create a beta testing flag for…',
+                requiresUserInput: true,
             },
         ],
     },
@@ -712,9 +727,11 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
         suggestions: [
             {
                 content: 'Create an experiment to test…',
+                requiresUserInput: true,
             },
             {
                 content: 'Set up an A/B test with a 70/30 split between control and test for…',
+                requiresUserInput: true,
             },
         ],
     },
@@ -759,6 +776,83 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
             },
         ],
         tooltip: 'PostHog AI has access to PostHog docs and can help you get the most out of PostHog.',
+    },
+]
+
+export const RESEARCH_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
+    {
+        label: 'User behavior',
+        icon: iconForType('product_analytics'),
+        suggestions: [
+            {
+                content: 'Investigate how retained users behave differently from churned ones',
+            },
+            {
+                content: 'Map the most common user journeys from sign-up to first value moment',
+            },
+            {
+                content: 'Compare behavior patterns between power users and casual users',
+            },
+        ],
+    },
+    {
+        label: 'Growth analysis',
+        icon: iconForType('product_analytics'),
+        suggestions: [
+            {
+                content: 'What are the strongest drivers of user activation?',
+            },
+            {
+                content: 'Compare funnel conversion rates across acquisition channels',
+            },
+            {
+                content: 'Which features correlate most with long-term retention?',
+            },
+        ],
+    },
+    {
+        label: 'Root cause analysis',
+        icon: iconForType('error_tracking'),
+        suggestions: [
+            {
+                content: 'Investigate why <metric> dropped last week',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Find what caused the spike in <event> on <date>',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Analyze where and why users drop off in the onboarding funnel',
+            },
+        ],
+    },
+    {
+        label: 'UX research',
+        icon: iconForType('session_replay'),
+        suggestions: [
+            {
+                content: 'Find session replays showing common user pain points or confusion',
+            },
+            {
+                content: 'Analyze how errors and crashes impact user experience and retention',
+            },
+        ],
+    },
+    {
+        label: 'Data deep dive',
+        icon: iconForType('insight/hog'),
+        suggestions: [
+            {
+                content: 'Build a comprehensive report on power user behavior and characteristics',
+            },
+            {
+                content: 'Run a cohort analysis comparing users by sign-up month',
+            },
+            {
+                content: 'Analyze LLM usage patterns and costs across features',
+            },
+        ],
     },
 ]
 

--- a/frontend/src/scenes/max/utils.test.ts
+++ b/frontend/src/scenes/max/utils.test.ts
@@ -6,89 +6,9 @@ import {
 } from '~/queries/schema/schema-assistant-messages'
 
 import { EnhancedToolCall } from './Thread'
-import {
-    checkSuggestionRequiresUserInput,
-    formatSuggestion,
-    isMultiQuestionFormMessage,
-    stripSuggestionPlaceholders,
-    threadEndsWithMultiQuestionForm,
-} from './utils'
+import { isMultiQuestionFormMessage, threadEndsWithMultiQuestionForm } from './utils'
 
 describe('max/utils', () => {
-    describe('checkSuggestionRequiresUserInput()', () => {
-        it('returns true for suggestions with angle brackets', () => {
-            expect(checkSuggestionRequiresUserInput('Show me <metric> over time')).toBe(true)
-            expect(checkSuggestionRequiresUserInput('Compare <event1> vs <event2>')).toBe(true)
-            expect(checkSuggestionRequiresUserInput('Filter by <property>')).toBe(true)
-        })
-
-        it('returns true for suggestions with ellipsis', () => {
-            expect(checkSuggestionRequiresUserInput('Show me trends for…')).toBe(true)
-            expect(checkSuggestionRequiresUserInput('Create a funnel…')).toBe(true)
-        })
-
-        it('returns true for suggestions with mixed placeholders', () => {
-            expect(checkSuggestionRequiresUserInput('Show <metric> trends for…')).toBe(true)
-            expect(checkSuggestionRequiresUserInput('Compare <event> over…')).toBe(true)
-        })
-
-        it('returns false for suggestions without placeholders', () => {
-            expect(checkSuggestionRequiresUserInput('Show me page views')).toBe(false)
-            expect(checkSuggestionRequiresUserInput('Create a simple funnel')).toBe(false)
-            expect(checkSuggestionRequiresUserInput('Display user retention')).toBe(false)
-        })
-
-        it('handles empty and edge cases', () => {
-            expect(checkSuggestionRequiresUserInput('')).toBe(false)
-            expect(checkSuggestionRequiresUserInput('No special characters')).toBe(false)
-            expect(checkSuggestionRequiresUserInput('Just some text')).toBe(false)
-        })
-    })
-
-    describe('stripSuggestionPlaceholders()', () => {
-        it('removes angle bracket placeholders', () => {
-            expect(stripSuggestionPlaceholders('Show me <metric> over time')).toBe('Show me  over time ')
-            expect(stripSuggestionPlaceholders('Filter by <property>')).toBe('Filter by ')
-        })
-
-        it('handles empty string', () => {
-            expect(stripSuggestionPlaceholders('')).toBe(' ')
-        })
-    })
-
-    describe('formatSuggestion()', () => {
-        it('removes angle brackets but keeps content', () => {
-            expect(formatSuggestion('Show me <metric> over time')).toBe('Show me metric over time')
-            expect(formatSuggestion('Compare <event1> vs <event2>')).toBe('Compare event1 vs event2')
-            expect(formatSuggestion('Filter by <property>')).toBe('Filter by property')
-        })
-
-        it('preserves ellipsis at the end', () => {
-            expect(formatSuggestion('Show me trends for…')).toBe('Show me trends for…')
-            expect(formatSuggestion('Create a funnel…')).toBe('Create a funnel…')
-        })
-
-        it('handles mixed placeholders', () => {
-            expect(formatSuggestion('Show <metric> trends for…')).toBe('Show metric trends for…')
-            expect(formatSuggestion('Compare <event> over…')).toBe('Compare event over…')
-        })
-
-        it('handles suggestions without placeholders', () => {
-            expect(formatSuggestion('Show me page views')).toBe('Show me page views')
-            expect(formatSuggestion('Create a simple funnel')).toBe('Create a simple funnel')
-        })
-
-        it('trims whitespace', () => {
-            expect(formatSuggestion('  Show me data  ')).toBe('Show me data')
-            expect(formatSuggestion('  Show <metric>  ')).toBe('Show metric')
-            expect(formatSuggestion('  Show data…  ')).toBe('Show data…')
-        })
-
-        it('handles empty string', () => {
-            expect(formatSuggestion('')).toBe('')
-        })
-    })
-
     describe('isMultiQuestionFormMessage()', () => {
         it('returns true for AssistantMessage with create_form tool call', () => {
             const message = {

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -144,37 +144,6 @@ export function getSlackThreadUrl(slackThreadKey: string, slackWorkspaceDomain?:
     return `https://${domain}.slack.com/archives/${channel}/${urlTs}`
 }
 
-/**
- * Checks if a suggestion requires user input.
- * @param suggestion - The suggestion to check.
- * @returns True if the suggestion requires input, false otherwise.
- */
-export function checkSuggestionRequiresUserInput(suggestion: string): boolean {
-    const matches = suggestion.match(/<|>|…/g)
-    return !!matches && matches.length > 0
-}
-
-/**
- * Strips the user input placeholder (`<`, `>`, `…`) from a suggestion.
- * @param suggestion - The suggestion to strip.
- * @returns The stripped suggestion.
- */
-export function stripSuggestionPlaceholders(suggestion: string): string {
-    return `${suggestion
-        .replace(/<[^>]*>/g, '')
-        .replace(/…$/, '')
-        .trim()} `
-}
-
-/**
- * Formats a suggestion by stripping the placeholder characters (`<`, `>`) from a suggestion.
- * @param suggestion - The suggestion to format.
- * @returns The formatted suggestion.
- */
-export function formatSuggestion(suggestion: string): string {
-    return `${suggestion.replace(/[<>]/g, '').replace(/…$/, '').trim()}${suggestion.endsWith('…') ? '…' : ''}`
-}
-
 // Utility functions for transforming data to max context
 export const insightToMaxContext = (
     insight: Partial<QueryBasedInsightModel>,


### PR DESCRIPTION
## Problem
Research mode still uses the base suggestions, let's fix that.
Also, the suggestion system was using utility functions to parse placeholder text, which are brittle and created a confusing UX where useful placeholders were being removed from the suggestion.

![image.png](https://app.graphite.com/user-attachments/assets/7e236243-3e52-4401-95c2-81abc01b9ced.png)

![image.png](https://app.graphite.com/user-attachments/assets/494fda31-864b-442d-8e2f-0674eb6d16ec.png)

## Changes

- Added `requiresUserInput` boolean property to the `SuggestionItem` interface to explicitly mark suggestions that need user completion
- Removed utility functions `checkSuggestionRequiresUserInput`, `stripSuggestionPlaceholders`, and `formatSuggestion` from the codebase
- Updated all suggestion items in `QUESTION_SUGGESTIONS_DATA` to include the `requiresUserInput` flag where appropriate
- Added new `RESEARCH_SUGGESTIONS_DATA` constant with research-focused suggestions for the AI research mode
- Modified `FloatingSuggestionsDisplay` to accept `suggestionsData` as a prop instead of importing it directly
- Updated `SidebarQuestionInputWithSuggestions` to conditionally pass either research or standard suggestions based on the current agent mode
- Replaced all utility function calls with direct property checks on the suggestion objects
- Updated the tip text to differentiate between regular AI mode and research mode

## How did you test this code?
Locally

## Publish to changelog?

No