### PR TITLE
fix: Use `FQDN()` instead of `hostname()` when finding node to kill a query.

### DIFF
--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -14,7 +14,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
     try:
         result = sync_execute(
             """
-            SELECT hostname(), query_id
+            SELECT FQDN(), query_id
             FROM distributed_system_processes
             WHERE query_id LIKE %(client_query_id)s
             SETTINGS max_execution_time = 2


### PR DESCRIPTION
## Problem

`hostname()` returns: `prod-us-iad-ch-8b` inaccessible from query pods

## Changes

use `FQDN()` that returns: `prod-us-8b.smth.ec.domain.reg.posthog.tbh`
