### PR TITLE
feat(signals): Add signal input schema validation

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16890,6 +16890,64 @@
             "required": ["cache_key", "is_cached", "last_refresh", "next_allowed_client_refresh", "timezone"],
             "type": "object"
         },
+        "GithubIssueSignalExtra": {
+            "additionalProperties": false,
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "html_url": {
+                    "type": "string"
+                },
+                "labels": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "locked": {
+                    "type": "boolean"
+                },
+                "number": {
+                    "type": "number"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            },
+            "required": ["html_url", "number", "labels", "created_at", "updated_at", "locked", "state"],
+            "type": "object"
+        },
+        "GithubIssueSignalInput": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/GithubIssueSignalExtra"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "const": "github",
+                    "type": "string"
+                },
+                "source_type": {
+                    "const": "issue",
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "type": "object"
+        },
         "GoalLine": {
             "additionalProperties": false,
             "properties": {
@@ -19116,6 +19174,58 @@
         "LinkedinAdsTableKeywords": {
             "enum": ["campaigns"],
             "type": "string"
+        },
+        "LlmEvalSignalExtra": {
+            "additionalProperties": false,
+            "properties": {
+                "evaluation_id": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "target_event_id": {
+                    "type": "string"
+                },
+                "target_event_type": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            },
+            "required": ["evaluation_id", "trace_id"],
+            "type": "object"
+        },
+        "LlmEvaluationSignalInput": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/LlmEvalSignalExtra"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "const": "llm_analytics",
+                    "type": "string"
+                },
+                "source_type": {
+                    "const": "evaluation",
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "type": "object"
         },
         "LoadingBlock": {
             "additionalProperties": false,
@@ -30612,6 +30722,93 @@
             "required": ["type", "session_id", "timestamp_ms"],
             "type": "object"
         },
+        "SessionReplaySegment": {
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "distinct_id": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                }
+            },
+            "required": ["session_id", "start_time", "end_time", "distinct_id", "content"],
+            "type": "object"
+        },
+        "SessionSegmentClusterMetrics": {
+            "additionalProperties": false,
+            "properties": {
+                "active_users_in_period": {
+                    "type": "number"
+                },
+                "occurrence_count": {
+                    "type": "number"
+                },
+                "relevant_user_count": {
+                    "type": "number"
+                }
+            },
+            "required": ["relevant_user_count", "active_users_in_period", "occurrence_count"],
+            "type": "object"
+        },
+        "SessionSegmentClusterSignalExtra": {
+            "additionalProperties": false,
+            "properties": {
+                "actionable": {
+                    "type": "boolean"
+                },
+                "label_title": {
+                    "type": "string"
+                },
+                "metrics": {
+                    "$ref": "#/definitions/SessionSegmentClusterMetrics"
+                },
+                "segments": {
+                    "items": {
+                        "$ref": "#/definitions/SessionReplaySegment"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["label_title", "actionable", "segments", "metrics"],
+            "type": "object"
+        },
+        "SessionSegmentClusterSignalInput": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/SessionSegmentClusterSignalExtra"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "const": "session_replay",
+                    "type": "string"
+                },
+                "source_type": {
+                    "const": "session_segment_cluster",
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "type": "object"
+        },
         "SessionsQuery": {
             "additionalProperties": false,
             "properties": {
@@ -30873,6 +31070,27 @@
                     "type": "boolean"
                 }
             },
+            "type": "object"
+        },
+        "SignalInput": {
+            "discriminator": {
+                "propertyName": "source_type"
+            },
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/SessionSegmentClusterSignalInput"
+                },
+                {
+                    "$ref": "#/definitions/LlmEvaluationSignalInput"
+                },
+                {
+                    "$ref": "#/definitions/ZendeskTicketSignalInput"
+                },
+                {
+                    "$ref": "#/definitions/GithubIssueSignalInput"
+                }
+            ],
+            "required": ["source_type"],
             "type": "object"
         },
         "SimilarIssue": {
@@ -35219,6 +35437,61 @@
                     "type": "boolean"
                 }
             },
+            "type": "object"
+        },
+        "ZendeskTicketSignalExtra": {
+            "additionalProperties": false,
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "tags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": ["url", "type", "tags", "created_at", "priority", "status"],
+            "type": "object"
+        },
+        "ZendeskTicketSignalInput": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/ZendeskTicketSignalExtra"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "const": "zendesk",
+                    "type": "string"
+                },
+                "source_type": {
+                    "const": "ticket",
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
             "type": "object"
         },
         "integer": {

--- a/frontend/src/queries/schema/index.ts
+++ b/frontend/src/queries/schema/index.ts
@@ -12,6 +12,7 @@ export * from './schema-assistant-replay'
 export * from './schema-assistant-revenue-analytics'
 export * from './schema-assistant-web-analytics'
 export * from './schema-general'
+export * from './schema-signals'
 export * from './schema-surveys'
 // Must be kept after schema-general.
 export * from './schema-assistant-messages'

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -1,0 +1,103 @@
+// Signal taxonomy types - shared contract between emitters and consumers
+
+// Session replay segment cluster
+
+export interface SessionReplaySegment {
+    session_id: string
+    start_time: string
+    end_time: string
+    distinct_id: string
+    content: string
+}
+
+export interface SessionSegmentClusterMetrics {
+    relevant_user_count: number
+    active_users_in_period: number
+    occurrence_count: number
+}
+
+export interface SessionSegmentClusterSignalExtra {
+    label_title: string
+    actionable: boolean
+    segments: SessionReplaySegment[]
+    metrics: SessionSegmentClusterMetrics
+}
+
+export interface SessionSegmentClusterSignalInput {
+    source_type: 'session_segment_cluster'
+    source_product: 'session_replay'
+    source_id: string
+    description: string
+    weight: number
+    extra: SessionSegmentClusterSignalExtra
+}
+
+// LLM evaluation
+
+export interface LlmEvalSignalExtra {
+    evaluation_id: string
+    target_event_id?: string
+    target_event_type?: string
+    trace_id: string
+    model?: string
+    provider?: string
+}
+
+export interface LlmEvaluationSignalInput {
+    source_type: 'evaluation'
+    source_product: 'llm_analytics'
+    source_id: string
+    description: string
+    weight: number
+    extra: LlmEvalSignalExtra
+}
+
+// Zendesk ticket
+
+export interface ZendeskTicketSignalExtra {
+    url: string
+    type: string
+    tags: string[]
+    created_at: string
+    priority: string
+    status: string
+}
+
+export interface ZendeskTicketSignalInput {
+    source_type: 'ticket'
+    source_product: 'zendesk'
+    source_id: string
+    description: string
+    weight: number
+    extra: ZendeskTicketSignalExtra
+}
+
+// GitHub issue
+
+export interface GithubIssueSignalExtra {
+    html_url: string
+    number: number
+    labels: string[]
+    created_at: string
+    updated_at: string
+    locked: boolean
+    state: string
+}
+
+export interface GithubIssueSignalInput {
+    source_type: 'issue'
+    source_product: 'github'
+    source_id: string
+    description: string
+    weight: number
+    extra: GithubIssueSignalExtra
+}
+
+// Discriminated union over all signal variants
+
+/** @discriminator source_type */
+export type SignalInput =
+    | SessionSegmentClusterSignalInput
+    | LlmEvaluationSignalInput
+    | ZendeskTicketSignalInput
+    | GithubIssueSignalInput

--- a/frontend/src/scenes/inbox/SignalCard.tsx
+++ b/frontend/src/scenes/inbox/SignalCard.tsx
@@ -11,47 +11,12 @@ import { humanFriendlyDetailedTime } from 'lib/utils'
 import { sourceProductColor } from 'scenes/debug/signals/helpers'
 import type { SignalNode } from 'scenes/debug/signals/types'
 
-interface SessionReplaySegment {
-    session_id: string
-    start_time: string
-    end_time: string
-    distinct_id: string
-    content: string
-}
-
-interface SessionReplaySignalExtra {
-    label_title: string
-    actionable: boolean
-    segments: SessionReplaySegment[]
-    metrics: { relevant_user_count: number; active_users_in_period: number; occurrence_count: number }
-}
-
-interface GithubIssueSignalExtra {
-    html_url: string
-    number: number
-    labels: string[]
-    created_at: string
-    updated_at: string
-    state: string
-}
-
-interface ZendeskTicketSignalExtra {
-    url: string
-    type: string
-    tags: string[]
-    created_at: string
-    priority: string
-    status: string
-}
-
-interface LlmEvalSignalExtra {
-    evaluation_id: string
-    target_event_id: string
-    target_event_type: string
-    trace_id: string
-    model: string
-    provider: string
-}
+import type {
+    GithubIssueSignalExtra,
+    LlmEvalSignalExtra,
+    SessionSegmentClusterSignalExtra,
+    ZendeskTicketSignalExtra,
+} from '~/queries/schema/schema-signals'
 
 export function SignalCard({ signal }: { signal: SignalNode }): JSX.Element {
     if (isSessionReplayExtra(signal.extra)) {
@@ -74,7 +39,7 @@ function SessionReplaySignalCard({
     extra,
 }: {
     signal: SignalNode
-    extra: SessionReplaySignalExtra
+    extra: SessionSegmentClusterSignalExtra
 }): JSX.Element {
     const [showAllSegments, setShowAllSegments] = useState(false)
     const maxVisible = 3
@@ -283,7 +248,7 @@ function SignalCardHeader({ signal, label }: { signal: SignalNode; label?: strin
 
 function isSessionReplayExtra(
     extra: Record<string, unknown>
-): extra is Record<string, unknown> & SessionReplaySignalExtra {
+): extra is Record<string, unknown> & SessionSegmentClusterSignalExtra {
     return 'segments' in extra && Array.isArray(extra.segments)
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1982,6 +1982,31 @@ class FunnelVizType(StrEnum):
     FLOW = "flow"
 
 
+class GithubIssueSignalExtra(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    created_at: str
+    html_url: str
+    labels: list[str]
+    locked: bool
+    number: float
+    state: str
+    updated_at: str
+
+
+class GithubIssueSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: GithubIssueSignalExtra
+    source_id: str
+    source_product: Literal["github"] = "github"
+    source_type: Literal["issue"] = "issue"
+    weight: float
+
+
 class Position(StrEnum):
     START = "start"
     END = "end"
@@ -2322,6 +2347,30 @@ class LinkedinAdsTableExclusions(StrEnum):
 
 class LinkedinAdsTableKeywords(StrEnum):
     CAMPAIGNS = "campaigns"
+
+
+class LlmEvalSignalExtra(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    evaluation_id: str
+    model: str | None = None
+    provider: str | None = None
+    target_event_id: str | None = None
+    target_event_type: str | None = None
+    trace_id: str
+
+
+class LlmEvaluationSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: LlmEvalSignalExtra
+    source_id: str
+    source_product: Literal["llm_analytics"] = "llm_analytics"
+    source_type: Literal["evaluation"] = "evaluation"
+    weight: float
 
 
 class LoadingBlock(BaseModel):
@@ -3661,6 +3710,48 @@ class SessionReplayBlock(BaseModel):
     type: Literal["session_replay"] = "session_replay"
 
 
+class SessionReplaySegment(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    content: str
+    distinct_id: str
+    end_time: str
+    session_id: str
+    start_time: str
+
+
+class SessionSegmentClusterMetrics(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    active_users_in_period: float
+    occurrence_count: float
+    relevant_user_count: float
+
+
+class SessionSegmentClusterSignalExtra(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actionable: bool
+    label_title: str
+    metrics: SessionSegmentClusterMetrics
+    segments: list[SessionReplaySegment]
+
+
+class SessionSegmentClusterSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: SessionSegmentClusterSignalExtra
+    source_id: str
+    source_product: Literal["session_replay"] = "session_replay"
+    source_type: Literal["session_segment_cluster"] = "session_segment_cluster"
+    weight: float
+
+
 class SharingConfigurationSettings(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4322,6 +4413,30 @@ class YAxisSettings(BaseModel):
     showGridLines: bool | None = None
     showTicks: bool | None = None
     startAtZero: bool | None = Field(default=None, description="Whether the Y axis should start at zero")
+
+
+class ZendeskTicketSignalExtra(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    created_at: str
+    priority: str
+    status: str
+    tags: list[str]
+    type: str
+    url: str
+
+
+class ZendeskTicketSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: ZendeskTicketSignalExtra
+    source_id: str
+    source_product: Literal["zendesk"] = "zendesk"
+    source_type: Literal["ticket"] = "ticket"
+    weight: float
 
 
 class Integer(RootModel[int]):
@@ -6539,6 +6654,16 @@ class SessionsTimelineQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
+
+
+class SignalInput(
+    RootModel[
+        SessionSegmentClusterSignalInput | LlmEvaluationSignalInput | ZendeskTicketSignalInput | GithubIssueSignalInput
+    ]
+):
+    root: (
+        SessionSegmentClusterSignalInput | LlmEvaluationSignalInput | ZendeskTicketSignalInput | GithubIssueSignalInput
+    ) = Field(..., discriminator="source_type")
 
 
 class SourceFieldFileUploadConfig(BaseModel):

--- a/products/signals/backend/api.py
+++ b/products/signals/backend/api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 
-from posthog.schema import EmbeddingModelName
+from posthog.schema import EmbeddingModelName, SignalInput
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
@@ -106,14 +106,26 @@ async def emit_signal(
     Example:
         await emit_signal(
             team=team,
-            source_product="experiments",
-            source_type="significance_reached",
-            source_id=str(experiment.id),
-            description="Experiment 'Homepage CTA' reached statistical significance...",
+            source_product="github",
+            source_type="issue",
+            source_id="posthog/posthog#12345",
+            description="GitHub Issue #12345: Button doesn't work on Safari\nLabels: bug\n...",
             weight=0.8,
-            extra={"variant": "B", "p_value": 0.003},
+            extra={"html_url": "https://github.com/posthog/posthog/issues/12345", "number": 12345, ...},
         )
     """
+    # Raise if signal doesn't match any known schema
+    SignalInput.model_validate(
+        {
+            "source_product": source_product,
+            "source_type": source_type,
+            "source_id": source_id,
+            "description": description,
+            "weight": weight,
+            "extra": extra or {},
+        }
+    )
+
     organization = await database_sync_to_async(lambda: team.organization)()
     if not organization.is_ai_data_processing_approved:
         return

--- a/products/signals/backend/management/commands/ingest_github_issues.py
+++ b/products/signals/backend/management/commands/ingest_github_issues.py
@@ -43,12 +43,13 @@ def _build_description(issue: dict) -> str:
 def _build_extra(issue: dict) -> dict:
     """Extract useful metadata into the extra dict."""
     return {
-        "url": issue.get("html_url", ""),
-        "author": issue.get("user", {}).get("login", ""),
+        "html_url": issue.get("html_url", ""),
+        "number": issue.get("number", 0),
         "labels": [lbl["name"] for lbl in issue.get("labels", []) if isinstance(lbl, dict)],
-        "comments": issue.get("comments", 0),
         "created_at": issue.get("created_at", ""),
         "updated_at": issue.get("updated_at", ""),
+        "locked": issue.get("locked", False),
+        "state": issue.get("state", ""),
     }
 
 
@@ -110,7 +111,7 @@ class Command(BaseCommand):
                 await emit_signal(
                     team=team,
                     source_product="github",
-                    source_type="open_issue",
+                    source_type="issue",
                     source_id=source_id,
                     description=_build_description(issue),
                     weight=weight,

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pydantic
+
+from products.signals.backend.api import emit_signal
+
+
+@pytest.fixture
+def team_stub() -> MagicMock:
+    org = MagicMock()
+    org.is_ai_data_processing_approved = True
+    team = MagicMock()
+    team.id = 1
+    team.organization = org
+    return team
+
+
+SESSION_SEGMENT_CLUSTER_EXTRA = {
+    "label_title": "Frustrated users on checkout",
+    "actionable": True,
+    "segments": [
+        {
+            "session_id": "abc-123",
+            "start_time": "2025-01-01T00:00:00Z",
+            "end_time": "2025-01-01T00:05:00Z",
+            "distinct_id": "user-1",
+            "content": "User clicked around and rage-clicked the submit button",
+        }
+    ],
+    "metrics": {
+        "relevant_user_count": 42,
+        "active_users_in_period": 1000,
+        "occurrence_count": 7,
+    },
+}
+
+EVALUATION_EXTRA = {
+    "evaluation_id": "eval-001",
+    "trace_id": "trace-abc",
+}
+
+ZENDESK_TICKET_EXTRA = {
+    "url": "https://example.zendesk.com/tickets/1",
+    "type": "problem",
+    "tags": ["billing", "urgent"],
+    "created_at": "2025-06-01T12:00:00Z",
+    "priority": "high",
+    "status": "open",
+}
+
+GITHUB_ISSUE_EXTRA = {
+    "html_url": "https://github.com/org/repo/issues/42",
+    "number": 42,
+    "labels": ["bug", "critical"],
+    "created_at": "2025-06-01T12:00:00Z",
+    "updated_at": "2025-06-02T08:00:00Z",
+    "locked": False,
+    "state": "open",
+}
+
+
+@pytest.mark.asyncio
+class TestEmitSignalValidation:
+    @pytest.mark.parametrize(
+        "source_product, source_type, extra",
+        [
+            ("session_replay", "session_segment_cluster", SESSION_SEGMENT_CLUSTER_EXTRA),
+            ("llm_analytics", "evaluation", EVALUATION_EXTRA),
+            ("zendesk", "ticket", ZENDESK_TICKET_EXTRA),
+            ("github", "issue", GITHUB_ISSUE_EXTRA),
+        ],
+        ids=["session_segment_cluster", "evaluation", "ticket", "issue"],
+    )
+    async def test_emit_signal_accepts_valid_input(self, source_product, source_type, extra, team_stub):
+        client = AsyncMock()
+
+        with patch("products.signals.backend.api.async_connect", return_value=client):
+            await emit_signal(
+                team=team_stub,
+                source_product=source_product,
+                source_type=source_type,
+                source_id="test-id-1",
+                description="A valid signal",
+                extra=extra,
+            )
+
+        client.start_workflow.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "source_product, source_type, extra",
+        [
+            ("session_replay", "nonexistent", {}),
+            ("github", "issue", {}),
+            ("zendesk", "ticket", {**ZENDESK_TICKET_EXTRA, "tags": "not-a-list"}),
+            ("llm_analytics", "evaluation", {**EVALUATION_EXTRA, "bogus": 1}),
+        ],
+        ids=["unknown_source_type", "missing_extra_fields", "wrong_extra_field_type", "unexpected_extra_field"],
+    )
+    async def test_emit_signal_rejects_invalid_input(self, source_product, source_type, extra, team_stub):
+        client = AsyncMock()
+
+        with patch("products.signals.backend.api.async_connect", return_value=client):
+            with pytest.raises(pydantic.ValidationError):
+                await emit_signal(
+                    team=team_stub,
+                    source_product=source_product,
+                    source_type=source_type,
+                    source_id="test-id-1",
+                    description="An invalid signal",
+                    extra=extra,
+                )
+
+        client.start_workflow.assert_not_awaited()


### PR DESCRIPTION
## Problem

We talked with @oliverb123 about making the signal source config stricter schema-wise, as loose JSON is hard to reason about.

But the same goes for signals themselves. E.g. currently developing rich display of signal types, there are no shared definitions ensuring that both the emitters and consumers are in sync (Replay, GitHub, Zendesk, LLM Analytics, and more to come).

## Changes

Adding a discriminated union type `SignalInput` in TypeScript, which is emitted to Pydantic via our existing type sharing infra. That allows us validate signal inputs of all types, right now:

  - `SessionSegmentClusterSignalInput`
  - `LlmEvalSignalInput`
  - `ZendeskTicketSignalInput`
  - `GithubIssueSignalInput`

Updated the `SignalCard` component to use the new interfaces too.

## How did you test this code?

Added a couple unit tests to verify non-matching signals are rejected.

## Publish to changelog?

No, internal.