### PR TITLE
feat(capture): simplify global rate limit response msg

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -1,7 +1,6 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -80,8 +79,8 @@ pub enum CaptureError {
     #[error("rate limited")]
     RateLimited,
 
-    #[error("{0}: {1} events submitted between {2} and {3} exceeds limit of {4} events per {5}s")]
-    GlobalRateLimitExceeded(String, u64, DateTime<Utc>, DateTime<Utc>, u64, u64),
+    #[error("rate limit exceeded: events per minute")]
+    GlobalRateLimitExceeded(),
 
     #[error("payload empty after filtering invalid event types")]
     EmptyPayloadFiltered,
@@ -123,7 +122,7 @@ impl CaptureError {
             CaptureError::NonRetryableSinkError => "non_retry_sink",
             CaptureError::BillingLimit => "billing_limit",
             CaptureError::RateLimited => "rate_limited",
-            CaptureError::GlobalRateLimitExceeded(_, _, _, _, _, _) => "global_rate_limit",
+            CaptureError::GlobalRateLimitExceeded() => "global_rate_limit",
             CaptureError::EmptyPayloadFiltered => "empty_filtered_payload",
             CaptureError::ServiceUnavailable(_) => "service_unavailable",
             CaptureError::BodyReadTimeout => "body_read_timeout",
@@ -164,7 +163,7 @@ impl IntoResponse for CaptureError {
                 (StatusCode::TOO_MANY_REQUESTS, self.to_string())
             }
 
-            CaptureError::GlobalRateLimitExceeded(_, _, _, _, _, _) => {
+            CaptureError::GlobalRateLimitExceeded() => {
                 (StatusCode::TOO_MANY_REQUESTS, self.to_string())
             }
 

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -16,11 +16,7 @@ use crate::{
     api::CaptureError,
     debug_or_info,
     extractors::extract_body_with_timeout,
-    payload::{
-        extract_and_record_metadata, extract_payload_bytes,
-        types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
-        EventQuery,
-    },
+    payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     utils::extract_and_verify_token,
     v0_request::{ProcessingContext, RawRequest},
@@ -145,21 +141,12 @@ pub async fn handle_event_payload(
             .is_limited(&context.token, events.len() as u64)
             .await
         {
-            let limit_type = if limited.is_custom_limited {
-                GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM
-            } else {
-                GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL
-            };
-            debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
-                limit_type, "global rate limit applied");
-            return Err(CaptureError::GlobalRateLimitExceeded(
-                context.token.clone(),
-                events.len() as u64,
-                limited.window_start,
-                limited.window_end,
-                limited.threshold,
-                limited.window_interval.as_secs(),
-            ));
+            debug_or_info!(chatty_debug_enabled,
+                context=?context,
+                event_count=?events.len(),
+                details=?limited,
+                "global rate limit applied");
+            return Err(CaptureError::GlobalRateLimitExceeded());
         }
     }
 

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -16,11 +16,7 @@ use crate::{
     debug_or_info,
     events::recordings::RawRecording,
     extractors::extract_body_with_timeout,
-    payload::{
-        decompress_payload, extract_and_record_metadata, extract_payload_bytes,
-        types::{GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM, GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL},
-        EventQuery,
-    },
+    payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     v0_request::ProcessingContext,
 };
@@ -139,21 +135,12 @@ pub async fn handle_recording_payload(
             .is_limited(&context.token, events.len() as u64)
             .await
         {
-            let limit_type = if limited.is_custom_limited {
-                GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM
-            } else {
-                GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL
-            };
-            debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(),
-                limit_type, "global rate limit applied");
-            return Err(CaptureError::GlobalRateLimitExceeded(
-                context.token.clone(),
-                events.len() as u64,
-                limited.window_start,
-                limited.window_end,
-                limited.threshold,
-                limited.window_interval.as_secs(),
-            ));
+            debug_or_info!(chatty_debug_enabled,
+                context=?context,
+                event_count=?events.len(),
+                details=?limited,
+                "global rate limit applied");
+            return Err(CaptureError::GlobalRateLimitExceeded());
         }
     }
 

--- a/rust/capture/src/payload/types.rs
+++ b/rust/capture/src/payload/types.rs
@@ -107,9 +107,6 @@ pub struct EventFormData {
     pub lib_version: Option<String>,
 }
 
-pub const GLOBAL_RATE_LIMIT_KEY_TYPE_GLOBAL: &str = "global";
-pub const GLOBAL_RATE_LIMIT_KEY_TYPE_CUSTOM: &str = "custom";
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Problem
Just some housekeeping prior to shipping this to prod deploys. We don't want to include the limiter details in the responses now that we're past smoke testing stage 👍 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Update debug logging on limited responses with metadata
* Remove chatty message in 429 global rate limiter `capture` responses
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
