### PR TITLE
fix: add minimum search character requirement UI for taxonomic filters

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -457,6 +457,8 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         showPopover,
         items,
         hasRemoteDataSource,
+        needsMoreSearchCharacters,
+        minSearchQueryLength,
     } = useValues(infiniteListLogic)
     const { onRowsRendered, setIndex, expand, updateRemoteItem } = useActions(infiniteListLogic)
     const [highlightedItemElement, setHighlightedItemElement] = useState<HTMLDivElement | null>(null)
@@ -502,12 +504,12 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         <div
             className={cn(
                 'taxonomic-infinite-list',
-                showEmptyState && 'empty-infinite-list',
+                (showEmptyState || needsMoreSearchCharacters) && 'empty-infinite-list',
                 'h-full',
                 isSuggestedFilters && 'empty-infinite-list--start'
             )}
         >
-            {showEmptyState ? (
+            {showEmptyState || needsMoreSearchCharacters ? (
                 <div className="no-infinite-results flex flex-col gap-y-1 items-center">
                     {isSuggestedFilters ? (
                         <>
@@ -516,6 +518,16 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                                 Start searching and we'll suggest filters...
                             </span>
                             <SuggestedFiltersSearchHint taxonomicGroupTypes={taxonomicGroupTypes} />
+                        </>
+                    ) : needsMoreSearchCharacters ? (
+                        <>
+                            <IconSearch className="text-5xl text-tertiary" />
+                            <span className="text-secondary text-center">
+                                Search for {group?.searchPlaceholder || group?.name?.toLowerCase() || 'items'}
+                            </span>
+                            <span className="text-center text-secondary italic">
+                                Type at least {minSearchQueryLength} characters to search
+                            </span>
                         </>
                     ) : (
                         <>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -426,20 +426,59 @@ const InfiniteListRow = ({
     )
 }
 
+function InfiniteListEmptyState(): JSX.Element {
+    const { searchQuery, taxonomicGroupTypes } = useValues(taxonomicFilterLogic)
+
+    const { group, needsMoreSearchCharacters, minSearchQueryLength, isSuggestedFilters } = useValues(infiniteListLogic)
+
+    return (
+        <div className="no-infinite-results flex flex-col gap-y-1 items-center">
+            {isSuggestedFilters ? (
+                <>
+                    <IconSearch className="text-5xl text-tertiary" />
+                    <span className="text-secondary text-center">Start searching and we'll suggest filters...</span>
+                    <SuggestedFiltersSearchHint taxonomicGroupTypes={taxonomicGroupTypes} />
+                </>
+            ) : needsMoreSearchCharacters ? (
+                <>
+                    <IconSearch className="text-5xl text-tertiary" />
+                    <span className="text-secondary text-center">
+                        Search for{' '}
+                        {group?.searchDescription || group?.searchPlaceholder || group?.name?.toLowerCase() || 'items'}
+                    </span>
+                    <span className="text-center text-secondary italic">
+                        Type at least {minSearchQueryLength} characters to search
+                    </span>
+                </>
+            ) : (
+                <>
+                    <IconArchive className="text-5xl text-tertiary" />
+                    <span>
+                        {searchQuery ? (
+                            <>
+                                No results for "<strong>{searchQuery}</strong>"
+                            </>
+                        ) : (
+                            'No results'
+                        )}
+                    </span>
+                </>
+            )}
+        </div>
+    )
+}
+
 export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: InfiniteListProps): JSX.Element {
     const {
         mouseInteractionsEnabled,
         activeTab,
         searchQuery,
         eventNames,
-        allowNonCapturedEvents,
         groupType,
         value,
         taxonomicGroups,
-        taxonomicGroupTypes,
         selectedProperties,
         dataWarehousePopoverFields,
-        anyGroupLoading,
     } = useValues(taxonomicFilterLogic)
     const { selectItem } = useActions(taxonomicFilterLogic)
     const {
@@ -456,41 +495,16 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         expandedCount,
         showPopover,
         items,
-        hasRemoteDataSource,
-        needsMoreSearchCharacters,
-        minSearchQueryLength,
+        showNonCapturedEventOption,
+        showEmptyState,
+        showLoadingState,
+        isSuggestedFilters,
     } = useValues(infiniteListLogic)
     const { onRowsRendered, setIndex, expand, updateRemoteItem } = useActions(infiniteListLogic)
     const [highlightedItemElement, setHighlightedItemElement] = useState<HTMLDivElement | null>(null)
     const isActiveTab = listGroupType === activeTab
     const listRef = useListRef(null)
-
     const trimmedSearchQuery = searchQuery.trim()
-
-    // Show "Add non-captured event" option for CustomEvents group when searching
-    const showNonCapturedEventOption =
-        allowNonCapturedEvents &&
-        (listGroupType === TaxonomicFilterGroupType.CustomEvents ||
-            listGroupType === TaxonomicFilterGroupType.Events) &&
-        trimmedSearchQuery.length > 0 &&
-        !isLoading &&
-        // Only show if no results found at all
-        results.length === 0
-
-    // Only show empty state if:
-    // 1. There are no results
-    // 2. We're not currently loading
-    // 3. We have a search query (otherwise if hasRemoteDataSource=true, we're just waiting for data)
-    // 4. We're not showing the non-captured event option
-    const isSuggestedFilters = listGroupType === TaxonomicFilterGroupType.SuggestedFilters
-    const showEmptyState =
-        totalListCount === 0 &&
-        !isLoading &&
-        !(isSuggestedFilters && anyGroupLoading) &&
-        (!!searchQuery || !hasRemoteDataSource) &&
-        !showNonCapturedEventOption
-    const showLoadingState =
-        (isLoading || (isSuggestedFilters && anyGroupLoading)) && (!results || results.length === 0)
 
     useEffect(() => {
         if (index >= 0 && listRef.current) {
@@ -504,50 +518,13 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         <div
             className={cn(
                 'taxonomic-infinite-list',
-                (showEmptyState || needsMoreSearchCharacters) && 'empty-infinite-list',
+                showEmptyState && 'empty-infinite-list',
                 'h-full',
                 isSuggestedFilters && 'empty-infinite-list--start'
             )}
         >
-            {showEmptyState || needsMoreSearchCharacters ? (
-                <div className="no-infinite-results flex flex-col gap-y-1 items-center">
-                    {isSuggestedFilters ? (
-                        <>
-                            <IconSearch className="text-5xl text-tertiary" />
-                            <span className="text-secondary text-center">
-                                Start searching and we'll suggest filters...
-                            </span>
-                            <SuggestedFiltersSearchHint taxonomicGroupTypes={taxonomicGroupTypes} />
-                        </>
-                    ) : needsMoreSearchCharacters ? (
-                        <>
-                            <IconSearch className="text-5xl text-tertiary" />
-                            <span className="text-secondary text-center">
-                                Search for{' '}
-                                {group?.searchDescription ||
-                                    group?.searchPlaceholder ||
-                                    group?.name?.toLowerCase() ||
-                                    'items'}
-                            </span>
-                            <span className="text-center text-secondary italic">
-                                Type at least {minSearchQueryLength} characters to search
-                            </span>
-                        </>
-                    ) : (
-                        <>
-                            <IconArchive className="text-5xl text-tertiary" />
-                            <span>
-                                {searchQuery ? (
-                                    <>
-                                        No results for "<strong>{searchQuery}</strong>"
-                                    </>
-                                ) : (
-                                    'No results'
-                                )}
-                            </span>
-                        </>
-                    )}
-                </div>
+            {showEmptyState ? (
+                <InfiniteListEmptyState />
             ) : showLoadingState ? (
                 <div className="flex items-center justify-center h-full">
                     <Spinner className="text-3xl" />

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -523,7 +523,11 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                         <>
                             <IconSearch className="text-5xl text-tertiary" />
                             <span className="text-secondary text-center">
-                                Search for {group?.searchPlaceholder || group?.name?.toLowerCase() || 'items'}
+                                Search for{' '}
+                                {group?.searchDescription ||
+                                    group?.searchPlaceholder ||
+                                    group?.name?.toLowerCase() ||
+                                    'items'}
                             </span>
                             <span className="text-center text-secondary italic">
                                 Type at least {minSearchQueryLength} characters to search

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -85,7 +85,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
     connect((props: InfiniteListLogicProps) => ({
         values: [
             taxonomicFilterLogic(props),
-            ['searchQuery', 'value', 'groupType', 'taxonomicGroups', 'topMatchItems'],
+            ['searchQuery', 'value', 'groupType', 'taxonomicGroups', 'topMatchItems', 'anyGroupLoading'],
             teamLogic,
             ['currentTeamId'],
         ],
@@ -293,6 +293,11 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
     })),
     selectors({
         listGroupType: [(_, p) => [p.listGroupType], (listGroupType) => listGroupType],
+        isSuggestedFilters: [
+            (s) => [s.listGroupType],
+            (listGroupType: TaxonomicFilterGroupType): boolean =>
+                listGroupType === TaxonomicFilterGroupType.SuggestedFilters,
+        ],
         allowNonCapturedEvents: [
             () => [(_, props) => props.allowNonCapturedEvents],
             (allowNonCapturedEvents: boolean | undefined) => allowNonCapturedEvents ?? false,
@@ -306,13 +311,13 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         minSearchQueryLength: [(s) => [s.group], (group) => group?.minSearchQueryLength ?? 0],
         needsMoreSearchCharacters: [
-            (s) => [s.minSearchQueryLength, s.searchQuery, s.swappedInQuery],
-            (minSearchQueryLength, searchQuery, swappedInQuery) => {
+            (s) => [s.minSearchQueryLength, s.searchQuery],
+            (minSearchQueryLength, searchQuery) => {
                 if (minSearchQueryLength <= 0) {
                     return false
                 }
-                const effectiveQuery = swappedInQuery || searchQuery
-                return effectiveQuery.length < minSearchQueryLength
+
+                return searchQuery.trim().length < minSearchQueryLength
             },
         ],
         excludedProperties: [(s) => [s.group], (group) => group?.excludedProperties],
@@ -334,6 +339,59 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             (isExpandable, index, totalListCount) => isExpandable && index === totalListCount - 1,
         ],
         hasRemoteDataSource: [(s) => [s.remoteEndpoint], (remoteEndpoint) => !!remoteEndpoint],
+        showNonCapturedEventOption: [
+            (s) => [s.allowNonCapturedEvents, s.listGroupType, s.searchQuery, s.isLoading, s.results],
+            (
+                allowNonCapturedEvents: boolean,
+                listGroupType: TaxonomicFilterGroupType,
+                searchQuery: string,
+                isLoading: boolean,
+                results: TaxonomicDefinitionTypes[]
+            ): boolean =>
+                allowNonCapturedEvents &&
+                (listGroupType === TaxonomicFilterGroupType.CustomEvents ||
+                    listGroupType === TaxonomicFilterGroupType.Events) &&
+                searchQuery.trim().length > 0 &&
+                !isLoading &&
+                results.length === 0,
+        ],
+        showEmptyState: [
+            (s) => [
+                s.totalListCount,
+                s.isLoading,
+                s.isSuggestedFilters,
+                s.anyGroupLoading,
+                s.searchQuery,
+                s.hasRemoteDataSource,
+                s.showNonCapturedEventOption,
+                s.needsMoreSearchCharacters,
+            ],
+            (
+                totalListCount: number,
+                isLoading: boolean,
+                isSuggestedFilters: boolean,
+                anyGroupLoading: boolean,
+                searchQuery: string,
+                hasRemoteDataSource: boolean,
+                showNonCapturedEventOption: boolean,
+                needsMoreSearchCharacters: boolean
+            ): boolean =>
+                (totalListCount === 0 &&
+                    !isLoading &&
+                    !(isSuggestedFilters && anyGroupLoading) &&
+                    (!!searchQuery || !hasRemoteDataSource) &&
+                    !showNonCapturedEventOption) ||
+                needsMoreSearchCharacters,
+        ],
+        showLoadingState: [
+            (s) => [s.isLoading, s.isSuggestedFilters, s.anyGroupLoading, s.results],
+            (
+                isLoading: boolean,
+                isSuggestedFilters: boolean,
+                anyGroupLoading: boolean,
+                results: TaxonomicDefinitionTypes[]
+            ): boolean => (isLoading || (isSuggestedFilters && anyGroupLoading)) && (!results || results.length === 0),
+        ],
         rawLocalItems: [
             (selectors) => [
                 (state, props: InfiniteListLogicProps) => {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -305,6 +305,16 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         ],
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         minSearchQueryLength: [(s) => [s.group], (group) => group?.minSearchQueryLength ?? 0],
+        needsMoreSearchCharacters: [
+            (s) => [s.minSearchQueryLength, s.searchQuery, s.swappedInQuery],
+            (minSearchQueryLength, searchQuery, swappedInQuery) => {
+                if (minSearchQueryLength <= 0) {
+                    return false
+                }
+                const effectiveQuery = swappedInQuery || searchQuery
+                return effectiveQuery.length < minSearchQueryLength
+            },
+        ],
         excludedProperties: [(s) => [s.group], (group) => group?.excludedProperties],
         propertyAllowList: [(s) => [s.group], (group) => group?.propertyAllowList],
         scopedRemoteEndpoint: [(s) => [s.group], (group) => group?.scopedEndpoint || null],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -754,7 +754,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Pageview URL`,
                         minSearchQueryLength: 3,
-                        searchDescription: 'URLs from pageview events',
+                        searchDescription: 'URLs seen on pageview events',
                     },
                     {
                         name: 'Pageview events',
@@ -781,7 +781,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Screen`,
                         minSearchQueryLength: 3,
-                        searchDescription: 'screen names from screen events',
+                        searchDescription: 'screen names seen on screen events',
                     },
                     {
                         name: 'Screen events',
@@ -805,7 +805,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Email address`,
                         minSearchQueryLength: 5,
-                        searchDescription: 'person email addresses',
+                        searchDescription: 'email addresses seen in person properties',
                     },
                     {
                         name: 'Autocapture events',
@@ -817,7 +817,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Autocapture event`,
                         minSearchQueryLength: 3,
-                        searchDescription: 'autocapture events filtered by element text',
+                        searchDescription: 'element text seen on autocapture events',
                     },
                     {
                         name: 'Custom Events',

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -754,6 +754,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Pageview URL`,
                         minSearchQueryLength: 3,
+                        searchDescription: 'URLs from pageview events',
                     },
                     {
                         name: 'Pageview events',
@@ -765,6 +766,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Pageview event`,
                         minSearchQueryLength: 3,
+                        searchDescription: 'pageview events filtered by URL',
                     },
                     // Screens returns a screen name value, used in paths and property filters.
                     // ScreenEvents creates a $screen event with $screen_name property filter,
@@ -779,6 +781,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Screen`,
                         minSearchQueryLength: 3,
+                        searchDescription: 'screen names from screen events',
                     },
                     {
                         name: 'Screen events',
@@ -790,6 +793,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Screen event`,
                         minSearchQueryLength: 3,
+                        searchDescription: 'screen events filtered by screen name',
                     },
                     {
                         name: 'Email addresses',
@@ -801,6 +805,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Email address`,
                         minSearchQueryLength: 5,
+                        searchDescription: 'person email addresses',
                     },
                     {
                         name: 'Autocapture events',
@@ -812,6 +817,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (option: SimpleOption) => option.name,
                         getPopoverHeader: () => `Autocapture event`,
                         minSearchQueryLength: 3,
+                        searchDescription: 'autocapture events filtered by element text',
                     },
                     {
                         name: 'Custom Events',

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -170,6 +170,8 @@ export interface TaxonomicFilterGroup {
     componentProps?: Record<string, any>
     /** Minimum number of characters before a remote search is issued. */
     minSearchQueryLength?: number
+    /** Description shown in the empty state when minSearchQueryLength is set. */
+    searchDescription?: string
 }
 
 export enum TaxonomicFilterGroupType {


### PR DESCRIPTION
## Problem

When a taxonomic filter group has a `minSearchQueryLength` requirement, users receive no feedback about why no results are displayed when their search query is too short. This creates a poor user experience as they don't understand the constraint.

## Changes

![CleanShot 2026-02-23 at 20.52.53@2x.png](https://app.graphite.com/user-attachments/assets/4bdaf523-5e38-45d3-b4c8-0828d59ef61d.png)



Added UI feedback when a search query is shorter than the required minimum character length:

## Publish to changelog?

no

https://claude.ai/code/session_01NHHm3FmwL4zxyL1ghtDLK1