### PR TITLE
fix: remove local-only evaluation for query cache migration flag

### DIFF
--- a/posthog/caching/query_cache_routing.py
+++ b/posthog/caching/query_cache_routing.py
@@ -27,7 +27,6 @@ def use_cluster_cache(team_id: int) -> bool:
     return posthoganalytics.feature_enabled(
         "query-cache-cluster-migration",
         str(team_id),
-        only_evaluate_locally=True,
         send_feature_flag_events=False,
     )
 


### PR DESCRIPTION
## Summary
- Removes `only_evaluate_locally=True` from the `query-cache-cluster-migration` feature flag evaluation

I think the feature flag might be returning false on pod starts because the posthog sdk tries to fetch the flag definitions first with a 10s timeout. If that timeout fails we may try to read from the wrong cache

Example logs where cache miss (feature flag returned false so request went to wrong cache) was soon after a pod start.
https://grafana.prod-us.posthog.dev/goto/afe88tkid6wowb?orgId=1

- 13:00:26 - first request on the pod 
- 13:00:39 - cache miss (export_cache_key_miss) - 13 seconds later
