### PR TITLE
chore(endpoints): add endpoints nodetype to modeling

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
@@ -460,14 +460,18 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
         availableDagIds: [
             (s) => [s.filteredNodes],
             (nodes: DataModelingNode[]): string[] => {
-                const viewableNodes = nodes.filter((n) => n.type === 'matview' || n.type === 'view')
+                const viewableNodes = nodes.filter(
+                    (n) => n.type === 'matview' || n.type === 'view' || n.type === 'endpoint'
+                )
                 return [...new Set(viewableNodes.map((n) => n.dag_id))].sort()
             },
         ],
         availableTypes: [
             (s) => [s.filteredNodes],
             (nodes: DataModelingNode[]): DataModelingNodeType[] => {
-                const viewableNodes = nodes.filter((n) => n.type === 'matview' || n.type === 'view')
+                const viewableNodes = nodes.filter(
+                    (n) => n.type === 'matview' || n.type === 'view' || n.type === 'endpoint'
+                )
                 return [...new Set(viewableNodes.map((n) => n.type))].sort()
             },
         ],
@@ -479,7 +483,7 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
                 filterTypes: DataModelingNodeType[]
             ): DataModelingNode[] => {
                 return nodes
-                    .filter((n) => n.type === 'matview' || n.type === 'view')
+                    .filter((n) => n.type === 'matview' || n.type === 'view' || n.type === 'endpoint')
                     .filter((n) => filterDagIds.length === 0 || filterDagIds.includes(n.dag_id))
                     .filter((n) => filterTypes.length === 0 || filterTypes.includes(n.type))
             },

--- a/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
@@ -33,6 +33,7 @@ const NODE_TYPE_COLORS: Record<DataModelingNodeType, string> = {
     table: 'var(--muted)',
     view: 'var(--primary-3000)',
     matview: 'var(--success)',
+    endpoint: 'var(--purple)',
 }
 
 const NODES_TO_SHOW: CreateModelNodeType[] = [
@@ -45,6 +46,11 @@ const NODES_TO_SHOW: CreateModelNodeType[] = [
         type: 'matview',
         name: 'Materialized view',
         description: 'A persisted view with improved query performance',
+    },
+    {
+        type: 'endpoint',
+        name: 'Endpoint',
+        description: 'A materialized endpoint for API access',
     },
 ]
 

--- a/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
@@ -19,6 +19,7 @@ const NODE_TYPE_SETTINGS: Record<DataModelingNodeType, { label: string; color: s
     table: { label: 'table', color: 'var(--muted)' },
     view: { label: 'view', color: 'var(--primary-3000)' },
     matview: { label: 'matview', color: 'var(--success)' },
+    endpoint: { label: 'endpoint', color: 'var(--purple)' },
 }
 
 function NodeHandles({ handles }: { handles: NodeHandle[] }): JSX.Element {
@@ -184,6 +185,7 @@ function NodeMetadata({
     const shortHandSyncInterval = syncIntervalToShorthand(syncInterval)
     switch (type) {
         case 'matview':
+        case 'endpoint':
             return (
                 <div className="flex items-center bg-primary dark:bg-primary/60 rounded-b-lg px-2.5 py-1.5 justify-between">
                     <div className="flex gap-1 text-[10px]">
@@ -252,7 +254,7 @@ const NodeInner = React.memo(function NodeInner({
 
     const nodeTypeSettings = NODE_TYPE_SETTINGS[type]
 
-    const canRun = type === 'matview' || type === 'view'
+    const canRun = type === 'matview' || type === 'view' || type === 'endpoint'
     const canOpenInEditor = type !== 'table' && savedQueryId
     const shouldRenderArrows = canRun && isHovered && !isRunning
 
@@ -297,7 +299,7 @@ const NodeInner = React.memo(function NodeInner({
                 <NodeTags color={nodeTypeSettings.color} label={nodeTypeSettings.label} userTag={userTag} />
                 <NodeLabelAndAction
                     label={name}
-                    showAction={canRun && type === 'matview'}
+                    showAction={canRun && (type === 'matview' || type === 'endpoint')}
                     isActionRunning={isRunning ?? false}
                     action={onMaterialize}
                 />
@@ -365,12 +367,14 @@ const NodeComponent = React.memo(function NodeComponent(props: { id: string; dat
         [id, materializeNode]
     )
 
-    const canOpenInEditor = type !== 'table' && savedQueryId
+    const canOpenInEditor = type !== 'table' && type !== 'endpoint' && savedQueryId
     const handleNodeClick = useCallback((): void => {
-        if (canOpenInEditor) {
+        if (type === 'endpoint') {
+            newTab(urls.endpoint(props.data.name))
+        } else if (canOpenInEditor) {
             newTab(urls.sqlEditor({ view_id: savedQueryId }))
         }
-    }, [canOpenInEditor, savedQueryId, newTab])
+    }, [type, canOpenInEditor, savedQueryId, newTab])
 
     const handleMouseEnter = useCallback(() => setHoveredNodeId(id), [id, setHoveredNodeId])
     const handleMouseLeave = useCallback(() => setHoveredNodeId(null), [setHoveredNodeId])

--- a/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
@@ -370,7 +370,12 @@ const NodeComponent = React.memo(function NodeComponent(props: { id: string; dat
     const canOpenInEditor = type !== 'table' && type !== 'endpoint' && savedQueryId
     const handleNodeClick = useCallback((): void => {
         if (type === 'endpoint') {
-            newTab(urls.endpoint(props.data.name))
+            const versionMatch = props.data.name.match(/^(.+)_v(\d+)$/)
+            if (versionMatch) {
+                newTab(urls.endpoint(versionMatch[1], parseInt(versionMatch[2])))
+            } else {
+                newTab(urls.endpoint(props.data.name))
+            }
         } else if (canOpenInEditor) {
             newTab(urls.sqlEditor({ view_id: savedQueryId }))
         }

--- a/frontend/src/scenes/data-warehouse/scene/modeling/TableView.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/TableView.tsx
@@ -22,6 +22,7 @@ const NODE_TYPE_TAG_SETTINGS: Record<DataModelingNodeType, { label: string; type
     table: { label: 'Table', type: 'default' },
     view: { label: 'View', type: 'primary' },
     matview: { label: 'Materialized view', type: 'success' },
+    endpoint: { label: 'Endpoint', type: 'completion' },
 }
 
 function NodeDependencyCount({ count, loading }: { count?: number; loading?: boolean }): JSX.Element {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5300,7 +5300,7 @@ export interface DataWarehouseSavedQueryDependencies {
     downstream_count: number
 }
 
-export type DataModelingNodeType = 'table' | 'view' | 'matview'
+export type DataModelingNodeType = 'table' | 'view' | 'matview' | 'endpoint'
 
 export interface DataModelingNode {
     /** UUID */

--- a/products/data_modeling/backend/migrations/0010_add_endpoint_node_type.py
+++ b/products/data_modeling/backend/migrations/0010_add_endpoint_node_type.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_modeling", "0009_edge_dag_id_text_node_dag_id_text"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="node",
+            name="type",
+            field=models.TextField(
+                choices=[("table", "Table"), ("view", "View"), ("matview", "Mat View"), ("endpoint", "Endpoint")],
+                default="table",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/products/data_modeling/backend/migrations/max_migration.txt
+++ b/products/data_modeling/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0009_edge_dag_id_text_node_dag_id_text
+0010_add_endpoint_node_type

--- a/products/data_modeling/backend/models/node.py
+++ b/products/data_modeling/backend/models/node.py
@@ -11,6 +11,7 @@ class NodeType(models.TextChoices):
     TABLE = "table"
     VIEW = "view"
     MAT_VIEW = "matview"
+    ENDPOINT = "endpoint"
 
 
 class Node(UUIDModel, CreatedMetaFields, UpdatedMetaFields):

--- a/products/data_modeling/backend/services/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/services/saved_query_dag_sync.py
@@ -125,6 +125,8 @@ def sync_saved_query_to_dag(
 
     Returns the Node for the SavedQuery, or None if query parsing fails.
     """
+    from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+
     extra_properties = extra_properties or {}
     team = saved_query.team
     dag_id = get_dag_id(team.id)
@@ -133,7 +135,13 @@ def sync_saved_query_to_dag(
         raise ValueError(f"DataWarehouseSavedQuery has no query: saved_query_id={saved_query.id}")
 
     # determine node type based on materialization status (fk to datawarehouse table)
-    node_type = NodeType.MAT_VIEW if saved_query.table else NodeType.VIEW
+    if saved_query.origin == DataWarehouseSavedQuery.Origin.ENDPOINT:
+        node_type = NodeType.ENDPOINT
+    elif saved_query.table:
+        node_type = NodeType.MAT_VIEW
+    else:
+        node_type = NodeType.VIEW
+
     target, _ = Node.objects.get_or_create(
         team=team,
         saved_query=saved_query,

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -31,6 +31,7 @@ export interface PaginatedEdgeListApi {
  * * `table` - Table
  * `view` - View
  * `matview` - Mat View
+ * `endpoint` - Endpoint
  */
 export type NodeTypeEnumApi = (typeof NodeTypeEnumApi)[keyof typeof NodeTypeEnumApi]
 
@@ -38,6 +39,7 @@ export const NodeTypeEnumApi = {
     Table: 'table',
     View: 'view',
     Matview: 'matview',
+    Endpoint: 'endpoint',
 } as const
 
 export interface NodeApi {
@@ -62,6 +64,8 @@ export interface NodeApi {
     readonly user_tag: string | null
     /** @nullable */
     readonly sync_interval: string | null
+    /** @nullable */
+    readonly endpoint_name: string | null
 }
 
 export interface PaginatedNodeListApi {

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -64,8 +64,6 @@ export interface NodeApi {
     readonly user_tag: string | null
     /** @nullable */
     readonly sync_interval: string | null
-    /** @nullable */
-    readonly endpoint_name: string | null
 }
 
 export interface PaginatedNodeListApi {

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -883,7 +883,26 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
         saved_query.schedule_materialization()
 
-        # Update version with materialization info
+        from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
+
+        try:
+            sync_saved_query_to_dag(saved_query)
+        except Exception as e:
+            logger.exception(
+                "Failed to sync endpoint node to DAG",
+                endpoint_name=endpoint.name,
+                saved_query_id=version.saved_query.id if version and version.saved_query else None,
+            )
+            capture_exception(
+                e,
+                {
+                    "product": Product.ENDPOINTS,
+                    "team_id": self.team_id,
+                    "endpoint_name": endpoint.name,
+                    "saved_query_id": version.saved_query.id if version and version.saved_query else None,
+                },
+            )
+
         version.saved_query = saved_query
         version.save(update_fields=["saved_query"])
 
@@ -894,6 +913,26 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         """
         version = version or endpoint.get_version()
         if version:
+            if version.saved_query:
+                from products.data_modeling.backend.services.saved_query_dag_sync import delete_node_from_dag
+
+                try:
+                    delete_node_from_dag(version.saved_query)
+                except Exception as e:
+                    logger.exception(
+                        "Failed to remove endpoint node from DAG",
+                        endpoint_name=endpoint.name,
+                        saved_query_id=version.saved_query.id if version and version.saved_query else None,
+                    )
+                    capture_exception(
+                        e,
+                        {
+                            "product": Product.ENDPOINTS,
+                            "team_id": self.team_id,
+                            "endpoint_name": endpoint.name,
+                            "saved_query_id": version.saved_query.id if version and version.saved_query else None,
+                        },
+                    )
             version.disable_materialization()
         clear_endpoint_materialization_cache(self.team_id, endpoint.name)
 
@@ -902,6 +941,29 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name, deleted=False)
         endpoint_id = str(endpoint.id)
         endpoint_name = endpoint.name
+
+        # Remove DAG nodes before soft_delete (which soft-deletes saved queries)
+        from products.data_modeling.backend.services.saved_query_dag_sync import delete_node_from_dag
+
+        for version in endpoint.versions.filter(saved_query__isnull=False):
+            try:
+                if version.saved_query:
+                    delete_node_from_dag(version.saved_query)
+            except Exception as e:
+                logger.exception(
+                    "Failed to remove endpoint node from DAG on destroy",
+                    endpoint_name=endpoint.name,
+                    saved_query_id=version.saved_query.id if version.saved_query else None,
+                )
+                capture_exception(
+                    e,
+                    {
+                        "product": Product.ENDPOINTS,
+                        "team_id": self.team_id,
+                        "endpoint_name": endpoint.name,
+                        "saved_query_id": version.saved_query.id if version and version.saved_query else None,
+                    },
+                )
 
         endpoint.soft_delete()
         clear_endpoint_materialization_cache(self.team_id, endpoint.name)

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1087,6 +1087,94 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["materialization"]["error"], expected_error)
 
+    def test_enable_materialization_creates_dag_node(self):
+        endpoint = create_endpoint_with_version(
+            name="dag_node_endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        from products.data_modeling.backend.models import Node
+
+        version = endpoint.versions.first()
+        version.refresh_from_db()
+        assert version.saved_query is not None
+
+        node = Node.objects.filter(team=self.team, saved_query=version.saved_query).first()
+        self.assertIsNotNone(node)
+
+    def test_disable_materialization_removes_dag_node(self):
+        endpoint = create_endpoint_with_version(
+            name="remove_dag_endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
+            format="json",
+        )
+
+        version = endpoint.versions.first()
+        version.refresh_from_db()
+        assert version.saved_query is not None
+        saved_query_id = version.saved_query.id
+
+        from products.data_modeling.backend.models import Node
+
+        self.assertTrue(Node.objects.filter(team=self.team, saved_query_id=saved_query_id).exists())
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": False},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertFalse(Node.objects.filter(team=self.team, saved_query_id=saved_query_id).exists())
+
+    def test_delete_endpoint_removes_dag_node(self):
+        endpoint = create_endpoint_with_version(
+            name="delete_dag_endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
+            format="json",
+        )
+
+        version = endpoint.versions.first()
+        version.refresh_from_db()
+        assert version.saved_query is not None
+        saved_query_id = version.saved_query.id
+
+        from products.data_modeling.backend.models import Node
+
+        self.assertTrue(Node.objects.filter(team=self.team, saved_query_id=saved_query_id).exists())
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Node.objects.filter(team=self.team, saved_query_id=saved_query_id).exists())
+
 
 @pytest.mark.asyncio
 class TestEndpointMaterializationTemporal:

--- a/tach.toml
+++ b/tach.toml
@@ -149,6 +149,7 @@ layer = "non_isolated"
 path = "products.endpoints"
 depends_on = [
     "posthog",
+    "products.data_modeling",
     "products.data_warehouse",
 ]
 layer = "non_isolated"


### PR DESCRIPTION
## Problem

endpoints wer?

## Changes

- Added `endpoint` as a new node type to the data modeling system
- Extended filtering logic to include endpoint nodes alongside materialized views and regular views
- Added endpoint name property to node data structure for proper navigation
- Modified node type determination logic to prioritize endpoint origin over materialization status
- Integrated endpoint lifecycle management with DAG operations (creation, updates, deletion)

![image.png](https://app.graphite.com/user-attachments/assets/54af7400-80a5-4117-a97e-8cbe71505d18.png)

![image.png](https://app.graphite.com/user-attachments/assets/bca293a7-ed80-41a4-bd17-a3152010bd04.png)



## How did you test this code?

unit tests

## Publish to changelog?

No