### PR TITLE
feat(llma): add sentiment column to generations tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -188,7 +188,10 @@ function LLMAnalyticsGenerations(): JSX.Element {
 
         const columns =
             generationsQuery.source.select ||
-            getDefaultGenerationsColumns(!!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT])
+            getDefaultGenerationsColumns(
+                !!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT],
+                !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SENTIMENT]
+            )
 
         const uuidIndex = columns.findIndex((col) => col === 'uuid')
         const traceIdIndex = columns.findIndex((col) => col === 'properties.$ai_trace_id')
@@ -220,7 +223,8 @@ function LLMAnalyticsGenerations(): JSX.Element {
                 ...generationsQuery,
                 showSavedFilters: true,
                 defaultColumns: getDefaultGenerationsColumns(
-                    !!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT]
+                    !!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT],
+                    !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SENTIMENT]
                 ),
             }}
             setQuery={(query) => {
@@ -280,6 +284,7 @@ function LLMAnalyticsGenerations(): JSX.Element {
                         },
                     },
                     person: llmAnalyticsColumnRenderers.person,
+                    "'' -- Sentiment": llmAnalyticsColumnRenderers["'' -- Sentiment"],
                     "f'{properties.$ai_model}' -- Model": {
                         renderTitle: () => renderSortableColumnTitle('properties.$ai_model', 'Model'),
                     },

--- a/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
@@ -218,6 +218,47 @@ function LazySentimentColumnCell({ traceId }: { traceId: string }): JSX.Element 
     )
 }
 
+function LazyGenerationSentimentCell({
+    traceId,
+    generationEventId,
+}: {
+    traceId: string
+    generationEventId: string
+}): JSX.Element {
+    const { sentimentByTraceId, isTraceLoading } = useValues(llmSentimentLazyLoaderLogic)
+    const { ensureSentimentLoaded } = useActions(llmSentimentLazyLoaderLogic)
+    const { dateFilter } = useValues(llmAnalyticsSharedLogic)
+
+    const cached = sentimentByTraceId[traceId]
+    const loading = isTraceLoading(traceId)
+
+    if (cached === undefined && !loading) {
+        ensureSentimentLoaded(traceId, dateFilter)
+    }
+
+    if (loading || cached === undefined) {
+        return <AIDataLoading variant="inline" />
+    }
+
+    if (cached === null) {
+        return <>–</>
+    }
+
+    const generationSentiment = cached.generations?.[generationEventId]
+    if (!generationSentiment) {
+        return <>–</>
+    }
+
+    return (
+        <SentimentBar
+            label={generationSentiment.label}
+            score={generationSentiment.score}
+            size="full"
+            messages={generationSentiment.messages}
+        />
+    )
+}
+
 function AIInputCell({ eventData }: { eventData: EventData }): JSX.Element {
     const { input, isLoading } = useAIData(eventData)
 
@@ -408,6 +449,31 @@ export const llmAnalyticsColumnRenderers: Record<string, QueryContextColumn> = {
                 return <>–</>
             }
             return <LazySentimentColumnCell traceId={traceRecord.id} />
+        },
+    },
+    "'' -- Sentiment": {
+        title: 'Sentiment',
+        render: ({ record, query }) => {
+            if (!Array.isArray(record) || !isDataTableNode(query) || !isEventsQuery(query.source)) {
+                return <>–</>
+            }
+
+            const select = query.source.select ?? []
+            const uuidIdx = select.findIndex((c) => c === 'uuid')
+            const traceIdIdx = select.findIndex((c) => c === 'properties.$ai_trace_id')
+
+            if (uuidIdx < 0 || traceIdIdx < 0) {
+                return <>–</>
+            }
+
+            const uuid = record[uuidIdx]
+            const traceId = record[traceIdIdx]
+
+            if (typeof uuid !== 'string' || typeof traceId !== 'string') {
+                return <>–</>
+            }
+
+            return <LazyGenerationSentimentCell traceId={traceId} generationEventId={uuid} />
         },
     },
     // LLM person column for Users tab - clicking filter redirects to traces page

--- a/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
@@ -225,7 +225,7 @@ function LazyGenerationSentimentCell({
     traceId: string
     generationEventId: string
 }): JSX.Element {
-    const { sentimentByTraceId, isTraceLoading } = useValues(llmSentimentLazyLoaderLogic)
+    const { sentimentByTraceId, isTraceLoading, getGenerationSentiment } = useValues(llmSentimentLazyLoaderLogic)
     const { ensureSentimentLoaded } = useActions(llmSentimentLazyLoaderLogic)
     const { dateFilter } = useValues(llmAnalyticsSharedLogic)
 
@@ -244,7 +244,7 @@ function LazyGenerationSentimentCell({
         return <>–</>
     }
 
-    const generationSentiment = cached.generations?.[generationEventId]
+    const generationSentiment = getGenerationSentiment(traceId, generationEventId)
     if (!generationSentiment) {
         return <>–</>
     }

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsGenerationsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsGenerationsLogic.ts
@@ -15,12 +15,13 @@ export interface LLMAnalyticsGenerationsLogicProps {
     tabId?: string
 }
 
-export function getDefaultGenerationsColumns(showInputOutput: boolean): string[] {
+export function getDefaultGenerationsColumns(showInputOutput: boolean, showSentiment: boolean = false): string[] {
     return [
         'uuid',
         'properties.$ai_trace_id',
         ...(showInputOutput ? ['properties.$ai_input[-1]', 'properties.$ai_output_choices'] : []),
         'person',
+        ...(showSentiment ? ["'' -- Sentiment"] : []),
         "f'{properties.$ai_model}' -- Model",
         "if(properties.$ai_is_error = 'true', '❌', '') -- Error",
         "f'{round(toFloat(properties.$ai_latency), 2)} s' -- Latency",
@@ -178,7 +179,10 @@ export const llmAnalyticsGenerationsLogic = kea<llmAnalyticsGenerationsLogicType
                     limit: 100,
                     select:
                         generationsColumns ||
-                        getDefaultGenerationsColumns(!!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT]),
+                        getDefaultGenerationsColumns(
+                            !!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT],
+                            !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SENTIMENT]
+                        ),
                     orderBy: [`${generationsSort.column} ${generationsSort.direction}`],
                     after: dateFilter.dateFrom || undefined,
                     before: dateFilter.dateTo || undefined,


### PR DESCRIPTION
## Problem

Sentiment classification is only shown on the traces tab and trace detail view. The generations tab, where each row is a single generation, is a natural fit for per-generation sentiment since the backend already returns generation-level sentiment data.

## Changes

Adds a sentiment column to the generations tab, gated behind the existing `LLM_ANALYTICS_SENTIMENT` feature flag.

Three files changed (all frontend, no backend changes):

- **`llmAnalyticsGenerationsLogic.ts`**: Added `showSentiment` param to `getDefaultGenerationsColumns()`. Includes `"'' -- Sentiment"` in the column list when the flag is on.
- **`llmAnalyticsColumnRenderers.tsx`**: Added `LazyGenerationSentimentCell` component that uses the existing `llmSentimentLazyLoaderLogic` and its `getGenerationSentiment` selector to show per-generation sentiment (not trace-level aggregate). Added `"'' -- Sentiment"` column renderer that extracts `uuid` and `traceId` from the EventsQuery array row.
- **`LLMAnalyticsScene.tsx`**: Wired the new renderer into the generations DataTable context. Updated `getDefaultGenerationsColumns` calls to pass the sentiment flag.

Key design decisions:
- Uses `"'' -- Sentiment"` as a dummy HogQL expression (zero backend cost, title extracted from `-- Sentiment` comment)
- Shows per-generation sentiment, not trace-level aggregate
- Reuses existing `SentimentBar` component and `llmSentimentLazyLoaderLogic` with no new loading infrastructure

## How did you test this code?

I am an agent and have not tested this manually. Automated checks:

- All 37 `llmSentimentLazyLoaderLogic.test.ts` tests pass
- TypeScript check passes (no new errors introduced; pre-existing errors in unrelated files)
- Lint/format passes

## Publish to changelog?

No