### PR TITLE
chore(mcp): add OpenAI domain verification for ChatGPT App Directory

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -91,6 +91,13 @@ const handleRequest = async (
         })
     }
 
+    // OpenAI ChatGPT App Directory domain verification
+    if (url.pathname === '/.well-known/openai-apps-challenge') {
+        return new Response('pRLV9JYbPOF5Dy039v3Rn3-qrMuKqZ2_4SsX9GoL9aU', {
+            headers: { 'content-type': 'text/plain' },
+        })
+    }
+
     // Detect region from hostname (mcp-eu.posthog.com) or query param (?region=eu)
     // Hostname takes precedence as it's the workaround for Claude Code's OAuth bug
     const effectiveRegion = getRegionFromRequest(request)


### PR DESCRIPTION
## Problem

We're submitting PostHog to the ChatGPT App Directory so users can discover and connect PostHog directly from ChatGPT/Codex. OpenAI requires domain verification by serving a challenge token at a well-known URL.

## Changes

Adds a `/.well-known/openai-apps-challenge` endpoint to the MCP server that returns the OpenAI verification token. This is a standard domain ownership verification pattern (same as Google Search Console, Stripe, etc.) — the token is not a secret.

## How did you test this code?

- Verified the route is placed before auth checks so it's publicly accessible
- Token format matches what OpenAI provided in the app submission dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)