### PR TITLE
feat(experiments): make baseline variant key configurable in ExperimentQueryRunner

### DIFF
--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -101,14 +101,15 @@ def get_experiment_stats_method(experiment) -> str:
 
 def split_baseline_and_test_variants(
     variants: list[V],
+    baseline_key: str = CONTROL_VARIANT_KEY,
 ) -> tuple[V, list[V]]:
-    control_variants = [variant for variant in variants if variant.key == CONTROL_VARIANT_KEY]
+    control_variants = [variant for variant in variants if variant.key == baseline_key]
     if not control_variants:
         raise ValueError("No control variant found")
     if len(control_variants) > 1:
         raise ValueError("Multiple control variants found")
     control_variant = control_variants[0]
-    test_variants = [variant for variant in variants if variant.key != CONTROL_VARIANT_KEY]
+    test_variants = [variant for variant in variants if variant.key != baseline_key]
 
     return control_variant, test_variants
 


### PR DESCRIPTION
## Problem

The experiment evaluation system hardcodes `"control"` as the baseline variant via `CONTROL_VARIANT_KEY`. This is the first in a series of PRs to allow users to dynamically configure which variant is the baseline.

## Changes

- Add `baseline_key` parameter to `split_baseline_and_test_variants` (defaults to `CONTROL_VARIANT_KEY`)
- Add `baseline_variant_key` attribute to `ExperimentQueryRunner.__init__`
- Pass `baseline_variant_key` through to `split_baseline_and_test_variants`

## Testing

Existing experiment query runner tests pass with no regressions — default behavior is unchanged.