### PR TITLE
perf(llma): only fetch $ai_input in sentiment HogQL query

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -31,7 +31,7 @@ BATCH_MAX_TRACE_IDS = 25
 
 # HogQL query template for fetching $ai_generation events
 GENERATIONS_QUERY = """
-    SELECT uuid, properties, properties.$ai_trace_id AS trace_id
+    SELECT uuid, properties.$ai_input AS ai_input, properties.$ai_trace_id AS trace_id
     FROM events
     WHERE event = '$ai_generation'
       AND timestamp >= toDateTime({date_from}, 'UTC')

--- a/posthog/temporal/llm_analytics/sentiment/tests/test_classify.py
+++ b/posthog/temporal/llm_analytics/sentiment/tests/test_classify.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -8,7 +6,7 @@ from posthog.temporal.llm_analytics.sentiment.schema import ClassifySentimentInp
 
 
 def _make_row(uuid: str, messages: list[dict], trace_id: str = "trace-1") -> tuple:
-    return (uuid, json.dumps({"$ai_input": messages, "$ai_trace_id": trace_id}), trace_id)
+    return (uuid, messages, trace_id)
 
 
 def _make_sentiment_result(label: str = "positive", score: float = 0.9) -> SentimentResult:

--- a/posthog/temporal/llm_analytics/sentiment/utils.py
+++ b/posthog/temporal/llm_analytics/sentiment/utils.py
@@ -77,7 +77,7 @@ def build_trace_result(
 
 
 def collect_pending(
-    generations: list[tuple[str, dict]],
+    generations: list[tuple[str, object]],
     trace_id: str,
     cap: int,
 ) -> list[PendingClassification]:
@@ -89,8 +89,8 @@ def collect_pending(
 
     pending: list[PendingClassification] = []
 
-    for event_uuid, props in generations:
-        user_messages = extract_user_messages_individually(props.get("$ai_input"))
+    for event_uuid, ai_input in generations:
+        user_messages = extract_user_messages_individually(ai_input)
         if not user_messages:
             continue
 


### PR DESCRIPTION
## Problem

The sentiment classification HogQL query fetches the full `properties` blob from ClickHouse (`SELECT uuid, properties, ...`), but only uses `$ai_input` for extraction. This transfers large `$ai_output` payloads and tool call data unnecessarily, contributing to activity timeouts when processing batches of traces.

## Changes

- Updated `GENERATIONS_QUERY` to select `properties.$ai_input AS ai_input` instead of the full `properties` column
- Updated `fetch_generations` to return `(event_uuid, ai_input)` tuples instead of `(event_uuid, full_props_dict)`
- Updated `collect_pending` to pass `ai_input` directly to extraction instead of `props.get("$ai_input")`
- Updated test helper `_make_row` to match the new row format

## How did you test this code?

All 40 existing sentiment tests pass (`pytest posthog/temporal/llm_analytics/sentiment/tests/ -x -q`).

## Publish to changelog?

No