### PR TITLE
fix: show only lost features on downgrade

### DIFF
--- a/frontend/src/scenes/billing/AddonFeatureLossNotice.tsx
+++ b/frontend/src/scenes/billing/AddonFeatureLossNotice.tsx
@@ -29,8 +29,8 @@ export const AddonFeatureLossNotice = ({ product, targetProduct }: AddonFeatureL
     const currentPlatformPlan = platformAndSupportProduct?.plans?.find((plan) => plan.current_plan)
     const basePlatformFeatures = currentPlatformPlan?.features?.filter((f) => !f.entitlement_only) || []
 
-    const featuresToGet = targetProduct ? targetFeatures : basePlatformFeatures
-    const featuresToLose = currentFeatures.filter((feature) => !featuresToGet.some((f) => f.key === feature.key))
+    const featuresToKeep = targetProduct ? [...targetFeatures, ...basePlatformFeatures] : basePlatformFeatures
+    const featuresToLose = currentFeatures.filter((feature) => !featuresToKeep.some((f) => f.key === feature.key))
 
     if (!featuresToLose?.length) {
         return null

--- a/frontend/src/scenes/billing/AddonFeatureLossNotice.tsx
+++ b/frontend/src/scenes/billing/AddonFeatureLossNotice.tsx
@@ -11,34 +11,26 @@ import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
 
 import { BillingAddonFeaturesList } from './BillingAddonFeaturesList'
 import { billingLogic } from './billingLogic'
-import { billingProductLogic } from './billingProductLogic'
 
 interface AddonFeatureLossNoticeProps {
     product: BillingProductV2Type | BillingProductV2AddonType
+    targetProduct?: BillingProductV2Type | BillingProductV2AddonType
 }
 
-export const AddonFeatureLossNotice = ({ product }: AddonFeatureLossNoticeProps): JSX.Element | null => {
+export const AddonFeatureLossNotice = ({ product, targetProduct }: AddonFeatureLossNoticeProps): JSX.Element | null => {
     const [isExpanded, setIsExpanded] = useState(false)
     const { billing } = useValues(billingLogic)
 
-    const { currentAndUpgradePlans } = useValues(billingProductLogic({ product }))
-    const addonFeatures = (
-        currentAndUpgradePlans?.upgradePlan?.features ||
-        currentAndUpgradePlans?.currentPlan?.features ||
-        product.features ||
-        []
-    ).filter((f) => !f.entitlement_only)
+    const currentFeatures = product.features.filter((f) => !f.entitlement_only)
+    const targetFeatures = (targetProduct?.features || []).filter((f) => !f.entitlement_only)
 
-    // Current base platform and support plan and features
+    // Fall back to base platform plan features if no target product
     const platformAndSupportProduct = billing?.products?.find((p) => p.type === ProductKey.PLATFORM_AND_SUPPORT)
     const currentPlatformPlan = platformAndSupportProduct?.plans?.find((plan) => plan.current_plan)
-    // TODO: instead of assuming they are moving to paid, support the move from one addon to another (e.g. from scale to boost)
-    const currentPlanFeatures = currentPlatformPlan?.features?.filter((feature) => !feature.entitlement_only) || []
+    const basePlatformFeatures = currentPlatformPlan?.features?.filter((f) => !f.entitlement_only) || []
 
-    // Difference between addon plan and the plan they are moving to
-    const featuresToLose = addonFeatures.filter(
-        (addonFeature) => !currentPlanFeatures.some((planFeature) => planFeature.key === addonFeature.key)
-    )
+    const featuresToGet = targetProduct ? targetFeatures : basePlatformFeatures
+    const featuresToLose = currentFeatures.filter((feature) => !featuresToGet.some((f) => f.key === feature.key))
 
     if (!featuresToLose?.length) {
         return null

--- a/frontend/src/scenes/billing/ConfirmDowngradeModal.tsx
+++ b/frontend/src/scenes/billing/ConfirmDowngradeModal.tsx
@@ -104,7 +104,7 @@ export function ConfirmDowngradeModal({ product }: { product: BillingProductV2Ad
                     unused time to your next invoice(s).
                 </p>
 
-                <AddonFeatureLossNotice product={currentPlatformAddon} />
+                <AddonFeatureLossNotice product={currentPlatformAddon} targetProduct={product} />
 
                 <LemonTable dataSource={rows} columns={columns} className="mt-4" uppercaseHeader={false} />
 


### PR DESCRIPTION
## Problem

When a customer clicks downgrade (e.g., from Teams to Boost), we show all features from their current plan as "features to lose" instead of only the features that exist in Teams but not in Boost.

![Screenshot 2026-02-23 at 11.53.20 (1).png](https://app.graphite.com/user-attachments/assets/2566ec12-623d-45d5-8f4c-111bf2417c11.png)

## Changes
Added optional `targetProduct` prop to `<AddonFeatureLossNotice>`. When provided, compares current product features against target product features. 

## How did you test this code?

Downgraded from Scale to Boost, checked the feature list. 

![2026-02-25 23 21 43](https://github.com/user-attachments/assets/9cc1a80d-4421-43cf-bbe3-bd02514e1895)


## Publish to changelog?

No