### PR TITLE
feat(surveys): survey query optimizations

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -751,6 +751,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportSurveyArchived: (survey: Survey) => ({ survey }),
         reportSurveyTemplateClicked: (template: SurveyTemplateType) => ({ template }),
         reportSurveyCycleDetected: (survey: Survey | NewSurvey) => ({ survey }),
+        reportSurveyConsolidatedResultsQuery: (
+            survey: Survey,
+            totalDurationMs: number,
+            queryDurations: { aggregate: number; openEnded: number }
+        ) => ({ survey, totalDurationMs, queryDurations }),
         reportProductTourViewed: (tour: ProductTour) => ({ tour }),
         reportProductTourCreated: (tour: ProductTour, creationSource?: 'app' | 'toolbar') => ({
             tour,
@@ -1832,6 +1837,15 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 id: survey.id,
                 start_date: survey.start_date,
                 end_date: survey.end_date,
+            })
+        },
+        reportSurveyConsolidatedResultsQuery: ({ survey, totalDurationMs, queryDurations }) => {
+            posthog.capture('survey consolidated results query completed', {
+                name: survey.name,
+                id: survey.id,
+                duration: totalDurationMs,
+                aggregate_duration: queryDurations.aggregate,
+                open_ended_duration: queryDurations.openEnded,
             })
         },
         reportProductTourViewed: ({ tour }) => {

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -168,7 +168,7 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
 }
 
 export function SurveyQuestionVisualization({ question, questionIndex, demoData }: Props): JSX.Element | null {
-    const { consolidatedSurveyResults, consolidatedSurveyResultsLoading, surveyBaseStatsLoading } =
+    const { enrichedConsolidatedSurveyResults, consolidatedSurveyResultsLoading, surveyBaseStatsLoading } =
         useValues(surveyLogic)
 
     if (demoData) {
@@ -216,7 +216,7 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
     }
 
     const processedData: QuestionProcessedResponses | undefined =
-        consolidatedSurveyResults?.responsesByQuestion[question.id]
+        enrichedConsolidatedSurveyResults?.responsesByQuestion[question.id]
 
     if (consolidatedSurveyResultsLoading || surveyBaseStatsLoading || !processedData) {
         return (

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1,7 +1,13 @@
 import { expectLogic, partial } from 'kea-test-utils'
 
 import { dayjs } from 'lib/dayjs'
-import { processResultsForSurveyQuestions, surveyLogic } from 'scenes/surveys/surveyLogic'
+import {
+    mergeResponsesByQuestion,
+    processOpenEndedResults,
+    processResultsForSurveyQuestions,
+    surveyLogic,
+} from 'scenes/surveys/surveyLogic'
+import { OpenEndedColumnMap } from 'scenes/surveys/utils'
 
 import { initKeaTests } from '~/test/init'
 import {
@@ -12,6 +18,7 @@ import {
     OpenQuestionProcessedResponses,
     PropertyFilterType,
     PropertyOperator,
+    ResponsesByQuestion,
     Survey,
     SurveyEventName,
     SurveyEventProperties,
@@ -20,7 +27,6 @@ import {
     SurveyQuestionBranchingType,
     SurveyQuestionType,
     SurveyRates,
-    SurveyRawResults,
     SurveySchedule,
     SurveyStats,
     SurveyType,
@@ -1729,46 +1735,90 @@ describe('survey stats calculation', () => {
 })
 
 describe('processResultsForSurveyQuestions', () => {
+    // Input format: AggregateRow[] = [question_id, label, count][]
     describe('Rating Questions', () => {
-        it('processes 10-point scale correctly (0-10)', () => {
+        it.each([
+            {
+                name: '10-point NPS scale (0-10)',
+                scale: 10 as const,
+                rows: [
+                    ['rating-q', '0', 1],
+                    ['rating-q', '5', 2],
+                    ['rating-q', '10', 1],
+                ] as [string, string, number][],
+                expectedTotal: 4,
+                expectedLength: 11,
+                expectedSlots: [
+                    { index: 0, label: '0', value: 1 },
+                    { index: 5, label: '5', value: 2 },
+                    { index: 10, label: '10', value: 1 },
+                    { index: 1, label: '1', value: 0 },
+                ],
+            },
+            {
+                name: '5-point scale (1-5)',
+                scale: 5 as const,
+                rows: [
+                    ['rating-q', '1', 1],
+                    ['rating-q', '3', 2],
+                    ['rating-q', '5', 1],
+                ] as [string, string, number][],
+                expectedTotal: 4,
+                expectedLength: 5,
+                expectedSlots: [
+                    { index: 0, label: '1', value: 1 },
+                    { index: 1, label: '2', value: 0 },
+                    { index: 2, label: '3', value: 2 },
+                    { index: 3, label: '4', value: 0 },
+                    { index: 4, label: '5', value: 1 },
+                ],
+            },
+            {
+                name: '3-point scale rejects out-of-range values',
+                scale: 3 as const,
+                rows: [
+                    ['rating-q', '1', 1],
+                    ['rating-q', '2', 1],
+                    ['rating-q', '3', 1],
+                    ['rating-q', '0', 1],
+                ] as [string, string, number][],
+                expectedTotal: 3,
+                expectedLength: 3,
+                expectedSlots: [
+                    { index: 0, label: '1', value: 1 },
+                    { index: 1, label: '2', value: 1 },
+                    { index: 2, label: '3', value: 1 },
+                ],
+            },
+        ])('processes $name', ({ scale, rows, expectedTotal, expectedLength, expectedSlots }) => {
             const questions = [
                 {
-                    id: 'rating-q1',
+                    id: 'rating-q',
                     type: SurveyQuestionType.Rating as const,
                     question: 'Rate us',
-                    scale: 10 as const,
+                    scale,
                     display: 'number' as const,
                     lowerBoundLabel: 'Poor',
                     upperBoundLabel: 'Excellent',
                 },
             ]
-            const results = [
-                ['0'], // User 1: rated 0 for question 0
-                ['5'], // User 2: rated 5 for question 0
-                ['10'], // User 3: rated 10 for question 0
-                ['5'], // User 4: rated 5 for question 0
-                ['invalid'], // User 5: invalid response (should be ignored)
-                [''], // User 6: empty response (should be ignored)
-            ]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const ratingData = processed['rating-q1'] as ChoiceQuestionProcessedResponses
+            const processed = processResultsForSurveyQuestions(questions, rows)
+            const ratingData = processed['rating-q'] as ChoiceQuestionProcessedResponses
 
             expect(ratingData.type).toBe(SurveyQuestionType.Rating)
-            expect(ratingData.totalResponses).toBe(4) // 4 valid responses
-            expect(ratingData.data).toHaveLength(11) // 0-10 = 11 values
+            expect(ratingData.totalResponses).toBe(expectedTotal)
+            expect(ratingData.data).toHaveLength(expectedLength)
 
-            // Check specific ratings for NPS (0-10 scale)
-            expect(ratingData.data[0]).toEqual({ label: '0', value: 1, isPredefined: true })
-            expect(ratingData.data[5]).toEqual({ label: '5', value: 2, isPredefined: true })
-            expect(ratingData.data[10]).toEqual({ label: '10', value: 1, isPredefined: true })
-            expect(ratingData.data[1]).toEqual({ label: '1', value: 0, isPredefined: true })
+            for (const { index, label, value } of expectedSlots) {
+                expect(ratingData.data[index]).toEqual({ label, value, isPredefined: true })
+            }
         })
 
-        it('processes 5-point scale correctly - reveals the bug', () => {
+        it('ignores non-numeric labels', () => {
             const questions = [
                 {
-                    id: 'rating-q2',
+                    id: 'rating-q',
                     type: SurveyQuestionType.Rating as const,
                     question: 'Rate us',
                     scale: 5 as const,
@@ -1777,61 +1827,20 @@ describe('processResultsForSurveyQuestions', () => {
                     upperBoundLabel: 'Excellent',
                 },
             ]
-            // Each user response array contains answers to all questions in order
-            const results: SurveyRawResults = [
-                ['1'], // User 1: rating 1 for question 0
-                ['3'], // User 2: rating 3 for question 0
-                ['5'], // User 3: rating 5 for question 0
-                ['3'], // User 4: rating 3 for question 0
+            const rows: [string, string, number][] = [
+                ['rating-q', 'invalid', 3],
+                ['rating-q', '3', 2],
             ]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const ratingData = processed['rating-q2'] as ChoiceQuestionProcessedResponses
+            const processed = processResultsForSurveyQuestions(questions, rows)
+            const ratingData = processed['rating-q'] as ChoiceQuestionProcessedResponses
 
-            expect(ratingData.type).toBe(SurveyQuestionType.Rating)
-            expect(ratingData.totalResponses).toBe(4) // Should count all 4 responses including rating "5"
-            expect(ratingData.data).toHaveLength(5) // Should have 5 elements for a 5-point scale
-
-            // After fix: Regular scales should show labels 1-5 (not 0-4)
-            expect(ratingData.data[0]).toEqual({ label: '1', value: 1, isPredefined: true }) // One person rated 1
-            expect(ratingData.data[1]).toEqual({ label: '2', value: 0, isPredefined: true }) // No one rated 2
-            expect(ratingData.data[2]).toEqual({ label: '3', value: 2, isPredefined: true }) // Two people rated 3
-            expect(ratingData.data[3]).toEqual({ label: '4', value: 0, isPredefined: true }) // No one rated 4
-            expect(ratingData.data[4]).toEqual({ label: '5', value: 1, isPredefined: true }) // One person rated 5
-        })
-
-        it('demonstrates the bounds checking bug with 3-point scale', () => {
-            const questions = [
-                {
-                    id: 'rating-q3',
-                    type: SurveyQuestionType.Rating as const,
-                    question: 'Rate us',
-                    scale: 3 as const,
-                    display: 'number' as const,
-                    lowerBoundLabel: 'Poor',
-                    upperBoundLabel: 'Excellent',
-                },
-            ]
-            const results = [
-                ['1'], // User 1: should be valid
-                ['2'], // User 2: should be valid
-                ['3'], // User 3: should be valid after fix
-                ['0'], // User 4: should be invalid for 1-N scale
-            ]
-
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const ratingData = processed['rating-q3'] as ChoiceQuestionProcessedResponses
-
-            // After fix: Should count 3 valid responses (1, 2, 3), reject 0
-            expect(ratingData.totalResponses).toBe(3) // Should count ratings 1, 2, 3 but not 0
-            expect(ratingData.data[0]).toEqual({ label: '1', value: 1, isPredefined: true })
-            expect(ratingData.data[1]).toEqual({ label: '2', value: 1, isPredefined: true })
-            expect(ratingData.data[2]).toEqual({ label: '3', value: 1, isPredefined: true })
+            expect(ratingData.totalResponses).toBe(2)
         })
     })
 
     describe('Single Choice Questions', () => {
-        it('processes single choice correctly', () => {
+        it('processes counts, sorts by value, and zero-fills predefined choices', () => {
             const questions = [
                 {
                     id: 'single-q1',
@@ -1840,51 +1849,28 @@ describe('processResultsForSurveyQuestions', () => {
                     choices: ['Yes', 'No', 'Maybe'],
                 },
             ]
-            const results = [
-                ['Yes', null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
-                ['No', null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
-                ['Yes', null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
-                ['Custom answer', null, 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
+            const rows: [string, string, number][] = [
+                ['single-q1', 'Yes', 2],
+                ['single-q1', 'No', 1],
+                ['single-q1', 'Custom answer', 1],
             ]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
+            const processed = processResultsForSurveyQuestions(questions, rows)
             const singleData = processed['single-q1'] as ChoiceQuestionProcessedResponses
 
             expect(singleData.type).toBe(SurveyQuestionType.SingleChoice)
             expect(singleData.totalResponses).toBe(4)
 
-            // Check that all values exist (order may vary due to sorting)
             const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
-            expect(dataMap.get('Yes')).toEqual({
-                label: 'Yes',
-                value: 2,
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:30:00Z',
-            })
-            expect(dataMap.get('No')).toEqual({
-                label: 'No',
-                value: 1,
-                isPredefined: true,
-                distinctId: 'user2',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:15:00Z',
-            })
+            expect(dataMap.get('Yes')).toEqual({ label: 'Yes', value: 2, isPredefined: true })
+            expect(dataMap.get('No')).toEqual({ label: 'No', value: 1, isPredefined: true })
             expect(dataMap.get('Maybe')).toEqual({ label: 'Maybe', value: 0, isPredefined: true })
-            expect(dataMap.get('Custom answer')).toEqual({
-                label: 'Custom answer',
-                value: 1,
-                isPredefined: false,
-                distinctId: 'user4',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:45:00Z',
-            })
+            expect(dataMap.get('Custom answer')).toEqual({ label: 'Custom answer', value: 1, isPredefined: false })
         })
     })
 
     describe('Multiple Choice Questions', () => {
-        it('processes multiple choice correctly', () => {
+        it('uses __total__ for totalResponses and counts per-choice', () => {
             const questions = [
                 {
                     id: 'multi-q1',
@@ -1893,58 +1879,30 @@ describe('processResultsForSurveyQuestions', () => {
                     choices: ['A', 'B', 'C'],
                 },
             ]
-            // For multiple choice questions, the response at questionIndex is an array of selected choices
-            const results: SurveyRawResults = [
-                [['A', 'B'], null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked A and B for question 0
-                [['A'], null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked A only for question 0
-                [['C', 'Custom'], null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked C and a custom answer for question 0
+            const rows: [string, string, number][] = [
+                ['multi-q1', 'A', 2],
+                ['multi-q1', 'B', 1],
+                ['multi-q1', 'C', 1],
+                ['multi-q1', 'Custom', 1],
+                ['multi-q1', '__total__', 3],
             ]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
+            const processed = processResultsForSurveyQuestions(questions, rows)
             const multiData = processed['multi-q1'] as ChoiceQuestionProcessedResponses
 
             expect(multiData.type).toBe(SurveyQuestionType.MultipleChoice)
             expect(multiData.totalResponses).toBe(3)
 
-            // Check that data exists for each choice
             const dataMap = new Map(multiData.data.map((item) => [item.label, item]))
-            expect(dataMap.get('A')).toEqual({
-                label: 'A',
-                value: 2,
-                isPredefined: true,
-                distinctId: 'user2',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:15:00Z',
-            })
-            expect(dataMap.get('B')).toEqual({
-                label: 'B',
-                value: 1,
-                isPredefined: true,
-                distinctId: 'user1',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:00:00Z',
-            })
-            expect(dataMap.get('C')).toEqual({
-                label: 'C',
-                value: 1,
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:30:00Z',
-            })
-            expect(dataMap.get('Custom')).toEqual({
-                label: 'Custom',
-                value: 1,
-                isPredefined: false,
-                distinctId: 'user3',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T10:30:00Z',
-            })
+            expect(dataMap.get('A')).toEqual({ label: 'A', value: 2, isPredefined: true })
+            expect(dataMap.get('B')).toEqual({ label: 'B', value: 1, isPredefined: true })
+            expect(dataMap.get('C')).toEqual({ label: 'C', value: 1, isPredefined: true })
+            expect(dataMap.get('Custom')).toEqual({ label: 'Custom', value: 1, isPredefined: false })
         })
     })
 
     describe('Open Questions', () => {
-        it('processes open text correctly', () => {
+        it('returns total count with empty data (raw data comes from open-ended query)', () => {
             const questions = [
                 {
                     id: 'open-q1',
@@ -1952,163 +1910,214 @@ describe('processResultsForSurveyQuestions', () => {
                     question: 'Tell us more',
                 },
             ]
-            const results = [
-                ['Great product!', 'John', 'user123', '2024-01-15T10:30:00Z'], // User 1: response, person_display_name, distinct_id, timestamp
-                ['Could be better', null, 'user456', '2024-01-15T11:45:00Z'], // User 2: response, no person props, distinct_id, timestamp
-                ['', null, 'user789', '2024-01-15T12:00:00Z'], // User 3: empty response (should be ignored)
-            ] as Array<Array<string | string[]>>
+            const rows: [string, string, number][] = [['open-q1', '__total__', 42]]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
+            const processed = processResultsForSurveyQuestions(questions, rows)
             const openData = processed['open-q1'] as OpenQuestionProcessedResponses
 
             expect(openData.type).toBe(SurveyQuestionType.Open)
-            expect(openData.totalResponses).toBe(2) // Empty response ignored
-            expect(openData.data).toHaveLength(2)
-
-            expect(openData.data[0]).toEqual({
-                distinctId: 'user123',
-                response: 'Great product!',
-                personDisplayName: 'John',
-                timestamp: '2024-01-15T10:30:00Z',
-            })
-            expect(openData.data[1]).toEqual({
-                distinctId: 'user456',
-                response: 'Could be better',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T11:45:00Z',
-            })
+            expect(openData.totalResponses).toBe(42)
+            expect(openData.data).toHaveLength(0)
         })
     })
 
-    describe('Latest Person Data Storage', () => {
-        it('stores latest person data for single choice questions', () => {
-            const questions = [
-                {
-                    id: 'single-latest',
-                    type: SurveyQuestionType.SingleChoice as const,
-                    question: 'Pick one',
-                    choices: ['Yes', 'No'],
-                },
-            ]
-            // Multiple people picking the same choice - should store the LATEST person's data
-            const results = [
-                ['Yes', 'Alice', 'user1', '2024-01-15T10:00:00Z'], // Alice picks Yes at 10:00
-                ['Yes', 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Bob picks Yes at 11:00 (later)
-                ['Yes', 'Carol', 'user3', '2024-01-15T12:00:00Z'], // Carol picks Yes at 12:00 (latest)
-                ['No', 'Dave', 'user4', '2024-01-15T13:00:00Z'], // Dave picks No
-            ]
+    it('returns empty object for null rows', () => {
+        const questions = [{ id: 'q1', type: SurveyQuestionType.Open as const, question: 'Q' }]
+        expect(processResultsForSurveyQuestions(questions, null)).toEqual({})
+    })
 
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const singleData = processed['single-latest'] as ChoiceQuestionProcessedResponses
+    it('skips Link questions', () => {
+        const questions = [
+            { id: 'link-q', type: SurveyQuestionType.Link as const, question: 'Visit', link: 'https://example.com' },
+        ]
+        const rows: [string, string, number][] = [['link-q', '__total__', 5]]
+        expect(processResultsForSurveyQuestions(questions, rows)).toEqual({})
+    })
 
-            expect(singleData.totalResponses).toBe(4)
+    it('handles multiple questions in one result set', () => {
+        const questions = [
+            {
+                id: 'rating-q',
+                type: SurveyQuestionType.Rating as const,
+                question: 'Rate',
+                scale: 5 as const,
+                display: 'number' as const,
+                lowerBoundLabel: '',
+                upperBoundLabel: '',
+            },
+            {
+                id: 'choice-q',
+                type: SurveyQuestionType.SingleChoice as const,
+                question: 'Pick',
+                choices: ['A', 'B'],
+            },
+        ]
+        const rows: [string, string, number][] = [
+            ['rating-q', '3', 10],
+            ['choice-q', 'A', 5],
+            ['choice-q', 'B', 3],
+        ]
 
-            const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
+        const processed = processResultsForSurveyQuestions(questions, rows)
+        expect(processed['rating-q']).not.toBeUndefined()
+        expect(processed['choice-q']).not.toBeUndefined()
+        expect((processed['choice-q'] as ChoiceQuestionProcessedResponses).totalResponses).toBe(8)
+    })
+})
 
-            // "Yes" should have Carol's data (latest timestamp)
-            expect(dataMap.get('Yes')).toEqual({
-                label: 'Yes',
-                value: 3,
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: 'Carol',
-                timestamp: '2024-01-15T12:00:00Z',
-            })
+describe('processOpenEndedResults', () => {
+    it('collects raw responses for open text questions', () => {
+        const questions = [{ id: 'open-q1', type: SurveyQuestionType.Open as const, question: 'Tell us more' }]
+        const columnMap: OpenEndedColumnMap = {
+            'open-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.Open },
+        }
+        const rows = [
+            ['Great product!', 'user123', '2024-01-15T10:30:00Z'],
+            ['Could be better', 'user456', '2024-01-15T11:45:00Z'],
+            ['', 'user789', '2024-01-15T12:00:00Z'],
+        ]
 
-            // "No" should have Dave's data (only person who picked it)
-            expect(dataMap.get('No')).toEqual({
-                label: 'No',
-                value: 1,
-                isPredefined: true,
-                distinctId: 'user4',
-                personDisplayName: 'Dave',
-                timestamp: '2024-01-15T13:00:00Z',
-            })
+        const result = processOpenEndedResults(questions, columnMap, rows)
+        const openData = result['open-q1'] as OpenQuestionProcessedResponses
+
+        expect(openData.type).toBe(SurveyQuestionType.Open)
+        expect(openData.totalResponses).toBe(2)
+        expect(openData.data).toHaveLength(2)
+        expect(openData.data[0]).toEqual({
+            distinctId: 'user123',
+            response: 'Great product!',
+            timestamp: '2024-01-15T10:30:00Z',
         })
-
-        it('stores latest person data for multiple choice questions', () => {
-            const questions = [
-                {
-                    id: 'multi-latest',
-                    type: SurveyQuestionType.MultipleChoice as const,
-                    question: 'Pick many',
-                    choices: ['A', 'B', 'C'],
-                },
-            ]
-            // Multiple people picking the same choices - should store the LATEST person's data for each choice
-            const results: SurveyRawResults = [
-                [['A', 'B'], 'Alice', 'user1', '2024-01-15T10:00:00Z'], // Alice picks A,B at 10:00
-                [['A'], 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Bob picks A at 11:00 (later for A)
-                [['B', 'C'], 'Carol', 'user3', '2024-01-15T12:00:00Z'], // Carol picks B,C at 12:00 (later for B)
-            ]
-
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const multiData = processed['multi-latest'] as ChoiceQuestionProcessedResponses
-
-            expect(multiData.totalResponses).toBe(3)
-
-            const dataMap = new Map(multiData.data.map((item) => [item.label, item]))
-
-            // "A" should have Bob's data (latest person to pick A)
-            expect(dataMap.get('A')).toEqual({
-                label: 'A',
-                value: 2, // Alice and Bob both picked A
-                isPredefined: true,
-                distinctId: 'user2',
-                personDisplayName: 'Bob',
-                timestamp: '2024-01-15T11:00:00Z',
-            })
-
-            // "B" should have Carol's data (latest person to pick B)
-            expect(dataMap.get('B')).toEqual({
-                label: 'B',
-                value: 2, // Alice and Carol both picked B
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: 'Carol',
-                timestamp: '2024-01-15T12:00:00Z',
-            })
-
-            // "C" should have Carol's data (only person to pick C)
-            expect(dataMap.get('C')).toEqual({
-                label: 'C',
-                value: 1,
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: 'Carol',
-                timestamp: '2024-01-15T12:00:00Z',
-            })
+        expect(openData.data[1]).toEqual({
+            distinctId: 'user456',
+            response: 'Could be better',
+            timestamp: '2024-01-15T11:45:00Z',
         })
+    })
 
-        it('stores latest person display name, handling null values gracefully', () => {
-            const questions = [
-                {
-                    id: 'single-invalid-props',
-                    type: SurveyQuestionType.SingleChoice as const,
-                    question: 'Pick one',
-                    choices: ['Option'],
-                },
-            ]
-            const results = [
-                ['Option', 'invalid', 'user1', '2024-01-15T10:00:00Z'], // Invalid display name (not same as distinct_id)
-                ['Option', 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Valid display name "Bob"
-                ['Option', null, 'user3', '2024-01-15T12:00:00Z'], // Empty props (most recent)
-            ]
+    it('collects non-predefined "Other" text from single choice with hasOpenChoice', () => {
+        const questions = [
+            {
+                id: 'choice-q1',
+                type: SurveyQuestionType.SingleChoice as const,
+                question: 'Pick one',
+                choices: ['Yes', 'No', 'Other'],
+                hasOpenChoice: true,
+            },
+        ]
+        const columnMap: OpenEndedColumnMap = {
+            'choice-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.SingleChoice },
+        }
+        const rows = [
+            ['Yes', 'user1', '2024-01-15T10:00:00Z'],
+            ['Something custom', 'user2', '2024-01-15T11:00:00Z'],
+            ['No', 'user3', '2024-01-15T12:00:00Z'],
+        ]
 
-            const processed = processResultsForSurveyQuestions(questions, results)
-            const singleData = processed['single-invalid-props'] as ChoiceQuestionProcessedResponses
+        const result = processOpenEndedResults(questions, columnMap, rows)
+        const choiceData = result['choice-q1'] as ChoiceQuestionProcessedResponses
 
-            const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
+        expect(choiceData.data).toHaveLength(1)
+        expect(choiceData.data[0].label).toBe('Something custom')
+        expect(choiceData.data[0].distinctId).toBe('user2')
+    })
 
-            // Should have user3's data (latest timestamp) with undefined personDisplayName (null value)
-            expect(dataMap.get('Option')).toEqual({
-                label: 'Option',
-                value: 3,
-                isPredefined: true,
-                distinctId: 'user3',
-                personDisplayName: undefined,
-                timestamp: '2024-01-15T12:00:00Z',
-            })
-        })
+    it('collects non-predefined "Other" text from multiple choice with hasOpenChoice', () => {
+        const questions = [
+            {
+                id: 'multi-q1',
+                type: SurveyQuestionType.MultipleChoice as const,
+                question: 'Pick many',
+                choices: ['A', 'B', 'Other'],
+                hasOpenChoice: true,
+            },
+        ]
+        const columnMap: OpenEndedColumnMap = {
+            'multi-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.MultipleChoice },
+        }
+        const rows = [
+            [['A', 'Custom text'], 'user1', '2024-01-15T10:00:00Z'],
+            [['B'], 'user2', '2024-01-15T11:00:00Z'],
+        ]
+
+        const result = processOpenEndedResults(questions, columnMap, rows)
+        const choiceData = result['multi-q1'] as ChoiceQuestionProcessedResponses
+
+        expect(choiceData.data).toHaveLength(1)
+        expect(choiceData.data[0].label).toBe('Custom text')
+    })
+
+    it('returns empty object for null rows', () => {
+        expect(processOpenEndedResults([], {}, null)).toEqual({})
+    })
+})
+
+describe('mergeResponsesByQuestion', () => {
+    it('merges open question: takes data from open-ended, totalResponses from aggregate', () => {
+        const aggregate: ResponsesByQuestion = {
+            'open-q': { type: SurveyQuestionType.Open, data: [], totalResponses: 100 },
+        }
+        const openEnded: ResponsesByQuestion = {
+            'open-q': {
+                type: SurveyQuestionType.Open,
+                data: [{ distinctId: 'u1', response: 'Great', timestamp: '2024-01-15T10:00:00Z' }],
+                totalResponses: 1,
+            },
+        }
+
+        const merged = mergeResponsesByQuestion(aggregate, openEnded)
+        const result = merged['open-q'] as OpenQuestionProcessedResponses
+
+        expect(result.data).toHaveLength(1)
+        expect(result.totalResponses).toBe(100)
+    })
+
+    it('merges choice question with open choice: appends "Other" data to aggregate data', () => {
+        const aggregate: ResponsesByQuestion = {
+            'choice-q': {
+                type: SurveyQuestionType.SingleChoice,
+                data: [{ label: 'Yes', value: 5, isPredefined: true }],
+                totalResponses: 6,
+            },
+        }
+        const openEnded: ResponsesByQuestion = {
+            'choice-q': {
+                type: SurveyQuestionType.SingleChoice,
+                data: [{ label: 'Custom answer', value: 1, isPredefined: false, distinctId: 'u1', timestamp: 'ts' }],
+                totalResponses: 0,
+            },
+        }
+
+        const merged = mergeResponsesByQuestion(aggregate, openEnded)
+        const result = merged['choice-q'] as ChoiceQuestionProcessedResponses
+
+        expect(result.data).toHaveLength(2)
+        expect(result.totalResponses).toBe(6)
+    })
+
+    it('passes through aggregate-only questions unchanged', () => {
+        const aggregate: ResponsesByQuestion = {
+            'rating-q': {
+                type: SurveyQuestionType.Rating,
+                data: [{ label: '5', value: 10, isPredefined: true }],
+                totalResponses: 10,
+            },
+        }
+
+        const merged = mergeResponsesByQuestion(aggregate, {})
+        expect(merged['rating-q']).toEqual(aggregate['rating-q'])
+    })
+
+    it('passes through open-ended-only questions when no aggregate exists', () => {
+        const openEnded: ResponsesByQuestion = {
+            'open-q': {
+                type: SurveyQuestionType.Open,
+                data: [{ distinctId: 'u1', response: 'Hello', timestamp: 'ts' }],
+                totalResponses: 1,
+            },
+        }
+
+        const merged = mergeResponsesByQuestion({}, openEnded)
+        expect(merged['open-q']).toEqual(openEnded['open-q'])
     })
 })

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -8,7 +8,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
-import { FEATURE_FLAGS, PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES } from 'lib/constants'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
 import { allOperatorsMapping, hasFormErrors, isObject, objectClean } from 'lib/utils'
@@ -29,7 +29,6 @@ import { userLogic } from 'scenes/userLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { MAX_SELECT_RETURNED_ROWS } from '~/queries/nodes/DataTable/DataTableExport'
 import {
     CompareFilter,
     DataTableNode,
@@ -58,7 +57,6 @@ import {
     ProjectTreeRef,
     PropertyFilterType,
     PropertyOperator,
-    QuestionProcessedResponses,
     RatingSurveyQuestion,
     ResponsesByQuestion,
     Survey,
@@ -71,8 +69,6 @@ import {
     SurveyQuestionBranchingType,
     SurveyQuestionType,
     SurveyRates,
-    SurveyRawResults,
-    SurveyResponseRow,
     SurveySchedule,
     SurveyStats,
 } from '~/types'
@@ -90,6 +86,10 @@ import { getSurveyStatus, surveysLogic } from './surveysLogic'
 import { SurveyFeatureWarning, getSurveyWarnings } from './surveyVersionRequirements'
 import {
     DATE_FORMAT,
+    type OpenEndedColumnMap,
+    type SurveyQueryFilters,
+    buildAggregateQuery,
+    buildOpenEndedQuery,
     buildPartialResponsesFilter,
     buildSurveyTimestampFilter,
     calculateSurveyRates,
@@ -200,138 +200,39 @@ export interface SurveyDateRange {
     date_to: string | null
 }
 
-function isEmptyOrUndefined(value: any): boolean {
-    return value === null || value === undefined || value === ''
-}
+type AggregateRow = [string, string, number]
+type AggregateEntries = [string, number][]
 
-function isQuestionOpenChoice(question: SurveyQuestion, choiceIndex: number): boolean {
-    if (question.type !== SurveyQuestionType.SingleChoice && question.type !== SurveyQuestionType.MultipleChoice) {
-        return false
-    }
-    return !!(choiceIndex === question.choices.length - 1 && question?.hasOpenChoice)
-}
-
-// Builds a COALESCE expression that tries each display name property in order,
-// falling back to distinct_id if none are set. Respects team-level customization.
-function buildPersonDisplayNameExpression(personDisplayNameProperties: string[]): string {
-    const propertyExpressions = personDisplayNameProperties.map((prop) => {
-        // Handle property names with special characters
-        if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)) {
-            return `toString(person.properties.${prop})`
-        }
-        return `toString(person.properties.\`${prop}\`)`
-    })
-    // COALESCE returns the first non-null value; fall back to distinct_id
-    return `coalesce(${[...propertyExpressions, 'toString(events.distinct_id)'].join(', ')})`
-}
-
-// Helper to extract person data from a survey response row
-// Query structure: [...questions, person_display_name, distinct_id, timestamp]
-function extractPersonData(row: SurveyResponseRow): {
-    distinctId: string
-    personDisplayName?: string
-    timestamp: string
-} {
-    const timestamp = row.at(-1) as string
-    const distinctId = row.at(-2) as string
-    const personDisplayName = row.at(-3) as string | null
-
-    return {
-        distinctId,
-        // Only include display name if it's different from distinct_id (meaning a real name was found)
-        personDisplayName: personDisplayName && personDisplayName !== distinctId ? personDisplayName : undefined,
-        timestamp,
-    }
-}
-
-// Helper to count a choice and store person data for latest occurrence
-function countChoice(
-    choice: string,
-    counts: { [key: string]: number },
-    latestResponsePersonData: { [key: string]: ReturnType<typeof extractPersonData> },
-    personData: ReturnType<typeof extractPersonData>
-): void {
-    if (isEmptyOrUndefined(choice)) {
-        return
-    }
-
-    counts[choice] = (counts[choice] || 0) + 1
-
-    // Always store the latest person data - this gives us the most recent respondent
-    // for each choice to display in the UI (e.g., "Sarah was the last to pick this option")
-    latestResponsePersonData[choice] = personData
-}
-
-// Shared utility for processing choice-based questions
 function processChoiceQuestion(
     question: MultipleSurveyQuestion,
-    questionIndex: number,
-    results: SurveyRawResults,
+    entries: AggregateEntries,
     questionType: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice
 ): ChoiceQuestionProcessedResponses {
-    const counts: { [key: string]: number } = {}
-    // Store person data for the most recent person who selected each choice - used in UI to show
-    // "who last picked this option" with avatar/name when hovering over choice visualizations
-    const latestResponsePersonData: { [key: string]: ReturnType<typeof extractPersonData> } = {}
+    const totalEntry = entries.find(([l]) => l === '__total__')
+    const dataEntries = entries.filter(([l]) => l !== '__total__')
+    const predefined = new Set(question.choices ?? [])
+
     let total = 0
+    const data: ChoiceQuestionResponseData[] = dataEntries
+        .map(([label, count]) => {
+            if (questionType === SurveyQuestionType.SingleChoice) {
+                total += count
+            }
+            return { label, value: count, isPredefined: predefined.has(label) }
+        })
+        .sort((a, b) => b.value - a.value)
+
+    if (questionType === SurveyQuestionType.MultipleChoice && totalEntry) {
+        total = totalEntry[1]
+    }
 
     // Zero-fill predefined choices (excluding open choice)
     question.choices?.forEach((choice: string, choiceIndex: number) => {
-        if (!isQuestionOpenChoice(question, choiceIndex)) {
-            counts[choice] = 0
+        const isOpenChoice = question.hasOpenChoice && choiceIndex === question.choices.length - 1
+        if (!isOpenChoice && !data.some((d) => d.label === choice)) {
+            data.push({ label: choice, value: 0, isPredefined: true })
         }
     })
-
-    // Process each response
-    results?.forEach((row: SurveyResponseRow) => {
-        const rawValue = row[questionIndex]
-        if (rawValue === null || rawValue === undefined) {
-            return
-        }
-
-        const personData = extractPersonData(row)
-
-        if (questionType === SurveyQuestionType.SingleChoice) {
-            const value = rawValue as string
-            if (!isEmptyOrUndefined(value)) {
-                countChoice(value, counts, latestResponsePersonData, personData)
-                total += 1
-            }
-        } else {
-            // Multiple choice
-            const choices = rawValue as string[]
-
-            if (choices.length > 0) {
-                total += 1
-                choices.forEach((choice) => {
-                    const cleaned = choice.replace(/^['"]+|['"]+$/g, '')
-                    countChoice(cleaned, counts, latestResponsePersonData, personData)
-                })
-            }
-        }
-    })
-
-    const data = Object.entries(counts)
-        .map(([label, value]) => {
-            const baseData = {
-                label,
-                value,
-                isPredefined: question.choices?.includes(label) ?? false,
-            }
-
-            // Attach the latest person's data who selected this choice (for UI display)
-            if (latestResponsePersonData[label]) {
-                return {
-                    ...baseData,
-                    distinctId: latestResponsePersonData[label].distinctId,
-                    personDisplayName: latestResponsePersonData[label].personDisplayName,
-                    timestamp: latestResponsePersonData[label].timestamp,
-                }
-            }
-
-            return baseData
-        })
-        .sort((a, b) => b.value - a.value)
 
     return {
         type: questionType,
@@ -342,37 +243,35 @@ function processChoiceQuestion(
 
 function processRatingQuestion(
     question: RatingSurveyQuestion,
-    questionIndex: number,
-    results: SurveyRawResults
+    entries: AggregateEntries
 ): ChoiceQuestionProcessedResponses {
     const scaleSize = question.scale === SURVEY_RATING_SCALE.NPS_10_POINT ? 11 : question.scale
     const counts = new Array(scaleSize).fill(0)
     let total = 0
 
-    results?.forEach((row: SurveyResponseRow) => {
-        const value = row[questionIndex] as string
-        if (!isEmptyOrUndefined(value)) {
-            const parsedValue = parseInt(value, 10)
-            if (!isNaN(parsedValue)) {
-                let arrayIndex: number
-                let isValid = false
+    entries.forEach(([label, count]) => {
+        const parsedValue = parseInt(label, 10)
+        if (isNaN(parsedValue)) {
+            return
+        }
 
-                if (question.scale === SURVEY_RATING_SCALE.NPS_10_POINT) {
-                    // NPS scale: 0-10 (11 values)
-                    isValid = parsedValue >= 0 && parsedValue <= 10
-                    arrayIndex = parsedValue
-                } else {
-                    // Regular rating scales: 1-N (N values, but we use 0-based indexing)
-                    // For a 5-point scale, accept ratings 1-5 and map them to indices 0-4
-                    isValid = parsedValue >= 1 && parsedValue <= question.scale
-                    arrayIndex = parsedValue - 1 // Convert 1-based to 0-based
-                }
+        let arrayIndex: number
+        let isValid = false
 
-                if (isValid) {
-                    counts[arrayIndex] += 1
-                    total += 1
-                }
-            }
+        if (question.scale === SURVEY_RATING_SCALE.NPS_10_POINT) {
+            // NPS scale: 0-10 (11 values)
+            isValid = parsedValue >= 0 && parsedValue <= 10
+            arrayIndex = parsedValue
+        } else {
+            // Regular rating scales: 1-N (N values, but we use 0-based indexing)
+            // For a 5-point scale, accept ratings 1-5 and map them to indices 0-4
+            isValid = parsedValue >= 1 && parsedValue <= question.scale
+            arrayIndex = parsedValue - 1 // Convert 1-based to 0-based
+        }
+
+        if (isValid) {
+            counts[arrayIndex] = count
+            total += count
         }
     })
 
@@ -396,69 +295,155 @@ function processRatingQuestion(
     }
 }
 
-function processOpenQuestion(questionIndex: number, results: SurveyRawResults): OpenQuestionProcessedResponses {
-    const data: { distinctId: string; response: string; personDisplayName?: string; timestamp?: string }[] = []
-    let totalResponses = 0
-
-    results?.forEach((row: SurveyResponseRow) => {
-        const value = row[questionIndex] as string
-        if (isEmptyOrUndefined(value)) {
-            return
-        }
-
-        const personData = extractPersonData(row)
-        const response = {
-            distinctId: personData.distinctId,
-            response: value,
-            personDisplayName: personData.personDisplayName,
-            timestamp: personData.timestamp,
-        }
-
-        totalResponses += 1
-        data.push(response)
-    })
-
-    return {
-        type: SurveyQuestionType.Open,
-        data,
-        totalResponses,
-    }
+function processOpenQuestion(entries: AggregateEntries): OpenQuestionProcessedResponses {
+    const total = entries.find(([l]) => l === '__total__')?.[1] ?? 0
+    return { type: SurveyQuestionType.Open, data: [], totalResponses: total }
 }
 
 export function processResultsForSurveyQuestions(
     questions: SurveyQuestion[],
-    results: SurveyRawResults
+    rows: AggregateRow[] | null
 ): ResponsesByQuestion {
+    if (!rows) {
+        return {}
+    }
+
+    const grouped: Record<string, AggregateEntries> = {}
+    for (const [qid, label, count] of rows) {
+        if (!grouped[qid]) {
+            grouped[qid] = []
+        }
+        grouped[qid].push([label, count])
+    }
+
     const responsesByQuestion: ResponsesByQuestion = {}
 
-    questions.forEach((question, index) => {
+    questions.forEach((question) => {
         // Skip questions without IDs or Link questions
-        if (!question.id || question.type === SurveyQuestionType.Link) {
+        if (!question.id || !grouped[question.id] || question.type === SurveyQuestionType.Link) {
             return
         }
-
-        let processedData: QuestionProcessedResponses
+        const entries = grouped[question.id]
 
         switch (question.type) {
             case SurveyQuestionType.SingleChoice:
             case SurveyQuestionType.MultipleChoice:
-                processedData = processChoiceQuestion(question, index, results, question.type)
+                responsesByQuestion[question.id] = processChoiceQuestion(question, entries, question.type)
                 break
             case SurveyQuestionType.Rating:
-                processedData = processRatingQuestion(question, index, results)
+                responsesByQuestion[question.id] = processRatingQuestion(question, entries)
                 break
             case SurveyQuestionType.Open:
-                processedData = processOpenQuestion(index, results)
+                responsesByQuestion[question.id] = processOpenQuestion(entries)
                 break
-            default:
-                // Skip unknown question types
-                return
         }
-
-        responsesByQuestion[question.id] = processedData
     })
 
     return responsesByQuestion
+}
+
+function collectOpenChoiceResponses(
+    question: MultipleSurveyQuestion,
+    questionType: SurveyQuestionType,
+    rows: any[][],
+    columnIndex: number,
+    distinctIdIdx: number,
+    timestampIdx: number
+): ChoiceQuestionResponseData[] {
+    const predefined = new Set(question.choices ?? [])
+    const otherData: ChoiceQuestionResponseData[] = []
+
+    for (const row of rows) {
+        const rawValue = row[columnIndex]
+        if (!rawValue) {
+            continue
+        }
+
+        // Multiple choice values come as string arrays, single choice as a single string
+        let choices: string[]
+        if (questionType === SurveyQuestionType.MultipleChoice) {
+            choices = (rawValue as string[]).map((v) => v.replace(/^['"]+|['"]+$/g, ''))
+        } else {
+            choices = [rawValue as string]
+        }
+
+        for (const choice of choices) {
+            if (choice && !predefined.has(choice)) {
+                otherData.push({
+                    label: choice,
+                    value: 1,
+                    isPredefined: false,
+                    distinctId: row[distinctIdIdx] as string,
+                    timestamp: row[timestampIdx] as string,
+                })
+            }
+        }
+    }
+
+    return otherData
+}
+
+export function processOpenEndedResults(
+    questions: SurveyQuestion[],
+    columnMap: OpenEndedColumnMap,
+    rows: any[][] | null
+): ResponsesByQuestion {
+    if (!rows) {
+        return {}
+    }
+
+    const numCols = Object.keys(columnMap).length
+    const distinctIdIdx = numCols
+    const timestampIdx = numCols + 1
+    const result: ResponsesByQuestion = {}
+
+    for (const [questionId, { columnIndex, type }] of Object.entries(columnMap)) {
+        if (type === SurveyQuestionType.Open) {
+            const data: OpenQuestionResponseData[] = []
+            for (const row of rows) {
+                const value = row[columnIndex] as string
+                if (!value) {
+                    continue
+                }
+                data.push({
+                    distinctId: row[distinctIdIdx] as string,
+                    response: value,
+                    timestamp: row[timestampIdx] as string,
+                })
+            }
+            result[questionId] = { type: SurveyQuestionType.Open, data, totalResponses: data.length }
+        } else {
+            const question = questions.find((q) => q.id === questionId) as MultipleSurveyQuestion | undefined
+            if (!question) {
+                continue
+            }
+            const otherData = collectOpenChoiceResponses(question, type, rows, columnIndex, distinctIdIdx, timestampIdx)
+            if (otherData.length > 0) {
+                result[questionId] = { type, data: otherData, totalResponses: 0 }
+            }
+        }
+    }
+
+    return result
+}
+
+export function mergeResponsesByQuestion(
+    aggregate: ResponsesByQuestion,
+    openEnded: ResponsesByQuestion
+): ResponsesByQuestion {
+    const merged = { ...aggregate }
+    for (const [qid, openData] of Object.entries(openEnded)) {
+        const agg = merged[qid]
+        if (!agg) {
+            merged[qid] = openData
+        } else if (openData.type === SurveyQuestionType.Open) {
+            merged[qid] = { ...openData, totalResponses: agg.totalResponses }
+        } else {
+            const aggChoice = agg as ChoiceQuestionProcessedResponses
+            merged[qid] = { ...aggChoice, data: [...aggChoice.data, ...openData.data] }
+        }
+    }
+    return merged
 }
 
 export const surveyLogic = kea<surveyLogicType>([
@@ -476,6 +461,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 'reportSurveyArchived',
                 'reportSurveyViewed',
                 'reportSurveyCycleDetected',
+                'reportSurveyConsolidatedResultsQuery',
             ],
             teamLogic,
             ['addProductIntent'],
@@ -556,6 +542,7 @@ export const surveyLogic = kea<surveyLogicType>([
             notificationId,
             enabled,
         }),
+        setPersonNames: (personNames: Record<string, string>) => ({ personNames }),
     }),
     loaders(({ props, actions, values }) => ({
         surveyHeadline: [
@@ -766,10 +753,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     }
                 )
                 actions.setBaseStatsResults(response.results as SurveyBaseStatsResult)
-                const numberOfSurveySentEvents = response.results?.find(
-                    (result) => result[0] === SurveyEventName.SENT
-                )?.[1]
-                actions.loadConsolidatedSurveyResults(numberOfSurveySentEvents)
+                actions.loadConsolidatedSurveyResults()
                 return response.results as SurveyBaseStatsResult
             },
         },
@@ -823,60 +807,59 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         },
         consolidatedSurveyResults: {
-            loadConsolidatedSurveyResults: async (
-                limit = MAX_SELECT_RETURNED_ROWS
-            ): Promise<ConsolidatedSurveyResults> => {
+            loadConsolidatedSurveyResults: async (): Promise<ConsolidatedSurveyResults> => {
                 if (props.id === NEW_SURVEY.id || !values.survey?.start_date) {
                     return { responsesByQuestion: {} }
                 }
 
-                // Build an array of all questions with their types
-                const questionFields = values.survey.questions.map((question, index) => {
-                    return `${getSurveyResponse(question, index)} AS q${index}_response`
+                const survey = values.survey as Survey
+                const queryFilters: SurveyQueryFilters = {
+                    timestampFilter: values.timestampFilter,
+                    answerFilterHogQLExpression: values.answerFilterHogQLExpression,
+                    archivedResponsesFilter: values.archivedResponsesFilter,
+                }
+                const queryParams = {
+                    queryParams: { filters: { properties: values.propertyFilters } },
+                }
+                const queryOpts = { scene: 'Survey' as const, productKey: 'surveys' as const }
+
+                const aggregateQuery = buildAggregateQuery(survey, queryFilters, values.dateRange)
+                const openEndedResult = buildOpenEndedQuery(survey, queryFilters, values.dateRange)
+
+                const startMs = performance.now()
+                let aggregateDuration = 0
+                let openEndedDuration = 0
+
+                const [aggregateResponse, openEndedResponse] = await Promise.all([
+                    aggregateQuery
+                        ? api.queryHogQL(aggregateQuery as HogQLQueryString, queryOpts, queryParams).then((r) => {
+                              aggregateDuration = performance.now() - startMs
+                              return r
+                          })
+                        : Promise.resolve({ results: null }),
+                    openEndedResult
+                        ? api
+                              .queryHogQL(openEndedResult.query as HogQLQueryString, queryOpts, queryParams)
+                              .then((r) => {
+                                  openEndedDuration = performance.now() - startMs
+                                  return r
+                              })
+                        : Promise.resolve({ results: null }),
+                ])
+
+                const endMs = performance.now()
+
+                actions.reportSurveyConsolidatedResultsQuery(survey, endMs - startMs, {
+                    aggregate: aggregateDuration,
+                    openEnded: openEndedDuration,
                 })
 
-                // Build person display name using team settings or defaults
-                const personDisplayNameProps =
-                    teamLogic.values.currentTeam?.person_display_name_properties ||
-                    PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
-                const personDisplayNameExpr = buildPersonDisplayNameExpression(personDisplayNameProps)
+                const aggregate = processResultsForSurveyQuestions(survey.questions, aggregateResponse.results)
+                const openEnded = openEndedResult
+                    ? processOpenEndedResults(survey.questions, openEndedResult.columnMap, openEndedResponse.results)
+                    : {}
 
-                // Query structure: [question_responses..., person_display_name, distinct_id, timestamp]
-                const query = `
-                    -- QUERYING ALL SURVEY RESPONSES IN ONE GO
-                    SELECT
-                        ${questionFields.join(',\n')},
-                        ${personDisplayNameExpr} AS person_display_name,
-                        events.distinct_id,
-                        events.timestamp
-                    FROM events
-                    WHERE event = '${SurveyEventName.SENT}'
-                        AND properties.${SurveyEventProperties.SURVEY_ID} = '${props.id}'
-                        ${values.timestampFilter}
-                        ${values.answerFilterHogQLExpression}
-                        ${values.partialResponsesFilter}
-                        ${values.archivedResponsesFilter}
-                        AND {filters}
-                    ORDER BY events.timestamp DESC
-                    LIMIT ${limit}` as HogQLQueryString
-
-                const responseJSON = await api.queryHogQL(
-                    query,
-                    { scene: 'Survey', productKey: 'surveys' },
-                    {
-                        queryParams: {
-                            filters: {
-                                properties: values.propertyFilters,
-                            },
-                        },
-                    }
-                )
-                const { results } = responseJSON
-
-                // Process the results into a format that can be used by each question type
-                const responsesByQuestion = processResultsForSurveyQuestions(values.survey.questions, results)
-
-                return { responsesByQuestion }
+                return { responsesByQuestion: mergeResponsesByQuestion(aggregate, openEnded) }
             },
         },
         archivedResponseUuids: [
@@ -988,6 +971,53 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (values.survey.id !== NEW_SURVEY.id && values.survey.start_date) {
                     actions.loadSurveyBaseStats()
                     actions.loadSurveyDismissedAndSentCount()
+                }
+            },
+            loadConsolidatedSurveyResultsSuccess: async ({ consolidatedSurveyResults }) => {
+                const distinctIds = new Set<string>()
+                for (const data of Object.values(consolidatedSurveyResults.responsesByQuestion)) {
+                    for (const r of data.data) {
+                        const id = 'distinctId' in r ? r.distinctId : undefined
+                        if (id) {
+                            distinctIds.add(id)
+                        }
+                    }
+                }
+
+                if (distinctIds.size === 0) {
+                    return
+                }
+
+                const teamId = teamLogic.values.currentTeamId
+                if (!teamId) {
+                    return
+                }
+
+                try {
+                    const allIds = Array.from(distinctIds)
+                    const BATCH_SIZE = 200
+                    const personNames: Record<string, string> = {}
+
+                    for (let i = 0; i < allIds.length; i += BATCH_SIZE) {
+                        const batch = allIds.slice(i, i + BATCH_SIZE)
+                        const response = await api.create(`api/environments/${teamId}/persons/batch_by_distinct_ids/`, {
+                            distinct_ids: batch,
+                        })
+
+                        for (const [distinctId, person] of Object.entries(
+                            response.results as Record<string, { name: string }>
+                        )) {
+                            if (person.name) {
+                                personNames[distinctId] = person.name
+                            }
+                        }
+                    }
+
+                    if (Object.keys(personNames).length > 0) {
+                        actions.setPersonNames(personNames)
+                    }
+                } catch {
+                    // Person enrichment is best-effort — don't block survey results
                 }
             },
             loadSurveyBaseStatsSuccess: () => {
@@ -1145,6 +1175,12 @@ export const surveyLogic = kea<surveyLogicType>([
         }
     }),
     reducers({
+        personNames: [
+            {} as Record<string, string>,
+            {
+                setPersonNames: (state, { personNames }) => ({ ...state, ...personNames }),
+            },
+        ],
         showArchivedResponses: [
             false,
             { persist: true },
@@ -1399,6 +1435,27 @@ export const surveyLogic = kea<surveyLogicType>([
         ],
     }),
     selectors({
+        enrichedConsolidatedSurveyResults: [
+            (s) => [s.consolidatedSurveyResults, s.personNames],
+            (results: ConsolidatedSurveyResults, personNames: Record<string, string>): ConsolidatedSurveyResults => {
+                if (!results?.responsesByQuestion || Object.keys(personNames).length === 0) {
+                    return results
+                }
+
+                const enriched: ResponsesByQuestion = {}
+                for (const [qid, data] of Object.entries(results.responsesByQuestion)) {
+                    enriched[qid] = {
+                        ...data,
+                        data: data.data.map((r) => {
+                            const id = 'distinctId' in r ? r.distinctId : undefined
+                            return id && personNames[id] ? { ...r, personDisplayName: personNames[id] } : r
+                        }),
+                    } as typeof data
+                }
+
+                return { responsesByQuestion: enriched }
+            },
+        ],
         timestampFilter: [
             (s) => [s.survey, s.dateRange],
             (survey: Survey, dateRange: SurveyDateRange): string => {
@@ -2048,7 +2105,7 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
         formattedOpenEndedResponses: [
-            (s) => [s.consolidatedSurveyResults, s.survey],
+            (s) => [s.enrichedConsolidatedSurveyResults, s.survey],
             (
                 consolidatedResults: ConsolidatedSurveyResults,
                 survey: Survey | NewSurvey

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -499,6 +499,130 @@ export function buildPartialResponsesFilter(survey: Survey, dateRange?: SurveyDa
     ) --- Filter to ensure we only get one response per ${SurveyEventProperties.SURVEY_SUBMISSION_ID}`
 }
 
+export interface SurveyQueryFilters {
+    timestampFilter: string
+    answerFilterHogQLExpression: string
+    archivedResponsesFilter: string
+}
+
+export interface OpenEndedColumnMap {
+    [questionId: string]: {
+        columnIndex: number
+        questionIndex: number
+        type: SurveyQuestionType.Open | SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice
+    }
+}
+
+export function buildAggregateQuery(
+    survey: Survey,
+    filters: SurveyQueryFilters,
+    dateRange?: SurveyDateRange | null
+): string | null {
+    const dedupFilter = buildPartialResponsesFilter(survey, dateRange)
+    const branches: string[] = []
+
+    const baseWhere = `event = '${SurveyEventName.SENT}'
+        AND properties.${SurveyEventProperties.SURVEY_ID} = '${survey.id}'
+        ${filters.timestampFilter}
+        ${filters.answerFilterHogQLExpression}
+        ${filters.archivedResponsesFilter}
+        ${dedupFilter}
+        AND {filters}`
+
+    for (const [index, question] of survey.questions.entries()) {
+        if (!question.id || question.type === SurveyQuestionType.Link) {
+            continue
+        }
+
+        const responseExpr = getSurveyResponse(question, index)
+
+        if (question.type === SurveyQuestionType.Rating || question.type === SurveyQuestionType.SingleChoice) {
+            branches.push(`SELECT '${question.id}' AS question_id,
+                ${responseExpr} AS label,
+                count() AS cnt
+            FROM events
+            WHERE ${baseWhere} AND ${responseExpr} != ''
+            GROUP BY label`)
+        } else if (question.type === SurveyQuestionType.MultipleChoice) {
+            branches.push(`SELECT '${question.id}' AS question_id,
+                trim(BOTH '"\\'' FROM arrayJoin(${responseExpr})) AS label,
+                count() AS cnt
+            FROM events
+            WHERE ${baseWhere}
+            GROUP BY label HAVING label != ''`)
+
+            branches.push(`SELECT '${question.id}' AS question_id,
+                '__total__' AS label,
+                count() AS cnt
+            FROM events
+            WHERE ${baseWhere} AND length(${responseExpr}) > 0`)
+        } else if (question.type === SurveyQuestionType.Open) {
+            branches.push(`SELECT '${question.id}' AS question_id,
+                '__total__' AS label,
+                count() AS cnt
+            FROM events
+            WHERE ${baseWhere} AND ${responseExpr} != ''`)
+        }
+    }
+
+    if (branches.length === 0) {
+        return null
+    }
+
+    return branches.join('\nUNION ALL\n')
+}
+
+export function buildOpenEndedQuery(
+    survey: Survey,
+    filters: SurveyQueryFilters,
+    dateRange?: SurveyDateRange | null,
+    limit: number = 50000
+): { query: string; columnMap: OpenEndedColumnMap } | null {
+    const dedupFilter = buildPartialResponsesFilter(survey, dateRange)
+    const openColumns: string[] = []
+    const columnMap: OpenEndedColumnMap = {}
+    let columnIndex = 0
+
+    for (const [index, question] of survey.questions.entries()) {
+        if (!question.id || question.type === SurveyQuestionType.Link) {
+            continue
+        }
+
+        const isOpen = question.type === SurveyQuestionType.Open
+        const hasOpenChoice =
+            (question.type === SurveyQuestionType.SingleChoice ||
+                question.type === SurveyQuestionType.MultipleChoice) &&
+            (question as MultipleSurveyQuestion).hasOpenChoice
+
+        if (isOpen || hasOpenChoice) {
+            openColumns.push(`${getSurveyResponse(question, index)} AS q${index}_response`)
+            columnMap[question.id] = { columnIndex, questionIndex: index, type: question.type }
+            columnIndex++
+        }
+    }
+
+    if (openColumns.length === 0) {
+        return null
+    }
+
+    const query = `SELECT
+            ${openColumns.join(',\n')},
+            events.distinct_id,
+            events.timestamp
+        FROM events
+        WHERE event = '${SurveyEventName.SENT}'
+            AND properties.${SurveyEventProperties.SURVEY_ID} = '${survey.id}'
+            ${filters.timestampFilter}
+            ${filters.answerFilterHogQLExpression}
+            ${filters.archivedResponsesFilter}
+            ${dedupFilter}
+            AND {filters}
+        ORDER BY events.timestamp DESC
+        LIMIT ${limit}`
+
+    return { query, columnMap }
+}
+
 interface SanitizeSurveyOptions {
     keepEmptyConditions?: boolean
 }

--- a/frontend/src/scenes/surveys/utils/demoDataGenerator.ts
+++ b/frontend/src/scenes/surveys/utils/demoDataGenerator.ts
@@ -8,6 +8,8 @@ import { dayjs } from 'lib/dayjs'
 import { calculateSurveyRates } from 'scenes/surveys/utils'
 
 import {
+    ChoiceQuestionProcessedResponses,
+    OpenQuestionProcessedResponses,
     ResponsesByQuestion,
     Survey,
     SurveyEventName,
@@ -20,7 +22,6 @@ import {
 } from '~/types'
 
 import { NewSurvey, SURVEY_RATING_SCALE } from '../constants'
-import { processResultsForSurveyQuestions } from '../surveyLogic'
 
 // Demo configuration constants
 export const DEMO_CONFIG = {
@@ -369,6 +370,70 @@ export function generateDemoSurveyStats(): SurveyStats {
     }
 }
 
+// Process raw demo rows directly into ResponsesByQuestion.
+// This avoids the aggregate query format that the production path uses.
+function processDemoResults(questions: SurveyQuestion[], rawResults: SurveyRawResults): ResponsesByQuestion {
+    const result: ResponsesByQuestion = {}
+
+    questions.forEach((question, index) => {
+        if (!question.id || question.type === SurveyQuestionType.Link) {
+            return
+        }
+
+        if (question.type === SurveyQuestionType.Open) {
+            const data = rawResults
+                .filter((row) => row[index] != null && row[index] !== '')
+                .map((row) => ({
+                    distinctId: row[row.length - 2] as string,
+                    response: row[index] as string,
+                    timestamp: row[row.length - 1] as string,
+                }))
+            result[question.id] = { type: SurveyQuestionType.Open, data, totalResponses: data.length }
+        } else if (
+            question.type === SurveyQuestionType.SingleChoice ||
+            question.type === SurveyQuestionType.MultipleChoice ||
+            question.type === SurveyQuestionType.Rating
+        ) {
+            const counts: Record<string, number> = {}
+            let total = 0
+
+            for (const row of rawResults) {
+                const value = row[index]
+                if (value == null || value === '') {
+                    continue
+                }
+                if (question.type === SurveyQuestionType.MultipleChoice) {
+                    const choices = value as string[]
+                    if (choices.length > 0) {
+                        total++
+                        for (const c of choices) {
+                            const cleaned = c.replace(/^['"]+|['"]+$/g, '')
+                            if (cleaned) {
+                                counts[cleaned] = (counts[cleaned] || 0) + 1
+                            }
+                        }
+                    }
+                } else {
+                    counts[value as string] = (counts[value as string] || 0) + 1
+                    total++
+                }
+            }
+
+            const data = Object.entries(counts)
+                .map(([label, value]) => ({ label, value, isPredefined: true }))
+                .sort((a, b) => b.value - a.value)
+
+            result[question.id] = {
+                type: question.type,
+                data,
+                totalResponses: total,
+            } as ChoiceQuestionProcessedResponses | OpenQuestionProcessedResponses
+        }
+    })
+
+    return result
+}
+
 export function getDemoDataForSurvey(survey: Survey | NewSurvey): {
     demoStats: ReturnType<typeof generateDemoSurveyStats>
     demoResults: SurveyRawResults
@@ -380,7 +445,7 @@ export function getDemoDataForSurvey(survey: Survey | NewSurvey): {
     const demoRates = calculateSurveyRates(demoStats)
     const demoResponseCount = demoStats[SurveyEventName.SENT].total_count
     const demoResults = generateDemoSurveyResults(survey, demoResponseCount)
-    const demoProcessedResults = processResultsForSurveyQuestions(survey.questions, demoResults)
+    const demoProcessedResults = processDemoResults(survey.questions, demoResults)
 
     return {
         demoStats: demoStats,


### PR DESCRIPTION
## Problem

the consolidated survey results query is _very slow_

see https://posthog.slack.com/archives/C07QD3LT8U9/p1771960464626299

i tested the normal query for consolidated survey results in that ^ project and the sql editor took 109 seconds to return 48 records

meanwhile the data table & stats summary queries are decently quick, but the consolidated query is what populates _most_ of the UI, so it feels even worse

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

replaces the consolidated survey results query with three smaller queries

1. get aggregated results for non-open-text questions 
2. get raw text values for the open responses
3. get persons data for each user

the first two run in parallel, 3rd runs after to enrich persons data

i think the most impactful change here is just removing the persons join from the original query 

## How did you test this code?

testing query timing in local dev is pointless, but i did run the two new queries against that same customer project for comparsion:

- original query: 109s
- new aggregate query: 2s
- new open-text query: 0.6s

also loaded the surveys page and grabbed `hogql` from the network requests:

**query 1** **\-** **UNCHANGED** `loadSurveyBaseStates`

```sql
SELECT
    event AS event_name,
    count() AS total_count,
    count(DISTINCT person_id) AS unique_persons,
    if(greater(count(), 0), min(timestamp), NULL) AS first_seen,
    if(greater(count(), 0), max(timestamp), NULL) AS last_seen
FROM
    events
WHERE
    and(equals(team_id, 1), in(event, tuple('survey shown', 'survey dismissed', 'survey sent')), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), 1, or(notEquals(event, 'survey dismissed'), equals(COALESCE(JSONExtractBool(properties, '$survey_partially_completed'), false), false)), or(notEquals(event, 'survey sent'), and(equals(1, 1), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)))))
GROUP BY
    event
LIMIT 101
OFFSET 0
```

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

**query** **2** **UNCHANGED** **\-** `surveyDismissedAndSentCount`

```sql
SELECT
    count()
FROM
    (SELECT
        person_id
    FROM
        events
    WHERE
        and(equals(team_id, 1), in(event, tuple('survey dismissed', 'survey sent')), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(notEquals(event, 'survey dismissed'), equals(COALESCE(JSONExtractBool(properties, '$survey_partially_completed'), false), false)), 1)
    GROUP BY
        person_id
    HAVING
        and(greater(sum(if(equals(event, 'survey dismissed'), 1, 0)), 0), greater(sum(if(and(equals(event, 'survey sent'), equals(1, 1)), 1, 0)), 0))) AS PersonsWithBothEvents
LIMIT 101
OFFSET 0
```

**query 3 - NEW aggregate query** `consolidatedSurveyResults` **part 1**

this query does all the counting+aggregation for non-link questions

```sql
SELECT
    '602ea93e-4195-42eb-b1b4-a7c23fa3ceef' AS question_id,
    COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_602ea93e-4195-42eb-b1b4-a7c23fa3ceef'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response'), '')) AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1, notEquals(COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_602ea93e-4195-42eb-b1b4-a7c23fa3ceef'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response'), '')), ''))
GROUP BY
    label
LIMIT 100
UNION ALL
SELECT
    '060036d5-512b-4d93-a0cd-5cab5fcd8c87' AS question_id,
    trim(arrayJoin(if(and(JSONHas(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), greater(length(JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87')), 0)), JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), JSONExtractArrayRaw(events.properties, '$survey_response_1'))), '"\'') AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1)
GROUP BY
    label
HAVING
    notEquals(label, '')
LIMIT 100
UNION ALL
SELECT
    '060036d5-512b-4d93-a0cd-5cab5fcd8c87' AS question_id,
    '__total__' AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1, greater(length(if(and(JSONHas(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), greater(length(JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87')), 0)), JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), JSONExtractArrayRaw(events.properties, '$survey_response_1'))), 0))
LIMIT 100
UNION ALL
SELECT
    '1a036448-737f-4558-be52-025397ae4130' AS question_id,
    COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_1a036448-737f-4558-be52-025397ae4130'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_2'), '')) AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1, notEquals(COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_1a036448-737f-4558-be52-025397ae4130'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_2'), '')), ''))
GROUP BY
    label
LIMIT 100
UNION ALL
SELECT
    '6fc05ea6-571c-4c40-a57e-2cc4f829ea67' AS question_id,
    COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_6fc05ea6-571c-4c40-a57e-2cc4f829ea67'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_3'), '')) AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1, notEquals(COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_6fc05ea6-571c-4c40-a57e-2cc4f829ea67'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_3'), '')), ''))
GROUP BY
    label
LIMIT 100
UNION ALL
SELECT
    'f07258fe-9107-4345-85b5-000b497f0c66' AS question_id,
    '__total__' AS label,
    count() AS cnt
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1, notEquals(COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_f07258fe-9107-4345-85b5-000b497f0c66'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_4'), '')), ''))
LIMIT 100
```

**query** **4** **\-** **NEW** **open-ended** **questions** **query** `consolidatedSurveyResults` **part** **2**

this query fetches all the raw text open-ended responses (open question + "other" choices)

```sql
SELECT
    COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_602ea93e-4195-42eb-b1b4-a7c23fa3ceef'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response'), '')) AS q0_response,
    if(and(JSONHas(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), greater(length(JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87')), 0)), JSONExtractArrayRaw(events.properties, '$survey_response_060036d5-512b-4d93-a0cd-5cab5fcd8c87'), JSONExtractArrayRaw(events.properties, '$survey_response_1')) AS q1_response,
    COALESCE(NULLIF(JSONExtractString(events.properties, '$survey_response_f07258fe-9107-4345-85b5-000b497f0c66'), ''), NULLIF(JSONExtractString(events.properties, '$survey_response_4'), '')) AS q4_response,
    events.distinct_id,
    events.timestamp
FROM
    events
WHERE
    and(equals(event, 'survey sent'), equals(properties.$survey_id, '019c8d82-e280-0000-060e-83370ef3c937'), greaterOrEquals(timestamp, '2026-01-24T00:00:00'), lessOrEquals(timestamp, '2026-02-25T23:59:59'), or(not(JSONHas(properties, '$survey_completed')), equals(JSONExtractBool(properties, '$survey_completed'), true)), 1)
ORDER BY
    events.timestamp DESC
LIMIT 50000
```

**"query"** **5** **\-** **person** **enrichment**

```
http://localhost:8010/api/environments/1/persons/batch_by_distinct_ids/
```

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->