### PR TITLE
chore: Support double for MongoDB incremental fields

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -65,6 +65,8 @@ def filter_mongo_incremental_fields(
             results.append((column_name, IncrementalFieldType.Timestamp))
         elif type == "integer":
             results.append((column_name, IncrementalFieldType.Integer))
+        elif type == "double":
+            results.append((column_name, IncrementalFieldType.Numeric))
         elif column_name == "_id" and type == "string":
             results.append((column_name, IncrementalFieldType.ObjectID))
 


### PR DESCRIPTION
## Problem

I was testing some things with MongoDB and this caused me some confusion - one of my indexed fields had a mixed `["int", "double"]` type, and the `double` was causing it not to be detected as a candidate for incremental/append-only syncs.

## Changes

Although I can't think of great real-world use cases for using a decimal field (maybe a decimal field containing timestamps with millisecond precision, although there are other BSON types for that...), and given MongoDBs loose schema approach, I couldn't think of a great reason not to just support it.

Both `decimal` and `double` get mapped to `double` in `type_priority` via `_determine_field_type_from_bson_types`.

Complemented by https://github.com/PostHog/posthog.com/pull/15274