### PR TITLE
fix(marketing-analytics): prevent dashboard crash from invalid DW conversion goals

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
@@ -67,15 +67,20 @@ export function MarketingAnalyticsOverview(props: {
     const conversionGoalMetrics = conversion_goals.length * 2 // Each conversion goal adds 2 metrics: goal + cost per conversion
     const numSkeletons = BASE_METRICS_COUNT + conversionGoalMetrics
 
-    if (responseError && !responseLoading) {
+    const hasResults = overviewItems.length > 0
+    if (responseError && !responseLoading && !hasResults) {
         return <InsightErrorState title={responseError} />
     }
 
+    // Combine validation warnings with any backend warnings (e.g. skipped conversion goals)
+    const allWarnings = [
+        ...(validationWarnings ?? []),
+        ...(responseError && hasResults ? [{ message: responseError, link: undefined } as const] : []),
+    ]
+
     return (
         <>
-            {validationWarnings && validationWarnings.length > 0 && (
-                <MarketingAnalyticsValidationWarningBanner warnings={validationWarnings} />
-            )}
+            {allWarnings.length > 0 && <MarketingAnalyticsValidationWarningBanner warnings={allWarnings} />}
             <OverviewGrid
                 compact
                 items={overviewItems}

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -147,12 +147,10 @@ export const conversionGoalPopoverFields: DataWarehousePopoverField[] = [
         key: UTM_CAMPAIGN_NAME_SCHEMA_FIELD,
         label: 'UTM Campaign Name',
         type: 'string',
-        optional: true,
     },
     {
         key: UTM_SOURCE_NAME_SCHEMA_FIELD,
         label: 'UTM Source Name',
         type: 'string',
-        optional: true,
     },
 ]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -989,8 +989,6 @@ products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processo
 products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py:0: error: Incompatible types in assignment (expression has type "list[Expr]", variable has type "list[CompareOperation]")  [assignment]
 products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py:0: error: Item "None" of "JoinConstraint | None" has no attribute "constraint_type"  [union-attr]
 products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py:0: error: Item "None" of "JoinConstraint | None" has no attribute "expr"  [union-attr]
-products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py:0: error: Incompatible default for argument "query" (default has type "None", argument has type "MarketingAnalyticsTableQuery")  [assignment]
-products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py:0: error: Statement is unreachable  [unreachable]
 products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_business.py:0: error: "TestMarketingAnalyticsTableQueryRunnerBusiness" has no attribute "test_data_configs"  [attr-defined]
 products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_business.py:0: error: "TestMarketingAnalyticsTableQueryRunnerBusiness" has no attribute "test_data_configs"  [attr-defined]
 products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_business.py:0: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -160,6 +160,7 @@ class MarketingAnalyticsAggregatedQueryRunner(
             hogql=response.hogql,
             timings=response.timings,
             modifiers=self.modifiers,
+            error="; ".join(self._conversion_goal_warnings) if self._conversion_goal_warnings else None,
         )
 
     def calculate_without_compare(self) -> ast.SelectQuery:

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -100,6 +100,7 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             hasMore=has_more,
             limit=requested_limit,
             offset=self.query.offset or 0,
+            error="; ".join(self._conversion_goal_warnings) if self._conversion_goal_warnings else None,
         )
 
     def _get_filtered_select_columns(self, query: ast.SelectQuery) -> list[ast.Expr]:

--- a/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
@@ -117,6 +117,7 @@ class NonIntegratedConversionsTableQueryRunner(
             hasMore=has_more,
             limit=requested_limit,
             offset=self.query.offset or 0,
+            error="; ".join(self._conversion_goal_warnings) if self._conversion_goal_warnings else None,
         )
 
     def _get_filtered_select_columns(self, query: ast.SelectQuery) -> list[ast.Expr]:


### PR DESCRIPTION
## Problem

Closes #49073

When a Data Warehouse conversion goal references columns that don't exist on the selected table (e.g., `utm_campaign`, `utm_source`), the entire marketing analytics dashboard crashes with "Unable to resolve field". One misconfigured goal breaks all three query runners because they share the unified conversion goals CTE via UNION ALL.

## Changes

### Frontend
- **Made UTM fields required in DW popover** (`taxonomy.tsx`): Removed `optional: true` from `utm_campaign_name` and `utm_source_name` fields, so the "Select" button is disabled until both are mapped
- **Show backend warnings as banner** (`MarketingAnalyticsOverview.tsx`): When the backend skips invalid goals but still returns results, warnings are shown in the existing `MarketingAnalyticsValidationWarningBanner` instead of hiding the entire dashboard

### Backend
- **Validate DW goals before query execution** (`marketing_analytics_base_query_runner.py`): Extended `_filter_invalid_conversion_goals` to check that:
  - The referenced DW table exists (using `get_view_or_table_by_name` which handles dot-to-underscore name conversion)
  - The mapped UTM columns exist on that table
  - Handles `None` values in `schema_map` (when user didn't set a mapping)
- **Surface warnings in response**: All three query runners pass skipped-goal warnings via the `error` field
- Invalid goals are silently skipped so the rest of the dashboard keeps working

### Tests
- 4 new tests covering: missing table, missing columns, valid columns, mixed valid/invalid goals
- Updated existing "All Events" filter test for new return type

## How did you test this code?

- Ran `pytest products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py` — 14 tests pass
- Manually tested with a DW conversion goal referencing a table with missing UTM columns — dashboard renders with warning banner instead of crashing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

<img width="353" height="380" alt="image" src="https://github.com/user-attachments/assets/f6bc5d3a-e321-4fb2-a96d-2d116f9215a0" />

<img width="1276" height="84" alt="Screenshot 2026-02-25 at 1 39 25 PM" src="https://github.com/user-attachments/assets/6ad087fc-e51c-4c41-82af-1217a11f5971" />

## Publish to changelog?

no