### PR TITLE
fix: enforce access control for marketing analytics config on backend

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -237,7 +237,7 @@ class TeamRevenueAnalyticsConfigSerializer(serializers.ModelSerializer, UserAcce
         return internal_value
 
 
-class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer):
+class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     sources_map = serializers.JSONField(required=False)
     conversion_goals = serializers.JSONField(required=False)
     attribution_window_days = serializers.IntegerField(required=False, min_value=1, max_value=90)
@@ -259,6 +259,20 @@ class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer):
             "custom_source_mappings",
             "campaign_field_preferences",
         ]
+
+    def to_internal_value(self, data):
+        internal_value = super().to_internal_value(data)
+        if "sources_map" in internal_value:
+            internal_value["_sources_map"] = internal_value["sources_map"]
+        if "conversion_goals" in internal_value:
+            internal_value["_conversion_goals"] = internal_value["conversion_goals"]
+        if "campaign_name_mappings" in internal_value:
+            internal_value["_campaign_name_mappings"] = internal_value["campaign_name_mappings"]
+        if "custom_source_mappings" in internal_value:
+            internal_value["_custom_source_mappings"] = internal_value["custom_source_mappings"]
+        if "campaign_field_preferences" in internal_value:
+            internal_value["_campaign_field_preferences"] = internal_value["campaign_field_preferences"]
+        return internal_value
 
     def update(self, instance, validated_data):
         # Handle sources_map with partial updates
@@ -962,7 +976,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         }
 
         marketing_serializer = TeamMarketingAnalyticsConfigSerializer(
-            instance.marketing_analytics_config, data=validated_data, partial=True
+            instance.marketing_analytics_config,
+            data=validated_data,
+            partial=True,
+            context={**self.context, "user_access_control": self.user_access_control},
         )
         if not marketing_serializer.is_valid():
             raise serializers.ValidationError(_format_serializer_errors(marketing_serializer.errors))

--- a/posthog/models/team/team_marketing_analytics_config.py
+++ b/posthog/models/team/team_marketing_analytics_config.py
@@ -7,6 +7,7 @@ from posthog.schema import AttributionMode, NodeKind, SourceMap
 
 from posthog.models.team import Team
 from posthog.models.team.extensions import register_team_extension_signal
+from posthog.rbac.decorators import field_access_control
 
 # ruff: noqa: DJ012  # Properties act as field accessors for mangled DB fields, so they need to come before save()
 
@@ -264,39 +265,61 @@ class TeamMarketingAnalyticsConfig(models.Model):
     team = models.OneToOneField(Team, on_delete=models.CASCADE, primary_key=True)
 
     # Attribution settings
-    attribution_window_days = models.IntegerField(default=90, help_text="Attribution window in days (1-90)")
-    attribution_mode = models.CharField(
-        max_length=20,
-        default=AttributionMode.LAST_TOUCH,
-        choices=[(mode.value, mode.value.replace("_", " ").title()) for mode in AttributionMode],
-        help_text="Attribution mode: first_touch or last_touch",
+    attribution_window_days = field_access_control(
+        models.IntegerField(default=90, help_text="Attribution window in days (1-90)"), "project", "admin"
+    )
+    attribution_mode = field_access_control(
+        models.CharField(
+            max_length=20,
+            default=AttributionMode.LAST_TOUCH,
+            choices=[(mode.value, mode.value.replace("_", " ").title()) for mode in AttributionMode],
+            help_text="Attribution mode: first_touch or last_touch",
+        ),
+        "project",
+        "admin",
     )
 
     # Mangled fields incoming:
     # Because we want to validate the schema for these fields, we'll have mangled DB fields/columns
     # that are then wrapped by schema-validation getters/setters
-    _sources_map = models.JSONField(default=dict, db_column="sources_map", null=False, blank=True)
-    _conversion_goals = models.JSONField(default=list, db_column="conversion_goals", null=True, blank=True)
-    _campaign_name_mappings = models.JSONField(
-        default=dict,
-        db_column="campaign_name_mappings",
-        null=False,
-        blank=True,
-        help_text="Maps campaign names to lists of raw UTM values per data source",
+    _sources_map = field_access_control(
+        models.JSONField(default=dict, db_column="sources_map", null=False, blank=True), "project", "admin"
     )
-    _custom_source_mappings = models.JSONField(
-        default=dict,
-        db_column="custom_source_mappings",
-        null=False,
-        blank=True,
-        help_text="Custom UTM source mappings: maps integration types to lists of custom UTM source values",
+    _conversion_goals = field_access_control(
+        models.JSONField(default=list, db_column="conversion_goals", null=True, blank=True), "project", "admin"
     )
-    _campaign_field_preferences = models.JSONField(
-        default=dict,
-        db_column="campaign_field_preferences",
-        null=False,
-        blank=True,
-        help_text="Campaign field matching preferences: defines which field (campaign_name or campaign_id) to match utm_campaign against per integration. Manual mappings always take precedence.",
+    _campaign_name_mappings = field_access_control(
+        models.JSONField(
+            default=dict,
+            db_column="campaign_name_mappings",
+            null=False,
+            blank=True,
+            help_text="Maps campaign names to lists of raw UTM values per data source",
+        ),
+        "project",
+        "admin",
+    )
+    _custom_source_mappings = field_access_control(
+        models.JSONField(
+            default=dict,
+            db_column="custom_source_mappings",
+            null=False,
+            blank=True,
+            help_text="Custom UTM source mappings: maps integration types to lists of custom UTM source values",
+        ),
+        "project",
+        "admin",
+    )
+    _campaign_field_preferences = field_access_control(
+        models.JSONField(
+            default=dict,
+            db_column="campaign_field_preferences",
+            null=False,
+            blank=True,
+            help_text="Campaign field matching preferences: defines which field (campaign_name or campaign_id) to match utm_campaign against per integration. Manual mappings always take precedence.",
+        ),
+        "project",
+        "admin",
     )
 
     def clean(self):


### PR DESCRIPTION
## Problem

For marketing analytics settings we are not enforcing access controls on the backend when updating the settings.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Update marketing analytics config serializer to check access controls for the fields
- Add internal name mapping for mangled fields
- Add access control decorators for marketing analytics config fields

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
