### PR TITLE
fix(cdp): use internal fetch

### DIFF
--- a/nodejs/src/cdp/services/job-queue/warpstream-fetch-tester.ts
+++ b/nodejs/src/cdp/services/job-queue/warpstream-fetch-tester.ts
@@ -4,7 +4,7 @@ import { Counter, Histogram } from 'prom-client'
 import { getKafkaConfigFromEnv } from '../../../kafka/config'
 import { PluginsServerConfig } from '../../../types'
 import { logger } from '../../../utils/logger'
-import { fetch } from '../../../utils/request'
+import { internalFetch as fetch } from '../../../utils/request'
 
 export const cdpSeekLatencyMs = new Histogram({
     name: 'cdp_seek_latency_ms',


### PR DESCRIPTION
### Problem: 

The fetch utility uses a SecureAgent that blocks requests to internal/private IPs hostnames resolving to non-global IPv4 addresses). The WarpStream endpoint is a cluster-internal service that resolves to a private IP, causing SecureRequestError: Hostname is not allowed.                                                                                    
                                                                                                  
Solution: Switch to internalFetch which uses the InsecureAgent that skips the private IP check. 