### PR TITLE
feat(llma): add passthrough cost model source for pre-set costs

### DIFF
--- a/nodejs/src/ingestion/ai/costs/cost-model-matching.ts
+++ b/nodejs/src/ingestion/ai/costs/cost-model-matching.ts
@@ -12,6 +12,7 @@ export enum CostModelSource {
     OpenRouter = 'openrouter',
     Manual = 'manual',
     Custom = 'custom',
+    Passthrough = 'passthrough',
 }
 
 export interface CostModelResult {

--- a/nodejs/src/ingestion/ai/costs/index.ts
+++ b/nodejs/src/ingestion/ai/costs/index.ts
@@ -116,6 +116,7 @@ export const processCost = (event: EventWithProperties): EventWithProperties => 
             trackCostOutcome(totalCost)
         }
 
+        event.properties['$ai_cost_model_source'] = CostModelSource.Passthrough
         return event
     }
 

--- a/nodejs/src/ingestion/ai/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.test.ts
@@ -470,6 +470,8 @@ describe('processAiEvent()', () => {
             // Should not set model_cost_used when bypassing
             expect(result.properties!.$ai_model_cost_used).toBeUndefined()
             expect(result.properties!.$ai_cost_model_provider).toBeUndefined()
+            // Should mark as passthrough so we know costs were not calculated by the pipeline
+            expect(result.properties!.$ai_cost_model_source).toBe(CostModelSource.Passthrough)
         })
 
         it('calculates total when input/output exist but total is missing', () => {
@@ -592,6 +594,7 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_total_cost_usd).toBe(9)
             expect(result.properties!.$ai_model_cost_used).toBeUndefined()
             expect(result.properties!.$ai_cost_model_provider).toBeUndefined()
+            expect(result.properties!.$ai_cost_model_source).toBe(CostModelSource.Passthrough)
         })
 
         it('treats object cost values as unset and falls through to model calculation', () => {


### PR DESCRIPTION
## Summary

- When AI events arrive with pre-calculated costs (`$ai_input_cost_usd`, `$ai_output_cost_usd`), the pipeline skips cost calculation but previously did not set `$ai_cost_model_source`
- This made it impossible to distinguish between "pipeline calculated costs from token counts" vs "costs were passed through from the client as-is"
- Adds `Passthrough = 'passthrough'` to `CostModelSource` enum and sets it on the early return path

This gives us better observability when debugging cost discrepancies -- we can now check `$ai_cost_model_source` to know whether the pipeline computed costs or just passed them through unchanged.

## Test plan

- [x] Existing tests updated to assert `$ai_cost_model_source` is `passthrough` for pre-set cost events
- [x] All 118 process-ai-event tests pass
- [x] All 219 cost tests pass