### PR TITLE
fix: Ensure CLI port parameter is consistently handled as string

### DIFF
--- a/frontend/src/scenes/authentication/cliLiveLogic.ts
+++ b/frontend/src/scenes/authentication/cliLiveLogic.ts
@@ -63,7 +63,7 @@ export const cliLiveLogic = kea<cliLiveLogicType>([
                 return
             }
             const portNum = parseInt(values.port, 10)
-            if (isNaN(portNum) || portNum < 1 || portNum > 65535 || String(portNum) !== values.port) {
+            if (isNaN(portNum) || portNum < 1 || portNum > 65535 || String(portNum) !== String(values.port)) {
                 actions.setError('Invalid port parameter')
                 return
             }
@@ -89,7 +89,7 @@ export const cliLiveLogic = kea<cliLiveLogicType>([
         '/cli/live': (_, searchParams) => {
             const port = searchParams.port
             if (port) {
-                actions.setPort(port)
+                actions.setPort(String(port)) // Ensure stored as string, `searchParams` sometimes automatically parses number
             }
         },
     })),


### PR DESCRIPTION
## Problem

The CLI live authentication logic has type inconsistencies when handling port parameters from URL search params, which can cause validation errors when comparing string and number types.

## Changes

- Fixed type comparison in port validation by ensuring both sides of the comparison are strings
- Added explicit string conversion when setting port from search params to handle cases where the parameter is automatically parsed as a number
- Added clarifying comment explaining the string conversion requirement

## How did you test this code?

As an agent, I have not manually tested this code. The changes should be tested by:
- Navigating to CLI live authentication with port parameters in the URL
- Verifying that valid port numbers are accepted without validation errors
- Testing edge cases like ports with leading zeros or invalid formats

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No