### PR TITLE
fix(surveys): fix numeric vs string properties

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.test.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.test.tsx
@@ -1,0 +1,14 @@
+import { getThumbIcon } from './SurveyView'
+
+describe('getThumbIcon', () => {
+    it.each([
+        ['string "1"', '1', true],
+        ['number 1', 1, true],
+        ['string "2"', '2', false],
+        ['number 2', 2, false],
+    ])('returns correct icon for %s', (_label, value, expectThumbsUp) => {
+        const result = getThumbIcon(value)
+        expect(result).not.toBeNull()
+        expect(result!.props.className).toContain(expectThumbsUp ? 'text-brand-blue' : 'text-warning')
+    })
+})

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1060,3 +1060,39 @@ describe('timezone handling in survey date queries', () => {
         })
     })
 })
+
+describe('getSurveyResponse', () => {
+    it('includes JSONExtractInt fallback for numeric values', () => {
+        const question = { id: 'q1', type: SurveyQuestionType.Rating } as any
+
+        const result = getSurveyResponse(question, 0)
+
+        expect(result).toContain('JSONExtractString')
+        expect(result).toContain('JSONExtractInt')
+        expect(result).toContain('JSONType')
+        expect(result).toContain('toString')
+    })
+
+    it.each([
+        [0, '$survey_response_q1', '$survey_response'],
+        [1, '$survey_response_q1', '$survey_response_1'],
+        [2, '$survey_response_q1', '$survey_response_2'],
+    ])('uses correct index-based key for question index %d', (index, _idKey, expectedIndexKey) => {
+        const question = { id: 'q1', type: SurveyQuestionType.Rating } as any
+        const result = getSurveyResponse(question, index)
+        expect(result).toContain(expectedIndexKey)
+    })
+
+    it('uses id-based key from question id', () => {
+        const question = { id: 'abc-123', type: SurveyQuestionType.Rating } as any
+        const result = getSurveyResponse(question, 0)
+        expect(result).toContain('$survey_response_abc-123')
+    })
+
+    it('uses JSONExtractArrayRaw for multiple choice (no numeric fallback)', () => {
+        const question = { id: 'q1', type: SurveyQuestionType.MultipleChoice } as any
+        const result = getSurveyResponse(question, 0)
+        expect(result).toContain('JSONExtractArrayRaw')
+        expect(result).not.toContain('JSONExtractInt')
+    })
+})

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -291,7 +291,9 @@ export function getSurveyResponse(question: SurveyQuestion, index: number): stri
 
     return `COALESCE(
         NULLIF(JSONExtractString(events.properties, '${idBasedKey}'), ''),
-        NULLIF(JSONExtractString(events.properties, '${indexBasedKey}'), '')
+        NULLIF(JSONExtractString(events.properties, '${indexBasedKey}'), ''),
+        if(JSONType(events.properties, '${idBasedKey}') = 'Int64', toString(JSONExtractInt(events.properties, '${idBasedKey}')), NULL),
+        if(JSONType(events.properties, '${indexBasedKey}') = 'Int64', toString(JSONExtractInt(events.properties, '${indexBasedKey}')), NULL)
     )`
 }
 

--- a/posthog/hogql/functions/survey.py
+++ b/posthog/hogql/functions/survey.py
@@ -88,10 +88,46 @@ def _build_property_access(key: str | ast.Expr) -> ast.Expr:
     )
 
 
+def _build_numeric_property_access(key: str | ast.Expr) -> ast.Expr:
+    """Build numeric fallback: if(JSONType(properties, key) = 'Int64', toString(JSONExtractInt(properties, key)), NULL).
+
+    JSONExtractString returns empty for numeric JSON values, so this
+    provides a fallback that converts numeric values to strings.
+    Uses JSONType instead of JSONHas to avoid false positives on
+    non-numeric values (e.g. empty strings would otherwise become '0').
+    """
+    key_expr = _key_as_expr(key)
+    return ast.Call(
+        name="if",
+        args=[
+            ast.Call(
+                name="equals",
+                args=[
+                    ast.Call(
+                        name="JSONType",
+                        args=[ast.Field(chain=["properties"]), key_expr],
+                    ),
+                    ast.Constant(value="Int64"),
+                ],
+            ),
+            ast.Call(
+                name="toString",
+                args=[
+                    ast.Call(
+                        name="JSONExtractInt",
+                        args=[ast.Field(chain=["properties"]), key_expr],
+                    ),
+                ],
+            ),
+            ast.Constant(value=None),
+        ],
+    )
+
+
 def _build_coalesce_expr(id_based_key: str | ast.Expr, index_based_key: str) -> ast.Expr:
     """Build COALESCE expression for single-choice survey response."""
-    # coalesce(nullif(properties.$id_key, ''), nullif(properties.$index_key, ''))
-    # Using ast.Field enables materialized column optimization when available
+    # First try string extraction (handles string JSON values), then fall back to
+    # numeric extraction (handles numeric JSON values like rating responses).
     return ast.Call(
         name="coalesce",
         args=[
@@ -103,6 +139,8 @@ def _build_coalesce_expr(id_based_key: str | ast.Expr, index_based_key: str) -> 
                 name="nullif",
                 args=[_build_property_access(index_based_key), ast.Constant(value="")],
             ),
+            _build_numeric_property_access(id_based_key),
+            _build_numeric_property_access(index_based_key),
         ],
     )
 

--- a/posthog/hogql/functions/test/test_survey.py
+++ b/posthog/hogql/functions/test/test_survey.py
@@ -1,0 +1,76 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.hogql.errors import QueryError
+from posthog.hogql.query import execute_hogql_query
+
+
+class TestGetSurveyResponse(BaseTest):
+    def test_single_choice_includes_numeric_fallback(self):
+        result = execute_hogql_query(
+            "SELECT getSurveyResponse(0, 'q1') FROM events",
+            team=self.team,
+        )
+        assert result.clickhouse is not None
+        self.assertIn("JSONExtractString", result.clickhouse)
+        self.assertIn("JSONExtractInt", result.clickhouse)
+        self.assertIn("JSONType", result.clickhouse)
+        self.assertIn("toString", result.clickhouse)
+
+    def test_dynamic_key_includes_numeric_fallback(self):
+        result = execute_hogql_query(
+            "SELECT getSurveyResponse(0) FROM events",
+            team=self.team,
+        )
+        assert result.clickhouse is not None
+        self.assertIn("JSONExtractInt", result.clickhouse)
+        self.assertIn("JSONType", result.clickhouse)
+
+    def test_multiple_choice_does_not_include_numeric_fallback(self):
+        result = execute_hogql_query(
+            "SELECT getSurveyResponse(0, 'q1', true) FROM events",
+            team=self.team,
+        )
+        assert result.clickhouse is not None
+        self.assertIn("JSONExtractArrayRaw", result.clickhouse)
+        self.assertNotIn("JSONExtractInt", result.clickhouse)
+
+    @parameterized.expand(
+        [
+            ("index_0", 0, "$survey_response"),
+            ("index_1", 1, "$survey_response_1"),
+            ("index_2", 2, "$survey_response_2"),
+        ]
+    )
+    def test_index_based_key(self, _name, question_index, expected_key):
+        result = execute_hogql_query(
+            f"SELECT getSurveyResponse({question_index}, 'q1') FROM events",
+            team=self.team,
+        )
+        assert result.clickhouse is not None
+        self.assertIn(expected_key, result.clickhouse)
+
+    def test_all_coalesce_branches_return_string_type(self):
+        result = execute_hogql_query(
+            "SELECT getSurveyResponse(0, 'q1') FROM events",
+            team=self.team,
+        )
+        assert result.clickhouse is not None
+        # toString wraps JSONExtractInt so all branches return String
+        self.assertNotIn("Float64", result.clickhouse)
+        self.assertNotIn("accurateCastOrNull", result.clickhouse)
+
+    def test_rejects_non_constant_index(self):
+        with self.assertRaises(QueryError):
+            execute_hogql_query(
+                "SELECT getSurveyResponse(uuid) FROM events",
+                team=self.team,
+            )
+
+    def test_rejects_non_integer_index(self):
+        with self.assertRaises(QueryError):
+            execute_hogql_query(
+                "SELECT getSurveyResponse('abc') FROM events",
+                team=self.team,
+            )

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -638,8 +638,12 @@ class Command(BaseCommand):
             "response_sampling_daily_limits": None,
         }
 
-    def generate_response_for_question(self, question: dict[str, Any]) -> str | list[str] | None:
-        """Generate a realistic response for a given question type."""
+    def generate_response_for_question(self, question: dict[str, Any]) -> str | int | list[str] | None:
+        """Generate a realistic response for a given question type.
+
+        Returns the raw value — may be int for ratings (matching real SDK behavior
+        where numeric values are sent as JSON numbers) or str for text responses.
+        """
         question_type = question.get("type")
         question_text = question.get("question", "").lower()
 
@@ -666,19 +670,24 @@ class Command(BaseCommand):
             # 1 = thumbs up, 2 = thumbs down
             if scale == 2 and display == "emoji":
                 # Realistic distribution: ~70% thumbs up, ~30% thumbs down
-                return "1" if random.random() < 0.7 else "2"
+                value = 1 if random.random() < 0.7 else 2
+                # Real SDK sends numbers; mix in some string values for variety
+                return value if random.random() < 0.7 else str(value)
 
             # Realistic distribution: skewed positive with some variation
             rand = random.random()
             if rand < 0.1:
-                return "1"
+                value = 1
             elif rand < 0.2:
-                return "2"
+                value = 2
             elif rand < 0.35:
-                return str(min(3, scale))
+                value = min(3, scale)
             elif rand < 0.65:
-                return str(min(4, scale))
-            return str(scale)
+                value = min(4, scale)
+            else:
+                value = scale
+            # Real SDK sends numbers; mix in some string values for variety
+            return value if random.random() < 0.7 else str(value)
 
         elif question_type == "single_choice":
             choices = question.get("choices", [])
@@ -871,19 +880,36 @@ class Command(BaseCommand):
                         # Fall back to random UUID if no real traces exist
                         response_properties["$ai_trace_id"] = str(uuid.uuid4())
 
+                submission_id = str(uuid.uuid4())
+                response_properties["$survey_submission_id"] = submission_id
+
                 # Generate response for each question, respecting branching logic
                 questions = survey.questions or []
                 skip_remaining = False
+                survey_questions_meta: list[dict[str, Any]] = []
                 for idx, question in enumerate(questions):
                     if skip_remaining:
                         break
 
                     response = self.generate_response_for_question(question)
                     if response is not None:
-                        if idx == 0:
+                        question_id = question.get("id")
+                        # Use id-based key when question has an id (matches real SDK behavior),
+                        # fall back to index-based key otherwise
+                        if question_id:
+                            response_properties[f"$survey_response_{question_id}"] = response
+                        elif idx == 0:
                             response_properties["$survey_response"] = response
                         else:
                             response_properties[f"$survey_response_{idx}"] = response
+
+                        survey_questions_meta.append(
+                            {
+                                "id": question_id,
+                                "question": question.get("question", ""),
+                                "response": response,
+                            }
+                        )
 
                         # Check branching logic
                         branching = question.get("branching")
@@ -893,10 +919,13 @@ class Command(BaseCommand):
                             # 1 = thumbs up (positive), 2 = thumbs down (negative)
                             scale = question.get("scale", 5)
                             if question.get("type") == "rating" and scale == 2:
-                                sentiment = "positive" if response == "1" else "negative"
+                                sentiment = "positive" if str(response) == "1" else "negative"
                                 next_step = response_values.get(sentiment)
                                 if next_step == "end":
                                     skip_remaining = True
+
+                response_properties["$survey_completed"] = True
+                response_properties["$survey_questions"] = survey_questions_meta
 
                 insert, event_params = self._build_event_row(
                     event_name="survey sent",

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
@@ -13,7 +13,7 @@ import { GroupedResponse } from './utils'
 
 function QuestionResponse({ question, value }: { question: SurveyQuestion; value: unknown }): JSX.Element {
     if (isThumbQuestion(question)) {
-        return <ThumbsResponse isPositive={value === '1'} question={question} />
+        return <ThumbsResponse isPositive={Number(value) === 1} question={question} />
     }
 
     if (question.type === SurveyQuestionType.Rating) {

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/utils.test.ts
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/utils.test.ts
@@ -1,0 +1,189 @@
+import { LLMTraceEvent } from '~/queries/schema/schema-general'
+import { Survey, SurveyQuestionType } from '~/types'
+
+import { groupEventsBySubmission } from './utils'
+
+const SURVEY_RATING_SCALE_THUMB_2_POINT = 2
+
+const thumbQuestion = {
+    id: 'q1',
+    type: SurveyQuestionType.Rating,
+    display: 'emoji',
+    scale: SURVEY_RATING_SCALE_THUMB_2_POINT,
+    question: 'Was this helpful?',
+}
+
+const openTextQuestion = {
+    id: 'q2',
+    type: SurveyQuestionType.Open,
+    question: 'Any feedback?',
+}
+
+const makeSurvey = (questions: any[]): Survey =>
+    ({
+        id: 'survey-1',
+        name: 'Test survey',
+        questions,
+    }) as unknown as Survey
+
+const makeEvent = (overrides: Partial<LLMTraceEvent> & { properties: Record<string, any> }): LLMTraceEvent =>
+    ({
+        id: 'evt-1',
+        event: 'survey sent',
+        createdAt: '2026-02-23T00:00:00Z',
+        ...overrides,
+    }) as LLMTraceEvent
+
+describe('groupEventsBySubmission', () => {
+    it.each([
+        ['numeric 1', 1],
+        ['string "1"', '1'],
+    ])('extracts thumb response stored as %s', (_label, responseValue) => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion]) }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_completed: true,
+                    $survey_response_q1: responseValue,
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].responses).toHaveLength(1)
+        expect(result[0].responses[0].value).toBe(responseValue)
+        expect(result[0].isComplete).toBe(true)
+    })
+
+    it('extracts response value 0 (falsy but valid)', () => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion]) }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_completed: true,
+                    $survey_response_q1: 0,
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].responses).toHaveLength(1)
+        expect(result[0].responses[0].value).toBe(0)
+    })
+
+    it('returns empty responses when survey question IDs do not match event properties', () => {
+        const surveyWithNewId = makeSurvey([{ ...thumbQuestion, id: 'new-id' }])
+        const surveys = { 'survey-1': surveyWithNewId }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_completed: true,
+                    $survey_response_q1: 1, // old id-based key, won't match 'new-id'
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].responses).toHaveLength(0)
+    })
+
+    it('falls back to index-based key when id-based key is missing', () => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion]) }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_completed: true,
+                    $survey_response: '1', // index-based key (question index 0)
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].responses).toHaveLength(1)
+        expect(result[0].responses[0].value).toBe('1')
+    })
+
+    it('handles multi-question surveys', () => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion, openTextQuestion]) }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_completed: true,
+                    $survey_response_q1: 1,
+                    $survey_response_q2: 'Great product!',
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].responses).toHaveLength(2)
+        expect(result[0].responses[0].value).toBe(1)
+        expect(result[0].responses[1].value).toBe('Great product!')
+    })
+
+    it('skips events whose survey_id is not in the surveys map', () => {
+        const surveys = {} as Record<string, Survey>
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'unknown-survey',
+                    $survey_response_q1: 1,
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(0)
+    })
+
+    it('uses event id as submission id when $survey_submission_id is missing', () => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion]) }
+        const events = [
+            makeEvent({
+                id: 'fallback-id',
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_completed: true,
+                    $survey_response_q1: 1,
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].submissionId).toBe('fallback-id')
+    })
+
+    it('marks incomplete submissions', () => {
+        const surveys = { 'survey-1': makeSurvey([thumbQuestion]) }
+        const events = [
+            makeEvent({
+                properties: {
+                    $survey_id: 'survey-1',
+                    $survey_submission_id: 'sub-1',
+                    $survey_response_q1: 1,
+                    // $survey_completed is absent
+                },
+            }),
+        ]
+
+        const result = groupEventsBySubmission(events, surveys)
+        expect(result).toHaveLength(1)
+        expect(result[0].isComplete).toBe(false)
+    })
+})


### PR DESCRIPTION
## Problem

if the sdk sends survey event properties as integers, sometimes things break

see https://posthoghelp.zendesk.com/agent/tickets/51402 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52903)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds JSONExtractInt fallback to survey response queries
- updates demo data generator to sometimes send numeric values
- bunch of new tests

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

unit tests

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->