### PR TITLE
Scim endpoint pagination

### DIFF
--- a/ee/api/scim/test/test_groups_api.py
+++ b/ee/api/scim/test/test_groups_api.py
@@ -46,6 +46,30 @@ class TestSCIMGroupsAPI(APILicensedTest):
         data = response.json()
         assert "Resources" in data
 
+    def test_groups_list_pagination(self):
+        for index in range(4):
+            Role.objects.create(
+                name=f"PaginationGroup{index}",
+                organization=self.organization,
+            )
+
+        expected_group_ids = list(
+            Role.objects.filter(organization=self.organization).order_by("id").values_list("id", flat=True)
+        )
+        expected_page_ids = [str(group_id) for group_id in expected_group_ids[1:3]]
+
+        response = self.client.get(
+            f"/scim/v2/{self.domain.id}/Groups",
+            {"startIndex": 2, "count": 2},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["totalResults"] == len(expected_group_ids)
+        assert data["startIndex"] == 2
+        assert data["itemsPerPage"] == len(expected_page_ids)
+        assert [resource["id"] for resource in data["Resources"]] == expected_page_ids
+
     def test_groups_list_filter_exact_match(self):
         Role.objects.create(name="Engineering", organization=self.organization)
         Role.objects.create(name="engineering", organization=self.organization)
@@ -63,6 +87,21 @@ class TestSCIMGroupsAPI(APILicensedTest):
         assert data["totalResults"] == 1
         assert data["itemsPerPage"] == 1
         assert data["Resources"][0]["displayName"] == "Engineering"
+
+    def test_groups_list_filter_count_zero_keeps_total_results(self):
+        Role.objects.create(name="FilterCountZeroGroup", organization=self.organization)
+
+        response = self.client.get(
+            f"/scim/v2/{self.domain.id}/Groups",
+            {"filter": 'displayName eq "FilterCountZeroGroup"', "count": 0},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["totalResults"] == 1
+        assert data["startIndex"] == 1
+        assert data["itemsPerPage"] == 0
+        assert data["Resources"] == []
 
     def test_groups_list_filter_excludes_groups_from_other_orgs(self):
         # Create role with same name in different organization

--- a/ee/api/scim/test/test_scim_api.py
+++ b/ee/api/scim/test/test_scim_api.py
@@ -114,6 +114,23 @@ class TestSCIMAPI(APILicensedTest):
         assert response.status_code == status.HTTP_200_OK
         assert "Resources" in response.json()
 
+    @parameterized.expand(
+        [
+            ("startIndex", "0", "startIndex must be greater than or equal to 1"),
+            ("startIndex", "invalid", "startIndex must be an integer"),
+            ("count", "-1", "count must be greater than or equal to 0"),
+            ("count", "invalid", "count must be an integer"),
+        ]
+    )
+    def test_scim_users_list_rejects_invalid_pagination_params(self, param: str, value: str, expected_detail: str):
+        self.client.credentials(**self.scim_headers)
+        response = self.client.get(f"/scim/v2/{self.domain.id}/Users", {param: value})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        data = response.json()
+        assert data["schemas"] == ["urn:ietf:params:scim:api:messages:2.0:Error"]
+        assert data["status"] == 400
+        assert data["detail"] == expected_detail
+
     def _create_user_in_other_org(self):
         other_org = Organization.objects.create(name="OtherCorp")
         other_user = User.objects.create(

--- a/ee/api/scim/test/test_users_api.py
+++ b/ee/api/scim/test/test_users_api.py
@@ -46,6 +46,40 @@ class TestSCIMUsersAPI(APILicensedTest):
         assert "Resources" in data
         assert data["totalResults"] >= 1  # At least the test user
 
+    def test_users_list_pagination(self):
+        for index in range(4):
+            user = User.objects.create_user(
+                email=f"pagination-user-{index}@example.com",
+                password=None,
+                first_name=f"Pagination{index}",
+                last_name="User",
+                is_email_verified=True,
+            )
+            OrganizationMembership.objects.create(
+                user=user,
+                organization=self.organization,
+                level=OrganizationMembership.Level.MEMBER,
+            )
+
+        expected_user_ids = list(
+            User.objects.filter(organization_membership__organization=self.organization)
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+        expected_page_ids = [str(user_id) for user_id in expected_user_ids[1:3]]
+
+        response = self.client.get(
+            f"/scim/v2/{self.domain.id}/Users",
+            {"startIndex": 2, "count": 2},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["totalResults"] == len(expected_user_ids)
+        assert data["startIndex"] == 2
+        assert data["itemsPerPage"] == len(expected_page_ids)
+        assert [resource["id"] for resource in data["Resources"]] == expected_page_ids
+
     def test_users_list_filter_exact_match(self):
         user_a = User.objects.create_user(
             email="engineering@example.com",
@@ -90,6 +124,39 @@ class TestSCIMUsersAPI(APILicensedTest):
         assert data["totalResults"] == 1
         assert data["itemsPerPage"] == 1
         assert data["Resources"][0]["userName"] == "engineering@example.com"
+
+    def test_users_list_filter_count_zero_keeps_total_results(self):
+        user = User.objects.create_user(
+            email="filter-count-zero@example.com",
+            password=None,
+            first_name="Filter",
+            last_name="Zero",
+            is_email_verified=True,
+        )
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        SCIMProvisionedUser.objects.create(
+            user=user,
+            organization_domain=self.domain,
+            username="filter-count-zero@example.com",
+            identity_provider=SCIMProvisionedUser.IdentityProvider.OTHER,
+            active=True,
+        )
+
+        response = self.client.get(
+            f"/scim/v2/{self.domain.id}/Users",
+            {"filter": 'userName eq "filter-count-zero@example.com"', "count": 0},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["totalResults"] == 1
+        assert data["startIndex"] == 1
+        assert data["itemsPerPage"] == 0
+        assert data["Resources"] == []
 
     def test_users_list_filter_excludes_users_from_other_orgs(self):
         # Create user that belongs only to a different organization

--- a/ee/api/scim/views.py
+++ b/ee/api/scim/views.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 from django.db.models import Q, QuerySet
 
@@ -28,6 +28,9 @@ from ee.models.rbac.role import Role
 from ee.models.scim_provisioned_user import SCIMProvisionedUser
 
 logger = structlog.get_logger(__name__)
+
+SCIM_DEFAULT_START_INDEX = 1
+SCIM_MAX_RESULTS = 200
 
 SCIM_USER_ATTR_MAP = {
     ("emails", "value", None): "email",
@@ -59,6 +62,65 @@ class SCIMBaseView(APIView):
     authentication_classes = [SCIMBearerTokenAuthentication]
     renderer_classes = [SCIMJSONRenderer, JSONRenderer]
     parser_classes = [SCIMJSONParser, JSONParser]
+
+    @staticmethod
+    def _get_validation_error_detail(detail: Any) -> str:
+        if isinstance(detail, list):
+            return str(detail[0]) if detail else "Invalid request"
+        if isinstance(detail, dict):
+            if not detail:
+                return "Invalid request"
+            first_value = next(iter(detail.values()))
+            if isinstance(first_value, list):
+                return str(first_value[0]) if first_value else "Invalid request"
+            return str(first_value)
+        return str(detail)
+
+    def get_pagination_params(self, request: Request) -> tuple[int, int | None]:
+        start_index_param = request.query_params.get("startIndex")
+        count_param = request.query_params.get("count")
+
+        if start_index_param is None:
+            start_index = SCIM_DEFAULT_START_INDEX
+        else:
+            try:
+                start_index = int(start_index_param)
+            except ValueError as error:
+                raise drf_exceptions.ValidationError("startIndex must be an integer") from error
+            if start_index < SCIM_DEFAULT_START_INDEX:
+                raise drf_exceptions.ValidationError("startIndex must be greater than or equal to 1")
+
+        if count_param is None:
+            return start_index, None
+
+        try:
+            count = int(count_param)
+        except ValueError as error:
+            raise drf_exceptions.ValidationError("count must be an integer") from error
+
+        if count < 0:
+            raise drf_exceptions.ValidationError("count must be greater than or equal to 0")
+
+        return start_index, min(count, SCIM_MAX_RESULTS)
+
+    @staticmethod
+    def paginate_queryset(queryset: QuerySet, start_index: int, count: int | None) -> QuerySet:
+        offset = start_index - 1
+        if count is None:
+            return queryset[offset:]
+        return queryset[offset : offset + count]
+
+    @staticmethod
+    def build_list_response(resources: list[dict[str, Any]], total_results: int, start_index: int) -> Response:
+        return Response(
+            {
+                "schemas": [constants.SchemaURI.LIST_RESPONSE],
+                "totalResults": total_results,
+                "startIndex": start_index,
+                "itemsPerPage": len(resources),
+                "Resources": resources,
+            }
+        )
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
@@ -105,6 +167,16 @@ class SCIMBaseView(APIView):
                     "detail": "Authentication failed",
                 },
                 status=status.HTTP_403_FORBIDDEN,
+            )
+        if isinstance(exc, drf_exceptions.ValidationError):
+            detail = self._get_validation_error_detail(exc.detail)
+            return Response(
+                {
+                    "schemas": [constants.SchemaURI.ERROR],
+                    "status": 400,
+                    "detail": detail,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
             )
         return super().handle_exception(exc)
 
@@ -154,11 +226,11 @@ class SCIMUsersView(SCIMBaseView):
     def get(self, request: Request, domain_id: str) -> Response:
         organization_domain = cast(OrganizationDomain, request.auth)
         filter_param = request.query_params.get("filter")
+        start_index, count = self.get_pagination_params(request)
 
         if filter_param:
             try:
                 queryset = PostHogUserFilterQuery.search(filter_param, request)
-                users = [PostHogSCIMUser(u, organization_domain) for u in queryset]
             except Exception as e:
                 capture_exception(
                     e,
@@ -169,18 +241,20 @@ class SCIMUsersView(SCIMBaseView):
                         "organization_id": organization_domain.organization.id,
                     },
                 )
-                users = []
+                queryset = User.objects.none()
         else:
-            users = PostHogSCIMUser.get_for_organization(organization_domain)
+            queryset = User.objects.filter(
+                organization_membership__organization=organization_domain.organization,
+            )
 
-        return Response(
-            {
-                "schemas": [constants.SchemaURI.LIST_RESPONSE],
-                "totalResults": len(users),
-                "startIndex": 1,
-                "itemsPerPage": len(users),
-                "Resources": [user.to_dict() for user in users],
-            }
+        queryset = queryset.order_by("id").distinct()
+        total_results = queryset.count()
+        paginated_queryset = self.paginate_queryset(queryset, start_index, count)
+        users = [PostHogSCIMUser(user, organization_domain) for user in paginated_queryset]
+        return self.build_list_response(
+            resources=[user.to_dict() for user in users],
+            total_results=total_results,
+            start_index=start_index,
         )
 
     def post(self, request: Request, domain_id: str) -> Response:
@@ -289,11 +363,11 @@ class SCIMGroupsView(SCIMBaseView):
     def get(self, request: Request, domain_id: str) -> Response:
         organization_domain = cast(OrganizationDomain, request.auth)
         filter_param = request.query_params.get("filter")
+        start_index, count = self.get_pagination_params(request)
 
         if filter_param:
             try:
                 queryset = PostHogGroupFilterQuery.search(filter_param, request)
-                groups = [PostHogSCIMGroup(role, organization_domain) for role in queryset]
             except Exception as e:
                 capture_exception(
                     e,
@@ -304,18 +378,18 @@ class SCIMGroupsView(SCIMBaseView):
                         "organization_id": organization_domain.organization.id,
                     },
                 )
-                groups = []
+                queryset = Role.objects.none()
         else:
-            groups = PostHogSCIMGroup.get_for_organization(organization_domain)
+            queryset = Role.objects.filter(organization=organization_domain.organization)
 
-        return Response(
-            {
-                "schemas": [constants.SchemaURI.LIST_RESPONSE],
-                "totalResults": len(groups),
-                "startIndex": 1,
-                "itemsPerPage": len(groups),
-                "Resources": [group.to_dict() for group in groups],
-            }
+        queryset = queryset.order_by("id").distinct()
+        total_results = queryset.count()
+        paginated_queryset = self.paginate_queryset(queryset, start_index, count)
+        groups = [PostHogSCIMGroup(role, organization_domain) for role in paginated_queryset]
+        return self.build_list_response(
+            resources=[group.to_dict() for group in groups],
+            total_results=total_results,
+            start_index=start_index,
         )
 
     def post(self, request: Request, domain_id: str) -> Response:
@@ -416,7 +490,7 @@ class SCIMServiceProviderConfigView(SCIMBaseView):
                 "documentationUri": "https://posthog.com/docs/scim",
                 "patch": {"supported": True},
                 "bulk": {"supported": False, "maxOperations": 0, "maxPayloadSize": 0},
-                "filter": {"supported": True, "maxResults": 200},
+                "filter": {"supported": True, "maxResults": SCIM_MAX_RESULTS},
                 "changePassword": {"supported": False},
                 "sort": {"supported": False},
                 "etag": {"supported": False},


### PR DESCRIPTION
## Problem

SCIM clients, particularly Identity Providers (IdPs) like Okta, require pagination support for collection endpoints such as `GET /scim/v2/Users` and `GET /scim/v2/Groups`. The existing endpoints did not support `startIndex` and `count` parameters and always returned full datasets, failing to conform to the SCIM `ListResponse` specification (1-based `startIndex`, `totalResults`, `itemsPerPage`).

## Changes

- Implemented shared pagination parsing (`startIndex`, `count`) and `ListResponse` construction in `ee/api/scim/views.py` for `SCIMBaseView`.
- Applied pagination logic to `GET /scim/v2/{domain_id}/Users` and `GET /scim/v2/{domain_id}/Groups`.
- `totalResults` is now computed from the full filtered queryset before slicing.
- `itemsPerPage` reflects the actual number of resources returned on the page.
- Invalid pagination parameters now return SCIM-compliant `400` error payloads.
- Added stable ordering (`order_by("id")`) and `distinct()` to querysets before pagination.
- Added new API tests in `ee/api/scim/test/` covering pagination metadata, slicing, filtered queries with `count=0`, and invalid parameter error handling.

## How did you test this code?

- Automated unit tests: `pytest ee/api/scim/test/test_scim_utils.py` (43 passed).
- Code quality checks: `ruff check --fix`, `ruff format`, `python -m compileall`.
- *Note: Full SCIM API integration tests (`test_scim_api.py`, `test_users_api.py`, `test_groups_api.py`) were blocked by ClickHouse setup issues in the environment where the agent ran tests.*

## Publish to changelog?

yes

---
<p><a href="https://cursor.com/agents/bc-21dc983f-e019-4477-8c84-298f8b09d9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21dc983f-e019-4477-8c84-298f8b09d9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

