### PR TITLE
revert(): fix(ci): ensure event definitions exist for MCP integration tests

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -300,7 +300,6 @@ jobs:
                   django.setup()
                   from posthog.models import Organization, Team, User
                   from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
-                  from posthog.models.event_definition import EventDefinition
                   org = Organization.objects.first()
                   team = Team.objects.first()
                   user = User.objects.first()
@@ -309,9 +308,6 @@ jobs:
                       label='mcp_ci_api_key',
                       secure_value=hash_key_value('e2e_demo_api_key'),
                   )
-                  # Ensure common event definitions exist for MCP integration tests
-                  for event_name in ['\$pageview', '\$pageleave', '\$autocapture', '\$screen']:
-                      EventDefinition.objects.get_or_create(name=event_name, team=team)
                   print(f'TEST_ORG_ID={org.id}')
                   print(f'TEST_PROJECT_ID={team.id}')
                   " >> $GITHUB_ENV


### PR DESCRIPTION
Reverts PostHog/posthog#48834

This breaks MCP CI (a required action) due to a bad import `ModuleNotFoundError: No module named 'posthog.models.event_definition'`

I need this fixed in order to get a different revert in 😓 