### PR TITLE
chore(endpoints): pagination baby

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11962,6 +11962,10 @@
                     "$ref": "#/definitions/integer",
                     "description": "Maximum number of results to return. If not provided, returns all results."
                 },
+                "offset": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints."
+                },
                 "refresh": {
                     "$ref": "#/definitions/EndpointRefreshMode",
                     "default": "cache"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1795,6 +1795,8 @@ export interface EndpointRunRequest {
     debug?: boolean
     /** Maximum number of results to return. If not provided, returns all results. */
     limit?: integer
+    /** Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints. */
+    offset?: integer
 }
 
 export interface EndpointLastExecutionTimesRequest {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -10681,6 +10681,12 @@ class EndpointRunRequest(BaseModel):
         default=None,
         description=("Maximum number of results to return. If not provided, returns all results."),
     )
+    offset: int | None = Field(
+        default=None,
+        description=(
+            "Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints."
+        ),
+    )
     refresh: EndpointRefreshMode | None = EndpointRefreshMode.CACHE
     variables: dict[str, Any] | None = Field(
         default=None,

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -3503,6 +3503,11 @@ export interface EndpointRunRequestApi {
      * @nullable
      */
     limit?: number | null
+    /**
+     * Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints.
+     * @nullable
+     */
+    offset?: number | null
     refresh?: EndpointRefreshModeApi | null
     /**
    * Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

sql-based endpoints can't paginate

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

closes #48920 

## Changes

- add offset to EndpointRunRequest
- handle pagination on hogql-based endpoints

LIMIT clause in the query is the absolute cap of results you can get. I intend to introduce a hard cap on endpoints OR check the SQL that it's not simply `select * from events`-ing.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- units and local tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
yeah, this is useful
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
