### PR TITLE
chore(flags): assign flags platform routes to team-flags-platform

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -129,19 +129,18 @@ posthog/tasks/exports/** @PostHog/team-analytics-platform
 # Revenue Analytics - owned by @rafaeelaudibert and @PostHog/team-customer-analytics
 products/revenue_analytics/\*\* @rafaeelaudibert @PostHog/team-customer-analytics
 
-# Feature Flags platform (the `/flags` and `/decide` endpoints + associated utils) - owned by @PostHog/team-feature-flags
-rust/feature-flags/ @PostHog/team-feature-flags
-posthog/api/decide.py @PostHog/team-feature-flags
-posthog/models/flag_matching.py @PostHog/team-feature-flags
+# Feature Flags platform (the `/flags` endpoint + associated utils) - owned by @PostHog/team-flags-platform
+rust/feature-flags/ @PostHog/team-flags-platform
+posthog/models/feature_flag/flag_matching.py @PostHog/team-flags-platform
 
-# Feature Flags CRUD operations - owned by @PostHog/team-feature-flags
-posthog/models/feature_flag/ @PostHog/team-feature-flags
-posthog/api/feature_flag.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags
-posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags
-posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
-posthog/test/test_feature_flag.py @PostHog/team-feature-flags
+# Feature Flags CRUD operations - owned by @PostHog/team-feature-flags and @PostHog/team-flags-platform
+posthog/models/feature_flag/ @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/api/feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/api/test/test_feature_flag_dependency_deletion.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/api/test/test_feature_flag_utils.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/api/test/test_feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags @PostHog/team-flags-platform
+posthog/test/test_feature_flag.py @PostHog/team-feature-flags @PostHog/team-flags-platform
 
 # Cohorts - owned by @PostHog/team-feature-flags
 posthog/api/cohort.py @PostHog/team-feature-flags


### PR DESCRIPTION
## Problem

The Feature Flags platform team (`@PostHog/team-flags-platform`) now owns the flags platform infrastructure (the `/flags` and `/decide` endpoints), but CODEOWNERS-soft was still assigning all flags-related paths to `@PostHog/team-feature-flags`.

## Changes

- Platform routes (`rust/feature-flags/`, `posthog/api/decide.py`, `posthog/models/flag_matching.py`) are now assigned to `@PostHog/team-flags-platform`
- CRUD operations (`posthog/models/feature_flag/`, `posthog/api/feature_flag.py`) are assigned to both `@PostHog/team-feature-flags` and `@PostHog/team-flags-platform`

## How did you test this code?

Config-only change to CODEOWNERS-soft. No automated tests needed.

## Publish to changelog?

No