### PR TITLE
feat(surveys): ai-first empty state

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -214,6 +214,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys
     SURVEYS_REDESIGNED_VIEW: 'surveys-redesigned-view', // owner: #team-surveys, enables the redesigned survey view with sidebar
+    SURVEYS_AI_FIRST_EMPTY_STATE: 'surveys-ai-first-empty-state', // owner: #team-surveys, enables ai-first empty state
     TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
     TRACK_REACT_FRAMERATE: 'track-react-framerate', // owner: @pauldambra #team-replay
     WEB_ANALYTICS_API: 'web-analytics-api', // owner: #team-web-analytics

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -765,6 +765,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             totalDurationMs: number,
             queryDurations: { aggregate: number; openEnded: number }
         ) => ({ survey, totalDurationMs, queryDurations }),
+        reportSurveyEmptyStateViewed: true,
+        reportSurveyAiPromptSubmitted: (source: string) => ({ source }),
         reportProductTourViewed: (tour: ProductTour) => ({ tour }),
         reportProductTourCreated: (tour: ProductTour, creationSource?: 'app' | 'toolbar') => ({
             tour,
@@ -1851,6 +1853,14 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportSurveyTemplateClicked: ({ template, source }) => {
             posthog.capture('survey template clicked', {
                 template,
+                source,
+            })
+        },
+        reportSurveyEmptyStateViewed: () => {
+            posthog.capture('survey empty state viewed')
+        },
+        reportSurveyAiPromptSubmitted: ({ source }) => {
+            posthog.capture('survey AI prompt submitted', {
                 source,
             })
         },

--- a/frontend/src/scenes/surveys/SurveyTemplates.tsx
+++ b/frontend/src/scenes/surveys/SurveyTemplates.tsx
@@ -33,6 +33,7 @@ interface TemplateCardProps {
     reportSurveyTemplateClicked: (templateType: SurveyTemplateType) => void
     surveyAppearance: SurveyAppearance
     handleTemplateClick: (template: SurveyTemplate) => void
+    hideTag?: boolean
 }
 
 export function FeaturedTemplateCard({
@@ -78,7 +79,13 @@ export function FeaturedTemplateCard({
     )
 }
 
-export function TemplateCard({ template, idx, handleTemplateClick, surveyAppearance }: TemplateCardProps): JSX.Element {
+export function TemplateCard({
+    template,
+    idx,
+    handleTemplateClick,
+    surveyAppearance,
+    hideTag,
+}: TemplateCardProps): JSX.Element {
     return (
         <button
             className="relative flex flex-col bg-bg-light border border-border rounded-lg hover:border-primary-3000-hover focus:border-primary-3000-hover focus:outline-none transition-colors text-left h-full group p-4 cursor-pointer overflow-hidden"
@@ -92,9 +99,11 @@ export function TemplateCard({ template, idx, handleTemplateClick, surveyAppeara
                     <h3 className="text-sm font-semibold text-default line-clamp-2 flex-1 mb-0">
                         {template.templateType}
                     </h3>
-                    <LemonTag type={template.tagType || 'default'} size="small" className="ml-2 flex-shrink-0">
-                        {template.category || 'General'}
-                    </LemonTag>
+                    {!hideTag && (
+                        <LemonTag type={template.tagType || 'default'} size="small" className="ml-2 flex-shrink-0">
+                            {template.category || 'General'}
+                        </LemonTag>
+                    )}
                 </div>
                 <p className="text-sm text-secondary leading-relaxed line-clamp-3">{template.description}</p>
             </div>

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { router } from 'kea-router'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
@@ -13,7 +12,6 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
 import { SurveysTable } from 'scenes/surveys/components/SurveysTable'
-import { captureMaxAISurveyCreationException } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -68,7 +66,7 @@ function NewSurveyButton(): JSX.Element {
 
 function Surveys(): JSX.Element {
     const { tab } = useValues(surveysLogic)
-    const { setTab, loadSurveys, addProductIntent } = useActions(surveysLogic)
+    const { setTab, handleMaxSurveyCreated } = useActions(surveysLogic)
 
     return (
         <SceneContent>
@@ -94,34 +92,7 @@ function Surveys(): JSX.Element {
                         'Create a quick satisfaction survey for support interactions',
                     ],
                     context: {},
-                    callback: (toolOutput: {
-                        survey_id?: string
-                        survey_name?: string
-                        survey_type?: string
-                        error?: string
-                        error_message?: string
-                    }) => {
-                        addProductIntent({
-                            product_type: ProductKey.SURVEYS,
-                            intent_context: ProductIntentContext.SURVEY_CREATED,
-                            metadata: {
-                                survey_id: toolOutput.survey_id,
-                                source: SURVEY_CREATED_SOURCE.MAX_AI,
-                                created_successfully: !toolOutput?.error,
-                            },
-                        })
-
-                        if (toolOutput?.error || !toolOutput?.survey_id) {
-                            return captureMaxAISurveyCreationException(toolOutput.error, SURVEY_CREATED_SOURCE.MAX_AI)
-                        }
-
-                        loadSurveys()
-                        if (toolOutput.survey_type === 'popover') {
-                            router.actions.push(urls.surveyWizard(toolOutput.survey_id))
-                        } else {
-                            router.actions.push(urls.survey(toolOutput.survey_id) + '?edit=true')
-                        }
-                    },
+                    callback: (toolOutput) => handleMaxSurveyCreated(toolOutput, SURVEY_CREATED_SOURCE.MAX_AI),
                 }}
             />
             <SurveysDisabledBanner />

--- a/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
+++ b/frontend/src/scenes/surveys/components/empty-state/SurveysEmptyState.tsx
@@ -1,11 +1,17 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconArrowRight, IconSparkles } from '@posthog/icons'
+import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
 
+import { MicrophoneHog } from 'lib/components/hedgehogs'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { useMaxTool } from 'scenes/max/useMaxTool'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
+import { FeaturedTemplateCard, TemplateCard } from 'scenes/surveys/SurveyTemplates'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -19,14 +25,23 @@ import {
     defaultSurveyAppearance,
     defaultSurveyTemplates,
 } from '../../constants'
-import { FeaturedTemplateCard, TemplateCard } from '../../SurveyTemplates'
+import { surveysLogic } from '../../surveysLogic'
 
-export function SurveysEmptyState(): JSX.Element {
+const TEMPLATE_TYPES = [SurveyTemplateType.NPS, SurveyTemplateType.CSAT, SurveyTemplateType.PMF]
+
+function SurveysEmptyStateContent(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { reportSurveyTemplateClicked } = useActions(eventUsageLogic)
+    const { handleMaxSurveyCreated } = useActions(surveysLogic)
 
     const [quickModalOpen, setQuickModalOpen] = useState<boolean>(false)
     const [quickSurveyContext, setQuickSurveyContext] = useState<QuickSurveyFromTemplate | undefined>(undefined)
+
+    const { openMax } = useMaxTool({
+        identifier: 'create_survey',
+        initialMaxPrompt: `Create a survey to collect `,
+        callback: (toolOutput) => handleMaxSurveyCreated(toolOutput, SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE),
+    })
 
     const templateToSurvey = (template: SurveyTemplate): Partial<Survey> & SurveyTemplate => {
         return {
@@ -102,6 +117,9 @@ export function SurveysEmptyState(): JSX.Element {
                         </div>
 
                         <div className="flex items-center gap-x-4 gap-y-2 flex-wrap">
+                            <LemonButton type="primary" icon={<IconSparkles />} onClick={() => openMax?.()}>
+                                Create your own custom survey with PostHog AI
+                            </LemonButton>
                             <LemonButton type="secondary" onClick={() => router.actions.push(urls.surveyWizard())}>
                                 See all other templates
                             </LemonButton>
@@ -118,4 +136,123 @@ export function SurveysEmptyState(): JSX.Element {
             />
         </>
     )
+}
+
+function SurveysEmptyStateAIContent(): JSX.Element {
+    const [prompt, setPrompt] = useState('')
+
+    const { reportSurveyTemplateClicked, reportSurveyAiPromptSubmitted } = useActions(eventUsageLogic)
+    const { handleMaxSurveyCreated } = useActions(surveysLogic)
+    const { openMax } = useMaxTool({
+        identifier: 'create_survey',
+        initialMaxPrompt: `!${prompt.trim()}`,
+        callback: (toolOutput) => handleMaxSurveyCreated(toolOutput, SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE),
+    })
+    const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+    const handleSubmit = (): void => {
+        if (prompt.trim()) {
+            reportSurveyAiPromptSubmitted(SURVEY_CREATED_SOURCE.SURVEY_EMPTY_STATE)
+            openMax?.()
+            setPrompt('')
+        }
+    }
+
+    const templates = defaultSurveyTemplates.filter((t) => TEMPLATE_TYPES.includes(t.templateType))
+
+    const handleTemplateClick = (survey: SurveyTemplate): void => {
+        reportSurveyTemplateClicked(survey.templateType, 'empty_state')
+        router.actions.push(urls.surveyWizard('new', survey.templateType))
+    }
+
+    return (
+        <div className="w-full max-w-5xl mx-auto py-10 px-4">
+            <div className="text-center mb-6">
+                <MicrophoneHog className="size-20 mx-auto -mb-1" />
+                <h2 className="text-2xl font-bold mb-1">Create your first survey</h2>
+                <p className="text-secondary text-sm mb-0">
+                    Tell AI what you want to learn from your users, or pick a template below.
+                </p>
+            </div>
+
+            <div className="rounded-xl border-2 border-[var(--color-ai)] mb-8">
+                <label
+                    htmlFor="survey-ai-prompt"
+                    className="flex flex-col cursor-text"
+                    onClick={() => textAreaRef.current?.focus()}
+                >
+                    <LemonTextArea
+                        id="survey-ai-prompt"
+                        ref={textAreaRef}
+                        value={prompt}
+                        onChange={setPrompt}
+                        onPressEnter={handleSubmit}
+                        placeholder="e.g., Create an NPS survey for users who completed onboarding, shown on the dashboard page"
+                        minRows={2}
+                        maxRows={5}
+                        className="!border-none !bg-transparent !shadow-none !rounded-none px-4 pt-4 pb-2 resize-none text-sm"
+                        hideFocus
+                        data-attr="survey-ai-prompt-input"
+                    />
+                    <div className="flex items-center justify-between px-4 pb-3">
+                        <div className="flex items-center gap-1.5 text-xs text-tertiary">
+                            <IconSparkles className="text-ai size-3.5" />
+                            <span>PostHog AI</span>
+                        </div>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            icon={<IconArrowRight />}
+                            onClick={handleSubmit}
+                            disabledReason={!prompt.trim() ? 'Describe the survey you want' : undefined}
+                            data-attr="survey-ai-prompt-submit"
+                        >
+                            Create with AI
+                        </LemonButton>
+                    </div>
+                </label>
+            </div>
+
+            <div className="flex items-center gap-4 mb-6">
+                <div className="flex-1 border-t border-primary" />
+                <span className="text-xs text-tertiary uppercase tracking-wide">or start with a template</span>
+                <div className="flex-1 border-t border-primary" />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+                {templates.map((template, idx) => (
+                    <TemplateCard
+                        key={template.templateType}
+                        template={template}
+                        idx={idx + 1}
+                        reportSurveyTemplateClicked={() => {}}
+                        surveyAppearance={template.appearance ?? defaultSurveyAppearance}
+                        handleTemplateClick={handleTemplateClick}
+                        hideTag={true}
+                    />
+                ))}
+            </div>
+
+            <div className="flex items-center justify-center text-center">
+                <LemonButton type="secondary" size="small" onClick={() => router.actions.push(urls.surveyWizard())}>
+                    See more templates
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+export function SurveysEmptyState(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { reportSurveyEmptyStateViewed } = useActions(eventUsageLogic)
+
+    useEffect(() => {
+        reportSurveyEmptyStateViewed()
+    }, [])
+
+    if (featureFlags[FEATURE_FLAGS.SURVEYS_AI_FIRST_EMPTY_STATE] === 'test') {
+        return <SurveysEmptyStateAIContent />
+    }
+
+    return <SurveysEmptyStateContent />
 }

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -23,8 +23,10 @@ import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLog
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { ActivityScope, AvailableFeature, Breadcrumb, ProgressStatus, Survey, SurveyType } from '~/types'
 
+import { SURVEY_CREATED_SOURCE } from './constants'
 import type { surveysLogicType } from './surveysLogicType'
 import { surveysSdkLogic } from './surveysSdkLogic'
+import { captureMaxAISurveyCreationException } from './utils'
 
 export enum SurveysTabs {
     Active = 'active',
@@ -134,6 +136,16 @@ export const surveysLogic = kea<surveysLogicType>([
         loadNextPage: true,
         loadNextSearchPage: true,
         setSurveyToDuplicate: (survey: Survey | null) => ({ survey }),
+        handleMaxSurveyCreated: (
+            toolOutput: {
+                survey_id?: string
+                survey_name?: string
+                survey_type?: string
+                error?: string
+                error_message?: string
+            },
+            source: SURVEY_CREATED_SOURCE
+        ) => ({ toolOutput, source }),
     }),
     loaders(({ values, actions }) => ({
         data: {
@@ -364,6 +376,29 @@ export const surveysLogic = kea<surveysLogicType>([
         },
         setTab: ({ tab }) => {
             actions.setSurveysFilters({ ...values.filters, archived: tab === SurveysTabs.Archived })
+        },
+        handleMaxSurveyCreated: ({ toolOutput, source }) => {
+            actions.addProductIntent({
+                product_type: ProductKey.SURVEYS,
+                intent_context: ProductIntentContext.SURVEY_CREATED,
+                metadata: {
+                    survey_id: toolOutput.survey_id,
+                    source,
+                    created_successfully: !toolOutput?.error,
+                },
+            })
+
+            if (toolOutput?.error || !toolOutput?.survey_id) {
+                captureMaxAISurveyCreationException(toolOutput.error, source)
+                return
+            }
+
+            actions.loadSurveys()
+            if (toolOutput.survey_type === 'popover') {
+                router.actions.push(urls.surveyWizard(toolOutput.survey_id))
+            } else {
+                router.actions.push(urls.survey(toolOutput.survey_id) + '?edit=true')
+            }
         },
         setSearchTerm: async ({ searchTerm }, breakpoint) => {
             await breakpoint(300) // Debounce for 300ms

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -87,6 +87,10 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         setPreviewPageIndex((current) => (current > maxPreviewIndex ? Math.max(0, maxPreviewIndex) : current))
     }, [maxPreviewIndex])
 
+    const handleCustomizeMore = (): void => {
+        router.actions.push(urls.survey(id) + (isEditing ? '?edit=true' : '#fromTemplate=true'))
+    }
+
     // Show loading state while loading existing survey
     if (isEditing && surveyLoading) {
         return (
@@ -109,7 +113,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                             Surveys
                         </LemonButton>
                     </div>
-                    <TemplateStep />
+                    <TemplateStep handleCustomizeMore={handleCustomizeMore} />
                 </div>
             </div>
         )
@@ -119,10 +123,6 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         ...survey,
         id,
     } as NewSurvey
-
-    const handleCustomizeMore = (): void => {
-        router.actions.push(urls.survey(id) + (isEditing ? '?edit=true' : '#fromTemplate=true'))
-    }
 
     const getConditionsSummary = (): string[] => {
         const conditions = survey.conditions

--- a/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/TemplateStep.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import {
+    IconArrowRight,
     IconChevronDown,
     IconChevronRight,
     IconComment,
@@ -18,9 +19,13 @@ import {
     IconTrending,
     IconWarning,
 } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
 
-import { SurveyTemplate, SurveyTemplateType } from '../../constants'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { useMaxTool } from 'scenes/max/useMaxTool'
+
+import { SURVEY_CREATED_SOURCE, SurveyTemplate, SurveyTemplateType } from '../../constants'
+import { surveysLogic } from '../../surveysLogic'
 import { surveyWizardLogic } from '../surveyWizardLogic'
 
 const TEMPLATE_ICONS: Partial<Record<SurveyTemplateType, React.ComponentType<{ className?: string }>>> = {
@@ -82,10 +87,27 @@ function TemplateCard({ template, onClick, featured }: TemplateCardProps): JSX.E
     )
 }
 
-export function TemplateStep(): JSX.Element {
+export function TemplateStep({ handleCustomizeMore }: { handleCustomizeMore: () => void }): JSX.Element {
     const { coreTemplates, otherTemplates } = useValues(surveyWizardLogic)
     const { selectTemplate } = useActions(surveyWizardLogic)
+    const { reportSurveyAiPromptSubmitted } = useActions(eventUsageLogic)
+    const { handleMaxSurveyCreated } = useActions(surveysLogic)
     const [showOthers, setShowOthers] = useState(false)
+    const [prompt, setPrompt] = useState('')
+    const textAreaRef = useRef<HTMLTextAreaElement>(null)
+    const { openMax } = useMaxTool({
+        identifier: 'create_survey',
+        initialMaxPrompt: `!${prompt.trim()}`,
+        callback: (toolOutput) => handleMaxSurveyCreated(toolOutput, SURVEY_CREATED_SOURCE.SURVEY_WIZARD),
+    })
+
+    const handleAiSubmit = (): void => {
+        if (prompt.trim()) {
+            reportSurveyAiPromptSubmitted(SURVEY_CREATED_SOURCE.SURVEY_WIZARD)
+            openMax?.()
+            setPrompt('')
+        }
+    }
 
     return (
         <div className="space-y-6">
@@ -108,7 +130,7 @@ export function TemplateStep(): JSX.Element {
 
             {/* Other templates - collapsible */}
             {otherTemplates.length > 0 && (
-                <div className="border-t border-border pt-6 space-y-4">
+                <div className="space-y-4">
                     <LemonButton
                         type="tertiary"
                         onClick={() => setShowOthers(!showOthers)}
@@ -130,6 +152,59 @@ export function TemplateStep(): JSX.Element {
                     )}
                 </div>
             )}
+
+            <div className="flex items-center gap-4">
+                <div className="flex-1 border-t border-border" />
+                <span className="text-xs text-tertiary uppercase tracking-wide">
+                    or tell PostHog AI what you want to learn
+                </span>
+                <div className="flex-1 border-t border-border" />
+            </div>
+
+            <div className="rounded-xl border-2 border-[var(--color-ai)]">
+                <label
+                    htmlFor="wizard-ai-prompt"
+                    className="flex flex-col cursor-text"
+                    onClick={() => textAreaRef.current?.focus()}
+                >
+                    <LemonTextArea
+                        id="wizard-ai-prompt"
+                        ref={textAreaRef}
+                        value={prompt}
+                        onChange={setPrompt}
+                        onPressEnter={handleAiSubmit}
+                        placeholder="e.g., Create an NPS survey for users who completed onboarding"
+                        minRows={2}
+                        maxRows={5}
+                        className="!border-none !bg-transparent !shadow-none !rounded-none px-4 pt-4 pb-2 resize-none text-sm"
+                        hideFocus
+                        data-attr="wizard-ai-prompt-input"
+                    />
+                    <div className="flex items-center justify-between px-4 pb-3">
+                        <div className="flex items-center gap-1.5 text-xs text-tertiary">
+                            <IconSparkles className="text-ai size-3.5" />
+                            <span>PostHog AI</span>
+                        </div>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            icon={<IconArrowRight />}
+                            onClick={handleAiSubmit}
+                            disabledReason={!prompt.trim() ? 'Describe the survey you want' : undefined}
+                            data-attr="wizard-ai-prompt-submit"
+                        >
+                            Create with AI
+                        </LemonButton>
+                    </div>
+                </label>
+            </div>
+
+            <p className="text-center text-xs text-muted">
+                Need more control?{' '}
+                <button type="button" onClick={handleCustomizeMore} className="text-link hover:underline">
+                    Open full editor
+                </button>
+            </p>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -54,7 +54,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             surveysLogic,
             ['loadSurveys'],
             eventUsageLogic,
-            ['reportSurveyCreated', 'reportSurveyEdited'],
+            ['reportSurveyCreated', 'reportSurveyEdited', 'reportSurveyTemplateClicked'],
             teamLogic,
             ['addProductIntent'],
         ],
@@ -260,6 +260,8 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                 ...template.conditions,
                 seenSurveyWaitPeriodInDays: frequencyToDays[frequencyValue],
             })
+
+            actions.reportSurveyTemplateClicked(template.templateType, SURVEY_CREATED_SOURCE.SURVEY_WIZARD)
         },
         restoreDefaultQuestions: () => {
             const template = values.selectedTemplate

--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -150,6 +150,10 @@ SURVEY_CREATION_TOOL_DESCRIPTION = dedent("""
     - "single_choice": pick one from choices
     - "multiple_choice": pick many from choices
     - "link": call-to-action link
+
+    # After creation
+    Always share the survey link with the user so they can view and configure it.
+    The link is included in the tool response.
     """).strip()
 
 
@@ -269,7 +273,12 @@ class CreateSurveyTool(MaxTool):
             created_survey = await Survey.objects.acreate(team=self._team, created_by=self._user, **survey_data)
 
             launch_msg = " and launched" if should_launch else ""
-            return f"Survey '{created_survey.name}' created{launch_msg} successfully!", {
+            survey_id = str(created_survey.id)
+            if survey_type == "popover":
+                survey_url = f"/surveys/guided/{survey_id}"
+            else:
+                survey_url = f"/surveys/{survey_id}?edit=true"
+            return f"Survey '{created_survey.name}' created{launch_msg} successfully! [View survey]({survey_url})", {
                 "survey_id": created_survey.id,
                 "survey_name": created_survey.name,
                 "survey_type": survey_type,


### PR DESCRIPTION
## Problem

now that the surveys AI tools work better, the empty state needs some AI love :heart::robot_face:

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds new posthog ai prompt to the empty state UI (behind experiment!)

opens sidepanel instead of the full-page AI view so we keep the surveys context, and the callback will fire to redirect to the newly-created survey

experiment: https://us.posthog.com/project/2/experiments/359188

| old | new |
| --- | --- |
| ![Screenshot 2026-02-23 at 1.34.49 PM.png](https://app.graphite.com/user-attachments/assets/cfe2d816-74bf-4b7a-aa24-8a8286a42684.png)<br> | ![Screenshot 2026-02-23 at 1.35.13 PM.png](https://app.graphite.com/user-attachments/assets/cbd0011b-123a-45b3-8196-39146c8cec2c.png)<br> |

also, adds an AI prompt input to the wizard!

![Screenshot 2026-02-23 at 1.34.34 PM.png](https://app.graphite.com/user-attachments/assets/f5c02e39-461d-43a8-aa07-8aad8bbc6aea.png)

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->