### PR TITLE
chore(web-analytics): Point reverse proxy CTA to the settings page

### DIFF
--- a/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
+++ b/frontend/src/scenes/web-analytics/health/webAnalyticsHealthLogic.ts
@@ -207,7 +207,7 @@ export const webAnalyticsHealthLogic = kea<webAnalyticsHealthLogicType>([
                               ? undefined
                               : {
                                     label: 'Set up reverse proxy',
-                                    to: 'https://posthog.com/docs/advanced/proxy',
+                                    to: urls.settings('organization-proxy'),
                                 },
                           docsUrl: 'https://posthog.com/docs/advanced/proxy',
                           urgent: true,


### PR DESCRIPTION
## Problem
The reverse proxy CTA in the installation health tab pointed to the documentation. Now that managed proxies are in beta we can point that to the actual configuration page.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Change CTA URL

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
