### PR TITLE
chore(web-analytics): Cache browser logos and only update data when needed in Live Dashboard

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
@@ -131,38 +131,4 @@ const BreakdownLiveCardInner = <T extends BreakdownItem>({
     )
 }
 
-function breakdownLiveCardPropsAreEqual<T extends BreakdownItem>(
-    prev: BreakdownLiveCardProps<T>,
-    next: BreakdownLiveCardProps<T>
-): boolean {
-    if (
-        prev.title !== next.title ||
-        prev.emptyMessage !== next.emptyMessage ||
-        prev.statLabel !== next.statLabel ||
-        prev.totalCount !== next.totalCount ||
-        prev.isLoading !== next.isLoading ||
-        prev.getKey !== next.getKey ||
-        prev.getLabel !== next.getLabel ||
-        prev.renderIcon !== next.renderIcon
-    ) {
-        return false
-    }
-
-    if (prev.data === next.data) {
-        return true
-    }
-    if (prev.data.length !== next.data.length) {
-        return false
-    }
-    for (let i = 0; i < prev.data.length; i++) {
-        if (prev.data[i].count !== next.data[i].count || prev.data[i].percentage !== next.data[i].percentage) {
-            return false
-        }
-    }
-    return true
-}
-
-export const BreakdownLiveCard = React.memo(
-    BreakdownLiveCardInner,
-    breakdownLiveCardPropsAreEqual
-) as typeof BreakdownLiveCardInner
+export const BreakdownLiveCard = React.memo(BreakdownLiveCardInner) as typeof BreakdownLiveCardInner

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/BreakdownLiveCard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { Spinner, Tooltip } from '@posthog/lemon-ui'
 
@@ -22,7 +22,7 @@ interface BreakdownLiveCardProps<T extends BreakdownItem> {
     isLoading?: boolean
 }
 
-export const BreakdownLiveCard = <T extends BreakdownItem>({
+const BreakdownLiveCardInner = <T extends BreakdownItem>({
     title,
     data,
     getKey,
@@ -130,3 +130,39 @@ export const BreakdownLiveCard = <T extends BreakdownItem>({
         </div>
     )
 }
+
+function breakdownLiveCardPropsAreEqual<T extends BreakdownItem>(
+    prev: BreakdownLiveCardProps<T>,
+    next: BreakdownLiveCardProps<T>
+): boolean {
+    if (
+        prev.title !== next.title ||
+        prev.emptyMessage !== next.emptyMessage ||
+        prev.statLabel !== next.statLabel ||
+        prev.totalCount !== next.totalCount ||
+        prev.isLoading !== next.isLoading ||
+        prev.getKey !== next.getKey ||
+        prev.getLabel !== next.getLabel ||
+        prev.renderIcon !== next.renderIcon
+    ) {
+        return false
+    }
+
+    if (prev.data === next.data) {
+        return true
+    }
+    if (prev.data.length !== next.data.length) {
+        return false
+    }
+    for (let i = 0; i < prev.data.length; i++) {
+        if (prev.data[i].count !== next.data[i].count || prev.data[i].percentage !== next.data[i].percentage) {
+            return false
+        }
+    }
+    return true
+}
+
+export const BreakdownLiveCard = React.memo(
+    BreakdownLiveCardInner,
+    breakdownLiveCardPropsAreEqual
+) as typeof BreakdownLiveCardInner

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -15,6 +15,15 @@ import { liveWebAnalyticsMetricsLogic } from './liveWebAnalyticsMetricsLogic'
 
 const STATS_POLL_INTERVAL_MS = 1000
 
+const renderBrowserIcon = (d: BrowserBreakdownItem): JSX.Element => {
+    const Logo = getBrowserLogo(d.browser)
+    return <Logo className="w-4 h-4 flex-shrink-0" />
+}
+const getBrowserKey = (d: BrowserBreakdownItem): string => d.browser
+const getBrowserLabel = (d: BrowserBreakdownItem): string => d.browser
+const getDeviceKey = (d: DeviceBreakdownItem): string => d.device
+const getDeviceLabel = (d: DeviceBreakdownItem): string => d.device
+
 export const LiveWebAnalyticsMetrics = (): JSX.Element => {
     const {
         chartData,
@@ -73,8 +82,8 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                 <BreakdownLiveCard<DeviceBreakdownItem>
                     title="Devices"
                     data={deviceBreakdown}
-                    getKey={(d) => d.device}
-                    getLabel={(d) => d.device}
+                    getKey={getDeviceKey}
+                    getLabel={getDeviceLabel}
                     emptyMessage="No device data"
                     statLabel="unique devices"
                     isLoading={isLoading}
@@ -82,12 +91,9 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                 <BreakdownLiveCard<BrowserBreakdownItem>
                     title="Browsers"
                     data={browserBreakdown}
-                    getKey={(d) => d.browser}
-                    getLabel={(d) => d.browser}
-                    renderIcon={(d) => {
-                        const Logo = getBrowserLogo(d.browser)
-                        return <Logo className="w-4 h-4 flex-shrink-0" />
-                    }}
+                    getKey={getBrowserKey}
+                    getLabel={getBrowserLabel}
+                    renderIcon={renderBrowserIcon}
                     emptyMessage="No browser data"
                     statLabel="unique browsers"
                     totalCount={totalBrowsers}

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/browserLogos.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/browserLogos.tsx
@@ -31,12 +31,16 @@ const BROWSER_LOGOS: Record<string, { src: string; alt: string }> = {
     'samsung internet': { src: samsungInternetSvg, alt: 'Samsung Internet' },
 }
 
-export const getBrowserLogo = (browserName: string | undefined): React.ComponentType<BrowserLogoProps> => {
-    const logo = BROWSER_LOGOS[browserName?.toLowerCase() ?? '']
-
-    if (!logo) {
-        return ({ className }: BrowserLogoProps) => <IconWeb className={className} />
-    }
-
-    return ({ className }: BrowserLogoProps) => <img src={logo.src} alt={logo.alt} className={className} />
+const BrowserLogoCache = new Map<string, React.ComponentType<BrowserLogoProps>>()
+for (const [key, logo] of Object.entries(BROWSER_LOGOS)) {
+    const Component = ({ className }: BrowserLogoProps): JSX.Element => (
+        <img src={logo.src} alt={logo.alt} className={className} />
+    )
+    Component.displayName = `BrowserLogo_${logo.alt}`
+    BrowserLogoCache.set(key, Component)
 }
+
+const FallbackBrowserLogo = ({ className }: BrowserLogoProps): JSX.Element => <IconWeb className={className} />
+
+export const getBrowserLogo = (browserName: string | undefined): React.ComponentType<BrowserLogoProps> =>
+    BrowserLogoCache.get(browserName?.toLowerCase() ?? '') ?? FallbackBrowserLogo

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -1,3 +1,4 @@
+import equal from 'fast-deep-equal'
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -38,13 +39,25 @@ const MAX_RETRY_DELAY_MS = 30000
 const COOKIELESS_TRANSFORM_PREFIX = 'cookieless_transform'
 const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 
+interface UpdateMask {
+    chart: boolean
+    deviceBreakdown: boolean
+    browserBreakdown: boolean
+    topPaths: boolean
+    totals: boolean
+}
+
 export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType>([
     path(['scenes', 'web-analytics', 'livePageviewsLogic']),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
     })),
     actions(() => ({
-        addEvents: (events: LiveEvent[], newerThan: Date) => ({ events, newerThan }),
+        addEvents: (events: LiveEvent[], newerThan: Date, updateMask: UpdateMask) => ({
+            events,
+            newerThan,
+            updateMask,
+        }),
         setInitialData: (buckets: { timestamp: number; bucket: SlidingWindowBucket }[]) => ({ buckets }),
         setIsLoading: (loading: boolean) => ({ loading }),
         loadInitialData: true,
@@ -96,12 +109,43 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 },
             },
         ],
-        // This is used to force a re-render every time we add an event or a minute passes
-        windowVersion: [
+        chartVersion: [
             0,
             {
                 setInitialData: (v) => v + 1,
-                addEvents: (v) => v + 1,
+                addEvents: (v, { updateMask }) => (updateMask.chart ? v + 1 : v),
+                tickCurrentMinute: (v) => v + 1,
+            },
+        ],
+        deviceBreakdownVersion: [
+            0,
+            {
+                setInitialData: (v) => v + 1,
+                addEvents: (v, { updateMask }) => (updateMask.deviceBreakdown ? v + 1 : v),
+                tickCurrentMinute: (v) => v + 1,
+            },
+        ],
+        browserBreakdownVersion: [
+            0,
+            {
+                setInitialData: (v) => v + 1,
+                addEvents: (v, { updateMask }) => (updateMask.browserBreakdown ? v + 1 : v),
+                tickCurrentMinute: (v) => v + 1,
+            },
+        ],
+        topPathsVersion: [
+            0,
+            {
+                setInitialData: (v) => v + 1,
+                addEvents: (v, { updateMask }) => (updateMask.topPaths ? v + 1 : v),
+                tickCurrentMinute: (v) => v + 1,
+            },
+        ],
+        totalsVersion: [
+            0,
+            {
+                setInitialData: (v) => v + 1,
+                addEvents: (v, { updateMask }) => (updateMask.totals ? v + 1 : v),
                 tickCurrentMinute: (v) => v + 1,
             },
         ],
@@ -114,7 +158,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     }),
     selectors({
         chartData: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.chartVersion],
             (slidingWindow: LiveMetricsSlidingWindow): ChartDataPoint[] => {
                 const bucketMap = new Map(slidingWindow.getSortedBuckets())
                 const result: ChartDataPoint[] = []
@@ -153,27 +197,30 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             },
         ],
         deviceBreakdown: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.deviceBreakdownVersion],
             (slidingWindow: LiveMetricsSlidingWindow): DeviceBreakdownItem[] => slidingWindow.getDeviceBreakdown(),
+            { resultEqualityCheck: equal },
         ],
         browserBreakdown: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.browserBreakdownVersion],
             (slidingWindow: LiveMetricsSlidingWindow): BrowserBreakdownItem[] => slidingWindow.getBrowserBreakdown(6),
+            { resultEqualityCheck: equal },
         ],
         topPaths: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.topPathsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): PathItem[] => slidingWindow.getTopPaths(10),
+            { resultEqualityCheck: equal },
         ],
         totalPageviews: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.totalsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalPageviews(),
         ],
         totalUniqueVisitors: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.totalsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalUniqueUsers(),
         ],
         totalBrowsers: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.browserBreakdownVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBrowsers(),
         ],
     }),
@@ -280,7 +327,29 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     // Flush events when we have enough or enough time has passed
                     const timeSinceLastBatch = performance.now() - cache.lastBatchTime
                     if (cache.batch.length >= BATCH_SIZE_THRESHOLD || timeSinceLastBatch > BATCH_FLUSH_INTERVAL_MS) {
-                        actions.addEvents(cache.batch, cache.newerThan)
+                        const batch = cache.batch as LiveEvent[]
+                        const mask: UpdateMask = {
+                            chart: true,
+                            totals: true,
+                            deviceBreakdown: false,
+                            browserBreakdown: false,
+                            topPaths: false,
+                        }
+                        for (const ev of batch) {
+                            if (ev.properties?.$device_type) {
+                                mask.deviceBreakdown = true
+                            }
+                            if (ev.properties?.$browser) {
+                                mask.browserBreakdown = true
+                            }
+                            if (ev.event === '$pageview' && ev.properties?.$pathname) {
+                                mask.topPaths = true
+                            }
+                            if (mask.deviceBreakdown && mask.browserBreakdown && mask.topPaths) {
+                                break
+                            }
+                        }
+                        actions.addEvents(batch, cache.newerThan, mask)
                         cache.batch = []
                         cache.lastBatchTime = performance.now()
                     }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -39,25 +39,13 @@ const MAX_RETRY_DELAY_MS = 30000
 const COOKIELESS_TRANSFORM_PREFIX = 'cookieless_transform'
 const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 
-interface UpdateMask {
-    chart: boolean
-    deviceBreakdown: boolean
-    browserBreakdown: boolean
-    topPaths: boolean
-    totals: boolean
-}
-
 export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType>([
     path(['scenes', 'web-analytics', 'livePageviewsLogic']),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
     })),
     actions(() => ({
-        addEvents: (events: LiveEvent[], newerThan: Date, updateMask: UpdateMask) => ({
-            events,
-            newerThan,
-            updateMask,
-        }),
+        addEvents: (events: LiveEvent[], newerThan: Date) => ({ events, newerThan }),
         setInitialData: (buckets: { timestamp: number; bucket: SlidingWindowBucket }[]) => ({ buckets }),
         setIsLoading: (loading: boolean) => ({ loading }),
         loadInitialData: true,
@@ -109,43 +97,11 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 },
             },
         ],
-        chartVersion: [
+        windowVersion: [
             0,
             {
                 setInitialData: (v) => v + 1,
-                addEvents: (v, { updateMask }) => (updateMask.chart ? v + 1 : v),
-                tickCurrentMinute: (v) => v + 1,
-            },
-        ],
-        deviceBreakdownVersion: [
-            0,
-            {
-                setInitialData: (v) => v + 1,
-                addEvents: (v, { updateMask }) => (updateMask.deviceBreakdown ? v + 1 : v),
-                tickCurrentMinute: (v) => v + 1,
-            },
-        ],
-        browserBreakdownVersion: [
-            0,
-            {
-                setInitialData: (v) => v + 1,
-                addEvents: (v, { updateMask }) => (updateMask.browserBreakdown ? v + 1 : v),
-                tickCurrentMinute: (v) => v + 1,
-            },
-        ],
-        topPathsVersion: [
-            0,
-            {
-                setInitialData: (v) => v + 1,
-                addEvents: (v, { updateMask }) => (updateMask.topPaths ? v + 1 : v),
-                tickCurrentMinute: (v) => v + 1,
-            },
-        ],
-        totalsVersion: [
-            0,
-            {
-                setInitialData: (v) => v + 1,
-                addEvents: (v, { updateMask }) => (updateMask.totals ? v + 1 : v),
+                addEvents: (v) => v + 1,
                 tickCurrentMinute: (v) => v + 1,
             },
         ],
@@ -158,7 +114,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     }),
     selectors({
         chartData: [
-            (s) => [s.slidingWindow, s.chartVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): ChartDataPoint[] => {
                 const bucketMap = new Map(slidingWindow.getSortedBuckets())
                 const result: ChartDataPoint[] = []
@@ -197,30 +153,30 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             },
         ],
         deviceBreakdown: [
-            (s) => [s.slidingWindow, s.deviceBreakdownVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): DeviceBreakdownItem[] => slidingWindow.getDeviceBreakdown(),
             { resultEqualityCheck: equal },
         ],
         browserBreakdown: [
-            (s) => [s.slidingWindow, s.browserBreakdownVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): BrowserBreakdownItem[] => slidingWindow.getBrowserBreakdown(6),
             { resultEqualityCheck: equal },
         ],
         topPaths: [
-            (s) => [s.slidingWindow, s.topPathsVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): PathItem[] => slidingWindow.getTopPaths(10),
             { resultEqualityCheck: equal },
         ],
         totalPageviews: [
-            (s) => [s.slidingWindow, s.totalsVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalPageviews(),
         ],
         totalUniqueVisitors: [
-            (s) => [s.slidingWindow, s.totalsVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalUniqueUsers(),
         ],
         totalBrowsers: [
-            (s) => [s.slidingWindow, s.browserBreakdownVersion],
+            (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBrowsers(),
         ],
     }),
@@ -327,29 +283,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     // Flush events when we have enough or enough time has passed
                     const timeSinceLastBatch = performance.now() - cache.lastBatchTime
                     if (cache.batch.length >= BATCH_SIZE_THRESHOLD || timeSinceLastBatch > BATCH_FLUSH_INTERVAL_MS) {
-                        const batch = cache.batch as LiveEvent[]
-                        const mask: UpdateMask = {
-                            chart: true,
-                            totals: true,
-                            deviceBreakdown: false,
-                            browserBreakdown: false,
-                            topPaths: false,
-                        }
-                        for (const ev of batch) {
-                            if (ev.properties?.$device_type) {
-                                mask.deviceBreakdown = true
-                            }
-                            if (ev.properties?.$browser) {
-                                mask.browserBreakdown = true
-                            }
-                            if (ev.event === '$pageview' && ev.properties?.$pathname) {
-                                mask.topPaths = true
-                            }
-                            if (mask.deviceBreakdown && mask.browserBreakdown && mask.topPaths) {
-                                break
-                            }
-                        }
-                        actions.addEvents(batch, cache.newerThan, mask)
+                        actions.addEvents(cache.batch, cache.newerThan)
                         cache.batch = []
                         cache.lastBatchTime = performance.now()
                     }


### PR DESCRIPTION
## Problem
Constant re-renders are causing browser logos to flicker. Charts are also always re-rendered during an event flush whether the data has actually changed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Cache the browser logos and use deep equals for graph data compares


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
