### PR TITLE
fix(toolbar): main app bundle bugfix

### DIFF
--- a/frontend/src/toolbar/actions/actionsTabLogic.test.ts
+++ b/frontend/src/toolbar/actions/actionsTabLogic.test.ts
@@ -1,0 +1,135 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { actionsLogic } from '~/toolbar/actions/actionsLogic'
+import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
+import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
+import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+
+const mockAction = {
+    id: 42,
+    name: 'Test Action',
+    steps: [],
+    created_at: '',
+    created_by: null,
+    pinned_at: null,
+}
+
+describe('actionsTabLogic form submission', () => {
+    let logic: ReturnType<typeof actionsTabLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        toolbarConfigLogic.build({ apiURL: 'http://localhost' }).mount()
+        toolbarLogic().mount()
+        actionsLogic().mount()
+        logic = actionsTabLogic()
+        logic.mount()
+    })
+
+    it('creates a new action via POST', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve(mockAction),
+            } as any as Response)
+        )
+
+        logic.actions.newAction()
+        logic.actions.setActionFormValue('name', 'Test Action')
+
+        await expectLogic(logic, () => {
+            logic.actions.submitActionForm()
+        })
+            .delay(0)
+            .toDispatchActions(['submitActionForm', 'submitActionFormSuccess'])
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/api/projects/@current/actions/'),
+            expect.objectContaining({ method: 'POST' })
+        )
+    })
+
+    it('updates an existing action via PATCH', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve(mockAction),
+            } as any as Response)
+        )
+
+        logic.actions.selectAction(42)
+        logic.actions.setActionFormValue('name', 'Updated Action')
+
+        await expectLogic(logic, () => {
+            logic.actions.submitActionForm()
+        })
+            .delay(0)
+            .toDispatchActions(['submitActionForm', 'submitActionFormSuccess'])
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/api/projects/@current/actions/42/'),
+            expect.objectContaining({ method: 'PATCH' })
+        )
+    })
+
+    it('handles error response with detail message', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+                status: 400,
+                json: () => Promise.resolve({ detail: 'Validation error' }),
+            } as any as Response)
+        )
+
+        logic.actions.newAction()
+        logic.actions.setActionFormValue('name', 'Bad Action')
+
+        await expectLogic(logic, () => {
+            logic.actions.submitActionForm()
+        })
+            .delay(0)
+            .toDispatchActions(['submitActionForm', 'submitActionFormFailure'])
+    })
+
+    it('handles error response when json parsing fails', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new Error('parse error')),
+            } as any as Response)
+        )
+
+        logic.actions.newAction()
+        logic.actions.setActionFormValue('name', 'Server Error Action')
+
+        await expectLogic(logic, () => {
+            logic.actions.submitActionForm()
+        })
+            .delay(0)
+            .toDispatchActions(['submitActionForm', 'submitActionFormFailure'])
+    })
+
+    it('sets creation_context when automatic action creation is enabled', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve(mockAction),
+            } as any as Response)
+        )
+
+        logic.actions.setAutomaticActionCreationEnabled(true, 'Auto Action')
+        logic.actions.newAction()
+
+        await expectLogic(logic, () => {
+            logic.actions.submitActionForm()
+        })
+            .delay(0)
+            .toDispatchActions(['submitActionForm', 'submitActionFormSuccess'])
+
+        const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+        const body = JSON.parse(fetchCall[1].body)
+        expect(body.creation_context).toBe('onboarding')
+    })
+})

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -7,7 +7,7 @@ import { PostHog } from 'posthog-js'
 import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
 
 import { elementToSelector } from 'lib/actionUtils'
-import { PaginatedResponse } from 'lib/api'
+import type { PaginatedResponse } from 'lib/api'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { createVersionChecker } from 'lib/utils/semver'
 

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -3,14 +3,13 @@ import { forms } from 'kea-forms'
 import { subscriptions } from 'kea-subscriptions'
 
 import { EXPERIMENT_TARGET_SELECTOR } from 'lib/actionUtils'
-import api, { ApiError } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from 'scenes/urls'
 
 import { percentageDistribution } from '~/scenes/experiments/utils'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
-import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { WebExperiment, WebExperimentDraftType, WebExperimentForm } from '~/toolbar/types'
 import { elementToQuery, joinWithUiHost } from '~/toolbar/utils'
@@ -101,16 +100,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
     connect(() => ({
         values: [
             toolbarConfigLogic,
-            [
-                'dataAttributes',
-                'apiHost',
-                'uiHost',
-                'temporaryToken',
-                'buttonVisible',
-                'userIntent',
-                'dataAttributes',
-                'experimentId',
-            ],
+            ['dataAttributes', 'uiHost', 'buttonVisible', 'userIntent', 'dataAttributes', 'experimentId'],
             experimentsLogic,
             ['allExperiments'],
         ],
@@ -192,22 +182,28 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 // This property is only used in the editor to undo transforms
                 delete experimentToSave.original_html_state
 
-                const { apiHost, uiHost, temporaryToken } = values
+                const { uiHost } = values
                 const { selectedExperimentId } = values
 
                 let response: WebExperiment
                 try {
+                    let res: Response
                     if (selectedExperimentId && selectedExperimentId !== 'new') {
-                        response = await api.update(
-                            `${apiHost}/api/projects/@current/web_experiments/${selectedExperimentId}/?temporary_token=${temporaryToken}`,
+                        res = await toolbarFetch(
+                            `/api/projects/@current/web_experiments/${selectedExperimentId}/`,
+                            'PATCH',
                             experimentToSave
                         )
                     } else {
-                        response = await api.create(
-                            `${apiHost}/api/projects/@current/web_experiments/?temporary_token=${temporaryToken}`,
-                            experimentToSave
-                        )
+                        res = await toolbarFetch(`/api/projects/@current/web_experiments/`, 'POST', experimentToSave)
                     }
+
+                    if (!res.ok) {
+                        const errorData = await res.json().catch(() => ({}))
+                        throw new Error(errorData.detail || `Request failed: ${res.status}`)
+                    }
+
+                    response = await res.json()
 
                     experimentsLogic.actions.updateExperiment({ experiment: response })
                     actions.selectExperiment(null)
@@ -220,9 +216,8 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     })
                     breakpoint()
                 } catch (e) {
-                    const apiError = e as ApiError
-                    if (apiError) {
-                        lemonToast.error(`Experiment save failed: ${apiError.data.detail}`)
+                    if (e instanceof Error) {
+                        lemonToast.error(`Experiment save failed: ${e.message}`)
                     }
                 }
             },

--- a/frontend/src/toolbar/shims/featureFlagLogic.ts
+++ b/frontend/src/toolbar/shims/featureFlagLogic.ts
@@ -1,0 +1,14 @@
+import { kea, path, reducers } from 'kea'
+
+// Toolbar shim — no feature flags available in toolbar context
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getFeatureFlagPayload(_flag: string): undefined {
+    return undefined
+}
+
+export const featureFlagLogic = kea([
+    path(['toolbar', 'shims', 'featureFlagLogic']),
+    reducers({
+        featureFlags: [{} as Record<string, string | boolean>, {}],
+    }),
+])

--- a/frontend/src/toolbar/shims/featureFlagLogic.ts
+++ b/frontend/src/toolbar/shims/featureFlagLogic.ts
@@ -1,12 +1,14 @@
 import { kea, path, reducers } from 'kea'
 
+import type { featureFlagLogicType } from './featureFlagLogicType'
+
 // Toolbar shim — no feature flags available in toolbar context
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getFeatureFlagPayload(_flag: string): undefined {
     return undefined
 }
 
-export const featureFlagLogic = kea([
+export const featureFlagLogic = kea<featureFlagLogicType>([
     path(['toolbar', 'shims', 'featureFlagLogic']),
     reducers({
         featureFlags: [{} as Record<string, string | boolean>, {}],

--- a/frontend/src/toolbar/shims/membersLogic.ts
+++ b/frontend/src/toolbar/shims/membersLogic.ts
@@ -1,0 +1,12 @@
+import { actions, kea, path, reducers } from 'kea'
+
+// Toolbar shim — prevents the real membersLogic from auto-mounting and making API requests to the wrong host
+export const membersLogic = kea([
+    path(['toolbar', 'shims', 'membersLogic']),
+    actions({
+        ensureAllMembersLoaded: true,
+    }),
+    reducers({
+        members: [[] as unknown[], {}],
+    }),
+])

--- a/frontend/src/toolbar/shims/membersLogic.ts
+++ b/frontend/src/toolbar/shims/membersLogic.ts
@@ -1,7 +1,9 @@
 import { actions, kea, path, reducers } from 'kea'
 
+import type { membersLogicType } from './membersLogicType'
+
 // Toolbar shim — prevents the real membersLogic from auto-mounting and making API requests to the wrong host
-export const membersLogic = kea([
+export const membersLogic = kea<membersLogicType>([
     path(['toolbar', 'shims', 'membersLogic']),
     actions({
         ensureAllMembersLoaded: true,

--- a/frontend/src/toolbar/shims/sceneLogic.ts
+++ b/frontend/src/toolbar/shims/sceneLogic.ts
@@ -1,0 +1,10 @@
+import { kea, path, reducers } from 'kea'
+
+// Toolbar shim — prevents the real sceneLogic from hijacking routing.
+// null sceneConfig makes themeLogic fall through to system dark mode preference.
+export const sceneLogic = kea([
+    path(['toolbar', 'shims', 'sceneLogic']),
+    reducers({
+        sceneConfig: [null as Record<string, unknown> | null, {}],
+    }),
+])

--- a/frontend/src/toolbar/shims/sceneLogic.ts
+++ b/frontend/src/toolbar/shims/sceneLogic.ts
@@ -1,8 +1,10 @@
 import { kea, path, reducers } from 'kea'
 
+import type { sceneLogicType } from './sceneLogicType'
+
 // Toolbar shim — prevents the real sceneLogic from hijacking routing.
 // null sceneConfig makes themeLogic fall through to system dark mode preference.
-export const sceneLogic = kea([
+export const sceneLogic = kea<sceneLogicType>([
     path(['toolbar', 'shims', 'sceneLogic']),
     reducers({
         sceneConfig: [null as Record<string, unknown> | null, {}],

--- a/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
+++ b/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
@@ -1,0 +1,78 @@
+jest.mock('scenes/userLogic', () => require('~/toolbar/shims/userLogic'))
+jest.mock('scenes/organization/membersLogic', () => require('~/toolbar/shims/membersLogic'))
+jest.mock('scenes/sceneLogic', () => require('~/toolbar/shims/sceneLogic'))
+jest.mock('scenes/teamLogic', () => require('~/toolbar/shims/teamLogic'))
+jest.mock('lib/logic/featureFlagLogic', () => require('~/toolbar/shims/featureFlagLogic'))
+jest.mock('lib/api', () => ({
+    __esModule: true,
+    default: { get: jest.fn().mockResolvedValue(null), update: jest.fn().mockResolvedValue(null) },
+}))
+
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+    } as any as Response)
+)
+
+describe('shim consumer integration', () => {
+    beforeEach(() => {
+        initKeaTests(false)
+        toolbarConfigLogic.build({ apiURL: 'http://localhost' }).mount()
+        jest.clearAllMocks()
+    })
+
+    describe('hedgehogModeLogic with shims', () => {
+        it('mounts without error and has shimmed defaults', async () => {
+            const { hedgehogModeLogic } = await import('~/lib/components/HedgehogMode/hedgehogModeLogic')
+            const logic = hedgehogModeLogic.build()
+
+            expect(() => logic.mount()).not.toThrow()
+            expect(logic.values.hedgehogMode).toBeNull()
+            expect(logic.values.user).toBeNull()
+        })
+
+        it('afterMount falls through to loadRemoteConfig when shimmed user is null', async () => {
+            const { hedgehogModeLogic } = await import('~/lib/components/HedgehogMode/hedgehogModeLogic')
+            const logic = hedgehogModeLogic.build()
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            }).toDispatchActions(['loadRemoteConfig'])
+        })
+    })
+
+    describe('themeLogic with shims', () => {
+        it('mounts without error and provides isDarkModeOn', async () => {
+            const { themeLogic } = await import('~/layout/navigation-3000/themeLogic')
+            const logic = themeLogic.build()
+            logic.mount()
+
+            expect(typeof logic.values.isDarkModeOn).toBe('boolean')
+        })
+
+        it('isDarkModeOn falls through to system preference when sceneConfig is null', async () => {
+            const { themeLogic } = await import('~/layout/navigation-3000/themeLogic')
+            const logic = themeLogic.build()
+            logic.mount()
+
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+            expect(logic.values.isDarkModeOn).toBe(systemPrefersDark)
+        })
+    })
+
+    describe('teamLogic shim contract', () => {
+        it('provides weekStartDay for DateFilter', () => {
+            const { teamLogic } = require('scenes/teamLogic')
+            teamLogic.mount()
+            expect(teamLogic.values.weekStartDay).toBe(0)
+            expect(teamLogic.values.timezone).toBe('UTC')
+        })
+    })
+})

--- a/frontend/src/toolbar/shims/shims.test.ts
+++ b/frontend/src/toolbar/shims/shims.test.ts
@@ -1,0 +1,76 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { featureFlagLogic, getFeatureFlagPayload } from './featureFlagLogic'
+import { membersLogic } from './membersLogic'
+import { sceneLogic } from './sceneLogic'
+import { isAuthenticatedTeam, teamLogic } from './teamLogic'
+import { userLogic } from './userLogic'
+
+describe('toolbar shims', () => {
+    beforeEach(() => {
+        initKeaTests(false)
+    })
+
+    describe('default values', () => {
+        it.each([
+            ['userLogic', userLogic, { user: null, themeMode: 'system' }],
+            ['membersLogic', membersLogic, { members: [] }],
+            ['sceneLogic', sceneLogic, { sceneConfig: null }],
+            ['teamLogic', teamLogic, { currentTeam: null, timezone: 'UTC', weekStartDay: 0 }],
+            ['featureFlagLogic', featureFlagLogic, { featureFlags: {} }],
+        ])('%s provides expected defaults', (_name, logic, expected) => {
+            logic.mount()
+            expectLogic(logic).toMatchValues(expected)
+        })
+    })
+
+    describe('actions are callable without side effects', () => {
+        it.each([
+            ['userLogic.updateUser', () => userLogic.mount() && userLogic.actions.updateUser({})],
+            ['userLogic.loadUserSuccess', () => userLogic.mount() && userLogic.actions.loadUserSuccess({})],
+            [
+                'membersLogic.ensureAllMembersLoaded',
+                () => membersLogic.mount() && membersLogic.actions.ensureAllMembersLoaded(),
+            ],
+        ])('%s does not throw', (_name, fn) => {
+            expect(fn).not.toThrow()
+        })
+    })
+
+    it('sceneLogic exposes sceneConfig selector for direct reference', () => {
+        sceneLogic.mount()
+        expect(typeof sceneLogic.selectors.sceneConfig).toBe('function')
+    })
+
+    it('no shim triggers fetch when mounted', () => {
+        const fetchSpy = jest.fn()
+        global.fetch = fetchSpy
+
+        userLogic.mount()
+        membersLogic.mount()
+        sceneLogic.mount()
+        teamLogic.mount()
+        featureFlagLogic.mount()
+
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    describe('isAuthenticatedTeam', () => {
+        it.each([
+            [null, false],
+            [undefined, false],
+            [{}, false],
+            [{ api_token: 'phc_abc123' }, true],
+        ])('isAuthenticatedTeam(%j) returns %s', (input, expected) => {
+            expect(isAuthenticatedTeam(input)).toBe(expected)
+        })
+    })
+
+    describe('getFeatureFlagPayload', () => {
+        it.each([['SOME_FLAG'], ['ANOTHER_FLAG'], ['']])('returns undefined for %s', (flag) => {
+            expect(getFeatureFlagPayload(flag)).toBeUndefined()
+        })
+    })
+})

--- a/frontend/src/toolbar/shims/teamLogic.ts
+++ b/frontend/src/toolbar/shims/teamLogic.ts
@@ -1,11 +1,13 @@
 import { kea, path, reducers, selectors } from 'kea'
 
+import type { teamLogicType } from './teamLogicType'
+
 // Toolbar shim — prevents the real teamLogic from auto-mounting and making API requests to the wrong host
 export function isAuthenticatedTeam(team: unknown): boolean {
     return !!team && typeof team === 'object' && 'api_token' in team
 }
 
-export const teamLogic = kea([
+export const teamLogic = kea<teamLogicType>([
     path(['toolbar', 'shims', 'teamLogic']),
     reducers({
         currentTeam: [null as Record<string, unknown> | null, {}],

--- a/frontend/src/toolbar/shims/teamLogic.ts
+++ b/frontend/src/toolbar/shims/teamLogic.ts
@@ -1,0 +1,17 @@
+import { kea, path, reducers, selectors } from 'kea'
+
+// Toolbar shim — prevents the real teamLogic from auto-mounting and making API requests to the wrong host
+export function isAuthenticatedTeam(team: unknown): boolean {
+    return !!team && typeof team === 'object' && 'api_token' in team
+}
+
+export const teamLogic = kea([
+    path(['toolbar', 'shims', 'teamLogic']),
+    reducers({
+        currentTeam: [null as Record<string, unknown> | null, {}],
+    }),
+    selectors({
+        timezone: [(s) => [s.currentTeam], (): string => 'UTC'],
+        weekStartDay: [(s) => [s.currentTeam], (): number => 0],
+    }),
+])

--- a/frontend/src/toolbar/shims/userLogic.ts
+++ b/frontend/src/toolbar/shims/userLogic.ts
@@ -1,0 +1,14 @@
+import { actions, kea, path, reducers } from 'kea'
+
+// Toolbar shim — prevents the real userLogic from auto-mounting and making API requests to the wrong host
+export const userLogic = kea([
+    path(['toolbar', 'shims', 'userLogic']),
+    actions({
+        updateUser: (payload: unknown) => ({ payload }),
+        loadUserSuccess: (user: unknown) => ({ user }),
+    }),
+    reducers({
+        user: [null as Record<string, unknown> | null, {}],
+        themeMode: ['system' as string, {}],
+    }),
+])

--- a/frontend/src/toolbar/shims/userLogic.ts
+++ b/frontend/src/toolbar/shims/userLogic.ts
@@ -1,7 +1,9 @@
 import { actions, kea, path, reducers } from 'kea'
 
+import type { userLogicType } from './userLogicType'
+
 // Toolbar shim — prevents the real userLogic from auto-mounting and making API requests to the wrong host
-export const userLogic = kea([
+export const userLogic = kea<userLogicType>([
     path(['toolbar', 'shims', 'userLogic']),
     actions({
         updateUser: (payload: unknown) => ({ payload }),

--- a/frontend/toolbar-config.mjs
+++ b/frontend/toolbar-config.mjs
@@ -2,10 +2,23 @@ import * as path from 'path'
 
 import { isDev } from '@posthog/esbuilder'
 
+// Modules replaced with lightweight kea logic shims that satisfy connect() contracts
+// without side effects. If the upstream logic adds new connect() values, the shim
+// will silently return undefined — keep shims in sync when connect contracts change.
+const shimmedModules = {
+    'scenes/userLogic': 'src/toolbar/shims/userLogic.ts',
+    'scenes/organization/membersLogic': 'src/toolbar/shims/membersLogic.ts',
+    'scenes/sceneLogic': 'src/toolbar/shims/sceneLogic.ts',
+    'scenes/teamLogic': 'src/toolbar/shims/teamLogic.ts',
+    'lib/logic/featureFlagLogic': 'src/toolbar/shims/featureFlagLogic.ts',
+}
+
+// Modules replaced with an inert proxy that logs access in debug mode
 const deniedPaths = [
     '~/lib/hooks/useUploadFiles',
     '~/queries/nodes/InsightViz/InsightViz',
     'lib/hog',
+    'lib/api',
     'scenes/activity/explore/EventDetails',
     'scenes/web-analytics/WebAnalyticsDashboard',
     'scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts',
@@ -24,57 +37,62 @@ const deniedPatterns = [
     /LineGraph/,
 ]
 
-const denylistPlugin = {
-    /**
-     * The toolbar includes many parts of the main posthog app,
-     * but we don't want to include everything in the toolbar bundle.
-     * Partly because it would be too big, and partly because some things
-     * in the main app cause problems for people using CSPs on their sites.
-     *
-     * It wasn't possible to tree-shake the dependencies out of the bundle,
-     * and we don't want to change the app code significantly just for the toolbar
-     *
-     * So instead we replace some imports in the toolbar with a fake empty module
-     *
-     * This is ever so slightly hacky, but it gets customers up and running
-     *
-     * */
-    name: 'denylist-imports',
-    setup(build) {
-        build.onResolve({ filter: /.*/ }, (args) => {
-            const shouldDeny =
-                deniedPaths.includes(args.path) || deniedPatterns.some((pattern) => pattern.test(args.path))
-
-            if (shouldDeny) {
-                return {
-                    path: args.path,
-                    namespace: 'empty-module',
-                    sideEffects: false,
+/**
+ * The toolbar includes many parts of the main posthog app,
+ * but we don't want to include everything in the toolbar bundle.
+ * Partly because it would be too big, and partly because some things
+ * in the main app cause problems for people using CSPs on their sites.
+ *
+ * It wasn't possible to tree-shake the dependencies out of the bundle,
+ * and we don't want to change the app code significantly just for the toolbar.
+ *
+ * So instead we replace some imports in the toolbar:
+ * - Shimmed modules get swapped for lightweight kea logics (needed by connect())
+ * - Denied modules get replaced with an inert proxy
+ */
+function createToolbarModulePlugin(dirname) {
+    return {
+        name: 'toolbar-module-replacements',
+        setup(build) {
+            build.onResolve({ filter: /.*/ }, (args) => {
+                const shimFile = shimmedModules[args.path]
+                if (shimFile) {
+                    return { path: path.resolve(dirname, shimFile) }
                 }
-            }
-        })
 
-        build.onLoad({ filter: /.*/, namespace: 'empty-module' }, (args) => {
-            return {
-                contents: `
-                                module.exports = new Proxy({}, {
-                                    get: function() {
-                                        const shouldLog = window?.posthog?.config?.debug
-                                        if (shouldLog) {
-                                            console.warn('[TOOLBAR] Attempted to use denied module:', ${JSON.stringify(
-                                                args.path
-                                            )});
-                                        }
-                                        return function() {
-                                            return {}
-                                        }
-                                    }
-                                });
-                            `,
-                loader: 'js',
-            }
-        })
-    },
+                const shouldDeny =
+                    deniedPaths.includes(args.path) || deniedPatterns.some((pattern) => pattern.test(args.path))
+                if (shouldDeny) {
+                    return { path: args.path, namespace: 'empty-module', sideEffects: false }
+                }
+            })
+
+            build.onLoad({ filter: /.*/, namespace: 'empty-module' }, (args) => {
+                return {
+                    contents: `
+                        module.exports = new Proxy({}, {
+                            get: function(target, prop) {
+                                // Prevent proxy from being treated as a Promise (thenable detection)
+                                if (prop === 'then') return undefined;
+                                // Tell bundler this is a CommonJS module, not ESM
+                                if (prop === '__esModule') return false;
+                                const shouldLog = window && window.posthog && window.posthog.config && window.posthog.config.debug;
+                                if (shouldLog) {
+                                    console.warn('[TOOLBAR] Attempted to use denied module:', ${JSON.stringify(
+                                        args.path
+                                    )});
+                                }
+                                return function() {
+                                    return {}
+                                }
+                            }
+                        });
+                    `,
+                    loader: 'js',
+                }
+            })
+        },
+    }
 }
 
 export function getToolbarBuildConfig(dirname) {
@@ -88,6 +106,6 @@ export function getToolbarBuildConfig(dirname) {
         footer: { js: 'return posthogToolbar })();' },
         publicPath: isDev ? '/static/' : 'https://us.posthog.com/static/',
         writeMetaFile: true,
-        extraPlugins: [denylistPlugin],
+        extraPlugins: [createToolbarModulePlugin(dirname)],
     }
 }


### PR DESCRIPTION
## Problem

The toolbar bundle pulls in main-app kea logics (`userLogic`, `teamLogic`, `sceneLogic`, `membersLogic`, `featureFlagLogic`) that auto-mount and fire API requests to the wrong host, causing CORS errors and page redirects. Similarly, `actionsTabLogic` and `experimentsTabLogic` use `lib/api` directly, which also routes requests incorrectly.

Closes PostHog/posthog-js#3114

## Changes

- **esbuild shim plugin**: Merged the existing denylist plugin into a unified `createToolbarModulePlugin` that redirects 5 main-app kea logics to lightweight shims at build time — real kea logics with minimal reducers/selectors/actions, just enough to satisfy `connect()` contracts without side effects
- **`toolbarFetch` migration**: Replaced `api.update()`/`api.create()` in `actionsTabLogic` and `experimentsTabLogic` with `toolbarFetch`, added missing `res.ok` error handling
- **Type-only import**: Changed `heatmapToolbarMenuLogic` to `import type` for `PaginatedResponse` to avoid pulling in `lib/api` at runtime
- Added `lib/api` to the denied modules list

## How did you test this code?

30 new tests across 4 files (117 total toolbar tests pass):
- `shims.test.ts` — parameterized defaults, callable actions, no fetch on mount, exported helpers
- `shimConsumerIntegration.test.ts` — `jest.mock()` simulates build-time replacement, verifies `hedgehogModeLogic`, `themeLogic`, `teamLogic` mount with shims
- `actionsTabLogic.test.ts` — POST/PATCH, error handling, `creation_context`
- `experimentsTabLogic.test.ts` — error toast assertions (detail, generic, network error)

## Publish to changelog?

No
