### PR TITLE
feat(mcp): Use posthog user agent for all MCP requests

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -142,20 +142,26 @@ export class ApiClient {
         this.generated = createApiClient(buildApiFetcher(this.config), this.baseUrl)
     }
 
-    private buildHeaders(): Record<string, string> {
-        return {
-            Authorization: `Bearer ${this.config.apiToken}`,
-            'Content-Type': 'application/json',
-            'User-Agent': USER_AGENT,
-        }
-    }
-
     getProjectBaseUrl(projectId: string): string {
         if (projectId === '@current') {
             return this.baseUrl
         }
 
         return `${this.baseUrl}/project/${projectId}`
+    }
+
+    private async fetch(url: string, options?: RequestInit): Promise<Response> {
+        // TODO: should we move rate limiting from `fetchWithSchema` to here?
+        const contentType = options?.body ? 'application/json' : undefined
+        return fetch(url, {
+            ...options,
+            headers: {
+                Authorization: `Bearer ${this.config.apiToken}`,
+                'Content-Type': contentType,
+                'User-Agent': USER_AGENT,
+                ...options?.headers,
+            },
+        })
     }
 
     private async fetchWithSchema<T>(url: string, schema: z.ZodType<T>, options?: RequestInit): Promise<Result<T>> {
@@ -168,13 +174,7 @@ export class ApiClient {
                 // Apply rate limiting before making the request
                 await globalRateLimiter.throttle()
 
-                const response = await fetch(url, {
-                    ...options,
-                    headers: {
-                        ...this.buildHeaders(),
-                        ...options?.headers,
-                    },
-                })
+                const response = await this.fetch(url, options)
 
                 // Handle rate limiting with exponential backoff
                 if (response.status === 429) {
@@ -367,11 +367,7 @@ export class ApiClient {
 
                     const url = `${this.baseUrl}/api/projects/${projectId}/property_definitions/?${searchParams}`
 
-                    const response = await fetch(url, {
-                        headers: {
-                            Authorization: `Bearer ${this.config.apiToken}`,
-                        },
-                    })
+                    const response = await this.fetch(url)
 
                     if (!response.ok) {
                         throw new Error(`Failed to fetch property definitions: ${response.statusText}`)
@@ -411,11 +407,7 @@ export class ApiClient {
 
                     const requestUrl = `${this.baseUrl}/api/projects/${projectId}/event_definitions/?${searchParams}`
 
-                    const response = await fetch(requestUrl, {
-                        headers: {
-                            Authorization: `Bearer ${this.config.apiToken}`,
-                        },
-                    })
+                    const response = await this.fetch(requestUrl)
 
                     if (!response.ok) {
                         throw new Error(`Failed to fetch event definitions: ${response.statusText}`)
@@ -450,11 +442,7 @@ export class ApiClient {
                     const searchParams = new URLSearchParams({ name: eventName })
                     const findUrl = `${this.baseUrl}/api/projects/${projectId}/event_definitions/by_name/?${searchParams}`
 
-                    const findResponse = await fetch(findUrl, {
-                        headers: {
-                            Authorization: `Bearer ${this.config.apiToken}`,
-                        },
-                    })
+                    const findResponse = await this.fetch(findUrl)
 
                     if (findResponse.status === 404) {
                         return {
@@ -473,12 +461,8 @@ export class ApiClient {
                     // Updating the event definition by ID
                     const updateUrl = `${this.baseUrl}/api/projects/${projectId}/event_definitions/${parsedEventDef.id}/`
 
-                    const updateResponse = await fetch(updateUrl, {
+                    const updateResponse = await this.fetch(updateUrl, {
                         method: 'PATCH',
-                        headers: {
-                            Authorization: `Bearer ${this.config.apiToken}`,
-                            'Content-Type': 'application/json',
-                        },
                         body: JSON.stringify(data),
                     })
 
@@ -785,11 +769,10 @@ export class ApiClient {
                 experimentId: number
             }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
-                    const deleteResponse = await fetch(
+                    const deleteResponse = await this.fetch(
                         `${this.baseUrl}/api/projects/${projectId}/experiments/${experimentId}/`,
                         {
                             method: 'PATCH',
-                            headers: this.buildHeaders(),
                             body: JSON.stringify({ deleted: true }),
                         }
                     )
@@ -932,11 +915,13 @@ export class ApiClient {
 
             delete: async ({ flagId }: { flagId: number }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
-                    const response = await fetch(`${this.baseUrl}/api/projects/${projectId}/feature_flags/${flagId}/`, {
-                        method: 'PATCH',
-                        headers: this.buildHeaders(),
-                        body: JSON.stringify({ deleted: true }),
-                    })
+                    const response = await this.fetch(
+                        `${this.baseUrl}/api/projects/${projectId}/feature_flags/${flagId}/`,
+                        {
+                            method: 'PATCH',
+                            body: JSON.stringify({ deleted: true }),
+                        }
+                    )
 
                     if (!response.ok) {
                         throw new Error(`Failed to delete feature flag: ${response.statusText}`)
@@ -1044,11 +1029,13 @@ export class ApiClient {
                 insightId: number
             }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
-                    const response = await fetch(`${this.baseUrl}/api/projects/${projectId}/insights/${insightId}/`, {
-                        method: 'PATCH',
-                        headers: this.buildHeaders(),
-                        body: JSON.stringify({ deleted: true }),
-                    })
+                    const response = await this.fetch(
+                        `${this.baseUrl}/api/projects/${projectId}/insights/${insightId}/`,
+                        {
+                            method: 'PATCH',
+                            body: JSON.stringify({ deleted: true }),
+                        }
+                    )
 
                     if (!response.ok) {
                         throw new Error(`Failed to delete insight: ${response.statusText}`)
@@ -1212,11 +1199,10 @@ export class ApiClient {
                 dashboardId: number
             }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
-                    const response = await fetch(
+                    const response = await this.fetch(
                         `${this.baseUrl}/api/projects/${projectId}/dashboards/${dashboardId}/`,
                         {
                             method: 'PATCH',
-                            headers: this.buildHeaders(),
                             body: JSON.stringify({ deleted: true }),
                         }
                     )
@@ -1431,14 +1417,13 @@ export class ApiClient {
                 try {
                     const fetchOptions: RequestInit = {
                         method: softDelete ? 'PATCH' : 'DELETE',
-                        headers: this.buildHeaders(),
                     }
 
                     if (softDelete) {
                         fetchOptions.body = JSON.stringify({ archived: true })
                     }
 
-                    const response = await fetch(
+                    const response = await this.fetch(
                         `${this.baseUrl}/api/projects/${projectId}/surveys/${surveyId}/`,
                         fetchOptions
                     )
@@ -1640,10 +1625,12 @@ export class ApiClient {
             }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
                     // First fetch the action to get its name (required by backend validation)
-                    const getResponse = await fetch(`${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`, {
-                        method: 'GET',
-                        headers: this.buildHeaders(),
-                    })
+                    const getResponse = await this.fetch(
+                        `${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`,
+                        {
+                            method: 'GET',
+                        }
+                    )
 
                     if (!getResponse.ok) {
                         throw new Error(`Failed to fetch action: ${getResponse.statusText}`)
@@ -1651,11 +1638,13 @@ export class ApiClient {
 
                     const action = (await getResponse.json()) as { name: string }
 
-                    const response = await fetch(`${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`, {
-                        method: 'PATCH',
-                        headers: this.buildHeaders(),
-                        body: JSON.stringify({ name: action.name, deleted: true }),
-                    })
+                    const response = await this.fetch(
+                        `${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`,
+                        {
+                            method: 'PATCH',
+                            body: JSON.stringify({ name: action.name, deleted: true }),
+                        }
+                    )
 
                     if (!response.ok) {
                         throw new Error(`Failed to delete action: ${response.statusText}`)

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -152,13 +152,17 @@ export class ApiClient {
 
     private async fetch(url: string, options?: RequestInit): Promise<Response> {
         // TODO: should we move rate limiting from `fetchWithSchema` to here?
-        const contentType = options?.body ? 'application/json' : undefined
+        const defaultHeaders: HeadersInit = {
+            Authorization: `Bearer ${this.config.apiToken}`,
+            'User-Agent': USER_AGENT,
+        }
+        if (options?.body) {
+            defaultHeaders['Content-Type'] = 'application/json'
+        }
         return fetch(url, {
             ...options,
             headers: {
-                Authorization: `Bearer ${this.config.apiToken}`,
-                'Content-Type': contentType,
-                'User-Agent': USER_AGENT,
+                ...defaultHeaders,
                 ...options?.headers,
             },
         })


### PR DESCRIPTION
## Problem

The user agent is picked up and used when reporting what the source of an action (e.g. creating a dashboard) is.

The problem is that not all MCP requests set the user agent

## Changes

Ensure that all fetch() calls in the MCP code go via a code path that sets the correct user agent

## How did you test this code?

Tests still pass!

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
