### PR TITLE
feat(sql-editor): auto chart type (take 2)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -4,6 +4,7 @@ import { ChartDisplayCategory, ChartDisplayType, Region, SDKKey, SSOProvider } f
 
 // Sync with backend DISPLAY_TYPES_TO_CATEGORIES
 export const DISPLAY_TYPES_TO_CATEGORIES: Record<ChartDisplayType, ChartDisplayCategory> = {
+    [ChartDisplayType.Auto]: ChartDisplayCategory.TimeSeries,
     [ChartDisplayType.ActionsLineGraph]: ChartDisplayCategory.TimeSeries,
     [ChartDisplayType.ActionsBar]: ChartDisplayCategory.TimeSeries,
     [ChartDisplayType.ActionsUnstackedBar]: ChartDisplayCategory.TimeSeries,

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -27,7 +27,7 @@ import { AxisBreakdownSeries, seriesBreakdownLogic } from './seriesBreakdownLogi
 import { YSeriesLogicProps, YSeriesSettingsTab, ySeriesLogic } from './ySeriesLogic'
 
 export const SeriesTab = (): JSX.Element => {
-    const { visualizationType } = useValues(dataVisualizationLogic)
+    const { effectiveVisualizationType } = useValues(dataVisualizationLogic)
     const {
         columns,
         numericalColumns,
@@ -47,7 +47,7 @@ export const SeriesTab = (): JSX.Element => {
     const hideAddYSeries = yData.length >= numericalColumns.length
     const hideAddSeriesBreakdown = !(!showSeriesBreakdown && selectedXAxis && columns.length > yData.length)
 
-    if (visualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
+    if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         return <HeatmapSeriesTab />
     }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -38,18 +38,18 @@ const TABS_TO_CONTENT: Record<SideBarTab, TabContent> = {
 }
 
 export const SideBar = (): JSX.Element => {
-    const { activeSideBarTab, visualizationType } = useValues(dataVisualizationLogic)
+    const { activeSideBarTab, effectiveVisualizationType } = useValues(dataVisualizationLogic)
     const { setSideBarTab } = useActions(dataVisualizationLogic)
 
     const tabs: LemonTab<string>[] = useMemo(
         () =>
             Object.entries(TABS_TO_CONTENT)
-                .filter(([_, tab]) => tab.shouldShow(visualizationType))
+                .filter(([_, tab]) => tab.shouldShow(effectiveVisualizationType))
                 .map(([key, tab]) => ({
                     label: tab.label,
                     key,
                 })),
-        [visualizationType]
+        [effectiveVisualizationType]
     )
 
     return (

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -13,9 +13,47 @@ interface TableDisplayProps extends Pick<LemonSelectProps<ChartDisplayType>, 'di
 
 export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
-    const { visualizationType } = useValues(dataVisualizationLogic)
+    const { autoVisualizationType, hasDateTimeColumns, visualizationType } = useValues(dataVisualizationLogic)
+
+    const displayTypeLabels: Record<ChartDisplayType, string> = {
+        [ChartDisplayType.Auto]: 'Auto',
+        [ChartDisplayType.ActionsLineGraph]: 'Line chart',
+        [ChartDisplayType.ActionsBar]: 'Bar chart',
+        [ChartDisplayType.ActionsUnstackedBar]: 'Unstacked bar chart',
+        [ChartDisplayType.ActionsStackedBar]: 'Stacked bar chart',
+        [ChartDisplayType.ActionsAreaGraph]: 'Area chart',
+        [ChartDisplayType.ActionsLineGraphCumulative]: 'Cumulative line chart',
+        [ChartDisplayType.BoldNumber]: 'Big number',
+        [ChartDisplayType.ActionsPie]: 'Pie chart',
+        [ChartDisplayType.ActionsBarValue]: 'Value chart',
+        [ChartDisplayType.ActionsTable]: 'Table',
+        [ChartDisplayType.WorldMap]: 'World map',
+        [ChartDisplayType.CalendarHeatmap]: 'Calendar heatmap',
+        [ChartDisplayType.TwoDimensionalHeatmap]: '2d heatmap',
+    }
+
+    const renderDisplayTypeLabel = (displayType: ChartDisplayType): string => {
+        const selectedLabel = displayTypeLabels[displayType] ?? displayType
+
+        if (displayType !== ChartDisplayType.Auto) {
+            return selectedLabel
+        }
+
+        const resolvedLabel = displayTypeLabels[autoVisualizationType] ?? autoVisualizationType
+        return `Auto (${resolvedLabel})`
+    }
 
     const options: LemonSelectOptions<ChartDisplayType> = [
+        {
+            title: 'Auto',
+            options: [
+                {
+                    value: ChartDisplayType.Auto,
+                    icon: <IconTrends />,
+                    label: renderDisplayTypeLabel(ChartDisplayType.Auto),
+                },
+            ],
+        },
         {
             title: 'Table',
             options: [
@@ -38,6 +76,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.ActionsLineGraph,
                     icon: <IconTrends />,
                     label: 'Line chart',
+                    disabledReason: !hasDateTimeColumns ? 'Requires a date or datetime column' : undefined,
                 },
                 {
                     value: ChartDisplayType.ActionsBar,
@@ -53,6 +92,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.ActionsAreaGraph,
                     icon: <IconAreaChart />,
                     label: 'Area chart',
+                    disabledReason: !hasDateTimeColumns ? 'Requires a date or datetime column' : undefined,
                 },
                 {
                     value: ChartDisplayType.TwoDimensionalHeatmap,
@@ -67,6 +107,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
         <LemonSelect
             disabledReason={disabledReason}
             value={visualizationType}
+            renderButtonContent={() => renderDisplayTypeLabel(visualizationType)}
             onChange={(value) => {
                 setVisualizationType(value)
             }}

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -161,7 +161,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
 
     const {
         query,
-        visualizationType,
+        effectiveVisualizationType,
         showResultControls,
         sourceFeatures,
         response,
@@ -214,7 +214,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 <StatelessInsightLoadingState queryId={queryId} pollResponse={pollResponse} />
             </div>
         )
-    } else if (visualizationType === ChartDisplayType.ActionsTable) {
+    } else if (effectiveVisualizationType === ChartDisplayType.ActionsTable) {
         component = (
             <Table
                 uniqueKey={props.uniqueKey}
@@ -224,10 +224,10 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
             />
         )
     } else if (
-        visualizationType === ChartDisplayType.ActionsLineGraph ||
-        visualizationType === ChartDisplayType.ActionsBar ||
-        visualizationType === ChartDisplayType.ActionsAreaGraph ||
-        visualizationType === ChartDisplayType.ActionsStackedBar
+        effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
+        effectiveVisualizationType === ChartDisplayType.ActionsBar ||
+        effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
+        effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
     ) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         const _yData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.seriesData : yData
@@ -236,23 +236,23 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 className="p-2"
                 xData={_xData}
                 yData={_yData}
-                visualizationType={visualizationType}
+                visualizationType={effectiveVisualizationType}
                 chartSettings={chartSettings}
                 dashboardId={dashboardId}
                 goalLines={goalLines}
                 presetChartHeight={presetChartHeight}
             />
         )
-    } else if (visualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
+    } else if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         component = <TwoDimensionalHeatmap />
-    } else if (visualizationType === ChartDisplayType.BoldNumber) {
+    } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     }
 
     return (
         <div
             className={clsx('DataVisualization flex flex-1 gap-2', {
-                'h-full': visualizationType !== ChartDisplayType.ActionsTable,
+                'h-full': effectiveVisualizationType !== ChartDisplayType.ActionsTable,
             })}
         >
             <div className="relative w-full flex flex-col gap-4 flex-1 overflow-hidden">
@@ -293,7 +293,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                                     {props.exportContext && (
                                         <ExportButton
                                             disabledReason={
-                                                visualizationType != ChartDisplayType.ActionsTable &&
+                                                effectiveVisualizationType !== ChartDisplayType.ActionsTable &&
                                                 'Only table results are exportable'
                                             }
                                             type="secondary"

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -1,0 +1,327 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { dataNodeLogic } from '../DataNode/dataNodeLogic'
+import { DataVisualizationLogicProps, dataVisualizationLogic } from './dataVisualizationLogic'
+
+const testKey = 'test-auto-visualization'
+const dataNodeCollectionId = 'new-test-SQL'
+
+const defaultQuery: DataVisualizationNode = {
+    kind: NodeKind.DataVisualizationNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: 'select 1',
+    },
+    display: ChartDisplayType.Auto,
+}
+
+describe('dataVisualizationLogic', () => {
+    let logic: ReturnType<typeof dataVisualizationLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+
+        logic = dataVisualizationLogic({
+            key: testKey,
+            query: defaultQuery,
+            dataNodeCollectionId,
+        } as DataVisualizationLogicProps)
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    test.each([
+        {
+            name: 'shows a big number for a single numeric column',
+            response: {
+                columns: ['value'],
+                types: [['value', 'Int64']],
+                results: [[1]],
+            },
+            expected: ChartDisplayType.BoldNumber,
+        },
+        {
+            name: 'shows a line chart when a timestamp column is present',
+            response: {
+                columns: ['timestamp', 'value'],
+                types: [
+                    ['timestamp', 'DateTime'],
+                    ['value', 'Int64'],
+                ],
+                results: [
+                    ['2025-01-01 00:00:00', 1],
+                    ['2025-01-02 00:00:00', 2],
+                ],
+            },
+            expected: ChartDisplayType.ActionsLineGraph,
+        },
+        {
+            name: 'shows a bar chart when only one timeseries point is present',
+            response: {
+                columns: ['timestamp', 'value'],
+                types: [
+                    ['timestamp', 'DateTime'],
+                    ['value', 'Int64'],
+                ],
+                results: [['2025-01-01 00:00:00', 1]],
+            },
+            expected: ChartDisplayType.ActionsBar,
+        },
+        {
+            name: 'shows a 2d heatmap for two string columns and one numeric column',
+            response: {
+                columns: ['region', 'segment', 'count'],
+                types: [
+                    ['region', 'String'],
+                    ['segment', 'String'],
+                    ['count', 'Int64'],
+                ],
+                results: [['US', 'Enterprise', 10]],
+            },
+            expected: ChartDisplayType.TwoDimensionalHeatmap,
+        },
+        {
+            name: 'shows a bar chart for non-time-series numeric data',
+            response: {
+                columns: ['group', 'value'],
+                types: [
+                    ['group', 'String'],
+                    ['value', 'Int64'],
+                ],
+                results: [['A', 1]],
+            },
+            expected: ChartDisplayType.ActionsBar,
+        },
+    ])('$name', async ({ response, expected }) => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse(response)
+
+        await expectLogic(logic).toMatchValues({
+            effectiveVisualizationType: expected,
+        })
+    })
+
+    it('auto-selects the first non-y-axis column as x-axis for bar charts', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['fruit', 'count'],
+            types: [
+                ['fruit', 'String'],
+                ['count', 'Int64'],
+            ],
+            results: [
+                ['banana', 1],
+                ['pineapple', 2],
+            ],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            selectedXAxis: 'fruit',
+            selectedYAxis: [
+                {
+                    name: 'count',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+            ],
+        })
+    })
+
+    it('resets axes when y-axis columns are no longer numerical', async () => {
+        const dataNode = dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId })
+
+        dataNode.actions.setResponse({
+            columns: ['1', '2', '3'],
+            types: [
+                ['1', 'Int64'],
+                ['2', 'Int64'],
+                ['3', 'Int64'],
+            ],
+            results: [[1, 2, 3]],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            selectedXAxis: null,
+            selectedYAxis: [
+                {
+                    name: '1',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+                {
+                    name: '2',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+                {
+                    name: '3',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+            ],
+        })
+
+        dataNode.actions.setResponse({
+            columns: ['1', '2', '3'],
+            types: [
+                ['1', 'String'],
+                ['2', 'Int64'],
+                ['3', 'String'],
+            ],
+            results: [['a', 2, 'b']],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            selectedXAxis: '1',
+            selectedYAxis: [
+                {
+                    name: '2',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+            ],
+        })
+    })
+
+    it('does not resolve to a time-series chart without a date column', async () => {
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
+
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['first_value', 'second_value'],
+            types: [
+                ['first_value', 'Int64'],
+                ['second_value', 'Int64'],
+            ],
+            results: [[1, 2]],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            effectiveVisualizationType: ChartDisplayType.ActionsBar,
+        })
+    })
+
+    it('fills x-axis labels with empty values when no x-axis is selected', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['first_value', 'second_value', 'third_value'],
+            types: [
+                ['first_value', 'Int64'],
+                ['second_value', 'Int64'],
+                ['third_value', 'Int64'],
+            ],
+            results: [
+                [1, 2, 3],
+                [4, 5, 6],
+            ],
+        })
+
+        logic.actions.clearAxis()
+
+        await expectLogic(logic).toMatchValues({
+            xData: {
+                column: {
+                    name: 'None',
+                    type: {
+                        name: 'STRING',
+                        isNumerical: false,
+                    },
+                    label: 'None',
+                    dataIndex: -1,
+                },
+                data: ['', ''],
+            },
+        })
+    })
+
+    it('does not resolve to a time-series chart when there is only one row', async () => {
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
+
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['timestamp', 'value'],
+            types: [
+                ['timestamp', 'DateTime'],
+                ['value', 'Int64'],
+            ],
+            results: [['2025-01-01 00:00:00', 1]],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            effectiveVisualizationType: ChartDisplayType.ActionsBar,
+        })
+    })
+
+    it('auto-fills 2d heatmap columns when auto resolves to heatmap', async () => {
+        logic.actions.toggleChartSettingsPanel(true)
+
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['region', 'segment', 'count'],
+            types: [
+                ['region', 'String'],
+                ['segment', 'String'],
+                ['count', 'Int64'],
+            ],
+            results: [['US', 'Enterprise', 10]],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            effectiveVisualizationType: ChartDisplayType.TwoDimensionalHeatmap,
+            chartSettings: {
+                heatmap: {
+                    xAxisColumn: 'region',
+                    yAxisColumn: 'segment',
+                    valueColumn: 'count',
+                },
+            },
+        })
+    })
+    it('auto-fills 2d heatmap columns when selecting auto on heatmap data', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['region', 'segment', 'count'],
+            types: [
+                ['region', 'String'],
+                ['segment', 'String'],
+                ['count', 'Int64'],
+            ],
+            results: [['US', 'Enterprise', 10]],
+        })
+
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsBar)
+        logic.actions.setVisualizationType(ChartDisplayType.Auto)
+
+        await expectLogic(logic).toMatchValues({
+            visualizationType: ChartDisplayType.Auto,
+            effectiveVisualizationType: ChartDisplayType.TwoDimensionalHeatmap,
+            chartSettings: {
+                heatmap: {
+                    xAxisColumn: 'region',
+                    yAxisColumn: 'segment',
+                    valueColumn: 'count',
+                },
+            },
+        })
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -221,7 +221,7 @@ describe('dataVisualizationLogic', () => {
         })
 
         await expectLogic(logic).toMatchValues({
-            effectiveVisualizationType: ChartDisplayType.ActionsBar,
+            effectiveVisualizationType: ChartDisplayType.ActionsLineGraph,
         })
     })
 
@@ -270,7 +270,26 @@ describe('dataVisualizationLogic', () => {
         })
 
         await expectLogic(logic).toMatchValues({
-            effectiveVisualizationType: ChartDisplayType.ActionsBar,
+            effectiveVisualizationType: ChartDisplayType.ActionsLineGraph,
+        })
+    })
+
+    it('respects explicit line chart display even when auto would choose heatmap', async () => {
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
+
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['bucket', 'flag_state', 'reverse_proxy'],
+            types: [
+                ['bucket', 'String'],
+                ['flag_state', 'String'],
+                ['reverse_proxy', 'Float64'],
+            ],
+            results: [['2025-01-01', 'control', 0.2]],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            autoVisualizationType: ChartDisplayType.TwoDimensionalHeatmap,
+            effectiveVisualizationType: ChartDisplayType.ActionsLineGraph,
         })
     })
 

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -239,6 +239,49 @@ const isNumericalType = (type: ColumnScalar): boolean => {
     return false
 }
 
+const isTimeSeriesVisualizationType = (visualizationType: ChartDisplayType): boolean => {
+    return (
+        visualizationType === ChartDisplayType.ActionsLineGraph ||
+        visualizationType === ChartDisplayType.ActionsAreaGraph ||
+        visualizationType === ChartDisplayType.ActionsLineGraphCumulative
+    )
+}
+
+const resolveNonTimeSeriesVisualizationType = (columns: Column[]): ChartDisplayType => {
+    const stringColumns = columns.filter((column) => column.type.name === 'STRING')
+    const numericalColumns = columns.filter((column) => column.type.isNumerical)
+
+    if (stringColumns.length >= 2 && numericalColumns.length >= 1) {
+        return ChartDisplayType.TwoDimensionalHeatmap
+    }
+
+    if (numericalColumns.length === 1 && columns.length === 1) {
+        return ChartDisplayType.BoldNumber
+    }
+
+    if (numericalColumns.length > 0) {
+        return ChartDisplayType.ActionsBar
+    }
+
+    return ChartDisplayType.ActionsTable
+}
+
+const hasTimeSeriesData = (columns: Column[], response: AnyResponseType | null): boolean => {
+    const hasDateColumn = columns.some((column) => ['DATE', 'DATETIME'].includes(column.type.name))
+    const hasNumericColumn = columns.some((column) => column.type.isNumerical)
+    const results = response?.['results'] ?? response?.['result'] ?? []
+
+    return hasDateColumn && hasNumericColumn && results.length > 1
+}
+
+const getAutoVisualizationType = (columns: Column[], response: AnyResponseType | null): ChartDisplayType => {
+    if (hasTimeSeriesData(columns, response)) {
+        return ChartDisplayType.ActionsLineGraph
+    }
+
+    return resolveNonTimeSeriesVisualizationType(columns)
+}
+
 const getHeatmapAutoSettings = (columns: Column[], heatmapSettings: HeatmapSettings): Partial<HeatmapSettings> => {
     const stringColumns = columns.filter((column) => column.type.name === 'STRING')
     const numericalColumns = columns.filter((column) => column.type.isNumerical)
@@ -258,6 +301,25 @@ const getHeatmapAutoSettings = (columns: Column[], heatmapSettings: HeatmapSetti
     }
 
     return nextSettings
+}
+
+const applyAutoHeatmapSettings = (
+    actions: { updateChartSettings: (settings: ChartSettings) => void },
+    columns: Column[],
+    heatmapSettings: HeatmapSettings
+): void => {
+    const autoSettings = getHeatmapAutoSettings(columns, heatmapSettings)
+
+    if (Object.keys(autoSettings).length === 0) {
+        return
+    }
+
+    actions.updateChartSettings({
+        heatmap: {
+            ...heatmapSettings,
+            ...autoSettings,
+        },
+    })
 }
 
 export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
@@ -681,6 +743,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return columns.filter((n) => n.type.isNumerical)
             },
         ],
+        hasDateTimeColumns: [
+            (s) => [s.columns],
+            (columns): boolean => columns.some((column) => ['DATE', 'DATETIME'].includes(column.type.name)),
+        ],
         dashboardId: [() => [(_, props) => props.dashboardId], (dashboardId) => dashboardId ?? null],
         showEditingUI: [
             (s) => [(_, props: DataVisualizationLogicProps) => props.editMode, s.dashboardId],
@@ -782,7 +848,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         xData: [
             (s) => [s.selectedXAxis, s.response, s.columns],
             (xSeries, response, columns): AxisSeries<string> | null => {
-                if (!response || xSeries === null) {
+                if (!response) {
                     return {
                         column: {
                             name: 'None',
@@ -798,6 +864,21 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 }
 
                 const data: any[] = response?.['results'] ?? response?.['result'] ?? []
+
+                if (xSeries === null) {
+                    return {
+                        column: {
+                            name: 'None',
+                            type: {
+                                name: 'STRING',
+                                isNumerical: false,
+                            },
+                            label: 'None',
+                            dataIndex: -1,
+                        },
+                        data: data.map(() => ''),
+                    }
+                }
 
                 const column = columns.find((n) => n.name === xSeries)
                 if (!column) {
@@ -906,15 +987,35 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         dataVisualizationProps: [() => [(_, props) => props], (props): DataVisualizationLogicProps => props],
+        effectiveVisualizationType: [
+            (s) => [s.visualizationType, s.autoVisualizationType, s.columns, s.response],
+            (visualizationType, autoVisualizationType, columns, response): ChartDisplayType => {
+                const isTimeSeriesData = hasTimeSeriesData(columns, response)
+
+                if (visualizationType === ChartDisplayType.Auto) {
+                    return autoVisualizationType
+                }
+
+                if (!isTimeSeriesData && isTimeSeriesVisualizationType(visualizationType)) {
+                    return resolveNonTimeSeriesVisualizationType(columns)
+                }
+
+                return visualizationType
+            },
+        ],
+        autoVisualizationType: [
+            (s) => [s.columns, s.response],
+            (columns, response): ChartDisplayType => getAutoVisualizationType(columns, response),
+        ],
         isTableVisualization: [
-            (s) => [s.visualizationType],
+            (s) => [s.effectiveVisualizationType],
             (visualizationType): boolean =>
                 // BoldNumber relies on yAxis formatting so it's considered a table visualization
                 visualizationType === ChartDisplayType.ActionsTable ||
                 visualizationType === ChartDisplayType.BoldNumber,
         ],
         showTableSettings: [
-            (s) => [s.visualizationType],
+            (s) => [s.effectiveVisualizationType],
             (visualizationType): boolean =>
                 visualizationType === ChartDisplayType.ActionsTable ||
                 visualizationType === ChartDisplayType.BoldNumber,
@@ -995,6 +1096,14 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 ...query,
                 display: visualizationType,
             }))
+
+            const isAutoHeatmap =
+                visualizationType === ChartDisplayType.Auto &&
+                getAutoVisualizationType(values.columns, values.response) === ChartDisplayType.TwoDimensionalHeatmap
+
+            if (visualizationType === ChartDisplayType.TwoDimensionalHeatmap || isAutoHeatmap) {
+                applyAutoHeatmapSettings(actions, values.columns, values.chartSettings.heatmap ?? {})
+            }
         },
         toggleChartSettingsPanel: ({ open }) => {
             const shouldOpen = open ?? !values.isChartSettingsPanelOpen
@@ -1006,19 +1115,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return
             }
 
-            const heatmapSettings = values.chartSettings.heatmap ?? {}
-            const autoSettings = getHeatmapAutoSettings(values.columns, heatmapSettings)
-
-            if (Object.keys(autoSettings).length === 0) {
-                return
-            }
-
-            actions.updateChartSettings({
-                heatmap: {
-                    ...heatmapSettings,
-                    ...autoSettings,
-                },
-            })
+            applyAutoHeatmapSettings(actions, values.columns, values.chartSettings.heatmap ?? {})
         },
         clearAxis: [sharedListeners.axesChanged],
         updateXSeries: [sharedListeners.axesChanged],
@@ -1043,7 +1140,22 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 JSON.stringify(values.tabularColumnSettings)
             )
 
-            if (oldValue && oldValue.length) {
+            const currentColumnNames = new Set(value.map((column) => column.name))
+            const hasInvalidSelectedXAxis =
+                values.selectedXAxis !== null && !currentColumnNames.has(values.selectedXAxis)
+            const hasInvalidSelectedYAxis =
+                values.selectedYAxis?.some((series) => {
+                    if (series === null) {
+                        return false
+                    }
+
+                    const column = value.find((nextColumn) => nextColumn.name === series.name)
+                    return !column || !column.type.isNumerical
+                }) ?? false
+
+            if (hasInvalidSelectedXAxis || hasInvalidSelectedYAxis) {
+                actions.clearAxis()
+            } else if (oldValue && oldValue.length) {
                 if (JSON.stringify(value) !== JSON.stringify(oldValue)) {
                     actions.clearAxis()
                 }
@@ -1079,24 +1191,18 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                 if (xAxisTypes) {
                     actions.updateXSeries(xAxisTypes.name)
+                } else {
+                    const yAxisColumnNames = new Set(yAxisTypes.map((column) => column.name))
+                    const firstRemainingColumn = value.find((column) => !yAxisColumnNames.has(column.name))
+
+                    if (firstRemainingColumn) {
+                        actions.updateXSeries(firstRemainingColumn.name)
+                    }
                 }
             }
 
-            if (
-                values.isChartSettingsPanelOpen &&
-                values.visualizationType === ChartDisplayType.TwoDimensionalHeatmap
-            ) {
-                const heatmapSettings = values.chartSettings.heatmap ?? {}
-                const autoSettings = getHeatmapAutoSettings(value, heatmapSettings)
-
-                if (Object.keys(autoSettings).length > 0) {
-                    actions.updateChartSettings({
-                        heatmap: {
-                            ...heatmapSettings,
-                            ...autoSettings,
-                        },
-                    })
-                }
+            if (values.effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
+                applyAutoHeatmapSettings(actions, value, values.chartSettings.heatmap ?? {})
             }
         },
     })),

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -239,14 +239,6 @@ const isNumericalType = (type: ColumnScalar): boolean => {
     return false
 }
 
-const isTimeSeriesVisualizationType = (visualizationType: ChartDisplayType): boolean => {
-    return (
-        visualizationType === ChartDisplayType.ActionsLineGraph ||
-        visualizationType === ChartDisplayType.ActionsAreaGraph ||
-        visualizationType === ChartDisplayType.ActionsLineGraphCumulative
-    )
-}
-
 const resolveNonTimeSeriesVisualizationType = (columns: Column[]): ChartDisplayType => {
     const stringColumns = columns.filter((column) => column.type.name === 'STRING')
     const numericalColumns = columns.filter((column) => column.type.isNumerical)
@@ -988,16 +980,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         ],
         dataVisualizationProps: [() => [(_, props) => props], (props): DataVisualizationLogicProps => props],
         effectiveVisualizationType: [
-            (s) => [s.visualizationType, s.autoVisualizationType, s.columns, s.response],
-            (visualizationType, autoVisualizationType, columns, response): ChartDisplayType => {
-                const isTimeSeriesData = hasTimeSeriesData(columns, response)
-
+            (s) => [s.visualizationType, s.autoVisualizationType],
+            (visualizationType, autoVisualizationType): ChartDisplayType => {
                 if (visualizationType === ChartDisplayType.Auto) {
                     return autoVisualizationType
-                }
-
-                if (!isTimeSeriesData && isTimeSeriesVisualizationType(visualizationType)) {
-                    return resolveNonTimeSeriesVisualizationType(columns)
                 }
 
                 return visualizationType

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2134,6 +2134,10 @@
         "AssistantTrendsDisplayType": {
             "anyOf": [
                 {
+                    "const": "Auto",
+                    "type": "string"
+                },
+                {
                     "const": "ActionsLineGraph",
                     "type": "string"
                 },
@@ -2261,6 +2265,7 @@
                     "default": "ActionsLineGraph",
                     "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
                     "enum": [
+                        "Auto",
                         "ActionsLineGraph",
                         "ActionsBar",
                         "ActionsUnstackedBar",
@@ -8048,6 +8053,7 @@
         },
         "ChartDisplayType": {
             "enum": [
+                "Auto",
                 "ActionsLineGraph",
                 "ActionsBar",
                 "ActionsUnstackedBar",

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -640,7 +640,7 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
 function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX.Element | null {
     const {
         query,
-        visualizationType,
+        effectiveVisualizationType,
         showEditingUI,
         response,
         responseLoading,
@@ -665,7 +665,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 <LoadingBar />
             </div>
         )
-    } else if (visualizationType === ChartDisplayType.ActionsTable) {
+    } else if (effectiveVisualizationType === ChartDisplayType.ActionsTable) {
         component = (
             <Table
                 uniqueKey={props.uniqueKey}
@@ -676,10 +676,10 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
             />
         )
     } else if (
-        visualizationType === ChartDisplayType.ActionsLineGraph ||
-        visualizationType === ChartDisplayType.ActionsBar ||
-        visualizationType === ChartDisplayType.ActionsAreaGraph ||
-        visualizationType === ChartDisplayType.ActionsStackedBar
+        effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
+        effectiveVisualizationType === ChartDisplayType.ActionsBar ||
+        effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
+        effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
     ) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         const _yData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.seriesData : yData
@@ -688,16 +688,16 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 className="p-2"
                 xData={_xData}
                 yData={_yData}
-                visualizationType={visualizationType}
+                visualizationType={effectiveVisualizationType}
                 chartSettings={chartSettings}
                 dashboardId={dashboardId}
                 goalLines={goalLines}
                 presetChartHeight={presetChartHeight}
             />
         )
-    } else if (visualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
+    } else if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         component = <TwoDimensionalHeatmap />
-    } else if (visualizationType === ChartDisplayType.BoldNumber) {
+    } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     }
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -8,9 +8,10 @@ import { urls } from 'scenes/urls'
 import { useMocks } from '~/mocks/jest'
 import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { InsightShortId, QueryBasedInsightModel } from '~/types'
+import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
-import { sqlEditorLogic } from './sqlEditorLogic'
+import { OutputTab } from './outputPaneLogic'
+import { getDisplayTypeToSaveInsight, sqlEditorLogic } from './sqlEditorLogic'
 
 // endpointLogic uses permanentlyMount() with a keyed logic, which crashes in
 // tests without the full React component tree — disable auto-mounting
@@ -147,6 +148,43 @@ describe('sqlEditorLogic', () => {
             window.history.replaceState({}, '', `${urls.sqlEditor()}?open_insight=${MOCK_INSIGHT_SHORT_ID}`)
 
             expect(logic.values.titleSectionProps.name).toEqual('Loading insight...')
+        })
+    })
+
+    describe('getDisplayTypeToSaveInsight', () => {
+        it.each([
+            {
+                name: 'saves table when results tab is selected',
+                outputTab: OutputTab.Results,
+                sourceQueryDisplay: ChartDisplayType.Auto,
+                effectiveVisualizationType: ChartDisplayType.ActionsBar,
+                expected: ChartDisplayType.ActionsTable,
+            },
+            {
+                name: 'saves explicit display from source query when not auto',
+                outputTab: OutputTab.Visualization,
+                sourceQueryDisplay: ChartDisplayType.ActionsAreaGraph,
+                effectiveVisualizationType: ChartDisplayType.ActionsBar,
+                expected: ChartDisplayType.ActionsAreaGraph,
+            },
+            {
+                name: 'saves effective visualization when source query is auto',
+                outputTab: OutputTab.Visualization,
+                sourceQueryDisplay: ChartDisplayType.Auto,
+                effectiveVisualizationType: ChartDisplayType.BoldNumber,
+                expected: ChartDisplayType.BoldNumber,
+            },
+            {
+                name: 'falls back to line graph when there is no effective visualization',
+                outputTab: OutputTab.Visualization,
+                sourceQueryDisplay: ChartDisplayType.Auto,
+                effectiveVisualizationType: undefined,
+                expected: ChartDisplayType.ActionsLineGraph,
+            },
+        ])('$name', ({ outputTab, sourceQueryDisplay, effectiveVisualizationType, expected }) => {
+            expect(getDisplayTypeToSaveInsight(outputTab, sourceQueryDisplay, effectiveVisualizationType)).toEqual(
+                expected
+            )
         })
     })
 

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -124,6 +124,8 @@ export const validateQuery = (q: DataNode): boolean => {
 }
 
 const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
+    [ChartDisplayType.Auto]: ChartDisplayType.ActionsLineGraph,
+
     // time series
     [ChartDisplayType.ActionsLineGraph]: ChartDisplayType.ActionsLineGraph,
     [ChartDisplayType.ActionsBar]: ChartDisplayType.ActionsLineGraph,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2566,6 +2566,7 @@ export interface DatedAnnotationType extends Omit<AnnotationType, 'date_marker'>
 }
 
 export enum ChartDisplayType {
+    Auto = 'Auto',
     ActionsLineGraph = 'ActionsLineGraph',
     // TODO: remove this as ActionsBar was meant to be for unstacked bar charts
     // but with current logic for all insights with this setting saved in the query

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -411,6 +411,7 @@ class AssistantTrendsDisplayType(RootModel[str | Any]):
 
 
 class Display(StrEnum):
+    AUTO = "Auto"
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"
@@ -683,6 +684,7 @@ class ChartDisplayCategory(StrEnum):
 
 
 class ChartDisplayType(StrEnum):
+    AUTO = "Auto"
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -1697,6 +1697,7 @@ export const DetailedResultsAggregationTypeApi = {
 export type ChartDisplayTypeApi = (typeof ChartDisplayTypeApi)[keyof typeof ChartDisplayTypeApi]
 
 export const ChartDisplayTypeApi = {
+    Auto: 'Auto',
     ActionsLineGraph: 'ActionsLineGraph',
     ActionsBar: 'ActionsBar',
     ActionsUnstackedBar: 'ActionsUnstackedBar',


### PR DESCRIPTION
## Problem

The SQL editor chart is always a "line chart", no matter if we have data that can be displayed in the format or not.

The first time around we introduced some bugs. [Oops](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771977895110159).

## Changes

Add better chart autodetection.

![2026-02-24 14 04 56](https://github.com/user-attachments/assets/14e9af79-8a4d-400d-9ed0-56aea82c64ee)

<img width="393" height="550" alt="image" src="https://github.com/user-attachments/assets/cfa2492e-a6e3-45bb-be8b-006ab91cccb8" />


## How did you test this code?

See gif. Clicked around between different queries a lot. Saving an insight saves the right chart type, not "auto".

## Publish to changelog?

no