### PR TITLE
fix: Replace "project API key" with "project token" in documentation

### DIFF
--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -78,7 +78,7 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                     <Markdown>
                         We call Cohere through the OpenAI-compatible API and generate a response. We'll use PostHog's
                         OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project API key and host from [your project settings](https://app.posthog.com/settings/project),
+                        project token and host from [your project settings](https://app.posthog.com/settings/project),
                         then pass the PostHog client along with the Cohere config (the base URL and API key) to our
                         OpenAI wrapper.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -78,7 +78,7 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                     <Markdown>
                         We call Fireworks AI through the OpenAI client and generate a response. We'll use PostHog's
                         OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project API key and host from [your project settings](https://app.posthog.com/settings/project),
+                        project token and host from [your project settings](https://app.posthog.com/settings/project),
                         then pass the PostHog client along with the Fireworks AI config (the base URL and API key) to
                         our OpenAI wrapper.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -78,7 +78,7 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Markdown>
                         We call Together AI through the OpenAI client and generate a response. We'll use PostHog's
                         OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project API key and host from [your project settings](https://app.posthog.com/settings/project),
+                        project token and host from [your project settings](https://app.posthog.com/settings/project),
                         then pass the PostHog client along with the Together AI config (the base URL and API key) to our
                         OpenAI wrapper.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -85,7 +85,7 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                     <Markdown>
                         We call Vercel AI Gateway through the OpenAI client and generate a response. We'll use PostHog's
                         OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project API key and host from [your project settings](https://app.posthog.com/settings/project),
+                        project token and host from [your project settings](https://app.posthog.com/settings/project),
                         then pass the PostHog client along with the Vercel AI Gateway base URL to our OpenAI wrapper.
                     </Markdown>
 

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -78,7 +78,7 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                     <Markdown>
                         We call xAI through the OpenAI-compatible API and generate a response. We'll use PostHog's
                         OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project API key and host from [your project settings](https://app.posthog.com/settings/project),
+                        project token and host from [your project settings](https://app.posthog.com/settings/project),
                         then pass the PostHog client along with the xAI config (the base URL and API key) to our OpenAI
                         wrapper.
                     </Markdown>

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -871,7 +871,7 @@ export function BatchExportsEditFields({
                             ]}
                         />
                     </LemonField>
-                    <LemonField name="token" label="Destination project API Key">
+                    <LemonField name="token" label="Destination project token">
                         <LemonInput placeholder="e.g. phc_12345..." />
                     </LemonField>
                 </>


### PR DESCRIPTION
## Problem

The documentation and UI inconsistently referred to PostHog credentials as "project API key" when the correct terminology is "project token". This inconsistency could confuse users during onboarding and configuration.

## Changes

- Updated LLM analytics onboarding documentation for Cohere, Fireworks AI, Together AI, Vercel AI Gateway, and xAI to use "project token" instead of "project API key"
- Updated the batch export form label to use "Destination project token" instead of "Destination project API Key"

## How did you test this code?

I am an agent and have not manually tested this code. The changes are purely textual updates to documentation and UI labels that maintain the same functionality while using consistent terminology.

## Publish to changelog?

No