### PR TITLE
chore(flags): give tokio 25% available cores

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -484,20 +484,21 @@ pub struct Config {
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
 ///
 /// Tokio handles request I/O (DB, Redis, network) and lightweight sequential flag
-/// evaluation. Workers spend most of their time in `.await`, so half the core count
-/// is sufficient. Rayon handles CPU-bound parallel batch evaluation for large flag
-/// sets (>= PARALLEL_EVAL_THRESHOLD). Because `rayon::spawn` + `oneshot` frees the
-/// Tokio worker, the two pools never compete for the same work — but they do share
-/// the CFS budget.
+/// evaluation. Workers spend most of their time in `.await`, so a quarter of the
+/// core count is sufficient. Rayon handles CPU-bound parallel batch evaluation for
+/// large flag sets (>= PARALLEL_EVAL_THRESHOLD). Because `rayon::spawn` + `oneshot`
+/// frees the Tokio worker, the two pools never compete for the same work — but they
+/// do share the CFS budget.
 ///
-/// We give Rayon the full core count and Tokio half, accepting ~50% oversubscription
-/// (e.g. 3 + 6 = 9 threads on 6 cores). This is safe because Tokio threads are mostly
-/// idle (parked in `.await`), so actual concurrent CPU demand rarely exceeds the core
-/// count. Canary testing on EU (6-core pods) showed that a strict 50/50 split
-/// (3 Tokio + 3 Rayon = 6 threads, 0% CFS throttling) starved the Rayon pool: p99
-/// parallel batch time was ~1900ms vs the fleet's ~240ms, while CPU utilization sat
-/// at only 1.3 of 6 cores. The fleet runs 12 threads on 6 cores (7–30% throttling)
-/// with no issues, confirming moderate oversubscription is well-tolerated.
+/// We give Rayon the full core count and Tokio a quarter (ceil), accepting ~25%
+/// oversubscription (e.g. 2 + 8 = 10 threads on 8 cores). Production profiling
+/// showed Tokio workers at only 12.8% busy ratio with 50% of cores (4 workers on
+/// 8 vCPUs), parking ~9,000 times per 15s interval. Meanwhile, CFS throttling
+/// spikes (10–15%) correlated with every p99 latency spike above 1,000ms — the
+/// extra Tokio threads competed with Rayon during parallel batch evaluations.
+/// Reducing to 25% of cores (2 workers on 8 vCPUs) projects ~25% busy ratio,
+/// still well below the 0.6 saturation threshold, while cutting total thread count
+/// from 12→10 and reducing CFS contention during parallel batches.
 pub struct ThreadCounts {
     pub tokio_workers: usize,
     pub rayon_threads: usize,
@@ -525,7 +526,7 @@ impl ThreadCounts {
     }
 
     fn from_cores(cores: usize) -> Self {
-        let tokio_workers = (cores / 2).max(1);
+        let tokio_workers = cores.div_ceil(4).max(1);
         let rayon_threads = cores.max(1);
 
         Self {
@@ -1071,10 +1072,10 @@ mod thread_counts_tests {
     #[rstest]
     #[case::single_core(1, 1, 1)]
     #[case::two_cores(2, 1, 2)]
-    #[case::four_cores(4, 2, 4)]
-    #[case::six_cores(6, 3, 6)]
-    #[case::eight_cores(8, 4, 8)]
-    #[case::sixteen_cores(16, 8, 16)]
+    #[case::four_cores(4, 1, 4)]
+    #[case::six_cores(6, 2, 6)]
+    #[case::eight_cores(8, 2, 8)]
+    #[case::sixteen_cores(16, 4, 16)]
     fn test_thread_allocation(
         #[case] cores: usize,
         #[case] expected_tokio: usize,
@@ -1112,13 +1113,13 @@ mod thread_counts_tests {
     }
 
     #[test]
-    fn test_tokio_gets_half_cores() {
-        for cores in 2..=128 {
+    fn test_tokio_gets_quarter_cores_ceil() {
+        for cores in 1..=128 {
             let counts = ThreadCounts::from_cores(cores);
             assert_eq!(
                 counts.tokio_workers,
-                cores / 2,
-                "tokio should get half the cores for {cores} cores"
+                cores.div_ceil(4).max(1),
+                "tokio should get ceil(cores/4) for {cores} cores"
             );
         }
     }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -483,22 +483,13 @@ pub struct Config {
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
 ///
-/// Tokio handles request I/O (DB, Redis, network) and lightweight sequential flag
-/// evaluation. Workers spend most of their time in `.await`, so a quarter of the
-/// core count is sufficient. Rayon handles CPU-bound parallel batch evaluation for
-/// large flag sets (>= PARALLEL_EVAL_THRESHOLD). Because `rayon::spawn` + `oneshot`
-/// frees the Tokio worker, the two pools never compete for the same work — but they
-/// do share the CFS budget.
-///
-/// We give Rayon the full core count and Tokio a quarter (ceil), accepting ~25%
-/// oversubscription (e.g. 2 + 8 = 10 threads on 8 cores). Production profiling
-/// showed Tokio workers at only 12.8% busy ratio with 50% of cores (4 workers on
-/// 8 vCPUs), parking ~9,000 times per 15s interval. Meanwhile, CFS throttling
-/// spikes (10–15%) correlated with every p99 latency spike above 1,000ms — the
-/// extra Tokio threads competed with Rayon during parallel batch evaluations.
-/// Reducing to 25% of cores (2 workers on 8 vCPUs) projects ~25% busy ratio,
-/// still well below the 0.6 saturation threshold, while cutting total thread count
-/// from 12→10 and reducing CFS contention during parallel batches.
+/// The two pools share a single CFS budget (cores × 100ms per period).
+/// Rayon bursts — all threads active during `into_par_iter` — can consume
+/// the entire budget, throttling Tokio workers and stalling sequential
+/// requests that happen to overlap. To prevent this, total threads are
+/// capped at the core count: Tokio gets ceil(cores/4), Rayon gets the rest.
+/// This guarantees that even worst-case concurrent activity stays within
+/// the CFS quota and eliminates throttle-induced tail-latency spikes.
 pub struct ThreadCounts {
     pub tokio_workers: usize,
     pub rayon_threads: usize,
@@ -519,15 +510,15 @@ impl ThreadCounts {
     /// `into_par_iter` degrades toward sequential execution.
     pub fn default_max_concurrent_batch_evals(&self) -> usize {
         // Integer ceil(rayon_threads / 3): keeps ~3 threads per batch.
+        //   4 threads → 2 batches  (2 threads each)
         //   6 threads → 2 batches  (3 threads each)
-        //   8 threads → 3 batches  (~2.7 threads each)
         //  12 threads → 4 batches  (3 threads each)
         self.rayon_threads.div_ceil(3).max(1)
     }
 
     fn from_cores(cores: usize) -> Self {
         let tokio_workers = cores.div_ceil(4).max(1);
-        let rayon_threads = cores.max(1);
+        let rayon_threads = cores.saturating_sub(tokio_workers).max(1);
 
         Self {
             tokio_workers,
@@ -1071,11 +1062,11 @@ mod thread_counts_tests {
 
     #[rstest]
     #[case::single_core(1, 1, 1)]
-    #[case::two_cores(2, 1, 2)]
-    #[case::four_cores(4, 1, 4)]
-    #[case::six_cores(6, 2, 6)]
-    #[case::eight_cores(8, 2, 8)]
-    #[case::sixteen_cores(16, 4, 16)]
+    #[case::two_cores(2, 1, 1)]
+    #[case::four_cores(4, 1, 3)]
+    #[case::six_cores(6, 2, 4)]
+    #[case::eight_cores(8, 2, 6)]
+    #[case::sixteen_cores(16, 4, 12)]
     fn test_thread_allocation(
         #[case] cores: usize,
         #[case] expected_tokio: usize,
@@ -1102,12 +1093,31 @@ mod thread_counts_tests {
     }
 
     #[test]
-    fn test_rayon_gets_full_core_count() {
+    fn test_total_threads_never_exceed_core_count() {
+        // 1 core is the only exception: both pools need at least 1 thread,
+        // so total is 2. On all real multi-core pods (>= 2 cores) the
+        // invariant holds strictly.
+        for cores in 2..=128 {
+            let counts = ThreadCounts::from_cores(cores);
+            assert!(
+                counts.tokio_workers + counts.rayon_threads <= cores,
+                "total threads ({} + {} = {}) must not exceed {cores} cores",
+                counts.tokio_workers,
+                counts.rayon_threads,
+                counts.tokio_workers + counts.rayon_threads,
+            );
+        }
+    }
+
+    #[test]
+    fn test_rayon_gets_remaining_cores() {
         for cores in 1..=128 {
             let counts = ThreadCounts::from_cores(cores);
+            let tokio = cores.div_ceil(4).max(1);
             assert_eq!(
-                counts.rayon_threads, cores,
-                "rayon should get full core count for {cores} cores"
+                counts.rayon_threads,
+                cores.saturating_sub(tokio).max(1),
+                "rayon should get cores - tokio for {cores} cores"
             );
         }
     }


### PR DESCRIPTION
## Problem

The feature-flags service runs 4 Tokio workers + 8 Rayon threads on 8-vCPU pods (prod-us),
oversubscribing by 50% (12 threads on 8 cores). When parallel batch evaluations fire all 8 Rayon
threads while Tokio workers are also polling, CFS throttles the pod. Every p99 spike above 1,000ms
in the last 6 hours correlated with a CFS throttling surge (avg 10-15%, hottest pod 14-18%).
Meanwhile, p50 latency stays rock-solid at ~34ms because it takes the sequential path and never
triggers thread contention.

Tokio runtime profiling shows workers are idle 87% of the time: 12.8% avg busy ratio, ~9,000 parks
per 15s interval, global queue depth permanently at 0, near-perfect worker balance (<2% variance).
The runtime has 3-4x more capacity than it needs.

## Changes

Reduces Tokio worker allocation from `cores / 2` (50%) to `cores.div_ceil(4)` (~25%):

| Environment | Cores | Tokio workers (before) | Tokio workers (after) | Total threads |
|-------------|-------|------------------------|-----------------------|---------------|
| prod-us     | 8     | 4                      | **2**                 | 10 (was 12)   |
| prod-eu     | 6     | 3                      | **2**                 | 8 (was 9)     |
| dev/staging | 1-2   | 1                      | 1 (unchanged)         | 2-3           |

Projected impact at 2 workers:
- Tokio busy ratio: ~25% avg, ~40% max pod (below the 0.6 alarm threshold)
- CFS oversubscription: 25% (was 50%) — fewer scheduling periods where threads exceed quota
- p99 tail spikes should compress as Tokio workers stop competing with Rayon for cores

## What to watch after deploy

On the [Sequential vs Parallel dashboard](https://grafana.prod-us.posthog.dev/d/dbfct69t3sbgg0b/feature-flags-sequential-vs-parallel):

1. `flags_tokio_busy_ratio` — should stay below 0.4; alarm if sustained above 0.6
2. `flags_tokio_global_queue_depth` — should stay at 0; any sustained non-zero means workers can't keep up
3. `flags_requests_duration_ms` p99 — should not regress
4. CFS throttling ratio — should decrease
5. Per-worker balance — with only 2 workers, imbalance is more impactful


## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
