### PR TITLE
feat(llma): reduce sentiment batch size from 10 to 5 trace IDs

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -28,7 +28,7 @@ MAX_RETRY_ATTEMPTS = 2  # retry policy for both workflow and activity
 
 # API config
 CACHE_TTL = 60 * 60 * 24  # 24 hours — events are immutable once ingested
-BATCH_MAX_TRACE_IDS = 10
+BATCH_MAX_TRACE_IDS = 5
 
 # HogQL query template for fetching $ai_generation events.
 # Uses a window function to cap rows per trace at the ClickHouse level,

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -391,7 +391,7 @@ export interface PatchedLLMProviderKeyApi {
 export interface SentimentRequestApi {
     /**
      * @minItems 1
-     * @maxItems 10
+     * @maxItems 5
      */
     trace_ids: string[]
     force_refresh?: boolean

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
@@ -43,7 +43,7 @@ function isValidSentimentResult(value: unknown): value is SentimentResult {
     return !!value && typeof value === 'object' && 'label' in value && !('error' in value)
 }
 
-const BATCH_MAX_SIZE = 10
+const BATCH_MAX_SIZE = 5
 
 function chunk<T>(arr: T[], size: number): T[][] {
     const chunks: T[][] = []


### PR DESCRIPTION
## Problem

Sentiment classification activities take ~17s per workflow when batching 10 trace IDs.
With `MAX_CONCURRENT_ACTIVITIES=1` per pod, this means users wait ~17s for results
to appear in the traces table after scrolling.

## Changes

- `BATCH_MAX_TRACE_IDS`: 10 -> 5

Halves the work per workflow so activities finish in ~8s instead of ~17s, returning
results to the UI faster. With 12 pods available (charts PR #8552), doubling the
number of workflows has no capacity impact -- Temporal distributes them across idle pods.

## How did you test this code?

Monitoring prod-us after deploying PR #48980 (query-level workload reduction).
Current metrics show inference is the dominant cost at ~15-17s per 10-trace batch.
Halving batch size should roughly halve that.

do not publish to changelog