### PR TITLE
fix(hobby): fix persistent preview not updating docker image on new commits

### DIFF
--- a/bin/hobby-installer/core/install.go
+++ b/bin/hobby-installer/core/install.go
@@ -124,7 +124,7 @@ func GetInstallSteps() []InstallStep {
 		{
 			Name: "Copy Docker Compose files",
 			Run: func(cfg InstallConfig) InstallResult {
-				if err := CopyComposeFiles(cfg.Version); err != nil {
+				if err := CopyComposeFiles(); err != nil {
 					return InstallResult{Err: err}
 				}
 				return InstallResult{Detail: "copied"}

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -288,7 +288,7 @@ export function Login(): JSX.Element {
                 )}
                 {!isEmailVerificationSent && !precheckResponse.saml_available && !precheckResponse.sso_enforcement && (
                     <SocialLoginButtons
-                        caption="Or log in with 🦔"
+                        caption="Or log in with"
                         topDivider
                         lastUsedProvider={lastLoginMethod}
                         showPasskey

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -288,7 +288,7 @@ export function Login(): JSX.Element {
                 )}
                 {!isEmailVerificationSent && !precheckResponse.saml_available && !precheckResponse.sso_enforcement && (
                     <SocialLoginButtons
-                        caption="Or log in with"
+                        caption="Or log in with 🦔"
                         topDivider
                         lastUsedProvider={lastLoginMethod}
                         showPasskey


### PR DESCRIPTION
**Root cause:** `copyFileWithEnvSubst` was baking `POSTHOG_APP_TAG` (and `REGISTRY_URL`, `POSTHOG_NODE_TAG`) directly into `docker-compose.yml` at install time. `update_existing_deployment` in `hobby-ci.py` correctly updated `.env` with the new SHA, but since `$POSTHOG_APP_TAG` no longer existed in the compose file after install, `docker-compose pull` just kept pulling the old hardcoded image. The deployment appeared to succeed but was running stale code.

A secondary bug enabled this: `UpdateEnvForUpgrade` never actually updated `POSTHOG_APP_TAG` in `.env` (it received the version param but ignored it), which made baking seem necessary for the upgrade path too. The pattern dates back to the original shell script (`envsubst`), and the Go migration faithfully reproduced it.

**Changes:**

Two commits — the fix and the root cause removal:

1. `hobby-ci.py`: `update_existing_deployment` now also sed-patches the baked-in image tags in `docker-compose.yml` before pulling. This is backward compat for existing droplets that still have baked SHA values.

2. Installer: `copyFileWithEnvSubst` removed — `CopyComposeFiles` now just copies the file as-is. `UpdateEnvValue` helper added. `UpdateEnvForUpgrade` now actually updates `POSTHOG_APP_TAG`. Docker Compose already reads all three vars from `.env` natively and the compose file was already written with DC variable substitution in mind (`$$topic` escapes, `${VAR:-default}` syntax).

The sed in `hobby-ci.py` becomes a no-op for new droplets created after this change.