### PR TITLE
fix(product tours): fix auto-save validation

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -15,10 +15,15 @@ import { ProductTourStepsEditor } from './editor'
 import { productTourLogic } from './productTourLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
-    const { productTour, productTourForm, isEditingProductTour, draftSaveStatus, draftActionInProgress } = useValues(
-        productTourLogic({ id })
-    )
-    const { discardDraft, publishDraft, setProductTourFormValue, openToolbarModal } = useActions(
+    const {
+        productTour,
+        productTourForm,
+        isEditingProductTour,
+        draftSaveStatus,
+        draftActionInProgress,
+        isProductTourFormSubmitting,
+    } = useValues(productTourLogic({ id }))
+    const { discardDraft, submitProductTourForm, setProductTourFormValue, openToolbarModal } = useActions(
         productTourLogic({ id })
     )
 
@@ -63,8 +68,8 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 size="small"
-                                onClick={publishDraft}
-                                loading={draftActionInProgress === 'publish'}
+                                onClick={submitProductTourForm}
+                                loading={isProductTourFormSubmitting}
                                 disabledReason={draftActionInProgress ? 'Saving...' : undefined}
                             >
                                 Save

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -186,9 +186,9 @@ export const productTourLogic = kea<productTourLogicType>([
         launchProductTour: true,
         stopProductTour: true,
         resumeProductTour: true,
-        publishDraft: true,
         discardDraft: true,
         draftAutoSave: true,
+        setDraftSaveStatus: (status: 'unsaved' | 'saving' | 'saved' | null) => ({ status }),
         setDraftActionInProgress: (action: 'publish' | 'discard' | null) => ({ action }),
         openToolbarModal: (toolbarMode?: 'preview' | 'edit') => ({ toolbarMode: toolbarMode ?? 'edit' }),
         closeToolbarModal: true,
@@ -319,7 +319,7 @@ export const productTourLogic = kea<productTourLogicType>([
             },
         },
     })),
-    forms(({ props }) => ({
+    forms(({ values, actions }) => ({
         productTourForm: {
             defaults: NEW_PRODUCT_TOUR as ProductTourForm,
             alwaysShowErrors: true,
@@ -389,9 +389,14 @@ export const productTourLogic = kea<productTourLogicType>([
                 return errors
             },
             submit: async (formValues: ProductTourForm) => {
-                if (props.id && props.id !== 'new') {
-                    await api.productTours.saveDraft(props.id, buildDraftPayload(formValues))
+                if (!values.productTour) {
+                    return
                 }
+                await api.productTours.publishDraft(values.productTour.id, buildDraftPayload(formValues))
+                lemonToast.success('Product tour saved')
+                actions.editingProductTour(false)
+                actions.loadProductTour()
+                actions.loadProductTours()
             },
         },
     })),
@@ -444,9 +449,7 @@ export const productTourLogic = kea<productTourLogicType>([
             null as 'unsaved' | 'saving' | 'saved' | null,
             {
                 draftAutoSave: () => 'unsaved' as const,
-                submitProductTourForm: () => 'saving' as const,
-                submitProductTourFormSuccess: () => 'saved' as const,
-                submitProductTourFormFailure: () => null,
+                setDraftSaveStatus: (_, { status }) => status,
                 editingProductTour: () => null,
             },
         ],
@@ -476,23 +479,6 @@ export const productTourLogic = kea<productTourLogicType>([
                 values.productTourFormAllErrors.name ||
                 'Failed to save product tour'
             lemonToast.error(errorMessage)
-        },
-        publishDraft: async () => {
-            if (!values.productTour) {
-                return
-            }
-            actions.setDraftActionInProgress('publish')
-            try {
-                await api.productTours.publishDraft(values.productTour.id, buildDraftPayload(values.productTourForm))
-                lemonToast.success('Product tour saved')
-                actions.editingProductTour(false)
-                actions.loadProductTour()
-                actions.loadProductTours()
-            } catch (e: any) {
-                lemonToast.error(e.detail || 'Failed to save product tour')
-            } finally {
-                actions.setDraftActionInProgress(null)
-            }
         },
         discardDraft: async () => {
             if (!values.productTour) {
@@ -585,8 +571,14 @@ export const productTourLogic = kea<productTourLogicType>([
         },
         draftAutoSave: async (_, breakpoint) => {
             await breakpoint(1000)
-            if (values.isEditingProductTour && values.productTourForm.name) {
-                actions.submitProductTourForm()
+            if (values.isEditingProductTour && values.productTourForm.name && props.id && props.id !== 'new') {
+                actions.setDraftSaveStatus('saving')
+                try {
+                    await api.productTours.saveDraft(props.id, buildDraftPayload(values.productTourForm))
+                    actions.setDraftSaveStatus('saved')
+                } finally {
+                    actions.setDraftActionInProgress(null)
+                }
             }
         },
         setDateRange: () => {


### PR DESCRIPTION
## Problem

product tours auto-save was running standard form validation; it should basically never do this

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

updates auto-save to hit the draft API directly, then we only use the real form submit (with validation) on explicit user button clicks

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
