### PR TITLE
feat(insights-ai): keep insight/results in context for posthog ai

### DIFF
--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -197,6 +197,7 @@ class AssistantContextManager(AssistantContextMixin):
                             short_id=insight.id,
                             filters_override=filters_override,
                             variables_override=variables_override,
+                            result=insight.result,
                         )
                     )
 
@@ -309,6 +310,7 @@ class AssistantContextManager(AssistantContextMixin):
             dashboard_filters=dashboard_filters,
             filters_override=filters_override,
             variables_override=variables_override,
+            result=insight.result,
         )
 
     async def _execute_and_format_insight(self, context: InsightContext) -> str | None:

--- a/ee/hogai/context/dashboard/context.py
+++ b/ee/hogai/context/dashboard/context.py
@@ -25,6 +25,7 @@ class DashboardInsightContext(BaseModel, Generic[AnyPydanticModelQuery]):
     filters_override: dict | None = None
     variables_override: dict | None = None
     layout: dict | None = None
+    result: object | None = None
 
 
 class DashboardContext:
@@ -153,4 +154,5 @@ class DashboardContext:
             dashboard_filters=self.dashboard_filters,
             filters_override=data.filters_override,
             variables_override=data.variables_override,
+            result=data.result,
         )

--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -21,6 +21,7 @@ class InsightContext:
 
     Accepts insight data directly and provides methods to format schema or execute and format results.
     Supports optional dashboard filter/variable overrides before execution.
+    If `result` is provided, the query will not be re-executed on the backend.
     """
 
     def __init__(
@@ -36,6 +37,8 @@ class InsightContext:
         dashboard_filters: dict | None = None,
         filters_override: dict | None = None,
         variables_override: dict | None = None,
+        # Pre-calculated result from the frontend - skips backend query execution
+        result: object | None = None,
     ):
         self.team = team
         self.query = query
@@ -47,6 +50,7 @@ class InsightContext:
         self.dashboard_filters = dashboard_filters
         self.filters_override = filters_override
         self.variables_override = variables_override
+        self.result = result
 
     @property
     def insight_url(self) -> str | None:
@@ -75,7 +79,7 @@ class InsightContext:
         return_exceptions: bool = False,
         truncate_results: bool = True,
     ) -> str:
-        """Execute query and format results."""
+        """Execute query and format results. Uses pre-calculated result if available."""
         effective_query = await self._get_effective_query()
         query_schema = effective_query.model_dump_json(exclude_none=True)
 
@@ -85,6 +89,7 @@ class InsightContext:
                 effective_query,
                 insight_id=self.insight_model_id,
                 truncate_results=truncate_results,
+                precalculated_result=self.result,
             )
         except Exception as e:
             error_message = f"Error executing query: {str(e)}"

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -2,7 +2,7 @@ import json
 import time
 import asyncio
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Optional, cast
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -550,11 +550,12 @@ async def execute_and_format_query(
         try:
             results = await query_runner._compress_results(
                 query,
-                {"results": precalculated_result},
+                cast(dict, precalculated_result),
                 truncate_results=truncate_results,
             )
             used_fallback = False
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Failed to format precalculated result: {str(e)}, falling back to query execution")
             # Fall back to executing the query if formatting the precalculated result fails
             results, used_fallback = await query_runner.arun_and_format_query(
                 query, execution_mode, insight_id, truncate_results=truncate_results

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -522,6 +522,7 @@ async def execute_and_format_query(
     execution_mode: Optional[ExecutionMode] = None,
     insight_id: Optional[int] = None,
     truncate_results: bool = True,
+    precalculated_result: object | None = None,
 ) -> str:
     """
     Executes a supported query and formats the results for the AI assistant:
@@ -537,15 +538,31 @@ async def execute_and_format_query(
         query: The query to execute.
         execution_mode: The execution mode to use.
         insight_id: The insight ID to use.
+        precalculated_result: Pre-calculated result from the frontend. If provided, skips backend query execution.
     Returns:
         The formatted query results.
     """
     query = validate_assistant_query(query_model.model_dump(mode="json"))
     utc_now_datetime = timezone.now().astimezone(UTC)
     query_runner = AssistantQueryExecutor(team, utc_now_datetime)
-    results, used_fallback = await query_runner.arun_and_format_query(
-        query, execution_mode, insight_id, truncate_results=truncate_results
-    )
+
+    if precalculated_result is not None and is_supported_query(query):
+        try:
+            results = await query_runner._compress_results(
+                query,
+                {"results": precalculated_result},
+                truncate_results=truncate_results,
+            )
+            used_fallback = False
+        except Exception:
+            # Fall back to executing the query if formatting the precalculated result fails
+            results, used_fallback = await query_runner.arun_and_format_query(
+                query, execution_mode, insight_id, truncate_results=truncate_results
+            )
+    else:
+        results, used_fallback = await query_runner.arun_and_format_query(
+            query, execution_mode, insight_id, truncate_results=truncate_results
+        )
     example_prompt = FALLBACK_EXAMPLE_PROMPT if used_fallback else get_example_prompt(query)
     currency = team.base_currency or CurrencyCode.USD.value
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21499,6 +21499,7 @@
                 "query": {
                     "$ref": "#/definitions/QuerySchema"
                 },
+                "result": {},
                 "type": {
                     "const": "insight",
                     "type": "string"

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -224,6 +224,22 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             ],
             (insightQuery) => insightQuery,
         ],
+        insightDataSelector: [
+            (s) => [s.insightDataLogicRef],
+            (insightDataLogicRef) => insightDataLogicRef?.logic.selectors.insightData,
+        ],
+        insightData: [
+            (s) => [
+                (state, props) => {
+                    try {
+                        return s.insightDataSelector?.(state, props)?.(state, props)
+                    } catch {
+                        return null
+                    }
+                },
+            ],
+            (insightData) => insightData,
+        ],
         insightSelector: [(s) => [s.insightLogicRef], (insightLogicRef) => insightLogicRef?.logic.selectors.insight],
         insight: [
             (s) => [
@@ -330,13 +346,21 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             },
         ],
         maxContext: [
-            (s) => [s.insight, s.filtersOverride, s.variablesOverride],
-            (insight: Partial<QueryBasedInsightModel>, filtersOverride, variablesOverride): MaxContextInput[] => {
+            (s) => [s.insight, s.filtersOverride, s.variablesOverride, s.insightData],
+            (
+                insight: Partial<QueryBasedInsightModel>,
+                filtersOverride,
+                variablesOverride,
+                insightData
+            ): MaxContextInput[] => {
                 if (!insight || !insight.short_id || !insight.query) {
                     return []
                 }
+                // Merge the latest result from insightDataLogic (more up-to-date than insight.result)
+                const insightWithResult =
+                    insightData?.result != null ? { ...insight, result: insightData.result } : insight
                 return [
-                    createMaxContextHelpers.insight(insight, {
+                    createMaxContextHelpers.insight(insightWithResult, {
                         filtersOverride: filtersOverride ?? undefined,
                         variablesOverride: variablesOverride ?? undefined,
                     }),

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -21,6 +21,7 @@ export interface MaxInsightContext {
     name?: string | null
     description?: string | null
     query: QuerySchema // The actual query node, e.g., TrendsQuery, HogQLQuery
+    result?: any // Pre-calculated query results, avoids re-execution on the backend
     filtersOverride?: DashboardFilter
     variablesOverride?: Record<string, HogQLVariable>
 }

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -190,6 +190,7 @@ export const insightToMaxContext = (
         name: insight.name || insight.derived_name,
         description: insight.description,
         query: source,
+        result: insight.result ?? undefined,
         filtersOverride,
         variablesOverride,
     }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -18973,6 +18973,7 @@ class MaxInsightContext(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
     ) = Field(..., discriminator="kind")
+    result: Any | None = None
     type: Literal["insight"] = "insight"
     variablesOverride: dict[str, HogQLVariable] | None = None
 


### PR DESCRIPTION
## Problem
Right now asking Posthog AI to analyse the insight doesn't work as it doesn't have the insight/insight results loaded in context

<img width="1098" height="372" alt="image" src="https://github.com/user-attachments/assets/66814b36-1442-4aac-a011-e187e06dd4e0" />

## Changes
Load the insight/insight results in context and use it to respond to the user

<img width="2294" height="1362" alt="image" src="https://github.com/user-attachments/assets/3a4cbead-aad1-4a73-89a1-27805712d293" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
