### PR TITLE
fix(replay): fix infinite recursion loop

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -481,7 +481,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         stopAnimation: true,
         pauseIframePlayback: true,
         restartIframePlayback: true,
-        setCurrentSegment: (segment: RecordingSegment) => ({ segment }),
+        setCurrentSegment: (segment: RecordingSegment, shouldSeek: boolean = true) => ({ segment, shouldSeek }),
         setRootFrame: (frame: HTMLDivElement | null) => ({ frame }),
         checkBufferingCompleted: true,
         initializePlayerFromStart: true,
@@ -1374,7 +1374,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 }
             }
         },
-        setCurrentSegment: ({ segment }) => {
+        setCurrentSegment: ({ segment, shouldSeek }) => {
             // Check if we should skip this segment
             if (!segment.isActive && values.skipInactivitySetting && segment.kind !== 'buffer') {
                 // In video export mode with metadata footer, instantly seek past inactive segments
@@ -1407,7 +1407,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 }
                 // Otherwise keep existing player visible (last valid frame)
             }
-            if (values.currentTimestamp !== undefined) {
+            // Only seek if requested - prevents infinite recursion when called from updateAnimation
+            if (shouldSeek && values.currentTimestamp !== undefined) {
                 actions.seekToTimestamp(values.currentTimestamp, values.playingState === SessionPlayerState.PLAY)
             }
         },
@@ -1826,7 +1827,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     // NOTE: confusingly this setCurrentTimestamp call is essential to playback
                     // we rely on the segmentation to travel smoothly through the recording
                     actions.setCurrentTimestamp(Math.max(newTimestamp, nextSegment.startTimestamp))
-                    actions.setCurrentSegment(nextSegment)
+                    // Pass false to prevent seeking - we're already updating animation, don't recurse
+                    actions.setCurrentSegment(nextSegment, false)
                 } else {
                     // At the end of the recording. Pause the player and set fully to the end
                     actions.setEndReached()


### PR DESCRIPTION
## Problem

zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/51167 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53679)  
stack trace shows infinite loop recursion   
  
  updateAnimation
→ setCurrentSegment (segment boundary crossed)
→ seekToTimestamp (added https://github.com/PostHog/posthog/pull/47911)
→ updateAnimation (when forcePlay=true)
→ infinite loop

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

add a shouldSeek flag to prevent infinite loop

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->