### PR TITLE
fix(llma): always show validate button for provider keys

### DIFF
--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -563,22 +563,20 @@ export function LLMProviderKeysSettings(): JSX.Element {
             width: 150,
             render: (_, key) => (
                 <div className="flex gap-1">
-                    {key.state !== 'ok' && (
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.LlmAnalytics}
-                            minAccessLevel={AccessControlLevel.Editor}
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.LlmAnalytics}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconRefresh />}
+                            loading={validatingKeyId === key.id}
+                            onClick={() => validateProviderKey({ id: key.id })}
                         >
-                            <LemonButton
-                                size="small"
-                                type="secondary"
-                                icon={<IconRefresh />}
-                                loading={validatingKeyId === key.id}
-                                onClick={() => validateProviderKey({ id: key.id })}
-                            >
-                                Validate
-                            </LemonButton>
-                        </AccessControlAction>
-                    )}
+                            Validate
+                        </LemonButton>
+                    </AccessControlAction>
                     <AccessControlAction
                         resourceType={AccessControlResourceType.LlmAnalytics}
                         minAccessLevel={AccessControlLevel.Editor}


### PR DESCRIPTION
## Problem

The "Validate" button for provider API keys was only shown when the key was already in an error/invalid state. This made it impossible to re-validate a key that appeared as "ok" in PostHog but had been revoked externally (e.g. on the Fireworks dashboard).

## Changes

- Remove the `key.state !== 'ok'` guard so the Validate button is always visible in the provider keys settings table

## How did you test this code?

- Manually verified the Validate button now appears for keys in all states (ok, error, invalid)
- Confirmed re-validating a revoked key correctly flips its state to error/invalid

## Publish to changelog?

no