### PR TITLE
fix(replay): handle S3 NoSuchKey as not_found in recording-api

### DIFF
--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -11,7 +11,7 @@ import {
     RedisPool,
 } from '../../types'
 import { createRedisPoolFromConfig } from '../../utils/db/redis'
-import { logger } from '../../utils/logger'
+import { logger, serializeError } from '../../utils/logger'
 import { getBlockDecryptor } from '../shared/crypto'
 import { getKeyStore } from '../shared/keystore'
 import { RedisCachedKeyStore } from '../shared/keystore/cache'
@@ -233,7 +233,7 @@ export class RecordingApi {
             res.send(result.data)
         } catch (error) {
             logger.error('[RecordingApi] Error fetching block from S3', {
-                error,
+                error: serializeError(error),
                 key,
                 start: startByte,
                 end: endByte,
@@ -269,7 +269,10 @@ export class RecordingApi {
             const result = await this.recordingService.bulkDeleteRecordings(sessionIds, teamId)
             res.json(result)
         } catch (error) {
-            logger.error('[RecordingApi] Error in bulk delete', { error, teamId })
+            logger.error('[RecordingApi] Error in bulk delete', {
+                error: serializeError(error),
+                teamId,
+            })
             res.status(500).json({ error: 'Failed to bulk delete recordings' })
         }
     }
@@ -302,7 +305,11 @@ export class RecordingApi {
 
             res.json({ team_id: teamId, session_id: sessionId, status: 'deleted', deleted_at: result.deletedAt })
         } catch (error) {
-            logger.error('[RecordingApi] Error deleting recording key', { error, teamId, sessionId })
+            logger.error('[RecordingApi] Error deleting recording key', {
+                error: serializeError(error),
+                teamId,
+                sessionId,
+            })
             res.status(500).json({ error: 'Failed to delete recording key' })
         }
     }

--- a/nodejs/src/session-replay/recording-api/recording-service.test.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.test.ts
@@ -1,4 +1,4 @@
-import { S3Client } from '@aws-sdk/client-s3'
+import { NoSuchKey, S3Client } from '@aws-sdk/client-s3'
 
 import { PostgresRouter } from '../../utils/db/postgres'
 import { SessionMetadataStore } from '../shared/metadata/session-metadata-store'
@@ -140,6 +140,14 @@ describe('RecordingService', () => {
             const result = await service.getBlock(validParams)
 
             expect(result).toEqual({ ok: false, error: 'deleted', deletedAt: undefined })
+        })
+
+        it('returns not_found when S3 throws NoSuchKey', async () => {
+            mockS3Send.mockRejectedValue(new NoSuchKey({ message: 'The specified key does not exist.', $metadata: {} }))
+
+            const result = await service.getBlock(validParams)
+
+            expect(result).toEqual({ ok: false, error: 'not_found' })
         })
 
         it('propagates unexpected S3 errors', async () => {

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -1,7 +1,7 @@
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
 
 import { PostgresRouter, PostgresUse } from '../../utils/db/postgres'
-import { logger } from '../../utils/logger'
+import { logger, serializeError } from '../../utils/logger'
 import { ValidRetentionPeriods } from '../shared/constants'
 import { createDeletionBlockMetadata } from '../shared/metadata/session-block-metadata'
 import { SessionMetadataStore } from '../shared/metadata/session-metadata-store'
@@ -135,8 +135,8 @@ export class RecordingService {
                 logger.error('[RecordingService] Post-deletion cleanup failed', {
                     sessionId,
                     teamId,
-                    metadataError: metadataError ?? null,
-                    postgresError: postgresError ?? null,
+                    metadataError: serializeError(metadataError) ?? null,
+                    postgresError: serializeError(postgresError) ?? null,
                 })
                 RecordingApiMetrics.observeDeleteRecording('cleanup_failed', (performance.now() - startTime) / 1000)
                 return { ok: false, error: 'cleanup_failed', metadataError, postgresError }
@@ -239,7 +239,7 @@ export class RecordingService {
                     sessionId,
                     teamId,
                     table: tables[i],
-                    error: result.reason,
+                    error: serializeError(result.reason),
                 })
             }
         }

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand, NoSuchKey, S3Client } from '@aws-sdk/client-s3'
 
 import { PostgresRouter, PostgresUse } from '../../utils/db/postgres'
 import { logger, serializeError } from '../../utils/logger'
@@ -101,6 +101,16 @@ export class RecordingService {
             RecordingApiMetrics.observeGetBlock('success', (performance.now() - startTime) / 1000)
             return { ok: true, data: decrypted }
         } catch (error) {
+            if (error instanceof NoSuchKey) {
+                logger.warn('[RecordingService] S3 object not found (NoSuchKey)', {
+                    key,
+                    teamId,
+                    sessionId,
+                })
+                RecordingApiMetrics.observeGetBlock('not_found', (performance.now() - startTime) / 1000)
+                return { ok: false, error: 'not_found' }
+            }
+
             if (error instanceof SessionKeyDeletedError) {
                 logger.info('[RecordingService] Session key has been deleted', {
                     teamId,

--- a/nodejs/src/utils/logger.ts
+++ b/nodejs/src/utils/logger.ts
@@ -109,6 +109,13 @@ export class Logger {
 
 export const logger = new Logger(defaultConfig.PLUGIN_SERVER_MODE ?? 'MAIN')
 
+export function serializeError(error: unknown): Record<string, unknown> | unknown {
+    if (error instanceof Error) {
+        return { name: error.name, message: error.message }
+    }
+    return error
+}
+
 export async function shutdownLogger(): Promise<void> {
     await logger.shutdown()
 }


### PR DESCRIPTION
## Summary

- Catch `NoSuchKey` from S3 explicitly in `getBlock` instead of letting it fall through to the generic error handler
- Records as `result="not_found"` in metrics instead of `result="error"`
- Fixes `RecordingApiGetBlockErrorRate` alert firing on blocks whose S3 objects have been removed by lifecycle rules

## Test plan

- [x] Unit test added for NoSuchKey → not_found
- [x] All recording-api tests pass (126/126)
- [ ] After deploy: verify EU `RecordingApiGetBlockErrorRate` alert stops firing for the 2-hourly batch requests