### PR TITLE
fix(mcp): use npx for tsx in cloudflare build command

### DIFF
--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -7,7 +7,7 @@
     "name": "mcp1",
     "main": "src/index.ts",
     "build": {
-        "command": "tsx scripts/copy-instructions.ts",
+        "command": "npx tsx scripts/copy-instructions.ts",
         "watch_dir": "src",
     },
     "compatibility_date": "2025-03-10",


### PR DESCRIPTION
## Problem

The MCP Cloudflare Worker build is broken since #48770 was merged. The build command `tsx scripts/copy-instructions.ts` fails because Cloudflare's build environment doesn't have `node_modules/.bin` in PATH, so the `tsx` binary isn't found:

```
/bin/sh: 1: tsx: not found
```

This means the MCP server hasn't been deploying since that PR merged.

## Changes

Changed `tsx` to `npx tsx` in the wrangler build command so it resolves correctly in Cloudflare's build environment.

## How did you test this code

- Verified `tsx` is listed as a devDependency in `services/mcp/package.json`
- Confirmed the build error in Cloudflare dashboard (screenshot shows the failure)
- `npx tsx` is the standard way to invoke local binaries when `node_modules/.bin` isn't in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)