### PR TITLE
fix(flags): Clear property value when switching to a date operator

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -14,6 +14,7 @@ import {
     chooseOperatorMap,
     isMobile,
     isOperatorCohort,
+    isOperatorDate,
     isOperatorFlag,
     isOperatorMulti,
     isOperatorRange,
@@ -219,6 +220,12 @@ export function OperatorValueSelect({
                                 onChange(newOperator, value || null)
                             } else if (isOperatorRange(newOperator) && isNaN(value as any)) {
                                 // If the new operator is range and the value is not a number, we want to set the new value to null
+                                onChange(newOperator, null)
+                            } else if (
+                                isOperatorDate(newOperator) &&
+                                !isOperatorDate(currentOperator || PropertyOperator.Exact)
+                            ) {
+                                // Switching to a date operator from a non-date operator: clear the value
                                 onChange(newOperator, null)
                             } else if (isOperatorFlag(newOperator)) {
                                 onChange(newOperator, newOperator)


### PR DESCRIPTION
## Summary

Fixes #47703.

- When switching from a string/numeric operator (e.g. "equals") to a date operator (e.g. "is after"), the old value was silently preserved internally even though the UI rendered a date picker that appeared empty. Saving would persist the invalid value.
- Added an `isOperatorDate` check in the operator change handler in `OperatorValueSelect` that clears the value to `null` when transitioning from a non-date to a date operator. Switching between date operators (e.g. "is after" → "is before") preserves the value.
- Follows the existing pattern used for range operators.

## Test plan

- [ ] Edit a feature flag condition: set a person property with operator "equals" and value "garbage"
- [ ] Switch operator to "is after" — value should clear and date picker should appear empty
- [ ] Switch between date operators (e.g. "is after" → "is before") — value should be preserved
- [ ] Save the flag — no garbage values should be stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)