### PR TITLE
fix(billing): add missing fields to quota limiting .only() to prevent deferred-field queries

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -708,6 +708,8 @@ def update_all_orgs_billing_quotas(
             "organization__usage",
             "organization__created_at",
             "organization__never_drop_data",
+            "organization__customer_trust_scores",
+            "organization__customer_id",
         )
     )
 


### PR DESCRIPTION
## Problem

The `.only()` clause in `update_all_orgs_billing_quotas()` is missing `customer_trust_scores` and `customer_id`. When Django accesses these deferred fields, it silently issues a separate SELECT per org - a hidden N+1 problem.

- `customer_trust_scores` is accessed for every org (~251K deferred SELECTs per run)
- `customer_id` is accessed for every limited/suspended org (~2.3K deferred SELECTs per run)

This is a follow up from #48874 

## Changes

Add `organization__customer_trust_scores` and `organization__customer_id` to the `.only()` query.

Memory impact validated on prod (US) via `pg_column_size`: ~375 MB -> ~416 MB for 251K orgs (+41 MB) to eliminate ~253K deferred SELECT round-trips.

Next steps:
- Add status/metrics to temporal hearbeat
- Add prometheus metrics
- Other performance improvements

## How did you test this code?

Ran existing tests

## Publish to changelog?

No