### PR TITLE
Add 'hs_additional_emails' to DEFAULT_CONTACT_PROPS

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/settings.py
+++ b/posthog/temporal/data_imports/sources/hubspot/settings.py
@@ -85,6 +85,7 @@ DEFAULT_COMPANY_PROPS = [
 DEFAULT_CONTACT_PROPS = [
     "createdate",
     "email",
+    "hs_additional_emails",
     "firstname",
     "hs_object_id",
     "hs_lead_status",


### PR DESCRIPTION
for Hubspot Data Source

## Problem

Fixes Issue #48934
Only the primary email is getting synched from Hubspot contacts, but contacts can have more than one email address within Hubspot, and these additional emails are not getting synched.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I didn't test this code; it does seem like a minimal change.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
