### PR TITLE
feat(clickhouse): ClickHouse kill switch in temporal workers

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -3,6 +3,7 @@ import ssl
 import sys
 import enum
 import json
+import time
 import uuid
 import socket
 import typing
@@ -23,9 +24,28 @@ from temporalio import activity
 
 import posthog.temporal.common.asyncpa as asyncpa
 from posthog.clickhouse import query_tagging
+from posthog.clickhouse.client.limit import lua_script as _concurrency_lua_script
 from posthog.clickhouse.query_tagging import QueryTags, TemporalTags, get_query_tags
 
 LOGGER = get_logger(__name__)
+
+_TEMPORAL_CH_LIMITS: dict[str, int] = {
+    "light": 10,
+    "full": 3,
+}
+_TEMPORAL_CH_REDIS_KEY = "temporal_ch_concurrency"
+_TEMPORAL_CH_TTL = 300  # 5 min safety net
+
+
+async def _acquire_temporal_ch_slot(redis_client: typing.Any, task_id: str, max_concurrent: int) -> bool:
+    result = await redis_client.eval(
+        _concurrency_lua_script, 1, _TEMPORAL_CH_REDIS_KEY, int(time.time()), task_id, max_concurrent, _TEMPORAL_CH_TTL
+    )
+    return result == 1
+
+
+async def _release_temporal_ch_slot(redis_client: typing.Any, task_id: str) -> None:
+    await redis_client.zrem(_TEMPORAL_CH_REDIS_KEY, task_id)
 
 
 def encode_clickhouse_data(data: typing.Any, quote_char="'") -> bytes:
@@ -845,9 +865,17 @@ class ClickHouseClient:
         return False
 
 
+class TemporalCHConcurrencyLimitExceeded(Exception):
+    pass
+
+
 @contextlib.asynccontextmanager
 async def get_client(
-    *, team_id: typing.Optional[int] = None, clickhouse_url: str | None = None, **kwargs
+    *,
+    team_id: typing.Optional[int] = None,
+    clickhouse_url: str | None = None,
+    kill_switch_exempt: bool = False,
+    **kwargs,
 ) -> collections.abc.AsyncIterator[ClickHouseClient]:
     """
     Returns a ClickHouse client based on the aiochclient library. This is an
@@ -894,19 +922,50 @@ async def get_client(
     else:
         url = clickhouse_url
 
-    async with ClickHouseClient(
-        url=url,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        database=settings.CLICKHOUSE_DATABASE,
-        timeout=timeout,
-        ssl=False,
-        max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
-        max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
-        max_block_size=max_block_size,
-        cancel_http_readonly_queries_on_client_close=1,
-        output_format_arrow_string_as_string="true",
-        http_send_timeout=http_send_timeout,
-        **kwargs,
-    ) as client:
-        yield client
+    from posthog.clickhouse.client.execute import get_kill_switch_level
+
+    slot_task_id: str | None = None
+    async_redis: typing.Any = None
+
+    if not kill_switch_exempt and not settings.TEST:
+        level = get_kill_switch_level()
+        max_concurrent = _TEMPORAL_CH_LIMITS.get(level.value)
+
+        if max_concurrent is not None:
+            from posthog.redis import get_async_client
+
+            async_redis = get_async_client()
+            slot_task_id = str(uuid.uuid4())
+
+            acquired = False
+            for attempt in range(8):  # ~30s total with backoff
+                if await _acquire_temporal_ch_slot(async_redis, slot_task_id, max_concurrent):
+                    acquired = True
+                    break
+                await asyncio.sleep(min(0.5 * (1.5**attempt), 5.0))
+
+            if not acquired:
+                raise TemporalCHConcurrencyLimitExceeded(
+                    f"Temporal CH concurrency limit ({max_concurrent}) exceeded for kill switch level '{level.value}'"
+                )
+
+    try:
+        async with ClickHouseClient(
+            url=url,
+            user=settings.CLICKHOUSE_USER,
+            password=settings.CLICKHOUSE_PASSWORD,
+            database=settings.CLICKHOUSE_DATABASE,
+            timeout=timeout,
+            ssl=False,
+            max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
+            max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
+            max_block_size=max_block_size,
+            cancel_http_readonly_queries_on_client_close=1,
+            output_format_arrow_string_as_string="true",
+            http_send_timeout=http_send_timeout,
+            **kwargs,
+        ) as client:
+            yield client
+    finally:
+        if async_redis is not None and slot_task_id is not None:
+            await _release_temporal_ch_slot(async_redis, slot_task_id)

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -14,8 +14,10 @@ from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
+    TemporalCHConcurrencyLimitExceeded,
     add_log_comment_param,
     encode_clickhouse_data,
+    get_client,
 )
 
 
@@ -408,3 +410,95 @@ async def test_stream_query_as_jsonl_handles_whitespace_only_lines(clickhouse_cl
     assert results[0] == {"id": 1}
     assert results[1] == {"id": 2}
     assert results[2] == {"id": 3}
+
+
+class TestTemporalCHConcurrencyLimiter:
+    @pytest.fixture(autouse=True)
+    def _setup_redis(self):
+        import fakeredis
+
+        self.fake_redis = fakeredis.FakeAsyncRedis()
+
+    @pytest.mark.parametrize(
+        "level,max_concurrent",
+        [
+            ("full", 3),
+            ("light", 10),
+        ],
+    )
+    async def test_concurrency_limit_enforced(self, level, max_concurrent):
+        from posthog.clickhouse.client.execute import KillSwitchLevel
+
+        with (
+            patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=KillSwitchLevel(level)),
+            patch("posthog.redis.get_async_client", return_value=self.fake_redis),
+            patch("django.conf.settings.TEST", False),
+        ):
+            active_contexts: list[contextlib.AsyncExitStack] = []
+            for _ in range(max_concurrent):
+                stack = contextlib.AsyncExitStack()
+                await stack.enter_async_context(get_client())
+                active_contexts.append(stack)
+
+            with (
+                patch("posthog.temporal.common.clickhouse.asyncio.sleep", return_value=None),
+                pytest.raises(TemporalCHConcurrencyLimitExceeded),
+            ):
+                async with get_client():
+                    pass
+
+            for stack in active_contexts:
+                await stack.aclose()
+
+    async def test_kill_switch_exempt_bypasses_limiter(self):
+        from posthog.clickhouse.client.execute import KillSwitchLevel
+
+        with (
+            patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=KillSwitchLevel.FULL),
+            patch("posthog.redis.get_async_client", return_value=self.fake_redis),
+            patch("django.conf.settings.TEST", False),
+        ):
+            active_contexts: list[contextlib.AsyncExitStack] = []
+            for _ in range(3):
+                stack = contextlib.AsyncExitStack()
+                await stack.enter_async_context(get_client())
+                active_contexts.append(stack)
+
+            # exempt call succeeds even though limit is reached
+            async with get_client(kill_switch_exempt=True):
+                pass
+
+            for stack in active_contexts:
+                await stack.aclose()
+
+    async def test_slot_released_after_context_exit(self):
+        from posthog.clickhouse.client.execute import KillSwitchLevel
+
+        with (
+            patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=KillSwitchLevel.FULL),
+            patch("posthog.redis.get_async_client", return_value=self.fake_redis),
+            patch("django.conf.settings.TEST", False),
+        ):
+            for _ in range(3):
+                async with get_client():
+                    pass
+
+            # all slots released, should succeed
+            async with get_client():
+                pass
+
+    async def test_no_limiting_when_kill_switch_off(self):
+        from posthog.clickhouse.client.execute import KillSwitchLevel
+
+        with (
+            patch("posthog.clickhouse.client.execute.get_kill_switch_level", return_value=KillSwitchLevel.OFF),
+            patch("django.conf.settings.TEST", False),
+        ):
+            active_contexts: list[contextlib.AsyncExitStack] = []
+            for _ in range(20):
+                stack = contextlib.AsyncExitStack()
+                await stack.enter_async_context(get_client())
+                active_contexts.append(stack)
+
+            for stack in active_contexts:
+                await stack.aclose()

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -187,7 +187,7 @@ async def insert_into_http_activity(inputs: HttpInsertInputs) -> BatchExportResu
         inputs.url,
     )
 
-    async with get_client(team_id=inputs.team_id) as client:
+    async with get_client(team_id=inputs.team_id, kill_switch_exempt=True) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 

--- a/products/batch_exports/backend/temporal/monitoring.py
+++ b/products/batch_exports/backend/temporal/monitoring.py
@@ -132,7 +132,7 @@ async def get_clickhouse_event_counts(inputs: GetEventCountsInputs) -> list[Even
         "include_events": inputs.include_events,
         "exclude_events": inputs.exclude_events,
     }
-    async with Heartbeater(), get_client() as client:
+    async with Heartbeater(), get_client(kill_switch_exempt=True) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -486,7 +486,7 @@ async def _write_batch_export_record_batches_to_internal_stage(
     await wait_for_delta_past_data_interval_end(end_at, delta)
 
     done_ranges: list[tuple[dt.datetime, dt.datetime]] = []
-    async with get_client(team_id=team_id, clickhouse_url=clickhouse_url) as client:
+    async with get_client(team_id=team_id, clickhouse_url=clickhouse_url, kill_switch_exempt=True) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -478,7 +478,7 @@ class Producer:
         end_at = full_range[1]
         await wait_for_delta_past_data_interval_end(end_at, delta)
 
-        async with get_client(team_id=team_id, clickhouse_url=clickhouse_url) as client:
+        async with get_client(team_id=team_id, clickhouse_url=clickhouse_url, kill_switch_exempt=True) as client:
             if not await client.is_alive():
                 raise ConnectionError("Cannot establish connection to ClickHouse")
 


### PR DESCRIPTION
Add support for kill switch exemption in ClickHouse client usage, implement concurrency limiter tests for Temporal CH
