### PR TITLE
fix(ph-ai): fix mode descriptions + research flags mode

### DIFF
--- a/ee/hogai/core/agent_modes/presets/error_tracking.py
+++ b/ee/hogai/core/agent_modes/presets/error_tracking.py
@@ -55,7 +55,7 @@ Assistant: I'll help you analyze how error tracking issues are impacting your ch
 Based on your event taxonomy, the checkout-related events are: checkout_started, payment_submitted, and order_completed. These are the events you should analyze to understand which issues may be blocking or affecting your checkout conversion.
 """.strip()
 
-MODE_DESCRIPTION = "Specialized mode for analyzing error tracking issues. This mode allows you to search and filter error tracking issues by status, date range, frequency, and other criteria. You can also retrieve detailed stack trace information for any issue to analyze and explain its root cause."
+ERROR_TRACKING_MODE_DESCRIPTION = "Specialized mode for analyzing error tracking issues. This mode allows you to search and filter error tracking issues by status, date range, frequency, and other criteria. You can also retrieve detailed stack trace information for any issue to analyze and explain its root cause."
 
 POSITIVE_EXAMPLE_IMPACT_ANALYSIS_REASONING = """
 The assistant used the read_taxonomy tool because:
@@ -95,7 +95,7 @@ class ErrorTrackingAgentToolkit(AgentToolkit):
 
 error_tracking_agent = AgentModeDefinition(
     mode=AgentMode.ERROR_TRACKING,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=ERROR_TRACKING_MODE_DESCRIPTION,
     toolkit_class=ErrorTrackingAgentToolkit,
     node_class=ChatAgentExecutable,
     tools_node_class=ChatAgentToolsExecutable,
@@ -104,7 +104,7 @@ error_tracking_agent = AgentModeDefinition(
 
 chat_agent_plan_error_tracking_agent = AgentModeDefinition(
     mode=AgentMode.ERROR_TRACKING,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=ERROR_TRACKING_MODE_DESCRIPTION,
     toolkit_class=ErrorTrackingAgentToolkit,
     node_class=ChatAgentPlanExecutable,
     tools_node_class=ChatAgentPlanToolsExecutable,

--- a/ee/hogai/core/agent_modes/presets/flags.py
+++ b/ee/hogai/core/agent_modes/presets/flags.py
@@ -83,18 +83,39 @@ class FlagsAgentToolkit(AgentToolkit):
         return tools
 
 
-MODE_DESCRIPTION = "Specialized mode for creating and managing feature flags and experiments. This mode allows you to create feature flags with property-based targeting and rollout percentages, set up A/B test experiments with multivariate flags, and analyze experiment results with statistical summaries."
+FLAGS_MODE_DESCRIPTION = "Specialized mode for creating and managing feature flags and experiments. This mode allows you to create feature flags with property-based targeting and rollout percentages, set up A/B test experiments with multivariate flags, and analyze experiment results with statistical summaries."
 
 flags_agent = AgentModeDefinition(
     mode=AgentMode.FLAGS,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=FLAGS_MODE_DESCRIPTION,
     toolkit_class=FlagsAgentToolkit,
 )
 
+
+class ReadOnlyFlagsAgentToolkit(AgentToolkit):
+    """Flags toolkit for readonly operations"""
+
+    POSITIVE_TODO_EXAMPLES = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT,
+            reasoning=POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT_REASONING,
+        ),
+    ]
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        tools: list[type[MaxTool]] = [SessionReplaySummaryTool]
+        if has_experiment_summary_tool_feature_flag(self._team, self._user):
+            tools.append(ExperimentSummaryTool)
+        return tools
+
+
+READ_ONLY_FLAGS_MODE_DESCRIPTION = "Specialized mode for analyzing feature flags and experiments. This mode allows you to analyze experiment results and session replay patterns across experiment variants with statistical summaries."
+
 chat_agent_plan_flags_agent = AgentModeDefinition(
     mode=AgentMode.FLAGS,
-    mode_description=MODE_DESCRIPTION,
-    toolkit_class=FlagsAgentToolkit,
+    mode_description=READ_ONLY_FLAGS_MODE_DESCRIPTION,
+    toolkit_class=ReadOnlyFlagsAgentToolkit,
     node_class=ChatAgentPlanExecutable,
     tools_node_class=ChatAgentPlanToolsExecutable,
 )

--- a/ee/hogai/core/agent_modes/presets/product_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/product_analytics.py
@@ -41,7 +41,7 @@ The assistant used the todo list because:
 4. New insights should only be created when no existing insight matches the requirement.
 """.strip()
 
-MODE_DESCRIPTION = "General-purpose mode for product analytics tasks."
+PRODUCT_ANALYTICS_MODE_DESCRIPTION = "General-purpose mode for product analytics tasks."
 
 
 class ProductAnalyticsAgentToolkit(AgentToolkit):
@@ -60,7 +60,7 @@ class ProductAnalyticsAgentToolkit(AgentToolkit):
 
 product_analytics_agent = AgentModeDefinition(
     mode=AgentMode.PRODUCT_ANALYTICS,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=PRODUCT_ANALYTICS_MODE_DESCRIPTION,
     toolkit_class=ProductAnalyticsAgentToolkit,
     node_class=ChatAgentExecutable,
     tools_node_class=ChatAgentToolsExecutable,
@@ -81,7 +81,7 @@ subagent_product_analytics_agent = replace(product_analytics_agent, toolkit_clas
 
 chat_agent_plan_product_analytics_agent = AgentModeDefinition(
     mode=AgentMode.PRODUCT_ANALYTICS,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=PRODUCT_ANALYTICS_MODE_DESCRIPTION,
     toolkit_class=ReadOnlyProductAnalyticsAgentToolkit,  # Only CreateInsightTool
     node_class=ChatAgentPlanExecutable,
     tools_node_class=ChatAgentPlanToolsExecutable,

--- a/ee/hogai/core/agent_modes/presets/session_replay.py
+++ b/ee/hogai/core/agent_modes/presets/session_replay.py
@@ -79,7 +79,7 @@ The assistant used the todo list because:
 5. This approach allows for tracking progress across multiple recording queries and summaries
 """.strip()
 
-MODE_DESCRIPTION = "Specialized mode for analyzing session recordings and user behavior. This mode allows you to filter session recordings, and summarize entire sessions or a set of them."
+SESSION_REPLAY_MODE_DESCRIPTION = "Specialized mode for analyzing session recordings and user behavior. This mode allows you to filter session recordings, and summarize entire sessions or a set of them."
 
 
 class SessionReplayAgentToolkit(AgentToolkit):
@@ -106,7 +106,7 @@ class SessionReplayAgentToolkit(AgentToolkit):
 
 session_replay_agent = AgentModeDefinition(
     mode=AgentMode.SESSION_REPLAY,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=SESSION_REPLAY_MODE_DESCRIPTION,
     toolkit_class=SessionReplayAgentToolkit,
     node_class=ChatAgentExecutable,
     tools_node_class=ChatAgentToolsExecutable,
@@ -115,7 +115,7 @@ session_replay_agent = AgentModeDefinition(
 
 chat_agent_plan_session_replay_agent = AgentModeDefinition(
     mode=AgentMode.SESSION_REPLAY,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=SESSION_REPLAY_MODE_DESCRIPTION,
     toolkit_class=SessionReplayAgentToolkit,
     node_class=ChatAgentPlanExecutable,
     tools_node_class=ChatAgentPlanToolsExecutable,

--- a/ee/hogai/core/agent_modes/presets/sql.py
+++ b/ee/hogai/core/agent_modes/presets/sql.py
@@ -75,7 +75,7 @@ The assistant used the todo list because:
 3. This approach allows for tracking progress across the entire request
 """.strip()
 
-MODE_DESCRIPTION = "Specialized mode capable of generating and executing SQL queries. This mode allows you to query the ClickHouse database, which contains both data collected by PostHog (events, groups, persons, sessions) and data warehouse sources connected by the user, such as SQL tables, CRMs, and external systems. This mode can also be used to search for specific data that can be used in other modes."
+SQL_MODE_DESCRIPTION = "Specialized mode capable of generating and executing SQL queries. This mode allows you to query the ClickHouse database, which contains both data collected by PostHog (events, groups, persons, sessions) and data warehouse sources connected by the user, such as SQL tables, CRMs, and external systems. This mode can also be used to search for specific data that can be used in other modes."
 
 
 class SQLAgentToolkit(AgentToolkit):
@@ -102,7 +102,7 @@ class SQLAgentToolkit(AgentToolkit):
 
 sql_agent = AgentModeDefinition(
     mode=AgentMode.SQL,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=SQL_MODE_DESCRIPTION,
     toolkit_class=SQLAgentToolkit,
     node_class=ChatAgentExecutable,
     tools_node_class=ChatAgentToolsExecutable,
@@ -111,7 +111,7 @@ sql_agent = AgentModeDefinition(
 
 chat_agent_plan_sql_agent = AgentModeDefinition(
     mode=AgentMode.SQL,
-    mode_description=MODE_DESCRIPTION,
+    mode_description=SQL_MODE_DESCRIPTION,
     toolkit_class=SQLAgentToolkit,
     node_class=ChatAgentPlanExecutable,
     tools_node_class=ChatAgentPlanToolsExecutable,

--- a/ee/hogai/core/agent_modes/presets/survey.py
+++ b/ee/hogai/core/agent_modes/presets/survey.py
@@ -124,4 +124,8 @@ class SubagentSurveyAgentToolkit(AgentToolkit):
         return [SurveyAnalysisTool]
 
 
-subagent_survey_agent = replace(survey_agent, toolkit_class=SubagentSurveyAgentToolkit)
+SUBAGENT_MODE_DESCRIPTION = "Specialized mode for analyzing surveys. Analyze survey responses to extract themes, sentiment, and actionable insights."
+
+subagent_survey_agent = replace(
+    survey_agent, toolkit_class=SubagentSurveyAgentToolkit, mode_description=SUBAGENT_MODE_DESCRIPTION
+)

--- a/ee/hogai/research_agent/mode_manager.py
+++ b/ee/hogai/research_agent/mode_manager.py
@@ -17,10 +17,14 @@ from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.agent_modes import AgentToolkit
 from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.mode_manager import AgentModeManager
-from ee.hogai.core.agent_modes.presets.error_tracking import ErrorTrackingAgentToolkit
-from ee.hogai.core.agent_modes.presets.product_analytics import ReadOnlyProductAnalyticsAgentToolkit
-from ee.hogai.core.agent_modes.presets.session_replay import SessionReplayAgentToolkit
-from ee.hogai.core.agent_modes.presets.sql import SQLAgentToolkit
+from ee.hogai.core.agent_modes.presets.error_tracking import ERROR_TRACKING_MODE_DESCRIPTION, ErrorTrackingAgentToolkit
+from ee.hogai.core.agent_modes.presets.flags import READ_ONLY_FLAGS_MODE_DESCRIPTION, ReadOnlyFlagsAgentToolkit
+from ee.hogai.core.agent_modes.presets.product_analytics import (
+    PRODUCT_ANALYTICS_MODE_DESCRIPTION,
+    ReadOnlyProductAnalyticsAgentToolkit,
+)
+from ee.hogai.core.agent_modes.presets.session_replay import SESSION_REPLAY_MODE_DESCRIPTION, SessionReplayAgentToolkit
+from ee.hogai.core.agent_modes.presets.sql import SQL_MODE_DESCRIPTION, SQLAgentToolkit
 from ee.hogai.core.agent_modes.prompt_builder import AgentPromptBuilder, AgentPromptBuilderBase
 from ee.hogai.core.agent_modes.toolkit import AgentToolkitManager
 from ee.hogai.core.plan_mode import PLANNING_TASK_PROMPT
@@ -74,7 +78,7 @@ research_agent = AgentModeDefinition(
 
 research_agent_product_analytics_agent = AgentModeDefinition(
     mode=AgentMode.PRODUCT_ANALYTICS,
-    mode_description="General-purpose mode for product analytics tasks.",
+    mode_description=PRODUCT_ANALYTICS_MODE_DESCRIPTION,
     toolkit_class=ReadOnlyProductAnalyticsAgentToolkit,
     node_class=ResearchAgentExecutable,
     tools_node_class=ResearchAgentToolsExecutable,
@@ -82,7 +86,7 @@ research_agent_product_analytics_agent = AgentModeDefinition(
 
 research_agent_sql_agent = AgentModeDefinition(
     mode=AgentMode.SQL,
-    mode_description="SQL mode for researching data.",
+    mode_description=SQL_MODE_DESCRIPTION,
     toolkit_class=SQLAgentToolkit,
     node_class=ResearchAgentExecutable,
     tools_node_class=ResearchAgentToolsExecutable,
@@ -90,7 +94,7 @@ research_agent_sql_agent = AgentModeDefinition(
 
 research_agent_session_replay_agent = AgentModeDefinition(
     mode=AgentMode.SESSION_REPLAY,
-    mode_description="Session replay mode for researching data.",
+    mode_description=SESSION_REPLAY_MODE_DESCRIPTION,
     toolkit_class=SessionReplayAgentToolkit,
     node_class=ResearchAgentExecutable,
     tools_node_class=ResearchAgentToolsExecutable,
@@ -98,8 +102,16 @@ research_agent_session_replay_agent = AgentModeDefinition(
 
 research_agent_error_tracking_agent = AgentModeDefinition(
     mode=AgentMode.ERROR_TRACKING,
-    mode_description="Error tracking mode for researching data.",
+    mode_description=ERROR_TRACKING_MODE_DESCRIPTION,
     toolkit_class=ErrorTrackingAgentToolkit,
+    node_class=ResearchAgentExecutable,
+    tools_node_class=ResearchAgentToolsExecutable,
+)
+
+research_agent_flags_agent = AgentModeDefinition(
+    mode=AgentMode.FLAGS,
+    mode_description=READ_ONLY_FLAGS_MODE_DESCRIPTION,
+    toolkit_class=ReadOnlyFlagsAgentToolkit,
     node_class=ResearchAgentExecutable,
     tools_node_class=ResearchAgentToolsExecutable,
 )
@@ -217,6 +229,7 @@ class ResearchAgentModeManager(AgentModeManager):
             AgentMode.SESSION_REPLAY: research_agent_session_replay_agent,
             AgentMode.ERROR_TRACKING: research_agent_error_tracking_agent,
             AgentMode.PRODUCT_ANALYTICS: research_agent_product_analytics_agent,
+            AgentMode.FLAGS: research_agent_flags_agent,
         }
         return {
             AgentMode.PLAN: {


### PR DESCRIPTION
## Problem
Research mode had wrong mode descriptions + it missed a flags mode + plan agent mode had write tools.

## Changes
- Exported right mode descriptions to research mode

- Added a new `ReadOnlyFlagsAgentToolkit` class for read-only flag operations with limited tools (SessionReplaySummaryTool and ExperimentSummaryTool)

- Updated the chat agent plan flags agent to use the read-only toolkit and description

- Added a new `research_agent_flags_agent` definition for the research agent mode manager

- Updated all agent mode definitions to use the renamed constants


## How did you test this code?
Locally

## Publish to changelog?

No