### PR TITLE
feat: search saved filters in the taxonomic filters in replay

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -48,7 +48,6 @@ import {
     replayTaxonomicFiltersProperties,
 } from 'scenes/session-recordings/filters/ReplayTaxonomicFilters'
 import { SavedFiltersTaxonomicGroup } from 'scenes/session-recordings/filters/SavedFiltersTaxonomicGroup'
-import { sessionRecordingSavedFiltersLogic } from 'scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -998,8 +997,10 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         name: 'Saved filters',
                         searchPlaceholder: 'saved filters',
                         type: TaxonomicFilterGroupType.ReplaySavedFilters,
-                        logic: sessionRecordingSavedFiltersLogic,
-                        value: 'savedFilters',
+                        endpoint: combineUrl(`api/projects/${projectId}/session_recording_playlists/`, {
+                            type: 'filters',
+                            order: '-last_modified_at',
+                        }).url,
                         render: SavedFiltersTaxonomicGroup,
                         getName: (filter: SessionRecordingPlaylistType) =>
                             filter.name || filter.derived_name || 'Unnamed',

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -47,6 +47,8 @@ import {
     ReplayTaxonomicFilters,
     replayTaxonomicFiltersProperties,
 } from 'scenes/session-recordings/filters/ReplayTaxonomicFilters'
+import { SavedFiltersTaxonomicGroup } from 'scenes/session-recordings/filters/SavedFiltersTaxonomicGroup'
+import { sessionRecordingSavedFiltersLogic } from 'scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -70,6 +72,7 @@ import {
     PropertyDefinition,
     PropertyDefinitionType,
     QueryBasedInsightModel,
+    SessionRecordingPlaylistType,
     TeamType,
 } from '~/types'
 
@@ -990,6 +993,18 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             }
                         },
                         getPopoverHeader: () => 'Replay',
+                    },
+                    {
+                        name: 'Saved filters',
+                        searchPlaceholder: 'saved filters',
+                        type: TaxonomicFilterGroupType.ReplaySavedFilters,
+                        logic: sessionRecordingSavedFiltersLogic,
+                        value: 'savedFilters',
+                        render: SavedFiltersTaxonomicGroup,
+                        getName: (filter: SessionRecordingPlaylistType) =>
+                            filter.name || filter.derived_name || 'Unnamed',
+                        getValue: (filter: SessionRecordingPlaylistType) => filter.short_id,
+                        getPopoverHeader: () => 'Saved filter',
                     },
                     {
                         name: 'On this page',

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -218,6 +218,7 @@ export enum TaxonomicFilterGroupType {
     LogResourceAttributes = 'log_resource_attributes',
     // Misc
     Replay = 'replay',
+    ReplaySavedFilters = 'replay_saved_filters',
     RevenueAnalyticsProperties = 'revenue_analytics_properties',
     Resources = 'resources',
     ErrorTrackingProperties = 'error_tracking_properties',

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -5,6 +5,7 @@ import {
     taxonomicFilterTypeToPropertyFilterType,
 } from 'lib/components/PropertyFilters/utils'
 import { taxonomicFilterGroupTypeToEntityType } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
+import { sessionRecordingSavedFiltersLogic } from 'scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { EntityTypes } from '~/types'
@@ -16,6 +17,7 @@ import {
     PersonPropertyFilter,
     PropertyFilterType,
     PropertyOperator,
+    SessionRecordingPlaylistType,
     UniversalFiltersGroup,
     UniversalFiltersGroupValue,
 } from '~/types'
@@ -141,6 +143,12 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
         removeGroupValue: () => props.onChange(values.filterGroup),
 
         addGroupFilter: ({ taxonomicGroup, propertyKey, item }) => {
+            if (taxonomicGroup.type === TaxonomicFilterGroupType.ReplaySavedFilters) {
+                sessionRecordingSavedFiltersLogic
+                    .findMounted()
+                    ?.actions.requestApplySavedFilter(item as unknown as SessionRecordingPlaylistType)
+                return
+            }
             const newValues = [...values.filterGroup.values]
 
             if (isQuickFilterItem(item)) {

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -31,6 +31,12 @@ import {
 } from '../TaxonomicFilter/types'
 import type { universalFiltersLogicType } from './universalFiltersLogicType'
 
+function isApplicableSavedFilter(
+    item: unknown
+): item is SessionRecordingPlaylistType & { filters: NonNullable<SessionRecordingPlaylistType['filters']> } {
+    return typeof item === 'object' && item !== null && 'short_id' in item && 'filters' in item && item.filters != null
+}
+
 export const DEFAULT_UNIVERSAL_GROUP_FILTER: UniversalFiltersGroup = {
     type: FilterLogicalOperator.And,
     values: [
@@ -144,9 +150,9 @@ export const universalFiltersLogic = kea<universalFiltersLogicType>([
 
         addGroupFilter: ({ taxonomicGroup, propertyKey, item }) => {
             if (taxonomicGroup.type === TaxonomicFilterGroupType.ReplaySavedFilters) {
-                sessionRecordingSavedFiltersLogic
-                    .findMounted()
-                    ?.actions.requestApplySavedFilter(item as unknown as SessionRecordingPlaylistType)
+                if (isApplicableSavedFilter(item)) {
+                    sessionRecordingSavedFiltersLogic.findMounted()?.actions.requestApplySavedFilter(item)
+                }
                 return
             }
             const newValues = [...values.filterGroup.values]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32122,6 +32122,7 @@
                 "log_attributes",
                 "log_resource_attributes",
                 "replay",
+                "replay_saved_filters",
                 "revenue_analytics_properties",
                 "resources",
                 "error_tracking_properties",

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import equal from 'fast-deep-equal'
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
     IconAsterisk,
@@ -412,6 +412,7 @@ const ReplayFiltersTab = ({
 
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.Replay,
+        TaxonomicFilterGroupType.ReplaySavedFilters,
         TaxonomicFilterGroupType.Events,
         TaxonomicFilterGroupType.EventProperties,
         TaxonomicFilterGroupType.Actions,
@@ -431,8 +432,20 @@ const ReplayFiltersTab = ({
 
     taxonomicGroupTypes.unshift(TaxonomicFilterGroupType.SuggestedFilters)
 
-    const { appliedSavedFilter } = useValues(sessionRecordingSavedFiltersLogic)
-    const { loadSavedFilters, setAppliedSavedFilter } = useActions(sessionRecordingSavedFiltersLogic)
+    const { appliedSavedFilter, pendingFilterApplication } = useValues(sessionRecordingSavedFiltersLogic)
+    const { loadSavedFilters, setAppliedSavedFilter, clearPendingFilterApplication } = useActions(
+        sessionRecordingSavedFiltersLogic
+    )
+    const { setActiveFilterTab } = useActions(playlistFiltersLogic)
+
+    useEffect(() => {
+        if (pendingFilterApplication) {
+            setFilters(pendingFilterApplication.filters as Partial<RecordingUniversalFilters>)
+            setAppliedSavedFilter(pendingFilterApplication)
+            setActiveFilterTab('filters')
+            clearPendingFilterApplication()
+        }
+    }, [pendingFilterApplication, setFilters, setActiveFilterTab, setAppliedSavedFilter, clearPendingFilterApplication])
 
     const updateSavedFilter = async (): Promise<void> => {
         if (appliedSavedFilter === null) {

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -439,12 +439,17 @@ const ReplayFiltersTab = ({
     const { setActiveFilterTab } = useActions(playlistFiltersLogic)
 
     useEffect(() => {
-        if (pendingFilterApplication) {
+        if (!pendingFilterApplication) {
+            return
+        }
+
+        if (pendingFilterApplication.filters) {
             setFilters(pendingFilterApplication.filters as Partial<RecordingUniversalFilters>)
             setAppliedSavedFilter(pendingFilterApplication)
             setActiveFilterTab('filters')
-            clearPendingFilterApplication()
         }
+
+        clearPendingFilterApplication()
     }, [pendingFilterApplication, setFilters, setActiveFilterTab, setAppliedSavedFilter, clearPendingFilterApplication])
 
     const updateSavedFilter = async (): Promise<void> => {

--- a/frontend/src/scenes/session-recordings/filters/SavedFiltersTaxonomicGroup.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFiltersTaxonomicGroup.tsx
@@ -1,23 +1,28 @@
 import { useValues } from 'kea'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
 import { TaxonomicFilterRenderProps } from 'lib/components/TaxonomicFilter/types'
 
 import { SessionRecordingPlaylistType } from '~/types'
 
-import { sessionRecordingSavedFiltersLogic } from './sessionRecordingSavedFiltersLogic'
-
 export function SavedFiltersTaxonomicGroup({
     onChange,
     infiniteListLogicProps,
 }: Pick<TaxonomicFilterRenderProps, 'onChange' | 'infiniteListLogicProps'>): JSX.Element {
-    const { items, searchQuery } = useValues(infiniteListLogic(infiniteListLogicProps))
-    const { requestApplySavedFilter } = sessionRecordingSavedFiltersLogic.actions
+    const { items, searchQuery, isLoading } = useValues(infiniteListLogic(infiniteListLogicProps))
 
     const filters = items.results as unknown as SessionRecordingPlaylistType[]
     const hasResults = filters.length > 0
+
+    if (isLoading && !hasResults) {
+        return (
+            <div className="p-2 flex items-center justify-center">
+                <Spinner className="text-2xl" />
+            </div>
+        )
+    }
 
     return (
         <div className="px-1 pt-1.5 pb-2.5">
@@ -31,7 +36,6 @@ export function SavedFiltersTaxonomicGroup({
                                 size="small"
                                 fullWidth
                                 onClick={() => {
-                                    requestApplySavedFilter(filter)
                                     onChange(filter.short_id, filter)
                                 }}
                             >

--- a/frontend/src/scenes/session-recordings/filters/SavedFiltersTaxonomicGroup.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFiltersTaxonomicGroup.tsx
@@ -1,0 +1,50 @@
+import { useValues } from 'kea'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
+import { TaxonomicFilterRenderProps } from 'lib/components/TaxonomicFilter/types'
+
+import { SessionRecordingPlaylistType } from '~/types'
+
+import { sessionRecordingSavedFiltersLogic } from './sessionRecordingSavedFiltersLogic'
+
+export function SavedFiltersTaxonomicGroup({
+    onChange,
+    infiniteListLogicProps,
+}: Pick<TaxonomicFilterRenderProps, 'onChange' | 'infiniteListLogicProps'>): JSX.Element {
+    const { items, searchQuery } = useValues(infiniteListLogic(infiniteListLogicProps))
+    const { requestApplySavedFilter } = sessionRecordingSavedFiltersLogic.actions
+
+    const filters = items.results as unknown as SessionRecordingPlaylistType[]
+    const hasResults = filters.length > 0
+
+    return (
+        <div className="px-1 pt-1.5 pb-2.5">
+            {hasResults ? (
+                <ul className="gap-y-px">
+                    {filters.map((filter) => {
+                        const name = filter.name || filter.derived_name || 'Unnamed'
+                        return (
+                            <LemonButton
+                                key={filter.short_id}
+                                size="small"
+                                fullWidth
+                                onClick={() => {
+                                    requestApplySavedFilter(filter)
+                                    onChange(filter.short_id, filter)
+                                }}
+                            >
+                                {name}
+                            </LemonButton>
+                        )
+                    })}
+                </ul>
+            ) : (
+                <div className="p-2 text-secondary text-center">
+                    {searchQuery ? 'No saved filters match your search' : 'No saved filters yet'}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
@@ -43,6 +43,8 @@ export const sessionRecordingSavedFiltersLogic = kea<sessionRecordingSavedFilter
         deletePlaylist: (playlist: SessionRecordingPlaylistType) => ({ playlist }),
         checkForSavedFilterRedirect: true,
         setAppliedSavedFilter: (appliedSavedFilter: SessionRecordingPlaylistType | null) => ({ appliedSavedFilter }),
+        requestApplySavedFilter: (filter: SessionRecordingPlaylistType) => ({ filter }),
+        clearPendingFilterApplication: true,
     })),
     reducers(() => ({
         filters: [
@@ -60,6 +62,13 @@ export const sessionRecordingSavedFiltersLogic = kea<sessionRecordingSavedFilter
             null as SessionRecordingPlaylistType | null,
             {
                 setAppliedSavedFilter: (_, { appliedSavedFilter }) => appliedSavedFilter,
+            },
+        ],
+        pendingFilterApplication: [
+            null as SessionRecordingPlaylistType | null,
+            {
+                requestApplySavedFilter: (_, { filter }) => filter,
+                clearPendingFilterApplication: () => null,
             },
         ],
         loadSavedFiltersFailed: [

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4003,6 +4003,7 @@ class TaxonomicFilterGroupType(StrEnum):
     LOG_ATTRIBUTES = "log_attributes"
     LOG_RESOURCE_ATTRIBUTES = "log_resource_attributes"
     REPLAY = "replay"
+    REPLAY_SAVED_FILTERS = "replay_saved_filters"
     REVENUE_ANALYTICS_PROPERTIES = "revenue_analytics_properties"
     RESOURCES = "resources"
     ERROR_TRACKING_PROPERTIES = "error_tracking_properties"


### PR DESCRIPTION
let's make it easier to find saved filters by surfacing them in the taxonomic filters

![CleanShot 2026-02-23 at 20.07.28.gif](https://app.graphite.com/user-attachments/assets/98a8973a-0e9d-40a4-b051-5d9dbb93f390.gif)

