### PR TITLE
fix: enforce access control for customer analytics config on backend

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -237,7 +237,7 @@ class TeamRevenueAnalyticsConfigSerializer(serializers.ModelSerializer, UserAcce
         return internal_value
 
 
-class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer):
+class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     sources_map = serializers.JSONField(required=False)
     conversion_goals = serializers.JSONField(required=False)
     attribution_window_days = serializers.IntegerField(required=False, min_value=1, max_value=90)
@@ -297,7 +297,7 @@ class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer):
         return instance
 
 
-class TeamCustomerAnalyticsConfigSerializer(serializers.ModelSerializer):
+class TeamCustomerAnalyticsConfigSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     activity_event = serializers.JSONField(required=False)
     signup_pageview_event = serializers.JSONField(required=False)
     signup_event = serializers.JSONField(required=False)
@@ -991,7 +991,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         }
 
         serializer = TeamCustomerAnalyticsConfigSerializer(
-            instance.customer_analytics_config, data=validated_data, partial=True
+            instance.customer_analytics_config,
+            data=validated_data,
+            partial=True,
+            context={**self.context, "user_access_control": self.user_access_control},
         )
         if not serializer.is_valid():
             raise serializers.ValidationError(_format_serializer_errors(serializer.errors))

--- a/products/customer_analytics/backend/models/team_customer_analytics_config.py
+++ b/products/customer_analytics/backend/models/team_customer_analytics_config.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from posthog.models import Team
 from posthog.models.team.extensions import register_team_extension_signal
+from posthog.rbac.decorators import field_access_control
 
 from products.customer_analytics.backend.constants import DEFAULT_ACTIVITY_EVENT
 
@@ -13,11 +14,11 @@ logger = logging.getLogger(__name__)
 class TeamCustomerAnalyticsConfig(models.Model):
     team = models.OneToOneField(Team, on_delete=models.CASCADE, primary_key=True)
 
-    activity_event = models.JSONField(default=dict)
-    signup_pageview_event = models.JSONField(default=dict)
-    signup_event = models.JSONField(default=dict)
-    subscription_event = models.JSONField(default=dict)
-    payment_event = models.JSONField(default=dict)
+    activity_event = field_access_control(models.JSONField(default=dict), "project", "admin")
+    signup_pageview_event = field_access_control(models.JSONField(default=dict), "project", "admin")
+    signup_event = field_access_control(models.JSONField(default=dict), "project", "admin")
+    subscription_event = field_access_control(models.JSONField(default=dict), "project", "admin")
+    payment_event = field_access_control(models.JSONField(default=dict), "project", "admin")
 
     def to_cache_key_dict(self) -> dict:
         return {


### PR DESCRIPTION
## Problem

On the backend we are not enforcing access control checks for customer analytics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Enforce project admin access for all customer analytics settings.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
