### PR TITLE
feat: Added starting place for redis backed idempotency service

### DIFF
--- a/nodejs/src/common/services/idempotency.service.test.ts
+++ b/nodejs/src/common/services/idempotency.service.test.ts
@@ -1,0 +1,264 @@
+import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
+import { Hub } from '~/types'
+import { closeHub, createHub } from '~/utils/db/hub'
+
+import { deleteKeysWithPrefix } from '../../cdp/_tests/redis'
+import { IdempotencyService, IdempotencyState, idempotencyKey } from './idempotency.service'
+
+const mockNow = jest.spyOn(Date, 'now')
+
+describe('IdempotencyService', () => {
+    jest.retryTimes(3)
+
+    let now: number
+    let hub: Hub
+    let redis: RedisV2
+    let service: IdempotencyService
+
+    const NS = 'test'
+
+    const advanceTime = (ms: number) => {
+        now += ms
+        mockNow.mockReturnValue(now)
+    }
+
+    beforeEach(async () => {
+        hub = await createHub()
+        now = 1720000000000
+        mockNow.mockReturnValue(now)
+
+        redis = createRedisV2PoolFromConfig({
+            connection: { url: hub.REDIS_URL },
+            poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+        })
+        await deleteKeysWithPrefix(redis, '@posthog-test/idempotency')
+        service = new IdempotencyService(redis, { maxSize: 100 })
+    })
+
+    afterEach(async () => {
+        await closeHub(hub)
+        jest.clearAllMocks()
+    })
+
+    describe('idempotencyKey', () => {
+        it('produces consistent hashes for the same input', () => {
+            expect(idempotencyKey('a', 'b')).toBe(idempotencyKey('a', 'b'))
+        })
+
+        it('produces different hashes for different inputs', () => {
+            expect(idempotencyKey('a', 'b')).not.toBe(idempotencyKey('a', 'c'))
+            expect(idempotencyKey('a', 'b')).not.toBe(idempotencyKey('b', 'a'))
+        })
+
+        it('produces 32-character hex strings', () => {
+            const key = idempotencyKey('some-namespace', 'some-very-long-identifier-that-could-be-anything')
+            expect(key).toHaveLength(32)
+            expect(key).toMatch(/^[0-9a-f]{32}$/)
+        })
+    })
+
+    describe('claim', () => {
+        it.each([
+            {
+                scenario: 'new key',
+                setup: async () => {},
+                expected: IdempotencyState.New,
+            },
+            {
+                scenario: 'already-claimed key',
+                setup: async () => {
+                    await service.claim(NS, idempotencyKey('event-1'))
+                    advanceTime(10)
+                },
+                expected: IdempotencyState.Existing,
+            },
+            {
+                scenario: 'acked key',
+                setup: async () => {
+                    await service.claim(NS, idempotencyKey('event-1'))
+                    await service.ack(NS, idempotencyKey('event-1'))
+                    advanceTime(10)
+                },
+                expected: IdempotencyState.Acked,
+            },
+            {
+                scenario: 'released key (re-claimable)',
+                setup: async () => {
+                    await service.claim(NS, idempotencyKey('event-1'))
+                    await service.release(NS, idempotencyKey('event-1'))
+                    advanceTime(10)
+                },
+                expected: IdempotencyState.New,
+            },
+        ])('returns $expected for $scenario', async ({ setup, expected }) => {
+            await setup()
+            const result = await service.claim(NS, idempotencyKey('event-1'))
+            expect(result).toBe(expected)
+        })
+    })
+
+    describe('bounded size', () => {
+        it('evicts oldest claimed entries when exceeding maxSize', async () => {
+            const smallService = new IdempotencyService(redis, { maxSize: 5 })
+
+            for (let i = 0; i < 7; i++) {
+                advanceTime(100)
+                await smallService.claim(NS, idempotencyKey(`event-${i}`))
+            }
+
+            advanceTime(100)
+            expect(await smallService.claim(NS, idempotencyKey('event-0'))).toBe(IdempotencyState.New)
+            advanceTime(100)
+            expect(await smallService.claim(NS, idempotencyKey('event-1'))).toBe(IdempotencyState.New)
+            advanceTime(100)
+            expect(await smallService.claim(NS, idempotencyKey('event-6'))).toBe(IdempotencyState.Existing)
+        })
+
+        it('acked entries survive eviction over claimed entries', async () => {
+            const smallService = new IdempotencyService(redis, { maxSize: 5 })
+            const ns = 'ack-survive'
+
+            await smallService.claim(ns, idempotencyKey('acked-event'))
+            await smallService.ack(ns, idempotencyKey('acked-event'))
+            advanceTime(100)
+            await smallService.claim(ns, idempotencyKey('claimed-1'))
+            advanceTime(100)
+            await smallService.claim(ns, idempotencyKey('claimed-2'))
+
+            for (let i = 3; i < 7; i++) {
+                advanceTime(100)
+                await smallService.claim(ns, idempotencyKey(`filler-${i}`))
+            }
+
+            advanceTime(100)
+            expect(await smallService.claim(ns, idempotencyKey('acked-event'))).toBe(IdempotencyState.Acked)
+            advanceTime(100)
+            expect(await smallService.claim(ns, idempotencyKey('claimed-1'))).toBe(IdempotencyState.New)
+            advanceTime(100)
+            expect(await smallService.claim(ns, idempotencyKey('claimed-2'))).toBe(IdempotencyState.New)
+        })
+    })
+
+    describe('claimBatch', () => {
+        it('returns correct states for a mix of new, existing, and acked keys', async () => {
+            const existingKey = idempotencyKey('existing')
+            const ackedKey = idempotencyKey('acked')
+            const newKey = idempotencyKey('new')
+
+            await service.claim(NS, existingKey)
+            await service.claim(NS, ackedKey)
+            await service.ack(NS, ackedKey)
+            advanceTime(100)
+
+            const results = await service.claimBatch([
+                [NS, existingKey],
+                [NS, ackedKey],
+                [NS, newKey],
+            ])
+            expect(results).not.toBeNull()
+            expect(results!.get(existingKey)).toBe(IdempotencyState.Existing)
+            expect(results!.get(ackedKey)).toBe(IdempotencyState.Acked)
+            expect(results!.get(newKey)).toBe(IdempotencyState.New)
+        })
+
+        it('handles entries across multiple namespaces in one call', async () => {
+            const key = idempotencyKey('shared-event')
+
+            await service.claim('ns-a', key)
+            await service.ack('ns-a', key)
+            advanceTime(10)
+
+            const results = await service.claimBatch([
+                ['ns-a', key],
+                ['ns-b', key],
+            ])
+            expect(results!.get(key)).toBe(IdempotencyState.New) // ns-b wins last-write in the map
+            // Verify ns-a is still acked via single call
+            expect(await service.claim('ns-a', key)).toBe(IdempotencyState.Acked)
+        })
+
+        it('returns empty map for empty input', async () => {
+            const results = await service.claimBatch([])
+            expect(results).toEqual(new Map())
+        })
+    })
+
+    describe('namespaces are isolated', () => {
+        it('same key in different namespaces are independent', async () => {
+            const key = idempotencyKey('shared-event')
+
+            await service.claim('ns-a', key)
+            await service.ack('ns-a', key)
+            advanceTime(10)
+
+            expect(await service.claim('ns-b', key)).toBe(IdempotencyState.New)
+            expect(await service.claim('ns-a', key)).toBe(IdempotencyState.Acked)
+        })
+    })
+
+    describe('ackBatch', () => {
+        it('marks multiple keys as acked', async () => {
+            const keys = [idempotencyKey('a'), idempotencyKey('b'), idempotencyKey('c')]
+            const entries: [string, (typeof keys)[number]][] = keys.map((k) => [NS, k])
+            await service.claimBatch(entries)
+            await service.ackBatch(entries)
+            advanceTime(100)
+
+            const results = await service.claimBatch(entries)
+            for (const key of keys) {
+                expect(results!.get(key)).toBe(IdempotencyState.Acked)
+            }
+        })
+    })
+
+    describe('releaseBatch', () => {
+        it('makes multiple keys re-claimable', async () => {
+            const keys = [idempotencyKey('a'), idempotencyKey('b')]
+            const entries: [string, (typeof keys)[number]][] = keys.map((k) => [NS, k])
+            await service.claimBatch(entries)
+            await service.releaseBatch(entries)
+            advanceTime(100)
+
+            const results = await service.claimBatch(entries)
+            for (const key of keys) {
+                expect(results!.get(key)).toBe(IdempotencyState.New)
+            }
+        })
+    })
+
+    describe('touch behavior', () => {
+        it('refreshes score on existing entries to prevent eviction', async () => {
+            const smallService = new IdempotencyService(redis, { maxSize: 3 })
+            const ns = 'touch'
+
+            await smallService.claim(ns, idempotencyKey('A'))
+            advanceTime(100)
+            await smallService.claim(ns, idempotencyKey('B'))
+            advanceTime(100)
+            await smallService.claim(ns, idempotencyKey('C'))
+            advanceTime(100)
+
+            // Touch A by re-claiming (returns Existing but refreshes score)
+            expect(await smallService.claim(ns, idempotencyKey('A'))).toBe(IdempotencyState.Existing)
+            advanceTime(100)
+
+            // Add D — should evict B (oldest untouched), not A (recently touched)
+            await smallService.claim(ns, idempotencyKey('D'))
+            advanceTime(100)
+
+            // Check all at once via batch to avoid sequential claim side effects
+            const results = await smallService.claimBatch([
+                [ns, idempotencyKey('A')],
+                [ns, idempotencyKey('B')],
+                [ns, idempotencyKey('C')],
+                [ns, idempotencyKey('D')],
+            ])
+
+            expect(results!.get(idempotencyKey('A'))).toBe(IdempotencyState.Existing)
+            expect(results!.get(idempotencyKey('B'))).toBe(IdempotencyState.New) // evicted
+            expect(results!.get(idempotencyKey('C'))).toBe(IdempotencyState.Existing)
+            expect(results!.get(idempotencyKey('D'))).toBe(IdempotencyState.Existing)
+        })
+    })
+})

--- a/nodejs/src/common/services/idempotency.service.ts
+++ b/nodejs/src/common/services/idempotency.service.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'crypto'
+
+import { RedisV2 } from '../redis/redis-v2'
+
+// Branded type — callers must use idempotencyKey() to construct, can't pass raw strings
+export type IdempotencyKey = string & { readonly __brand: 'IdempotencyKey' }
+
+export function idempotencyKey(...parts: string[]): IdempotencyKey {
+    const hash = createHash('sha256').update(parts.join(':')).digest('hex').slice(0, 32)
+    return hash as IdempotencyKey
+}
+
+export enum IdempotencyState {
+    /** We claimed it — proceed with processing */
+    New = 'new',
+    /** Already exists but not acked — caller decides what to do */
+    Existing = 'existing',
+    /** Definitely processed — safe to skip */
+    Acked = 'acked',
+}
+
+// Scores below this threshold are claimed (score = unix timestamp in ms).
+// Scores at or above are acked (score = timestamp + offset).
+// This keeps acked entries at the top of the ZSET so they survive eviction longest.
+// Current ms timestamps are ~1.7e12, so 1e16 is safely above any real timestamp.
+const ACKED_SCORE_OFFSET = 1e16
+
+const BASE_REDIS_KEY = process.env.NODE_ENV === 'test' ? '@posthog-test/idempotency' : '@posthog/idempotency'
+
+export interface IdempotencyServiceConfig {
+    maxSize: number
+    /** TTL on the ZSET key itself as a safety net — refreshed on every operation (default 86400s / 24h) */
+    keyTtlSeconds?: number
+}
+
+export class IdempotencyService {
+    private readonly maxSize: number
+    private readonly keyTtlSeconds: number
+
+    constructor(
+        private redis: RedisV2,
+        config: IdempotencyServiceConfig
+    ) {
+        this.maxSize = config.maxSize
+        this.keyTtlSeconds = config.keyTtlSeconds ?? 86400
+    }
+
+    private redisKey(namespace: string): string {
+        return `${BASE_REDIS_KEY}:${namespace}`
+    }
+
+    async claim(namespace: string, key: IdempotencyKey): Promise<IdempotencyState | null> {
+        const result = await this.claimBatch([[namespace, key]])
+        return result?.get(key) ?? null
+    }
+
+    async ack(namespace: string, key: IdempotencyKey): Promise<void> {
+        await this.ackBatch([[namespace, key]])
+    }
+
+    async release(namespace: string, key: IdempotencyKey): Promise<void> {
+        await this.releaseBatch([[namespace, key]])
+    }
+
+    async claimBatch(
+        entries: [namespace: string, key: IdempotencyKey][]
+    ): Promise<Map<IdempotencyKey, IdempotencyState> | null> {
+        if (entries.length === 0) {
+            return new Map()
+        }
+
+        const now = Date.now()
+
+        // Pipeline 1: attempt claim (ZADD NX) + check state (ZSCORE) for each entry, then trim + expire per namespace
+        const namespacesUsed = new Set<string>()
+        const results = await this.redis.usePipeline({ name: 'idempotency-claim', failOpen: true }, (pipeline) => {
+            for (const [namespace, key] of entries) {
+                const zsetKey = this.redisKey(namespace)
+                pipeline.zadd(zsetKey, 'NX', now, key)
+                pipeline.zscore(zsetKey, key)
+                namespacesUsed.add(namespace)
+            }
+            for (const namespace of namespacesUsed) {
+                const zsetKey = this.redisKey(namespace)
+                pipeline.zremrangebyrank(zsetKey, 0, -(this.maxSize + 1))
+                pipeline.expire(zsetKey, this.keyTtlSeconds)
+            }
+        })
+
+        if (!results) {
+            return null
+        }
+
+        const states = new Map<IdempotencyKey, IdempotencyState>()
+        const toTouch: [string, IdempotencyKey][] = []
+
+        for (let i = 0; i < entries.length; i++) {
+            const [namespace, key] = entries[i]
+            const [, zaddResult] = results[i * 2]
+            const [, scoreResult] = results[i * 2 + 1]
+
+            if (zaddResult === 1) {
+                states.set(key, IdempotencyState.New)
+            } else {
+                const score = scoreResult !== null ? parseFloat(scoreResult) : 0
+                if (score >= ACKED_SCORE_OFFSET) {
+                    states.set(key, IdempotencyState.Acked)
+                } else {
+                    states.set(key, IdempotencyState.Existing)
+                    toTouch.push([namespace, key])
+                }
+            }
+        }
+
+        // Pipeline 2: touch existing non-acked entries to refresh their LRU position
+        if (toTouch.length > 0) {
+            await this.redis.usePipeline({ name: 'idempotency-touch', failOpen: true }, (pipeline) => {
+                for (const [namespace, key] of toTouch) {
+                    pipeline.zadd(this.redisKey(namespace), 'XX', now, key)
+                }
+            })
+        }
+
+        return states
+    }
+
+    async ackBatch(entries: [namespace: string, key: IdempotencyKey][]): Promise<void> {
+        if (entries.length === 0) {
+            return
+        }
+
+        const now = Date.now()
+        const ackScore = now + ACKED_SCORE_OFFSET
+
+        await this.redis.usePipeline({ name: 'idempotency-ack', failOpen: true }, (pipeline) => {
+            const namespacesUsed = new Set<string>()
+            for (const [namespace, key] of entries) {
+                pipeline.zadd(this.redisKey(namespace), 'XX', ackScore, key)
+                namespacesUsed.add(namespace)
+            }
+            for (const namespace of namespacesUsed) {
+                pipeline.expire(this.redisKey(namespace), this.keyTtlSeconds)
+            }
+        })
+    }
+
+    async releaseBatch(entries: [namespace: string, key: IdempotencyKey][]): Promise<void> {
+        if (entries.length === 0) {
+            return
+        }
+
+        await this.redis.usePipeline({ name: 'idempotency-release', failOpen: true }, (pipeline) => {
+            for (const [namespace, key] of entries) {
+                pipeline.zrem(this.redisKey(namespace), key)
+            }
+        })
+    }
+}

--- a/nodejs/src/common/services/idempotency.service.ts
+++ b/nodejs/src/common/services/idempotency.service.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto'
+import { Counter, Histogram } from 'prom-client'
 
 import { RedisV2 } from '../redis/redis-v2'
 
@@ -26,6 +27,25 @@ export enum IdempotencyState {
 const ACKED_SCORE_OFFSET = 1e16
 
 const BASE_REDIS_KEY = process.env.NODE_ENV === 'test' ? '@posthog-test/idempotency' : '@posthog/idempotency'
+
+const idempotencyClaimResults = new Counter({
+    name: 'idempotency_claim_results_total',
+    help: 'Count of claim results by state and namespace',
+    labelNames: ['state', 'namespace'],
+})
+
+const idempotencyOperationDuration = new Histogram({
+    name: 'idempotency_operation_duration_ms',
+    help: 'Duration of idempotency operations in ms',
+    labelNames: ['operation', 'namespace'],
+    buckets: [0.5, 1, 2, 5, 10, 20, 50, 100],
+})
+
+const idempotencyErrors = new Counter({
+    name: 'idempotency_errors_total',
+    help: 'Count of idempotency operations that failed (Redis unavailable)',
+    labelNames: ['operation', 'namespace'],
+})
 
 export interface IdempotencyServiceConfig {
     maxSize: number
@@ -69,6 +89,7 @@ export class IdempotencyService {
             return new Map()
         }
 
+        const startTime = performance.now()
         const now = Date.now()
 
         // Pipeline 1: attempt claim (ZADD NX) + check state (ZSCORE) for each entry, then trim + expire per namespace
@@ -88,6 +109,9 @@ export class IdempotencyService {
         })
 
         if (!results) {
+            for (const ns of namespacesUsed) {
+                idempotencyErrors.inc({ operation: 'claim', namespace: ns })
+            }
             return null
         }
 
@@ -101,12 +125,15 @@ export class IdempotencyService {
 
             if (zaddResult === 1) {
                 states.set(key, IdempotencyState.New)
+                idempotencyClaimResults.inc({ state: 'new', namespace })
             } else {
                 const score = scoreResult !== null ? parseFloat(scoreResult) : 0
                 if (score >= ACKED_SCORE_OFFSET) {
                     states.set(key, IdempotencyState.Acked)
+                    idempotencyClaimResults.inc({ state: 'acked', namespace })
                 } else {
                     states.set(key, IdempotencyState.Existing)
+                    idempotencyClaimResults.inc({ state: 'existing', namespace })
                     toTouch.push([namespace, key])
                 }
             }
@@ -121,6 +148,10 @@ export class IdempotencyService {
             })
         }
 
+        for (const ns of namespacesUsed) {
+            idempotencyOperationDuration.observe({ operation: 'claim', namespace: ns }, performance.now() - startTime)
+        }
+
         return states
     }
 
@@ -129,11 +160,12 @@ export class IdempotencyService {
             return
         }
 
+        const startTime = performance.now()
         const now = Date.now()
         const ackScore = now + ACKED_SCORE_OFFSET
+        const namespacesUsed = new Set<string>()
 
-        await this.redis.usePipeline({ name: 'idempotency-ack', failOpen: true }, (pipeline) => {
-            const namespacesUsed = new Set<string>()
+        const results = await this.redis.usePipeline({ name: 'idempotency-ack', failOpen: true }, (pipeline) => {
             for (const [namespace, key] of entries) {
                 pipeline.zadd(this.redisKey(namespace), 'XX', ackScore, key)
                 namespacesUsed.add(namespace)
@@ -142,6 +174,14 @@ export class IdempotencyService {
                 pipeline.expire(this.redisKey(namespace), this.keyTtlSeconds)
             }
         })
+
+        for (const ns of namespacesUsed) {
+            if (!results) {
+                idempotencyErrors.inc({ operation: 'ack', namespace: ns })
+            } else {
+                idempotencyOperationDuration.observe({ operation: 'ack', namespace: ns }, performance.now() - startTime)
+            }
+        }
     }
 
     async releaseBatch(entries: [namespace: string, key: IdempotencyKey][]): Promise<void> {
@@ -149,10 +189,25 @@ export class IdempotencyService {
             return
         }
 
-        await this.redis.usePipeline({ name: 'idempotency-release', failOpen: true }, (pipeline) => {
+        const startTime = performance.now()
+        const namespacesUsed = new Set<string>()
+
+        const results = await this.redis.usePipeline({ name: 'idempotency-release', failOpen: true }, (pipeline) => {
             for (const [namespace, key] of entries) {
                 pipeline.zrem(this.redisKey(namespace), key)
+                namespacesUsed.add(namespace)
             }
         })
+
+        for (const ns of namespacesUsed) {
+            if (!results) {
+                idempotencyErrors.inc({ operation: 'release', namespace: ns })
+            } else {
+                idempotencyOperationDuration.observe(
+                    { operation: 'release', namespace: ns },
+                    performance.now() - startTime
+                )
+            }
+        }
     }
 }

--- a/nodejs/src/common/services/idempotency.service.ts
+++ b/nodejs/src/common/services/idempotency.service.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto'
 import { Counter, Histogram } from 'prom-client'
 
+import { LazyLoader } from '../../utils/lazy-loader'
 import { RedisV2 } from '../redis/redis-v2'
 
 // Branded type — callers must use idempotencyKey() to construct, can't pass raw strings
@@ -28,6 +29,8 @@ const ACKED_SCORE_OFFSET = 1e16
 
 const BASE_REDIS_KEY = process.env.NODE_ENV === 'test' ? '@posthog-test/idempotency' : '@posthog/idempotency'
 
+const KEY_SEPARATOR = '\0'
+
 const idempotencyClaimResults = new Counter({
     name: 'idempotency_claim_results_total',
     help: 'Count of claim results by state and namespace',
@@ -47,15 +50,27 @@ const idempotencyErrors = new Counter({
     labelNames: ['operation', 'namespace'],
 })
 
+function encodeEntry(namespace: string, key: IdempotencyKey): string {
+    return `${namespace}${KEY_SEPARATOR}${key}`
+}
+
+function decodeEntry(encoded: string): [string, IdempotencyKey] {
+    const idx = encoded.indexOf(KEY_SEPARATOR)
+    return [encoded.substring(0, idx), encoded.substring(idx + 1) as IdempotencyKey]
+}
+
 export interface IdempotencyServiceConfig {
     maxSize: number
     /** TTL on the ZSET key itself as a safety net — refreshed on every operation (default 86400s / 24h) */
     keyTtlSeconds?: number
+    /** How long to buffer claim calls before flushing as a batch (default 0 = next tick) */
+    bufferMs?: number
 }
 
 export class IdempotencyService {
     private readonly maxSize: number
     private readonly keyTtlSeconds: number
+    private readonly claimLoader: LazyLoader<IdempotencyState>
 
     constructor(
         private redis: RedisV2,
@@ -63,6 +78,14 @@ export class IdempotencyService {
     ) {
         this.maxSize = config.maxSize
         this.keyTtlSeconds = config.keyTtlSeconds ?? 86400
+
+        this.claimLoader = new LazyLoader<IdempotencyState>({
+            name: 'idempotency-claim',
+            loader: (encodedKeys) => this.loadClaims(encodedKeys),
+            refreshAgeMs: 0,
+            refreshJitterMs: 0,
+            bufferMs: config.bufferMs ?? 0,
+        })
     }
 
     private redisKey(namespace: string): string {
@@ -70,8 +93,14 @@ export class IdempotencyService {
     }
 
     async claim(namespace: string, key: IdempotencyKey): Promise<IdempotencyState | null> {
-        const result = await this.claimBatch([[namespace, key]])
-        return result?.get(key) ?? null
+        const encoded = encodeEntry(namespace, key)
+        try {
+            const result = await this.claimLoader.get(encoded)
+            this.claimLoader.markForRefresh(encoded)
+            return result
+        } catch {
+            return null
+        }
     }
 
     async ack(namespace: string, key: IdempotencyKey): Promise<void> {
@@ -89,70 +118,23 @@ export class IdempotencyService {
             return new Map()
         }
 
-        const startTime = performance.now()
-        const now = Date.now()
+        const encoded = entries.map(([ns, key]) => encodeEntry(ns, key))
 
-        // Pipeline 1: attempt claim (ZADD NX) + check state (ZSCORE) for each entry, then trim + expire per namespace
-        const namespacesUsed = new Set<string>()
-        const results = await this.redis.usePipeline({ name: 'idempotency-claim', failOpen: true }, (pipeline) => {
-            for (const [namespace, key] of entries) {
-                const zsetKey = this.redisKey(namespace)
-                pipeline.zadd(zsetKey, 'NX', now, key)
-                pipeline.zscore(zsetKey, key)
-                namespacesUsed.add(namespace)
-            }
-            for (const namespace of namespacesUsed) {
-                const zsetKey = this.redisKey(namespace)
-                pipeline.zremrangebyrank(zsetKey, 0, -(this.maxSize + 1))
-                pipeline.expire(zsetKey, this.keyTtlSeconds)
-            }
-        })
+        try {
+            const results = await this.claimLoader.getMany(encoded)
+            this.claimLoader.markForRefresh(encoded)
 
-        if (!results) {
-            for (const ns of namespacesUsed) {
-                idempotencyErrors.inc({ operation: 'claim', namespace: ns })
+            const states = new Map<IdempotencyKey, IdempotencyState>()
+            for (let i = 0; i < entries.length; i++) {
+                const state = results[encoded[i]]
+                if (state !== null && state !== undefined) {
+                    states.set(entries[i][1], state)
+                }
             }
+            return states
+        } catch {
             return null
         }
-
-        const states = new Map<IdempotencyKey, IdempotencyState>()
-        const toTouch: [string, IdempotencyKey][] = []
-
-        for (let i = 0; i < entries.length; i++) {
-            const [namespace, key] = entries[i]
-            const [, zaddResult] = results[i * 2]
-            const [, scoreResult] = results[i * 2 + 1]
-
-            if (zaddResult === 1) {
-                states.set(key, IdempotencyState.New)
-                idempotencyClaimResults.inc({ state: 'new', namespace })
-            } else {
-                const score = scoreResult !== null ? parseFloat(scoreResult) : 0
-                if (score >= ACKED_SCORE_OFFSET) {
-                    states.set(key, IdempotencyState.Acked)
-                    idempotencyClaimResults.inc({ state: 'acked', namespace })
-                } else {
-                    states.set(key, IdempotencyState.Existing)
-                    idempotencyClaimResults.inc({ state: 'existing', namespace })
-                    toTouch.push([namespace, key])
-                }
-            }
-        }
-
-        // Pipeline 2: touch existing non-acked entries to refresh their LRU position
-        if (toTouch.length > 0) {
-            await this.redis.usePipeline({ name: 'idempotency-touch', failOpen: true }, (pipeline) => {
-                for (const [namespace, key] of toTouch) {
-                    pipeline.zadd(this.redisKey(namespace), 'XX', now, key)
-                }
-            })
-        }
-
-        for (const ns of namespacesUsed) {
-            idempotencyOperationDuration.observe({ operation: 'claim', namespace: ns }, performance.now() - startTime)
-        }
-
-        return states
     }
 
     async ackBatch(entries: [namespace: string, key: IdempotencyKey][]): Promise<void> {
@@ -182,6 +164,8 @@ export class IdempotencyService {
                 idempotencyOperationDuration.observe({ operation: 'ack', namespace: ns }, performance.now() - startTime)
             }
         }
+
+        this.claimLoader.markForRefresh(entries.map(([ns, key]) => encodeEntry(ns, key)))
     }
 
     async releaseBatch(entries: [namespace: string, key: IdempotencyKey][]): Promise<void> {
@@ -209,5 +193,76 @@ export class IdempotencyService {
                 )
             }
         }
+
+        this.claimLoader.markForRefresh(entries.map(([ns, key]) => encodeEntry(ns, key)))
+    }
+
+    private async loadClaims(encodedKeys: string[]): Promise<Record<string, IdempotencyState | null | undefined>> {
+        const entries = encodedKeys.map(decodeEntry)
+        const startTime = performance.now()
+        const now = Date.now()
+
+        const namespacesUsed = new Set<string>()
+        const results = await this.redis.usePipeline({ name: 'idempotency-claim', failOpen: true }, (pipeline) => {
+            for (const [namespace, key] of entries) {
+                const zsetKey = this.redisKey(namespace)
+                pipeline.zadd(zsetKey, 'NX', now, key)
+                pipeline.zscore(zsetKey, key)
+                namespacesUsed.add(namespace)
+            }
+            for (const namespace of namespacesUsed) {
+                const zsetKey = this.redisKey(namespace)
+                pipeline.zremrangebyrank(zsetKey, 0, -(this.maxSize + 1))
+                pipeline.expire(zsetKey, this.keyTtlSeconds)
+            }
+        })
+
+        if (!results) {
+            for (const ns of namespacesUsed) {
+                idempotencyErrors.inc({ operation: 'claim', namespace: ns })
+            }
+            throw new Error('Redis unavailable for idempotency claim')
+        }
+
+        const states: Record<string, IdempotencyState> = {}
+        const toTouch: [string, IdempotencyKey][] = []
+
+        for (let i = 0; i < entries.length; i++) {
+            const [namespace, key] = entries[i]
+            const [, zaddResult] = results[i * 2]
+            const [, scoreResult] = results[i * 2 + 1]
+
+            let state: IdempotencyState
+            if (zaddResult === 1) {
+                state = IdempotencyState.New
+                idempotencyClaimResults.inc({ state: 'new', namespace })
+            } else {
+                const score = scoreResult !== null ? parseFloat(scoreResult) : 0
+                if (score >= ACKED_SCORE_OFFSET) {
+                    state = IdempotencyState.Acked
+                    idempotencyClaimResults.inc({ state: 'acked', namespace })
+                } else {
+                    state = IdempotencyState.Existing
+                    idempotencyClaimResults.inc({ state: 'existing', namespace })
+                    toTouch.push([namespace, key])
+                }
+            }
+            states[encodedKeys[i]] = state
+        }
+
+        // Touch existing non-acked entries to refresh their LRU position
+        if (toTouch.length > 0) {
+            await this.redis.usePipeline({ name: 'idempotency-touch', failOpen: true }, (pipeline) => {
+                for (const [namespace, key] of toTouch) {
+                    pipeline.zadd(this.redisKey(namespace), 'XX', now, key)
+                }
+            })
+        }
+
+        for (const ns of namespacesUsed) {
+            idempotencyOperationDuration.observe({ operation: 'claim', namespace: ns }, performance.now() - startTime)
+        }
+
+        return states
     }
 }


### PR DESCRIPTION
## Problem

We discussed needing this to give us better resilience in our distributed systems, especially when working with batch systems such as the CDP backfilling logic.

It's not complete, it was just a quick PoC of what could work for us whilst I was waiting on something else. 

## Changes

* Adds a generic, best-effort idempotency service backed by Redis ZSETs for short-lived retry deduplication
* Designed for services like webhook delivery and event processing that need to avoid duplicate work during retries, without requiring perfect guarantees
* Bounded memory per namespace via configurable maxSize with LRU eviction — no unbounded key growth

**How it works**
Each namespace maps to a single Redis ZSET. The ZSET score encodes both recency (for LRU eviction) and state (claimed vs acked, using a score offset). This means:

* ZADD NX provides atomic claiming — exactly one worker wins
* Checking a key refreshes its score (LRU touch), keeping active keys alive
* Acked entries get high scores so they survive eviction longer than unclaimed entries
* ZREMRANGEBYRANK trims to maxSize after each batch, keeping memory bounded
* All operations fail-open — if Redis is down, callers get null and decide what to do

Batch operations pipeline across multiple namespaces in 1-2 Redis round-trips. A branded IdempotencyKey type with SHA-256 hashing ensures consistent key sizes and prevents passing raw strings.


## TODO

- [ ] Validate the underlying data really makes sense for this and the limits are sane
- [ ] Implement it somewhere in the code behind a flag so that we can test it
- [ ] Dedicated redis for this? (Also allows us to service-ify it in the future)
- [ ] Swap to a LazyLoader to simplify the loading code for the callers

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
