### PR TITLE
feat(capture): implement global rate limiter checks for records mode too

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -82,6 +82,10 @@ pub struct Config {
     #[envconfig(default = "60")]
     pub global_rate_limit_window_interval_secs: u64,
 
+    /// Time bucket granularity in seconds for the sliding window counters
+    #[envconfig(default = "10")]
+    pub global_rate_limit_bucket_interval_secs: u64,
+
     /// CSV list of key=value pairs assigning custom global rate limit thresholds
     /// for particular keys.
     pub global_rate_limit_overrides_csv: Option<String>,

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -31,6 +31,7 @@ impl GlobalRateLimiter {
         let grl_config = GlobalRateLimiterConfig {
             global_threshold: config.global_rate_limit_threshold,
             window_interval: Duration::from_secs(config.global_rate_limit_window_interval_secs),
+            bucket_interval: Duration::from_secs(config.global_rate_limit_bucket_interval_secs),
             redis_key_prefix: redis_prefix,
             custom_keys: Self::format_custom_keys(config.global_rate_limit_overrides_csv.as_ref()),
             ..Default::default()

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -11,6 +11,9 @@ use limiters::global_rate_limiter::{
 };
 use tracing::error;
 
+#[cfg(test)]
+use chrono::DateTime;
+
 pub struct GlobalRateLimiter {
     limiter: Box<dyn CommonGlobalRateLimiter>,
 }
@@ -46,18 +49,29 @@ impl GlobalRateLimiter {
         })
     }
 
-    /// Evaluate key for global rate limit. Response with metadata is returned if limited.
+    /// Check if a key is rate limited. Routes to custom or global check based on
+    /// whether the key is registered in the custom_keys map. Exactly one check
+    /// fires per call — no double-enqueue to the Redis batch channel.
     pub async fn is_limited(&self, key: &str, count: u64) -> Option<GlobalRateLimitResponse> {
-        // call is instrumented internally
-        match self.limiter.check_limit(key, count, Some(Utc::now())).await {
-            EvalResult::Limited(response) => Some(response),
-            _ => None, // Allowed, NotApplicable, FailOpen all treated as "not limited"
+        if self.limiter.is_custom_key(key) {
+            self.is_custom_key_limited(key, count).await
+        } else {
+            self.is_global_key_limited(key, count).await
         }
     }
 
-    /// Evaluate a custom key candidate. If it was registered when the limiter was
-    /// created, evaluate the key against the custom limit. Otherwise, return None.
-    pub async fn is_custom_key_limited(
+    async fn is_global_key_limited(
+        &self,
+        key: &str,
+        count: u64,
+    ) -> Option<GlobalRateLimitResponse> {
+        match self.limiter.check_limit(key, count, Some(Utc::now())).await {
+            EvalResult::Limited(response) => Some(response),
+            _ => None,
+        }
+    }
+
+    async fn is_custom_key_limited(
         &self,
         key: &str,
         count: u64,
@@ -68,13 +82,20 @@ impl GlobalRateLimiter {
             .await
         {
             EvalResult::Limited(response) => Some(response),
-            _ => None, // Allowed, NotApplicable, FailOpen all treated as "not limited"
+            _ => None,
         }
     }
 
     // trigger shutdown and stop pushing updates to global cache
     pub fn shutdown(&mut self) {
         self.limiter.shutdown();
+    }
+
+    #[cfg(test)]
+    fn new_with(limiter: impl CommonGlobalRateLimiter + 'static) -> Self {
+        Self {
+            limiter: Box::new(limiter),
+        }
     }
 
     // In capture deploys, the custom keys and rate limit thresholds should be
@@ -112,5 +133,138 @@ impl GlobalRateLimiter {
         }
 
         custom_keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    type CallLog = Arc<Mutex<Vec<&'static str>>>;
+
+    struct MockLimiter {
+        custom_keys: HashSet<String>,
+        check_limit_result: EvalResult,
+        check_custom_limit_result: EvalResult,
+        calls: CallLog,
+    }
+
+    impl MockLimiter {
+        fn new(
+            custom_keys: HashSet<String>,
+            check_limit_result: EvalResult,
+            check_custom_limit_result: EvalResult,
+        ) -> (Self, CallLog) {
+            let calls: CallLog = Arc::new(Mutex::new(Vec::new()));
+            let mock = Self {
+                custom_keys,
+                check_limit_result,
+                check_custom_limit_result,
+                calls: calls.clone(),
+            };
+            (mock, calls)
+        }
+    }
+
+    #[async_trait]
+    impl CommonGlobalRateLimiter for MockLimiter {
+        async fn check_limit(
+            &self,
+            _key: &str,
+            _count: u64,
+            _timestamp: Option<DateTime<Utc>>,
+        ) -> EvalResult {
+            self.calls.lock().unwrap().push("check_limit");
+            self.check_limit_result.clone()
+        }
+
+        async fn check_custom_limit(
+            &self,
+            _key: &str,
+            _count: u64,
+            _timestamp: Option<DateTime<Utc>>,
+        ) -> EvalResult {
+            self.calls.lock().unwrap().push("check_custom_limit");
+            self.check_custom_limit_result.clone()
+        }
+
+        fn is_custom_key(&self, key: &str) -> bool {
+            self.calls.lock().unwrap().push("is_custom_key");
+            self.custom_keys.contains(key)
+        }
+
+        fn shutdown(&mut self) {}
+    }
+
+    fn make_limited_response(is_custom: bool) -> EvalResult {
+        let now = Utc::now();
+        EvalResult::Limited(GlobalRateLimitResponse {
+            key: "test".to_string(),
+            current_count: 100,
+            threshold: 10,
+            window_start: now - chrono::Duration::seconds(60),
+            window_end: now,
+            window_interval: Duration::from_secs(60),
+            update_interval: Duration::from_secs(10),
+            is_custom_limited: is_custom,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_is_limited_routes_to_global_for_unknown_key() {
+        let (mock, calls) = MockLimiter::new(
+            HashSet::new(),
+            make_limited_response(false),
+            EvalResult::NotApplicable,
+        );
+        let wrapper = GlobalRateLimiter::new_with(mock);
+
+        let result = wrapper.is_limited("unknown_key", 1).await;
+
+        assert!(result.is_some());
+        assert!(!result.unwrap().is_custom_limited);
+        assert_eq!(*calls.lock().unwrap(), vec!["is_custom_key", "check_limit"]);
+    }
+
+    #[tokio::test]
+    async fn test_is_limited_routes_to_custom_for_registered_key() {
+        let (mock, calls) = MockLimiter::new(
+            HashSet::from(["registered".to_string()]),
+            EvalResult::Allowed,
+            make_limited_response(true),
+        );
+        let wrapper = GlobalRateLimiter::new_with(mock);
+
+        let result = wrapper.is_limited("registered", 1).await;
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_custom_limited);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec!["is_custom_key", "check_custom_limit"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_limited_custom_key_allowed_does_not_fall_through_to_global() {
+        let (mock, calls) = MockLimiter::new(
+            HashSet::from(["custom".to_string()]),
+            EvalResult::Allowed,
+            EvalResult::Allowed,
+        );
+        let wrapper = GlobalRateLimiter::new_with(mock);
+
+        let result = wrapper.is_limited("custom", 1).await;
+
+        assert!(result.is_none());
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec!["is_custom_key", "check_custom_limit"],
+            "must NOT call check_limit when key is registered as custom"
+        );
     }
 }

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -16,9 +16,12 @@ use crate::{
     api::CaptureError,
     debug_or_info,
     extractors::extract_body_with_timeout,
-    payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
+    payload::{
+        extract_and_record_metadata, extract_payload_bytes,
+        types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
+        EventQuery,
+    },
     router,
-    types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
     utils::extract_and_verify_token,
     v0_request::{ProcessingContext, RawRequest},
 };

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -18,6 +18,7 @@ use crate::{
     extractors::extract_body_with_timeout,
     payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
+    types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
     utils::extract_and_verify_token,
     v0_request::{ProcessingContext, RawRequest},
 };
@@ -142,9 +143,9 @@ pub async fn handle_event_payload(
             .await
         {
             let limit_type = if limited.is_custom_limited {
-                "custom"
+                GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM
             } else {
-                "global"
+                GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL
             };
             debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
                 limit_type, "global rate limit applied");

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -141,6 +141,13 @@ pub async fn handle_event_payload(
             .is_limited(&context.token, events.len() as u64)
             .await
         {
+            let limit_type = if limited.is_custom_limited {
+                "custom"
+            } else {
+                "global"
+            };
+            debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
+                limit_type, "global rate limit applied");
             return Err(CaptureError::GlobalRateLimitExceeded(
                 context.token.clone(),
                 events.len() as u64,
@@ -150,7 +157,6 @@ pub async fn handle_event_payload(
                 limited.window_interval.as_secs(),
             ));
         }
-        debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "global rate limit applied");
     }
 
     // Apply all billing limit quotas and drop partial or whole

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -18,6 +18,7 @@ use crate::{
     extractors::extract_body_with_timeout,
     payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
+    types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
     v0_request::ProcessingContext,
 };
 
@@ -136,9 +137,9 @@ pub async fn handle_recording_payload(
             .await
         {
             let limit_type = if limited.is_custom_limited {
-                "custom"
+                GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM
             } else {
-                "global"
+                GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL
             };
             debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
                 limit_type, "global rate limit applied");

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -16,9 +16,12 @@ use crate::{
     debug_or_info,
     events::recordings::RawRecording,
     extractors::extract_body_with_timeout,
-    payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
+    payload::{
+        decompress_payload, extract_and_record_metadata, extract_payload_bytes,
+        types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
+        EventQuery,
+    },
     router,
-    types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
     v0_request::ProcessingContext,
 };
 

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -129,6 +129,30 @@ pub async fn handle_recording_payload(
         chatty_debug_enabled,
     };
 
+    // Apply global rate limit per team (API token) if enabled
+    if let Some(global_rate_limiter) = &state.global_rate_limiter {
+        if let Some(limited) = global_rate_limiter
+            .is_limited(&context.token, events.len() as u64)
+            .await
+        {
+            let limit_type = if limited.is_custom_limited {
+                "custom"
+            } else {
+                "global"
+            };
+            debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
+                limit_type, "global rate limit applied");
+            return Err(CaptureError::GlobalRateLimitExceeded(
+                context.token.clone(),
+                events.len() as u64,
+                limited.window_start,
+                limited.window_end,
+                limited.threshold,
+                limited.window_interval.as_secs(),
+            ));
+        }
+    }
+
     // Apply all billing limit quotas and drop partial or whole
     // payload if any are exceeded for this token (team)
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "evaluating quota limits");

--- a/rust/capture/src/payload/types.rs
+++ b/rust/capture/src/payload/types.rs
@@ -107,6 +107,9 @@ pub struct EventFormData {
     pub lib_version: Option<String>,
 }
 
+pub const GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL: &str = "global";
+pub const GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM: &str = "custom";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -41,6 +41,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     global_rate_limit_enabled: false,
     global_rate_limit_threshold: 10_000,
     global_rate_limit_window_interval_secs: 60,
+    global_rate_limit_bucket_interval_secs: 10,
     global_rate_limit_overrides_csv: None,
     global_rate_limit_redis_url: None,
     global_rate_limit_redis_response_timeout_ms: None,


### PR DESCRIPTION
## Problem
We need to do some prep to set up production `capture` to enable the new global rate limiter
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement `is_limited` checks in recordings handler 
* Consolidate `is_limited` check to handle custom team threshold checks as well as global limit in capture
* Expose custom key check method on `common/limiters` impl
* Update test suites in both projects
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will smoke test (and select final thresholds) prior to prod rollout
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
