### PR TITLE
feat(analytics-platform): Always convert UUID session IDs to lower-case

### DIFF
--- a/nodejs/src/utils/event.ts
+++ b/nodejs/src/utils/event.ts
@@ -4,7 +4,7 @@ import { ClickHouseEvent, PipelineEvent, PostIngestionEvent, RawClickHouseEvent 
 import { personInitialAndUTMProperties, sanitizeString } from './db/utils'
 import { chainToElements } from './elements-chain'
 import { parseJSON } from './json-parse'
-import { clickHouseTimestampToDateTime } from './utils'
+import { UUID, clickHouseTimestampToDateTime } from './utils'
 
 /** Parse an event row SELECTed from ClickHouse into a more malleable form. */
 export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHouseEvent {
@@ -126,6 +126,14 @@ export function sanitizeEvent<T extends PipelineEvent | PluginEvent>(event: T): 
 
     if (event.sent_at) {
         properties['$sent_at'] = event.sent_at
+    }
+
+    // If the session ID is a UUID, we should lowercase it.
+    // This is because some mobile apps send an uppercase session ID, which can cause problems on some query paths
+    // where the session ID is parsed as a UUID and then converted back to a string.
+    // See https://github.com/PostHog/posthog/issues/46111
+    if (typeof properties['$session_id'] === 'string' && UUID.validateString(properties['$session_id'], false)) {
+        properties['$session_id'] = properties['$session_id'].toLowerCase()
     }
 
     event.properties = properties

--- a/nodejs/src/utils/event.ts
+++ b/nodejs/src/utils/event.ts
@@ -132,6 +132,7 @@ export function sanitizeEvent<T extends PipelineEvent | PluginEvent>(event: T): 
     // This is because some mobile apps send an uppercase session ID, which can cause problems on some query paths
     // where the session ID is parsed as a UUID and then converted back to a string.
     // See https://github.com/PostHog/posthog/issues/46111
+    // Note: this is very defensive. In reality, session IDs should always be a UUIDv7 or undefined.
     if (typeof properties['$session_id'] === 'string' && UUID.validateString(properties['$session_id'], false)) {
         properties['$session_id'] = properties['$session_id'].toLowerCase()
     }

--- a/nodejs/src/utils/utils.ts
+++ b/nodejs/src/utils/utils.ts
@@ -185,6 +185,12 @@ export class UUID {
 /**
  * UUID (mostly) sortable by generation time.
  *
+ * Note: this class was created in 2020, before UUIDv7 was published in 2024 https://www.rfc-editor.org/rfc/rfc9562.
+ * Nowadays, you probably want to use UUIDv7 instead, as many DB engines have first-class support for them
+ * (e.g. clickhouse has [UUIDv7ToDateTime](https://clickhouse.com/docs/sql-reference/functions/uuid-functions#UUIDv7ToDateTime))
+ *
+ * Original comment from 2020 continues:
+ *
  * This doesn't adhere to any official UUID version spec, but it is superior as a primary key:
  * to incremented integers (as they can reveal sensitive business information about usage volumes and patterns),
  * to UUID v4 (as the complete randomness of v4 makes its indexing performance suboptimal),


### PR DESCRIPTION
## Problem
See https://github.com/PostHog/posthog/issues/46111

Question: why can't we just update the SDKs to send lowercase UUIDs
Answer: mobile app SDK updates take a long time to percolate, as end-users do not always update their mobile apps regularly

## Changes

Convert session IDs that are UUIDs to lowercase

## How did you test this code?

Added a few unit tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
