### PR TITLE
feat(flags): implement virtualization for LemonInputSelect to prevent OOM

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -958,106 +958,6 @@ export interface PatchedDashboardTemplateApi {
 }
 
 /**
- * * `allow` - Allow
- * `reject` - Reject
- */
-export type EnforcementModeEnumApi = (typeof EnforcementModeEnumApi)[keyof typeof EnforcementModeEnumApi]
-
-export const EnforcementModeEnumApi = {
-    Allow: 'allow',
-    Reject: 'reject',
-} as const
-
-/**
- * Serializer mixin that handles tags for objects.
- */
-export interface EnterpriseEventDefinitionApi {
-    readonly id: string
-    /** @maxLength 400 */
-    name: string
-    /** @nullable */
-    owner?: number | null
-    /** @nullable */
-    description?: string | null
-    tags?: unknown[]
-    /** @nullable */
-    readonly created_at: string | null
-    readonly updated_at: string
-    readonly updated_by: UserBasicApi
-    /** @nullable */
-    readonly last_seen_at: string | null
-    readonly last_updated_at: string
-    verified?: boolean
-    /** @nullable */
-    readonly verified_at: string | null
-    readonly verified_by: UserBasicApi
-    /** @nullable */
-    hidden?: boolean | null
-    enforcement_mode?: EnforcementModeEnumApi
-    readonly is_action: boolean
-    readonly action_id: number
-    readonly is_calculating: boolean
-    readonly last_calculated_at: string
-    readonly created_by: UserBasicApi
-    post_to_slack?: boolean
-    default_columns?: string[]
-    readonly media_preview_urls: readonly string[]
-}
-
-export interface PaginatedEnterpriseEventDefinitionListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: EnterpriseEventDefinitionApi[]
-}
-
-/**
- * Serializer mixin that handles tags for objects.
- */
-export interface PatchedEnterpriseEventDefinitionApi {
-    readonly id?: string
-    /** @maxLength 400 */
-    name?: string
-    /** @nullable */
-    owner?: number | null
-    /** @nullable */
-    description?: string | null
-    tags?: unknown[]
-    /** @nullable */
-    readonly created_at?: string | null
-    readonly updated_at?: string
-    readonly updated_by?: UserBasicApi
-    /** @nullable */
-    readonly last_seen_at?: string | null
-    readonly last_updated_at?: string
-    verified?: boolean
-    /** @nullable */
-    readonly verified_at?: string | null
-    readonly verified_by?: UserBasicApi
-    /** @nullable */
-    hidden?: boolean | null
-    enforcement_mode?: EnforcementModeEnumApi
-    readonly is_action?: boolean
-    readonly action_id?: number
-    readonly is_calculating?: boolean
-    readonly last_calculated_at?: string
-    readonly created_by?: UserBasicApi
-    post_to_slack?: boolean
-    default_columns?: string[]
-    readonly media_preview_urls?: readonly string[]
-}
-
-export type EventDefinitionApiProperties = { [key: string]: unknown }
-
-export interface EventDefinitionApi {
-    elements: unknown[]
-    event: string
-    properties: EventDefinitionApiProperties
-}
-
-/**
  * * `image/png` - image/png
  * `application/pdf` - application/pdf
  * `text/csv` - text/csv
@@ -1990,24 +1890,6 @@ export type DashboardTemplatesListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
-}
-
-export type EventDefinitionsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number
-}
-
-export type EventDefinitionsByNameRetrieveParams = {
-    /**
-     * The exact event name to look up
-     */
-    name: string
 }
 
 export type ExportsListParams = {

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -16,11 +16,7 @@ import type {
     DashboardTemplateApi,
     DashboardTemplatesListParams,
     DomainsListParams,
-    EnterpriseEventDefinitionApi,
     EnterprisePropertyDefinitionApi,
-    EventDefinitionApi,
-    EventDefinitionsByNameRetrieveParams,
-    EventDefinitionsListParams,
     ExportedAssetApi,
     ExportsListParams,
     FileSystemApi,
@@ -38,7 +34,6 @@ import type {
     PaginatedAnnotationListApi,
     PaginatedCommentListApi,
     PaginatedDashboardTemplateListApi,
-    PaginatedEnterpriseEventDefinitionListApi,
     PaginatedEnterprisePropertyDefinitionListApi,
     PaginatedExportedAssetListApi,
     PaginatedFileSystemListApi,
@@ -54,7 +49,6 @@ import type {
     PatchedAnnotationApi,
     PatchedCommentApi,
     PatchedDashboardTemplateApi,
-    PatchedEnterpriseEventDefinitionApi,
     PatchedEnterprisePropertyDefinitionApi,
     PatchedFileSystemApi,
     PatchedIntegrationApi,
@@ -1184,193 +1178,6 @@ export const getDashboardTemplatesJsonSchemaRetrieveUrl = (projectId: string) =>
 
 export const dashboardTemplatesJsonSchemaRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDashboardTemplatesJsonSchemaRetrieveUrl(projectId), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsListUrl = (projectId: string, params?: EventDefinitionsListParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/event_definitions/?${stringifiedParams}`
-        : `/api/projects/${projectId}/event_definitions/`
-}
-
-export const eventDefinitionsList = async (
-    projectId: string,
-    params?: EventDefinitionsListParams,
-    options?: RequestInit
-): Promise<PaginatedEnterpriseEventDefinitionListApi> => {
-    return apiMutator<PaginatedEnterpriseEventDefinitionListApi>(getEventDefinitionsListUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/`
-}
-
-export const eventDefinitionsCreate = async (
-    projectId: string,
-    enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
-    options?: RequestInit
-): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsCreateUrl(projectId), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(enterpriseEventDefinitionApi),
-    })
-}
-
-export const getEventDefinitionsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
-}
-
-export const eventDefinitionsRetrieve = async (
-    projectId: string,
-    id: string,
-    options?: RequestInit
-): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsUpdateUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
-}
-
-export const eventDefinitionsUpdate = async (
-    projectId: string,
-    id: string,
-    enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
-    options?: RequestInit
-): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsUpdateUrl(projectId, id), {
-        ...options,
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(enterpriseEventDefinitionApi),
-    })
-}
-
-export const getEventDefinitionsPartialUpdateUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
-}
-
-export const eventDefinitionsPartialUpdate = async (
-    projectId: string,
-    id: string,
-    patchedEnterpriseEventDefinitionApi: NonReadonly<PatchedEnterpriseEventDefinitionApi>,
-    options?: RequestInit
-): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsPartialUpdateUrl(projectId, id), {
-        ...options,
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedEnterpriseEventDefinitionApi),
-    })
-}
-
-export const getEventDefinitionsDestroyUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
-}
-
-export const eventDefinitionsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsDestroyUrl(projectId, id), {
-        ...options,
-        method: 'DELETE',
-    })
-}
-
-export const getEventDefinitionsMetricsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/metrics/`
-}
-
-export const eventDefinitionsMetricsRetrieve = async (
-    projectId: string,
-    id: string,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsMetricsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-/**
- * Get event definition by exact name
- */
-export const getEventDefinitionsByNameRetrieveUrl = (
-    projectId: string,
-    params: EventDefinitionsByNameRetrieveParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/event_definitions/by_name/?${stringifiedParams}`
-        : `/api/projects/${projectId}/event_definitions/by_name/`
-}
-
-export const eventDefinitionsByNameRetrieve = async (
-    projectId: string,
-    params: EventDefinitionsByNameRetrieveParams,
-    options?: RequestInit
-): Promise<EventDefinitionApi> => {
-    return apiMutator<EventDefinitionApi>(getEventDefinitionsByNameRetrieveUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsGolangRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/golang/`
-}
-
-export const eventDefinitionsGolangRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsGolangRetrieveUrl(projectId), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsPythonRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/python/`
-}
-
-export const eventDefinitionsPythonRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsPythonRetrieveUrl(projectId), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getEventDefinitionsTypescriptRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/typescript/`
-}
-
-export const eventDefinitionsTypescriptRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsTypescriptRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -55,6 +55,7 @@ export interface PropertyFiltersProps {
     addFilterDocLink?: string
     operatorAllowlist?: OperatorValueSelectProps['operatorAllowlist']
     hogQLGlobals?: Record<string, any>
+    enableLargeListVirtualization?: boolean
 }
 
 export function PropertyFilters({
@@ -91,6 +92,7 @@ export function PropertyFilters({
     addFilterDocLink,
     operatorAllowlist,
     hogQLGlobals,
+    enableLargeListVirtualization = false,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
@@ -163,6 +165,7 @@ export function PropertyFilters({
                                             editable={editable}
                                             operatorAllowlist={operatorAllowlist}
                                             hogQLGlobals={hogQLGlobals}
+                                            enableLargeListVirtualization={enableLargeListVirtualization}
                                         />
                                     )}
                                     errorMessage={errorMessages && errorMessages[index]}

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -60,6 +60,7 @@ export interface OperatorValueSelectProps {
      * Force single-select mode regardless of operator type
      * **/
     forceSingleSelect?: boolean
+    enableLargeListVirtualization?: boolean
 }
 
 interface OperatorSelectProps extends Omit<LemonSelectProps<any>, 'options'> {
@@ -114,6 +115,7 @@ export function OperatorValueSelect({
     startVisible,
     operatorAllowlist,
     forceSingleSelect,
+    enableLargeListVirtualization = false,
 }: OperatorValueSelectProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const semverTargetingEnabled = !!featureFlags[FEATURE_FLAGS.SEMVER_TARGETING]
@@ -275,6 +277,7 @@ export function OperatorValueSelect({
                         size={size}
                         forceSingleSelect={forceSingleSelect}
                         validationError={validationError}
+                        enableLargeListVirtualization={enableLargeListVirtualization}
                     />
                 </div>
             )}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -45,6 +45,7 @@ export interface PropertyValueProps {
     preloadValues?: boolean
     forceSingleSelect?: boolean
     validationError?: string | null
+    enableLargeListVirtualization?: boolean
 }
 
 export function PropertyValue({
@@ -65,6 +66,7 @@ export function PropertyValue({
     preloadValues = false,
     forceSingleSelect = false,
     validationError = null,
+    enableLargeListVirtualization = false,
 }: PropertyValueProps): JSX.Element {
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
@@ -319,6 +321,8 @@ export function PropertyValue({
                       : undefined
             }
             popoverClassName="max-w-200"
+            virtualized={enableLargeListVirtualization}
+            enableLargeListVirtualization={enableLargeListVirtualization}
             options={displayOptions.map(({ name: _name }, index) => {
                 const name = toString(_name)
                 const isSuggested = initialSuggestedValues.set.has(name)

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -79,6 +79,7 @@ export function TaxonomicPropertyFilter({
     operatorAllowlist,
     endpointFilters,
     hogQLGlobals,
+    enableLargeListVirtualization = false,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
@@ -227,6 +228,7 @@ export function TaxonomicPropertyFilter({
                     : undefined
             }
             operatorAllowlist={operatorAllowlist}
+            enableLargeListVirtualization={enableLargeListVirtualization}
         />
     )
 

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -65,4 +65,5 @@ export interface PropertyFilterInternalProps {
     addFilterDocLink?: string
     endpointFilters?: Record<string, any>
     hogQLGlobals?: Record<string, any>
+    enableLargeListVirtualization?: boolean
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -170,6 +170,7 @@ export const FEATURE_FLAGS = {
     // UX flags, used to control the UX of the app
     AI_FIRST: 'ai-first', // this a larger change, not released to team yet
     UX_REMOVE_SIDEPANEL: 'ux-remove-sidepanel', // used to remove the sidepanel from the experience
+    LEMON_INPUT_SELECT_VIRTUALIZATION: 'lemon-input-select-virtualization', // owner: @gustavo #team-feature-flags
 
     // Feature flags used to control opt-in for different behaviors, should not be removed
     CONTROL_SUPPORT_LOGIN: 'control_support_login', // owner: #team-security, used to control whether users can opt out of support impersonation

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -5,16 +5,14 @@ import { SortableContext, arrayMove, rectSortingStrategy, useSortable } from '@d
 import { CSS } from '@dnd-kit/utilities'
 import clsx from 'clsx'
 import Fuse from 'fuse.js'
-import { CSSProperties, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { List } from 'react-window'
+import React, { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconCheck, IconPencil, IconX } from '@posthog/icons'
 import { LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
 
-import { AutoSizer } from 'lib/components/AutoSizer'
-import { SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
+import { SortableDragIcon } from 'lib/lemon-ui/icons'
 import { range } from 'lib/utils'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
@@ -31,90 +29,9 @@ const NON_ESCAPED_COMMA_REGEX = /(?<!\\),/
 const VIRTUALIZED_SELECT_OPTION_HEIGHT = 33
 
 const VIRTUALIZED_MAX_DROPDOWN_HEIGHT = 420
-
-interface VirtualizedOptionRowProps<T = string> {
-    visibleOptions: LemonInputSelectOption<T>[]
-    selectedIndex: number
-    stringKeys: string[]
-    wasLimitReached: boolean
-    limit?: number
-    _onActionItem: (key: string, e?: MouseEvent) => void
-    setSelectedIndex: (index: number) => void
-    allowCustomValues?: boolean
-    disableEditing?: boolean
-    setInputValue: (value: string) => void
-    inputRef: React.RefObject<HTMLInputElement | null>
-    _onFocus: () => void
-    getInputLabel: (option: LemonInputSelectOption<T>) => React.ReactNode
-    getOptionIcon: (option: LemonInputSelectOption<T>, isSelected: boolean) => JSX.Element | null | undefined
-}
-
-function VirtualizedOptionRow<T = string>({
-    index,
-    style,
-    visibleOptions,
-    selectedIndex,
-    stringKeys,
-    wasLimitReached,
-    limit,
-    _onActionItem,
-    setSelectedIndex,
-    allowCustomValues,
-    disableEditing,
-    setInputValue,
-    inputRef,
-    _onFocus,
-    getInputLabel,
-    getOptionIcon,
-}: {
-    ariaAttributes: Record<string, unknown>
-    index: number
-    style: CSSProperties
-} & VirtualizedOptionRowProps<T>): JSX.Element {
-    const option = visibleOptions[index]
-    const isFocused = index === selectedIndex
-    const isSelected = stringKeys.includes(option.key)
-    const isDisabled = wasLimitReached && !isSelected
-    return (
-        <LemonButton
-            style={style}
-            key={option.key}
-            type="tertiary"
-            size="small"
-            fullWidth
-            active={isFocused}
-            onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-            onMouseEnter={() => setSelectedIndex(index)}
-            disabledReason={isDisabled ? `Limit of ${limit} options reached` : undefined}
-            tooltip={option.tooltip}
-            icon={getOptionIcon(option, isSelected)}
-            sideAction={
-                !option.__isInput && allowCustomValues && !disableEditing
-                    ? {
-                          icon: <IconPencil className={!isFocused ? 'invisible' : undefined} />,
-                          tooltip: (
-                              <>
-                                  Edit this value
-                                  <KeyboardShortcut option enter />
-                              </>
-                          ),
-                          onClick: () => {
-                              setInputValue(option.key)
-                              inputRef.current?.focus()
-                              _onFocus()
-                          },
-                      }
-                    : undefined
-            }
-        >
-            <span className="whitespace-nowrap ph-no-capture truncate">
-                {!option.__isInput && !option.__isCustomValue
-                    ? (option.labelComponent ?? option.label)
-                    : getInputLabel(option)}
-            </span>
-        </LemonButton>
-    )
-}
+// Maximum height for value snacks container
+const VALUE_SNACKS_MAX_HEIGHT = 320
+// Estimated height per snack row (snacks are variable width but consistent height)
 
 export interface LemonInputSelectOption<T = string> {
     key: string
@@ -169,6 +86,8 @@ export type LemonInputSelectProps<T = string> = Pick<
     disableCommaSplitting?: boolean
     action?: LemonInputSelectAction
     virtualized?: boolean
+    /** Enable virtualization for large lists (>100 values) with vertical layout */
+    enableLargeListVirtualization?: boolean
     /** Enable drag-and-drop reordering of values */
     sortable?: boolean
     /** Render single-mode values as snack pills (matching multi-mode appearance) */
@@ -208,6 +127,7 @@ export function LemonInputSelect<T = string>({
     disableCommaSplitting = false,
     action,
     virtualized = false,
+    enableLargeListVirtualization = false,
     sortable = false,
     status = 'default',
     singleValueAsSnack = false,
@@ -579,6 +499,15 @@ export function LemonInputSelect<T = string>({
         [values, getStringKey, onChange]
     )
 
+    // Check if we need to use virtualization for large lists
+    // Use virtualization for >100 values in multiple mode to prevent OOM
+    // Only when explicitly enabled via prop
+    // Memoize to prevent race conditions and unnecessary re-renders
+    const useVirtualization = useMemo(
+        () => enableLargeListVirtualization && mode === 'multiple' && values.length > 100,
+        [enableLargeListVirtualization, mode, values.length]
+    )
+
     const valuesPrefix = useMemo(() => {
         // For single mode with a selected value and no active input, show the value as prefix since
         // showing the entered value as placeholder was unintuitive
@@ -615,6 +544,11 @@ export function LemonInputSelect<T = string>({
             return null
         }
 
+        // For large lists, don't render as prefix - will be rendered with virtualization
+        if (useVirtualization) {
+            return null
+        }
+
         const preInputValues = itemBeingEditedIndex !== null ? values.slice(0, itemBeingEditedIndex) : values
 
         // TRICKY: We don't want the popover to affect the snack buttons
@@ -629,6 +563,8 @@ export function LemonInputSelect<T = string>({
                     }
                     sortable={sortable}
                     onDragEnd={handleDragEnd}
+                    limitHeight={true}
+                    enableVirtualization={useVirtualization}
                 />
             </PopoverReferenceContext.Provider>
         )
@@ -651,6 +587,43 @@ export function LemonInputSelect<T = string>({
         singleValueAsSnack,
         onChange,
         setInputValue,
+        useVirtualization,
+    ])
+
+    const virtualizedValues = useMemo(() => {
+        // Only render virtualized values for large lists
+        if (!useVirtualization) {
+            return null
+        }
+
+        return (
+            <div className="w-full mb-2">
+                <PopoverReferenceContext.Provider value={null}>
+                    <ValueSnacks
+                        values={values.map(getStringKey)}
+                        options={options}
+                        onClose={(value) => _onActionItem(value, null)}
+                        onInitiateEdit={
+                            allowCustomValues && !disableEditing ? (value) => _onActionItem(value, null, true) : null
+                        }
+                        sortable={sortable}
+                        onDragEnd={handleDragEnd}
+                        limitHeight={true}
+                        enableVirtualization={useVirtualization}
+                    />
+                </PopoverReferenceContext.Provider>
+            </div>
+        )
+    }, [
+        useVirtualization,
+        values,
+        getStringKey,
+        options,
+        _onActionItem,
+        allowCustomValues,
+        disableEditing,
+        sortable,
+        handleDragEnd,
     ])
 
     const valuesAndClearButtonSuffix = useMemo(() => {
@@ -682,6 +655,8 @@ export function LemonInputSelect<T = string>({
                     }
                     sortable={sortable}
                     onDragEnd={handleDragEnd}
+                    limitHeight={true}
+                    enableVirtualization={useVirtualization}
                 />
                 {isClearButtonVisible && (
                     <div
@@ -723,6 +698,7 @@ export function LemonInputSelect<T = string>({
         size,
         onChange,
         singleValueAsSnack,
+        useVirtualization,
     ])
 
     // Positioned like a placeholder but rendered via the suffix since the actual placeholder has to be a string
@@ -740,18 +716,6 @@ export function LemonInputSelect<T = string>({
             </span>
         )
     }, [displayMode, mode, inputValue, loading, values.length, options.length])
-
-    const virtualizedListHeight = useMemo(() => {
-        if (visibleOptions.length <= 1) {
-            return VIRTUALIZED_SELECT_OPTION_HEIGHT
-        }
-        const height = visibleOptions.length * VIRTUALIZED_SELECT_OPTION_HEIGHT
-
-        if (height > VIRTUALIZED_MAX_DROPDOWN_HEIGHT) {
-            return VIRTUALIZED_MAX_DROPDOWN_HEIGHT
-        }
-        return height
-    }, [visibleOptions])
 
     const wasLimitReached = values.length >= limit
 
@@ -786,7 +750,293 @@ export function LemonInputSelect<T = string>({
         return undefined
     }
 
-    return (
+    return useVirtualization ? (
+        <LemonDropdown
+            matchWidth
+            closeOnClickInside={false}
+            actionable
+            visible={showPopover}
+            onClickOutside={() => {
+                popoverFocusRef.current = false
+                setShowPopover(false)
+                // It seems more intuitive to lose focus of drop down entirely when clicking outside of the field.
+                // If this behavior at some point is not desired for multiple mode anymore, it should be kept for single mode.
+                inputRef.current?.blur()
+            }}
+            onClickInside={(e) => {
+                popoverFocusRef.current = true
+                e.stopPropagation()
+            }}
+            className={popoverClassName}
+            placement="top-start"
+            fallbackPlacements={['top-end', 'bottom-start', 'bottom-end']}
+            loadingBar={loading && visibleOptions.length > 0}
+            overlay={
+                <div className="deprecated-space-y-px overflow-y-auto">
+                    {title && <h5 className="mx-2 my-1">{title}</h5>}
+
+                    {bulkActions && mode === 'multiple' && (
+                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
+                            {bulkActions === 'select-and-clear-all' && (
+                                <LemonButton
+                                    size="small"
+                                    className="flex-1"
+                                    disabledReason={
+                                        values.length === allOptionsMap.size
+                                            ? 'All options are already selected'
+                                            : undefined
+                                    }
+                                    tooltipPlacement="top-start"
+                                    tooltipArrowOffset={50}
+                                    onClick={() => {
+                                        const allKeys = Array.from(allOptionsMap.keys())
+                                        const allTypedValues = allKeys.map(getTypedValue)
+                                        onChange?.(allTypedValues)
+                                    }}
+                                    icon={
+                                        <LemonCheckbox
+                                            checked={
+                                                values.length === allOptionsMap.size
+                                                    ? true
+                                                    : values.length
+                                                      ? 'indeterminate'
+                                                      : false
+                                            }
+                                            className="pointer-events-none"
+                                        />
+                                    }
+                                >
+                                    Select all
+                                </LemonButton>
+                            )}
+                            <LemonButton
+                                size="small"
+                                className={clsx({ 'flex-1': bulkActions === 'clear-all' })}
+                                tooltipPlacement={bulkActions === 'select-and-clear-all' ? 'top-end' : 'top-start'}
+                                tooltipArrowOffset={bulkActions === 'clear-all' ? 30 : undefined}
+                                disabledReason={values.length === 0 ? 'No options are selected' : undefined}
+                                onClick={() => onChange?.([])}
+                            >
+                                Clear all
+                            </LemonButton>
+                        </div>
+                    )}
+
+                    {action && (
+                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
+                            <LemonButton
+                                size="small"
+                                className="flex-1"
+                                disabledReason={action?.disabledReason}
+                                onClick={action?.onClick}
+                            >
+                                {action?.children}
+                            </LemonButton>
+                        </div>
+                    )}
+
+                    {visibleOptions.length > 0 ? (
+                        visibleOptions.length > 100 ? (
+                            <>
+                                <div
+                                    style={{
+                                        height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
+                                        overflowY: 'auto',
+                                    }}
+                                    className="space-y-px"
+                                >
+                                    {visibleOptions.map((option, index) => {
+                                        const isFocused = index === selectedIndex
+                                        const isSelected = stringKeys.includes(option.key)
+                                        const isDisabled = wasLimitReached && !isSelected
+                                        return (
+                                            <LemonButton
+                                                key={option.key}
+                                                type="tertiary"
+                                                size="small"
+                                                fullWidth
+                                                active={isFocused}
+                                                onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+                                                onMouseEnter={() => setSelectedIndex(index)}
+                                                disabledReason={
+                                                    isDisabled ? `Limit of ${limit} options reached` : undefined
+                                                }
+                                                tooltip={option.tooltip}
+                                                icon={getOptionIcon(option, isSelected)}
+                                                style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
+                                                sideAction={
+                                                    !option.__isInput && allowCustomValues && !disableEditing
+                                                        ? {
+                                                              icon: (
+                                                                  <IconPencil
+                                                                      className={!isFocused ? 'invisible' : undefined}
+                                                                  />
+                                                              ),
+                                                              tooltip: (
+                                                                  <>
+                                                                      Edit this value <KeyboardShortcut option enter />
+                                                                  </>
+                                                              ),
+                                                              onClick: () => {
+                                                                  setInputValue(option.key)
+                                                                  inputRef.current?.focus()
+                                                                  _onFocus()
+                                                              },
+                                                          }
+                                                        : undefined
+                                                }
+                                            >
+                                                <span className="whitespace-nowrap ph-no-capture truncate">
+                                                    {!option.__isInput && !option.__isCustomValue
+                                                        ? (option.labelComponent ?? option.label)
+                                                        : getInputLabel(option)}
+                                                </span>
+                                            </LemonButton>
+                                        )
+                                    })}
+                                </div>
+                                {/* Add value input visible at bottom of dropdown for large lists */}
+                                {allowCustomValues && inputValue && (
+                                    <div className="border-t border-border p-1">
+                                        <LemonButton
+                                            type="tertiary"
+                                            size="small"
+                                            fullWidth
+                                            onClick={() => _onActionItem(inputValue)}
+                                        >
+                                            <span className="whitespace-nowrap ph-no-capture truncate">
+                                                {getInputLabel({ key: inputValue, label: inputValue, __isInput: true })}
+                                            </span>
+                                        </LemonButton>
+                                    </div>
+                                )}
+                            </>
+                        ) : (
+                            visibleOptions.map((option, index) => {
+                                const isFocused = index === selectedIndex
+                                const isSelected = stringKeys.includes(option.key)
+                                const isDisabled = wasLimitReached && !isSelected
+                                return (
+                                    <LemonButton
+                                        key={option.key}
+                                        type="tertiary"
+                                        size="small"
+                                        fullWidth
+                                        active={isFocused}
+                                        onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+                                        onMouseEnter={() => setSelectedIndex(index)}
+                                        disabledReason={isDisabled ? `Limit of ${limit} options reached` : undefined}
+                                        tooltip={option.tooltip}
+                                        icon={getOptionIcon(option, isSelected)}
+                                        sideAction={
+                                            !option.__isInput && allowCustomValues && !disableEditing
+                                                ? {
+                                                      // To reduce visual clutter we only show the icon on focus or hover,
+                                                      // but we do want it present to make sure the layout is stable
+                                                      icon: (
+                                                          <IconPencil
+                                                              className={!isFocused ? 'invisible' : undefined}
+                                                          />
+                                                      ),
+                                                      tooltip: (
+                                                          <>
+                                                              Edit this value <KeyboardShortcut option enter />
+                                                          </>
+                                                      ),
+                                                      onClick: () => {
+                                                          setInputValue(option.key)
+                                                          inputRef.current?.focus()
+                                                          _onFocus()
+                                                      },
+                                                  }
+                                                : undefined
+                                        }
+                                    >
+                                        <span className="whitespace-nowrap ph-no-capture truncate">
+                                            {
+                                                !option.__isInput && !option.__isCustomValue
+                                                    ? (option.labelComponent ?? option.label) // Regular option
+                                                    : getInputLabel(option) // Input-based option
+                                            }
+                                        </span>
+                                    </LemonButton>
+                                )
+                            })
+                        )
+                    ) : loading ? (
+                        <>
+                            {range(5).map((x) => (
+                                // 33px is the height of a regular list item
+                                <div key={x} className="flex gap-2 items-center h-[33px] px-2">
+                                    <LemonSkeleton.Circle className="size-[18px]" />
+                                    <LemonSkeleton className="h-3.5 w-full" />
+                                </div>
+                            ))}
+                        </>
+                    ) : (
+                        <>
+                            {emptyStateComponent ? (
+                                emptyStateComponent
+                            ) : (
+                                <p className="text-secondary italic p-1">
+                                    {allowCustomValues
+                                        ? 'Start typing and press Enter to add options'
+                                        : `No options matching "${inputValue}"`}
+                                </p>
+                            )}
+                        </>
+                    )}
+                </div>
+            }
+        >
+            <LemonInput
+                inputRef={inputRef}
+                placeholder={
+                    displayMode === 'count'
+                        ? undefined
+                        : values.length === 0
+                          ? placeholder
+                          : mode === 'single'
+                            ? undefined // When value is selected in single mode, no placeholder (value shown but rendered as prefix)
+                            : allowCustomValues
+                              ? 'Add value'
+                              : disablePrompting
+                                ? undefined
+                                : 'Pick value'
+                }
+                autoWidth={fullWidth ? false : autoWidth}
+                fullWidth={fullWidth}
+                prefix={virtualizedValues}
+                suffix={
+                    <>
+                        {countPlaceholder}
+                        {valuesAndClearButtonSuffix}
+                    </>
+                }
+                onFocus={_onFocus}
+                onBlur={_onBlur}
+                value={inputValue}
+                onChange={setInputValue}
+                onClick={_onClick}
+                onKeyDown={_onKeyDown}
+                disabled={disabled}
+                autoFocus={autoFocus}
+                transparentBackground={transparentBackground}
+                className={clsx(
+                    '!h-auto leading-7 max-w-full w-full', // leading-7 means line height aligned with LemonSnack height
+                    // Putting button-like text styling on the single-select unfocused placeholder
+                    // NOTE: We need font-medium on both the input (for autosizing) and its placeholder (for display)
+                    mode === 'multiple' && 'flex-wrap',
+                    mode === 'single' && values.length > 0 && '*:*:font-medium *:*:placeholder:font-medium',
+                    mode === 'single' && values.length > 0 && !showPopover && '*:*:placeholder:text-default',
+                    className
+                )}
+                data-attr={dataAttr}
+                size={size}
+                status={status}
+            />
+        </LemonDropdown>
+    ) : (
         <LemonDropdown
             matchWidth
             closeOnClickInside={false}
@@ -872,38 +1122,81 @@ export function LemonInputSelect<T = string>({
                     )}
 
                     {visibleOptions.length > 0 ? (
-                        virtualized ? (
-                            <div>
-                                <AutoSizer
-                                    renderProp={({ width }) =>
-                                        width ? (
-                                            <List<VirtualizedOptionRowProps<T>>
-                                                style={{ width, height: virtualizedListHeight }}
-                                                rowCount={visibleOptions.length}
-                                                overscanCount={100}
-                                                rowHeight={VIRTUALIZED_SELECT_OPTION_HEIGHT}
-                                                rowComponent={VirtualizedOptionRow}
-                                                rowProps={{
-                                                    visibleOptions,
-                                                    selectedIndex,
-                                                    stringKeys,
-                                                    wasLimitReached,
-                                                    limit,
-                                                    _onActionItem,
-                                                    setSelectedIndex,
-                                                    allowCustomValues,
-                                                    disableEditing,
-                                                    setInputValue,
-                                                    inputRef,
-                                                    _onFocus,
-                                                    getInputLabel,
-                                                    getOptionIcon,
-                                                }}
-                                            />
-                                        ) : null
-                                    }
-                                />
-                            </div>
+                        visibleOptions.length > 100 ? (
+                            <>
+                                <div
+                                    style={{
+                                        height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
+                                        overflowY: 'auto',
+                                    }}
+                                    className="space-y-px"
+                                >
+                                    {visibleOptions.map((option, index) => {
+                                        const isFocused = index === selectedIndex
+                                        const isSelected = stringKeys.includes(option.key)
+                                        const isDisabled = wasLimitReached && !isSelected
+                                        return (
+                                            <LemonButton
+                                                key={option.key}
+                                                type="tertiary"
+                                                size="small"
+                                                fullWidth
+                                                active={isFocused}
+                                                onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+                                                onMouseEnter={() => setSelectedIndex(index)}
+                                                disabledReason={
+                                                    isDisabled ? `Limit of ${limit} options reached` : undefined
+                                                }
+                                                tooltip={option.tooltip}
+                                                icon={getOptionIcon(option, isSelected)}
+                                                style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
+                                                sideAction={
+                                                    !option.__isInput && allowCustomValues && !disableEditing
+                                                        ? {
+                                                              icon: (
+                                                                  <IconPencil
+                                                                      className={!isFocused ? 'invisible' : undefined}
+                                                                  />
+                                                              ),
+                                                              tooltip: (
+                                                                  <>
+                                                                      Edit this value <KeyboardShortcut option enter />
+                                                                  </>
+                                                              ),
+                                                              onClick: () => {
+                                                                  setInputValue(option.key)
+                                                                  inputRef.current?.focus()
+                                                                  _onFocus()
+                                                              },
+                                                          }
+                                                        : undefined
+                                                }
+                                            >
+                                                <span className="whitespace-nowrap ph-no-capture truncate">
+                                                    {!option.__isInput && !option.__isCustomValue
+                                                        ? (option.labelComponent ?? option.label)
+                                                        : getInputLabel(option)}
+                                                </span>
+                                            </LemonButton>
+                                        )
+                                    })}
+                                </div>
+                                {/* Input always visible at bottom for large lists */}
+                                {allowCustomValues && inputValue && (
+                                    <div className="border-t border-border p-1">
+                                        <LemonButton
+                                            type="tertiary"
+                                            size="small"
+                                            fullWidth
+                                            onClick={() => _onActionItem(inputValue)}
+                                        >
+                                            <span className="whitespace-nowrap ph-no-capture truncate">
+                                                {getInputLabel({ key: inputValue, label: inputValue, __isInput: true })}
+                                            </span>
+                                        </LemonButton>
+                                    </div>
+                                )}
+                            </>
                         ) : (
                             visibleOptions.map((option, index) => {
                                 const isFocused = index === selectedIndex
@@ -1106,6 +1399,157 @@ function DraggableValueSnack<T = string>({
     )
 }
 
+const VirtualizedValuesList = React.memo(function VirtualizedValuesList<T = string>({
+    values,
+    options,
+    onClose,
+    onInitiateEdit,
+}: {
+    values: string[]
+    options: LemonInputSelectOption<T>[]
+    onClose: (value: string) => void
+    onInitiateEdit: ((value: string) => void) | null
+}): JSX.Element {
+    const [scrollTop, setScrollTop] = useState(0)
+    const [rows, setRows] = useState<string[][]>([])
+    const measureRef = useRef<HTMLDivElement>(null)
+
+    // Create rows by measuring how many items fit per row
+    // Debounce measurements to avoid frequent re-renders that could cause focus loss
+    useEffect(() => {
+        const timeoutId = setTimeout(() => {
+            if (!measureRef.current) {
+                return
+            }
+
+            const containerWidth = measureRef.current.offsetWidth - 32 // Account for padding + scrollbar
+            const tempRows: string[][] = []
+            let currentRow: string[] = []
+            let currentRowWidth = 0
+
+            // Create a temporary element to measure text width
+            const tempSpan = document.createElement('span')
+            tempSpan.style.visibility = 'hidden'
+            tempSpan.style.position = 'absolute'
+            tempSpan.style.whiteSpace = 'nowrap'
+            tempSpan.className = 'LemonSnack' // Use same styling for measurement
+
+            try {
+                document.body.appendChild(tempSpan)
+
+                values.forEach((value) => {
+                    const option = options.find((opt) => opt.key === value)
+                    const label = option?.label ?? value
+
+                    // Estimate width (rough calculation for LemonSnack)
+                    tempSpan.textContent = label
+                    const itemWidth = tempSpan.offsetWidth + 40 // Add padding/borders/close button + extra margin
+
+                    if (currentRowWidth + itemWidth > containerWidth && currentRow.length > 0) {
+                        // Start new row
+                        tempRows.push([...currentRow])
+                        currentRow = [value]
+                        currentRowWidth = itemWidth + 4 // Add gap
+                    } else {
+                        // Add to current row
+                        currentRow.push(value)
+                        currentRowWidth += itemWidth + 4 // Add gap
+                    }
+                })
+
+                // Add final row
+                if (currentRow.length > 0) {
+                    tempRows.push(currentRow)
+                }
+            } finally {
+                // Ensure cleanup happens even if an error occurs
+                if (document.body.contains(tempSpan)) {
+                    document.body.removeChild(tempSpan)
+                }
+            }
+            setRows(tempRows)
+        }, 50) // 50ms debounce
+
+        return () => clearTimeout(timeoutId)
+    }, [values, options])
+
+    // Row-based virtualization
+    const rowHeight = 32 // Estimated height per row
+    const containerHeight = VALUE_SNACKS_MAX_HEIGHT
+    const visibleRowCount = Math.ceil(containerHeight / rowHeight)
+    const startRowIndex = Math.max(0, Math.floor(scrollTop / rowHeight))
+    const endRowIndex = Math.min(rows.length, startRowIndex + visibleRowCount + 2) // Extra buffer
+
+    const visibleRows = rows.slice(startRowIndex, endRowIndex)
+    const topSpacer = startRowIndex * rowHeight
+    const bottomSpacer = (rows.length - endRowIndex) * rowHeight
+
+    const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>): void => {
+        setScrollTop(e.currentTarget.scrollTop)
+    }, [])
+
+    const totalContentHeight = rows.length * rowHeight + (rows.length > 0 ? (rows.length - 1) * 4 : 0) // Add gap spacing
+    const isScrollable = totalContentHeight > VALUE_SNACKS_MAX_HEIGHT
+
+    return (
+        <div className="w-full">
+            <div
+                ref={measureRef}
+                style={{
+                    maxHeight: VALUE_SNACKS_MAX_HEIGHT,
+                    overflowY: isScrollable ? 'auto' : 'hidden',
+                }}
+                className="px-1 w-full"
+                onScroll={handleScroll}
+            >
+                {/* Top spacer for non-visible rows above */}
+                {topSpacer > 0 && <div style={{ height: topSpacer }} />}
+
+                {/* Visible rows */}
+                {visibleRows.map((row, rowIndex) => (
+                    <div
+                        key={startRowIndex + rowIndex}
+                        className="flex flex-wrap gap-1 mb-1"
+                        style={{ minHeight: rowHeight }}
+                    >
+                        {row.map((value) => {
+                            const option: LemonInputSelectOption<T> = options.find(
+                                (option) => option.key === value
+                            ) ?? {
+                                key: value,
+                                label: value,
+                                labelComponent: null,
+                            }
+
+                            return (
+                                <LemonSnack
+                                    key={value}
+                                    title={option?.label}
+                                    onClose={() => onClose(value)}
+                                    onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
+                                    className="cursor-text"
+                                >
+                                    {option?.labelComponent ?? option?.label}
+                                </LemonSnack>
+                            )
+                        })}
+                    </div>
+                ))}
+
+                {/* Bottom spacer for non-visible rows below */}
+                {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} />}
+            </div>
+
+            {/* Warning when content is scrollable */}
+            {isScrollable && (
+                <div className="text-xs text-muted mt-1 px-1">Scroll to see all {values.length} values</div>
+            )}
+        </div>
+    )
+})
+
+VirtualizedValuesList.displayName = 'VirtualizedValuesList'
+
 function ValueSnacks<T = string>({
     values,
     options,
@@ -1113,6 +1557,8 @@ function ValueSnacks<T = string>({
     onInitiateEdit,
     sortable = false,
     onDragEnd,
+    limitHeight = false,
+    enableVirtualization = false,
 }: {
     values: string[]
     options: LemonInputSelectOption<T>[]
@@ -1120,6 +1566,8 @@ function ValueSnacks<T = string>({
     onInitiateEdit: ((value: string) => void) | null
     sortable?: boolean
     onDragEnd?: (event: DragEndEvent) => void
+    limitHeight?: boolean
+    enableVirtualization?: boolean
 }): JSX.Element {
     const sensors = useSensors(
         useSensor(PointerSensor, {
@@ -1177,15 +1625,39 @@ function ValueSnacks<T = string>({
         )
     })
 
-    if (sortable && onDragEnd) {
-        return (
+    const contentElement =
+        sortable && onDragEnd ? (
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
                 <SortableContext items={values} strategy={rectSortingStrategy}>
                     {content}
                 </SortableContext>
             </DndContext>
+        ) : (
+            <>{content}</>
+        )
+
+    if (limitHeight) {
+        // Simple scrollable container for very large lists (>100 values)
+        if (values.length > 100 && enableVirtualization) {
+            // For large lists, use virtualized rendering (only render visible items)
+            return (
+                <VirtualizedValuesList
+                    values={values}
+                    options={options}
+                    onClose={onClose}
+                    onInitiateEdit={onInitiateEdit}
+                />
+            )
+        }
+
+        // For normal lists with limitHeight, use regular rendering with height limit
+        return (
+            <div className="flex flex-wrap gap-1 overflow-y-auto pr-1" style={{ maxHeight: VALUE_SNACKS_MAX_HEIGHT }}>
+                {contentElement}
+            </div>
         )
     }
 
-    return <>{content}</>
+    // For lists without height limit, return content directly
+    return contentElement
 }

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -1,1663 +1,1856 @@
-import './LemonInputSelect.scss'
+import "./LemonInputSelect.scss";
 
-import { DndContext, DragEndEvent, PointerSensor, closestCenter, useSensor, useSensors } from '@dnd-kit/core'
-import { SortableContext, arrayMove, rectSortingStrategy, useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import clsx from 'clsx'
-import Fuse from 'fuse.js'
-import React, { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import clsx from "clsx";
+import Fuse from "fuse.js";
+import React, {
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
-import { IconCheck, IconPencil, IconX } from '@posthog/icons'
-import { LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
+import { IconCheck, IconPencil, IconX } from "@posthog/icons";
+import { LemonCheckbox, Tooltip } from "@posthog/lemon-ui";
 
-import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
-import { SortableDragIcon } from 'lib/lemon-ui/icons'
-import { range } from 'lib/utils'
+import { LemonSkeleton } from "lib/lemon-ui/LemonSkeleton";
+import { LemonSnack } from "lib/lemon-ui/LemonSnack/LemonSnack";
+import { SortableDragIcon } from "lib/lemon-ui/icons";
+import { range } from "lib/utils";
 
-import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { KeyboardShortcut } from "~/layout/navigation-3000/components/KeyboardShortcut";
 
-import { LemonButton, LemonButtonPropsBase, SideAction } from '../LemonButton'
-import { LemonDropdown } from '../LemonDropdown'
-import { LemonInput, LemonInputProps } from '../LemonInput'
-import { PopoverReferenceContext } from '../Popover'
-import { TooltipTitle } from '../Tooltip/Tooltip'
+import { LemonButton, LemonButtonPropsBase, SideAction } from "../LemonButton";
+import { LemonDropdown } from "../LemonDropdown";
+import { LemonInput, LemonInputProps } from "../LemonInput";
+import { PopoverReferenceContext } from "../Popover";
+import { TooltipTitle } from "../Tooltip/Tooltip";
 
-const NON_ESCAPED_COMMA_REGEX = /(?<!\\),/
+const NON_ESCAPED_COMMA_REGEX = /(?<!\\),/;
 
 // This matches LemonButton's height when its size small
-const VIRTUALIZED_SELECT_OPTION_HEIGHT = 33
+const VIRTUALIZED_SELECT_OPTION_HEIGHT = 33;
 
-const VIRTUALIZED_MAX_DROPDOWN_HEIGHT = 420
+const VIRTUALIZED_MAX_DROPDOWN_HEIGHT = 420;
 // Maximum height for value snacks container
-const VALUE_SNACKS_MAX_HEIGHT = 320
+const VALUE_SNACKS_MAX_HEIGHT = 320;
 // Estimated height per snack row (snacks are variable width but consistent height)
 
 export interface LemonInputSelectOption<T = string> {
-    key: string
-    label: string
-    labelComponent?: React.ReactNode
-    tooltip?: TooltipTitle
-    /** @internal */
-    __isInput?: boolean
-    /** @internal - marks custom values (user-created, not in original options) */
-    __isCustomValue?: boolean
-    /** Original typed value - when provided, this will be used in onChange callbacks */
-    value?: T
+  key: string;
+  label: string;
+  labelComponent?: React.ReactNode;
+  tooltip?: TooltipTitle;
+  /** @internal */
+  __isInput?: boolean;
+  /** @internal - marks custom values (user-created, not in original options) */
+  __isCustomValue?: boolean;
+  /** Original typed value - when provided, this will be used in onChange callbacks */
+  value?: T;
 }
 
-export type LemonInputSelectAction = SideAction & Pick<LemonButtonPropsBase, 'children'>
+export type LemonInputSelectAction = SideAction &
+  Pick<LemonButtonPropsBase, "children">;
 
 export type LemonInputSelectProps<T = string> = Pick<
-    // NOTE: We explicitly pick rather than omit to ensure these components aren't used incorrectly
-    LemonInputProps,
-    'autoFocus' | 'autoWidth' | 'fullWidth' | 'status'
+  // NOTE: We explicitly pick rather than omit to ensure these components aren't used incorrectly
+  LemonInputProps,
+  "autoFocus" | "autoWidth" | "fullWidth" | "status"
 > & {
-    options?: LemonInputSelectOption<T>[]
-    value?: T[] | null
-    limit?: number // Limit the number of options to show
-    disabled?: boolean
-    loading?: boolean
-    placeholder?: string
-    title?: string // Title shown at the top of the list. Looks the same as section titles in LemonMenu.
-    disableFiltering?: boolean
-    disablePrompting?: boolean
-    mode: 'multiple' | 'single'
-    allowCustomValues?: boolean
-    /** Disable editing functionality (hides edit icons) while still allowing custom values */
-    disableEditing?: boolean
-    /** Format the label for custom values. Supports text (e.g. appending " (new entry)") and html. */
-    formatCreateLabel?: (input: string) => React.ReactNode
-    /** Transform input value as user types, e.g. normalization like replacing spaces with dashes. */
-    inputTransform?: (input: string) => string
-    emptyStateComponent?: React.ReactNode
-    onChange?: (newValue: T[]) => void
-    onBlur?: () => void
-    onFocus?: () => void
-    onInputChange?: (newValue: string) => void
-    'data-attr'?: string
-    className?: string
-    popoverClassName?: string
-    size?: 'xsmall' | 'small' | 'medium' | 'large'
-    transparentBackground?: boolean
-    displayMode?: 'snacks' | 'count'
-    bulkActions?: 'clear-all' | 'select-and-clear-all'
-    /** Disable comma splitting for properties that contain commas in their values (e.g., user agent strings) */
-    disableCommaSplitting?: boolean
-    action?: LemonInputSelectAction
-    virtualized?: boolean
-    /** Enable virtualization for large lists (>100 values) with vertical layout */
-    enableLargeListVirtualization?: boolean
-    /** Enable drag-and-drop reordering of values */
-    sortable?: boolean
-    /** Render single-mode values as snack pills (matching multi-mode appearance) */
-    singleValueAsSnack?: boolean
-}
+  options?: LemonInputSelectOption<T>[];
+  value?: T[] | null;
+  limit?: number; // Limit the number of options to show
+  disabled?: boolean;
+  loading?: boolean;
+  placeholder?: string;
+  title?: string; // Title shown at the top of the list. Looks the same as section titles in LemonMenu.
+  disableFiltering?: boolean;
+  disablePrompting?: boolean;
+  mode: "multiple" | "single";
+  allowCustomValues?: boolean;
+  /** Disable editing functionality (hides edit icons) while still allowing custom values */
+  disableEditing?: boolean;
+  /** Format the label for custom values. Supports text (e.g. appending " (new entry)") and html. */
+  formatCreateLabel?: (input: string) => React.ReactNode;
+  /** Transform input value as user types, e.g. normalization like replacing spaces with dashes. */
+  inputTransform?: (input: string) => string;
+  emptyStateComponent?: React.ReactNode;
+  onChange?: (newValue: T[]) => void;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  onInputChange?: (newValue: string) => void;
+  "data-attr"?: string;
+  className?: string;
+  popoverClassName?: string;
+  size?: "xsmall" | "small" | "medium" | "large";
+  transparentBackground?: boolean;
+  displayMode?: "snacks" | "count";
+  bulkActions?: "clear-all" | "select-and-clear-all";
+  /** Disable comma splitting for properties that contain commas in their values (e.g., user agent strings) */
+  disableCommaSplitting?: boolean;
+  action?: LemonInputSelectAction;
+  virtualized?: boolean;
+  /** Enable virtualization for large lists (>100 values) with vertical layout */
+  enableLargeListVirtualization?: boolean;
+  /** Enable drag-and-drop reordering of values */
+  sortable?: boolean;
+  /** Render single-mode values as snack pills (matching multi-mode appearance) */
+  singleValueAsSnack?: boolean;
+};
 
 export function LemonInputSelect<T = string>({
-    placeholder,
-    title,
-    options = [],
-    value,
-    limit = Number.POSITIVE_INFINITY,
-    loading,
-    emptyStateComponent,
-    onChange,
-    onInputChange,
-    onFocus,
-    onBlur,
-    mode,
-    disabled,
-    disableFiltering = false,
-    formatCreateLabel,
-    inputTransform,
-    disablePrompting = false,
-    allowCustomValues = false,
-    disableEditing = false,
-    autoFocus = false,
-    className,
-    popoverClassName,
-    'data-attr': dataAttr,
-    size = 'medium',
-    transparentBackground,
-    autoWidth = true,
-    fullWidth = false,
-    displayMode = 'snacks',
-    bulkActions,
-    disableCommaSplitting = false,
-    action,
-    virtualized = false,
-    enableLargeListVirtualization = false,
-    sortable = false,
-    status = 'default',
-    singleValueAsSnack = false,
+  placeholder,
+  title,
+  options = [],
+  value,
+  limit = Number.POSITIVE_INFINITY,
+  loading,
+  emptyStateComponent,
+  onChange,
+  onInputChange,
+  onFocus,
+  onBlur,
+  mode,
+  disabled,
+  disableFiltering = false,
+  formatCreateLabel,
+  inputTransform,
+  disablePrompting = false,
+  allowCustomValues = false,
+  disableEditing = false,
+  autoFocus = false,
+  className,
+  popoverClassName,
+  "data-attr": dataAttr,
+  size = "medium",
+  transparentBackground,
+  autoWidth = true,
+  fullWidth = false,
+  displayMode = "snacks",
+  bulkActions,
+  disableCommaSplitting = false,
+  action,
+  virtualized = false,
+  enableLargeListVirtualization = false,
+  sortable = false,
+  status = "default",
+  singleValueAsSnack = false,
 }: LemonInputSelectProps<T>): JSX.Element {
-    const [showPopover, setShowPopover] = useState(false)
-    const [inputValue, _setInputValue] = useState('')
-    const [itemBeingEditedIndex, setItemBeingEditedIndex] = useState<number | null>(null)
-    const popoverFocusRef = useRef<boolean>(false)
-    const inputRef = useRef<HTMLInputElement>(null)
-    const [selectedIndex, setSelectedIndex] = useState(0)
-    const values = value ? value.slice() : []
-    if (itemBeingEditedIndex !== null) {
-        // If we're editing an item, we don't want it to be in the values list - it's ephemeral in that state
-        values.splice(itemBeingEditedIndex, 1)
+  const [showPopover, setShowPopover] = useState(false);
+  const [inputValue, _setInputValue] = useState("");
+  const [itemBeingEditedIndex, setItemBeingEditedIndex] = useState<
+    number | null
+  >(null);
+  const popoverFocusRef = useRef<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const values = value ? value.slice() : [];
+  if (itemBeingEditedIndex !== null) {
+    // If we're editing an item, we don't want it to be in the values list - it's ephemeral in that state
+    values.splice(itemBeingEditedIndex, 1);
+  }
+
+  // Create lookup maps for O(1) performance - only recompute when options change
+  const optionMaps = useMemo(() => {
+    const valueToOption = new Map<T, LemonInputSelectOption<T>>();
+    const keyToOption = new Map<string, LemonInputSelectOption<T>>();
+    const keySet = new Set<string>();
+
+    for (const option of options) {
+      if (option.value !== undefined) {
+        valueToOption.set(option.value, option);
+      }
+      keyToOption.set(option.key, option);
+      keySet.add(option.key);
     }
 
-    // Create lookup maps for O(1) performance - only recompute when options change
-    const optionMaps = useMemo(() => {
-        const valueToOption = new Map<T, LemonInputSelectOption<T>>()
-        const keyToOption = new Map<string, LemonInputSelectOption<T>>()
-        const keySet = new Set<string>()
+    return { valueToOption, keyToOption, keySet };
+  }, [options]);
 
-        for (const option of options) {
-            if (option.value !== undefined) {
-                valueToOption.set(option.value, option)
-            }
-            keyToOption.set(option.key, option)
-            keySet.add(option.key)
+  // Simple helper functions using O(1) lookups
+  const getStringKey = useCallback(
+    (value: T): string => {
+      // First try to find an option with this exact value
+      const option = optionMaps.valueToOption.get(value);
+      if (option) {
+        return option.key;
+      }
+
+      // For backwards compatibility: if value is string and exists as key, use it
+      if (typeof value === "string" && optionMaps.keyToOption.has(value)) {
+        const keyOption = optionMaps.keyToOption.get(value);
+        if (keyOption?.value === undefined) {
+          return value as string;
         }
+      }
 
-        return { valueToOption, keyToOption, keySet }
-    }, [options])
+      // Fallback: convert to string
+      return String(value);
+    },
+    [optionMaps],
+  );
 
-    // Simple helper functions using O(1) lookups
-    const getStringKey = useCallback(
-        (value: T): string => {
-            // First try to find an option with this exact value
-            const option = optionMaps.valueToOption.get(value)
-            if (option) {
-                return option.key
-            }
+  const getDisplayLabel = useCallback(
+    (value: T): string => {
+      const option = optionMaps.valueToOption.get(value);
+      return option?.label ?? String(value);
+    },
+    [optionMaps],
+  );
 
-            // For backwards compatibility: if value is string and exists as key, use it
-            if (typeof value === 'string' && optionMaps.keyToOption.has(value)) {
-                const keyOption = optionMaps.keyToOption.get(value)
-                if (keyOption?.value === undefined) {
-                    return value as string
-                }
-            }
+  const getTypedValue = useCallback(
+    (key: string): T => {
+      const option = optionMaps.keyToOption.get(key);
+      if (option?.value !== undefined) {
+        return option.value;
+      }
+      // Backwards compatibility: if no value provided, use key as value
+      return key as T;
+    },
+    [optionMaps],
+  );
 
-            // Fallback: convert to string
-            return String(value)
+  const fuseRef = useRef<Fuse<LemonInputSelectOption<T>>>(
+    new Fuse(options, {
+      keys: ["label", "key"],
+    }),
+  );
+
+  const separateOnComma =
+    allowCustomValues && mode === "multiple" && !disableCommaSplitting;
+
+  // We stringify the objects to prevent wasteful recalculations (esp. Fuse). Note: labelComponent is not serializable
+  const optionsKey = JSON.stringify(options, (key, value) =>
+    key === "labelComponent" ? value?.name : value,
+  );
+  const stringKeys = values.map(getStringKey);
+  const valuesKey = JSON.stringify(stringKeys);
+  const allOptionsMap: Map<string, LemonInputSelectOption<T>> = useMemo(() => {
+    // Custom values are values that are not in the options list - O(n) instead of O(n×m)
+    const customValues = stringKeys.filter(
+      (key) => !optionMaps.keySet.has(key),
+    );
+    // Custom values are shown as options before other options (Map guarantees preserves insertion order)
+    const allOptionsMap = new Map<string, LemonInputSelectOption<T>>();
+    for (const customValue of customValues) {
+      // Mark custom values with __isCustomValue flag so they use formatCreateLabel in the dropdown not only when typing
+      // but also when re-opening the dropdown after typing
+      allOptionsMap.set(customValue, {
+        key: customValue,
+        label: customValue,
+        __isCustomValue: true,
+      });
+    }
+    for (const option of options) {
+      allOptionsMap.set(option.key, option);
+    }
+    // The below is a side effect (boo!) - but it's fine, since it's idempotent
+    fuseRef.current.setCollection(Array.from(allOptionsMap.values()));
+    return allOptionsMap;
+  }, [optionsKey, valuesKey, optionMaps, options, stringKeys]);
+
+  const visibleOptions = useMemo(() => {
+    const ret: LemonInputSelectOption<T>[] = [];
+    // Show the input value if custom values are allowed and it's not in the list
+    if (inputValue && !stringKeys.includes(inputValue)) {
+      if (allowCustomValues && !optionMaps.keySet.has(inputValue)) {
+        const unescapedInputValue = inputValue.replaceAll("\\,", ","); // Transform escaped commas to plain commas
+        ret.push({
+          key: unescapedInputValue,
+          label: unescapedInputValue,
+          __isInput: true,
+        });
+      }
+    } else if (mode === "single" && values.length > 0) {
+      // In single-select mode, show the selected value at the top
+      const firstKey = getStringKey(values[0]);
+      ret.push(
+        allOptionsMap.get(firstKey) ?? {
+          key: firstKey,
+          label: getDisplayLabel(values[0]),
         },
-        [optionMaps]
-    )
-
-    const getDisplayLabel = useCallback(
-        (value: T): string => {
-            const option = optionMaps.valueToOption.get(value)
-            return option?.label ?? String(value)
-        },
-        [optionMaps]
-    )
-
-    const getTypedValue = useCallback(
-        (key: string): T => {
-            const option = optionMaps.keyToOption.get(key)
-            if (option?.value !== undefined) {
-                return option.value
-            }
-            // Backwards compatibility: if no value provided, use key as value
-            return key as T
-        },
-        [optionMaps]
-    )
-
-    const fuseRef = useRef<Fuse<LemonInputSelectOption<T>>>(
-        new Fuse(options, {
-            keys: ['label', 'key'],
-        })
-    )
-
-    const separateOnComma = allowCustomValues && mode === 'multiple' && !disableCommaSplitting
-
-    // We stringify the objects to prevent wasteful recalculations (esp. Fuse). Note: labelComponent is not serializable
-    const optionsKey = JSON.stringify(options, (key, value) => (key === 'labelComponent' ? value?.name : value))
-    const stringKeys = values.map(getStringKey)
-    const valuesKey = JSON.stringify(stringKeys)
-    const allOptionsMap: Map<string, LemonInputSelectOption<T>> = useMemo(() => {
-        // Custom values are values that are not in the options list - O(n) instead of O(n×m)
-        const customValues = stringKeys.filter((key) => !optionMaps.keySet.has(key))
-        // Custom values are shown as options before other options (Map guarantees preserves insertion order)
-        const allOptionsMap = new Map<string, LemonInputSelectOption<T>>()
-        for (const customValue of customValues) {
-            // Mark custom values with __isCustomValue flag so they use formatCreateLabel in the dropdown not only when typing
-            // but also when re-opening the dropdown after typing
-            allOptionsMap.set(customValue, { key: customValue, label: customValue, __isCustomValue: true })
-        }
-        for (const option of options) {
-            allOptionsMap.set(option.key, option)
-        }
-        // The below is a side effect (boo!) - but it's fine, since it's idempotent
-        fuseRef.current.setCollection(Array.from(allOptionsMap.values()))
-        return allOptionsMap
-    }, [optionsKey, valuesKey, optionMaps, options, stringKeys])
-
-    const visibleOptions = useMemo(() => {
-        const ret: LemonInputSelectOption<T>[] = []
-        // Show the input value if custom values are allowed and it's not in the list
-        if (inputValue && !stringKeys.includes(inputValue)) {
-            if (allowCustomValues && !optionMaps.keySet.has(inputValue)) {
-                const unescapedInputValue = inputValue.replaceAll('\\,', ',') // Transform escaped commas to plain commas
-                ret.push({ key: unescapedInputValue, label: unescapedInputValue, __isInput: true })
-            }
-        } else if (mode === 'single' && values.length > 0) {
-            // In single-select mode, show the selected value at the top
-            const firstKey = getStringKey(values[0])
-            ret.push(allOptionsMap.get(firstKey) ?? { key: firstKey, label: getDisplayLabel(values[0]) })
-        }
-
-        let relevantOptions: LemonInputSelectOption<T>[]
-        if (!disableFiltering && inputValue) {
-            // If filtering is enabled and there's input, perform fuzzy search…
-            const results = fuseRef.current.search(inputValue)
-            relevantOptions = results.map((result) => result.item)
-        } else {
-            // …otherwise show all options
-            relevantOptions = Array.from(allOptionsMap.values())
-        }
-        for (const option of relevantOptions) {
-            if (option.key === inputValue && option.__isInput) {
-                // We don't want to show the input-based option again. The check for __isInput covers the case the user types something that is already an option, but we want to keep the original option
-                continue
-            }
-            if (mode === 'single' && values.length > 0 && option.key === getStringKey(values[0])) {
-                // In single-select mode, we've already added the selected value to the top earlier
-                continue
-            }
-            ret.push(option)
-            if (ret.length >= 100 && !virtualized) {
-                // :HACKY: This is a quick fix to make the select dropdown work for large values, as it was getting slow when
-                // we'd load more than ~10k entries. Ideally we'd make this a virtualized list.
-                break
-            }
-        }
-
-        return ret
-    }, [
-        allOptionsMap,
-        allowCustomValues,
-        inputValue,
-        mode,
-        stringKeys,
-        getDisplayLabel,
-        getStringKey,
-        values,
-        disableFiltering,
-        values.length,
-        virtualized,
-        optionMaps,
-    ])
-
-    // Reset the selected index when the visible options change
-    useEffect(() => {
-        setSelectedIndex(0)
-    }, [visibleOptions.map((option) => option.key).join(':::')])
-
-    const setInputValue = (newValue: string): void => {
-        // Apply input transformation if provided
-        if (inputTransform) {
-            newValue = inputTransform(newValue)
-        }
-
-        // Special case for multiple mode with custom values
-        if (separateOnComma && newValue.match(NON_ESCAPED_COMMA_REGEX)) {
-            const newValues = [...values]
-
-            // We split on commas EXCEPT if they're escaped (to allow for commas in values)
-            newValue.split(NON_ESCAPED_COMMA_REGEX).forEach((stringValue) => {
-                const trimmedValue = stringValue.replaceAll('\\,', ',').trim() // Transform escaped commas to plain commas
-                if (trimmedValue && !stringKeys.includes(trimmedValue)) {
-                    // Convert string back to typed value
-                    const typedValue = getTypedValue(trimmedValue)
-                    newValues.push(typedValue)
-                }
-            })
-
-            onChange?.(newValues)
-            newValue = ''
-        }
-
-        if (newValue) {
-            // If popover was hidden due to Enter being pressed, but we kept input focus and now the user typed again,
-            // we should show the popover again
-            setShowPopover(true)
-        }
-
-        _setInputValue(newValue)
-        onInputChange?.(newValue)
+      );
     }
 
-    const _removeItem = (item: string, currentValues: T[] = values): void => {
-        // Remove the item
-        if (mode === 'single') {
-            onChange?.([])
-            return
-        }
-        const newValues = currentValues.slice()
-        // Find the typed value that corresponds to this string key
-        const typedValue = getTypedValue(item)
-        const index = newValues.findIndex((val) => val === typedValue)
-        if (index !== -1) {
-            newValues.splice(index, 1)
-        }
-        onChange?.(newValues)
+    let relevantOptions: LemonInputSelectOption<T>[];
+    if (!disableFiltering && inputValue) {
+      // If filtering is enabled and there's input, perform fuzzy search…
+      const results = fuseRef.current.search(inputValue);
+      relevantOptions = results.map((result) => result.item);
+    } else {
+      // …otherwise show all options
+      relevantOptions = Array.from(allOptionsMap.values());
+    }
+    for (const option of relevantOptions) {
+      if (option.key === inputValue && option.__isInput) {
+        // We don't want to show the input-based option again. The check for __isInput covers the case the user types something that is already an option, but we want to keep the original option
+        continue;
+      }
+      if (
+        mode === "single" &&
+        values.length > 0 &&
+        option.key === getStringKey(values[0])
+      ) {
+        // In single-select mode, we've already added the selected value to the top earlier
+        continue;
+      }
+      ret.push(option);
+      if (ret.length >= 100 && !virtualized) {
+        // :HACKY: This is a quick fix to make the select dropdown work for large values, as it was getting slow when
+        // we'd load more than ~10k entries. Ideally we'd make this a virtualized list.
+        break;
+      }
     }
 
-    const _addItem = (item: string, atIndex?: number | null, currentValues: T[] = values): void => {
-        setInputValue('')
-        // Convert string key back to typed value
-        const actualTypedValue = getTypedValue(item)
-        if (mode === 'single') {
-            onChange?.([actualTypedValue])
-            return
-        }
-        const newValues = currentValues.slice()
-        if (!newValues.includes(actualTypedValue)) {
-            if (atIndex != undefined) {
-                newValues.splice(atIndex, 0, actualTypedValue)
-            } else {
-                newValues.push(actualTypedValue)
-            }
-        }
-        onChange?.(newValues)
+    return ret;
+  }, [
+    allOptionsMap,
+    allowCustomValues,
+    inputValue,
+    mode,
+    stringKeys,
+    getDisplayLabel,
+    getStringKey,
+    values,
+    disableFiltering,
+    values.length,
+    virtualized,
+    optionMaps,
+  ]);
+
+  // Reset the selected index when the visible options change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [visibleOptions.map((option) => option.key).join(":::")]);
+
+  const setInputValue = (newValue: string): void => {
+    // Apply input transformation if provided
+    if (inputTransform) {
+      newValue = inputTransform(newValue);
     }
 
-    const _onActionItem = (
-        item: string,
-        popoverOptionClickEvent?: MouseEvent | null,
-        shouldInitiateEdit?: boolean
-    ): void => {
-        if (shouldInitiateEdit && allowCustomValues) {
-            // In this case we want to remove it if added and set input to it
-            const typedValue = getTypedValue(item)
-            let indexOfValue = values.indexOf(typedValue)
-            if (indexOfValue > -1) {
-                if (itemBeingEditedIndex !== null && itemBeingEditedIndex < indexOfValue) {
-                    // If already editing an item that's earlier in the list the the one we're about to edit,
-                    // we need to adjust the index by 1
-                    indexOfValue += 1
-                }
-                setItemBeingEditedIndex(indexOfValue)
-            }
-            _setInputValue(item)
-            onInputChange?.(item)
-            inputRef.current?.focus()
-            return
-        }
-        setItemBeingEditedIndex(null)
-        if (mode === 'single') {
-            setShowPopover(false)
-            popoverFocusRef.current = false
-            // Prevent propagating to Popover's onClickInside, which would set popoverFocusRef.current back to true
-            popoverOptionClickEvent?.stopPropagation()
-            // Remove focus from input after selecting an option, since in single mode that feels better UX-wise
-            inputRef.current?.blur()
-        }
+    // Special case for multiple mode with custom values
+    if (separateOnComma && newValue.match(NON_ESCAPED_COMMA_REGEX)) {
+      const newValues = [...values];
 
-        if (stringKeys.includes(item)) {
-            // In single mode, clicking an already-selected value should keep it selected, not toggle it off
-            // (clicking an already selected item to toggle it off makes sense for multiple-select, not for single-select)
-            if (mode !== 'single') {
-                _removeItem(item)
-            }
-        } else {
-            _addItem(item, itemBeingEditedIndex)
+      // We split on commas EXCEPT if they're escaped (to allow for commas in values)
+      newValue.split(NON_ESCAPED_COMMA_REGEX).forEach((stringValue) => {
+        const trimmedValue = stringValue.replaceAll("\\,", ",").trim(); // Transform escaped commas to plain commas
+        if (trimmedValue && !stringKeys.includes(trimmedValue)) {
+          // Convert string back to typed value
+          const typedValue = getTypedValue(trimmedValue);
+          newValues.push(typedValue);
         }
+      });
+
+      onChange?.(newValues);
+      newValue = "";
     }
 
-    const _onBlur = (): void => {
-        const hasSelectedAutofilledValue = selectedIndex > 0
-        const hasCustomValue =
-            !hasSelectedAutofilledValue && allowCustomValues && inputValue.trim() && !stringKeys.includes(inputValue)
-        if (popoverFocusRef.current) {
-            popoverFocusRef.current = false
-            inputRef.current?.focus()
-            _onFocus()
-            // Don't add custom values here - if the user clicked on a popover option,
-            // the click handler will handle the selection. Adding it here causes a
-            // double-fire: the value gets added by _onBlur, the component re-renders,
-            // and then the click handler sees it already exists and removes it.
-            return
-        }
-        if (hasCustomValue) {
-            _onActionItem(inputValue.trim(), null)
-        } else {
-            setInputValue('')
-        }
-        setShowPopover(false)
-        onBlur?.()
+    if (newValue) {
+      // If popover was hidden due to Enter being pressed, but we kept input focus and now the user typed again,
+      // we should show the popover again
+      setShowPopover(true);
     }
 
-    const _onFocus = (): void => {
-        // In single mode, when focusing with a selected value, enter edit mode right away
-        if (mode === 'single' && values.length > 0 && !inputValue) {
-            setInputValue(getStringKey(values[0]))
+    _setInputValue(newValue);
+    onInputChange?.(newValue);
+  };
+
+  const _removeItem = (item: string, currentValues: T[] = values): void => {
+    // Remove the item
+    if (mode === "single") {
+      onChange?.([]);
+      return;
+    }
+    const newValues = currentValues.slice();
+    // Find the typed value that corresponds to this string key
+    const typedValue = getTypedValue(item);
+    const index = newValues.findIndex((val) => val === typedValue);
+    if (index !== -1) {
+      newValues.splice(index, 1);
+    }
+    onChange?.(newValues);
+  };
+
+  const _addItem = (
+    item: string,
+    atIndex?: number | null,
+    currentValues: T[] = values,
+  ): void => {
+    setInputValue("");
+    // Convert string key back to typed value
+    const actualTypedValue = getTypedValue(item);
+    if (mode === "single") {
+      onChange?.([actualTypedValue]);
+      return;
+    }
+    const newValues = currentValues.slice();
+    if (!newValues.includes(actualTypedValue)) {
+      if (atIndex != undefined) {
+        newValues.splice(atIndex, 0, actualTypedValue);
+      } else {
+        newValues.push(actualTypedValue);
+      }
+    }
+    onChange?.(newValues);
+  };
+
+  const _onActionItem = (
+    item: string,
+    popoverOptionClickEvent?: MouseEvent | null,
+    shouldInitiateEdit?: boolean,
+  ): void => {
+    if (shouldInitiateEdit && allowCustomValues) {
+      // In this case we want to remove it if added and set input to it
+      const typedValue = getTypedValue(item);
+      let indexOfValue = values.indexOf(typedValue);
+      if (indexOfValue > -1) {
+        if (
+          itemBeingEditedIndex !== null &&
+          itemBeingEditedIndex < indexOfValue
+        ) {
+          // If already editing an item that's earlier in the list the the one we're about to edit,
+          // we need to adjust the index by 1
+          indexOfValue += 1;
         }
-        onFocus?.()
-        setShowPopover(true)
-        popoverFocusRef.current = true
+        setItemBeingEditedIndex(indexOfValue);
+      }
+      _setInputValue(item);
+      onInputChange?.(item);
+      inputRef.current?.focus();
+      return;
+    }
+    setItemBeingEditedIndex(null);
+    if (mode === "single") {
+      setShowPopover(false);
+      popoverFocusRef.current = false;
+      // Prevent propagating to Popover's onClickInside, which would set popoverFocusRef.current back to true
+      popoverOptionClickEvent?.stopPropagation();
+      // Remove focus from input after selecting an option, since in single mode that feels better UX-wise
+      inputRef.current?.blur();
     }
 
-    const _onClick = (): void => {
-        // Open dropdown on click even if input already has focus
-        // This handles the case where user clicked outside to close dropdown but input stayed focused
-        if (!showPopover) {
-            setShowPopover(true)
-            popoverFocusRef.current = true
-        }
+    if (stringKeys.includes(item)) {
+      // In single mode, clicking an already-selected value should keep it selected, not toggle it off
+      // (clicking an already selected item to toggle it off makes sense for multiple-select, not for single-select)
+      if (mode !== "single") {
+        _removeItem(item);
+      }
+    } else {
+      _addItem(item, itemBeingEditedIndex);
     }
+  };
 
-    const _onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-        if (e.key === 'Enter') {
-            e.preventDefault()
-            const itemToAdd = visibleOptions[selectedIndex]?.key
-
-            if (itemToAdd) {
-                _onActionItem(visibleOptions[selectedIndex]?.key, null)
-            }
-            e.currentTarget.blur()
-        } else if (e.key === 'Backspace') {
-            if (!inputValue) {
-                e.preventDefault()
-                const newValues = [...values]
-                newValues.pop()
-                onChange?.(newValues)
-            } else if (mode === 'single') {
-                // In single mode, "selected all + backspace" should clear the selection
-                const input = e.currentTarget
-                if (input.selectionStart === 0 && input.selectionEnd === input.value.length) {
-                    e.preventDefault()
-                    setInputValue('')
-                    onChange?.([])
-                }
-            }
-        } else if (e.key === 'ArrowDown') {
-            e.preventDefault()
-            setSelectedIndex(Math.min(selectedIndex + 1, visibleOptions.length - 1))
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault()
-            setSelectedIndex(Math.max(selectedIndex - 1, 0))
-        }
+  const _onBlur = (): void => {
+    const hasSelectedAutofilledValue = selectedIndex > 0;
+    const hasCustomValue =
+      !hasSelectedAutofilledValue &&
+      allowCustomValues &&
+      inputValue.trim() &&
+      !stringKeys.includes(inputValue);
+    if (popoverFocusRef.current) {
+      popoverFocusRef.current = false;
+      inputRef.current?.focus();
+      _onFocus();
+      // Don't add custom values here - if the user clicked on a popover option,
+      // the click handler will handle the selection. Adding it here causes a
+      // double-fire: the value gets added by _onBlur, the component re-renders,
+      // and then the click handler sees it already exists and removes it.
+      return;
     }
+    if (hasCustomValue) {
+      _onActionItem(inputValue.trim(), null);
+    } else {
+      setInputValue("");
+    }
+    setShowPopover(false);
+    onBlur?.();
+  };
 
-    const handleDragEnd = useCallback(
-        (event: DragEndEvent): void => {
-            const { active, over } = event
+  const _onFocus = (): void => {
+    // In single mode, when focusing with a selected value, enter edit mode right away
+    if (mode === "single" && values.length > 0 && !inputValue) {
+      setInputValue(getStringKey(values[0]));
+    }
+    onFocus?.();
+    setShowPopover(true);
+    popoverFocusRef.current = true;
+  };
 
-            if (over && active.id !== over.id) {
-                const oldIndex = values.findIndex((val) => getStringKey(val) === active.id)
-                const newIndex = values.findIndex((val) => getStringKey(val) === over.id)
+  const _onClick = (): void => {
+    // Open dropdown on click even if input already has focus
+    // This handles the case where user clicked outside to close dropdown but input stayed focused
+    if (!showPopover) {
+      setShowPopover(true);
+      popoverFocusRef.current = true;
+    }
+  };
 
-                if (oldIndex !== -1 && newIndex !== -1) {
-                    const newValues = arrayMove(values, oldIndex, newIndex)
-                    onChange?.(newValues)
-                }
-            }
-        },
-        [values, getStringKey, onChange]
-    )
+  const _onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const itemToAdd = visibleOptions[selectedIndex]?.key;
 
-    // Check if we need to use virtualization for large lists
-    // Use virtualization for >100 values in multiple mode to prevent OOM
-    // Only when explicitly enabled via prop
-    // Memoize to prevent race conditions and unnecessary re-renders
-    const useVirtualization = useMemo(
-        () => enableLargeListVirtualization && mode === 'multiple' && values.length > 100,
-        [enableLargeListVirtualization, mode, values.length]
-    )
-
-    const valuesPrefix = useMemo(() => {
-        // For single mode with a selected value and no active input, show the value as prefix since
-        // showing the entered value as placeholder was unintuitive
-        if (mode === 'single' && values.length > 0 && !inputValue) {
-            const label = allOptionsMap.get(getStringKey(values[0]))?.label ?? getDisplayLabel(values[0])
-            if (singleValueAsSnack) {
-                const canClear = allowCustomValues && !disableEditing
-                return (
-                    <PopoverReferenceContext.Provider value={null}>
-                        <LemonSnack
-                            title={String(label)}
-                            onClose={
-                                canClear
-                                    ? () => {
-                                          setInputValue('')
-                                          onChange?.([])
-                                      }
-                                    : undefined
-                            }
-                        >
-                            {label}
-                        </LemonSnack>
-                    </PopoverReferenceContext.Provider>
-                )
-            }
-            return (
-                <PopoverReferenceContext.Provider value={null}>
-                    <span className="font-medium truncate">{label}</span>
-                </PopoverReferenceContext.Provider>
-            )
+      if (itemToAdd) {
+        _onActionItem(visibleOptions[selectedIndex]?.key, null);
+      }
+      e.currentTarget.blur();
+    } else if (e.key === "Backspace") {
+      if (!inputValue) {
+        e.preventDefault();
+        const newValues = [...values];
+        newValues.pop();
+        onChange?.(newValues);
+      } else if (mode === "single") {
+        // In single mode, "selected all + backspace" should clear the selection
+        const input = e.currentTarget;
+        if (
+          input.selectionStart === 0 &&
+          input.selectionEnd === input.value.length
+        ) {
+          e.preventDefault();
+          setInputValue("");
+          onChange?.([]);
         }
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex(Math.min(selectedIndex + 1, visibleOptions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex(Math.max(selectedIndex - 1, 0));
+    }
+  };
 
-        if (mode !== 'multiple' || values.length === 0 || displayMode !== 'snacks') {
-            return null
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent): void => {
+      const { active, over } = event;
+
+      if (over && active.id !== over.id) {
+        const oldIndex = values.findIndex(
+          (val) => getStringKey(val) === active.id,
+        );
+        const newIndex = values.findIndex(
+          (val) => getStringKey(val) === over.id,
+        );
+
+        if (oldIndex !== -1 && newIndex !== -1) {
+          const newValues = arrayMove(values, oldIndex, newIndex);
+          onChange?.(newValues);
         }
+      }
+    },
+    [values, getStringKey, onChange],
+  );
 
-        // For large lists, don't render as prefix - will be rendered with virtualization
-        if (useVirtualization) {
-            return null
-        }
+  // Check if we need to use virtualization for large lists
+  // Use virtualization for >100 values in multiple mode to prevent OOM
+  // Only when explicitly enabled via prop
+  // Memoize to prevent race conditions and unnecessary re-renders
+  const useVirtualization = useMemo(
+    () =>
+      enableLargeListVirtualization &&
+      mode === "multiple" &&
+      values.length > 100,
+    [enableLargeListVirtualization, mode, values.length],
+  );
 
-        const preInputValues = itemBeingEditedIndex !== null ? values.slice(0, itemBeingEditedIndex) : values
-
-        // TRICKY: We don't want the popover to affect the snack buttons
+  const valuesPrefix = useMemo(() => {
+    // For single mode with a selected value and no active input, show the value as prefix since
+    // showing the entered value as placeholder was unintuitive
+    if (mode === "single" && values.length > 0 && !inputValue) {
+      const label =
+        allOptionsMap.get(getStringKey(values[0]))?.label ??
+        getDisplayLabel(values[0]);
+      if (singleValueAsSnack) {
+        const canClear = allowCustomValues && !disableEditing;
         return (
-            <PopoverReferenceContext.Provider value={null}>
-                <ValueSnacks
-                    values={preInputValues.map(getStringKey)}
-                    options={options}
-                    onClose={(value) => _onActionItem(value, null)}
-                    onInitiateEdit={
-                        allowCustomValues && !disableEditing ? (value) => _onActionItem(value, null, true) : null
+          <PopoverReferenceContext.Provider value={null}>
+            <LemonSnack
+              title={String(label)}
+              onClose={
+                canClear
+                  ? () => {
+                      setInputValue("");
+                      onChange?.([]);
                     }
-                    sortable={sortable}
-                    onDragEnd={handleDragEnd}
-                    limitHeight={true}
-                    enableVirtualization={useVirtualization}
-                />
-            </PopoverReferenceContext.Provider>
-        )
-    }, [
-        mode,
-        values,
-        values.length,
-        inputValue,
-        allOptionsMap,
-        getStringKey,
-        getDisplayLabel,
-        displayMode,
-        itemBeingEditedIndex,
-        options,
-        allowCustomValues,
-        disableEditing,
-        _onActionItem,
-        sortable,
-        handleDragEnd,
-        singleValueAsSnack,
-        onChange,
-        setInputValue,
-        useVirtualization,
-    ])
-
-    const virtualizedValues = useMemo(() => {
-        // Only render virtualized values for large lists
-        if (!useVirtualization) {
-            return null
-        }
-
-        return (
-            <div className="w-full mb-2">
-                <PopoverReferenceContext.Provider value={null}>
-                    <ValueSnacks
-                        values={values.map(getStringKey)}
-                        options={options}
-                        onClose={(value) => _onActionItem(value, null)}
-                        onInitiateEdit={
-                            allowCustomValues && !disableEditing ? (value) => _onActionItem(value, null, true) : null
-                        }
-                        sortable={sortable}
-                        onDragEnd={handleDragEnd}
-                        limitHeight={true}
-                        enableVirtualization={useVirtualization}
-                    />
-                </PopoverReferenceContext.Provider>
-            </div>
-        )
-    }, [
-        useVirtualization,
-        values,
-        getStringKey,
-        options,
-        _onActionItem,
-        allowCustomValues,
-        disableEditing,
-        sortable,
-        handleDragEnd,
-    ])
-
-    const valuesAndClearButtonSuffix = useMemo(() => {
-        // In single-select mode with custom values, show a clear button when a value is selected and not in edit mode
-        // When singleValueAsSnack is enabled, the snack's own close button handles clearing
-        const isClearButtonVisible =
-            !singleValueAsSnack &&
-            mode !== 'multiple' &&
-            allowCustomValues &&
-            !disableEditing &&
-            values.length &&
-            !inputValue
-
-        const postInputValues =
-            displayMode === 'snacks' && itemBeingEditedIndex !== null ? values.slice(itemBeingEditedIndex) : []
-
-        if (!isClearButtonVisible && postInputValues.length === 0) {
-            return null
-        }
-
-        return (
-            <PopoverReferenceContext.Provider value={null}>
-                <ValueSnacks
-                    values={postInputValues.map(getStringKey)}
-                    options={options}
-                    onClose={(value) => _onActionItem(value, null)}
-                    onInitiateEdit={
-                        allowCustomValues && !disableEditing ? (value) => _onActionItem(value, null, true) : null
-                    }
-                    sortable={sortable}
-                    onDragEnd={handleDragEnd}
-                    limitHeight={true}
-                    enableVirtualization={useVirtualization}
-                />
-                {isClearButtonVisible && (
-                    <div
-                        className={clsx(
-                            'grow flex flex-col items-end LemonInputSelect__edit-button-wrapper',
-                            size && `LemonInputSelect__edit-button-wrapper--${size}`
-                        )}
-                    >
-                        <LemonButton
-                            icon={<IconX />}
-                            onClick={(e) => {
-                                e.preventDefault()
-                                e.stopPropagation()
-                                setInputValue('')
-                                onChange?.([])
-                            }}
-                            tooltip="Clear selection"
-                            noPadding
-                        />
-                    </div>
-                )}
-            </PopoverReferenceContext.Provider>
-        )
-    }, [
-        mode,
-        values,
-        allowCustomValues,
-        disableEditing,
-        itemBeingEditedIndex,
-        inputValue,
-        getStringKey,
-        _onActionItem,
-        displayMode,
-        _onFocus,
-        options,
-        setInputValue,
-        sortable,
-        handleDragEnd,
-        size,
-        onChange,
-        singleValueAsSnack,
-        useVirtualization,
-    ])
-
-    // Positioned like a placeholder but rendered via the suffix since the actual placeholder has to be a string
-    const countPlaceholder = useMemo(() => {
-        if (displayMode !== 'count' || mode !== 'multiple' || inputValue || loading) {
-            return null
-        }
-        return values.length === 0 ? (
-            <span className="-ml-2 text-muted">Select from {options.length} options</span>
-        ) : (
-            <span className="-ml-2">
-                {values.length === options.length
-                    ? `All ${options.length} selected`
-                    : `${values.length}/${options.length} selected`}
-            </span>
-        )
-    }, [displayMode, mode, inputValue, loading, values.length, options.length])
-
-    const wasLimitReached = values.length >= limit
-
-    const getInputLabel = (option: LemonInputSelectOption<T>): React.ReactNode => {
-        if (formatCreateLabel) {
-            return formatCreateLabel(option.key)
-        }
-        return mode === 'multiple' ? `Add "${option.key}"` : option.key
+                  : undefined
+              }
+            >
+              {label}
+            </LemonSnack>
+          </PopoverReferenceContext.Provider>
+        );
+      }
+      return (
+        <PopoverReferenceContext.Provider value={null}>
+          <span className="font-medium truncate">{label}</span>
+        </PopoverReferenceContext.Provider>
+      );
     }
 
-    const getOptionIcon = (
-        option: LemonInputSelectOption<T>,
-        isSelected: boolean
-    ): React.ReactElement | null | undefined => {
-        if (option.__isInput) {
-            return undefined
-        }
-
-        if (isSelected) {
-            return mode === 'multiple' ? (
-                // No pointer events, since it's only for visual feedback
-                <LemonCheckbox checked={true} className="pointer-events-none" />
-            ) : (
-                <IconCheck />
-            )
-        }
-
-        if (mode === 'multiple') {
-            return <LemonCheckbox checked={false} className="pointer-events-none" />
-        }
-
-        return undefined
+    if (
+      mode !== "multiple" ||
+      values.length === 0 ||
+      displayMode !== "snacks"
+    ) {
+      return null;
     }
 
-    return useVirtualization ? (
-        <LemonDropdown
-            matchWidth
-            closeOnClickInside={false}
-            actionable
-            visible={showPopover}
-            onClickOutside={() => {
-                popoverFocusRef.current = false
-                setShowPopover(false)
-                // It seems more intuitive to lose focus of drop down entirely when clicking outside of the field.
-                // If this behavior at some point is not desired for multiple mode anymore, it should be kept for single mode.
-                inputRef.current?.blur()
-            }}
-            onClickInside={(e) => {
-                popoverFocusRef.current = true
-                e.stopPropagation()
-            }}
-            className={popoverClassName}
-            placement="top-start"
-            fallbackPlacements={['top-end', 'bottom-start', 'bottom-end']}
-            loadingBar={loading && visibleOptions.length > 0}
-            overlay={
-                <div className="deprecated-space-y-px overflow-y-auto">
-                    {title && <h5 className="mx-2 my-1">{title}</h5>}
+    // For large lists, don't render as prefix - will be rendered with virtualization
+    if (useVirtualization) {
+      return null;
+    }
 
-                    {bulkActions && mode === 'multiple' && (
-                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
-                            {bulkActions === 'select-and-clear-all' && (
-                                <LemonButton
-                                    size="small"
-                                    className="flex-1"
-                                    disabledReason={
-                                        values.length === allOptionsMap.size
-                                            ? 'All options are already selected'
-                                            : undefined
-                                    }
-                                    tooltipPlacement="top-start"
-                                    tooltipArrowOffset={50}
-                                    onClick={() => {
-                                        const allKeys = Array.from(allOptionsMap.keys())
-                                        const allTypedValues = allKeys.map(getTypedValue)
-                                        onChange?.(allTypedValues)
-                                    }}
-                                    icon={
-                                        <LemonCheckbox
-                                            checked={
-                                                values.length === allOptionsMap.size
-                                                    ? true
-                                                    : values.length
-                                                      ? 'indeterminate'
-                                                      : false
-                                            }
-                                            className="pointer-events-none"
-                                        />
-                                    }
-                                >
-                                    Select all
-                                </LemonButton>
-                            )}
-                            <LemonButton
-                                size="small"
-                                className={clsx({ 'flex-1': bulkActions === 'clear-all' })}
-                                tooltipPlacement={bulkActions === 'select-and-clear-all' ? 'top-end' : 'top-start'}
-                                tooltipArrowOffset={bulkActions === 'clear-all' ? 30 : undefined}
-                                disabledReason={values.length === 0 ? 'No options are selected' : undefined}
-                                onClick={() => onChange?.([])}
-                            >
-                                Clear all
-                            </LemonButton>
-                        </div>
-                    )}
+    const preInputValues =
+      itemBeingEditedIndex !== null
+        ? values.slice(0, itemBeingEditedIndex)
+        : values;
 
-                    {action && (
-                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
-                            <LemonButton
-                                size="small"
-                                className="flex-1"
-                                disabledReason={action?.disabledReason}
-                                onClick={action?.onClick}
-                            >
-                                {action?.children}
-                            </LemonButton>
-                        </div>
-                    )}
+    // TRICKY: We don't want the popover to affect the snack buttons
+    return (
+      <PopoverReferenceContext.Provider value={null}>
+        <ValueSnacks
+          values={preInputValues.map(getStringKey)}
+          options={options}
+          onClose={(value) => _onActionItem(value, null)}
+          onInitiateEdit={
+            allowCustomValues && !disableEditing
+              ? (value) => _onActionItem(value, null, true)
+              : null
+          }
+          sortable={sortable}
+          onDragEnd={handleDragEnd}
+          limitHeight={true}
+          enableVirtualization={useVirtualization}
+        />
+      </PopoverReferenceContext.Provider>
+    );
+  }, [
+    mode,
+    values,
+    values.length,
+    inputValue,
+    allOptionsMap,
+    getStringKey,
+    getDisplayLabel,
+    displayMode,
+    itemBeingEditedIndex,
+    options,
+    allowCustomValues,
+    disableEditing,
+    _onActionItem,
+    sortable,
+    handleDragEnd,
+    singleValueAsSnack,
+    onChange,
+    setInputValue,
+    useVirtualization,
+  ]);
 
-                    {visibleOptions.length > 0 ? (
-                        visibleOptions.length > 100 ? (
-                            <>
-                                <div
-                                    style={{
-                                        height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
-                                        overflowY: 'auto',
-                                    }}
-                                    className="space-y-px"
-                                >
-                                    {visibleOptions.map((option, index) => {
-                                        const isFocused = index === selectedIndex
-                                        const isSelected = stringKeys.includes(option.key)
-                                        const isDisabled = wasLimitReached && !isSelected
-                                        return (
-                                            <LemonButton
-                                                key={option.key}
-                                                type="tertiary"
-                                                size="small"
-                                                fullWidth
-                                                active={isFocused}
-                                                onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-                                                onMouseEnter={() => setSelectedIndex(index)}
-                                                disabledReason={
-                                                    isDisabled ? `Limit of ${limit} options reached` : undefined
-                                                }
-                                                tooltip={option.tooltip}
-                                                icon={getOptionIcon(option, isSelected)}
-                                                style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
-                                                sideAction={
-                                                    !option.__isInput && allowCustomValues && !disableEditing
-                                                        ? {
-                                                              icon: (
-                                                                  <IconPencil
-                                                                      className={!isFocused ? 'invisible' : undefined}
-                                                                  />
-                                                              ),
-                                                              tooltip: (
-                                                                  <>
-                                                                      Edit this value <KeyboardShortcut option enter />
-                                                                  </>
-                                                              ),
-                                                              onClick: () => {
-                                                                  setInputValue(option.key)
-                                                                  inputRef.current?.focus()
-                                                                  _onFocus()
-                                                              },
-                                                          }
-                                                        : undefined
-                                                }
-                                            >
-                                                <span className="whitespace-nowrap ph-no-capture truncate">
-                                                    {!option.__isInput && !option.__isCustomValue
-                                                        ? (option.labelComponent ?? option.label)
-                                                        : getInputLabel(option)}
-                                                </span>
-                                            </LemonButton>
-                                        )
-                                    })}
-                                </div>
-                                {/* Add value input visible at bottom of dropdown for large lists */}
-                                {allowCustomValues && inputValue && (
-                                    <div className="border-t border-border p-1">
-                                        <LemonButton
-                                            type="tertiary"
-                                            size="small"
-                                            fullWidth
-                                            onClick={() => _onActionItem(inputValue)}
-                                        >
-                                            <span className="whitespace-nowrap ph-no-capture truncate">
-                                                {getInputLabel({ key: inputValue, label: inputValue, __isInput: true })}
-                                            </span>
-                                        </LemonButton>
-                                    </div>
-                                )}
-                            </>
-                        ) : (
-                            visibleOptions.map((option, index) => {
-                                const isFocused = index === selectedIndex
-                                const isSelected = stringKeys.includes(option.key)
-                                const isDisabled = wasLimitReached && !isSelected
-                                return (
-                                    <LemonButton
-                                        key={option.key}
-                                        type="tertiary"
-                                        size="small"
-                                        fullWidth
-                                        active={isFocused}
-                                        onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-                                        onMouseEnter={() => setSelectedIndex(index)}
-                                        disabledReason={isDisabled ? `Limit of ${limit} options reached` : undefined}
-                                        tooltip={option.tooltip}
-                                        icon={getOptionIcon(option, isSelected)}
-                                        sideAction={
-                                            !option.__isInput && allowCustomValues && !disableEditing
-                                                ? {
-                                                      // To reduce visual clutter we only show the icon on focus or hover,
-                                                      // but we do want it present to make sure the layout is stable
-                                                      icon: (
-                                                          <IconPencil
-                                                              className={!isFocused ? 'invisible' : undefined}
-                                                          />
-                                                      ),
-                                                      tooltip: (
-                                                          <>
-                                                              Edit this value <KeyboardShortcut option enter />
-                                                          </>
-                                                      ),
-                                                      onClick: () => {
-                                                          setInputValue(option.key)
-                                                          inputRef.current?.focus()
-                                                          _onFocus()
-                                                      },
-                                                  }
-                                                : undefined
-                                        }
-                                    >
-                                        <span className="whitespace-nowrap ph-no-capture truncate">
-                                            {
-                                                !option.__isInput && !option.__isCustomValue
-                                                    ? (option.labelComponent ?? option.label) // Regular option
-                                                    : getInputLabel(option) // Input-based option
-                                            }
-                                        </span>
-                                    </LemonButton>
-                                )
-                            })
-                        )
-                    ) : loading ? (
-                        <>
-                            {range(5).map((x) => (
-                                // 33px is the height of a regular list item
-                                <div key={x} className="flex gap-2 items-center h-[33px] px-2">
-                                    <LemonSkeleton.Circle className="size-[18px]" />
-                                    <LemonSkeleton className="h-3.5 w-full" />
-                                </div>
-                            ))}
-                        </>
-                    ) : (
-                        <>
-                            {emptyStateComponent ? (
-                                emptyStateComponent
-                            ) : (
-                                <p className="text-secondary italic p-1">
-                                    {allowCustomValues
-                                        ? 'Start typing and press Enter to add options'
-                                        : `No options matching "${inputValue}"`}
-                                </p>
-                            )}
-                        </>
-                    )}
-                </div>
+  const virtualizedValues = useMemo(() => {
+    // Only render virtualized values for large lists
+    if (!useVirtualization) {
+      return null;
+    }
+
+    return (
+      <div className="w-full mb-2">
+        <PopoverReferenceContext.Provider value={null}>
+          <ValueSnacks
+            values={values.map(getStringKey)}
+            options={options}
+            onClose={(value) => _onActionItem(value, null)}
+            onInitiateEdit={
+              allowCustomValues && !disableEditing
+                ? (value) => _onActionItem(value, null, true)
+                : null
             }
-        >
-            <LemonInput
-                inputRef={inputRef}
-                placeholder={
-                    displayMode === 'count'
-                        ? undefined
-                        : values.length === 0
-                          ? placeholder
-                          : mode === 'single'
-                            ? undefined // When value is selected in single mode, no placeholder (value shown but rendered as prefix)
-                            : allowCustomValues
-                              ? 'Add value'
-                              : disablePrompting
-                                ? undefined
-                                : 'Pick value'
-                }
-                autoWidth={fullWidth ? false : autoWidth}
-                fullWidth={fullWidth}
-                prefix={virtualizedValues}
-                suffix={
-                    <>
-                        {countPlaceholder}
-                        {valuesAndClearButtonSuffix}
-                    </>
-                }
-                onFocus={_onFocus}
-                onBlur={_onBlur}
-                value={inputValue}
-                onChange={setInputValue}
-                onClick={_onClick}
-                onKeyDown={_onKeyDown}
-                disabled={disabled}
-                autoFocus={autoFocus}
-                transparentBackground={transparentBackground}
-                className={clsx(
-                    '!h-auto leading-7 max-w-full w-full', // leading-7 means line height aligned with LemonSnack height
-                    // Putting button-like text styling on the single-select unfocused placeholder
-                    // NOTE: We need font-medium on both the input (for autosizing) and its placeholder (for display)
-                    mode === 'multiple' && 'flex-wrap',
-                    mode === 'single' && values.length > 0 && '*:*:font-medium *:*:placeholder:font-medium',
-                    mode === 'single' && values.length > 0 && !showPopover && '*:*:placeholder:text-default',
-                    className
-                )}
-                data-attr={dataAttr}
-                size={size}
-                status={status}
+            sortable={sortable}
+            onDragEnd={handleDragEnd}
+            limitHeight={true}
+            enableVirtualization={useVirtualization}
+          />
+        </PopoverReferenceContext.Provider>
+      </div>
+    );
+  }, [
+    useVirtualization,
+    values,
+    getStringKey,
+    options,
+    _onActionItem,
+    allowCustomValues,
+    disableEditing,
+    sortable,
+    handleDragEnd,
+  ]);
+
+  const valuesAndClearButtonSuffix = useMemo(() => {
+    // In single-select mode with custom values, show a clear button when a value is selected and not in edit mode
+    // When singleValueAsSnack is enabled, the snack's own close button handles clearing
+    const isClearButtonVisible =
+      !singleValueAsSnack &&
+      mode !== "multiple" &&
+      allowCustomValues &&
+      !disableEditing &&
+      values.length &&
+      !inputValue;
+
+    const postInputValues =
+      displayMode === "snacks" && itemBeingEditedIndex !== null
+        ? values.slice(itemBeingEditedIndex)
+        : [];
+
+    if (!isClearButtonVisible && postInputValues.length === 0) {
+      return null;
+    }
+
+    return (
+      <PopoverReferenceContext.Provider value={null}>
+        <ValueSnacks
+          values={postInputValues.map(getStringKey)}
+          options={options}
+          onClose={(value) => _onActionItem(value, null)}
+          onInitiateEdit={
+            allowCustomValues && !disableEditing
+              ? (value) => _onActionItem(value, null, true)
+              : null
+          }
+          sortable={sortable}
+          onDragEnd={handleDragEnd}
+          limitHeight={true}
+          enableVirtualization={useVirtualization}
+        />
+        {isClearButtonVisible && (
+          <div
+            className={clsx(
+              "grow flex flex-col items-end LemonInputSelect__edit-button-wrapper",
+              size && `LemonInputSelect__edit-button-wrapper--${size}`,
+            )}
+          >
+            <LemonButton
+              icon={<IconX />}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setInputValue("");
+                onChange?.([]);
+              }}
+              tooltip="Clear selection"
+              noPadding
             />
-        </LemonDropdown>
+          </div>
+        )}
+      </PopoverReferenceContext.Provider>
+    );
+  }, [
+    mode,
+    values,
+    allowCustomValues,
+    disableEditing,
+    itemBeingEditedIndex,
+    inputValue,
+    getStringKey,
+    _onActionItem,
+    displayMode,
+    _onFocus,
+    options,
+    setInputValue,
+    sortable,
+    handleDragEnd,
+    size,
+    onChange,
+    singleValueAsSnack,
+    useVirtualization,
+  ]);
+
+  // Positioned like a placeholder but rendered via the suffix since the actual placeholder has to be a string
+  const countPlaceholder = useMemo(() => {
+    if (
+      displayMode !== "count" ||
+      mode !== "multiple" ||
+      inputValue ||
+      loading
+    ) {
+      return null;
+    }
+    return values.length === 0 ? (
+      <span className="-ml-2 text-muted">
+        Select from {options.length} options
+      </span>
     ) : (
-        <LemonDropdown
-            matchWidth
-            closeOnClickInside={false}
-            actionable
-            visible={showPopover}
-            onClickOutside={() => {
-                popoverFocusRef.current = false
-                setShowPopover(false)
-                // It seems more intuitive to lose focus of drop down entirely when clicking outside of the field.
-                // If this behavior at some point is not desired for multiple mode anymore, it should be kept for single mode.
-                inputRef.current?.blur()
-            }}
-            onClickInside={(e) => {
-                popoverFocusRef.current = true
-                e.stopPropagation()
-            }}
-            className={popoverClassName}
-            placement="bottom-start"
-            fallbackPlacements={['bottom-end', 'top-start', 'top-end']}
-            loadingBar={loading && visibleOptions.length > 0}
-            overlay={
-                <div className="deprecated-space-y-px overflow-y-auto">
-                    {title && <h5 className="mx-2 my-1">{title}</h5>}
+      <span className="-ml-2">
+        {values.length === options.length
+          ? `All ${options.length} selected`
+          : `${values.length}/${options.length} selected`}
+      </span>
+    );
+  }, [displayMode, mode, inputValue, loading, values.length, options.length]);
 
-                    {bulkActions && mode === 'multiple' && (
-                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
-                            {bulkActions === 'select-and-clear-all' && (
-                                <LemonButton
-                                    size="small"
-                                    className="flex-1"
-                                    disabledReason={
-                                        values.length === allOptionsMap.size
-                                            ? 'All options are already selected'
-                                            : undefined
+  const wasLimitReached = values.length >= limit;
+
+  const getInputLabel = (
+    option: LemonInputSelectOption<T>,
+  ): React.ReactNode => {
+    if (formatCreateLabel) {
+      return formatCreateLabel(option.key);
+    }
+    return mode === "multiple" ? `Add "${option.key}"` : option.key;
+  };
+
+  const getOptionIcon = (
+    option: LemonInputSelectOption<T>,
+    isSelected: boolean,
+  ): React.ReactElement | null | undefined => {
+    if (option.__isInput) {
+      return undefined;
+    }
+
+    if (isSelected) {
+      return mode === "multiple" ? (
+        // No pointer events, since it's only for visual feedback
+        <LemonCheckbox checked={true} className="pointer-events-none" />
+      ) : (
+        <IconCheck />
+      );
+    }
+
+    if (mode === "multiple") {
+      return <LemonCheckbox checked={false} className="pointer-events-none" />;
+    }
+
+    return undefined;
+  };
+
+  return useVirtualization ? (
+    <LemonDropdown
+      matchWidth
+      closeOnClickInside={false}
+      actionable
+      visible={showPopover}
+      onClickOutside={() => {
+        popoverFocusRef.current = false;
+        setShowPopover(false);
+        // It seems more intuitive to lose focus of drop down entirely when clicking outside of the field.
+        // If this behavior at some point is not desired for multiple mode anymore, it should be kept for single mode.
+        inputRef.current?.blur();
+      }}
+      onClickInside={(e) => {
+        popoverFocusRef.current = true;
+        e.stopPropagation();
+      }}
+      className={popoverClassName}
+      placement="top-start"
+      fallbackPlacements={["top-end", "bottom-start", "bottom-end"]}
+      loadingBar={loading && visibleOptions.length > 0}
+      overlay={
+        <div className="deprecated-space-y-px overflow-y-auto">
+          {title && <h5 className="mx-2 my-1">{title}</h5>}
+
+          {bulkActions && mode === "multiple" && (
+            <div
+              className="flex items-center mb-0.5"
+              onMouseEnter={() => setSelectedIndex(-1)}
+            >
+              {bulkActions === "select-and-clear-all" && (
+                <LemonButton
+                  size="small"
+                  className="flex-1"
+                  disabledReason={
+                    values.length === allOptionsMap.size
+                      ? "All options are already selected"
+                      : undefined
+                  }
+                  tooltipPlacement="top-start"
+                  tooltipArrowOffset={50}
+                  onClick={() => {
+                    const allKeys = Array.from(allOptionsMap.keys());
+                    const allTypedValues = allKeys.map(getTypedValue);
+                    onChange?.(allTypedValues);
+                  }}
+                  icon={
+                    <LemonCheckbox
+                      checked={
+                        values.length === allOptionsMap.size
+                          ? true
+                          : values.length
+                            ? "indeterminate"
+                            : false
+                      }
+                      className="pointer-events-none"
+                    />
+                  }
+                >
+                  Select all
+                </LemonButton>
+              )}
+              <LemonButton
+                size="small"
+                className={clsx({ "flex-1": bulkActions === "clear-all" })}
+                tooltipPlacement={
+                  bulkActions === "select-and-clear-all"
+                    ? "top-end"
+                    : "top-start"
+                }
+                tooltipArrowOffset={
+                  bulkActions === "clear-all" ? 30 : undefined
+                }
+                disabledReason={
+                  values.length === 0 ? "No options are selected" : undefined
+                }
+                onClick={() => onChange?.([])}
+              >
+                Clear all
+              </LemonButton>
+            </div>
+          )}
+
+          {action && (
+            <div
+              className="flex items-center mb-0.5"
+              onMouseEnter={() => setSelectedIndex(-1)}
+            >
+              <LemonButton
+                size="small"
+                className="flex-1"
+                disabledReason={action?.disabledReason}
+                onClick={action?.onClick}
+              >
+                {action?.children}
+              </LemonButton>
+            </div>
+          )}
+
+          {visibleOptions.length > 0 ? (
+            visibleOptions.length > 100 ? (
+              <>
+                <div
+                  style={{
+                    height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
+                    overflowY: "auto",
+                  }}
+                  className="space-y-px"
+                >
+                  {visibleOptions.map((option, index) => {
+                    const isFocused = index === selectedIndex;
+                    const isSelected = stringKeys.includes(option.key);
+                    const isDisabled = wasLimitReached && !isSelected;
+                    return (
+                      <LemonButton
+                        key={option.key}
+                        type="tertiary"
+                        size="small"
+                        fullWidth
+                        active={isFocused}
+                        onClick={(e) =>
+                          !isDisabled && _onActionItem(option.key, e)
+                        }
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        disabledReason={
+                          isDisabled
+                            ? `Limit of ${limit} options reached`
+                            : undefined
+                        }
+                        tooltip={option.tooltip}
+                        icon={getOptionIcon(option, isSelected)}
+                        style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
+                        sideAction={
+                          !option.__isInput &&
+                          allowCustomValues &&
+                          !disableEditing
+                            ? {
+                                icon: (
+                                  <IconPencil
+                                    className={
+                                      !isFocused ? "invisible" : undefined
                                     }
-                                    tooltipPlacement="top-start"
-                                    tooltipArrowOffset={50}
-                                    onClick={() => {
-                                        const allKeys = Array.from(allOptionsMap.keys())
-                                        const allTypedValues = allKeys.map(getTypedValue)
-                                        onChange?.(allTypedValues)
-                                    }}
-                                    icon={
-                                        <LemonCheckbox
-                                            checked={
-                                                values.length === allOptionsMap.size
-                                                    ? true
-                                                    : values.length
-                                                      ? 'indeterminate'
-                                                      : false
-                                            }
-                                            className="pointer-events-none"
-                                        />
-                                    }
-                                >
-                                    Select all
-                                </LemonButton>
-                            )}
-                            <LemonButton
-                                size="small"
-                                className={clsx({ 'flex-1': bulkActions === 'clear-all' })}
-                                tooltipPlacement={bulkActions === 'select-and-clear-all' ? 'top-end' : 'top-start'}
-                                tooltipArrowOffset={bulkActions === 'clear-all' ? 30 : undefined}
-                                disabledReason={values.length === 0 ? 'No options are selected' : undefined}
-                                onClick={() => onChange?.([])}
-                            >
-                                Clear all
-                            </LemonButton>
-                        </div>
-                    )}
-
-                    {action && (
-                        <div className="flex items-center mb-0.5" onMouseEnter={() => setSelectedIndex(-1)}>
-                            <LemonButton
-                                size="small"
-                                className="flex-1"
-                                disabledReason={action?.disabledReason}
-                                onClick={action?.onClick}
-                            >
-                                {action?.children}
-                            </LemonButton>
-                        </div>
-                    )}
-
-                    {visibleOptions.length > 0 ? (
-                        visibleOptions.length > 100 ? (
-                            <>
-                                <div
-                                    style={{
-                                        height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
-                                        overflowY: 'auto',
-                                    }}
-                                    className="space-y-px"
-                                >
-                                    {visibleOptions.map((option, index) => {
-                                        const isFocused = index === selectedIndex
-                                        const isSelected = stringKeys.includes(option.key)
-                                        const isDisabled = wasLimitReached && !isSelected
-                                        return (
-                                            <LemonButton
-                                                key={option.key}
-                                                type="tertiary"
-                                                size="small"
-                                                fullWidth
-                                                active={isFocused}
-                                                onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-                                                onMouseEnter={() => setSelectedIndex(index)}
-                                                disabledReason={
-                                                    isDisabled ? `Limit of ${limit} options reached` : undefined
-                                                }
-                                                tooltip={option.tooltip}
-                                                icon={getOptionIcon(option, isSelected)}
-                                                style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
-                                                sideAction={
-                                                    !option.__isInput && allowCustomValues && !disableEditing
-                                                        ? {
-                                                              icon: (
-                                                                  <IconPencil
-                                                                      className={!isFocused ? 'invisible' : undefined}
-                                                                  />
-                                                              ),
-                                                              tooltip: (
-                                                                  <>
-                                                                      Edit this value <KeyboardShortcut option enter />
-                                                                  </>
-                                                              ),
-                                                              onClick: () => {
-                                                                  setInputValue(option.key)
-                                                                  inputRef.current?.focus()
-                                                                  _onFocus()
-                                                              },
-                                                          }
-                                                        : undefined
-                                                }
-                                            >
-                                                <span className="whitespace-nowrap ph-no-capture truncate">
-                                                    {!option.__isInput && !option.__isCustomValue
-                                                        ? (option.labelComponent ?? option.label)
-                                                        : getInputLabel(option)}
-                                                </span>
-                                            </LemonButton>
-                                        )
-                                    })}
-                                </div>
-                                {/* Input always visible at bottom for large lists */}
-                                {allowCustomValues && inputValue && (
-                                    <div className="border-t border-border p-1">
-                                        <LemonButton
-                                            type="tertiary"
-                                            size="small"
-                                            fullWidth
-                                            onClick={() => _onActionItem(inputValue)}
-                                        >
-                                            <span className="whitespace-nowrap ph-no-capture truncate">
-                                                {getInputLabel({ key: inputValue, label: inputValue, __isInput: true })}
-                                            </span>
-                                        </LemonButton>
-                                    </div>
-                                )}
-                            </>
-                        ) : (
-                            visibleOptions.map((option, index) => {
-                                const isFocused = index === selectedIndex
-                                const isSelected = stringKeys.includes(option.key)
-                                const isDisabled = wasLimitReached && !isSelected
-                                return (
-                                    <LemonButton
-                                        key={option.key}
-                                        type="tertiary"
-                                        size="small"
-                                        fullWidth
-                                        active={isFocused}
-                                        onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-                                        onMouseEnter={() => setSelectedIndex(index)}
-                                        disabledReason={isDisabled ? `Limit of ${limit} options reached` : undefined}
-                                        tooltip={option.tooltip}
-                                        icon={getOptionIcon(option, isSelected)}
-                                        sideAction={
-                                            !option.__isInput && allowCustomValues && !disableEditing
-                                                ? {
-                                                      // To reduce visual clutter we only show the icon on focus or hover,
-                                                      // but we do want it present to make sure the layout is stable
-                                                      icon: (
-                                                          <IconPencil
-                                                              className={!isFocused ? 'invisible' : undefined}
-                                                          />
-                                                      ),
-                                                      tooltip: (
-                                                          <>
-                                                              Edit this value <KeyboardShortcut option enter />
-                                                          </>
-                                                      ),
-                                                      onClick: () => {
-                                                          setInputValue(option.key)
-                                                          inputRef.current?.focus()
-                                                          _onFocus()
-                                                      },
-                                                  }
-                                                : undefined
-                                        }
-                                    >
-                                        <span className="whitespace-nowrap ph-no-capture truncate">
-                                            {
-                                                !option.__isInput && !option.__isCustomValue
-                                                    ? (option.labelComponent ?? option.label) // Regular option
-                                                    : getInputLabel(option) // Input-based option
-                                            }
-                                        </span>
-                                    </LemonButton>
-                                )
-                            })
-                        )
-                    ) : loading ? (
-                        <>
-                            {range(5).map((x) => (
-                                // 33px is the height of a regular list item
-                                <div key={x} className="flex gap-2 items-center h-[33px] px-2">
-                                    <LemonSkeleton.Circle className="size-[18px]" />
-                                    <LemonSkeleton className="h-3.5 w-full" />
-                                </div>
-                            ))}
-                        </>
-                    ) : (
-                        <>
-                            {emptyStateComponent ? (
-                                emptyStateComponent
-                            ) : (
-                                <p className="text-secondary italic p-1">
-                                    {allowCustomValues
-                                        ? 'Start typing and press Enter to add options'
-                                        : `No options matching "${inputValue}"`}
-                                </p>
-                            )}
-                        </>
-                    )}
+                                  />
+                                ),
+                                tooltip: (
+                                  <>
+                                    Edit this value{" "}
+                                    <KeyboardShortcut option enter />
+                                  </>
+                                ),
+                                onClick: () => {
+                                  setInputValue(option.key);
+                                  inputRef.current?.focus();
+                                  _onFocus();
+                                },
+                              }
+                            : undefined
+                        }
+                      >
+                        <span className="whitespace-nowrap ph-no-capture truncate">
+                          {!option.__isInput && !option.__isCustomValue
+                            ? (option.labelComponent ?? option.label)
+                            : getInputLabel(option)}
+                        </span>
+                      </LemonButton>
+                    );
+                  })}
                 </div>
-            }
-        >
-            <LemonInput
-                inputRef={inputRef}
-                placeholder={
-                    displayMode === 'count'
-                        ? undefined
-                        : values.length === 0
-                          ? placeholder
-                          : mode === 'single'
-                            ? undefined // When value is selected in single mode, no placeholder (value shown but rendered as prefix)
-                            : allowCustomValues
-                              ? 'Add value'
-                              : disablePrompting
-                                ? undefined
-                                : 'Pick value'
-                }
-                autoWidth={fullWidth ? false : autoWidth}
-                fullWidth={fullWidth}
-                prefix={valuesPrefix}
-                suffix={
-                    <>
-                        {countPlaceholder}
-                        {valuesAndClearButtonSuffix}
-                    </>
-                }
-                onFocus={_onFocus}
-                onBlur={_onBlur}
-                value={inputValue}
-                onChange={setInputValue}
-                onClick={_onClick}
-                onKeyDown={_onKeyDown}
-                disabled={disabled}
-                autoFocus={autoFocus}
-                transparentBackground={transparentBackground}
-                className={clsx(
-                    '!h-auto leading-7 max-w-full w-full', // leading-7 means line height aligned with LemonSnack height
-                    // Putting button-like text styling on the single-select unfocused placeholder
-                    // NOTE: We need font-medium on both the input (for autosizing) and its placeholder (for display)
-                    mode === 'multiple' && 'flex-wrap',
-                    mode === 'single' && values.length > 0 && '*:*:font-medium *:*:placeholder:font-medium',
-                    mode === 'single' && values.length > 0 && !showPopover && '*:*:placeholder:text-default',
-                    className
+                {/* Add value input visible at bottom of dropdown for large lists */}
+                {allowCustomValues && inputValue && (
+                  <div className="border-t border-border p-1">
+                    <LemonButton
+                      type="tertiary"
+                      size="small"
+                      fullWidth
+                      onClick={() => _onActionItem(inputValue)}
+                    >
+                      <span className="whitespace-nowrap ph-no-capture truncate">
+                        {getInputLabel({
+                          key: inputValue,
+                          label: inputValue,
+                          __isInput: true,
+                        })}
+                      </span>
+                    </LemonButton>
+                  </div>
                 )}
-                data-attr={dataAttr}
-                size={size}
-                status={status}
-            />
-        </LemonDropdown>
-    )
+              </>
+            ) : (
+              visibleOptions.map((option, index) => {
+                const isFocused = index === selectedIndex;
+                const isSelected = stringKeys.includes(option.key);
+                const isDisabled = wasLimitReached && !isSelected;
+                return (
+                  <LemonButton
+                    key={option.key}
+                    type="tertiary"
+                    size="small"
+                    fullWidth
+                    active={isFocused}
+                    onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    disabledReason={
+                      isDisabled
+                        ? `Limit of ${limit} options reached`
+                        : undefined
+                    }
+                    tooltip={option.tooltip}
+                    icon={getOptionIcon(option, isSelected)}
+                    sideAction={
+                      !option.__isInput && allowCustomValues && !disableEditing
+                        ? {
+                            // To reduce visual clutter we only show the icon on focus or hover,
+                            // but we do want it present to make sure the layout is stable
+                            icon: (
+                              <IconPencil
+                                className={!isFocused ? "invisible" : undefined}
+                              />
+                            ),
+                            tooltip: (
+                              <>
+                                Edit this value{" "}
+                                <KeyboardShortcut option enter />
+                              </>
+                            ),
+                            onClick: () => {
+                              setInputValue(option.key);
+                              inputRef.current?.focus();
+                              _onFocus();
+                            },
+                          }
+                        : undefined
+                    }
+                  >
+                    <span className="whitespace-nowrap ph-no-capture truncate">
+                      {
+                        !option.__isInput && !option.__isCustomValue
+                          ? (option.labelComponent ?? option.label) // Regular option
+                          : getInputLabel(option) // Input-based option
+                      }
+                    </span>
+                  </LemonButton>
+                );
+              })
+            )
+          ) : loading ? (
+            <>
+              {range(5).map((x) => (
+                // 33px is the height of a regular list item
+                <div key={x} className="flex gap-2 items-center h-[33px] px-2">
+                  <LemonSkeleton.Circle className="size-[18px]" />
+                  <LemonSkeleton className="h-3.5 w-full" />
+                </div>
+              ))}
+            </>
+          ) : (
+            <>
+              {emptyStateComponent ? (
+                emptyStateComponent
+              ) : (
+                <p className="text-secondary italic p-1">
+                  {allowCustomValues
+                    ? "Start typing and press Enter to add options"
+                    : `No options matching "${inputValue}"`}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      }
+    >
+      <LemonInput
+        inputRef={inputRef}
+        placeholder={
+          displayMode === "count"
+            ? undefined
+            : values.length === 0
+              ? placeholder
+              : mode === "single"
+                ? undefined // When value is selected in single mode, no placeholder (value shown but rendered as prefix)
+                : allowCustomValues
+                  ? "Add value"
+                  : disablePrompting
+                    ? undefined
+                    : "Pick value"
+        }
+        autoWidth={fullWidth ? false : autoWidth}
+        fullWidth={fullWidth}
+        prefix={virtualizedValues}
+        suffix={
+          <>
+            {countPlaceholder}
+            {valuesAndClearButtonSuffix}
+          </>
+        }
+        onFocus={_onFocus}
+        onBlur={_onBlur}
+        value={inputValue}
+        onChange={setInputValue}
+        onClick={_onClick}
+        onKeyDown={_onKeyDown}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        transparentBackground={transparentBackground}
+        className={clsx(
+          "!h-auto leading-7 max-w-full w-full", // leading-7 means line height aligned with LemonSnack height
+          // Putting button-like text styling on the single-select unfocused placeholder
+          // NOTE: We need font-medium on both the input (for autosizing) and its placeholder (for display)
+          mode === "multiple" && "flex-wrap",
+          mode === "single" &&
+            values.length > 0 &&
+            "*:*:font-medium *:*:placeholder:font-medium",
+          mode === "single" &&
+            values.length > 0 &&
+            !showPopover &&
+            "*:*:placeholder:text-default",
+          className,
+        )}
+        data-attr={dataAttr}
+        size={size}
+        status={status}
+      />
+    </LemonDropdown>
+  ) : (
+    <LemonDropdown
+      matchWidth
+      closeOnClickInside={false}
+      actionable
+      visible={showPopover}
+      onClickOutside={() => {
+        popoverFocusRef.current = false;
+        setShowPopover(false);
+        // It seems more intuitive to lose focus of drop down entirely when clicking outside of the field.
+        // If this behavior at some point is not desired for multiple mode anymore, it should be kept for single mode.
+        inputRef.current?.blur();
+      }}
+      onClickInside={(e) => {
+        popoverFocusRef.current = true;
+        e.stopPropagation();
+      }}
+      className={popoverClassName}
+      placement="bottom-start"
+      fallbackPlacements={["bottom-end", "top-start", "top-end"]}
+      loadingBar={loading && visibleOptions.length > 0}
+      overlay={
+        <div className="deprecated-space-y-px overflow-y-auto">
+          {title && <h5 className="mx-2 my-1">{title}</h5>}
+
+          {bulkActions && mode === "multiple" && (
+            <div
+              className="flex items-center mb-0.5"
+              onMouseEnter={() => setSelectedIndex(-1)}
+            >
+              {bulkActions === "select-and-clear-all" && (
+                <LemonButton
+                  size="small"
+                  className="flex-1"
+                  disabledReason={
+                    values.length === allOptionsMap.size
+                      ? "All options are already selected"
+                      : undefined
+                  }
+                  tooltipPlacement="top-start"
+                  tooltipArrowOffset={50}
+                  onClick={() => {
+                    const allKeys = Array.from(allOptionsMap.keys());
+                    const allTypedValues = allKeys.map(getTypedValue);
+                    onChange?.(allTypedValues);
+                  }}
+                  icon={
+                    <LemonCheckbox
+                      checked={
+                        values.length === allOptionsMap.size
+                          ? true
+                          : values.length
+                            ? "indeterminate"
+                            : false
+                      }
+                      className="pointer-events-none"
+                    />
+                  }
+                >
+                  Select all
+                </LemonButton>
+              )}
+              <LemonButton
+                size="small"
+                className={clsx({ "flex-1": bulkActions === "clear-all" })}
+                tooltipPlacement={
+                  bulkActions === "select-and-clear-all"
+                    ? "top-end"
+                    : "top-start"
+                }
+                tooltipArrowOffset={
+                  bulkActions === "clear-all" ? 30 : undefined
+                }
+                disabledReason={
+                  values.length === 0 ? "No options are selected" : undefined
+                }
+                onClick={() => onChange?.([])}
+              >
+                Clear all
+              </LemonButton>
+            </div>
+          )}
+
+          {action && (
+            <div
+              className="flex items-center mb-0.5"
+              onMouseEnter={() => setSelectedIndex(-1)}
+            >
+              <LemonButton
+                size="small"
+                className="flex-1"
+                disabledReason={action?.disabledReason}
+                onClick={action?.onClick}
+              >
+                {action?.children}
+              </LemonButton>
+            </div>
+          )}
+
+          {visibleOptions.length > 0 ? (
+            visibleOptions.length > 100 ? (
+              <>
+                <div
+                  style={{
+                    height: VIRTUALIZED_MAX_DROPDOWN_HEIGHT - 60,
+                    overflowY: "auto",
+                  }}
+                  className="space-y-px"
+                >
+                  {visibleOptions.map((option, index) => {
+                    const isFocused = index === selectedIndex;
+                    const isSelected = stringKeys.includes(option.key);
+                    const isDisabled = wasLimitReached && !isSelected;
+                    return (
+                      <LemonButton
+                        key={option.key}
+                        type="tertiary"
+                        size="small"
+                        fullWidth
+                        active={isFocused}
+                        onClick={(e) =>
+                          !isDisabled && _onActionItem(option.key, e)
+                        }
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        disabledReason={
+                          isDisabled
+                            ? `Limit of ${limit} options reached`
+                            : undefined
+                        }
+                        tooltip={option.tooltip}
+                        icon={getOptionIcon(option, isSelected)}
+                        style={{ minHeight: VIRTUALIZED_SELECT_OPTION_HEIGHT }}
+                        sideAction={
+                          !option.__isInput &&
+                          allowCustomValues &&
+                          !disableEditing
+                            ? {
+                                icon: (
+                                  <IconPencil
+                                    className={
+                                      !isFocused ? "invisible" : undefined
+                                    }
+                                  />
+                                ),
+                                tooltip: (
+                                  <>
+                                    Edit this value{" "}
+                                    <KeyboardShortcut option enter />
+                                  </>
+                                ),
+                                onClick: () => {
+                                  setInputValue(option.key);
+                                  inputRef.current?.focus();
+                                  _onFocus();
+                                },
+                              }
+                            : undefined
+                        }
+                      >
+                        <span className="whitespace-nowrap ph-no-capture truncate">
+                          {!option.__isInput && !option.__isCustomValue
+                            ? (option.labelComponent ?? option.label)
+                            : getInputLabel(option)}
+                        </span>
+                      </LemonButton>
+                    );
+                  })}
+                </div>
+                {/* Input always visible at bottom for large lists */}
+                {allowCustomValues && inputValue && (
+                  <div className="border-t border-border p-1">
+                    <LemonButton
+                      type="tertiary"
+                      size="small"
+                      fullWidth
+                      onClick={() => _onActionItem(inputValue)}
+                    >
+                      <span className="whitespace-nowrap ph-no-capture truncate">
+                        {getInputLabel({
+                          key: inputValue,
+                          label: inputValue,
+                          __isInput: true,
+                        })}
+                      </span>
+                    </LemonButton>
+                  </div>
+                )}
+              </>
+            ) : (
+              visibleOptions.map((option, index) => {
+                const isFocused = index === selectedIndex;
+                const isSelected = stringKeys.includes(option.key);
+                const isDisabled = wasLimitReached && !isSelected;
+                return (
+                  <LemonButton
+                    key={option.key}
+                    type="tertiary"
+                    size="small"
+                    fullWidth
+                    active={isFocused}
+                    onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    disabledReason={
+                      isDisabled
+                        ? `Limit of ${limit} options reached`
+                        : undefined
+                    }
+                    tooltip={option.tooltip}
+                    icon={getOptionIcon(option, isSelected)}
+                    sideAction={
+                      !option.__isInput && allowCustomValues && !disableEditing
+                        ? {
+                            // To reduce visual clutter we only show the icon on focus or hover,
+                            // but we do want it present to make sure the layout is stable
+                            icon: (
+                              <IconPencil
+                                className={!isFocused ? "invisible" : undefined}
+                              />
+                            ),
+                            tooltip: (
+                              <>
+                                Edit this value{" "}
+                                <KeyboardShortcut option enter />
+                              </>
+                            ),
+                            onClick: () => {
+                              setInputValue(option.key);
+                              inputRef.current?.focus();
+                              _onFocus();
+                            },
+                          }
+                        : undefined
+                    }
+                  >
+                    <span className="whitespace-nowrap ph-no-capture truncate">
+                      {
+                        !option.__isInput && !option.__isCustomValue
+                          ? (option.labelComponent ?? option.label) // Regular option
+                          : getInputLabel(option) // Input-based option
+                      }
+                    </span>
+                  </LemonButton>
+                );
+              })
+            )
+          ) : loading ? (
+            <>
+              {range(5).map((x) => (
+                // 33px is the height of a regular list item
+                <div key={x} className="flex gap-2 items-center h-[33px] px-2">
+                  <LemonSkeleton.Circle className="size-[18px]" />
+                  <LemonSkeleton className="h-3.5 w-full" />
+                </div>
+              ))}
+            </>
+          ) : (
+            <>
+              {emptyStateComponent ? (
+                emptyStateComponent
+              ) : (
+                <p className="text-secondary italic p-1">
+                  {allowCustomValues
+                    ? "Start typing and press Enter to add options"
+                    : `No options matching "${inputValue}"`}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      }
+    >
+      <LemonInput
+        inputRef={inputRef}
+        placeholder={
+          displayMode === "count"
+            ? undefined
+            : values.length === 0
+              ? placeholder
+              : mode === "single"
+                ? undefined // When value is selected in single mode, no placeholder (value shown but rendered as prefix)
+                : allowCustomValues
+                  ? "Add value"
+                  : disablePrompting
+                    ? undefined
+                    : "Pick value"
+        }
+        autoWidth={fullWidth ? false : autoWidth}
+        fullWidth={fullWidth}
+        prefix={valuesPrefix}
+        suffix={
+          <>
+            {countPlaceholder}
+            {valuesAndClearButtonSuffix}
+          </>
+        }
+        onFocus={_onFocus}
+        onBlur={_onBlur}
+        value={inputValue}
+        onChange={setInputValue}
+        onClick={_onClick}
+        onKeyDown={_onKeyDown}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        transparentBackground={transparentBackground}
+        className={clsx(
+          "!h-auto leading-7 max-w-full w-full", // leading-7 means line height aligned with LemonSnack height
+          // Putting button-like text styling on the single-select unfocused placeholder
+          // NOTE: We need font-medium on both the input (for autosizing) and its placeholder (for display)
+          mode === "multiple" && "flex-wrap",
+          mode === "single" &&
+            values.length > 0 &&
+            "*:*:font-medium *:*:placeholder:font-medium",
+          mode === "single" &&
+            values.length > 0 &&
+            !showPopover &&
+            "*:*:placeholder:text-default",
+          className,
+        )}
+        data-attr={dataAttr}
+        size={size}
+        status={status}
+      />
+    </LemonDropdown>
+  );
 }
 
 function DraggableValueSnack<T = string>({
-    value,
-    option,
-    onClose,
-    onInitiateEdit,
+  value,
+  option,
+  onClose,
+  onInitiateEdit,
 }: {
-    value: string
-    option: LemonInputSelectOption<T>
-    onClose: (value: string) => void
-    onInitiateEdit: ((value: string) => void) | null
+  value: string;
+  option: LemonInputSelectOption<T>;
+  onClose: (value: string) => void;
+  onInitiateEdit: ((value: string) => void) | null;
 }): JSX.Element {
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-        id: value,
-    })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: value,
+  });
 
-    const style = {
-        transform: CSS.Translate.toString(transform),
-        transition,
-        zIndex: isDragging ? 1 : undefined,
-        opacity: isDragging ? 0.5 : undefined,
-    }
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    zIndex: isDragging ? 1 : undefined,
+    opacity: isDragging ? 0.5 : undefined,
+  };
 
-    return (
-        <Tooltip
-            title={
-                <>
-                    <span>
-                        {onInitiateEdit && (
-                            <>
-                                Click on the text to edit.
-                                <br />
-                            </>
-                        )}
-                    </span>
-                    <span>Click on the X to remove.</span>
-                </>
-            }
+  return (
+    <Tooltip
+      title={
+        <>
+          <span>
+            {onInitiateEdit && (
+              <>
+                Click on the text to edit.
+                <br />
+              </>
+            )}
+          </span>
+          <span>Click on the X to remove.</span>
+        </>
+      }
+    >
+      <span
+        ref={setNodeRef}
+        // eslint-disable-next-line react/forbid-dom-props
+        style={style}
+        {...attributes}
+        className="inline-flex text-primary-alt max-w-full overflow-hidden break-all items-center py-1 leading-5 bg-accent-highlight-secondary rounded"
+      >
+        <span
+          className="shrink-0 flex items-center pl-1 pr-0.5 cursor-grab active:cursor-grabbing"
+          {...listeners}
         >
-            <span
-                ref={setNodeRef}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={style}
-                {...attributes}
-                className="inline-flex text-primary-alt max-w-full overflow-hidden break-all items-center py-1 leading-5 bg-accent-highlight-secondary rounded"
-            >
-                <span
-                    className="shrink-0 flex items-center pl-1 pr-0.5 cursor-grab active:cursor-grabbing"
-                    {...listeners}
-                >
-                    <SortableDragIcon className="text-muted-alt w-3.5" />
-                </span>
-                <span
-                    className="overflow-hidden text-ellipsis px-1 cursor-text"
-                    title={option?.label}
-                    onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
-                >
-                    {option?.labelComponent ?? option?.label}
-                </span>
-                <span className="shrink-0 mx-1">
-                    <LemonButton
-                        size="xsmall"
-                        noPadding
-                        icon={<IconX />}
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onClose(value)
-                        }}
-                    />
-                </span>
-            </span>
-        </Tooltip>
-    )
+          <SortableDragIcon className="text-muted-alt w-3.5" />
+        </span>
+        <span
+          className="overflow-hidden text-ellipsis px-1 cursor-text"
+          title={option?.label}
+          onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
+        >
+          {option?.labelComponent ?? option?.label}
+        </span>
+        <span className="shrink-0 mx-1">
+          <LemonButton
+            size="xsmall"
+            noPadding
+            icon={<IconX />}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose(value);
+            }}
+          />
+        </span>
+      </span>
+    </Tooltip>
+  );
 }
 
-const VirtualizedValuesList = React.memo(function VirtualizedValuesList<T = string>({
-    values,
-    options,
-    onClose,
-    onInitiateEdit,
+const VirtualizedValuesList = React.memo(function VirtualizedValuesList<
+  T = string,
+>({
+  values,
+  options,
+  onClose,
+  onInitiateEdit,
 }: {
-    values: string[]
-    options: LemonInputSelectOption<T>[]
-    onClose: (value: string) => void
-    onInitiateEdit: ((value: string) => void) | null
+  values: string[];
+  options: LemonInputSelectOption<T>[];
+  onClose: (value: string) => void;
+  onInitiateEdit: ((value: string) => void) | null;
 }): JSX.Element {
-    const [scrollTop, setScrollTop] = useState(0)
-    const [rows, setRows] = useState<string[][]>([])
-    const measureRef = useRef<HTMLDivElement>(null)
+  const [scrollTop, setScrollTop] = useState(0);
+  const [rows, setRows] = useState<string[][]>([]);
+  const measureRef = useRef<HTMLDivElement>(null);
 
-    // Create rows by measuring how many items fit per row
-    // Debounce measurements to avoid frequent re-renders that could cause focus loss
-    useEffect(() => {
-        const timeoutId = setTimeout(() => {
-            if (!measureRef.current) {
-                return
-            }
+  // Create rows by measuring how many items fit per row
+  // Debounce measurements to avoid frequent re-renders that could cause focus loss
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (!measureRef.current) {
+        return;
+      }
 
-            const containerWidth = measureRef.current.offsetWidth - 32 // Account for padding + scrollbar
-            const tempRows: string[][] = []
-            let currentRow: string[] = []
-            let currentRowWidth = 0
+      const containerWidth = measureRef.current.offsetWidth - 32; // Account for padding + scrollbar
+      const tempRows: string[][] = [];
+      let currentRow: string[] = [];
+      let currentRowWidth = 0;
 
-            // Create a temporary element to measure text width
-            const tempSpan = document.createElement('span')
-            tempSpan.style.visibility = 'hidden'
-            tempSpan.style.position = 'absolute'
-            tempSpan.style.whiteSpace = 'nowrap'
-            tempSpan.className = 'LemonSnack' // Use same styling for measurement
+      // Create a temporary element to measure text width
+      const tempSpan = document.createElement("span");
+      tempSpan.style.visibility = "hidden";
+      tempSpan.style.position = "absolute";
+      tempSpan.style.whiteSpace = "nowrap";
+      tempSpan.className = "LemonSnack"; // Use same styling for measurement
 
-            try {
-                document.body.appendChild(tempSpan)
+      try {
+        document.body.appendChild(tempSpan);
 
-                values.forEach((value) => {
-                    const option = options.find((opt) => opt.key === value)
-                    const label = option?.label ?? value
+        values.forEach((value) => {
+          const option = options.find((opt) => opt.key === value);
+          const label = option?.label ?? value;
 
-                    // Estimate width (rough calculation for LemonSnack)
-                    tempSpan.textContent = label
-                    const itemWidth = tempSpan.offsetWidth + 40 // Add padding/borders/close button + extra margin
+          // Estimate width (rough calculation for LemonSnack)
+          tempSpan.textContent = label;
+          const itemWidth = tempSpan.offsetWidth + 40; // Add padding/borders/close button + extra margin
 
-                    if (currentRowWidth + itemWidth > containerWidth && currentRow.length > 0) {
-                        // Start new row
-                        tempRows.push([...currentRow])
-                        currentRow = [value]
-                        currentRowWidth = itemWidth + 4 // Add gap
-                    } else {
-                        // Add to current row
-                        currentRow.push(value)
-                        currentRowWidth += itemWidth + 4 // Add gap
-                    }
-                })
+          if (
+            currentRowWidth + itemWidth > containerWidth &&
+            currentRow.length > 0
+          ) {
+            // Start new row
+            tempRows.push([...currentRow]);
+            currentRow = [value];
+            currentRowWidth = itemWidth + 4; // Add gap
+          } else {
+            // Add to current row
+            currentRow.push(value);
+            currentRowWidth += itemWidth + 4; // Add gap
+          }
+        });
 
-                // Add final row
-                if (currentRow.length > 0) {
-                    tempRows.push(currentRow)
-                }
-            } finally {
-                // Ensure cleanup happens even if an error occurs
-                if (document.body.contains(tempSpan)) {
-                    document.body.removeChild(tempSpan)
-                }
-            }
-            setRows(tempRows)
-        }, 50) // 50ms debounce
+        // Add final row
+        if (currentRow.length > 0) {
+          tempRows.push(currentRow);
+        }
+      } finally {
+        // Ensure cleanup happens even if an error occurs
+        if (document.body.contains(tempSpan)) {
+          document.body.removeChild(tempSpan);
+        }
+      }
+      setRows(tempRows);
+    }, 50); // 50ms debounce
 
-        return () => clearTimeout(timeoutId)
-    }, [values, options])
+    return () => clearTimeout(timeoutId);
+  }, [values, options]);
 
-    // Row-based virtualization
-    const rowHeight = 32 // Estimated height per row
-    const containerHeight = VALUE_SNACKS_MAX_HEIGHT
-    const visibleRowCount = Math.ceil(containerHeight / rowHeight)
-    const startRowIndex = Math.max(0, Math.floor(scrollTop / rowHeight))
-    const endRowIndex = Math.min(rows.length, startRowIndex + visibleRowCount + 2) // Extra buffer
+  // Row-based virtualization
+  const rowHeight = 32; // Estimated height per row
+  const containerHeight = VALUE_SNACKS_MAX_HEIGHT;
+  const visibleRowCount = Math.ceil(containerHeight / rowHeight);
+  const startRowIndex = Math.max(0, Math.floor(scrollTop / rowHeight));
+  const endRowIndex = Math.min(
+    rows.length,
+    startRowIndex + visibleRowCount + 2,
+  ); // Extra buffer
 
-    const visibleRows = rows.slice(startRowIndex, endRowIndex)
-    const topSpacer = startRowIndex * rowHeight
-    const bottomSpacer = (rows.length - endRowIndex) * rowHeight
+  const visibleRows = rows.slice(startRowIndex, endRowIndex);
+  const topSpacer = startRowIndex * rowHeight;
+  const bottomSpacer = (rows.length - endRowIndex) * rowHeight;
 
-    const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>): void => {
-        setScrollTop(e.currentTarget.scrollTop)
-    }, [])
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>): void => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
 
-    const totalContentHeight = rows.length * rowHeight + (rows.length > 0 ? (rows.length - 1) * 4 : 0) // Add gap spacing
-    const isScrollable = totalContentHeight > VALUE_SNACKS_MAX_HEIGHT
+  const totalContentHeight =
+    rows.length * rowHeight + (rows.length > 0 ? (rows.length - 1) * 4 : 0); // Add gap spacing
+  const isScrollable = totalContentHeight > VALUE_SNACKS_MAX_HEIGHT;
 
-    return (
-        <div className="w-full">
-            <div
-                ref={measureRef}
-                style={{
-                    maxHeight: VALUE_SNACKS_MAX_HEIGHT,
-                    overflowY: isScrollable ? 'auto' : 'hidden',
-                }}
-                className="px-1 w-full"
-                onScroll={handleScroll}
-            >
-                {/* Top spacer for non-visible rows above */}
-                {topSpacer > 0 && <div style={{ height: topSpacer }} />}
+  return (
+    <div className="w-full">
+      <div
+        ref={measureRef}
+        style={{
+          maxHeight: VALUE_SNACKS_MAX_HEIGHT,
+          overflowY: isScrollable ? "auto" : "hidden",
+        }}
+        className="px-1 w-full"
+        onScroll={handleScroll}
+      >
+        {/* Top spacer for non-visible rows above */}
+        {topSpacer > 0 && <div style={{ height: topSpacer }} />}
 
-                {/* Visible rows */}
-                {visibleRows.map((row, rowIndex) => (
-                    <div
-                        key={startRowIndex + rowIndex}
-                        className="flex flex-wrap gap-1 mb-1"
-                        style={{ minHeight: rowHeight }}
-                    >
-                        {row.map((value) => {
-                            const option: LemonInputSelectOption<T> = options.find(
-                                (option) => option.key === value
-                            ) ?? {
-                                key: value,
-                                label: value,
-                                labelComponent: null,
-                            }
+        {/* Visible rows */}
+        {visibleRows.map((row, rowIndex) => (
+          <div
+            key={startRowIndex + rowIndex}
+            className="flex flex-wrap gap-1 mb-1"
+            style={{ minHeight: rowHeight }}
+          >
+            {row.map((value) => {
+              const option: LemonInputSelectOption<T> = options.find(
+                (option) => option.key === value,
+              ) ?? {
+                key: value,
+                label: value,
+                labelComponent: null,
+              };
 
-                            return (
-                                <LemonSnack
-                                    key={value}
-                                    title={option?.label}
-                                    onClose={() => onClose(value)}
-                                    onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
-                                    className="cursor-text"
-                                >
-                                    {option?.labelComponent ?? option?.label}
-                                </LemonSnack>
-                            )
-                        })}
-                    </div>
-                ))}
+              return (
+                <LemonSnack
+                  key={value}
+                  title={option?.label}
+                  onClose={() => onClose(value)}
+                  onClick={
+                    onInitiateEdit ? () => onInitiateEdit(value) : undefined
+                  }
+                  className="cursor-text"
+                >
+                  {option?.labelComponent ?? option?.label}
+                </LemonSnack>
+              );
+            })}
+          </div>
+        ))}
 
-                {/* Bottom spacer for non-visible rows below */}
-                {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} />}
-            </div>
+        {/* Bottom spacer for non-visible rows below */}
+        {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} />}
+      </div>
 
-            {/* Warning when content is scrollable */}
-            {isScrollable && (
-                <div className="text-xs text-muted mt-1 px-1">Scroll to see all {values.length} values</div>
-            )}
+      {/* Warning when content is scrollable */}
+      {isScrollable && (
+        <div className="text-xs text-muted mt-1 px-1">
+          Scroll to see all {values.length} values
         </div>
-    )
-})
+      )}
+    </div>
+  );
+});
 
-VirtualizedValuesList.displayName = 'VirtualizedValuesList'
+VirtualizedValuesList.displayName = "VirtualizedValuesList";
 
 function ValueSnacks<T = string>({
-    values,
-    options,
-    onClose,
-    onInitiateEdit,
-    sortable = false,
-    onDragEnd,
-    limitHeight = false,
-    enableVirtualization = false,
+  values,
+  options,
+  onClose,
+  onInitiateEdit,
+  sortable = false,
+  onDragEnd,
+  limitHeight = false,
+  enableVirtualization = false,
 }: {
-    values: string[]
-    options: LemonInputSelectOption<T>[]
-    onClose: (value: string) => void
-    onInitiateEdit: ((value: string) => void) | null
-    sortable?: boolean
-    onDragEnd?: (event: DragEndEvent) => void
-    limitHeight?: boolean
-    enableVirtualization?: boolean
+  values: string[];
+  options: LemonInputSelectOption<T>[];
+  onClose: (value: string) => void;
+  onInitiateEdit: ((value: string) => void) | null;
+  sortable?: boolean;
+  onDragEnd?: (event: DragEndEvent) => void;
+  limitHeight?: boolean;
+  enableVirtualization?: boolean;
 }): JSX.Element {
-    const sensors = useSensors(
-        useSensor(PointerSensor, {
-            activationConstraint: {
-                distance: 8,
-            },
-        })
-    )
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+  );
 
-    const content = values.map((value) => {
-        const option: LemonInputSelectOption<T> = options.find((option) => option.key === value) ?? {
-            key: value,
-            label: value,
-            labelComponent: null,
-        }
+  const content = values.map((value) => {
+    const option: LemonInputSelectOption<T> = options.find(
+      (option) => option.key === value,
+    ) ?? {
+      key: value,
+      label: value,
+      labelComponent: null,
+    };
 
-        if (sortable) {
-            return (
-                <DraggableValueSnack
-                    key={value}
-                    value={value}
-                    option={option}
-                    onClose={onClose}
-                    onInitiateEdit={onInitiateEdit}
-                />
-            )
-        }
-
-        return (
-            <Tooltip
-                key={value}
-                title={
-                    <>
-                        <span>
-                            {onInitiateEdit && (
-                                <>
-                                    Click on the text to edit.
-                                    <br />
-                                </>
-                            )}
-                        </span>
-                        <span>Click on the X to remove.</span>
-                    </>
-                }
-            >
-                <LemonSnack
-                    title={option?.label}
-                    onClose={() => onClose(value)}
-                    onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
-                    className="cursor-text"
-                >
-                    {option?.labelComponent ?? option?.label}
-                </LemonSnack>
-            </Tooltip>
-        )
-    })
-
-    const contentElement =
-        sortable && onDragEnd ? (
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-                <SortableContext items={values} strategy={rectSortingStrategy}>
-                    {content}
-                </SortableContext>
-            </DndContext>
-        ) : (
-            <>{content}</>
-        )
-
-    if (limitHeight) {
-        // Simple scrollable container for very large lists (>100 values)
-        if (values.length > 100 && enableVirtualization) {
-            // For large lists, use virtualized rendering (only render visible items)
-            return (
-                <VirtualizedValuesList
-                    values={values}
-                    options={options}
-                    onClose={onClose}
-                    onInitiateEdit={onInitiateEdit}
-                />
-            )
-        }
-
-        // For normal lists with limitHeight, use regular rendering with height limit
-        return (
-            <div className="flex flex-wrap gap-1 overflow-y-auto pr-1" style={{ maxHeight: VALUE_SNACKS_MAX_HEIGHT }}>
-                {contentElement}
-            </div>
-        )
+    if (sortable) {
+      return (
+        <DraggableValueSnack
+          key={value}
+          value={value}
+          option={option}
+          onClose={onClose}
+          onInitiateEdit={onInitiateEdit}
+        />
+      );
     }
 
-    // For lists without height limit, return content directly
-    return contentElement
+    return (
+      <Tooltip
+        key={value}
+        title={
+          <>
+            <span>
+              {onInitiateEdit && (
+                <>
+                  Click on the text to edit.
+                  <br />
+                </>
+              )}
+            </span>
+            <span>Click on the X to remove.</span>
+          </>
+        }
+      >
+        <LemonSnack
+          title={option?.label}
+          onClose={() => onClose(value)}
+          onClick={onInitiateEdit ? () => onInitiateEdit(value) : undefined}
+          className="cursor-text"
+        >
+          {option?.labelComponent ?? option?.label}
+        </LemonSnack>
+      </Tooltip>
+    );
+  });
+
+  const contentElement =
+    sortable && onDragEnd ? (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={onDragEnd}
+      >
+        <SortableContext items={values} strategy={rectSortingStrategy}>
+          {content}
+        </SortableContext>
+      </DndContext>
+    ) : (
+      <>{content}</>
+    );
+
+  if (limitHeight) {
+    // Simple scrollable container for very large lists (>100 values)
+    if (values.length > 100 && enableVirtualization) {
+      // For large lists, use virtualized rendering (only render visible items)
+      return (
+        <VirtualizedValuesList
+          values={values}
+          options={options}
+          onClose={onClose}
+          onInitiateEdit={onInitiateEdit}
+        />
+      );
+    }
+
+    // For normal lists with limitHeight, use regular rendering with height limit
+    return (
+      <div
+        className="flex flex-wrap gap-1 overflow-y-auto pr-1"
+        style={{ maxHeight: VALUE_SNACKS_MAX_HEIGHT }}
+      >
+        {contentElement}
+      </div>
+    );
+  }
+
+  // For lists without height limit, return content directly
+  return contentElement;
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -144,6 +144,7 @@ export function FeatureFlagReleaseConditions({
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
     const showBucketingIdentifierUI = useFeatureFlag('FLAG_BUCKETING_IDENTIFIER')
+    const enableLargeListVirtualization = useFeatureFlag('LEMON_INPUT_SELECT_VIRTUALIZATION')
 
     const featureFlagVariants = nonEmptyFeatureFlagVariants || nonEmptyVariants
 
@@ -352,6 +353,7 @@ export function FeatureFlagReleaseConditions({
                                 hasRowOperator={false}
                                 sendAllKeyUpdates
                                 allowRelativeDateOptions
+                                enableLargeListVirtualization={enableLargeListVirtualization}
                                 excludedProperties={
                                     featureFlagKey
                                         ? { [TaxonomicFilterGroupType.FeatureFlags]: [featureFlagKey] }

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -9,6 +9,7 @@ import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
@@ -175,6 +176,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
         filters,
         onChange,
     })
+
+    const enableLargeListVirtualization = useFeatureFlag('LEMON_INPUT_SELECT_VIRTUALIZATION')
 
     const {
         taxonomicGroupTypes,
@@ -407,6 +410,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                     taxonomicGroupTypes={taxonomicGroupTypes}
                                                     taxonomicFilterOptionsFromProp={filtersTaxonomicOptions}
                                                     hasRowOperator={false}
+                                                    enableLargeListVirtualization={enableLargeListVirtualization}
                                                 />
                                             </div>
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -885,6 +885,7 @@ READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/[^/]+/run/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/last_execution_times/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/persons/batch_by_distinct_ids/?$"),
+    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/feature_flags/user_blast_radius/?$"),
     # Allow upgrading from read-only to read-write impersonation
     "/admin/impersonation/upgrade/",
 ]

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -777,6 +777,23 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         # Should not be blocked by impersonation middleware (might get other errors)
         assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
 
+    def test_read_only_impersonation_allows_user_blast_radius_endpoint(self):
+        """Verify read-only impersonation allows POST to user_blast_radius endpoint."""
+        self.login_as_other_user_read_only()
+
+        # Verify we're logged in as the other user
+        assert self.client.get("/api/users/@me").json()["email"] == "other-user@posthog.com"
+
+        # POST to user_blast_radius endpoint - the endpoint is read-only despite using POST
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/user_blast_radius/",
+            data={"condition": {"properties": []}},
+            content_type="application/json",
+        )
+
+        # Should not be blocked by impersonation middleware (might get other errors)
+        assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
+
     def test_regular_impersonation_allows_write(self):
         """Verify regular (non-read-only) impersonation can still write."""
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")

--- a/products/event_definitions/frontend/generated/api.schemas.ts
+++ b/products/event_definitions/frontend/generated/api.schemas.ts
@@ -1,0 +1,185 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+/**
+ * * `engineering` - Engineering
+ * `data` - Data
+ * `product` - Product Management
+ * `founder` - Founder
+ * `leadership` - Leadership
+ * `marketing` - Marketing
+ * `sales` - Sales / Success
+ * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+export const RoleAtOrganizationEnumApi = {
+    Engineering: 'engineering',
+    Data: 'data',
+    Product: 'product',
+    Founder: 'founder',
+    Leadership: 'leadership',
+    Marketing: 'marketing',
+    Sales: 'sales',
+    Other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+export const NullEnumApi = {} as const
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null | null
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi | null
+}
+
+/**
+ * * `allow` - Allow
+ * `reject` - Reject
+ */
+export type EnforcementModeEnumApi = (typeof EnforcementModeEnumApi)[keyof typeof EnforcementModeEnumApi]
+
+export const EnforcementModeEnumApi = {
+    Allow: 'allow',
+    Reject: 'reject',
+} as const
+
+/**
+ * Serializer mixin that handles tags for objects.
+ */
+export interface EnterpriseEventDefinitionApi {
+    readonly id: string
+    /** @maxLength 400 */
+    name: string
+    /** @nullable */
+    owner?: number | null
+    /** @nullable */
+    description?: string | null
+    tags?: unknown[]
+    /** @nullable */
+    readonly created_at: string | null
+    readonly updated_at: string
+    readonly updated_by: UserBasicApi
+    /** @nullable */
+    readonly last_seen_at: string | null
+    readonly last_updated_at: string
+    verified?: boolean
+    /** @nullable */
+    readonly verified_at: string | null
+    readonly verified_by: UserBasicApi
+    /** @nullable */
+    hidden?: boolean | null
+    enforcement_mode?: EnforcementModeEnumApi
+    readonly is_action: boolean
+    readonly action_id: number
+    readonly is_calculating: boolean
+    readonly last_calculated_at: string
+    readonly created_by: UserBasicApi
+    post_to_slack?: boolean
+    default_columns?: string[]
+    readonly media_preview_urls: readonly string[]
+}
+
+export interface PaginatedEnterpriseEventDefinitionListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: EnterpriseEventDefinitionApi[]
+}
+
+/**
+ * Serializer mixin that handles tags for objects.
+ */
+export interface PatchedEnterpriseEventDefinitionApi {
+    readonly id?: string
+    /** @maxLength 400 */
+    name?: string
+    /** @nullable */
+    owner?: number | null
+    /** @nullable */
+    description?: string | null
+    tags?: unknown[]
+    /** @nullable */
+    readonly created_at?: string | null
+    readonly updated_at?: string
+    readonly updated_by?: UserBasicApi
+    /** @nullable */
+    readonly last_seen_at?: string | null
+    readonly last_updated_at?: string
+    verified?: boolean
+    /** @nullable */
+    readonly verified_at?: string | null
+    readonly verified_by?: UserBasicApi
+    /** @nullable */
+    hidden?: boolean | null
+    enforcement_mode?: EnforcementModeEnumApi
+    readonly is_action?: boolean
+    readonly action_id?: number
+    readonly is_calculating?: boolean
+    readonly last_calculated_at?: string
+    readonly created_by?: UserBasicApi
+    post_to_slack?: boolean
+    default_columns?: string[]
+    readonly media_preview_urls?: readonly string[]
+}
+
+export type EventDefinitionApiProperties = { [key: string]: unknown }
+
+export interface EventDefinitionApi {
+    elements: unknown[]
+    event: string
+    properties: EventDefinitionApiProperties
+}
+
+export type EventDefinitionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type EventDefinitionsByNameRetrieveParams = {
+    /**
+     * The exact event name to look up
+     */
+    name: string
+}

--- a/products/event_definitions/frontend/generated/api.ts
+++ b/products/event_definitions/frontend/generated/api.ts
@@ -1,0 +1,222 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type {
+    EnterpriseEventDefinitionApi,
+    EventDefinitionApi,
+    EventDefinitionsByNameRetrieveParams,
+    EventDefinitionsListParams,
+    PaginatedEnterpriseEventDefinitionListApi,
+    PatchedEnterpriseEventDefinitionApi,
+} from './api.schemas'
+
+// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
+type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B
+
+type WritableKeys<T> = {
+    [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P>
+}[keyof T]
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
+
+type Writable<T> = Pick<T, WritableKeys<T>>
+type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
+    ? {
+          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+      }
+    : DistributeReadOnlyOverUnions<T>
+
+export const getEventDefinitionsListUrl = (projectId: string, params?: EventDefinitionsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/`
+}
+
+export const eventDefinitionsList = async (
+    projectId: string,
+    params?: EventDefinitionsListParams,
+    options?: RequestInit
+): Promise<PaginatedEnterpriseEventDefinitionListApi> => {
+    return apiMutator<PaginatedEnterpriseEventDefinitionListApi>(getEventDefinitionsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getEventDefinitionsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/event_definitions/`
+}
+
+export const eventDefinitionsCreate = async (
+    projectId: string,
+    enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
+    options?: RequestInit
+): Promise<EnterpriseEventDefinitionApi> => {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(enterpriseEventDefinitionApi),
+    })
+}
+
+export const getEventDefinitionsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/event_definitions/${id}/`
+}
+
+export const eventDefinitionsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<EnterpriseEventDefinitionApi> => {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getEventDefinitionsUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/event_definitions/${id}/`
+}
+
+export const eventDefinitionsUpdate = async (
+    projectId: string,
+    id: string,
+    enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
+    options?: RequestInit
+): Promise<EnterpriseEventDefinitionApi> => {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(enterpriseEventDefinitionApi),
+    })
+}
+
+export const getEventDefinitionsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/event_definitions/${id}/`
+}
+
+export const eventDefinitionsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedEnterpriseEventDefinitionApi: NonReadonly<PatchedEnterpriseEventDefinitionApi>,
+    options?: RequestInit
+): Promise<EnterpriseEventDefinitionApi> => {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedEnterpriseEventDefinitionApi),
+    })
+}
+
+export const getEventDefinitionsDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/event_definitions/${id}/`
+}
+
+export const eventDefinitionsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getEventDefinitionsMetricsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/event_definitions/${id}/metrics/`
+}
+
+export const eventDefinitionsMetricsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsMetricsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Get event definition by exact name
+ */
+export const getEventDefinitionsByNameRetrieveUrl = (
+    projectId: string,
+    params: EventDefinitionsByNameRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/by_name/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/by_name/`
+}
+
+export const eventDefinitionsByNameRetrieve = async (
+    projectId: string,
+    params: EventDefinitionsByNameRetrieveParams,
+    options?: RequestInit
+): Promise<EventDefinitionApi> => {
+    return apiMutator<EventDefinitionApi>(getEventDefinitionsByNameRetrieveUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getEventDefinitionsGolangRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/event_definitions/golang/`
+}
+
+export const eventDefinitionsGolangRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsGolangRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getEventDefinitionsPythonRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/event_definitions/python/`
+}
+
+export const eventDefinitionsPythonRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsPythonRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getEventDefinitionsTypescriptRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/event_definitions/typescript/`
+}
+
+export const eventDefinitionsTypescriptRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsTypescriptRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}


### PR DESCRIPTION
## Problem

Feature flag conditions with large numbers of property values (>9) were causing out-of-memory (OOM) issues in the browser for some users. Users attempting to add many property values to feature flag conditions experience browser crashes, making it impossible to configure complex targeting rules.

## Changes

![chrome-capture-2026-02-24](https://github.com/user-attachments/assets/4a56f007-a04e-418d-bba7-d9ee10d27b20)

- Implemented custom row-based virtualization for LemonInputSelect component
- Added feature flag `lemon-input-select-virtualization` to control virtualization activation
- Virtualization only activates when there are >100 values to prevent unnecessary overhead

## How did you test this code?

- Tested manually with feature flag conditions containing 150+ property values

## Publish to changelog?

no