### PR TITLE
feat: Skip `last_seen_at` updates with `$update_person_last_seen_at` property

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2167,7 +2167,7 @@
             "label": "Transformations succeeded",
             "used_for_debug": true
         },
-        "$update_last_seen_at": {
+        "$update_person_last_seen_at": {
             "description": "When set to false, the event will not update the person's last_seen_at timestamp",
             "label": "Update last seen at",
             "system": true
@@ -5176,7 +5176,7 @@
             "label": "Transformations succeeded",
             "used_for_debug": true
         },
-        "$update_last_seen_at": {
+        "$update_person_last_seen_at": {
             "description": "When set to false, the event will not update the person's last_seen_at timestamp",
             "label": "Update last seen at",
             "system": true

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2167,6 +2167,11 @@
             "label": "Transformations succeeded",
             "used_for_debug": true
         },
+        "$update_last_seen_at": {
+            "description": "When set to false, the event will not update the person's last_seen_at timestamp",
+            "label": "Update last seen at",
+            "system": true
+        },
         "$user_agent": {
             "description": "Some SDKs (like Android) send the raw user agent as $user_agent.",
             "examples": [
@@ -5170,6 +5175,11 @@
             "description": "Array of transformations that succeeded during ingestion.",
             "label": "Transformations succeeded",
             "used_for_debug": true
+        },
+        "$update_last_seen_at": {
+            "description": "When set to false, the event will not update the person's last_seen_at timestamp",
+            "label": "Update last seen at",
+            "system": true
         },
         "$user_agent": {
             "description": "Some SDKs (like Android) send the raw user agent as $user_agent.",

--- a/nodejs/src/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/src/ingestion/person-updates-e2e.test.ts
@@ -584,6 +584,52 @@ describe.each(FLAG_COMBINATIONS)('Person Updates E2E ($#)', (config) => {
             })
         })
 
+        it('should not update last_seen_at when $update_last_seen_at is false', async () => {
+            const distinctId = new UUIDT().toString()
+            const baseTime = DateTime.now().startOf('hour')
+            const firstTimestamp = baseTime.toMillis()
+            const secondTimestamp = baseTime.plus({ hours: 2 }).toMillis()
+
+            // First event creates the person
+            await ingester.handleKafkaBatch(
+                createKafkaMessages([
+                    new EventBuilder(team, distinctId)
+                        .withEvent('$identify')
+                        .withProperties({ $set: { initial: true } })
+                        .withTimestamp(firstTimestamp)
+                        .build(),
+                ])
+            )
+
+            await waitForKafkaMessages(hub)
+
+            await waitForExpect(async () => {
+                const person = await hub.personRepository.fetchPerson(team.id, distinctId)
+                expect(person).toBeDefined()
+                expect(person!.last_seen_at!.toMillis()).toBe(baseTime.toMillis())
+            })
+
+            // Second event 2 hours later with $update_last_seen_at=false should NOT update last_seen_at
+            await ingester.handleKafkaBatch(
+                createKafkaMessages([
+                    new EventBuilder(team, distinctId)
+                        .withEvent('pageview')
+                        .withProperties({ $update_last_seen_at: false })
+                        .withTimestamp(secondTimestamp)
+                        .build(),
+                ])
+            )
+
+            await waitForKafkaMessages(hub)
+
+            await waitForExpect(async () => {
+                const person = await hub.personRepository.fetchPerson(team.id, distinctId)
+                expect(person).toBeDefined()
+                // last_seen_at should remain unchanged
+                expect(person!.last_seen_at!.toMillis()).toBe(baseTime.toMillis())
+            })
+        })
+
         it('should set is_identified to true when merging via $identify with $anon_distinct_id', async () => {
             const anonDistinctId = new UUIDT().toString()
             const identifiedDistinctId = new UUIDT().toString()

--- a/nodejs/src/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/src/ingestion/person-updates-e2e.test.ts
@@ -584,7 +584,7 @@ describe.each(FLAG_COMBINATIONS)('Person Updates E2E ($#)', (config) => {
             })
         })
 
-        it('should not update last_seen_at when $update_last_seen_at is false', async () => {
+        it('should not update last_seen_at when $update_person_last_seen_at is false', async () => {
             const distinctId = new UUIDT().toString()
             const baseTime = DateTime.now().startOf('hour')
             const firstTimestamp = baseTime.toMillis()
@@ -609,12 +609,12 @@ describe.each(FLAG_COMBINATIONS)('Person Updates E2E ($#)', (config) => {
                 expect(person!.last_seen_at!.toMillis()).toBe(baseTime.toMillis())
             })
 
-            // Second event 2 hours later with $update_last_seen_at=false should NOT update last_seen_at
+            // Second event 2 hours later with $update_person_last_seen_at=false should NOT update last_seen_at
             await ingester.handleKafkaBatch(
                 createKafkaMessages([
                     new EventBuilder(team, distinctId)
                         .withEvent('pageview')
-                        .withProperties({ $update_last_seen_at: false })
+                        .withProperties({ $update_person_last_seen_at: false })
                         .withTimestamp(secondTimestamp)
                         .build(),
                 ])

--- a/nodejs/src/worker/ingestion/persons/person-property-service.ts
+++ b/nodejs/src/worker/ingestion/persons/person-property-service.ts
@@ -83,9 +83,12 @@ export class PersonPropertyService {
         }
 
         // Update last_seen_at if the event timestamp (rounded to hour) is newer
-        const roundedTimestamp = this.context.timestamp.startOf('hour')
-        if (!person.last_seen_at || roundedTimestamp > person.last_seen_at) {
-            otherUpdates.last_seen_at = roundedTimestamp
+        // and the event hasn't explicitly opted out of updates with $update_last_seen_at=false
+        if (this.context.eventProperties['$update_last_seen_at'] !== false) {
+            const roundedTimestamp = this.context.timestamp.startOf('hour')
+            if (!person.last_seen_at || roundedTimestamp > person.last_seen_at) {
+                otherUpdates.last_seen_at = roundedTimestamp
+            }
         }
 
         // Check if we have any changes to make

--- a/nodejs/src/worker/ingestion/persons/person-property-service.ts
+++ b/nodejs/src/worker/ingestion/persons/person-property-service.ts
@@ -83,8 +83,8 @@ export class PersonPropertyService {
         }
 
         // Update last_seen_at if the event timestamp (rounded to hour) is newer
-        // and the event hasn't explicitly opted out of updates with $update_last_seen_at=false
-        if (this.context.eventProperties['$update_last_seen_at'] !== false) {
+        // and the event hasn't explicitly opted out of updates with $update_person_last_seen_at=false
+        if (this.context.eventProperties['$update_person_last_seen_at'] !== false) {
             const roundedTimestamp = this.context.timestamp.startOf('hour')
             if (!person.last_seen_at || roundedTimestamp > person.last_seen_at) {
                 otherUpdates.last_seen_at = roundedTimestamp

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1770,7 +1770,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The setting from an SDK to control whether an event has person processing enabled",
             "system": True,
         },
-        "$update_last_seen_at": {
+        "$update_person_last_seen_at": {
             "label": "Update last seen at",
             "description": "When set to false, the event will not update the person's last_seen_at timestamp",
             "system": True,

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1770,6 +1770,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The setting from an SDK to control whether an event has person processing enabled",
             "system": True,
         },
+        "$update_last_seen_at": {
+            "label": "Update last seen at",
+            "description": "When set to false, the event will not update the person's last_seen_at timestamp",
+            "system": True,
+        },
         "$dead_clicks_enabled_server_side": {
             "label": "Dead clicks enabled server side",
             "description": "Whether dead clicks were enabled in remote config",


### PR DESCRIPTION
## Problem

[A user asked](https://posthoghelp.zendesk.com/agent/tickets/51115) how they could skip updates to `last_seen_at`. They run some sort of enrichment job to update person properties, but this doesn't reflect actual user activity.

## Changes

This seemed like it would be a fairly simple change to support - I've added a check on a new `$update_last_seen_at` event property, which when set to `false` means we skip updating. If you're keen on this change I'll also make sure we add something to our docs about it.

Based on the original set of changes in https://github.com/PostHog/posthog/pull/47085, I've not:
- added logic for person creation - IMO it wouldn't make sense to skip it here, i.e. `last_seen_at` should always get set
- changed anything around person merges

## How did you test this code?

Added a new end-to-end test to cover it.