### PR TITLE
feat(replay): add deleted_by to recording deleted UX

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -339,7 +339,10 @@ export class RateLimitError extends Error {
 }
 
 export class RecordingDeletedError extends Error {
-    constructor(public deletedAt: number | null) {
+    constructor(
+        public deletedAt: number | null,
+        public deletedBy: string | null
+    ) {
         super('Recording has been permanently deleted')
         this.name = 'RecordingDeletedError'
     }
@@ -3810,7 +3813,7 @@ const api = {
                     .getResponse({ headers })
             } catch (e) {
                 if (e instanceof ApiError && e.status === 410 && e.data?.error === 'recording_deleted') {
-                    throw new RecordingDeletedError(e.data?.deleted_at ?? null)
+                    throw new RecordingDeletedError(e.data?.deleted_at ?? null, e.data?.deleted_by ?? null)
                 }
                 throw e
             }

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -89,7 +89,7 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
         endReached,
     } = useValues(sessionRecordingPlayerLogic)
 
-    const { isNotFound, isRecentAndInvalid, isRecordingDeleted, recordingDeletedAt } = useValues(
+    const { isNotFound, isRecentAndInvalid, isRecordingDeleted, recordingDeletedAt, recordingDeletedBy } = useValues(
         sessionRecordingDataCoordinatorLogic(logicProps)
     )
     const { loadSnapshots } = useActions(sessionRecordingDataCoordinatorLogic(logicProps))
@@ -237,7 +237,7 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
     if (isRecordingDeleted) {
         return (
             <div className="flex-1 w-full flex justify-center items-center">
-                <RecordingDeleted deletedAt={recordingDeletedAt} />
+                <RecordingDeleted deletedAt={recordingDeletedAt} deletedBy={recordingDeletedBy} />
             </div>
         )
     }

--- a/frontend/src/scenes/session-recordings/player/RecordingDeleted.tsx
+++ b/frontend/src/scenes/session-recordings/player/RecordingDeleted.tsx
@@ -4,9 +4,10 @@ import { dayjs } from 'lib/dayjs'
 
 interface RecordingDeletedProps {
     deletedAt: number | null
+    deletedBy: string | null
 }
 
-export function RecordingDeleted({ deletedAt }: RecordingDeletedProps): JSX.Element {
+export function RecordingDeleted({ deletedAt, deletedBy }: RecordingDeletedProps): JSX.Element {
     return (
         <div className="flex flex-col items-center justify-center p-8 text-center text-wrap-balance max-w-lg mx-auto">
             <div className="w-16 h-16 rounded-full bg-border-bold/10 flex items-center justify-center mb-4">
@@ -19,6 +20,7 @@ export function RecordingDeleted({ deletedAt }: RecordingDeletedProps): JSX.Elem
                     Deleted {dayjs.unix(deletedAt).fromNow()} ({dayjs.unix(deletedAt).format('MMMM D, YYYY h:mm A')})
                 </p>
             )}
+            {deletedBy && <p className="text-muted-3000 text-xs mt-1 mb-0">Deleted by {deletedBy}</p>}
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -107,6 +107,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                     'getWindowId',
                     'isRecordingDeleted',
                     'recordingDeletedAt',
+                    'recordingDeletedBy',
                 ],
                 eventsLogic,
                 [

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
@@ -51,6 +51,7 @@ export const sessionRecordingMetaLogic = kea<sessionRecordingMetaLogicType>([
                     'isLoadingSnapshots',
                     'isRecordingDeleted',
                     'recordingDeletedAt',
+                    'recordingDeletedBy',
                 ],
                 registryLogic,
                 ['uuidToIndex', 'getWindowId'],

--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.test.ts
@@ -127,14 +127,16 @@ describe('snapshotDataLogic', () => {
         it('isRecordingDeleted is false when no error', () => {
             expect(logic.values.isRecordingDeleted).toBe(false)
             expect(logic.values.recordingDeletedAt).toBe(null)
+            expect(logic.values.recordingDeletedBy).toBe(null)
         })
 
         it('isRecordingDeleted is true when snapshotLoadError is RecordingDeletedError', () => {
-            const error = new RecordingDeletedError(1700000000)
+            const error = new RecordingDeletedError(1700000000, 'admin@example.com')
             logic.actions.loadSnapshotsForSourceFailure('Recording deleted', error)
 
             expect(logic.values.isRecordingDeleted).toBe(true)
             expect(logic.values.recordingDeletedAt).toBe(1700000000)
+            expect(logic.values.recordingDeletedBy).toBe('admin@example.com')
         })
 
         it('isRecordingDeleted is false for non-deleted errors', () => {
@@ -142,14 +144,16 @@ describe('snapshotDataLogic', () => {
 
             expect(logic.values.isRecordingDeleted).toBe(false)
             expect(logic.values.recordingDeletedAt).toBe(null)
+            expect(logic.values.recordingDeletedBy).toBe(null)
         })
 
         it('recordingDeletedAt is null when deleted_at is not provided', () => {
-            const error = new RecordingDeletedError(null)
+            const error = new RecordingDeletedError(null, null)
             logic.actions.loadSnapshotsForSourceFailure('Recording deleted', error)
 
             expect(logic.values.isRecordingDeleted).toBe(true)
             expect(logic.values.recordingDeletedAt).toBe(null)
+            expect(logic.values.recordingDeletedBy).toBe(null)
         })
     })
 

--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
@@ -637,6 +637,16 @@ export const snapshotDataLogic = kea<snapshotDataLogicType>([
                 return null
             },
         ],
+
+        recordingDeletedBy: [
+            (s) => [s.snapshotLoadError],
+            (snapshotLoadError): string | null => {
+                if (snapshotLoadError instanceof RecordingDeletedError) {
+                    return snapshotLoadError.deletedBy
+                }
+                return null
+            },
+        ],
     })),
     afterMount(({ actions, cache, values }) => {
         cache.playerActive = true


### PR DESCRIPTION
## Summary

Split from #48420 (branch 5c). Independent — can merge any time.

- Add `deletedBy` field to `RecordingDeletedError` in the frontend API client
- Propagate `recordingDeletedBy` through `snapshotDataLogic` → `sessionRecordingDataCoordinatorLogic` → `sessionRecordingMetaLogic`
- Display "Deleted by {email}" in the `RecordingDeleted` component when available
- Degrades gracefully to `null` when the backend doesn't include `deleted_by` in the 410 response (until the infra PR lands)

## Test plan

- [ ] `pnpm --filter=@posthog/frontend jest snapshotDataLogic` — 43 tests pass
- [ ] Verify `RecordingDeleted` renders correctly with and without `deletedBy`