### PR TITLE
chore(surveys): clean up empty state

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -749,7 +749,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         }),
         reportSurveyEdited: (survey: Survey) => ({ survey }),
         reportSurveyArchived: (survey: Survey) => ({ survey }),
-        reportSurveyTemplateClicked: (template: SurveyTemplateType) => ({ template }),
+        reportSurveyTemplateClicked: (template: SurveyTemplateType, source?: string) => ({ template, source }),
         reportSurveyCycleDetected: (survey: Survey | NewSurvey) => ({ survey }),
         reportSurveyConsolidatedResultsQuery: (
             survey: Survey,
@@ -1826,9 +1826,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 }),
             })
         },
-        reportSurveyTemplateClicked: ({ template }) => {
+        reportSurveyTemplateClicked: ({ template, source }) => {
             posthog.capture('survey template clicked', {
                 template,
+                source,
             })
         },
         reportSurveyCycleDetected: ({ survey }) => {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -799,8 +799,9 @@ export const productUrls = {
     surveys: (tab?: SurveysTabs): string => `/surveys${tab ? `?tab=${tab}` : ''}`,
     survey: (id: string): string => `/surveys/${id}`,
     surveyTemplates: (): string => '/survey_templates',
-    surveyWizard: (id: string = 'new'): string => `/surveys/guided/${id}`,
     surveyFormBuilder: (id: string = 'new'): string => `/surveys/form/${id}`,
+    surveyWizard: (id: string = 'new', template?: string): string =>
+        `/surveys/guided/${id}${template ? `?template=${encodeURIComponent(template)}` : ''}`,
     taskTracker: (): string => '/tasks',
     taskDetail: (taskId: string | number): string => `/tasks/${taskId}`,
     toolbarLaunch: (): string => '/toolbar',

--- a/frontend/src/scenes/surveys/SurveyTemplates.tsx
+++ b/frontend/src/scenes/surveys/SurveyTemplates.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useState } from 'react'
 
 import { LemonTag, Link } from '@posthog/lemon-ui'
@@ -13,7 +14,6 @@ import { Survey, SurveyAppearance } from '~/types'
 
 import { AbsoluteCornerBadge } from './components/AbsoluteCornerBadge'
 import {
-    NewSurvey,
     QuickSurveyFromTemplate,
     SurveyTemplate,
     SurveyTemplateType,
@@ -22,7 +22,6 @@ import {
 } from './constants'
 import { QuickSurveyModal } from './QuickSurveyModal'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
-import { surveyLogic } from './surveyLogic'
 
 export const scene: SceneExport = {
     component: SurveyTemplates,
@@ -31,7 +30,6 @@ export const scene: SceneExport = {
 interface TemplateCardProps {
     template: SurveyTemplate
     idx: number
-    setSurveyTemplateValues?: (values: Partial<NewSurvey>) => void
     reportSurveyTemplateClicked: (templateType: SurveyTemplateType) => void
     surveyAppearance: SurveyAppearance
     handleTemplateClick: (template: SurveyTemplate) => void
@@ -128,7 +126,6 @@ export function TemplateCard({ template, idx, handleTemplateClick, surveyAppeara
 }
 
 export function SurveyTemplates(): JSX.Element {
-    const { setSurveyTemplateValues } = useActions(surveyLogic({ id: 'new' }))
     const { reportSurveyTemplateClicked } = useActions(eventUsageLogic)
     const { currentTeam } = useValues(teamLogic)
     const surveyAppearance = {
@@ -164,7 +161,6 @@ export function SurveyTemplates(): JSX.Element {
                             key={idx}
                             template={template}
                             idx={idx}
-                            setSurveyTemplateValues={setSurveyTemplateValues}
                             reportSurveyTemplateClicked={reportSurveyTemplateClicked}
                             surveyAppearance={surveyAppearance}
                             handleTemplateClick={(template) => {
@@ -172,16 +168,7 @@ export function SurveyTemplates(): JSX.Element {
                                     setQuickSurveyContext(template.quickSurvey)
                                     setQuickModalOpen(true)
                                 } else {
-                                    setSurveyTemplateValues({
-                                        name: template.templateType,
-                                        questions: template.questions ?? [],
-                                        appearance: {
-                                            ...defaultSurveyAppearance,
-                                            ...template.appearance,
-                                            ...surveyAppearance,
-                                        },
-                                        conditions: template.conditions ?? null,
-                                    })
+                                    router.actions.push(urls.surveyWizard('new', template.templateType))
                                 }
                                 reportSurveyTemplateClicked(template.templateType)
                             }}

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -61,7 +61,7 @@ export function SurveysTable(): JSX.Element {
     const shouldShowEmptyState = !dataLoading && surveys.length === 0
 
     if (shouldShowEmptyState) {
-        return <SurveysEmptyState numOfSurveys={surveys.length} />
+        return <SurveysEmptyState />
     }
 
     return (

--- a/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
+++ b/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
@@ -1,21 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import posthog from 'posthog-js'
 import { useState } from 'react'
-import { toast } from 'react-toastify'
 
-import { IconSparkles } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import MaxTool from 'scenes/max/MaxTool'
-import { useOpenAi } from 'scenes/max/useOpenAi'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
-import { captureMaxAISurveyCreationException } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
-import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { Survey } from '~/types'
 
 import {
@@ -26,21 +19,11 @@ import {
     defaultSurveyAppearance,
     defaultSurveyTemplates,
 } from '../../constants'
-import { surveysLogic } from '../../surveysLogic'
 import { FeaturedTemplateCard, TemplateCard } from '../../SurveyTemplates'
 
-interface Props {
-    numOfSurveys: number
-}
-
-export function SurveysEmptyState({ numOfSurveys }: Props): JSX.Element {
-    const { createSurveyFromTemplate, addProductIntent } = useActions(surveysLogic)
-    const { user } = useValues(userLogic)
+export function SurveysEmptyState(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const { openAi } = useOpenAi()
-    const {
-        data: { surveysCount },
-    } = useValues(surveysLogic)
+    const { reportSurveyTemplateClicked } = useActions(eventUsageLogic)
 
     const [quickModalOpen, setQuickModalOpen] = useState<boolean>(false)
     const [quickSurveyContext, setQuickSurveyContext] = useState<QuickSurveyFromTemplate | undefined>(undefined)
@@ -71,19 +54,13 @@ export function SurveysEmptyState({ numOfSurveys }: Props): JSX.Element {
         .map(templateToSurvey)
         .at(0)
 
-    const handleTemplateClick = async (survey: SurveyTemplate): Promise<void> => {
+    const handleTemplateClick = (survey: SurveyTemplate): void => {
+        reportSurveyTemplateClicked(survey.templateType, SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE)
         if (survey.quickSurvey) {
             setQuickSurveyContext(survey.quickSurvey)
             setQuickModalOpen(true)
         } else {
-            try {
-                await createSurveyFromTemplate(survey)
-            } catch (error) {
-                posthog.captureException(error, {
-                    action: 'survey-creation-from-template-failed',
-                })
-                toast.error('Error while creating survey from template. Please try again.')
-            }
+            router.actions.push(urls.surveyWizard('new', survey.templateType))
         }
     }
 
@@ -93,19 +70,11 @@ export function SurveysEmptyState({ numOfSurveys }: Props): JSX.Element {
                 <div className="flex items-center justify-center">
                     <div className="space-y-6">
                         <div>
-                            <h2 className="mb-0">
-                                {surveysCount > 0 ? 'Create your next survey' : 'Create your first survey'}
-                            </h2>
+                            <h2 className="mb-0">Create your first survey</h2>
                             <p className="mb-0">
                                 Choose from our most popular templates to get started quickly, or create your own from
                                 scratch.
                             </p>
-                            {numOfSurveys > 0 && (
-                                <p className="mb-0">
-                                    Your team is already using surveys. You can take a look at what they're doing, or
-                                    get started yourself.
-                                </p>
-                            )}
                         </div>
 
                         {featuredTemplate && (
@@ -133,50 +102,7 @@ export function SurveysEmptyState({ numOfSurveys }: Props): JSX.Element {
                         </div>
 
                         <div className="flex items-center gap-x-4 gap-y-2 flex-wrap">
-                            {user?.uuid && (
-                                <MaxTool
-                                    identifier="create_survey"
-                                    initialMaxPrompt="Create a survey to collect "
-                                    suggestions={[
-                                        'Create an NPS survey for customers who completed checkout',
-                                        'Create a feedback survey asking about our new dashboard',
-                                    ]}
-                                    context={{}}
-                                    callback={(toolOutput: {
-                                        survey_id?: string
-                                        error?: string
-                                        error_message?: string
-                                    }) => {
-                                        addProductIntent({
-                                            product_type: ProductKey.SURVEYS,
-                                            intent_context: ProductIntentContext.SURVEY_CREATED,
-                                            metadata: {
-                                                survey_id: toolOutput.survey_id,
-                                                source: SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE,
-                                                created_successfully: !toolOutput?.error,
-                                            },
-                                        })
-
-                                        if (toolOutput?.error || !toolOutput?.survey_id) {
-                                            return captureMaxAISurveyCreationException(
-                                                toolOutput.error,
-                                                SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE
-                                            )
-                                        }
-
-                                        router.actions.push(urls.survey(toolOutput.survey_id))
-                                    }}
-                                >
-                                    <LemonButton
-                                        type="primary"
-                                        icon={<IconSparkles />}
-                                        onClick={() => openAi('Create a survey to collect ')}
-                                    >
-                                        Create your own custom survey with PostHog AI
-                                    </LemonButton>
-                                </MaxTool>
-                            )}
-                            <LemonButton type="secondary" onClick={() => router.actions.push(urls.surveyTemplates())}>
+                            <LemonButton type="secondary" onClick={() => router.actions.push(urls.surveyWizard())}>
                                 See all other templates
                             </LemonButton>
                         </div>

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -516,7 +516,6 @@ export const surveyLogic = kea<surveyLogicType>([
         deleteBranchingLogic: true,
         archiveSurvey: true,
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
-        setSurveyTemplateValues: (template: Partial<NewSurvey>) => ({ template }),
         setSelectedPageIndex: (idx: number | null) => ({ idx }),
         setSelectedSection: (section: SurveyEditSection | null) => ({ section }),
         resetTargeting: true,
@@ -1261,10 +1260,6 @@ export const surveyLogic = kea<surveyLogicType>([
                             thankYouMessageHeader,
                         },
                     }
-                },
-                setSurveyTemplateValues: (_, { template }) => {
-                    const newTemplateSurvey = { ...NEW_SURVEY, ...template }
-                    return newTemplateSurvey
                 },
                 setQuestionBranchingType: (state, { questionIndex, type, specificQuestionIndex }) => {
                     const newQuestions = [...state.questions]
@@ -2355,12 +2350,6 @@ export const surveyLogic = kea<surveyLogicType>([
         },
     })),
     actionToUrl(({ values }) => ({
-        setSurveyTemplateValues: () => {
-            const hashParams = router.values.hashParams
-            hashParams['fromTemplate'] = true
-
-            return [urls.survey(values.survey.id), router.values.searchParams, hashParams]
-        },
         editingSurvey: ({ editing }) => {
             const searchParams = router.values.searchParams
             if (editing) {

--- a/frontend/src/scenes/surveys/surveysLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveysLogic.test.ts
@@ -4,16 +4,8 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import {
-    AccessControlLevel,
-    Survey,
-    SurveyQuestionDescriptionContentType,
-    SurveyQuestionType,
-    SurveySchedule,
-    SurveyType,
-} from '~/types'
+import { AccessControlLevel, Survey, SurveySchedule, SurveyType } from '~/types'
 
-import { SURVEY_CREATED_SOURCE, SURVEY_RATING_SCALE, SurveyTemplate, SurveyTemplateType } from './constants'
 import { surveysLogic } from './surveysLogic'
 
 const createTestSurvey = (id: string, name: string): Survey => ({
@@ -230,50 +222,6 @@ describe('surveysLogic', () => {
             expect(capturedIntentRequests[0]).toEqual({
                 product_type: ProductKey.SURVEYS,
                 intent_context: ProductIntentContext.SURVEYS_VIEWED,
-            })
-        })
-
-        it('should track SURVEY_CREATED intent when creating survey from template', async () => {
-            const mockTemplate: SurveyTemplate = {
-                templateType: SurveyTemplateType.NPS,
-                questions: [
-                    {
-                        type: SurveyQuestionType.Rating,
-                        question: 'How likely are you to recommend us?',
-                        description: '',
-                        descriptionContentType: 'text' as SurveyQuestionDescriptionContentType,
-                        display: 'number',
-                        scale: SURVEY_RATING_SCALE.NPS_10_POINT,
-                        lowerBoundLabel: 'Not likely',
-                        upperBoundLabel: 'Very likely',
-                    },
-                ],
-                description: 'NPS survey',
-                type: SurveyType.Popover,
-            }
-
-            useMocks({
-                post: {
-                    '/api/projects/:team/surveys/': () => [200, { id: 'new-survey-123' }],
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.createSurveyFromTemplate(mockTemplate)
-            }).toFinishAllListeners()
-
-            const createIntent = capturedIntentRequests.find(
-                (req) => req.intent_context === ProductIntentContext.SURVEY_CREATED
-            )
-            expect(createIntent).toBeTruthy()
-            expect(createIntent).toMatchObject({
-                product_type: ProductKey.SURVEYS,
-                intent_context: ProductIntentContext.SURVEY_CREATED,
-                metadata: {
-                    survey_id: 'new-survey-123',
-                    source: SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE,
-                    template_type: 'Net promoter score (NPS)',
-                },
             })
         })
 

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -12,7 +12,7 @@ import { featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic
 import { pluralize } from 'lib/utils'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
-import { SURVEY_CREATED_SOURCE, SURVEY_PAGE_SIZE, SurveyTemplate } from 'scenes/surveys/constants'
+import { SURVEY_PAGE_SIZE } from 'scenes/surveys/constants'
 import { duplicateExistingSurvey, sanitizeSurvey } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -215,34 +215,6 @@ export const surveysLogic = kea<surveysLogicType>([
                     ...values.data,
                     surveys: updateSurvey(values.data.surveys, id, updatedSurvey),
                     searchSurveys: updateSurvey(values.data.searchSurveys, id, updatedSurvey),
-                }
-            },
-            createSurveyFromTemplate: async (surveyTemplate: SurveyTemplate) => {
-                const response = await api.surveys.create(
-                    sanitizeSurvey({
-                        ...surveyTemplate,
-                        name: surveyTemplate.templateType,
-                    })
-                )
-
-                actions.addProductIntent({
-                    product_type: ProductKey.SURVEYS,
-                    intent_context: ProductIntentContext.SURVEY_CREATED,
-                    metadata: {
-                        survey_id: response.id,
-                        source: SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE,
-                        template_type: surveyTemplate.templateType,
-                    },
-                })
-
-                // Navigate to the created survey
-                router.actions.push(urls.survey(response.id))
-
-                // Return updated data with the new survey
-                return {
-                    ...values.data,
-                    surveys: [response, ...values.data.surveys],
-                    surveysCount: values.data.surveysCount + 1,
                 }
             },
         },

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -1,5 +1,5 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -340,6 +340,19 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             actions.loadSurveys()
             actions.reportSurveyEdited(survey)
             router.actions.push(urls.survey(survey.id))
+        },
+    })),
+
+    urlToAction(({ actions, props }) => ({
+        [urls.surveyWizard(props.id)]: (_, searchParams) => {
+            const templateParam = searchParams.template
+            if (templateParam && props.id === 'new') {
+                const matchedTemplate = defaultSurveyTemplates.find((t) => t.templateType === templateParam)
+                if (matchedTemplate) {
+                    actions.resetSurvey()
+                    actions.selectTemplate(matchedTemplate)
+                }
+            }
         },
     })),
 

--- a/products/surveys/manifest.tsx
+++ b/products/surveys/manifest.tsx
@@ -12,8 +12,9 @@ export const manifest: ProductManifest = {
         /** @param id A UUID or 'new'. ':id' for routing. */
         survey: (id: string): string => `/surveys/${id}`,
         surveyTemplates: (): string => '/survey_templates',
-        surveyWizard: (id: string = 'new'): string => `/surveys/guided/${id}`,
         surveyFormBuilder: (id: string = 'new'): string => `/surveys/form/${id}`,
+        surveyWizard: (id: string = 'new', template?: string): string =>
+            `/surveys/guided/${id}${template ? `?template=${encodeURIComponent(template)}` : ''}`,
     },
     fileSystemTypes: {
         survey: {


### PR DESCRIPTION
## Problem

surveys empty state....

- has some dead code paths
- AI button is...
    - broken when you click it directly; the "Create a survey to collect" prompt auto-submits
    - also just generally broken, as the survey tools are unreliable
- does not use the new guided editor

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

i want to improve this further, but for some immediate fixes:

1. removes AI button (for now, fixing the AI tools in the meantime)
2. redirects template clicks to the guided editor

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->