### PR TITLE
fix(ci): ensure event definitions exist for MCP integration tests

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches: [master]
     pull_request:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -27,7 +27,7 @@ jobs:
             # Not only the MCP folder but any file that generates schema for the mcp folder
             - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              if: github.event_name == 'pull_request' # Run all tests on master push and workflow_dispatch
               with:
                   filters: |
                       mcp:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -298,7 +298,7 @@ jobs:
                   import django, os
                   os.environ['DJANGO_SETTINGS_MODULE'] = 'posthog.settings'
                   django.setup()
-                  from posthog.models import Organization, Team, User
+                  from posthog.models import Organization, Team, User, EventDefinition
                   from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
                   org = Organization.objects.first()
                   team = Team.objects.first()
@@ -308,6 +308,8 @@ jobs:
                       label='mcp_ci_api_key',
                       secure_value=hash_key_value('e2e_demo_api_key'),
                   )
+                  for event_name in ['\$pageview', '\$pageleave', '\$autocapture', '\$screen']:
+                      EventDefinition.objects.get_or_create(name=event_name, team=team)
                   print(f'TEST_ORG_ID={org.id}')
                   print(f'TEST_PROJECT_ID={team.id}')
                   " >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

The MCP integration tests in `projects.integration.test.ts` fail nondeterministically because `generate_demo_data` doesn't reliably create event definitions like `$pageview`. This causes 5 tests to fail when event definitions are missing.

Re-lands #48834 with the correct import path — `from posthog.models import EventDefinition` instead of `from posthog.models.event_definition import EventDefinition` (which doesn't exist and caused `ModuleNotFoundError` in CI, see #49002).

Also adds `workflow_dispatch` trigger to the MCP CI workflow so it can be manually triggered for testing, and fixes the paths filter to only apply on `pull_request` events (so `workflow_dispatch` and `push` always run the full suite).

## Changes

- Import `EventDefinition` from `posthog.models` (the re-export) rather than a non-existent submodule
- Seed common event definitions (`$pageview`, `$pageleave`, `$autocapture`, `$screen`) during MCP CI setup
- Add `workflow_dispatch` trigger to `ci-mcp.yml`
- Only run paths filter on `pull_request` events

## How did you test this code?

- Verified imports work locally in Django shell:
  ```
  from posthog.models import Organization, Team, User, EventDefinition
  # All imports successful
  # EventDefinition module: products.event_definitions.backend.models.event_definition
  # EventDefinition table: posthog_eventdefinition
  ```
- Manually triggered full MCP CI workflow via `workflow_dispatch` — all jobs passed: https://github.com/PostHog/posthog/actions/runs/22376480100