### PR TITLE
chore: migrate low level services off Hub

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -90,7 +90,7 @@ export class CdpApi {
             this.hogExecutor
         )
         this.recipientPreferencesService = new RecipientPreferencesService(this.recipientsManager)
-        this.recipientTokensService = new RecipientTokensService(hub)
+        this.recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
         this.hogFlowExecutor = new HogFlowExecutorService(
             this.hogFlowFunctionsService,
             this.recipientPreferencesService

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -53,7 +53,14 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase {
         super(hub)
         this.cyclotronJobQueue = new CyclotronJobQueue(hub, 'hogflow')
         this.kafkaConsumer = new KafkaConsumer({ groupId, topic })
-        this.hogRateLimiter = new HogRateLimiterService(hub, this.redis)
+        this.hogRateLimiter = new HogRateLimiterService(
+            {
+                bucketSize: hub.CDP_RATE_LIMITER_BUCKET_SIZE,
+                refillRate: hub.CDP_RATE_LIMITER_REFILL_RATE,
+                ttl: hub.CDP_RATE_LIMITER_TTL,
+            },
+            this.redis
+        )
 
         this.clickHouseRouter = new ClickHouseRouter(hub)
         this.clickHousePersonsRepository = new ClickHousePersonRepository(this.clickHouseRouter)

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -157,7 +157,7 @@ export class HogExecutorService {
     private recipientTokensService: RecipientTokensService
 
     constructor(private hub: HogExecutorServiceHub) {
-        this.recipientTokensService = new RecipientTokensService(hub)
+        this.recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
         this.hogInputsService = new HogInputsService(hub)
         this.emailService = new EmailService(hub)
     }

--- a/nodejs/src/cdp/services/hog-inputs.service.ts
+++ b/nodejs/src/cdp/services/hog-inputs.service.ts
@@ -17,7 +17,7 @@ export class HogInputsService {
     private recipientTokensService: RecipientTokensService
 
     constructor(private hub: HogInputsServiceHub) {
-        this.recipientTokensService = new RecipientTokensService(hub)
+        this.recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
     }
 
     public async buildInputs(

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -36,7 +36,7 @@ export class EmailService {
                   endpoint: this.hub.SES_ENDPOINT || undefined,
               })
             : null
-        this.recipientTokensService = new RecipientTokensService(hub)
+        this.recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
     }
 
     // Send email

--- a/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -444,7 +444,7 @@ describe('RecipientPreferencesService', () => {
         let tokensService: RecipientTokensService
 
         beforeEach(() => {
-            tokensService = new RecipientTokensService(hub)
+            tokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
         })
 
         it('should generate a preferences URL with a trailing slash', () => {

--- a/nodejs/src/cdp/services/messaging/recipient-tokens.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-tokens.service.test.ts
@@ -6,7 +6,7 @@ describe('RecipientTokensService', () => {
     let service: RecipientTokensService
     let fixedTime: DateTime
     beforeEach(() => {
-        service = new RecipientTokensService({ ENCRYPTION_SALT_KEYS: 'test-secret', SITE_URL: 'https://test.com' })
+        service = new RecipientTokensService('test-secret', 'https://test.com')
         fixedTime = DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'UTC' })
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())
     })

--- a/nodejs/src/cdp/services/messaging/recipient-tokens.service.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-tokens.service.ts
@@ -1,4 +1,3 @@
-import { Hub } from '~/types'
 import { logger } from '~/utils/logger'
 
 import { JWT, PosthogJwtAudience } from '../../utils/jwt-utils'
@@ -7,8 +6,11 @@ import { RecipientManagerRecipient } from '../managers/recipients-manager.servic
 export class RecipientTokensService {
     private jwt: JWT
 
-    constructor(protected hub: Pick<Hub, 'ENCRYPTION_SALT_KEYS' | 'SITE_URL'>) {
-        this.jwt = new JWT(hub.ENCRYPTION_SALT_KEYS ?? '')
+    constructor(
+        private encryptionSaltKeys: string,
+        private siteUrl: string
+    ) {
+        this.jwt = new JWT(encryptionSaltKeys ?? '')
     }
 
     public validatePreferencesToken(
@@ -44,7 +46,7 @@ export class RecipientTokensService {
 
     public generatePreferencesUrl(recipient: Pick<RecipientManagerRecipient, 'team_id' | 'identifier'>): string {
         const token = this.generatePreferencesToken(recipient)
-        return `${this.hub.SITE_URL}/messaging-preferences/${token}/` // NOTE: Trailing slash is required for the preferences page to work
+        return `${this.siteUrl}/messaging-preferences/${token}/` // NOTE: Trailing slash is required for the preferences page to work
     }
 
     public generateOneClickUnsubscribeUrl(

--- a/nodejs/src/cdp/services/monitoring/hog-rate-limiter.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-rate-limiter.service.test.ts
@@ -23,10 +23,6 @@ describe('HogRateLimiter', () => {
             now = 1720000000000
             mockNow.mockReturnValue(now)
 
-            hub.CDP_RATE_LIMITER_BUCKET_SIZE = 100
-            hub.CDP_RATE_LIMITER_REFILL_RATE = 10
-            hub.CDP_RATE_LIMITER_TTL = 60 * 60 * 24
-
             redis = createRedisV2PoolFromConfig({
                 connection: hub.CDP_REDIS_HOST
                     ? {
@@ -39,7 +35,7 @@ describe('HogRateLimiter', () => {
             })
             await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
 
-            rateLimiter = new HogRateLimiterService(hub, redis)
+            rateLimiter = new HogRateLimiterService({ bucketSize: 100, refillRate: 10, ttl: 60 * 60 * 24 }, redis)
         })
 
         const advanceTime = (ms: number) => {

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -269,7 +269,7 @@ export class PluginServer {
 
             // The service commands is always created
             serviceLoaders.push(() => {
-                const serverCommands = new ServerCommands(hub)
+                const serverCommands = new ServerCommands(hub.pubSub)
                 this.expressApp.use('/', serverCommands.router())
                 return Promise.resolve(serverCommands.service)
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -536,22 +536,18 @@ export interface PluginsServerConfig
     CLICKHOUSE_DATABASE: string
 }
 
-export interface Hub extends PluginsServerConfig {
-    // what tasks this server will tackle - e.g. ingestion, scheduled plugins or others.
+export interface HubServices {
     postgres: PostgresRouter
     redisPool: GenericPool<Redis>
     posthogRedisPool: GenericPool<Redis>
     cookielessRedisPool: GenericPool<Redis>
     kafkaProducer: KafkaProducerWrapper
-    // tools
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository
     clickhouseGroupRepository: ClickhouseGroupRepository
     personRepository: PersonRepository
-    // geoip database, setup in workers
     geoipService: GeoIPService
-    // lookups
     encryptedFields: EncryptedFields
     cookielessManager: CookielessManager
     pubSub: PubSub
@@ -559,6 +555,8 @@ export interface Hub extends PluginsServerConfig {
     quotaLimiting: QuotaLimiting
     internalCaptureService: InternalCaptureService
 }
+
+export interface Hub extends PluginsServerConfig, HubServices {}
 
 export interface PluginServerCapabilities {
     // Warning: when adding more entries, make sure to update worker/vm/capabilities.ts

--- a/nodejs/src/utils/commands.ts
+++ b/nodejs/src/utils/commands.ts
@@ -1,9 +1,7 @@
 import express from 'ultimate-express'
 
-import { HealthCheckResultOk, Hub, PluginServerService } from '../types'
-
-/** Narrowed Hub type for ServerCommands */
-export type ServerCommandsHub = Pick<Hub, 'pubSub'>
+import { HealthCheckResultOk, PluginServerService } from '../types'
+import { PubSub } from './pubsub'
 
 /**
  * We have various use cases where an external service like django needs to communicate with the node services
@@ -13,7 +11,7 @@ export type ServerCommandsHub = Pick<Hub, 'pubSub'>
  * don't need access to the pubsub redis
  */
 export class ServerCommands {
-    constructor(private hub: ServerCommandsHub) {}
+    constructor(private pubSub: PubSub) {}
 
     public get service(): PluginServerService {
         return {
@@ -41,7 +39,7 @@ export class ServerCommands {
         async (req: express.Request, res: express.Response): Promise<void> => {
             const { command, message } = req.body
 
-            await this.hub.pubSub.publish(command, JSON.stringify(message))
+            await this.pubSub.publish(command, JSON.stringify(message))
 
             res.json({ success: true })
         }


### PR DESCRIPTION
## Problem

To start https://github.com/PostHog/posthog/pull/48875, we first need to migrate lower level services off of using the Hub classes. This makes dependencies for each of those services clear

## Changes

- The following services now have clear dependencies injected:
  - HogRateLimiterService
  - ServerCommands
  - RecipientTokensService

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
