### PR TITLE
fix(insights): sql stacked bars chart tooltip limits

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -46,6 +46,8 @@ Chart.register(annotationPlugin)
 Chart.register(ChartjsPluginStacked100)
 Chart.register(chartTrendline)
 
+const TOOLTIP_ROW_CUTOFF = 8
+
 const getGraphType = (chartType: ChartDisplayType, settings: AxisSeriesSettings | undefined): GraphType => {
     if (!settings || !settings.display || !settings.display.displayType || settings.display?.displayType === 'auto') {
         return chartType === ChartDisplayType.ActionsBar || chartType === ChartDisplayType.ActionsStackedBar
@@ -404,7 +406,7 @@ export const LineGraph = ({
                                 const referenceDataPoint = tooltip.dataPoints[0]
 
                                 // Filter series data based on highlight mode
-                                const filteredSeriesData = isHighlightBarMode
+                                let filteredSeriesData = isHighlightBarMode
                                     ? ySeriesData.filter((_, index) => index === referenceDataPoint.datasetIndex)
                                     : ySeriesData
                                 const stackedSeriesTotalAtIndex =
@@ -414,6 +416,11 @@ export const LineGraph = ({
                                               0
                                           )
                                         : null
+
+                                const isTruncated = filteredSeriesData.length > TOOLTIP_ROW_CUTOFF
+                                if (isTruncated) {
+                                    filteredSeriesData = filteredSeriesData.slice(0, TOOLTIP_ROW_CUTOFF)
+                                }
 
                                 const tooltipData = filteredSeriesData.map((series, index) => {
                                     const seriesName =
@@ -473,9 +480,16 @@ export const LineGraph = ({
                                                     render: (value, record) => {
                                                         if (record.isTotalRow) {
                                                             return (
-                                                                <div className="datum-label-column font-extrabold">
-                                                                    Total
-                                                                </div>
+                                                                <>
+                                                                    <div className="datum-label-column">
+                                                                        <span className="font-extrabold">Total</span>
+                                                                        {isTruncated && (
+                                                                            <span className="text-xs text-muted ml-1">
+                                                                                (incl. hidden series)
+                                                                            </span>
+                                                                        )}
+                                                                    </div>
+                                                                </>
                                                             )
                                                         }
 
@@ -533,6 +547,11 @@ export const LineGraph = ({
                                             }}
                                             showHeader
                                         />
+                                        {isTruncated && (
+                                            <div className="text-xs text-muted p-2 border-t">
+                                                For readability, <b>not all series are displayed</b>
+                                            </div>
+                                        )}
                                         {isBarChart && isStackedBarChart && !isHighlightBarMode && (
                                             <div className="text-xs text-muted p-2 border-t">
                                                 Hold Shift (⇧) to highlight individual bars

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -480,16 +480,14 @@ export const LineGraph = ({
                                                     render: (value, record) => {
                                                         if (record.isTotalRow) {
                                                             return (
-                                                                <>
-                                                                    <div className="datum-label-column">
-                                                                        <span className="font-extrabold">Total</span>
-                                                                        {isTruncated && (
-                                                                            <span className="text-xs text-muted ml-1">
-                                                                                (incl. hidden series)
-                                                                            </span>
-                                                                        )}
-                                                                    </div>
-                                                                </>
+                                                                <div className="datum-label-column">
+                                                                    <span className="font-extrabold">Total</span>
+                                                                    {isTruncated && (
+                                                                        <span className="text-xs text-muted ml-1">
+                                                                            (incl. hidden series)
+                                                                        </span>
+                                                                    )}
+                                                                </div>
                                                             )
                                                         }
 


### PR DESCRIPTION
## Problem

When we have a stacked bar chart with many breakdown values, the tooltip is quite tall and overflows the screen. 
In trends, we limit the series to 8 and hide the rest. Applying the same concept to SQL insights.

<img width="1012" height="775" alt="Screenshot 2026-02-24 at 12 24 52" src="https://github.com/user-attachments/assets/aaac261c-1ff0-44d5-8458-c5a575c4277b" />


## Changes

<img width="1001" height="767" alt="Screenshot 2026-02-24 at 12 24 02" src="https://github.com/user-attachments/assets/c7ae9b04-570e-45d6-9b94-e92478480072" />


## How did you test this code?

Manually

## Publish to changelog?

No