### PR TITLE
fix(funnels): allow actors modal to display sessions when aggregating…

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -15,6 +15,7 @@ import {
     IntervalType,
     PropertyOperator,
     PropertyType,
+    SessionActorType,
     TimeUnitType,
 } from '~/types'
 
@@ -2151,6 +2152,10 @@ export function findLastIndex<T>(array: Array<T>, predicate: (value: T, index: n
 
 export function isGroupType(actor: ActorType): actor is GroupActorType {
     return actor.type === 'group'
+}
+
+export function isSessionType(actor: ActorType): actor is SessionActorType {
+    return actor.type === 'session'
 }
 
 export function getEventNamesForAction(actionId: string | number, allActions: ActionType[]): string[] {

--- a/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
+++ b/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
@@ -81,7 +81,18 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
         canOpenPersonModal: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): boolean => {
-                return !funnelsFilter?.funnelAggregateByHogQL
+                // Allow opening modal for session aggregation (properties.$session_id) as well as persons/groups
+                // The modal will display sessions with their properties and linked recordings
+                const aggregateByHogQL = funnelsFilter?.funnelAggregateByHogQL
+                if (!aggregateByHogQL) {
+                    return true
+                }
+                // Allow session aggregation to open the modal
+                if (aggregateByHogQL === 'properties.$session_id') {
+                    return true
+                }
+                // For other custom HogQL aggregations, don't allow the modal
+                return false
             },
         ],
     }),

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -5,7 +5,7 @@ import { router, urlToAction } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { isGroupType } from 'lib/utils'
+import { isGroupType, isSessionType } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { urls } from 'scenes/urls'
@@ -40,12 +40,65 @@ import {
     PropertyFilterType,
     PropertyOperator,
     RecordingUniversalFilters,
+    SessionActorType,
     UniversalFilterValue,
 } from '~/types'
 
 import type { personsModalLogicType } from './personsModalLogicType'
 
 const RESULTS_PER_PAGE = 100
+
+/**
+ * Checks if the result data represents a session rather than a person or group.
+ * Sessions lack person-specific fields (distinct_ids, is_identified) and may have session-specific fields.
+ */
+function isSessionData(data: Record<string, any>): boolean {
+    // Session data lacks person-specific fields and has session_id or lacks distinct_ids array
+    const hasPersonFields = Array.isArray(data.distinct_ids) || data.is_identified !== undefined
+    const hasGroupFields = data.group_type_index !== undefined
+
+    // If it's clearly person or group data, it's not session data
+    if (hasPersonFields || hasGroupFields) {
+        return false
+    }
+
+    // Session data has these characteristics:
+    // - Has session_id field OR has id that looks like a session UUID
+    // - May have $session_id, $start_timestamp, $end_timestamp, $session_duration fields
+    // - Has distinct_id (singular, not distinct_ids array)
+    const hasSessionFields =
+        data.session_id !== undefined ||
+        data.$session_id !== undefined ||
+        data.$start_timestamp !== undefined ||
+        data.$end_timestamp !== undefined ||
+        data.$session_duration !== undefined
+
+    // If it has session-specific fields or lacks both person and group identifiers
+    return hasSessionFields || (data.distinct_id !== undefined && !hasPersonFields)
+}
+
+/**
+ * Normalizes session data to match the schema expected by the actors modal.
+ * Moves session fields (other than id, distinct_id, session_id) under a `properties` key.
+ */
+function normalizeSessionData(data: Record<string, any>): SessionActorType {
+    const sessionId = data.session_id || data.$session_id || data.id
+    const distinctId = data.distinct_id
+
+    // Extract fields that should not be in properties
+    const { id, session_id, $session_id, distinct_id, matched_recordings, created_at, ...sessionProperties } = data
+
+    return {
+        type: 'session',
+        id: sessionId,
+        session_id: sessionId,
+        distinct_id: distinctId,
+        properties: sessionProperties,
+        created_at: created_at || data.$start_timestamp || '',
+        matched_recordings: matched_recordings || [],
+        value_at_data_point: null,
+    }
+}
 
 export interface PersonModalLogicProps {
     query?: InsightActorsQuery | FunnelsActorsQuery | FunnelCorrelationActorsQuery | null
@@ -146,6 +199,14 @@ export const personsModalLogic = kea<personsModalLogicType>([
                                                 group[field] = result[additionalFieldIndices[index]]
                                             })
                                             return group
+                                        }
+                                        // Check if this is session data (lacks person-specific fields)
+                                        if (isSessionData(result[0])) {
+                                            const session: SessionActorType = normalizeSessionData(result[0])
+                                            Object.keys(props.additionalSelect || {}).forEach((field, index) => {
+                                                session[field] = result[additionalFieldIndices[index]]
+                                            })
+                                            return session
                                         }
                                         const person: PersonActorType = {
                                             type: 'person',
@@ -307,6 +368,9 @@ export const personsModalLogic = kea<personsModalLogicType>([
 
                 if (!firstResult) {
                     return { singular: 'result', plural: 'results' }
+                }
+                if (isSessionType(firstResult)) {
+                    return { singular: 'session', plural: 'sessions' }
                 }
                 return aggregationLabel(isGroupType(firstResult) ? firstResult.group_type_index : undefined)
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1478,7 +1478,17 @@ export interface GroupActorType extends CommonActorType {
     group_type_index: integer
 }
 
-export type ActorType = PersonActorType | GroupActorType
+export interface SessionActorType extends CommonActorType {
+    type: 'session'
+    /** Session ID. */
+    id: string
+    /** Session ID (same as id). */
+    session_id: string
+    /** Distinct ID associated with the session. */
+    distinct_id?: string
+}
+
+export type ActorType = PersonActorType | GroupActorType | SessionActorType
 
 export interface CohortGroupType {
     id: string


### PR DESCRIPTION
… by session_id

When funnels are aggregated by sessions (properties.$session_id), the actors modal now properly handles and displays session data. This includes:

- Adding SessionActorType to support session actors alongside persons and groups
- Normalizing session data to include a properties key matching the expected schema
- Updating funnelPersonsModalLogic to allow opening the modal for session aggregation
- Adding isSessionType utility function to detect session actors

This fixes the "Unable to resolve field: properties" error that occurred when clicking funnel bars with session aggregation, and enables users to view session recordings linked to funnel conversions/dropoffs.

Slack thread: https://posthog.slack.com/archives/C0368RPHLQH/p1771952031557499

https://claude.ai/code/session_01V8RtVY8Sb9xXzobAspjoBJ

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
