### PR TITLE
fix(llma): use existing provider when validating API key on edit

### DIFF
--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -67,7 +67,7 @@ class LLMProviderKeySerializer(serializers.ModelSerializer):
         return "****"
 
     def validate_api_key(self, value: str) -> str:
-        provider = self.initial_data.get("provider", LLMProvider.OPENAI)
+        provider = self.initial_data.get("provider", self.instance.provider if self.instance else LLMProvider.OPENAI)
 
         if provider == LLMProvider.OPENAI:
             if not value.startswith(("sk-", "sk-proj-")):


### PR DESCRIPTION
## Problem

When editing a provider key's API key (e.g. for Fireworks or OpenRouter), the validation logic defaults to checking for OpenAI's `sk-` prefix format instead of using the key's actual provider. This rejects valid API keys for non-OpenAI providers.

## Changes

- Use `self.instance.provider` as the default provider during `validate_api_key` when updating an existing key, instead of always defaulting to `openai`
- Add test for updating a Fireworks provider key's API key

## How did you test this code?

- Added `test_can_update_fireworks_provider_key_api_key` to verify the fix
- Existing tests continue to pass

## Publish to changelog?

no