### PR TITLE
fix(sql-editor): add disabledReason tooltip when update insight needs running

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -380,7 +380,13 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                             </>
                         ) : editingInsight ? (
                             <LemonButton
-                                disabledReason={!updateInsightButtonEnabled ? 'No updates to save' : undefined}
+                                disabledReason={
+                                    !isSourceQueryLastRun
+                                        ? 'Run latest query changes before saving'
+                                        : !updateInsightButtonEnabled
+                                          ? 'No updates to save'
+                                          : undefined
+                                }
                                 loading={insightLoading}
                                 type="primary"
                                 size="small"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
no tooltip on update insight button
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- add another condition to disabledReason
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- checked locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
