### PR TITLE
fix: Onboarding plans step redirection

### DIFF
--- a/frontend/src/scenes/billing/PaymentEntryModal.tsx
+++ b/frontend/src/scenes/billing/PaymentEntryModal.tsx
@@ -5,12 +5,14 @@ import { useEffect, useState } from 'react'
 
 import { LemonBanner, LemonButton, LemonModal } from '@posthog/lemon-ui'
 
+import { urls } from 'scenes/urls'
+
 import { paymentEntryLogic } from './paymentEntryLogic'
 
 const stripeJs = async (): Promise<typeof import('@stripe/stripe-js')> => await import('@stripe/stripe-js')
 
 export const PaymentForm = (): JSX.Element => {
-    const { stripeError, isLoading } = useValues(paymentEntryLogic)
+    const { stripeError, isLoading, redirectPath } = useValues(paymentEntryLogic)
     const { setStripeError, clearErrors, hidePaymentEntryModal, pollAuthorizationStatus, setLoading } =
         useActions(paymentEntryLogic)
 
@@ -24,11 +26,12 @@ export const PaymentForm = (): JSX.Element => {
             return
         }
         setLoading(true)
+
+        const returnUrl = `${window.location.origin}${urls.billingAuthorizationStatus()}`
+        const queryParams = redirectPath ? `?postRedirectPath=${encodeURIComponent(redirectPath)}` : ''
         const result = await stripe.confirmPayment({
             elements,
-            confirmParams: {
-                return_url: `${window.location.origin}/billing/authorization_status`,
-            },
+            confirmParams: { return_url: `${returnUrl}${queryParams}` },
             redirect: 'if_required',
         })
 

--- a/frontend/src/scenes/billing/paymentEntryLogic.ts
+++ b/frontend/src/scenes/billing/paymentEntryLogic.ts
@@ -106,15 +106,17 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
                     if (response.success) {
                         await billingLogic.asyncActions.loadBilling()
                         if (redirectPath) {
-                            window.location.pathname = redirectPath
+                            const url = new URL(redirectPath, window.location.origin)
+                            const searchParams = Object.fromEntries(url.searchParams.entries())
+                            router.actions.push(url.pathname, { ...searchParams, upgraded: 'true' })
                         } else {
                             router.actions.push(router.values.location.pathname, {
                                 ...router.values.searchParams,
                                 upgraded: 'true',
                             })
-                            actions.loadCurrentOrganization()
-                            actions.loadUser()
                         }
+                        actions.loadCurrentOrganization()
+                        actions.loadUser()
                     } else if (response.must_setup_payment) {
                         // Card invalid or missing — show modal (same as new customer flow)
                         actions.setRedirectPath(redirectPath || null)
@@ -178,16 +180,18 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
                         // Load before doing anything to reload in entitlements on the organization
                         await billingLogic.asyncActions.loadBilling()
                         if (values.redirectPath) {
-                            window.location.pathname = values.redirectPath
+                            const url = new URL(values.redirectPath, window.location.origin)
+                            const searchParams = Object.fromEntries(url.searchParams.entries())
+                            router.actions.push(url.pathname, { ...searchParams, success: 'true' })
                         } else {
                             router.actions.push(router.values.location.pathname, {
                                 ...router.values.searchParams,
                                 success: true,
                             })
-                            actions.loadCurrentOrganization()
-                            actions.loadUser()
-                            actions.hidePaymentEntryModal()
                         }
+                        actions.loadCurrentOrganization()
+                        actions.loadUser()
+                        actions.hidePaymentEntryModal()
                         return
                     } else if (status === 'failed') {
                         actions.setApiError(errorMessage)

--- a/frontend/src/scenes/billing/paymentEntryLogic.ts
+++ b/frontend/src/scenes/billing/paymentEntryLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
@@ -12,14 +12,12 @@ import { billingLogic } from './billingLogic'
 import { billingProductLogic } from './billingProductLogic'
 import type { paymentEntryLogicType } from './paymentEntryLogicType'
 
-export const paymentEntryLogic = kea<paymentEntryLogicType>({
-    path: ['scenes', 'billing', 'PaymentEntryLogic'],
-
-    connect: {
+export const paymentEntryLogic = kea<paymentEntryLogicType>([
+    path(['scenes', 'billing', 'PaymentEntryLogic']),
+    connect({
         actions: [userLogic, ['loadUser'], organizationLogic, ['loadCurrentOrganization']],
-    },
-
-    actions: {
+    }),
+    actions({
         setClientSecret: (clientSecret) => ({ clientSecret }),
         setLoading: (loading) => ({ loading }),
         setStripeError: (error) => ({ error }),
@@ -35,9 +33,8 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
         showPaymentEntryModal: true,
         hidePaymentEntryModal: true,
         setRedirectPath: (redirectPath: string | null) => ({ redirectPath }),
-    },
-
-    reducers: {
+    }),
+    reducers({
         clientSecret: [
             null,
             {
@@ -83,19 +80,19 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
                 setRedirectPath: (_, { redirectPath }) => redirectPath,
             },
         ],
-    },
-
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         startPaymentEntryFlow: async ({ product, redirectPath }) => {
             const { billing } = billingLogic.values
 
             if (billing?.customer_id) {
                 // Returning customer — call POST API to activate subscription
-                if (product) {
-                    const { setBillingProductLoading } = billingProductLogic({ product }).actions
-                    setBillingProductLoading(product.type)
-                }
                 actions.setLoading(true)
+                if (product) {
+                    const theBillingProductLogic = billingProductLogic({ product })
+                    theBillingProductLogic.actions.setBillingProductLoading(product.type)
+                }
+
                 try {
                     const body: Record<string, string> = { products: 'all_products:' }
                     if (product?.type) {
@@ -159,11 +156,11 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
             }
         },
 
-        pollAuthorizationStatus: async ({ paymentIntentId }) => {
+        pollAuthorizationStatus: ({ paymentIntentId }) => {
             const pollInterval = 2000 // Poll every 2 seconds
             const maxAttempts = 30 // Max 1 minute of polling (30 * 2 seconds)
-            let attempts = 0
 
+            let attempts = 0
             const poll = async (): Promise<void> => {
                 try {
                     const urlParams = new URLSearchParams(window.location.search)
@@ -224,7 +221,8 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
                 }
             }
 
-            await poll()
+            // Fire and forget polling, it'll handle cancelation and stopping itself when it reaches max attempts
+            poll()
         },
 
         hidePaymentEntryModal: () => {
@@ -232,5 +230,14 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>({
             actions.setClientSecret(null)
             actions.clearErrors()
         },
+    })),
+    afterMount(({ actions }) => {
+        // In case the user gets redirected back to the app after completing payment on Stripe's hosted page,
+        // we need to set up the proper `redirectPath` so that polling sends us to the right place after successful payment
+        const urlParams = new URLSearchParams(window.location.search)
+        const postRedirectPath = urlParams.get('postRedirectPath')
+        if (postRedirectPath) {
+            actions.setRedirectPath(postRedirectPath)
+        }
     }),
-})
+])

--- a/frontend/src/scenes/billing/paymentEntryLogic.ts
+++ b/frontend/src/scenes/billing/paymentEntryLogic.ts
@@ -179,7 +179,7 @@ export const paymentEntryLogic = kea<paymentEntryLogicType>([
                         if (values.redirectPath) {
                             const url = new URL(values.redirectPath, window.location.origin)
                             const searchParams = Object.fromEntries(url.searchParams.entries())
-                            router.actions.push(url.pathname, { ...searchParams, success: 'true' })
+                            router.actions.push(url.pathname, { ...searchParams, success: true })
                         } else {
                             router.actions.push(router.values.location.pathname, {
                                 ...router.values.searchParams,

--- a/frontend/src/scenes/onboarding/billing/OnboardingUpgradeStep.tsx
+++ b/frontend/src/scenes/onboarding/billing/OnboardingUpgradeStep.tsx
@@ -63,7 +63,7 @@ const ProductSubscribed = ({ product }: { product: BillingProductV2Type }): JSX.
 
             {/* Text Below */}
             <h3 className="text-2xl font-bold mt-6">Go forth and build amazing products!</h3>
-            <p className="text-gray-700">
+            <p className="text-gray-700 dark:text-gray-400">
                 You've unlocked all features for <strong>{product.name}</strong>.
             </p>
         </div>


### PR DESCRIPTION
## Problem

Users were incorrectly redirected to the start of the onboarding flow after successfully adding a payment card on the Plans step. This caused a loss of progress and a disjointed user experience.

## Changes

- In `frontend/src/scenes/billing/paymentEntryLogic.ts`, replaced `window.location.pathname` with `router.actions.push()` to prevent full page reloads and preserve query parameters.
- Ensured the `redirectPath` is correctly parsed to include both the pathname and relevant query parameters (`success` or `upgraded`) for seamless onboarding flow continuation.
- Confirmed `loadCurrentOrganization()` and `loadUser()` are consistently called after payment processing.
- Also guaranteed that in the rare case where we have to redirect to an external Stripe page then we come back to the correct onboarding step.

## How did you test this code?

Verified TypeScript compilation and Kea type generation. The expected flow logic was confirmed through code analysis: after adding a card, the user should remain on the Plans step, see a celebration message, and be able to proceed by clicking "Next".

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771556625313369?thread_ts=1771556625.313369&cid=C0ACRAMJUAG)

<p><a href="https://cursor.com/agents/bc-3c82ffbd-206e-5d8e-898b-2873a92e5b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c82ffbd-206e-5d8e-898b-2873a92e5b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

