### PR TITLE
fix(mcp): coerce string-typed numbers and JSON-string objects in tool inputs

### DIFF
--- a/services/mcp/src/lib/preprocessParams.ts
+++ b/services/mcp/src/lib/preprocessParams.ts
@@ -1,0 +1,24 @@
+/**
+ * Preprocess MCP tool arguments to handle clients that serialize nested objects
+ * as JSON strings. Only coerces top-level string values that look like JSON
+ * objects or arrays.
+ */
+export function preprocessParams(params: Record<string, unknown>): Record<string, unknown> {
+    const result = { ...params }
+    for (const [key, value] of Object.entries(result)) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim()
+            if (
+                (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+                (trimmed.startsWith('[') && trimmed.endsWith(']'))
+            ) {
+                try {
+                    result[key] = JSON.parse(trimmed)
+                } catch {
+                    // Keep original string if not valid JSON
+                }
+            }
+        }
+    }
+    return result
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -15,6 +15,7 @@ import {
     toCloudRegion,
 } from '@/lib/constants'
 import { handleToolError } from '@/lib/errors'
+import { preprocessParams } from '@/lib/preprocessParams'
 import { formatResponse } from '@/lib/response'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
@@ -186,13 +187,17 @@ export class MCP extends McpAgent<Env> {
         handler: (params: z.infer<z.ZodObject<TSchema>>) => Promise<any>
     ): void {
         const wrappedHandler = async (params: z.infer<z.ZodObject<TSchema>>): Promise<any> => {
-            const validation = tool.schema.safeParse(params)
+            // Some MCP clients serialize nested objects as JSON strings instead of inline
+            // objects. Attempt to parse any top-level string values that look like JSON.
+            const preprocessed = preprocessParams(params as Record<string, unknown>)
+
+            const validation = tool.schema.safeParse(preprocessed)
 
             if (!validation.success) {
                 await this.trackEvent(AnalyticsEvent.MCP_TOOL_CALL, {
                     tool: tool.name,
                     valid_input: false,
-                    input: params,
+                    input: preprocessed,
                 })
                 return [
                     {
@@ -208,7 +213,7 @@ export class MCP extends McpAgent<Env> {
             })
 
             try {
-                const result = await handler(params)
+                const result = await handler(validation.data)
                 await this.trackEvent(AnalyticsEvent.MCP_TOOL_RESPONSE, {
                     tool: tool.name,
                 })

--- a/services/mcp/src/schema/dashboards.ts
+++ b/services/mcp/src/schema/dashboards.ts
@@ -81,14 +81,14 @@ export const ListDashboardsSchema = z.object({
 // Input schema for adding insight to dashboard
 export const AddInsightToDashboardSchema = z.object({
     insightId: z.string(),
-    dashboardId: z.number().int().positive(),
+    dashboardId: z.coerce.number().int().positive(),
 })
 
 // Input schema for reordering dashboard tiles
 export const ReorderDashboardTilesSchema = z.object({
-    dashboardId: z.number().int().positive().describe('The ID of the dashboard to reorder tiles on'),
+    dashboardId: z.coerce.number().int().positive().describe('The ID of the dashboard to reorder tiles on'),
     tileOrder: z
-        .array(z.number().int().positive())
+        .array(z.coerce.number().int().positive())
         .min(1)
         .describe('Array of tile IDs in the desired order from top to bottom'),
 })

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -30,11 +30,11 @@ export const DashboardCreateSchema = z.object({
 })
 
 export const DashboardDeleteSchema = z.object({
-    dashboardId: z.number(),
+    dashboardId: z.coerce.number(),
 })
 
 export const DashboardGetSchema = z.object({
-    dashboardId: z.number(),
+    dashboardId: z.coerce.number(),
 })
 
 export const DashboardGetAllSchema = z.object({
@@ -42,7 +42,7 @@ export const DashboardGetAllSchema = z.object({
 })
 
 export const DashboardUpdateSchema = z.object({
-    dashboardId: z.number(),
+    dashboardId: z.coerce.number(),
     data: UpdateDashboardInputSchema,
 })
 
@@ -59,23 +59,23 @@ export const ErrorTrackingListSchema = ListErrorsSchema
 export const ExperimentGetAllSchema = z.object({
     data: z
         .object({
-            limit: z.number().int().positive().optional(),
-            offset: z.number().int().min(0).optional(),
+            limit: z.coerce.number().int().positive().optional(),
+            offset: z.coerce.number().int().min(0).optional(),
         })
         .optional(),
 })
 
 export const ExperimentGetSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to retrieve'),
+    experimentId: z.coerce.number().describe('The ID of the experiment to retrieve'),
 })
 
 export const ExperimentResultsGetSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to get comprehensive results for'),
+    experimentId: z.coerce.number().describe('The ID of the experiment to get comprehensive results for'),
     refresh: z.boolean().describe('Force refresh of results instead of using cached values'),
 })
 
 export const ExperimentDeleteSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to delete'),
+    experimentId: z.coerce.number().describe('The ID of the experiment to delete'),
 })
 
 /**
@@ -133,7 +133,7 @@ export const ExperimentUpdateInputSchema = z.object({
         .optional()
         .describe('Update secondary metrics'),
 
-    minimum_detectable_effect: z.number().optional().describe('Update minimum detectable effect in percentage'),
+    minimum_detectable_effect: z.coerce.number().optional().describe('Update minimum detectable effect in percentage'),
 
     // Experiment state management
     launch: z.boolean().optional().describe('Launch experiment (set start_date) or keep as draft'),
@@ -151,7 +151,7 @@ export const ExperimentUpdateInputSchema = z.object({
 })
 
 export const ExperimentUpdateSchema = z.object({
-    experimentId: z.number().describe('The ID of the experiment to update'),
+    experimentId: z.coerce.number().describe('The ID of the experiment to update'),
     data: ExperimentUpdateInputSchema.describe('The experiment data to update using user-friendly format'),
 })
 
@@ -249,7 +249,11 @@ export const ExperimentCreateSchema = z.object({
             z.object({
                 key: z.string().describe("Variant key (e.g., 'control', 'variant_a', 'new_design')"),
                 name: z.string().optional().describe('Human-readable variant name'),
-                rollout_percentage: z.number().min(0).max(100).describe('Percentage of users to show this variant'),
+                rollout_percentage: z.coerce
+                    .number()
+                    .min(0)
+                    .max(100)
+                    .describe('Percentage of users to show this variant'),
             })
         )
         .optional()
@@ -301,14 +305,14 @@ export const FeatureFlagDeleteSchema = z.object({
 export const FeatureFlagGetAllSchema = z.object({
     data: z
         .object({
-            limit: z.number().int().positive().optional(),
-            offset: z.number().int().min(0).optional(),
+            limit: z.coerce.number().int().positive().optional(),
+            offset: z.coerce.number().int().min(0).optional(),
         })
         .optional(),
 })
 
 export const FeatureFlagGetDefinitionSchema = z.object({
-    flagId: z.number().int().positive().optional(),
+    flagId: z.coerce.number().int().positive().optional(),
     flagKey: z.string().optional(),
 })
 
@@ -350,8 +354,8 @@ export const InsightUpdateSchema = z.object({
 })
 
 export const LLMAnalyticsGetCostsSchema = z.object({
-    projectId: z.number().int().positive(),
-    days: z.number().optional(),
+    projectId: z.coerce.number().int().positive(),
+    days: z.coerce.number().optional(),
 })
 
 export const OrganizationGetDetailsSchema = z.object({})
@@ -366,8 +370,8 @@ export const ProjectGetAllSchema = z.object({})
 
 export const ProjectEventDefinitionsSchema = z.object({
     q: z.string().optional().describe('Search query to filter event names. Only use if there are lots of events.'),
-    limit: z.number().int().positive().optional(),
-    offset: z.number().int().min(0).optional(),
+    limit: z.coerce.number().int().positive().optional(),
+    offset: z.coerce.number().int().min(0).optional(),
 })
 
 export const EventDefinitionUpdateInputSchema = z.object({
@@ -397,12 +401,12 @@ export const ProjectPropertyDefinitionsInputSchema = z.object({
     type: z.enum(['event', 'person']).describe('Type of properties to get'),
     eventName: z.string().describe('Event name to filter properties by, required for event type').optional(),
     includePredefinedProperties: z.boolean().optional().describe('Whether to include predefined properties'),
-    limit: z.number().int().positive().optional(),
-    offset: z.number().int().min(0).optional(),
+    limit: z.coerce.number().int().positive().optional(),
+    offset: z.coerce.number().int().min(0).optional(),
 })
 
 export const ProjectSetActiveSchema = z.object({
-    projectId: z.number().int().positive(),
+    projectId: z.coerce.number().int().positive(),
 })
 
 export const SurveyCreateSchema = CreateSurveyInputSchema
@@ -437,11 +441,11 @@ export { LogsQueryInputSchema, LogsListAttributesInputSchema, LogsListAttributeV
 export const ActionCreateSchema = CreateActionInputSchema
 
 export const ActionDeleteSchema = z.object({
-    actionId: z.number().int().positive().describe('The ID of the action to delete'),
+    actionId: z.coerce.number().int().positive().describe('The ID of the action to delete'),
 })
 
 export const ActionGetSchema = z.object({
-    actionId: z.number().int().positive().describe('The ID of the action to retrieve'),
+    actionId: z.coerce.number().int().positive().describe('The ID of the action to retrieve'),
 })
 
 export const ActionGetAllSchema = z.object({
@@ -449,7 +453,7 @@ export const ActionGetAllSchema = z.object({
 })
 
 export const ActionUpdateSchema = z.object({
-    actionId: z.number().int().positive().describe('The ID of the action to update'),
+    actionId: z.coerce.number().int().positive().describe('The ID of the action to update'),
     data: UpdateActionInputSchema,
 })
 
@@ -513,7 +517,7 @@ const ReadEntityPropertiesQuerySchema = z.object({
 
 const ReadActionPropertiesQuerySchema = z.object({
     kind: z.literal('action_properties'),
-    action_id: z.number().int().describe('The ID of the action that you want to retrieve properties for.'),
+    action_id: z.coerce.number().int().describe('The ID of the action that you want to retrieve properties for.'),
 })
 
 const ReadEntitySamplePropertyValuesQuerySchema = z.object({
@@ -530,7 +534,7 @@ const ReadEventSamplePropertyValuesQuerySchema = z.object({
 
 const ReadActionSamplePropertyValuesQuerySchema = z.object({
     kind: z.literal('action_property_values'),
-    action_id: z.number().int().describe('Verified action ID'),
+    action_id: z.coerce.number().int().describe('Verified action ID'),
     property_name: z.string().describe('Verified property name of an action.'),
 })
 

--- a/services/mcp/tests/unit/schema.coercion.test.ts
+++ b/services/mcp/tests/unit/schema.coercion.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessParams } from '@/lib/preprocessParams'
+import {
+    ExperimentDeleteSchema,
+    ExperimentGetSchema,
+    ExperimentResultsGetSchema,
+    ExperimentUpdateSchema,
+    DashboardDeleteSchema,
+    DashboardGetSchema,
+    ActionDeleteSchema,
+    ActionGetSchema,
+} from '@/schema/tool-inputs'
+
+describe('MCP tool input coercion', () => {
+    describe('numeric ID coercion', () => {
+        it.each([
+            ['ExperimentGetSchema', ExperimentGetSchema, { experimentId: '74850' }],
+            ['ExperimentDeleteSchema', ExperimentDeleteSchema, { experimentId: '74850' }],
+            ['ExperimentResultsGetSchema', ExperimentResultsGetSchema, { experimentId: '74850', refresh: true }],
+            ['DashboardDeleteSchema', DashboardDeleteSchema, { dashboardId: '42' }],
+            ['DashboardGetSchema', DashboardGetSchema, { dashboardId: '42' }],
+            ['ActionDeleteSchema', ActionDeleteSchema, { actionId: '99' }],
+            ['ActionGetSchema', ActionGetSchema, { actionId: '99' }],
+        ])('%s accepts string-encoded numeric IDs', (_name, schema, input) => {
+            const result = schema.safeParse(input)
+            expect(result.success).toBe(true)
+        })
+
+        it.each([
+            ['ExperimentGetSchema', ExperimentGetSchema, { experimentId: 74850 }],
+            ['DashboardDeleteSchema', DashboardDeleteSchema, { dashboardId: 42 }],
+            ['ActionGetSchema', ActionGetSchema, { actionId: 99 }],
+        ])('%s still accepts proper numeric IDs', (_name, schema, input) => {
+            const result = schema.safeParse(input)
+            expect(result.success).toBe(true)
+        })
+
+        it('rejects non-numeric strings', () => {
+            const result = ExperimentGetSchema.safeParse({ experimentId: 'abc' })
+            expect(result.success).toBe(false)
+        })
+    })
+
+    describe('preprocessParams JSON string coercion', () => {
+        it('parses JSON-string objects into objects', () => {
+            const result = preprocessParams({
+                experimentId: '74850',
+                data: '{"name":"Test experiment"}',
+            })
+            expect(result).toEqual({
+                experimentId: '74850',
+                data: { name: 'Test experiment' },
+            })
+        })
+
+        it('parses JSON-string arrays into arrays', () => {
+            const result = preprocessParams({
+                ids: '[1, 2, 3]',
+            })
+            expect(result).toEqual({ ids: [1, 2, 3] })
+        })
+
+        it('leaves non-JSON strings unchanged', () => {
+            const result = preprocessParams({
+                name: 'hello world',
+                experimentId: '74850',
+            })
+            expect(result).toEqual({
+                name: 'hello world',
+                experimentId: '74850',
+            })
+        })
+
+        it('leaves invalid JSON strings unchanged', () => {
+            const result = preprocessParams({
+                data: '{invalid json}',
+            })
+            expect(result).toEqual({ data: '{invalid json}' })
+        })
+
+        it('leaves non-string values unchanged', () => {
+            const result = preprocessParams({
+                experimentId: 123,
+                data: { name: 'already an object' },
+                enabled: true,
+            })
+            expect(result).toEqual({
+                experimentId: 123,
+                data: { name: 'already an object' },
+                enabled: true,
+            })
+        })
+    })
+
+    describe('nested object coercion via ExperimentUpdateSchema', () => {
+        it('accepts data as an inline object', () => {
+            const result = ExperimentUpdateSchema.safeParse({
+                experimentId: 123,
+                data: { name: 'Test experiment' },
+            })
+            expect(result.success).toBe(true)
+        })
+
+        it('accepts experimentId as string with inline data object', () => {
+            const result = ExperimentUpdateSchema.safeParse({
+                experimentId: '123',
+                data: { name: 'Test experiment' },
+            })
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data.experimentId).toBe(123)
+            }
+        })
+
+        it('accepts experimentId as string with JSON-stringified data object', () => {
+            const preprocessed = preprocessParams({
+                experimentId: '123',
+                data: '{"name":"Test experiment"}',
+            })
+            const result = ExperimentUpdateSchema.safeParse(preprocessed)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data.experimentId).toBe(123)
+                expect(result.data.data).toEqual({ name: 'Test experiment' })
+            }
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Some MCP clients send tool arguments with incorrect types:
- Numeric IDs as strings (e.g., `"74850"` instead of `74850`)
- Nested objects as JSON strings (e.g., `"{\"start_date\":\"2026-02-24T14:51:00Z\"}"` instead of `{start_date: "2026-02-24T14:51:00Z"}`)

This caused validation errors like:
```
MCP error -32602: Invalid arguments for tool experiment-update: [
  { "code": "invalid_type", "expected": "number", "received": "string", "path": ["experimentId"] },
  { "code": "invalid_type", "expected": "object", "received": "string", "path": ["data"] }
]
```

## Changes

- **`src/schema/tool-inputs.ts`**: Changed all `z.number()` to `z.coerce.number()` so string-encoded numeric IDs (and other numeric params like limit/offset) are accepted
- **`src/schema/dashboards.ts`**: Same coercion for `AddInsightToDashboardSchema` and `ReorderDashboardTilesSchema`, which are used directly as tool input schemas
- **`src/lib/preprocessParams.ts`** (new): Utility that parses top-level string values that look like JSON objects/arrays before Zod validation runs
- **`src/mcp.ts`**: Calls `preprocessParams()` before `safeParse()`, and passes `validation.data` (coerced values) to handlers instead of raw params

## Testing

Added `tests/unit/schema.coercion.test.ts` with 18 tests covering:
- String-encoded numeric ID acceptance across experiment, dashboard, and action schemas
- Backward compatibility with proper numeric inputs
- Rejection of non-numeric strings (e.g., `"abc"`)
- `preprocessParams` JSON-string-to-object coercion
- Edge cases: invalid JSON, non-string values, plain strings