### PR TITLE
feat: some stack trace events improvements

### DIFF
--- a/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
+++ b/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -62,19 +62,21 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
         ],
     })),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         loadFromRawIds: () => {
             actions.setLoadStartTime(performance.now())
         },
         loadFromRawIdsSuccess: ({ stackFrameRecords }) => {
-            const durationMs =
+            const requestDurationMs =
                 values.loadStartTime !== null ? Math.round(performance.now() - values.loadStartTime) : null
+            const mountDurationMs = cache.mountedAt ? Math.round(performance.now() - cache.mountedAt) : null
             actions.setLoadStartTime(null)
 
             const recordsWithContext = Object.values(stackFrameRecords).filter((record) => record.context)
 
             posthog.capture('error_tracking_stack_trace_loaded', {
-                duration_ms: durationMs,
+                duration_ms: requestDurationMs,
+                duration_since_mount_ms: mountDurationMs,
                 frame_count: recordsWithContext.length,
             })
         },
@@ -82,4 +84,7 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
             actions.setLoadStartTime(null)
         },
     })),
+    afterMount(({ cache }) => {
+        cache.mountedAt = performance.now()
+    }),
 ])

--- a/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
+++ b/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
@@ -72,6 +72,7 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
             actions.setLoadStartTime(null)
 
             const recordsWithContext = Object.values(stackFrameRecords).filter((record) => record.context)
+
             posthog.capture('error_tracking_stack_trace_loaded', {
                 duration_ms: durationMs,
                 frame_count: recordsWithContext.length,

--- a/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
+++ b/frontend/src/lib/components/Errors/Frame/stackFrameLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -28,16 +28,6 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
     actions({
         loadFromRawIds: (rawIds: ErrorTrackingStackFrame['raw_id'][]) => ({ rawIds }),
         loadForSymbolSet: (symbolSetId: ErrorTrackingSymbolSet['id']) => ({ symbolSetId }),
-        setLoadStartTime: (startTime: number | null) => ({ startTime }),
-    }),
-
-    reducers({
-        loadStartTime: [
-            null as number | null,
-            {
-                setLoadStartTime: (_, { startTime }) => startTime,
-            },
-        ],
     }),
 
     loaders(({ values }) => ({
@@ -62,29 +52,45 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
         ],
     })),
 
-    listeners(({ actions, values, cache }) => ({
+    listeners(({ cache }) => ({
         loadFromRawIds: () => {
-            actions.setLoadStartTime(performance.now())
+            const loadStartedAt = performance.now()
+            cache.currentLoadStartedAt = loadStartedAt
+            cache.currentLoadType = cache.hasLoadedStackFrames ? 'subsequent' : 'initial'
         },
         loadFromRawIdsSuccess: ({ stackFrameRecords }) => {
+            const loadType = cache.currentLoadType ?? 'initial'
+            const loadStartedAt = cache.currentLoadStartedAt
             const requestDurationMs =
-                values.loadStartTime !== null ? Math.round(performance.now() - values.loadStartTime) : null
-            const mountDurationMs = cache.mountedAt ? Math.round(performance.now() - cache.mountedAt) : null
-            actions.setLoadStartTime(null)
+                loadStartedAt !== null && loadStartedAt !== undefined
+                    ? Math.round(performance.now() - loadStartedAt)
+                    : null
+            const mountDurationMs =
+                loadType === 'initial' && cache.mountedAt ? Math.round(performance.now() - cache.mountedAt) : null
+            cache.currentLoadStartedAt = null
+            cache.currentLoadType = null
 
             const recordsWithContext = Object.values(stackFrameRecords).filter((record) => record.context)
+            if (recordsWithContext.length > 0) {
+                cache.hasLoadedStackFrames = true
+            }
 
             posthog.capture('error_tracking_stack_trace_loaded', {
+                load_type: loadType,
                 duration_ms: requestDurationMs,
                 duration_since_mount_ms: mountDurationMs,
                 frame_count: recordsWithContext.length,
             })
         },
         loadFromRawIdsFailure: () => {
-            actions.setLoadStartTime(null)
+            cache.currentLoadStartedAt = null
+            cache.currentLoadType = null
         },
     })),
     afterMount(({ cache }) => {
         cache.mountedAt = performance.now()
+        cache.hasLoadedStackFrames = false
+        cache.currentLoadStartedAt = null as number | null
+        cache.currentLoadType = null as 'initial' | 'subsequent' | null
     }),
 ])

--- a/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
+++ b/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
@@ -103,7 +103,7 @@ export const miniBreakdownsLogic = kea<miniBreakdownsLogicType>([
 
     subscriptions(({ actions }) => ({
         dateRange: (value, oldValue) => {
-            if (oldValue && value !== oldValue) {
+            if (oldValue !== undefined && value !== oldValue) {
                 actions.loadResponse()
             }
         },

--- a/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
+++ b/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
@@ -102,11 +102,15 @@ export const miniBreakdownsLogic = kea<miniBreakdownsLogicType>([
     })),
 
     subscriptions(({ actions }) => ({
-        dateRange: () => {
-            actions.loadResponse()
+        dateRange: (value, oldValue) => {
+            if (oldValue && value !== oldValue) {
+                actions.loadResponse()
+            }
         },
-        filterTestAccounts: () => {
-            actions.loadResponse()
+        filterTestAccounts: (value, oldValue) => {
+            if (oldValue !== undefined && value !== oldValue) {
+                actions.loadResponse()
+            }
         },
     })),
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -245,7 +245,8 @@ const LeftHandColumn = (): JSX.Element => {
 }
 
 const ExceptionsTab = (): JSX.Element => {
-    const { eventsQuery, eventsQueryKey, selectedEvent } = useValues(errorTrackingIssueSceneLogic)
+    const { eventsQuery, eventsQueryKey, selectedEvent, issueFingerprints, issueFingerprintsLoading } =
+        useValues(errorTrackingIssueSceneLogic)
     const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
 
     return (
@@ -261,16 +262,22 @@ const ExceptionsTab = (): JSX.Element => {
             </div>
             <LemonDivider className="my-0 shrink-0" />
             <Metadata className="flex flex-col flex-1 min-h-0 overflow-y-auto">
-                <EventsTable
-                    query={eventsQuery}
-                    queryKey={eventsQueryKey}
-                    selectedEvent={selectedEvent}
-                    onEventSelect={(selectedEvent) => {
-                        if (selectedEvent) {
-                            selectEvent(selectedEvent)
-                        }
-                    }}
-                />
+                {issueFingerprintsLoading ? (
+                    <div className="text-muted text-sm px-2 py-3">Loading exceptions...</div>
+                ) : issueFingerprints.length === 0 ? (
+                    <div className="text-muted text-sm px-2 py-3">No exceptions found for this issue.</div>
+                ) : (
+                    <EventsTable
+                        query={eventsQuery}
+                        queryKey={eventsQueryKey}
+                        selectedEvent={selectedEvent}
+                        onEventSelect={(selectedEvent) => {
+                            if (selectedEvent) {
+                                selectEvent(selectedEvent)
+                            }
+                        }}
+                    />
+                )}
             </Metadata>
         </div>
     )


### PR DESCRIPTION
I discovered that we were running:
- 2x error tracking query - this is fine,
- 3x breakdowns query - this is not ok,
- 2x events query - this is not ok.

Fixed that so instead of running 7 queries we run 4.

I was also thinking about how we measure stack trace load time and I figured it is not very accurate. And that is because we were only measuring time of a request to backend to give us frames from raw ids but it actually depends on another query which needs to run first. So we are now additionally measuring total time it took from logic mount to displaying stack trace