### PR TITLE
fix(flags): implement missing icontains_multi operators in Rust feature flags service

### DIFF
--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -449,6 +449,8 @@ mod tests {
             ("is_not", OperatorType::IsNot),
             ("icontains", OperatorType::Icontains),
             ("not_icontains", OperatorType::NotIcontains),
+            ("icontains_multi", OperatorType::IcontainsMulti),
+            ("not_icontains_multi", OperatorType::NotIcontainsMulti),
             ("regex", OperatorType::Regex),
             ("not_regex", OperatorType::NotRegex),
             ("gt", OperatorType::Gt),

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -159,23 +159,22 @@ pub fn match_property(
         OperatorType::IcontainsMulti | OperatorType::NotIcontainsMulti => {
             if let Some(match_value) = match_value {
                 let match_string = to_string_representation(match_value).to_ascii_lowercase();
-                
+
                 // Handle both single values and arrays
                 let search_values: Vec<String> = match value {
-                    Value::Array(arr) => {
-                        arr.iter()
-                            .map(|v| to_string_representation(v).to_ascii_lowercase())
-                            .collect()
-                    }
+                    Value::Array(arr) => arr
+                        .iter()
+                        .map(|v| to_string_representation(v).to_ascii_lowercase())
+                        .collect(),
                     single_value => {
                         vec![to_string_representation(single_value).to_ascii_lowercase()]
                     }
                 };
 
                 // Check if any of the search values is contained in the match value
-                let any_contained = search_values.iter().any(|search_val| {
-                    match_string.contains(search_val)
-                });
+                let any_contained = search_values
+                    .iter()
+                    .any(|search_val| match_string.contains(search_val));
 
                 if operator == OperatorType::IcontainsMulti {
                     Ok(any_contained)

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -156,6 +156,39 @@ pub fn match_property(
                 Ok(operator == OperatorType::NotIcontains)
             }
         }
+        OperatorType::IcontainsMulti | OperatorType::NotIcontainsMulti => {
+            if let Some(match_value) = match_value {
+                let match_string = to_string_representation(match_value).to_ascii_lowercase();
+                
+                // Handle both single values and arrays
+                let search_values: Vec<String> = match value {
+                    Value::Array(arr) => {
+                        arr.iter()
+                            .map(|v| to_string_representation(v).to_ascii_lowercase())
+                            .collect()
+                    }
+                    single_value => {
+                        vec![to_string_representation(single_value).to_ascii_lowercase()]
+                    }
+                };
+
+                // Check if any of the search values is contained in the match value
+                let any_contained = search_values.iter().any(|search_val| {
+                    match_string.contains(search_val)
+                });
+
+                if operator == OperatorType::IcontainsMulti {
+                    Ok(any_contained)
+                } else {
+                    Ok(!any_contained)
+                }
+            } else {
+                // When value doesn't exist:
+                // - for IcontainsMulti: it's not a match (false)
+                // - for NotIcontainsMulti: it is a match (true)
+                Ok(operator == OperatorType::NotIcontainsMulti)
+            }
+        }
         OperatorType::Regex | OperatorType::NotRegex => {
             if match_value.is_none() {
                 // When value doesn't exist:
@@ -3069,5 +3102,197 @@ mod test_match_properties {
             "Expected InvalidRegexPattern error due to backtrack limit, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_match_properties_icontains_multi() {
+        // Test icontains_multi with array of values
+        let property_array = PropertyFilter {
+            key: "email".to_string(),
+            value: Some(json!(["@gmail.com", "@yahoo.com"])),
+            operator: Some(OperatorType::IcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Should match gmail
+        assert!(match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@gmail.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should match yahoo
+        assert!(match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@yahoo.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should not match hotmail
+        assert!(!match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@hotmail.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Test icontains_multi with single value
+        let property_single = PropertyFilter {
+            key: "name".to_string(),
+            value: Some(json!("john")),
+            operator: Some(OperatorType::IcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Should match case-insensitively
+        assert!(match_property(
+            &property_single,
+            &HashMap::from([("name".to_string(), json!("John Doe"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should not match different name
+        assert!(!match_property(
+            &property_single,
+            &HashMap::from([("name".to_string(), json!("Jane Doe"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should return error when key doesn't exist in partial mode
+        assert!(match_property(
+            &property_single,
+            &HashMap::from([("other_key".to_string(), json!("value"))]),
+            true
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_match_properties_not_icontains_multi() {
+        // Test not_icontains_multi with array of values
+        let property_array = PropertyFilter {
+            key: "email".to_string(),
+            value: Some(json!(["@gmail.com", "@yahoo.com"])),
+            operator: Some(OperatorType::NotIcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Should not match gmail (negated)
+        assert!(!match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@gmail.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should not match yahoo (negated)
+        assert!(!match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@yahoo.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should match hotmail (does not contain any of the blocked domains)
+        assert!(match_property(
+            &property_array,
+            &HashMap::from([("email".to_string(), json!("user@hotmail.com"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Test not_icontains_multi with single value
+        let property_single = PropertyFilter {
+            key: "name".to_string(),
+            value: Some(json!("spam")),
+            operator: Some(OperatorType::NotIcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Should match when value doesn't contain spam
+        assert!(match_property(
+            &property_single,
+            &HashMap::from([("name".to_string(), json!("John Doe"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Should not match when value contains spam
+        assert!(!match_property(
+            &property_single,
+            &HashMap::from([("name".to_string(), json!("Spam Email"))]),
+            true
+        )
+        .expect("expected match to exist"));
+    }
+
+    #[test]
+    fn test_match_properties_icontains_multi_empty_values() {
+        // Test with empty array
+        let property_empty = PropertyFilter {
+            key: "test".to_string(),
+            value: Some(json!([])),
+            operator: Some(OperatorType::IcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Empty array should not match anything
+        assert!(!match_property(
+            &property_empty,
+            &HashMap::from([("test".to_string(), json!("any value"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Test with missing key should default to false for icontains_multi
+        assert!(!match_property(
+            &property_empty,
+            &HashMap::from([("other_key".to_string(), json!("value"))]),
+            false // non-partial mode
+        )
+        .expect("expected match to exist"));
+    }
+
+    #[test]
+    fn test_match_properties_not_icontains_multi_empty_values() {
+        // Test with empty array
+        let property_empty = PropertyFilter {
+            key: "test".to_string(),
+            value: Some(json!([])),
+            operator: Some(OperatorType::NotIcontainsMulti),
+            prop_type: PropertyType::Person,
+            group_type_index: None,
+            negation: None,
+        };
+
+        // Empty array should match everything (nothing to exclude)
+        assert!(match_property(
+            &property_empty,
+            &HashMap::from([("test".to_string(), json!("any value"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        // Test with missing key should default to true for not_icontains_multi
+        assert!(match_property(
+            &property_empty,
+            &HashMap::from([("other_key".to_string(), json!("value"))]),
+            false // non-partial mode
+        )
+        .expect("expected match to exist"));
     }
 }

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -7,6 +7,8 @@ pub enum OperatorType {
     IsNot,
     Icontains,
     NotIcontains,
+    IcontainsMulti,
+    NotIcontainsMulti,
     Regex,
     NotRegex,
     Gt,


### PR DESCRIPTION
## Problem

When evaluating feature flags with cohort conditions that use the new "contains any of" filter, the Rust flags service was returning `cohort_filters_parsing_error` because the `icontains_multi` and `not_icontains_multi` operators were implemented in the Python codebase but missing from the Rust implementation.

Context: https://posthog.slack.com/archives/C09TNSLRKF1/p1771962221473969

## Changes

- Added `IcontainsMulti` and `NotIcontainsMulti` variants to the `OperatorType` enum
- Implemented property matching logic for both operators with support for:
  - Array values (checking if any array element is contained in the target)
  - Single values (treating as single-element array)
  - Case-insensitive matching
  - Proper handling of missing properties

## How did you test this code?

- Added unit tests
- Tested locally using flag with cohort with condition contains any of 

## Publish to changelog?

no