### PR TITLE
fix: failing capture build in macOS due to aws-lc-sys

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,3 +2,8 @@
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates
 SQLX_OFFLINE = "true"
+# Disable CPU jitter entropy in aws-lc-sys to fix macOS build failures.
+# The jitterentropy C code includes CoreServices.h which pulls in hfs_format.h,
+# hitting a missing uuid_string_t type on macOS SDKs. OS entropy sources still work.
+# See: https://github.com/aws/aws-lc-rs/issues/912
+AWS_LC_SYS_NO_JITTER_ENTROPY = "1"


### PR DESCRIPTION
## Problem

After the Cargo.lock refresh in #48562, `aws-lc-sys` was bumped from `0.29.0` to `0.37.1`, crossing the `0.32.0` threshold where jitterentropy C code was added. This code includes macOS SDK headers that reference an undefined `uuid_string_t` type, breaking the Rust build on macOS. Linux is unaffected.

## Changes

- Set `AWS_LC_SYS_NO_JITTER_ENTROPY=1` in `rust/.cargo/config.toml` to skip building the jitterentropy code, which is the upstream recommended workaround
  - https://github.com/aws/aws-lc-rs/issues/1008
  - https://github.com/aws/aws-lc-rs/issues/912
- Jitter entropy is a supplemental entropy source and disabling it is safe since the OS provides its own entropy


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
