### PR TITLE
fix(ci): ensure event definitions exist for MCP integration tests

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -300,6 +300,7 @@ jobs:
                   django.setup()
                   from posthog.models import Organization, Team, User
                   from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+                  from posthog.models.event_definition import EventDefinition
                   org = Organization.objects.first()
                   team = Team.objects.first()
                   user = User.objects.first()
@@ -308,6 +309,9 @@ jobs:
                       label='mcp_ci_api_key',
                       secure_value=hash_key_value('e2e_demo_api_key'),
                   )
+                  # Ensure common event definitions exist for MCP integration tests
+                  for event_name in ['\$pageview', '\$pageleave', '\$autocapture', '\$screen']:
+                      EventDefinition.objects.get_or_create(name=event_name, team=team)
                   print(f'TEST_ORG_ID={org.id}')
                   print(f'TEST_PROJECT_ID={team.id}')
                   " >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

The MCP integration tests in `projects.integration.test.ts` fail nondeterministically because `generate_demo_data` doesn't reliably create event definitions like `$pageview`. This causes 5 tests to fail every time the event definitions are missing:

- `should include common events like $pageview` — `expected undefined to be truthy`
- `should update event definition description` — `Event definition not found: $pageview`
- `should update event definition tags` — same
- `should update verified status` — same  
- `should update multiple fields at once` — same

This is the # 1 source of MCP CI integration test failures — it fails on master consistently (3 master failures today alone, all with these exact 5 tests).

## Changes

Added `EventDefinition.objects.get_or_create()` calls for common events (`$pageview`, `$pageleave`, `$autocapture`, `$screen`) in the CI seed data step, so the event definitions are guaranteed to exist regardless of what `generate_demo_data` produces.

## How did you test this code

- Verified that all 3 master failures today (runs [52980](https://github.com/PostHog/posthog/actions/runs/22314285087), [52778](https://github.com/PostHog/posthog/actions/runs/22307865313), [52514](https://github.com/PostHog/posthog/actions/runs/22299543209)) had the exact same 5 test failures
- Verified that PR runs which pass on retry (e.g. PR #48823 attempt 1 failed, attempt 2 passed) confirm the nondeterministic nature
- The fix uses `get_or_create` which is idempotent — no-op if data already exists

## Changelog

No