### PR TITLE
feat: add table of SCIM provisioned users to Django user page

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -15,6 +15,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
 from posthog.admin.inlines.personal_api_key_inline import PersonalAPIKeyInline
+from posthog.admin.inlines.scim_provisioned_user_inline import SCIMProvisionedUserInline
 from posthog.admin.inlines.totp_device_inline import TOTPDeviceInline
 from posthog.admin.inlines.user_social_auth_inline import UserSocialAuthInline
 from posthog.api.authentication import password_reset_token_generator
@@ -56,7 +57,13 @@ class UserAdmin(DjangoUserAdmin):
     change_password_form = None  # This view is not exposed in our subclass of UserChangeForm
     change_form_template = "admin/posthog/user/change_form.html"
 
-    inlines = [OrganizationMemberInline, PersonalAPIKeyInline, TOTPDeviceInline, UserSocialAuthInline]
+    inlines = [
+        OrganizationMemberInline,
+        PersonalAPIKeyInline,
+        TOTPDeviceInline,
+        UserSocialAuthInline,
+        SCIMProvisionedUserInline,
+    ]
     fieldsets = (
         (
             None,

--- a/posthog/admin/inlines/scim_provisioned_user_inline.py
+++ b/posthog/admin/inlines/scim_provisioned_user_inline.py
@@ -1,0 +1,28 @@
+from django.contrib import admin
+
+from ee.models.scim_provisioned_user import SCIMProvisionedUser
+
+
+class SCIMProvisionedUserInline(admin.TabularInline):
+    """
+    Inline table for SCIMProvisionedUser records on the User admin page.
+    Shows SCIM provisioning details and allows deletion.
+    """
+
+    model = SCIMProvisionedUser
+    extra = 0
+    fields = ("organization_domain", "identity_provider", "username", "active", "created_at")
+    readonly_fields = ("organization_domain", "identity_provider", "username", "active", "created_at")
+    can_delete = True
+    show_change_link = False
+    verbose_name = "SCIM provisioned user"
+    verbose_name_plural = "SCIM provisioned users"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return True


### PR DESCRIPTION
## Problem

No way to check SCIM provisioning details in Django admin when debugging provisioning issues.

Context: https://posthoghelp.zendesk.com/agent/tickets/51308 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54766)

## Changes
Added SCIMProvisionedUserInline to User admin showing: organization domain, identity provider, username, active status, created_at. Read-only with delete option.


![Screenshot 2026-02-24 at 17.39.46.png](https://app.graphite.com/user-attachments/assets/2ea43aa4-4aa0-46fe-8052-fe291bc6687d.png)

## Publish to changelog?

No