### PR TITLE
fix(surveys): do not allow star column to be configurable

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -49,12 +49,17 @@ interface ColumnConfiguratorProps {
 export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps): JSX.Element {
     const { columnsInQuery } = useValues(dataTableLogic)
 
+    // users should not be able to edit the '*' column
+    const hasStarColumn = columnsInQuery.includes('*')
+    const configurableColumns = columnsInQuery.filter((c) => c !== '*')
+
     const [key] = useState(() => String(uniqueNode++))
     const columnConfiguratorLogicProps: ColumnConfiguratorLogicProps = {
         key,
         isPersistent: !!query.showPersistentColumnConfigurator,
-        columns: columnsInQuery,
+        columns: configurableColumns,
         setColumns: (columns: string[]) => {
+            const allColumns = hasStarColumn ? ['*', ...columns] : columns
             if (isEventsQuery(query.source) || isSessionsQuery(query.source)) {
                 let orderBy = query.source.orderBy
                 if (orderBy && orderBy.length > 0) {
@@ -71,7 +76,7 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
                     source: {
                         ...query.source,
                         orderBy,
-                        select: columns,
+                        select: allColumns,
                     },
                 })
             } else if (isActorsQuery(query.source) || isGroupsQuery(query.source)) {
@@ -79,11 +84,11 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
                     ...query,
                     source: {
                         ...query.source,
-                        select: columns,
+                        select: allColumns,
                     },
                 })
             } else {
-                setQuery?.({ ...query, columns })
+                setQuery?.({ ...query, columns: allColumns })
             }
         },
         context: query.context

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -496,9 +496,10 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                                 return {}
                                             }
                                             return {
-                                                className: archivedResponseUuids.has(result[0].uuid)
-                                                    ? 'opacity-50'
-                                                    : undefined,
+                                                className:
+                                                    result[0]?.uuid && archivedResponseUuids.has(result[0].uuid)
+                                                        ? 'opacity-50'
+                                                        : undefined,
                                             }
                                         },
                                     }}

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -407,7 +407,10 @@ function SurveyResponsesContent(): JSX.Element {
                                     return {}
                                 }
                                 return {
-                                    className: archivedResponseUuids.has(result[0].uuid) ? 'opacity-50' : undefined,
+                                    className:
+                                        result[0]?.uuid && archivedResponseUuids.has(result[0].uuid)
+                                            ? 'opacity-50'
+                                            : undefined,
                                 }
                             },
                         }}


### PR DESCRIPTION
## Problem

see https://posthoghelp.zendesk.com/agent/tickets/50731 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52409)

the `*` column is user-configurable, it should not be, and it was causing surveys response table crashes when a user put a custom column above it

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

prevents `*` from being removed/re-ordered in the column configurator, and adds a guard in surveys tables to prevent the crash in case of any old broken configs

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
