### PR TITLE
fix(workflows): exclude semver operators from targeting

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -31,6 +31,7 @@ import {
     FunnelExclusionLegacy,
     InsightType,
     Optional,
+    PropertyOperator,
 } from '~/types'
 
 import { teamLogic } from '../../../teamLogic'
@@ -110,6 +111,7 @@ export interface ActionFilterProps {
     allowNonCapturedEvents?: boolean
     hogQLGlobals?: Record<string, any>
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    operatorAllowlist?: PropertyOperator[]
 }
 
 export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(function ActionFilter(
@@ -148,6 +150,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         allowNonCapturedEvents,
         hogQLGlobals,
         definitionPopoverRenderer,
+        operatorAllowlist,
     },
     ref
 ): JSX.Element {
@@ -228,6 +231,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         excludedProperties,
         allowNonCapturedEvents,
         hogQLGlobals,
+        operatorAllowlist,
         inlineEventsDocLink: isTrendsFilter(filters)
             ? 'https://posthog.com/docs/product-analytics/trends/overview#combine-events-inline'
             : 'https://posthog.com/docs/product-analytics/funnels#combine-events-inline',

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -191,6 +191,7 @@ export interface ActionFilterRowProps {
     allowNonCapturedEvents?: boolean
     hogQLGlobals?: Record<string, any>
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    operatorAllowlist?: PropertyOperator[]
 }
 
 export function ActionFilterRow({
@@ -231,6 +232,7 @@ export function ActionFilterRow({
     hogQLGlobals,
     inlineEventsDocLink,
     definitionPopoverRenderer,
+    operatorAllowlist,
 }: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties' | 'allowNonCapturedEvents'>): JSX.Element {
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
     const effectiveActionsTaxonomicGroupTypes = showQuickFilters
@@ -923,6 +925,7 @@ export function ActionFilterRow({
                         addFilterDocLink={addFilterDocLink}
                         excludedProperties={excludedProperties}
                         hogQLGlobals={hogQLGlobals}
+                        operatorAllowlist={operatorAllowlist}
                     />
                 </div>
             )}

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -3,15 +3,18 @@ import { useValues } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { isOperatorSemver } from 'lib/utils'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { FilterType } from '~/types'
+import { FilterType, PropertyOperator } from '~/types'
 
 import { workflowLogic } from '../../workflowLogic'
 import { HogFlowAction } from '../types'
+
+export const WORKFLOW_OPERATOR_ALLOWLIST = Object.values(PropertyOperator).filter((op) => !isOperatorSemver(op))
 
 function useSampleGlobals(): Record<string, any> {
     const { workflow } = useValues(workflowLogic)
@@ -87,6 +90,7 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
             buttonCopy={buttonCopy ?? 'Add filter'}
             allowNonCapturedEvents
             hogQLGlobals={sampleGlobals}
+            operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
         />
     )
 }
@@ -114,6 +118,7 @@ export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogF
                 after: '-30d',
             }}
             hogQLGlobals={sampleGlobals}
+            operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
         />
     )
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -45,7 +45,7 @@ import { PropertyFilterType } from '~/types'
 import 'products/workflows/frontend/Workflows/hogflows/registry/triggers'
 
 import { workflowLogic } from '../../workflowLogic'
-import { HogFlowEventFilters } from '../filters/HogFlowFilters'
+import { HogFlowEventFilters, WORKFLOW_OPERATOR_ALLOWLIST } from '../filters/HogFlowFilters'
 import { getRegisteredTriggerTypes } from '../registry/triggers/triggerTypeRegistry'
 import { HogFlowAction } from '../types'
 import { batchTriggerLogic } from './batchTriggerLogic'
@@ -505,6 +505,7 @@ function StepTriggerConfigurationBatch({
                         ],
                     }}
                     hasRowOperator={false}
+                    operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
                 />
             </div>
             <LemonDivider />
@@ -731,6 +732,7 @@ function ConversionGoalSection(): JSX.Element {
                             onChange={(filters) => setWorkflowValue('conversion', { ...workflow.conversion, filters })}
                             pageKey="workflow-conversion-properties"
                             hideBehavioralCohorts
+                            operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
                         />
                     </LemonField.Pure>
                     <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Problem

Semver operators (`semver_eq`, `semver_neq`, `semver_gt`, `semver_gte`, `semver_lt`, `semver_lte`, `semver_tilde`, `semver_caret`, `semver_wildcard`) are not supported by the workflow targeting engine. Users can currently select these operators in workflow property filters, which creates broken filter configurations.

context: https://posthog.slack.com/archives/C07QD3LT8U9/p1771867971943839?thread_ts=1771835574.992179&cid=C07QD3LT8U9

## Changes

- Added `operatorAllowlist` prop to `ActionFilter` and threaded it through `ActionFilterRow` to `PropertyFilters`
- Created `WORKFLOW_OPERATOR_ALLOWLIST` constant that excludes all semver operators
- Applied the allowlist to all property filter contexts in workflows:
  - Event filters (via `ActionFilter`)
  - Property filters (via `PropertyFilters`)
  - Batch trigger filters
  - Conversion goal filters

## How did you test this code?

Verified that TypeScript compiles without errors and no new errors were introduced. The `operatorAllowlist` prop was already implemented in the property filter chain—this change threads it through the ActionFilter component that was previously missing it.

No changelog entry needed.