### PR TITLE
feat(flags): add HyperCache configuration for flag definitions cache

### DIFF
--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -99,7 +99,7 @@ Feature flag local evaluation uses two separate HyperCache instances in `posthog
 
 ```python
 # Full flags with cohort definitions (for smart clients)
-flags_hypercache = HyperCache(
+flag_definitions_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_with_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(team, include_cohorts=True),
@@ -107,7 +107,7 @@ flags_hypercache = HyperCache(
 )
 
 # Simplified flags without cohorts (legacy)
-flags_without_cohorts_hypercache = HyperCache(
+flag_definitions_without_cohorts_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_without_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(team, include_cohorts=False),
@@ -115,7 +115,7 @@ flags_without_cohorts_hypercache = HyperCache(
 )
 ```
 
-All current SDKs support cohort evaluation locally, so the dual-cache strategy is legacy. The `flags_without_cohorts` cache exists for older SDK versions that couldn't handle cohort definitions. Once requests for flags without cohorts decline sufficiently, this cache can be removed.
+All current SDKs support cohort evaluation locally, so the dual-cache strategy is legacy. The `flag_definitions_without_cohorts_hypercache` cache exists for older SDK versions that couldn't handle cohort definitions. Once requests for flags without cohorts decline sufficiently, this cache can be removed.
 
 ### Cache invalidation
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -6402,7 +6402,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
     @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     def test_local_evaluation_cache_invalidation_on_feature_flag_delete(self, mock_on_commit):
         """Test that cache invalidates when FeatureFlag is deleted."""
-        from posthog.models.feature_flag.local_evaluation import flags_hypercache, flags_without_cohorts_hypercache
+        from posthog.models.feature_flag.local_evaluation import (
+            flag_definitions_hypercache,
+            flag_definitions_without_cohorts_hypercache,
+        )
 
         # Create two feature flags
         flag1 = FeatureFlag.objects.create(
@@ -6422,8 +6425,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         # Clear caches to start fresh
-        flags_hypercache.clear_cache(self.team)
-        flags_without_cohorts_hypercache.clear_cache(self.team)
+        flag_definitions_hypercache.clear_cache(self.team)
+        flag_definitions_without_cohorts_hypercache.clear_cache(self.team)
 
         # Populate both cache variants using use_cache parameter
         response1 = self.client.get(f"/api/feature_flag/local_evaluation?token={self.team.api_token}")
@@ -6474,7 +6477,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
     @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     def test_local_evaluation_cache_invalidation_on_cohort_delete(self, mock_on_commit):
         """Test that cache invalidates when Cohort is deleted."""
-        from posthog.models.feature_flag.local_evaluation import flags_hypercache, flags_without_cohorts_hypercache
+        from posthog.models.feature_flag.local_evaluation import (
+            flag_definitions_hypercache,
+            flag_definitions_without_cohorts_hypercache,
+        )
 
         # Create a cohort
         cohort = Cohort.objects.create(
@@ -6500,8 +6506,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         # Clear caches to start fresh
-        flags_hypercache.clear_cache(self.team)
-        flags_without_cohorts_hypercache.clear_cache(self.team)
+        flag_definitions_hypercache.clear_cache(self.team)
+        flag_definitions_without_cohorts_hypercache.clear_cache(self.team)
 
         # Populate cache with cohorts using use_cache parameter
         response = self.client.get(f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -6032,9 +6032,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
         # Clear both Redis and S3 caches
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         # First request should miss cache and populate it
         self.client.logout()
@@ -6567,9 +6567,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
         response = self.client.get(
@@ -6596,9 +6596,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6634,9 +6634,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6666,9 +6666,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6719,9 +6719,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6767,9 +6767,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6810,9 +6810,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 
@@ -6848,9 +6848,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+        from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
         self.client.logout()
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -486,15 +486,6 @@ def clear_flag_definition_caches(team: Team, kinds: list[str] | None = None):
     flag_definitions_without_cohorts_hypercache.clear_cache(team, kinds=kinds)
 
 
-def clear_flag_caches(team: Team, kinds: list[str] | None = None):
-    """Clear the flag definitions cache for a team.
-
-    Delegates to clear_flag_definition_caches for proper cleanup including
-    expiry tracking.
-    """
-    clear_flag_definition_caches(team, kinds=kinds)
-
-
 def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict[str, Any]:
     """Build the local-evaluation response for a single team."""
     results = _get_flags_response_for_local_evaluation_batch([team], include_cohorts)

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -1,3 +1,24 @@
+"""
+Flag Definitions HyperCache for SDK local evaluation.
+
+This module provides HyperCaches that store feature flag definitions for SDKs to use
+in local evaluation. Unlike the flags_cache.py which provides raw flag data for the
+Rust feature-flags service, this provides rich data including cohort definitions and
+group type mappings.
+
+Two cache variants are provided:
+- flag_definitions_hypercache: Includes full cohort definitions for smart clients
+- flag_definitions_without_cohorts_hypercache: Cohort filters transformed to properties for simple clients
+
+Cache Key Pattern:
+- Uses team_id as the key (ID-based cache)
+- Stored in both Redis and S3 via HyperCache
+
+Configuration:
+- Redis TTL: 7 days (configurable via FLAGS_CACHE_TTL env var)
+- Miss TTL: 1 day (configurable via FLAGS_CACHE_MISS_TTL env var)
+"""
+
 import time
 from collections import defaultdict
 from collections.abc import Generator
@@ -13,6 +34,7 @@ from django.dispatch import receiver
 
 import structlog
 from posthoganalytics import capture_exception
+from prometheus_client import Counter
 
 from posthog.models.cohort.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.util import get_nested_cohort_ids
@@ -25,8 +47,20 @@ from posthog.models.tag import Tag
 from posthog.models.team import Team
 from posthog.person_db_router import PERSONS_DB_FOR_READ
 from posthog.storage.hypercache import HyperCache, emit_cache_sync_metrics
+from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 
 logger = structlog.get_logger(__name__)
+
+
+# Sorted set keys for tracking cache expirations
+FLAG_DEFINITIONS_CACHE_EXPIRY_SORTED_SET = "flag_definitions_cache_expiry"
+FLAG_DEFINITIONS_NO_COHORTS_CACHE_EXPIRY_SORTED_SET = "flag_definitions_no_cohorts_cache_expiry"
+
+# Metric to track flags dropped during batch processing due to errors
+FLAG_PROCESSING_ERROR_COUNTER = Counter(
+    "posthog_flag_definitions_processing_error",
+    "Number of flags dropped from cache due to processing errors",
+)
 
 
 def _get_properties_from_filters(
@@ -330,26 +364,34 @@ DATABASE_FOR_LOCAL_EVALUATION = (
 # Use centralized database routing constant
 READ_ONLY_DATABASE_FOR_PERSONS = PERSONS_DB_FOR_READ
 
-flags_hypercache = HyperCache(
+flag_definitions_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_with_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(HyperCache.team_from_key(key), include_cohorts=True),
+    cache_ttl=settings.FLAGS_CACHE_TTL,
+    cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
+    batch_load_fn=lambda teams: _get_flags_response_for_local_evaluation_batch(teams, include_cohorts=True),
     enable_etag=True,
+    expiry_sorted_set_key=FLAG_DEFINITIONS_CACHE_EXPIRY_SORTED_SET,
 )
 
-flags_without_cohorts_hypercache = HyperCache(
+flag_definitions_without_cohorts_hypercache = HyperCache(
     namespace="feature_flags",
     value="flags_without_cohorts.json",
     load_fn=lambda key: _get_flags_response_for_local_evaluation(HyperCache.team_from_key(key), include_cohorts=False),
+    cache_ttl=settings.FLAGS_CACHE_TTL,
+    cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
+    batch_load_fn=lambda teams: _get_flags_response_for_local_evaluation_batch(teams, include_cohorts=False),
     enable_etag=True,
+    expiry_sorted_set_key=FLAG_DEFINITIONS_NO_COHORTS_CACHE_EXPIRY_SORTED_SET,
 )
 
 
 def get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict | None:
     return (
-        flags_hypercache.get_from_cache(team)
+        flag_definitions_hypercache.get_from_cache(team)
         if include_cohorts
-        else flags_without_cohorts_hypercache.get_from_cache(team)
+        else flag_definitions_without_cohorts_hypercache.get_from_cache(team)
     )
 
 
@@ -363,8 +405,45 @@ def get_flags_response_if_none_match(
     - If client_etag matches current: (None, current_etag, False) - 304 case
     - Otherwise: (data, current_etag, True) - 200 case with full data
     """
-    hypercache = flags_hypercache if include_cohorts else flags_without_cohorts_hypercache
+    hypercache = flag_definitions_hypercache if include_cohorts else flag_definitions_without_cohorts_hypercache
     return hypercache.get_if_none_match(team, client_etag)
+
+
+def _resolve_team(team: Team | int) -> Team | None:
+    """Resolve a Team object or ID to a Team, returning None if not found."""
+    if isinstance(team, int):
+        try:
+            return Team.objects.get(id=team)
+        except Team.DoesNotExist:
+            logger.warning("Team not found for flag definitions cache update", team_id=team)
+            return None
+    return team
+
+
+def update_flag_definitions_cache(team: Team | int, ttl: int | None = None) -> bool:
+    """
+    Update the flag definitions cache for a team.
+
+    Updates both cache variants (with and without cohorts). Delegates to
+    HyperCache.update_cache() which handles error logging and sync metrics.
+
+    Args:
+        team: Team object or team ID
+        ttl: Optional custom TTL in seconds (defaults to FLAGS_CACHE_TTL)
+
+    Returns:
+        True if both cache updates succeeded, False otherwise
+    """
+    resolved_team = _resolve_team(team)
+    if resolved_team is None:
+        return False
+
+    success = True
+    for hypercache in [flag_definitions_hypercache, flag_definitions_without_cohorts_hypercache]:
+        if not hypercache.update_cache(resolved_team, ttl=ttl):
+            success = False
+
+    return success
 
 
 def update_flag_caches(team: Team):
@@ -377,10 +456,10 @@ def update_flag_caches(team: Team):
     size_without_cohorts: int | None = None
     try:
         with_cohorts = _get_flags_response_for_local_evaluation(team, include_cohorts=True)
-        size_with_cohorts = flags_hypercache.set_cache_value(team, with_cohorts)
+        size_with_cohorts = flag_definitions_hypercache.set_cache_value(team, with_cohorts)
 
         without_cohorts = _get_flags_response_for_local_evaluation(team, include_cohorts=False)
-        size_without_cohorts = flags_without_cohorts_hypercache.set_cache_value(team, without_cohorts)
+        size_without_cohorts = flag_definitions_without_cohorts_hypercache.set_cache_value(team, without_cohorts)
 
         success = True
     except Exception as e:
@@ -396,9 +475,24 @@ def update_flag_caches(team: Team):
         emit_cache_sync_metrics(result, "feature_flags", "flags_without_cohorts.json", size=size_without_cohorts)
 
 
+def clear_flag_definition_caches(team: Team, kinds: list[str] | None = None):
+    """
+    Clear the flag definitions cache for a team.
+
+    Clears from shared cache and removes from expiry tracking.
+    Expiry tracking cleanup is handled by HyperCache.clear_cache() internally.
+    """
+    flag_definitions_hypercache.clear_cache(team, kinds=kinds)
+    flag_definitions_without_cohorts_hypercache.clear_cache(team, kinds=kinds)
+
+
 def clear_flag_caches(team: Team, kinds: list[str] | None = None):
-    flags_hypercache.clear_cache(team, kinds=kinds)
-    flags_without_cohorts_hypercache.clear_cache(team, kinds=kinds)
+    """Clear the flag definitions cache for a team.
+
+    Delegates to clear_flag_definition_caches for proper cleanup including
+    expiry tracking.
+    """
+    clear_flag_definition_caches(team, kinds=kinds)
 
 
 def _get_flags_response_for_local_evaluation(team: Team, include_cohorts: bool) -> dict[str, Any]:
@@ -561,6 +655,7 @@ def _get_flags_response_for_local_evaluation_batch(
 
             except Exception:
                 logger.error("Error processing feature flag", extra={"flag_id": feature_flag.pk}, exc_info=True)
+                FLAG_PROCESSING_ERROR_COUNTER.inc()
                 continue
 
         response_data: dict[str, Any] = {
@@ -581,6 +676,39 @@ def _get_flags_response_for_local_evaluation_batch(
             }
 
     return results
+
+
+# Per-variant update functions for management configs. Each updates only its own
+# cache variant so that warm_caches doesn't do double work when iterating configs.
+
+
+def _update_flag_definitions_with_cohorts(team: Team | int, ttl: int | None = None) -> bool:
+    resolved_team = _resolve_team(team)
+    if resolved_team is None:
+        return False
+    return flag_definitions_hypercache.update_cache(resolved_team, ttl=ttl)
+
+
+def _update_flag_definitions_without_cohorts(team: Team | int, ttl: int | None = None) -> bool:
+    resolved_team = _resolve_team(team)
+    if resolved_team is None:
+        return False
+    return flag_definitions_without_cohorts_hypercache.update_cache(resolved_team, ttl=ttl)
+
+
+# HyperCache management configs for warming/verification.
+# Two separate configs, one for each cache variant.
+FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
+    hypercache=flag_definitions_hypercache,
+    update_fn=_update_flag_definitions_with_cohorts,
+    cache_name="flag_definitions",
+)
+
+FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
+    hypercache=flag_definitions_without_cohorts_hypercache,
+    update_fn=_update_flag_definitions_without_cohorts,
+    cache_name="flag_definitions_no_cohorts",
+)
 
 
 # NOTE: All models that affect feature flag evaluation should have a signal to update the cache

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1,18 +1,27 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.test import override_settings
+
 from parameterized import parameterized
 
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.feature_flag.feature_flag import FeatureFlag, FeatureFlagEvaluationTag
 from posthog.models.feature_flag.local_evaluation import (
+    FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
+    FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
     _extract_cohort_ids_from_filters,
     _get_flags_response_for_local_evaluation,
     _get_flags_response_for_local_evaluation_batch,
+    _update_flag_definitions_with_cohorts,
+    _update_flag_definitions_without_cohorts,
     clear_flag_caches,
-    flags_hypercache,
+    clear_flag_definition_caches,
+    flag_definitions_hypercache,
+    flag_definitions_without_cohorts_hypercache,
     get_flags_response_for_local_evaluation,
     update_flag_caches,
+    update_flag_definitions_cache,
 )
 from posthog.models.project import Project
 from posthog.models.surveys.survey import Survey
@@ -177,25 +186,25 @@ class TestLocalEvaluationCache(BaseTest):
 
     def test_get_flags_cache_hot(self):
         update_flag_caches(self.team)
-        response, source = flags_hypercache.get_from_cache_with_source(self.team)
+        response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "redis"
         self._assert_payload_valid_with_cohorts(response)
 
     def test_get_flags_cache_warm(self):
         update_flag_caches(self.team)
         clear_flag_caches(self.team, kinds=["redis"])
-        response, source = flags_hypercache.get_from_cache_with_source(self.team)
+        response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "s3"
         self._assert_payload_valid_with_cohorts(response)
 
     def test_get_flags_cold(self):
         clear_flag_caches(self.team, kinds=["redis", "s3"])
-        response, source = flags_hypercache.get_from_cache_with_source(self.team)
+        response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "db"
         self._assert_payload_valid_with_cohorts(response)
 
         # second request should be cached in redis
-        response, source = flags_hypercache.get_from_cache_with_source(self.team)
+        response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "redis"
         self._assert_payload_valid_with_cohorts(response)
 
@@ -1009,3 +1018,147 @@ class TestLocalEvaluationBatch(BaseTest):
         flag_keys = [f["key"] for f in results[team.id]["flags"]]
         assert "flag-ref-deleted-cohort" in flag_keys
         assert str(cohort_id) not in results[team.id]["cohorts"]
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestFlagDefinitionsCache(BaseTest):
+    """Tests for flag definitions HyperCache operations."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
+
+    def test_cache_key_format_is_stable(self):
+        """
+        Changing the key format would orphan existing cached data,
+        causing a cold cache on deploy.
+        """
+        with_cohorts_key = flag_definitions_hypercache.get_cache_key(self.team)
+        without_cohorts_key = flag_definitions_without_cohorts_hypercache.get_cache_key(self.team)
+
+        assert with_cohorts_key == f"cache/teams/{self.team.id}/feature_flags/flags_with_cohorts.json"
+        assert without_cohorts_key == f"cache/teams/{self.team.id}/feature_flags/flags_without_cohorts.json"
+
+    def test_update_flag_definitions_cache_updates_both_variants(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = update_flag_definitions_cache(self.team)
+        assert result is True
+
+        with_cohorts, source1 = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        without_cohorts, source2 = flag_definitions_without_cohorts_hypercache.get_from_cache_with_source(self.team)
+
+        assert source1 == "redis"
+        assert source2 == "redis"
+        assert with_cohorts is not None
+        assert without_cohorts is not None
+        assert len(with_cohorts["flags"]) == 1
+        assert len(without_cohorts["flags"]) == 1
+
+    def test_update_flag_definitions_cache_accepts_team_id(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = update_flag_definitions_cache(self.team.id)
+        assert result is True
+
+        data, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        assert source == "redis"
+        assert data is not None
+        assert len(data["flags"]) == 1
+
+    def test_update_flag_definitions_cache_returns_false_for_nonexistent_team(self):
+        result = update_flag_definitions_cache(999999)
+        assert result is False
+
+    def test_clear_flag_definition_caches_clears_both_variants(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        _, source1 = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        _, source2 = flag_definitions_without_cohorts_hypercache.get_from_cache_with_source(self.team)
+        assert source1 == "redis"
+        assert source2 == "redis"
+
+        clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
+
+        _, source1 = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        _, source2 = flag_definitions_without_cohorts_hypercache.get_from_cache_with_source(self.team)
+        assert source1 == "db"
+        assert source2 == "db"
+
+    def test_hypercache_configs_are_properly_configured(self):
+        config1 = FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG
+        assert config1.cache_name == "flag_definitions"
+        assert config1.hypercache == flag_definitions_hypercache
+        assert config1.update_fn == _update_flag_definitions_with_cohorts
+
+        config2 = FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG
+        assert config2.cache_name == "flag_definitions_no_cohorts"
+        assert config2.hypercache == flag_definitions_without_cohorts_hypercache
+        assert config2.update_fn == _update_flag_definitions_without_cohorts
+
+    def test_update_flag_definitions_cache_returns_false_on_partial_failure(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        with patch.object(flag_definitions_hypercache, "update_cache", return_value=False):
+            result = update_flag_definitions_cache(self.team)
+
+        assert result is False
+
+        # The second variant should still have been updated
+        _, source = flag_definitions_without_cohorts_hypercache.get_from_cache_with_source(self.team)
+        assert source == "redis"
+
+    def test_update_flag_definitions_cache_passes_custom_ttl(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        with (
+            patch.object(flag_definitions_hypercache, "update_cache", return_value=True) as mock_with,
+            patch.object(
+                flag_definitions_without_cohorts_hypercache, "update_cache", return_value=True
+            ) as mock_without,
+        ):
+            update_flag_definitions_cache(self.team, ttl=3600)
+
+        mock_with.assert_called_once_with(self.team, ttl=3600)
+        mock_without.assert_called_once_with(self.team, ttl=3600)
+
+
+@override_settings(FLAGS_REDIS_URL=None)
+class TestFlagDefinitionsCacheWithoutRedis(BaseTest):
+    def test_update_flag_definitions_cache_returns_true_without_redis(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = update_flag_definitions_cache(self.team)
+        assert result is True

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -15,7 +15,6 @@ from posthog.models.feature_flag.local_evaluation import (
     _get_flags_response_for_local_evaluation_batch,
     _update_flag_definitions_with_cohorts,
     _update_flag_definitions_without_cohorts,
-    clear_flag_caches,
     clear_flag_definition_caches,
     flag_definitions_hypercache,
     flag_definitions_without_cohorts_hypercache,
@@ -40,7 +39,7 @@ class TestLocalEvaluationCache(BaseTest):
         )
         self.team = team
         self._create_examples(self.team)
-        clear_flag_caches(self.team)
+        clear_flag_definition_caches(self.team)
 
     def _create_examples(self, team: Team):
         FeatureFlag.objects.all().delete()
@@ -192,13 +191,13 @@ class TestLocalEvaluationCache(BaseTest):
 
     def test_get_flags_cache_warm(self):
         update_flag_caches(self.team)
-        clear_flag_caches(self.team, kinds=["redis"])
+        clear_flag_definition_caches(self.team, kinds=["redis"])
         response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "s3"
         self._assert_payload_valid_with_cohorts(response)
 
     def test_get_flags_cold(self):
-        clear_flag_caches(self.team, kinds=["redis", "s3"])
+        clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
         response, source = flag_definitions_hypercache.get_from_cache_with_source(self.team)
         assert source == "db"
         self._assert_payload_valid_with_cohorts(response)


### PR DESCRIPTION
## Summary

- Configure flag definitions HyperCache instances with TTL, batch loading, and expiry tracking to support scheduled refresh and verification tasks
- Add `update_flag_definitions_cache()` for updating both cache variants (with/without cohorts)
- Add `clear_flag_definition_caches()` with expiry tracking cleanup
- Add `HyperCacheManagementConfig` instances for warming/verification
- Add `FLAG_PROCESSING_ERROR_COUNTER` metric for batch processing errors

Extracted from #44701. This is the foundation that some follow-up PRs (verification, scheduled tasks, management commands) will build on.

There's no actual behavioral change in production with these changes.

## Test plan

- [x] 7 new tests covering cache update, clear, config, and no-redis behavior
- [x] All 36 existing + new tests pass
- [x] Lint clean