### PR TITLE
fix: ensure common event definitions exist in generate_demo_data

### DIFF
--- a/posthog/demo/matrix/taxonomy_inference.py
+++ b/posthog/demo/matrix/taxonomy_inference.py
@@ -7,6 +7,8 @@ from posthog.models.group.sql import GROUPS_TABLE
 from posthog.models.person.sql import PERSONS_TABLE
 from posthog.models.property_definition import PropertyType
 
+COMMON_EVENTS = ["$pageview", "$pageleave", "$autocapture", "$screen"]
+
 
 def infer_taxonomy_for_team(team_id: int) -> tuple[int, int, int]:
     """Infer event and property definitions based on ClickHouse data.
@@ -23,6 +25,9 @@ def infer_taxonomy_for_team(team_id: int) -> tuple[int, int, int]:
         batch_size=1000,
         ignore_conflicts=True,
     )
+    for event_name in COMMON_EVENTS:
+        if event_name not in events_last_seen_at:
+            EventDefinition.objects.get_or_create(team_id=team_id, name=event_name)
 
     # Property definitions, with types
     property_types = _get_property_types(team_id)


### PR DESCRIPTION
## Problem

Follow-up to #48834 (suggested by @rafaeelaudibert).

The `generate_demo_data` command creates EventDefinitions by inferring them from ClickHouse data via `infer_taxonomy_for_team()`. If the simulated data doesn't happen to include common events like `$pageview`, `$pageleave`, `$autocapture`, or `$screen`, their EventDefinition records won't be created. This was the root cause of flaky MCP CI tests — #48834 fixed it at the CI workflow level, but the underlying issue in `generate_demo_data` remained.

## Changes

Added `get_or_create` calls for common event definitions (`$pageview`, `$pageleave`, `$autocapture`, `$screen`) in `infer_taxonomy_for_team()`, so they're guaranteed to exist regardless of what the simulated data contains.

## How did you test this code

- Code inspection: `get_or_create` is idempotent — no-op if definitions already exist from the ClickHouse inference step
- Only creates missing definitions (skips events already in `events_last_seen_at`)

## Changelog

No