### PR TITLE
fix(replay): memory leak when browsing multiple recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -904,7 +904,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         highlightColor: (responseStatus || 0) >= 400 ? 'danger' : undefined,
                         windowId,
                         windowNumber: windowNumberForID(windowId),
-                        key: `performance-${event.uuid ?? event.name ?? 'unknown'}-${timestamp}`,
+                        key: `performance-${event.uuid ?? event.name ?? 'unknown'}-${timestamp.valueOf()}`,
                     })
                 }
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -904,7 +904,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         highlightColor: (responseStatus || 0) >= 400 ? 'danger' : undefined,
                         windowId,
                         windowNumber: windowNumberForID(windowId),
-                        key: `performance-${event.uuid}`,
+                        key: `performance-${event.uuid ?? event.name ?? 'unknown'}-${timestamp}`,
                     })
                 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^29.7.0
       version: 29.7.0
     kea:
-      specifier: ^4.0.0-pre.3
-      version: 4.0.0-pre.3
+      specifier: ^4.0.0-pre.5
+      version: 4.0.0-pre.5
     kea-forms:
       specifier: ^3.2.0
       version: 3.2.0
@@ -866,31 +866,31 @@ importers:
         version: 4.1.0
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-localstorage:
         specifier: 'catalog:'
-        version: 3.1.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       kea-waitfor:
         specifier: 'catalog:'
-        version: 0.2.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-window-values:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       liquidjs:
         specifier: ^10.21.1
         version: 10.21.1
@@ -1724,19 +1724,19 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1763,13 +1763,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1781,7 +1781,7 @@ importers:
         version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
-        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.3(react@18.3.1)))(kea@4.0.0-pre.3(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/core':
         specifier: '*'
         version: 3.19.0(@tiptap/pm@3.19.0)
@@ -1817,16 +1817,16 @@ importers:
         version: 1.2.1
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -1856,16 +1856,16 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -1889,13 +1889,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1922,19 +1922,19 @@ importers:
         version: 1.2.1
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1958,16 +1958,16 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2021,19 +2021,19 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -2069,13 +2069,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2096,13 +2096,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -2126,13 +2126,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2153,13 +2153,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2182,16 +2182,16 @@ importers:
         version: 1.2.1
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@18.3.1)
@@ -2206,7 +2206,7 @@ importers:
         version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
-        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.3(react@18.3.1)))(kea@4.0.0-pre.3(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -2221,10 +2221,10 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2234,7 +2234,7 @@ importers:
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/llm_analytics:
     dependencies:
@@ -2267,19 +2267,19 @@ importers:
         version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -2304,7 +2304,7 @@ importers:
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/logs:
     dependencies:
@@ -2352,16 +2352,16 @@ importers:
         version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       papaparse:
         specifier: '*'
         version: 5.4.1
@@ -2386,7 +2386,7 @@ importers:
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/managed_migrations:
     dependencies:
@@ -2395,22 +2395,22 @@ importers:
         version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
-        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.3(react@18.3.1)))(kea@4.0.0-pre.3(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2433,13 +2433,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2460,13 +2460,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2489,13 +2489,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2518,13 +2518,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2545,16 +2545,16 @@ importers:
         version: 1.2.1
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2569,13 +2569,13 @@ importers:
         version: 18.3.27
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2596,13 +2596,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2641,19 +2641,19 @@ importers:
         version: 3.1.3
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2666,7 +2666,7 @@ importers:
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/toolbar: {}
 
@@ -2683,13 +2683,13 @@ importers:
         version: 1.2.1
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -2713,13 +2713,13 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2749,19 +2749,19 @@ importers:
         version: 6.6.2
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.3(react@18.3.1)
+        version: 4.0.0-pre.5(react@18.3.1)
       kea-forms:
         specifier: 'catalog:'
-        version: 3.2.0(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       kea-subscriptions:
         specifier: 'catalog:'
-        version: 3.0.1(kea@4.0.0-pre.3(react@18.3.1))
+        version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
         version: 1.352.1
@@ -2777,7 +2777,7 @@ importers:
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
-        version: 0.2.4(kea@4.0.0-pre.3(react@18.3.1))
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   rust/cyclotron-node:
     devDependencies:
@@ -15767,8 +15767,8 @@ packages:
     peerDependencies:
       kea: '>= 3'
 
-  kea@4.0.0-pre.3:
-    resolution: {integrity: sha512-ijiU26sDD7W55B7tGQSBiDkcmj8j97hVyyyp9HeyoMk/i4tppKLKmKQNh+o8rsY+mYvMVOxyjupwvt/gs+2v9w==}
+  kea@4.0.0-pre.5:
+    resolution: {integrity: sha512-GMF6Bdfe7qt3xk7u3mFhhjrwt41neTlmG8JDXJxGyCojHRU8AuEtZ7Ac+x81JoqvCusHHvDVhvrdF/zYT0cn7Q==}
     peerDependencies:
       react: 18.3.1
 
@@ -28346,11 +28346,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/lemon-ui@0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.3(react@18.3.1)))(kea@4.0.0-pre.3(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@posthog/lemon-ui@0.0.0(antd@5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       antd: 5.26.0(date-fns@2.29.3)(luxon@3.5.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      kea: 4.0.0-pre.3(react@18.3.1)
-      kea-router: 3.4.1(kea@4.0.0-pre.3(react@18.3.1))
+      kea: 4.0.0-pre.5(react@18.3.1)
+      kea-router: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -38371,31 +38371,31 @@ snapshots:
 
   kdbush@4.0.2: {}
 
-  kea-forms@3.2.0(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-forms@3.2.0(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea-loaders@3.1.1(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-loaders@3.1.1(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea-localstorage@3.1.0(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-localstorage@3.1.0(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea-router@3.4.1(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
       url-pattern: 1.0.3
 
-  kea-subscriptions@3.0.1(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-subscriptions@3.0.1(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea-test-utils@0.2.4(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-test-utils@0.2.4(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
-      kea-waitfor: 0.2.1(kea@4.0.0-pre.3(react@18.3.1))
+      kea: 4.0.0-pre.5(react@18.3.1)
+      kea-waitfor: 0.2.1(kea@4.0.0-pre.5(react@18.3.1))
 
   kea-typegen@3.5.0(typescript@5.4.5):
     dependencies:
@@ -38410,15 +38410,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  kea-waitfor@0.2.1(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-waitfor@0.2.1(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea-window-values@3.0.1(kea@4.0.0-pre.3(react@18.3.1)):
+  kea-window-values@3.0.1(kea@4.0.0-pre.5(react@18.3.1)):
     dependencies:
-      kea: 4.0.0-pre.3(react@18.3.1)
+      kea: 4.0.0-pre.5(react@18.3.1)
 
-  kea@4.0.0-pre.3(react@18.3.1):
+  kea@4.0.0-pre.5(react@18.3.1):
     dependencies:
       react: 18.3.1
       redux: 5.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ packages:
 
 catalog:
     # Kea ecosystem - state management
-    kea: ^4.0.0-pre.3
+    kea: ^4.0.0-pre.5
     kea-forms: ^3.2.0
     kea-loaders: ^3.1.1
     kea-localstorage: ^3.1.0
@@ -64,7 +64,7 @@ minimumReleaseAgeExclude:
     - node-forge@1.3.2
     - '@posthog/*'
     - '@modelcontextprotocol/sdk' # Security update for GHSA-345p-7cg4-v4c7
-    - kea@4.0.0-pre.3
+    - kea@4.0.0-pre.5
     - chartjs-plugin-stacked100@1.7.1
     - torph@0.0.5
     - oxfmt@0.35.0


### PR DESCRIPTION
## Summary

- Upgrade kea to `4.0.0-pre.5` which fixes a bug in `unmountLogic` where connected logics were never removed from their `wrapperContext.builtLogics` cache — the old code used the parent logic's `wrapper`/`key` instead of the connected logic's own, causing stale logic instances (with reselect memoization caches holding `SnapshotStore` instances, inspector items, etc.) to accumulate for every recording viewed
- Fix inspector key generation to avoid ~115K identical `"performance-undefined"` string allocations when `event.uuid` is missing

## Context

A customer reported browser slowdown when browsing Session Replay recordings. Heap snapshot analysis (2 GB snapshot, 26M nodes) confirmed that `SnapshotStore` instances from previously-viewed recordings were being retained indefinitely through kea's `builtLogics` cache → reselect memoization → `mergedSnapshotsCache`.

A/B testing with 4 heap snapshots confirmed the fix:

| Run | Patch | SnapshotStore instances | Self-size |
|-----|-------|----------------------|-----------|
| 1 | patched | 3 | 492 MB |
| 2 | unpatched | 7 | 612 MB |
| 3 | unpatched | 10 | 1,119 MB |
| 4 | patched | 4 | 507 MB |

The upstream kea fix was published as `4.0.0-pre.5` by @mariusandra.

## Test plan

- [x] Verified fix with heap snapshot analysis (4 snapshots, patched vs unpatched)
- [ ] Smoke test: browse 10+ recordings, confirm memory stays stable