### PR TITLE
fix(persons): trim whitespace from person/group search queries

### DIFF
--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -126,28 +126,29 @@ class PersonStrategy(ActorStrategy):
         if self.query.fixedProperties:
             where_exprs.append(property_to_expr(self.query.fixedProperties, self.team, scope="person"))
 
-        if self.query.search is not None and self.query.search != "":
+        search = self.query.search.strip() if self.query.search else None
+        if search:
             where_exprs.append(
                 ast.Or(
                     exprs=[
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
                             left=ast.Call(name="toString", args=[ast.Field(chain=["properties", "email"])]),
-                            right=ast.Constant(value=f"%{self.query.search}%"),
+                            right=ast.Constant(value=f"%{search}%"),
                         ),
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
                             left=ast.Call(name="toString", args=[ast.Field(chain=["properties", "name"])]),
-                            right=ast.Constant(value=f"%{self.query.search}%"),
+                            right=ast.Constant(value=f"%{search}%"),
                         ),
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
                             left=ast.Call(name="toString", args=[ast.Field(chain=["id"])]),
-                            right=ast.Constant(value=f"%{self.query.search}%"),
+                            right=ast.Constant(value=f"%{search}%"),
                         ),
                         parse_expr(
                             "id in (select person_id from person_distinct_ids where ilike(distinct_id, {search}))",
-                            {"search": ast.Constant(value=f"%{self.query.search}%")},
+                            {"search": ast.Constant(value=f"%{search}%")},
                         ),
                     ]
                 )
@@ -202,19 +203,20 @@ class GroupStrategy(ActorStrategy):
     def filter_conditions(self) -> list[ast.Expr]:
         where_exprs: list[ast.Expr] = []
 
-        if self.query.search is not None and self.query.search != "":
+        search = self.query.search.strip() if self.query.search else None
+        if search:
             where_exprs.append(
                 ast.Or(
                     exprs=[
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
                             left=ast.Field(chain=["properties", "name"]),
-                            right=ast.Constant(value=f"%{self.query.search}%"),
+                            right=ast.Constant(value=f"%{search}%"),
                         ),
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.ILike,
                             left=ast.Call(name="toString", args=[ast.Field(chain=["key"])]),
-                            right=ast.Constant(value=f"%{self.query.search}%"),
+                            right=ast.Constant(value=f"%{search}%"),
                         ),
                     ]
                 )

--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -165,6 +165,13 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         runner = self._create_runner(ActorsQuery(search=f"id-{self.random_uuid}-9"))
         self.assertEqual(len(runner.calculate().results), 1)
 
+    def test_persons_query_search_trims_whitespace(self):
+        self.random_uuid = self._create_random_persons()
+        runner = self._create_runner(ActorsQuery(search=f"  jacob4@{self.random_uuid}.posthog  "))
+        self.assertEqual(len(runner.calculate().results), 1)
+        runner = self._create_runner(ActorsQuery(search=f"\tjacob4@{self.random_uuid}.posthog\n"))
+        self.assertEqual(len(runner.calculate().results), 1)
+
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_persons_query_search_snapshot(self):
         runner = self._create_runner(ActorsQuery(search="SEARCHSTRING"))


### PR DESCRIPTION
## Problem

Trailing/leading white space in the actors/group search field causes searches to fail:
https://posthog.slack.com/archives/C0ACRAMJUAG/p1771947077116009

https://claude.ai/code/session_01MXHrfM8boVqqJov1ihHzNf

## Changes

Trim whitespace