### PR TITLE
fix(experiments): Fix various cases of stale data in the experiment creation form

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -314,7 +314,17 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     })),
     events(({ actions, values, props }) => ({
         afterMount: () => {
-            if (props.experiment || values.experiment.id !== 'new') {
+            // When opened with an existing experiment (e.g. revisiting an
+            // incomplete draft), always sync the reducer to the prop value.
+            // This handles the case where a kea logic instance is reused
+            // across re-renders — the reducer's initial value was captured
+            // at first mount and won't reflect newer props without this.
+            if (props.experiment) {
+                actions.setExperiment(props.experiment)
+                return
+            }
+
+            if (values.experiment.id !== 'new') {
                 return
             }
 

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -278,7 +278,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
         if (showWizard) {
             return (
                 <BindLogic logic={createExperimentLogic} props={{ experiment, tabId }}>
-                    <BindLogic logic={experimentWizardLogic} props={{ tabId }}>
+                    <BindLogic logic={experimentWizardLogic} props={{ experiment, tabId }}>
                         <ExperimentWizard />
                     </BindLogic>
                 </BindLogic>

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
@@ -25,6 +25,7 @@ export const STEP_ORDER: Record<ExperimentWizardStep, number> = {
 
 export interface ExperimentWizardLogicProps {
     tabId: string
+    experiment?: Experiment
 }
 
 export const experimentWizardLogic = kea<experimentWizardLogicType>([
@@ -32,11 +33,11 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
 
     props({} as ExperimentWizardLogicProps),
 
-    key((props) => props.tabId),
+    key((props) => `${props.tabId}-${props.experiment?.id ?? 'create-experiment'}`),
 
     connect((props: ExperimentWizardLogicProps) => ({
         values: [
-            createExperimentLogic({ tabId: props.tabId }),
+            createExperimentLogic({ experiment: props.experiment, tabId: props.tabId }),
             [
                 'experiment',
                 'sharedMetrics',
@@ -46,7 +47,7 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
             ],
         ],
         actions: [
-            createExperimentLogic({ tabId: props.tabId }),
+            createExperimentLogic({ experiment: props.experiment, tabId: props.tabId }),
             [
                 'setExperiment',
                 'setExperimentValue',


### PR DESCRIPTION
## Problem

Fix various cases of stale data in the experiment creation form:
- Rendering an empty form when clicking on a draft experiment
- Showing stale data when clicking on "new experiment" while making sure multiple in-app tabs remain separate

## Changes

- Added setExperiment call in afterMount so revisiting a draft syncs the reducer state from props (handles kea logic reuse where initial reducer values are stale)
- Forwarded experiment prop through connect to createExperimentLogic so the wizard connects to the correct logic instance
- Changed key from props.tabId to ${props.tabId}-${props.experiment?.id ?? 'create-experiment'} so navigating between drafts and new experiments creates distinct logic instances
- Passed experiment prop to experimentWizardLogic in BindLogic

## How did you test this code?

- Test cases for a variety of cases
- Manually

## Publish to changelog?

No