### PR TITLE
fix(auth): match session user identity during reauth check

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -243,7 +243,11 @@ class LoginSerializer(serializers.Serializer):
         )
 
         axes_request = getattr(request, "_request", request)
-        was_authenticated_before_login_attempt = bool(getattr(request, "user", None) and request.user.is_authenticated)
+        was_authenticated_before_login_attempt = bool(
+            getattr(request, "user", None)
+            and request.user.is_authenticated
+            and request.user.email.lower() == validated_data.get("email", "").lower()
+        )
 
         # Initialize axes handler via proxy so request metadata is populated consistently
         from axes.exceptions import AxesBackendPermissionDenied

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -246,7 +246,7 @@ class LoginSerializer(serializers.Serializer):
         was_authenticated_before_login_attempt = bool(
             getattr(request, "user", None)
             and request.user.is_authenticated
-            and request.user.email.lower() == validated_data.get("email", "").lower()
+            and request.user.email.lower() == validated_data["email"].lower()
         )
 
         # Initialize axes handler via proxy so request metadata is populated consistently


### PR DESCRIPTION
## Summary

- The reauth detection in `LoginSerializer` previously only checked whether *any* user was authenticated, not whether the authenticated user matched the one logging in
- This could cause the reauth flag to be incorrectly set when switching between accounts in the same session
- Now compares the session user's email to the login email so reauth logic only applies to the same account

