### PR TITLE
fix(ph-ai): fix thinking message wrapping

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -856,7 +856,7 @@ function ShimmeringContent({ children }: { children: React.ReactNode }): JSX.Ele
 
     return (
         <span
-            className="inline-flex"
+            className="inline-flex min-w-0 max-w-full"
             style={{
                 animation: 'shimmer-opacity 3s linear infinite',
             }}
@@ -925,7 +925,7 @@ function AssistantActionComponent({
         <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
             <div
                 className={clsx(
-                    'transition-all duration-500 flex select-none',
+                    'transition-all duration-500 flex select-none min-w-0',
                     (isPending || isFailed) && 'text-muted',
                     !isInProgress && !isPending && !isFailed && 'text-default',
                     !showSubstepsChevron ? 'cursor-default' : 'cursor-pointer'
@@ -951,7 +951,7 @@ function AssistantActionComponent({
                     </div>
                 )}
                 <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
-                    <div>
+                    <div className="min-w-0">
                         {isInProgress && animate ? (
                             <ShimmeringContent>{markdownContent}</ShimmeringContent>
                         ) : (


### PR DESCRIPTION
## Problem
Text content in the Thread component was overflowing its container boundaries, causing layout issues where long text would break out of designated areas and potentially overlap with other UI elements.

## Changes
Added `min-w-0` and `max-w-full` CSS classes to key container elements in the Thread component:
- Updated `ShimmeringContent` span to include width constraints
- Added `min-w-0` to the assistant action container div
- Added `min-w-0` to the markdown content wrapper div

## How did you test this code?
Locally

## Publish to changelog?
No