### PR TITLE
Update CSP rules to fix redoc API page infinite loading

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -768,9 +768,9 @@ class CSPMiddleware:
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
-                f"script-src 'self' 'nonce-{nonce}' {resource_url} https://*.i.posthog.com",
+                f"script-src 'self' 'nonce-{nonce}' {resource_url} https://*.i.posthog.com https://cdn.jsdelivr.net",
                 f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://d1sdjtjk6xzm7.cloudfront.net https://fonts.gstatic.com https://cdn.jsdelivr.net https://assets.faircado.com https://use.typekit.net",
-                "worker-src 'self'",
+                "worker-src 'self' blob:",
                 "child-src 'none'",
                 "object-src 'none'",
                 "media-src https://res.cloudinary.com",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Trying to access https://app.posthog.com/api/schema/redoc/ displays an infinite loading spinner due to a couple CSP errors:

> Content-Security-Policy: (Report-Only policy) The page’s settings would block a script (script-src-elem) at https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js from being executed because it violates the following directive: “script-src 'self' 'nonce-6z9NSBbJ8TgnUHz9eDRI7L' https://*.posthog.com https://*.i.posthog.com” redoc
> Content-Security-Policy: (Report-Only policy) The page’s settings would block a worker script (worker-src) at blob:https://app.posthog.com/9cce9059-71c4-4246-9d29-e4d5a2a13cea from being executed because it violates the following directive: “worker-src 'self'”

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Add `https://cdn.jsdelivr.net` to `script-src` and `blob:` to `worker-src`.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
