### PR TITLE
feat(dwh): nullable incremental field warning

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
+import { IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonModal, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { useFloatingContainer } from 'lib/hooks/useFloatingContainerContext'
@@ -119,12 +120,19 @@ export default function SchemaForm(): JSX.Element {
 
                                         if (field) {
                                             return (
-                                                <>
+                                                <div className="flex items-center justify-end">
+                                                    {field.nullable && (
+                                                        <Tooltip
+                                                            title={`This field is nullable. Any rows where ${field.label} is null will not be synced.`}
+                                                        >
+                                                            <IconWarning className="mr-1 text-warning text-xl" />
+                                                        </Tooltip>
+                                                    )}
                                                     <span className="leading-5">{field.label}</span>
                                                     <LemonTag className="ml-2" type="success">
                                                         {field.type}
                                                     </LemonTag>
-                                                </>
+                                                </div>
                                             )
                                         }
                                     }

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { LemonButton, LemonSelect, LemonTag, lemonToast } from '@posthog/lemon-ui'
 
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 
 import { ExternalDataSourceSyncSchema } from '~/types'
@@ -139,23 +140,34 @@ export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }:
                                     such as a <code>updated_at</code> timestamp.
                                 </p>
                                 {!incrementalSyncSupported.disabled && (
-                                    <LemonSelect
-                                        value={incrementalFieldValue}
-                                        onChange={(newValue) => setIncrementalFieldValue(newValue)}
-                                        options={
-                                            schema.incremental_fields.map((n) => ({
-                                                value: n.field,
-                                                label: (
-                                                    <>
-                                                        <span className="leading-5">{n.label}</span>
-                                                        <LemonTag className="ml-2" type="success">
-                                                            {n.type}
-                                                        </LemonTag>
-                                                    </>
-                                                ),
-                                            })) ?? []
-                                        }
-                                    />
+                                    <>
+                                        <LemonSelect
+                                            value={incrementalFieldValue}
+                                            onChange={(newValue) => setIncrementalFieldValue(newValue)}
+                                            options={
+                                                schema.incremental_fields.map((n) => ({
+                                                    value: n.field,
+                                                    label: (
+                                                        <>
+                                                            <span className="leading-5">{n.label}</span>
+                                                            <LemonTag className="ml-2" type="success">
+                                                                {n.type}
+                                                            </LemonTag>
+                                                        </>
+                                                    ),
+                                                })) ?? []
+                                            }
+                                        />
+                                        {radioValue === 'incremental' &&
+                                            incrementalFieldValue &&
+                                            schema.incremental_fields.find((n) => n.field === incrementalFieldValue)
+                                                ?.nullable && (
+                                                <LemonBanner type="warning" className="mt-2">
+                                                    This field is nullable. Any rows where{' '}
+                                                    <code>{incrementalFieldValue}</code> is null will not be synced.
+                                                </LemonBanner>
+                                            )}
+                                    </>
                                 )}
                             </div>
                         ),
@@ -182,23 +194,34 @@ export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }:
                                     <code>created_at</code> timestamp.
                                 </p>
                                 {!appendSyncSupported.disabled && (
-                                    <LemonSelect
-                                        value={appendFieldValue}
-                                        onChange={(newValue) => setAppendFieldValue(newValue)}
-                                        options={
-                                            schema.incremental_fields.map((n) => ({
-                                                value: n.field,
-                                                label: (
-                                                    <>
-                                                        <span className="leading-5">{n.label}</span>
-                                                        <LemonTag className="ml-2" type="success">
-                                                            {n.type}
-                                                        </LemonTag>
-                                                    </>
-                                                ),
-                                            })) ?? []
-                                        }
-                                    />
+                                    <>
+                                        <LemonSelect
+                                            value={appendFieldValue}
+                                            onChange={(newValue) => setAppendFieldValue(newValue)}
+                                            options={
+                                                schema.incremental_fields.map((n) => ({
+                                                    value: n.field,
+                                                    label: (
+                                                        <>
+                                                            <span className="leading-5">{n.label}</span>
+                                                            <LemonTag className="ml-2" type="success">
+                                                                {n.type}
+                                                            </LemonTag>
+                                                        </>
+                                                    ),
+                                                })) ?? []
+                                            }
+                                        />
+                                        {radioValue === 'append' &&
+                                            appendFieldValue &&
+                                            schema.incremental_fields.find((n) => n.field === appendFieldValue)
+                                                ?.nullable && (
+                                                <LemonBanner type="warning" className="mt-2">
+                                                    This field is nullable. Any rows where{' '}
+                                                    <code>{appendFieldValue}</code> is null will not be synced.
+                                                </LemonBanner>
+                                            )}
+                                    </>
                                 )}
                             </div>
                         ),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5410,6 +5410,7 @@ export interface IncrementalField {
     type: IncrementalFieldType // the field type shown in the UI
     field: string // the actual database field name
     field_type: IncrementalFieldType // the actual database field type
+    nullable?: boolean // whether the field allows null values
 }
 
 export interface ExternalDataSourceSyncSchema {

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -60,8 +60,14 @@ class BigQuerySource(SimpleSource[BigQuerySourceConfig]):
                 supports_incremental=len(columns) > 0,
                 supports_append=len(columns) > 0,
                 incremental_fields=[
-                    {"label": column_name, "type": column_type, "field": column_name, "field_type": column_type}
-                    for column_name, column_type in columns
+                    {
+                        "label": column_name,
+                        "type": column_type,
+                        "field": column_name,
+                        "field_type": column_type,
+                        "nullable": nullable,
+                    }
+                    for column_name, column_type, nullable in columns
                 ],
             )
             for table_name, columns in filtered_results

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -113,17 +113,16 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
             )
 
         for table_name, columns in db_schemas.items():
-            column_info = [(col_name, col_type) for col_name, col_type in columns]
-
-            incremental_field_tuples = filter_mssql_incremental_fields(column_info)
+            incremental_field_tuples = filter_mssql_incremental_fields(columns)
             incremental_fields: list[IncrementalField] = [
                 {
                     "label": field_name,
                     "type": field_type,
                     "field": field_name,
                     "field_type": field_type,
+                    "nullable": nullable,
                 }
-                for field_name, field_type in incremental_field_tuples
+                for field_name, field_type, nullable in incremental_field_tuples
             ]
 
             schemas.append(

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -126,17 +126,16 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
             )
 
         for table_name, columns in db_schemas.items():
-            column_info = [(col_name, col_type) for col_name, col_type in columns]
-
-            incremental_field_tuples = filter_mysql_incremental_fields(column_info)
+            incremental_field_tuples = filter_mysql_incremental_fields(columns)
             incremental_fields: list[IncrementalField] = [
                 {
                     "label": field_name,
                     "type": field_type,
                     "field": field_name,
                     "field_type": field_type,
+                    "nullable": nullable,
                 }
-                for field_name, field_type in incremental_field_tuples
+                for field_name, field_type, nullable in incremental_field_tuples
             ]
 
             schemas.append(

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -171,17 +171,16 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                 row_counts = {}
 
         for table_name, columns in db_schemas.items():
-            column_info = [(col_name, col_type) for col_name, col_type in columns]
-
-            incremental_field_tuples = filter_postgres_incremental_fields(column_info)
+            incremental_field_tuples = filter_postgres_incremental_fields(columns)
             incremental_fields: list[IncrementalField] = [
                 {
                     "label": field_name,
                     "type": field_type,
                     "field": field_name,
                     "field_type": field_type,
+                    "nullable": nullable,
                 }
-                for field_name, field_type in incremental_field_tuples
+                for field_name, field_type, nullable in incremental_field_tuples
             ]
 
             schemas.append(

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -161,17 +161,16 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
                 row_counts = {}
 
         for table_name, columns in db_schemas.items():
-            column_info = [(col_name, col_type) for col_name, col_type in columns]
-
-            incremental_field_tuples = filter_redshift_incremental_fields(column_info)
+            incremental_field_tuples = filter_redshift_incremental_fields(columns)
             incremental_fields: list[IncrementalField] = [
                 {
                     "label": field_name,
                     "type": field_type,
                     "field": field_name,
                     "field_type": field_type,
+                    "nullable": nullable,
                 }
-                for field_name, field_type in incremental_field_tuples
+                for field_name, field_type, nullable in incremental_field_tuples
             ]
 
             schemas.append(

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -168,17 +168,16 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
         db_schemas = get_snowflake_schemas(config)
 
         for table_name, columns in db_schemas.items():
-            column_info = [(col_name, col_type) for col_name, col_type in columns]
-
-            incremental_field_tuples = filter_snowflake_incremental_fields(column_info)
+            incremental_field_tuples = filter_snowflake_incremental_fields(columns)
             incremental_fields: list[IncrementalField] = [
                 {
                     "label": field_name,
                     "type": field_type,
                     "field": field_name,
                     "field_type": field_type,
+                    "nullable": nullable,
                 }
-                for field_name, field_type in incremental_field_tuples
+                for field_name, field_type, nullable in incremental_field_tuples
             ]
 
             schemas.append(

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -181,7 +181,9 @@ class TestExternalDataSchema(APIBaseTest):
         payload = response.json()
 
         assert payload == {
-            "incremental_fields": [{"label": "id", "type": "integer", "field": "id", "field_type": "integer"}],
+            "incremental_fields": [
+                {"label": "id", "type": "integer", "field": "id", "field_type": "integer", "nullable": True}
+            ],
             "incremental_available": True,
             "append_available": True,
             "full_refresh_available": True,

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -450,7 +450,7 @@ class TestExternalDataSource(APIBaseTest):
         with patch(
             "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
         ) as mocked_get_bigquery_schemas:
-            mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE")]}
+            mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE", False)]}
 
             response = self.client.post(
                 f"/api/environments/{self.team.pk}/external_data_sources/",
@@ -796,7 +796,7 @@ class TestExternalDataSource(APIBaseTest):
 
     @patch(
         "posthog.temporal.data_imports.sources.postgres.source.get_postgres_schemas",
-        return_value={"table_1": [("id", "integer")]},
+        return_value={"table_1": [("id", "integer", True)]},
     )
     @patch(
         "posthog.temporal.data_imports.sources.postgres.source.get_postgres_row_count",
@@ -828,7 +828,9 @@ class TestExternalDataSource(APIBaseTest):
                     "table": "table_1",
                     "should_sync": False,
                     "rows": 42,
-                    "incremental_fields": [{"label": "id", "type": "integer", "field": "id", "field_type": "integer"}],
+                    "incremental_fields": [
+                        {"label": "id", "type": "integer", "field": "id", "field_type": "integer", "nullable": True}
+                    ],
                     "incremental_available": True,
                     "append_available": True,
                     "incremental_field": "id",
@@ -875,7 +877,9 @@ class TestExternalDataSource(APIBaseTest):
                     "table": "table_1",
                     "should_sync": False,
                     "rows": 42,
-                    "incremental_fields": [{"label": "id", "type": "integer", "field": "id", "field_type": "integer"}],
+                    "incremental_fields": [
+                        {"label": "id", "type": "integer", "field": "id", "field_type": "integer", "nullable": True}
+                    ],
                     "incremental_available": True,
                     "append_available": True,
                     "incremental_field": "id",
@@ -1520,7 +1524,7 @@ class TestExternalDataSource(APIBaseTest):
         with patch(
             "posthog.temporal.data_imports.sources.snowflake.source.get_snowflake_schemas"
         ) as mocked_get_snowflake_schemas:
-            mocked_get_snowflake_schemas.return_value = {"my_table": [("something", "DATE")]}
+            mocked_get_snowflake_schemas.return_value = {"my_table": [("something", "DATE", False)]}
 
             # Create a Snowflake source with password auth
             response = self.client.post(
@@ -1615,7 +1619,7 @@ class TestExternalDataSource(APIBaseTest):
         with patch(
             "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
         ) as mocked_get_bigquery_schemas:
-            mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE")]}
+            mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE", False)]}
 
             # Create a BigQuery source
             response = self.client.post(

--- a/products/data_warehouse/backend/types.py
+++ b/products/data_warehouse/backend/types.py
@@ -14,11 +14,12 @@ class IncrementalFieldType(StrEnum):
     ObjectID = "objectid"
 
 
-class IncrementalField(typing.TypedDict):
-    label: str  # Label shown in the UI
-    type: IncrementalFieldType  # Field type shown in the UI
-    field: str  # Actual DB field accessed
-    field_type: IncrementalFieldType  # Actual DB type of the field
+class IncrementalField(typing.TypedDict, total=False):
+    label: typing.Required[str]  # Label shown in the UI
+    type: typing.Required[IncrementalFieldType]  # Field type shown in the UI
+    field: typing.Required[str]  # Actual DB field accessed
+    field_type: typing.Required[IncrementalFieldType]  # Actual DB type of the field
+    nullable: bool  # Whether the field allows null values
 
 
 class PartitionSettings(typing.NamedTuple):


### PR DESCRIPTION
## Problem

With incremental mode or append-only mode selected, we'll ignore all rows where the incremental field is null without warning users.

## Changes

- Add a warning when selecting a nullable field as the incremental field

![2026-02-24 at 18.01.51.gif](https://app.graphite.com/user-attachments/assets/9ff6b75a-d109-466e-b562-2ca818a3b456.gif)

![2026-02-25 at 12.02.34.png](https://app.graphite.com/user-attachments/assets/d8440363-b8c1-43e1-837e-aa73e3f6ee13.png)



## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

NO