### PR TITLE
fix(flags): close loopholes in flag dependency guards

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -98,12 +98,19 @@ LOCAL_EVALUATION_ETAG_COUNTER = Counter(
 )
 
 
-def find_dependent_flags(flag_to_check: FeatureFlag) -> list[FeatureFlag]:
-    """Find all active flags that depend on the given flag via flag-type filter properties."""
+def find_dependent_flags(flag_to_check: FeatureFlag, active_only: bool = True) -> list[FeatureFlag]:
+    """Find flags that depend on the given flag via flag-type filter properties.
+
+    By default returns only active dependents (for disabling guards). Pass active_only=False
+    to include inactive dependents too (for deletion guards), since deleting a flag creates
+    irrecoverable orphaned references even when the dependent is inactive.
+    """
+    qs = FeatureFlag.objects.filter(team=flag_to_check.team, deleted=False)
+    if active_only:
+        qs = qs.filter(active=True)
     return list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=flag_to_check.team, deleted=False, active=True)
-        .exclude(id=flag_to_check.id)
+        qs.exclude(id=flag_to_check.id)
         .extra(
             where=[
                 """
@@ -123,11 +130,15 @@ def find_dependent_flags(flag_to_check: FeatureFlag) -> list[FeatureFlag]:
 
 def find_dependent_flags_batch(
     flags_to_check: list[FeatureFlag],
+    active_only: bool = True,
 ) -> dict[int, list[FeatureFlag]]:
-    """Find all active flags that depend on any of the given flags via flag-type filter properties.
+    """Find flags that depend on any of the given flags via flag-type filter properties.
 
     Returns a dict mapping each flag ID to its list of dependent flags.
     This is more efficient than calling find_dependent_flags for each flag individually.
+
+    By default returns only active dependents. Pass active_only=False to include inactive
+    dependents (for deletion guards).
     """
     if not flags_to_check:
         return {}
@@ -140,10 +151,13 @@ def find_dependent_flags_batch(
     # We need to find any flag that depends on ANY of these flags
     or_conditions = " OR ".join(["prop->>'key' = %s" for _ in flag_ids])
 
+    qs = FeatureFlag.objects.filter(team=team, deleted=False)
+    if active_only:
+        qs = qs.filter(active=True)
+
     dependent_flags = list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=team, deleted=False, active=True)
-        .exclude(id__in=flag_ids)
+        qs.exclude(id__in=flag_ids)
         .extra(
             where=[
                 f"""
@@ -1079,8 +1093,9 @@ class FeatureFlagSerializer(
                     f"Cannot delete a feature flag that is linked to active experiment(s) with ID(s): {', '.join(map(str, experiment_ids))}. Please delete the experiment(s) before deleting the flag."
                 )
 
-            # Check for other flags that depend on this flag
-            dependent_flags = self._find_dependent_flags(instance)
+            # Check for other flags that depend on this flag (including inactive ones,
+            # since deletion is irreversible and would leave orphaned references)
+            dependent_flags = self._find_dependent_flags(instance, active_only=False)
             if dependent_flags:
                 dependent_flag_names = [f"{flag.key} (ID: {flag.id})" for flag in dependent_flags[:5]]
                 if len(dependent_flags) > 5:
@@ -1120,15 +1135,23 @@ class FeatureFlagSerializer(
 
         # Check for dependency conflicts when enabling a flag
         if "active" in validated_data and validated_data["active"] is True and instance.active is False:
-            # Check if this flag depends on any disabled flags
-            disabled_dependencies = self._find_disabled_dependencies(instance)
-            if disabled_dependencies:
-                disabled_flag_names = [f"{flag.key} (ID: {flag.id})" for flag in disabled_dependencies[:5]]
-                if len(disabled_dependencies) > 5:
-                    disabled_flag_names.append(f"and {len(disabled_dependencies) - 5} more")
+            # Check if this flag depends on any disabled or deleted flags
+            disabled_deps, missing_dep_ids = self._find_unavailable_dependencies(instance)
+            if disabled_deps or missing_dep_ids:
+                error_parts = []
+                if disabled_deps:
+                    names = [f"{f.key} (ID: {f.id})" for f in disabled_deps[:5]]
+                    if len(disabled_deps) > 5:
+                        names.append(f"and {len(disabled_deps) - 5} more")
+                    error_parts.append(f"disabled flags: {', '.join(names)}")
+                if missing_dep_ids:
+                    id_strs = [str(dep_id) for dep_id in missing_dep_ids[:5]]
+                    if len(missing_dep_ids) > 5:
+                        id_strs.append(f"and {len(missing_dep_ids) - 5} more")
+                    error_parts.append(f"deleted or missing flags with IDs: {', '.join(id_strs)}")
                 raise exceptions.ValidationError(
-                    f"Cannot enable this feature flag because it depends on disabled flags: {', '.join(disabled_flag_names)}. "
-                    f"Please enable the dependency flags first."
+                    f"Cannot enable this feature flag because it depends on {' and '.join(error_parts)}. "
+                    f"Please update the flag's filters to remove these dependencies."
                 )
 
         # First apply all transformations to validated_data
@@ -1264,33 +1287,46 @@ class FeatureFlagSerializer(
             and validated_data[field] != getattr(current_instance, field)
         ]
 
-    def _find_dependent_flags(self, flag_to_check: FeatureFlag) -> list[FeatureFlag]:
-        """Find all active flags that depend on the given flag."""
-        return find_dependent_flags(flag_to_check)
+    def _find_dependent_flags(self, flag_to_check: FeatureFlag, active_only: bool = True) -> list[FeatureFlag]:
+        """Find flags that depend on the given flag."""
+        return find_dependent_flags(flag_to_check, active_only=active_only)
 
-    def _find_disabled_dependencies(self, flag_to_check: FeatureFlag) -> list[FeatureFlag]:
-        """Find all disabled flags that the given flag depends on."""
-        dependency_ids = []
+    def _find_unavailable_dependencies(self, flag_to_check: FeatureFlag) -> tuple[list[FeatureFlag], list[int]]:
+        """Find dependencies that are disabled or deleted/missing.
+
+        Returns (disabled_flags, missing_dependency_ids) where:
+        - disabled_flags: non-deleted but inactive dependency flags
+        - missing_dependency_ids: IDs of dependencies that are deleted or don't exist
+        """
+        dependency_ids: list[int] = []
 
         # Extract flag dependencies from filters
         filters = flag_to_check.filters or {}
         for group in filters.get("groups", []):
             for prop in group.get("properties", []):
                 if prop.get("type") == "flag":
-                    dependency_ids.append(int(prop.get("key")))
+                    try:
+                        dependency_ids.append(int(prop.get("key")))
+                    except (ValueError, TypeError):
+                        pass
 
         if not dependency_ids:
-            return []
+            return [], []
 
-        # Find disabled dependency flags
-        return list(
+        # Find all non-deleted dependencies to determine which are disabled vs missing
+        existing_deps = list(
             FeatureFlag.objects.filter(
                 team=flag_to_check.team,
                 id__in=dependency_ids,
                 deleted=False,
-                active=False,
             ).order_by("key")
         )
+        existing_ids = {f.id for f in existing_deps}
+
+        disabled_deps = [f for f in existing_deps if not f.active]
+        missing_ids = [dep_id for dep_id in dependency_ids if dep_id not in existing_ids]
+
+        return disabled_deps, missing_ids
 
     def _update_filters(self, validated_data):
         if "get_filters" in validated_data:
@@ -1813,9 +1849,9 @@ class FeatureFlagViewSet(
 
     @action(methods=["GET"], detail=True, required_scopes=["feature_flag:read"])
     def dependent_flags(self, request: request.Request, **kwargs):
-        """Get other active flags that depend on this flag."""
+        """Get other non-deleted flags that depend on this flag."""
         feature_flag: FeatureFlag = self.get_object()
-        dependent_flags = find_dependent_flags(feature_flag)
+        dependent_flags_list = find_dependent_flags(feature_flag, active_only=False)
         return Response(
             [
                 {
@@ -1823,7 +1859,7 @@ class FeatureFlagViewSet(
                     "key": flag.key,
                     "name": flag.name or flag.key,
                 }
-                for flag in dependent_flags
+                for flag in dependent_flags_list
             ],
             status=200,
         )
@@ -2091,8 +2127,8 @@ class FeatureFlagViewSet(
         queryset = queryset.prefetch_related("features", "experiment_set")
         flags_list = list(queryset)
 
-        # Batch query for dependent flags
-        dependent_flags_map = find_dependent_flags_batch(flags_list)
+        # Batch query for dependent flags (including inactive, since deletion is irreversible)
+        dependent_flags_map = find_dependent_flags_batch(flags_list, active_only=False)
 
         deleted = []
         errors = []

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -10241,6 +10241,44 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
         base_flag.refresh_from_db()
         assert base_flag.deleted is False
 
+    def test_bulk_delete_blocked_by_inactive_dependent_flags(self):
+        """Test that flags with inactive (but non-deleted) dependents cannot be bulk deleted."""
+        base_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="base_flag",
+            filters={"groups": [{"rollout_percentage": 100, "properties": []}]},
+        )
+        dependent_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="inactive_dependent",
+            active=False,
+            filters={
+                "groups": [
+                    {
+                        "rollout_percentage": 100,
+                        "properties": [{"key": str(base_flag.id), "type": "flag", "value": "true"}],
+                    }
+                ]
+            },
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_delete/",
+            {"ids": [base_flag.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["deleted"]) == 0
+        assert len(data["errors"]) == 1
+        assert "other flags depend on it" in data["errors"][0]["reason"]
+        assert dependent_flag.key in data["errors"][0]["reason"]
+
+        base_flag.refresh_from_db()
+        assert base_flag.deleted is False
+
     def test_bulk_delete_renames_key_with_soft_deleted_experiment(self):
         """Test that deleting a flag with a soft-deleted experiment renames the key."""
         flag = FeatureFlag.objects.create(

--- a/posthog/api/test/test_feature_flag_dependency_deletion.py
+++ b/posthog/api/test/test_feature_flag_dependency_deletion.py
@@ -82,8 +82,8 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
         flag.refresh_from_db()
         self.assertTrue(flag.deleted)
 
-    def test_can_delete_flag_with_inactive_dependents(self):
-        """Test that a flag can be deleted if dependent flags are inactive."""
+    def test_cannot_delete_flag_with_inactive_dependents(self):
+        """Deletion is irreversible, so even inactive dependents block it to prevent orphaned references."""
         # Create base flag
         base_flag = self.create_flag("base_flag")
 
@@ -92,14 +92,16 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
         dependent_flag.active = False
         dependent_flag.save()
 
-        # Should be able to delete base flag
+        # Should NOT be able to delete base flag
         response = self.client.patch(
             f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/",
             {"deleted": True},
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Cannot delete this feature flag because other flags depend on it", response.json()["detail"])
+        self.assertIn(f"{dependent_flag.key} (ID: {dependent_flag.id})", response.json()["detail"])
 
     def test_can_delete_flag_with_deleted_dependents(self):
         """Test that a flag can be deleted if dependent flags are already deleted."""
@@ -283,11 +285,26 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()), 1)
 
-    def test_dependent_flags_with_inactive_dependencies(self):
-        """Test dependent_flags returns empty list when dependent flags are inactive."""
+    def test_dependent_flags_includes_inactive_dependencies(self):
+        """Test dependent_flags returns inactive dependents so the UI can show the full picture."""
         base_flag = self.create_flag("base_flag")
         dependent_flag = self.create_flag("dependent_flag", dependencies=[base_flag.id])
         dependent_flag.active = False
+        dependent_flag.save()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/dependent_flags/",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]["id"], dependent_flag.id)
+
+    def test_dependent_flags_excludes_deleted_dependencies(self):
+        """Test dependent_flags does not return deleted dependents."""
+        base_flag = self.create_flag("base_flag")
+        dependent_flag = self.create_flag("dependent_flag", dependencies=[base_flag.id])
+        dependent_flag.deleted = True
         dependent_flag.save()
 
         response = self.client.get(

--- a/posthog/api/test/test_feature_flag_dependency_disabling.py
+++ b/posthog/api/test/test_feature_flag_dependency_disabling.py
@@ -458,3 +458,155 @@ class TestFeatureFlagDependencyDisabling(APIBaseTest):
         error_detail = response.json()["detail"]
         self.assertIn(f"Cannot create dependency on disabled flag '{disabled_flag.key}'", error_detail)
         self.assertIn(f"ID: {disabled_flag.id}", error_detail)
+
+    def test_cannot_enable_flag_with_deleted_dependency(self):
+        """Test that a flag cannot be enabled if its dependency has been deleted."""
+        # Create base flag and dependent flag
+        base_flag = self.create_flag("base_flag")
+        dependent_flag = self.create_flag("dependent_flag", dependencies=[base_flag.id], active=False)
+
+        # Delete the base flag directly (bypassing guards to simulate legacy data)
+        base_flag.deleted = True
+        base_flag.save()
+
+        # Try to enable dependent flag
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{dependent_flag.id}/",
+            {"active": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_detail = response.json()["detail"]
+        self.assertIn("Cannot enable this feature flag because it depends on", error_detail)
+        self.assertIn("deleted or missing flags with IDs", error_detail)
+        self.assertIn(str(base_flag.id), error_detail)
+
+    def test_cannot_enable_flag_with_both_disabled_and_deleted_dependencies(self):
+        """Test error message when flag has both disabled and deleted dependencies."""
+        # Create three flags
+        disabled_flag = self.create_flag("disabled_flag")
+        deleted_flag = self.create_flag("deleted_flag")
+        dependent_flag = self.create_flag(
+            "dependent_flag", dependencies=[disabled_flag.id, deleted_flag.id], active=False
+        )
+
+        # Disable one, delete the other
+        disabled_flag.active = False
+        disabled_flag.save()
+        deleted_flag.deleted = True
+        deleted_flag.save()
+
+        # Try to enable dependent flag
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{dependent_flag.id}/",
+            {"active": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_detail = response.json()["detail"]
+        self.assertIn("disabled flags", error_detail)
+        self.assertIn(f"{disabled_flag.key} (ID: {disabled_flag.id})", error_detail)
+        self.assertIn("deleted or missing flags with IDs", error_detail)
+        self.assertIn(str(deleted_flag.id), error_detail)
+
+    def test_cannot_enable_flag_with_nonexistent_dependency(self):
+        """Test that a flag cannot be enabled if its dependency ID never existed."""
+        nonexistent_id = 999999999
+        dependent_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="orphaned_flag",
+            name="Orphaned Flag",
+            active=False,
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": str(nonexistent_id),
+                                "type": "flag",
+                                "value": "true",
+                                "operator": "flag_evaluates_to",
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{dependent_flag.id}/",
+            {"active": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_detail = response.json()["detail"]
+        self.assertIn("deleted or missing flags with IDs", error_detail)
+        self.assertIn(str(nonexistent_id), error_detail)
+
+    def test_cannot_create_dependency_on_deleted_flag(self):
+        """Test that creating a dependency on a deleted flag is prevented."""
+        deleted_flag = self.create_flag("deleted_flag")
+        deleted_flag.deleted = True
+        deleted_flag.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "New Flag",
+                "key": "new_flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": str(deleted_flag.id),
+                                    "type": "flag",
+                                    "value": "true",
+                                    "operator": "flag_evaluates_to",
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        }
+                    ]
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_detail = response.json()["detail"]
+        self.assertIn("non-existent flag", error_detail)
+
+    def test_cannot_create_dependency_on_nonexistent_flag(self):
+        """Test that creating a dependency on a flag ID that never existed is prevented."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "New Flag",
+                "key": "new_flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "999999999",
+                                    "type": "flag",
+                                    "value": "true",
+                                    "operator": "flag_evaluates_to",
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        }
+                    ]
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_detail = response.json()["detail"]
+        self.assertIn("non-existent flag", error_detail)

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -284,7 +284,7 @@ export const featureFlagsDashboardCreate = async (
 }
 
 /**
- * Get other active flags that depend on this flag.
+ * Get other non-deleted flags that depend on this flag.
  */
 export const getFeatureFlagsDependentFlagsRetrieveUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/feature_flags/${id}/dependent_flags/`


### PR DESCRIPTION
## Summary

Closes loopholes in feature flag dependency guards that allowed orphaned references to be created, causing ~3M tombstone metric events/hr (`posthog_tombstone_total{operation="flag_dependency_missing"}`) in production.

### Root cause

Two gaps in the dependency validation:

1. **Deletion guard only checked active dependents** — deactivating a dependent flag then deleting its dependency was allowed, creating an irrecoverable orphaned reference
2. **Enable guard only checked for disabled dependencies** — deleted or completely missing dependencies were invisible, allowing flags with broken references to be re-enabled

These gaps were exploited by normal workflows: survey targeting flags would be deactivated when a survey ended, the dependency flag deleted, then the survey restarted (re-enabling the targeting flag with a broken dependency).

### Changes

- **Deletion guard**: now blocks when *any* non-deleted flag depends on the target (not just active ones), since deletion is irreversible
- **Enable guard**: now detects both disabled *and* deleted/missing dependencies, with distinct error messages for each
- **Batch deletion**: uses the same stricter check
- **`dependent_flags` API**: returns all non-deleted dependents (including inactive) so the frontend shows the full picture

### Affected teams (from production investigation)

| Team | Missing Flag ID | Referencing Flags | Status |
|------|----------------|-------------------|--------|
| 55348 | 257618) | 377204, 313975 | Both active |
| 129345 | 287479 (deleted) | 401419, 257311 | Both inactive |
| 21229 | 108982 (deleted) | 141720 | Inactive |
| 55742 (EU) | 71150, 73950 (deleted) | 94720, 120104, 116606 | Mixed |

These existing orphaned references will need a separate data cleanup. This PR prevents new ones from being created.

## Test plan

- [x] `test_cannot_delete_flag_with_inactive_dependents` — deletion blocked by inactive dependent
- [x] `test_bulk_delete_blocked_by_inactive_dependent_flags` — batch deletion blocked
- [x] `test_cannot_enable_flag_with_deleted_dependency` — enable blocked by deleted dep
- [x] `test_cannot_enable_flag_with_nonexistent_dependency` — enable blocked by missing dep
- [x] `test_cannot_enable_flag_with_both_disabled_and_deleted_dependencies` — combined error message
- [x] `test_cannot_create_dependency_on_deleted_flag` — creation guard for deleted flags
- [x] `test_cannot_create_dependency_on_nonexistent_flag` — creation guard for missing flags
- [x] `test_dependent_flags_excludes_deleted_dependencies` — endpoint excludes deleted
- [x] `test_dependent_flags_includes_inactive_dependencies` — endpoint includes inactive
- [x] All 246 existing feature flag tests pass (no regressions)