### PR TITLE
fix: add url validation to heatmap export

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -22,6 +22,7 @@ from posthog.event_usage import groups
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response
+from posthog.security.url_validation import is_url_allowed
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.tasks import exporter
@@ -147,6 +148,11 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                         ]
                     }
                 )
+
+        if export_context and export_context.get("heatmap_url"):
+            ok, err = is_url_allowed(export_context["heatmap_url"])
+            if not ok:
+                raise ValidationError({"export_context": ["heatmap_url not allowed"]})
 
         data["team_id"] = self.context["team_id"]
         return data

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -39,6 +39,7 @@ from posthog.models.exported_asset import ExportedAsset, asset_for_token, get_co
 from posthog.models.insight import Insight
 from posthog.models.user import User
 from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
+from posthog.security.url_validation import is_url_allowed
 from posthog.session_recordings.session_recording_api import SessionRecordingSerializer
 from posthog.user_permissions import UserPermissions
 from posthog.utils import get_ip_address, render_template
@@ -812,6 +813,10 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
 
             if not heatmap_url:
                 raise NotFound("Invalid heatmap export - missing heatmap_url")
+
+            ok, err = is_url_allowed(heatmap_url)
+            if not ok:
+                raise ValidationError("heatmap_url not allowed")
 
             heatmap_data_url = resource.export_context.get("heatmap_data_url")
             if not heatmap_data_url:

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -937,6 +937,48 @@ class TestExports(APIBaseTest):
         self.assertEqual(asset.failure_type, "user")
 
 
+class TestExportHeatmapSSRFValidation(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("metadata_endpoint", "http://169.254.169.254/latest/meta-data/"),
+            ("localhost", "http://localhost/admin"),
+            ("loopback_ip", "http://127.0.0.1:8080/secret"),
+            ("private_ip_10", "http://10.0.0.1/internal"),
+            ("private_ip_192", "http://192.168.1.1/internal"),
+            ("internal_domain", "http://service.cluster.local/api"),
+            ("file_scheme", "file:///etc/passwd"),
+        ]
+    )
+    def test_rejects_ssrf_heatmap_url(self, _name: str, url: str) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "image/png",
+                "export_context": {
+                    "heatmap_url": url,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.exports.exporter")
+    @patch("posthog.security.url_validation.resolve_host_ips")
+    def test_accepts_valid_external_heatmap_url(self, mock_resolve, mock_exporter_task) -> None:
+        import ipaddress
+
+        mock_resolve.return_value = {ipaddress.ip_address("93.184.216.34")}
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "image/png",
+                "export_context": {
+                    "heatmap_url": "https://example.com/page",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
 class TestExportMixin(APIBaseTest):
     def _get_export_output(self, path: str) -> list[str]:
         """


### PR DESCRIPTION
Use the same validation that we have elsewhere.