### PR TITLE
feat(onboarding): add experiment for session replay screenshot

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -342,6 +342,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_SUPPORT: 'product-support', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_SIDE_PANEL: 'product-support-side-panel', // owner: @veryayskiy #team-conversations
     ONBOARDING_AI_PRODUCT_RECOMMENDATIONS: 'onboarding-ai-product-recommendations', // owner: @rafaeelaudibert #team-growth, AI-powered product recommendations in onboarding multivariate=control,test,chat
+    ONBOARDING_SESSION_REPLAY_MEDIA: 'onboarding-session-replay-media', // owner: @fercgomes #team-growth multivariate=control,screenshot,demo
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer

--- a/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
@@ -17,6 +17,7 @@ export const OnboardingSessionReplayConfiguration: OnboardingStepComponentType =
     const mediaVariant = featureFlags[FEATURE_FLAGS.ONBOARDING_SESSION_REPLAY_MEDIA]
 
     const handleNext = (enabled: boolean): void => {
+        window.posthog?.capture('onboarding session replay toggled', { enabled })
         updateCurrentTeam({ session_recording_opt_in: enabled })
         goToNextStep()
     }

--- a/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
@@ -1,8 +1,10 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { FilmCameraHog } from 'lib/components/hedgehogs'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { OnboardingStepKey } from '~/types'
 
@@ -11,6 +13,8 @@ import { OnboardingStepComponentType, onboardingLogic } from './onboardingLogic'
 
 export const OnboardingSessionReplayConfiguration: OnboardingStepComponentType = () => {
     const { goToNextStep, updateCurrentTeam } = useActions(onboardingLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const mediaVariant = featureFlags[FEATURE_FLAGS.ONBOARDING_SESSION_REPLAY_MEDIA]
 
     const handleNext = (enabled: boolean): void => {
         updateCurrentTeam({ session_recording_opt_in: enabled })
@@ -19,34 +23,54 @@ export const OnboardingSessionReplayConfiguration: OnboardingStepComponentType =
 
     return (
         <OnboardingStep title="Record user sessions" stepKey={OnboardingStepKey.SESSION_REPLAY} showContinue={false}>
-            <div className="mb-4">
-                <p className="text-secondary">
-                    Session Replay records user sessions to help you understand their actions and uncover opportunities
-                    for product improvement.
-                </p>
-            </div>
+            {mediaVariant === 'screenshot' ? (
+                <>
+                    <p className="text-secondary mb-4">
+                        Session Replay records user sessions so you can watch exactly how people use your product and
+                        spot opportunities for improvement.
+                    </p>
 
-            <div className="flex flex-col md:flex-row items-center gap-6">
-                <div className="hidden md:block flex-shrink-0">
-                    <FilmCameraHog className="w-36 h-auto" />
-                </div>
-                <div className="flex-1 border border-gray-200 rounded-lg bg-bg-light dark:bg-bg-depth p-4">
-                    <h4 className="text-lg font-semibold mb-2">Why enable Session Replay?</h4>
-                    <ul className="deprecated-space-y-2 text-secondary">
-                        <li>
-                            <strong>Understand user behavior:</strong> Get a clear view of how people navigate and
-                            interact with your product.
-                        </li>
-                        <li>
-                            <strong>Identify UI/UX issues:</strong> Spot friction points and increase your product's
-                            usability.
-                        </li>
-                        <li>
-                            <strong>Improve customer support:</strong> Quickly diagnose problems for your customers.
-                        </li>
-                    </ul>
-                </div>
-            </div>
+                    <div className="rounded-lg overflow-hidden border border-border">
+                        <img
+                            className="w-full"
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/screenshot_23_02_05_15_26_pm_2b13578105.jpg"
+                            alt="Session Replay demo"
+                        />
+                    </div>
+                </>
+            ) : (
+                <>
+                    <div className="mb-4">
+                        <p className="text-secondary">
+                            Session Replay records user sessions to help you understand their actions and uncover
+                            opportunities for product improvement.
+                        </p>
+                    </div>
+
+                    <div className="flex flex-col md:flex-row items-center gap-6">
+                        <div className="hidden md:block flex-shrink-0">
+                            <FilmCameraHog className="w-36 h-auto" />
+                        </div>
+                        <div className="flex-1 border border-gray-200 rounded-lg bg-bg-light dark:bg-bg-depth p-4">
+                            <h4 className="text-lg font-semibold mb-2">Why enable Session Replay?</h4>
+                            <ul className="deprecated-space-y-2 text-secondary">
+                                <li>
+                                    <strong>Understand user behavior:</strong> Get a clear view of how people navigate
+                                    and interact with your product.
+                                </li>
+                                <li>
+                                    <strong>Identify UI/UX issues:</strong> Spot friction points and increase your
+                                    product's usability.
+                                </li>
+                                <li>
+                                    <strong>Improve customer support:</strong> Quickly diagnose problems for your
+                                    customers.
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </>
+            )}
             <div className="mt-6 w-full flex justify-end gap-2">
                 <LemonButton type="secondary" data-attr="skip-session-replay" onClick={() => handleNext(false)}>
                     No, thanks


### PR DESCRIPTION
## Problem

The session replay step at the onboarding has only text to convince the user to enable.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds a feature flag to optionally show a screenshot of the session replay feature (will test a demo later on).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually.


## Publish to changelog?

No.
