### PR TITLE
fix(flags): use shared redis for flag definitions HyperCacheReader

### DIFF
--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -244,9 +244,8 @@ pub async fn serve<F>(
         };
 
     // Create HyperCacheReader for flags with cohorts (used by /flags/definitions endpoint)
-    let flags_with_cohorts_redis_client = dedicated_redis_client
-        .clone()
-        .unwrap_or_else(|| redis_client.clone());
+    // Uses the shared cache (redis_client) - same cache Django writes to via HyperCache
+    let flags_with_cohorts_redis_client = redis_client.clone();
 
     let mut flags_with_cohorts_config = HyperCacheConfig::new(
         "feature_flags".to_string(),


### PR DESCRIPTION
## Summary

- Use shared `redis_client` instead of `dedicated_redis_client` for the flag definitions HyperCacheReader in the Rust feature-flags service
- The flag definitions HyperCache is written by Django via the shared redis cache (`REDIS_URL`), but the Rust service was reading from the dedicated flags cache (`FLAGS_REDIS_URL`) when available, causing a read/write mismatch

Extracted from #44701.

## Test plan

- [ ] Verify Rust compilation passes in CI
- [ ] Confirm flag definitions endpoint reads from the correct Redis instance