### PR TITLE
chore: add emitted events per distinct id metric

### DIFF
--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -88,7 +88,13 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
                     clickhouseJsonEventsTopic: options.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
                     groupId,
                 }),
-                [count('emitted_events', (input) => ({ team_id: String(input.eventToEmit.team_id) }))]
+                [
+                    count('emitted_events', (input) => ({ team_id: String(input.eventToEmit.team_id) })),
+                    count('emitted_events_per_distinct_id', (input) => ({
+                        team_id: String(input.eventToEmit.team_id),
+                        distinct_id: input.eventToEmit.distinct_id,
+                    })),
+                ]
             )
         )
 }


### PR DESCRIPTION
## Problem

We lack the ability to find "hot" distinct IDs.

## Changes

Adds a tophog metric to count emitted events per distinct ID.

## How did you test this code?

Will review data on production.