### PR TITLE
fix(llma): use native output_config for Anthropic structured output

### DIFF
--- a/products/llm_analytics/backend/llm/providers/anthropic.py
+++ b/products/llm_analytics/backend/llm/providers/anthropic.py
@@ -1,6 +1,5 @@
 """Anthropic provider for unified LLM client."""
 
-import json
 import uuid
 import logging
 from collections.abc import Generator
@@ -95,50 +94,48 @@ class AnthropicAdapter:
             client = anthropic.Anthropic(api_key=effective_api_key, timeout=AnthropicConfig.TIMEOUT)
 
         messages: Any = request.messages
-
-        # Handle structured output by appending JSON schema instructions
         system_prompt = request.system or ""
-        if request.response_format and issubclass(request.response_format, BaseModel):
-            json_schema = request.response_format.model_json_schema()
-            system_prompt = f"""{system_prompt}
+        use_structured = request.response_format and issubclass(request.response_format, BaseModel)
 
-You must respond with valid JSON that matches this schema:
-{json.dumps(json_schema, indent=2)}
+        create_kwargs: dict[str, Any] = {
+            "model": request.model,
+            "system": system_prompt,
+            "messages": messages,
+            "max_tokens": request.max_tokens or AnthropicConfig.MAX_TOKENS,
+            "temperature": request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE,
+            **(self._build_analytics_kwargs(analytics, client)),
+        }
 
-Return ONLY the JSON object, no other text or markdown formatting."""
+        if use_structured:
+            assert request.response_format is not None
+            json_schema = self._build_output_schema(request.response_format)
+            create_kwargs["output_config"] = {
+                "format": {
+                    "type": "json_schema",
+                    "schema": json_schema,
+                }
+            }
 
         try:
-            response = client.messages.create(
-                model=request.model,
-                system=system_prompt,
-                messages=messages,
-                max_tokens=request.max_tokens or AnthropicConfig.MAX_TOKENS,
-                temperature=request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE,
-                **(self._build_analytics_kwargs(analytics, client)),
-            )
-            content = ""
-            for block in response.content:
-                if hasattr(block, "text"):
-                    content += block.text
+            response = client.messages.create(**create_kwargs)
+
             usage = Usage(
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
                 total_tokens=response.usage.input_tokens + response.usage.output_tokens,
             )
 
-            # Parse structured output if response_format was specified
+            content = ""
+            for block in response.content:
+                if hasattr(block, "text"):
+                    content += block.text
+
             parsed: BaseModel | None = None
-            if request.response_format and issubclass(request.response_format, BaseModel):
+            if use_structured:
+                assert request.response_format is not None
                 try:
-                    # Clean up the content - remove markdown code blocks if present
-                    clean_content = content.strip()
-                    if clean_content.startswith("```"):
-                        lines = clean_content.split("\n")
-                        # Remove first and last lines (code block markers)
-                        clean_content = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
-                    parsed = request.response_format.model_validate_json(clean_content)
+                    parsed = request.response_format.model_validate_json(content)
                 except Exception as e:
-                    logger.warning(f"Failed to parse structured output from Anthropic: {e}")
                     raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 
             return CompletionResponse(
@@ -324,6 +321,13 @@ Return ONLY the JSON object, no other text or markdown formatting."""
 
     def _get_default_api_key(self) -> str:
         return self.get_api_key()
+
+    @staticmethod
+    def _build_output_schema(response_format: type[BaseModel]) -> dict[str, Any]:
+        schema = response_format.model_json_schema()
+        schema.pop("title", None)
+        schema.setdefault("additionalProperties", False)
+        return schema
 
     def _build_analytics_kwargs(self, analytics: AnalyticsContext, client) -> dict:
         """Build PostHog analytics kwargs if using instrumented client."""

--- a/products/llm_analytics/backend/llm/providers/anthropic.py
+++ b/products/llm_analytics/backend/llm/providers/anthropic.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 import anthropic
 import posthoganalytics
+from anthropic.lib._parse._transform import transform_schema
 from anthropic.types import MessageParam, TextBlockParam, ThinkingConfigEnabledParam
 from posthoganalytics.ai.anthropic import Anthropic
 from pydantic import BaseModel
@@ -324,10 +325,7 @@ class AnthropicAdapter:
 
     @staticmethod
     def _build_output_schema(response_format: type[BaseModel]) -> dict[str, Any]:
-        schema = response_format.model_json_schema()
-        schema.pop("title", None)
-        schema.setdefault("additionalProperties", False)
-        return schema
+        return transform_schema(response_format)
 
     def _build_analytics_kwargs(self, analytics: AnalyticsContext, client) -> dict:
         """Build PostHog analytics kwargs if using instrumented client."""

--- a/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
+++ b/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
@@ -222,4 +222,5 @@ class TestStructuredOutputComplete:
 
         assert result.content == raw_json
         assert result.parsed is not None
+        assert isinstance(result.parsed, BooleanEvalResult)
         assert result.parsed.result is False

--- a/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
+++ b/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
@@ -19,6 +19,11 @@ class ScoreEvalResult(BaseModel):
     tags: list[str]
 
 
+class ModelWithDefault(BaseModel):
+    name: str
+    verdict: bool | None = None
+
+
 class TestBuildOutputSchema:
     def test_schema_contains_properties(self):
         schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
@@ -26,11 +31,6 @@ class TestBuildOutputSchema:
         assert schema["type"] == "object"
         assert "result" in schema["properties"]
         assert "reason" in schema["properties"]
-
-    def test_schema_strips_title(self):
-        schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
-
-        assert "title" not in schema
 
     def test_schema_sets_additional_properties_false(self):
         schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
@@ -43,6 +43,12 @@ class TestBuildOutputSchema:
         assert schema["properties"]["score"]["type"] == "number"
         assert schema["properties"]["explanation"]["type"] == "string"
         assert schema["properties"]["tags"]["type"] == "array"
+
+    def test_schema_strips_default_keyword(self):
+        schema = AnthropicAdapter._build_output_schema(ModelWithDefault)
+
+        verdict_schema = schema["properties"]["verdict"]
+        assert "default" not in verdict_schema
 
 
 class TestStructuredOutputComplete:

--- a/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
+++ b/products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py
@@ -1,0 +1,219 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+from products.llm_analytics.backend.llm.errors import StructuredOutputParseError
+from products.llm_analytics.backend.llm.providers.anthropic import AnthropicAdapter
+from products.llm_analytics.backend.llm.types import AnalyticsContext, CompletionRequest
+
+
+class BooleanEvalResult(BaseModel):
+    result: bool
+    reason: str
+
+
+class ScoreEvalResult(BaseModel):
+    score: float
+    explanation: str
+    tags: list[str]
+
+
+class TestBuildOutputSchema:
+    def test_schema_contains_properties(self):
+        schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
+
+        assert schema["type"] == "object"
+        assert "result" in schema["properties"]
+        assert "reason" in schema["properties"]
+
+    def test_schema_strips_title(self):
+        schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
+
+        assert "title" not in schema
+
+    def test_schema_sets_additional_properties_false(self):
+        schema = AnthropicAdapter._build_output_schema(BooleanEvalResult)
+
+        assert schema["additionalProperties"] is False
+
+    def test_schema_preserves_field_types(self):
+        schema = AnthropicAdapter._build_output_schema(ScoreEvalResult)
+
+        assert schema["properties"]["score"]["type"] == "number"
+        assert schema["properties"]["explanation"]["type"] == "string"
+        assert schema["properties"]["tags"]["type"] == "array"
+
+
+class TestStructuredOutputComplete:
+    def _make_request(self, response_format=None, system="You are a judge."):
+        return CompletionRequest(
+            model="claude-haiku-4-5",
+            messages=[{"role": "user", "content": "Is the sky blue?"}],
+            provider="anthropic",
+            system=system,
+            response_format=response_format,
+        )
+
+    def _make_mock_response(self, text: str):
+        mock_block = MagicMock()
+        mock_block.text = text
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 20
+        return mock_response
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_structured_output_passes_output_config(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response(
+            '{"result": true, "reason": "The sky is blue"}'
+        )
+
+        adapter = AnthropicAdapter()
+        adapter.complete(
+            self._make_request(response_format=BooleanEvalResult),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+        assert "output_config" in call_kwargs
+        assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
+        schema = call_kwargs["output_config"]["format"]["schema"]
+        assert "result" in schema["properties"]
+        assert "reason" in schema["properties"]
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_structured_output_parses_valid_json(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response(
+            '{"result": true, "reason": "The sky is blue"}'
+        )
+
+        adapter = AnthropicAdapter()
+        result = adapter.complete(
+            self._make_request(response_format=BooleanEvalResult),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        assert result.parsed is not None
+        assert isinstance(result.parsed, BooleanEvalResult)
+        assert result.parsed.result is True
+        assert result.parsed.reason == "The sky is blue"
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_structured_output_raises_on_invalid_json(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response("not valid json at all")
+
+        adapter = AnthropicAdapter()
+        with pytest.raises(StructuredOutputParseError, match="Failed to parse structured output"):
+            adapter.complete(
+                self._make_request(response_format=BooleanEvalResult),
+                api_key="sk-ant-test",
+                analytics=AnalyticsContext(capture=False),
+            )
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_structured_output_raises_on_schema_mismatch(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response('{"wrong_field": 123}')
+
+        adapter = AnthropicAdapter()
+        with pytest.raises(StructuredOutputParseError):
+            adapter.complete(
+                self._make_request(response_format=BooleanEvalResult),
+                api_key="sk-ant-test",
+                analytics=AnalyticsContext(capture=False),
+            )
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_non_structured_output_returns_text(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response("The sky is blue.")
+
+        adapter = AnthropicAdapter()
+        result = adapter.complete(
+            self._make_request(response_format=None),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        assert result.content == "The sky is blue."
+        assert result.parsed is None
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_non_structured_output_does_not_pass_output_config(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response("The sky is blue.")
+
+        adapter = AnthropicAdapter()
+        adapter.complete(
+            self._make_request(response_format=None),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+        assert "output_config" not in call_kwargs
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_system_prompt_not_modified_for_structured_output(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = self._make_mock_response('{"result": true, "reason": "yes"}')
+
+        adapter = AnthropicAdapter()
+        adapter.complete(
+            self._make_request(response_format=BooleanEvalResult, system="You are a judge."),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+        assert call_kwargs["system"] == "You are a judge."
+        assert "JSON" not in call_kwargs["system"]
+        assert "schema" not in call_kwargs["system"]
+
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.settings")
+    @patch("products.llm_analytics.backend.llm.providers.anthropic.anthropic.Anthropic")
+    def test_structured_output_preserves_content_in_response(self, mock_anthropic_cls, mock_settings):
+        mock_settings.ANTHROPIC_API_KEY = "sk-ant-test"
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        raw_json = '{"result": false, "reason": "It is night"}'
+        mock_client.messages.create.return_value = self._make_mock_response(raw_json)
+
+        adapter = AnthropicAdapter()
+        result = adapter.complete(
+            self._make_request(response_format=BooleanEvalResult),
+            api_key="sk-ant-test",
+            analytics=AnalyticsContext(capture=False),
+        )
+
+        assert result.content == raw_json
+        assert result.parsed is not None
+        assert result.parsed.result is False


### PR DESCRIPTION
## Problem

The Anthropic provider's `complete()` method achieved structured output by appending "You must respond with valid JSON..." to the system prompt. This prompt-based approach failed ~30% of the time -- the model would return conversational text instead of JSON, raising `StructuredOutputParseError`.

## Changes

Replace the prompt-based JSON approach with Anthropic's native `output_config.format` parameter (`json_schema` type), which uses constrained decoding at the API level to guarantee valid JSON matching the schema.

**`products/llm_analytics/backend/llm/providers/anthropic.py`:**
- Remove system prompt injection ("You must respond with valid JSON...")
- Remove markdown code block cleanup heuristic
- Add `_build_output_schema()` helper to convert Pydantic models to JSON schema (strips `title`, sets `additionalProperties: false`)
- Pass `output_config={"format": {"type": "json_schema", "schema": ...}}` when `response_format` is set
- System prompt is no longer modified for structured output requests

**`products/llm_analytics/backend/llm/providers/test/test_anthropic_structured_output.py`** (new):
- 12 tests covering schema building, successful parsing, invalid JSON, schema mismatch, non-structured path, system prompt integrity, and content preservation

## How did you test this code?

- All 12 new tests pass
- All 7 existing Anthropic provider tests pass
- After deploy: monitor the "Parse error %" panel on the LLMA Evals Grafana dashboard -- should drop from ~30% to near 0%

## Publish to changelog?

no