### PR TITLE
chore(flags): refactor verification plumbing and remove unused task

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -269,6 +269,7 @@ def verify_team_flags(
             "status": "miss",
             "issue": "CACHE_MISS",
             "details": f"No cache entry found (team has {len(db_flags)} flags in DB)",
+            "db_data": db_data,
         }
 
     # Extract cached flags
@@ -351,6 +352,7 @@ def verify_team_flags(
         "issue": "DATA_MISMATCH",
         "details": f"{', '.join(summary_parts)} flags" if summary_parts else "unknown differences",
         "diff_flags": diff_flags,
+        "db_data": db_data,
     }
 
     if verbose:

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -354,7 +354,7 @@ def get_flags_response_if_none_match(
 
 def update_flag_caches(team: Team):
     """Update both flag cache variants."""
-    logger.info(f"Syncing feature_flags cache for team {team.id}")
+    logger.info("Syncing feature_flags cache for team", team_id=team.id)
 
     start_time = time.time()
     success = False
@@ -370,7 +370,7 @@ def update_flag_caches(team: Team):
         success = True
     except Exception as e:
         capture_exception(e)
-        logger.exception(f"Failed to sync feature_flags cache for team {team.id}", exception=str(e))
+        logger.exception("Failed to sync feature_flags cache for team", team_id=team.id, exception=str(e))
     finally:
         duration = time.time() - start_time
         result = "success" if success else "failure"

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -138,6 +138,7 @@ class TestFixAndRecord(BaseTest):
             issue_type=issue_type,
             cache_type="test_cache",
             result=result,
+            verification={"status": issue_type},
         )
 
         # Only the expected counter should be incremented
@@ -163,6 +164,7 @@ class TestFixAndRecord(BaseTest):
             issue_type="cache_miss",
             cache_type="test_cache",
             result=result,
+            verification={"status": "miss"},
         )
 
         assert result.cache_miss_fixed == 0
@@ -182,13 +184,14 @@ class TestFixAndRecord(BaseTest):
             issue_type="cache_miss",
             cache_type="test_cache",
             result=result,
+            verification={"status": "miss"},
         )
 
         assert result.cache_miss_fixed == 0
         assert result.fix_failed == 1
 
-    def test_uses_db_data_directly_when_provided(self):
-        """Test that _fix_and_record uses db_data to set cache directly, bypassing update_fn."""
+    def test_uses_db_data_from_verification_directly(self):
+        """Test that _fix_and_record uses verification['db_data'] to set cache directly, bypassing update_fn."""
         mock_config = MagicMock()
         db_data = {"flags": ["flag1", "flag2"]}
 
@@ -200,7 +203,7 @@ class TestFixAndRecord(BaseTest):
             issue_type="cache_miss",
             cache_type="test_cache",
             result=result,
-            db_data=db_data,
+            verification={"status": "miss", "db_data": db_data},
         )
 
         # Should call set_cache_value with db_data, NOT update_fn
@@ -208,8 +211,14 @@ class TestFixAndRecord(BaseTest):
         mock_config.update_fn.assert_not_called()
         assert result.cache_miss_fixed == 1
 
-    def test_falls_back_to_update_fn_when_db_data_is_none(self):
-        """Test that _fix_and_record falls back to update_fn when db_data is None."""
+    @parameterized.expand(
+        [
+            ("empty_dict", {}),
+            ("dict_without_db_data", {"status": "match", "issue": None}),
+        ]
+    )
+    def test_falls_back_to_update_fn_when_no_db_data_in_verification(self, _name, verification):
+        """Test that _fix_and_record falls back to update_fn when verification has no db_data."""
         mock_config = MagicMock()
         mock_config.update_fn.return_value = True
 
@@ -221,7 +230,7 @@ class TestFixAndRecord(BaseTest):
             issue_type="cache_miss",
             cache_type="test_cache",
             result=result,
-            db_data=None,
+            verification=verification,
         )
 
         # Should call update_fn, NOT set_cache_value
@@ -243,7 +252,7 @@ class TestFixAndRecord(BaseTest):
             issue_type="cache_miss",
             cache_type="test_cache",
             result=result,
-            db_data=db_data,
+            verification={"status": "miss", "db_data": db_data},
         )
 
         assert result.cache_miss_fixed == 0
@@ -404,18 +413,18 @@ class TestVerifyAndFixBatch(BaseTest):
             ("cache_mismatch", {"status": "mismatch", "issue": "DATA_MISMATCH"}, {}, "cache_mismatch_fixed"),
         ]
     )
-    def test_fix_uses_db_batch_data_directly(self, _name, verification_result, expiry_status, result_attr):
-        """Test that fixes use pre-loaded db_batch_data to avoid redundant DB queries."""
+    def test_fix_uses_db_data_from_verification(self, _name, base_verification_result, expiry_status, result_attr):
+        """Test that fixes use db_data from verify_fn result to avoid redundant DB queries."""
         mock_config = MagicMock()
-        mock_db_batch_data: dict = {self.team.id: {"flags": ["flag1", "flag2"]}}
-        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_load_fn.return_value = {self.team.id: {"flags": ["flag1", "flag2"]}}
         mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.get_team_ids_to_skip_fix_fn = None
 
         result = VerificationResult()
 
         def verify_fn(team, db_batch_data, cache_batch_data):
-            return verification_result
+            # Include db_data in verification result so _fix_and_record can use it directly
+            return {**base_verification_result, "db_data": {"flags": ["flag1", "flag2"]}}
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value=expiry_status):
             _verify_and_fix_batch(
@@ -426,16 +435,15 @@ class TestVerifyAndFixBatch(BaseTest):
                 result=result,
             )
 
-        # Should call set_cache_value with db_batch_data, NOT update_fn
+        # Should call set_cache_value with db_data from verification, NOT update_fn
         mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": ["flag1", "flag2"]})
         mock_config.update_fn.assert_not_called()
         assert getattr(result, result_attr) == 1
 
-    def test_expiry_missing_fix_uses_db_batch_data_directly(self):
-        """Test that expiry_missing fixes use pre-loaded db_batch_data to avoid redundant DB queries."""
+    def test_expiry_missing_fix_uses_batch_data_via_injection(self):
+        """Test that expiry_missing fixes use batch-loaded db_data even when verify_fn omits it."""
         mock_config = MagicMock()
-        mock_db_batch_data: dict = {self.team.id: {"flags": ["flag1", "flag2"]}}
-        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_load_fn.return_value = {self.team.id: {"flags": ["flag1", "flag2"]}}
         mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
         mock_config.get_team_ids_to_skip_fix_fn = None
@@ -443,7 +451,7 @@ class TestVerifyAndFixBatch(BaseTest):
         result = VerificationResult()
 
         def verify_fn(team, db_batch_data, cache_batch_data):
-            # Return match - but expiry tracking will be missing
+            # Return match with no db_data - the batch infrastructure injects it
             return {"status": "match", "issue": None}
 
         # Expiry status shows this team is NOT tracked (False)
@@ -458,7 +466,7 @@ class TestVerifyAndFixBatch(BaseTest):
                 result=result,
             )
 
-        # Should call set_cache_value with db_batch_data, NOT update_fn
+        # Batch infrastructure injects db_data, so set_cache_value is used (not update_fn)
         mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": ["flag1", "flag2"]})
         mock_config.update_fn.assert_not_called()
         assert result.expiry_missing_fixed == 1

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -55,15 +55,6 @@ def update_team_service_flags_cache(team_id: int) -> None:
     ).inc()
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)
-def sync_all_flags_cache() -> None:
-    # Meant to ensure we have all flags cache in sync in case something failed
-
-    # Only select the id from the team queryset
-    for team_id in Team.objects.values_list("id", flat=True):
-        update_team_flags_cache.delay(team_id)
-
-
 @shared_task(bind=True, base=PushGatewayTask, ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value)
 def refresh_expiring_flags_cache_entries(self: PushGatewayTask) -> None:
     """

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -19,6 +19,7 @@ import structlog
 from celery import shared_task
 
 from posthog.exceptions_capture import capture_exception
+from posthog.storage.hypercache_verifier import _run_verification_for_cache
 from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
@@ -57,8 +58,6 @@ def _run_cache_verification(cache_type: CacheType, chunk_size: int) -> None:
 
     try:
         logger.info("Starting cache verification", cache_type=cache_type, chunk_size=chunk_size)
-
-        from posthog.storage.hypercache_verifier import _run_verification_for_cache
 
         # Import cache-specific config and verify function
         if cache_type == "flags":

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -59,7 +59,6 @@
     'posthog.tasks.feature_flags.cleanup_stale_flags_expiry_tracking_task',
     'posthog.tasks.feature_flags.compute_feature_flag_metrics',
     'posthog.tasks.feature_flags.refresh_expiring_flags_cache_entries',
-    'posthog.tasks.feature_flags.sync_all_flags_cache',
     'posthog.tasks.feature_flags.update_team_flags_cache',
     'posthog.tasks.feature_flags.update_team_service_flags_cache',
     'posthog.tasks.heatmap_screenshot.generate_heatmap_screenshot',

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -19,7 +19,7 @@ from posthog.tasks.hypercache_verification import (
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestVerifyAndFixFlagsCacheTask(TestCase):
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verifies_flags_cache(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -30,7 +30,7 @@ class TestVerifyAndFixFlagsCacheTask(TestCase):
         assert call_kwargs["cache_type"] == "flags"
 
     @patch("posthog.tasks.hypercache_verification.capture_exception")
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
         error = Exception("flags verification failed")
         mock_run_verification.side_effect = error
@@ -41,7 +41,7 @@ class TestVerifyAndFixFlagsCacheTask(TestCase):
         mock_capture.assert_called_once_with(error)
         assert context.exception is error
 
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_does_not_raise_when_succeeds(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -53,7 +53,7 @@ class TestVerifyAndFixFlagsCacheTask(TestCase):
 
 @override_settings(FLAGS_REDIS_URL=None)
 class TestVerifyAndFixFlagsCacheTaskDisabled(TestCase):
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_skips_verification_when_no_redis_url(self, mock_run_verification: MagicMock) -> None:
         verify_and_fix_flags_cache_task()
 
@@ -62,7 +62,7 @@ class TestVerifyAndFixFlagsCacheTaskDisabled(TestCase):
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verifies_team_metadata_cache(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -73,7 +73,7 @@ class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
         assert call_kwargs["cache_type"] == "team_metadata"
 
     @patch("posthog.tasks.hypercache_verification.capture_exception")
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
         error = Exception("team_metadata verification failed")
         mock_run_verification.side_effect = error
@@ -84,7 +84,7 @@ class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
         mock_capture.assert_called_once_with(error)
         assert context.exception is error
 
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_does_not_raise_when_succeeds(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -96,7 +96,7 @@ class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
 
 @override_settings(FLAGS_REDIS_URL=None)
 class TestVerifyAndFixTeamMetadataCacheTaskDisabled(TestCase):
-    @patch("posthog.storage.hypercache_verifier._run_verification_for_cache")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_skips_verification_when_no_redis_url(self, mock_run_verification: MagicMock) -> None:
         verify_and_fix_team_metadata_cache_task()
 


### PR DESCRIPTION
## Summary

Prep refactorings extracted from the flag definitions HyperCache PR to keep that PR focused on new behavior.

- Use structured logging kwargs instead of f-strings in `update_flag_caches`
- Embed `db_data` in verification result dict so `_fix_and_record` no longer needs a separate parameter (simpler API)
- Move `_run_verification_for_cache` import to top-level in `hypercache_verification.py`
- Remove unused `sync_all_flags_cache` Celery task

## Test plan

- [x] All existing tests pass (hypercache verifier, verification tasks, task registration snapshot, local evaluation)
- [x] Lint clean