### PR TITLE
fix: add visual separator between standard and semver operators

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -309,16 +309,19 @@ export function OperatorSelect({
     const options: LemonSelectSection<PropertyOperator>[] | { label: JSX.Element; value: PropertyOperator }[] =
         hasSemver
             ? [
-                  { options: operators.filter((op) => !isOperatorSemver(op)).map(toOption) },
+                  ...(operators.some((op) => !isOperatorSemver(op))
+                      ? [{ options: operators.filter((op) => !isOperatorSemver(op)).map(toOption) }]
+                      : []),
                   {
-                      title: (
+                      title: 'Semver operators',
+                      footer: (
                           <div className="mx-2 my-1">
                               <Link
                                   to="https://posthog.com/docs/data/property-filters#semver-operators"
                                   target="_blank"
-                                  className="text-xs font-semibold uppercase"
+                                  className="text-xs"
                               >
-                                  Semver operators
+                                  Learn more
                               </Link>
                           </div>
                       ),

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -342,7 +342,7 @@ export function OperatorSelect({
             size={size}
             menu={{
                 closeParentPopoverOnClickInside: false,
-                className: '!max-h-[400px]',
+                ...(hasSemver ? { className: '!max-h-[400px]' } : {}),
             }}
             startVisible={startVisible}
         />

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import { RE2JS } from 're2js'
 import { useEffect, useState } from 'react'
 
-import { LemonBanner, LemonDropdownProps, LemonSelect, LemonSelectProps } from '@posthog/lemon-ui'
+import { LemonBanner, LemonDropdownProps, LemonSelect, LemonSelectProps, LemonSelectSection } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -290,6 +290,13 @@ export function OperatorValueSelect({
     )
 }
 
+function toOption(op: PropertyOperator): { label: JSX.Element; value: PropertyOperator } {
+    return {
+        label: <span className="operator-value-option">{allOperatorsMapping[op || PropertyOperator.Exact]}</span>,
+        value: op || PropertyOperator.Exact,
+    }
+}
+
 export function OperatorSelect({
     operator,
     operators,
@@ -298,16 +305,35 @@ export function OperatorSelect({
     size,
     startVisible,
 }: OperatorSelectProps): JSX.Element {
-    const operatorOptions = operators.map((op) => ({
-        label: <span className="operator-value-option">{allOperatorsMapping[op || PropertyOperator.Exact]}</span>,
-        value: op || PropertyOperator.Exact,
-    }))
+    const hasSemver = operators.some(isOperatorSemver)
+    const options: LemonSelectSection<PropertyOperator>[] | { label: JSX.Element; value: PropertyOperator }[] =
+        hasSemver
+            ? [
+                  { options: operators.filter((op) => !isOperatorSemver(op)).map(toOption) },
+                  {
+                      title: (
+                          <div className="mx-2 my-1">
+                              <Link
+                                  to="https://posthog.com/docs/data/property-filters#semver-operators"
+                                  target="_blank"
+                                  className="text-xs font-semibold uppercase"
+                              >
+                                  Semver operators
+                              </Link>
+                          </div>
+                      ),
+                      options: operators.filter(isOperatorSemver).map(toOption),
+                  },
+              ]
+            : operators.map(toOption)
+
     return (
         <LemonSelect
-            options={operatorOptions}
+            options={options}
             value={operator || '='}
             placeholder="Property key"
             dropdownMatchSelectWidth={false}
+            dropdownPlacement="bottom-start"
             fullWidth
             onChange={(op) => {
                 op && onChange(op)

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -342,6 +342,7 @@ export function OperatorSelect({
             size={size}
             menu={{
                 closeParentPopoverOnClickInside: false,
+                className: '!max-h-[300px]',
             }}
             startVisible={startVisible}
         />

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -342,7 +342,7 @@ export function OperatorSelect({
             size={size}
             menu={{
                 closeParentPopoverOnClickInside: false,
-                className: '!max-h-[300px]',
+                className: '!max-h-[400px]',
             }}
             startVisible={startVisible}
         />


### PR DESCRIPTION
## Problem

When a property has semver type, the operator dropdown shows all operators in a single flat list — standard operators followed by semver operators. This is overwhelming and makes it hard to distinguish between the two groups, especially if you're not expecting semver operators.

## Changes

When semver operators are present in the dropdown, they are now grouped under a "Semver" section header using `LemonSelectSection`. Standard operators appear in an untitled section above. When no semver operators are present, the dropdown renders as a flat list as before.

## How did you test this code?

TypeScript compiles without errors. The change only affects the visual grouping of operators in the `OperatorSelect` dropdown — no behavioral changes.

Do not publish to changelog.