### PR TITLE
feat(limiters): extend capture bucket_interval default to 20 seconds

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -83,7 +83,7 @@ pub struct Config {
     pub global_rate_limit_window_interval_secs: u64,
 
     /// Time bucket granularity in seconds for the sliding window counters
-    #[envconfig(default = "10")]
+    #[envconfig(default = "20")]
     pub global_rate_limit_bucket_interval_secs: u64,
 
     /// CSV list of key=value pairs assigning custom global rate limit thresholds

--- a/rust/common/limiters/src/global_rate_limiter.rs
+++ b/rust/common/limiters/src/global_rate_limiter.rs
@@ -1032,7 +1032,7 @@ mod tests {
         let config = GlobalRateLimiterConfig::default();
         assert_eq!(config.global_threshold, 1_000_000);
         assert_eq!(config.window_interval, Duration::from_secs(60));
-        assert_eq!(config.bucket_interval, Duration::from_secs(10));
+        assert_eq!(config.bucket_interval, Duration::from_secs(20));
         assert_eq!(config.redis_key_prefix, "@posthog/global_rate_limiter");
         assert_eq!(config.global_cache_ttl, Duration::from_secs(300));
         assert_eq!(config.local_cache_ttl, Duration::from_secs(600));

--- a/rust/common/limiters/src/global_rate_limiter.rs
+++ b/rust/common/limiters/src/global_rate_limiter.rs
@@ -101,7 +101,7 @@ impl Default for GlobalRateLimiterConfig {
         Self {
             global_threshold: 1_000_000,
             window_interval: Duration::from_secs(60),
-            bucket_interval: Duration::from_secs(10),
+            bucket_interval: Duration::from_secs(20),
             redis_key_prefix: "@posthog/global_rate_limiter".to_string(),
             // 10 minutes - long enough to benefit from hot cache under high cardinality
             local_cache_ttl: Duration::from_secs(600),


### PR DESCRIPTION
## Problem
We want to balance limiter sensitivity to traffic changes with Redis load
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Extend `bucket_interval` (window we accumulate team event counts for in global cache) to 20 seconds from 10

In smoke testing on full prod US traffic this bought more headroom wrt primary Redis pressures we saw (engine CPU utilization & read traffic volume)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, smoke test in prod US
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
