### PR TITLE
feat(analytics-platform): Optimize session id comparisons

### DIFF
--- a/posthog/hogql/database/schema/test/__snapshots__/test_sessions_v3.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_sessions_v3.ambr
@@ -344,7 +344,7 @@
      WHERE equals(person_distinct_id_overrides.team_id, 99999)
      GROUP BY person_distinct_id_overrides.distinct_id
      HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  WHERE and(equals(events.team_id, 99999), or(equals(events.`$session_id`, '00000000-0000-0000-0000-000000000000'), equals(events.`$session_id`, '00000000-0000-0000-0000-000000000000')))
+  WHERE and(equals(events.team_id, 99999), or(equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull('00000000-0000-0000-0000-000000000000', 'UUID'))), equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull('00000000-0000-0000-0000-000000000000', 'UUID')))))
   ORDER BY 2 ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -562,7 +562,7 @@
      FROM raw_sessions_v3
      WHERE and(equals(raw_sessions_v3.team_id, 99999), equals(raw_sessions_v3.session_timestamp, fromUnixTimestamp64Milli(toUInt64(bitShiftRight(toUInt128(accurateCastOrNull('00000000-0000-0000-0000-000000000000', 'UUID')), 80)))))
      GROUP BY raw_sessions_v3.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-  WHERE and(equals(events.team_id, 99999), equals(events.`$session_id`, '00000000-0000-0000-0000-000000000000'))
+  WHERE and(equals(events.team_id, 99999), equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull('00000000-0000-0000-0000-000000000000', 'UUID'))))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -806,6 +806,8 @@ class ClickHousePrinter(BasePrinter):
 
     def _get_events_session_id_table_type(self, node: ast.Expr) -> ast.BaseTableType | None:
         """If the expression resolves to $session_id on the events table, return the table type."""
+        from posthog.hogql.database.schema.events import EventsTable
+
         expr_type = resolve_field_type(node)
 
         if isinstance(expr_type, ast.FieldType) and expr_type.name == "$session_id":
@@ -819,15 +821,11 @@ class ClickHousePrinter(BasePrinter):
         else:
             return None
 
-        while True:
-            if isinstance(table_type, ast.TableType):
-                if table_type.table.to_printed_hogql() == "events":
-                    return table_type
-                return None
-            elif isinstance(table_type, ast.TableAliasType):
-                table_type = table_type.table_type
-            else:
-                return None
+        if isinstance(table_type, ast.TableAliasType):
+            table_type = table_type.table_type
+        if isinstance(table_type, ast.TableType) and isinstance(table_type.table, EventsTable):
+            return table_type
+        return None
 
     def _get_optimized_session_id_compare_operation(self, node: ast.CompareOperation) -> str | None:
         """Rewrite $session_id comparisons against UUID constants to use the $session_id_uuid column."""

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -821,7 +821,7 @@ class ClickHousePrinter(BasePrinter):
         else:
             return None
 
-        if isinstance(table_type, ast.TableAliasType):
+        while isinstance(table_type, ast.TableAliasType):
             table_type = table_type.table_type
         if isinstance(table_type, ast.TableType) and isinstance(table_type.table, EventsTable):
             return table_type

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -804,6 +804,91 @@ class ClickHousePrinter(BasePrinter):
             else:
                 return f"notIn({materialized_column_sql}, tuple({values_sql}))"
 
+    def _get_events_session_id_table_type(self, node: ast.Expr) -> ast.BaseTableType | None:
+        """If the expression resolves to $session_id on the events table, return the table type."""
+        expr_type = resolve_field_type(node)
+
+        if isinstance(expr_type, ast.FieldType) and expr_type.name == "$session_id":
+            table_type = expr_type.table_type
+        elif (
+            isinstance(expr_type, ast.PropertyType)
+            and expr_type.chain == ["$session_id"]
+            and expr_type.field_type.name == "properties"
+        ):
+            table_type = expr_type.field_type.table_type
+        else:
+            return None
+
+        while True:
+            if isinstance(table_type, ast.TableType):
+                if table_type.table.to_printed_hogql() == "events":
+                    return table_type
+                return None
+            elif isinstance(table_type, ast.TableAliasType):
+                table_type = table_type.table_type
+            else:
+                return None
+
+    def _wrap_constant_as_session_uuid(self, constant_sql: str) -> str:
+        return f"toUInt128(accurateCastOrNull({constant_sql}, 'UUID'))"
+
+    def _get_optimized_session_id_compare_operation(self, node: ast.CompareOperation) -> str | None:
+        """Rewrite $session_id comparisons against UUID constants to use the $session_id_uuid column."""
+        if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq):
+            return self._get_optimized_session_id_eq_operation(node)
+        elif node.op in (ast.CompareOperationOp.In, ast.CompareOperationOp.NotIn):
+            return self._get_optimized_session_id_in_operation(node)
+        return None
+
+    def _get_optimized_session_id_eq_operation(self, node: ast.CompareOperation) -> str | None:
+        session_id_table: ast.BaseTableType | None = None
+        constant: ast.Constant | None = None
+
+        if (table := self._get_events_session_id_table_type(node.left)) and isinstance(node.right, ast.Constant):
+            session_id_table, constant = table, node.right
+        elif (table := self._get_events_session_id_table_type(node.right)) and isinstance(node.left, ast.Constant):
+            session_id_table, constant = table, node.left
+
+        if session_id_table is None or constant is None:
+            return None
+
+        if not UUIDT.is_valid_uuid(constant.value):
+            return None
+
+        table_sql = self.visit(session_id_table)
+        field_sql = f"{table_sql}.{self._print_identifier('$session_id_uuid')}"
+        constant_sql = self._wrap_constant_as_session_uuid(self.visit(constant))
+
+        op_name = "equals" if node.op == ast.CompareOperationOp.Eq else "notEquals"
+        return f"{op_name}({field_sql}, {constant_sql})"
+
+    def _get_optimized_session_id_in_operation(self, node: ast.CompareOperation) -> str | None:
+        session_id_table = self._get_events_session_id_table_type(node.left)
+        if session_id_table is None:
+            return None
+
+        if isinstance(node.right, ast.Constant) and isinstance(node.right.value, str):
+            constants: list[ast.Constant] = [node.right]
+        elif isinstance(node.right, (ast.Tuple, ast.Array)):
+            constants = []
+            for expr in node.right.exprs:
+                if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+                    constants.append(expr)
+                else:
+                    return None
+        else:
+            return None
+
+        if not constants or not all(UUIDT.is_valid_uuid(c.value) for c in constants):
+            return None
+
+        table_sql = self.visit(session_id_table)
+        field_sql = f"{table_sql}.{self._print_identifier('$session_id_uuid')}"
+        values_sql = ", ".join(self._wrap_constant_as_session_uuid(self.visit(c)) for c in constants)
+
+        op_name = "in" if node.op == ast.CompareOperationOp.In else "notIn"
+        return f"{op_name}({field_sql}, tuple({values_sql}))"
+
     def _optimize_in_with_string_values(
         self, values: list[ast.Expr], property_source: PrintableMaterializedPropertyGroupItem
     ) -> str | None:
@@ -986,6 +1071,9 @@ class ClickHousePrinter(BasePrinter):
     def visit_compare_operation(self, node: ast.CompareOperation):
         # If either side of the operation is a property that is part of a property group, special optimizations may
         # apply here to ensure that data skipping indexes can be used when possible.
+        if optimized_session_id := self._get_optimized_session_id_compare_operation(node):
+            return optimized_session_id
+
         if optimized_property_group_compare_operation := self._get_optimized_property_group_compare_operation(node):
             return optimized_property_group_compare_operation
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -829,65 +829,51 @@ class ClickHousePrinter(BasePrinter):
             else:
                 return None
 
-    def _wrap_constant_as_session_uuid(self, constant_sql: str) -> str:
-        return f"toUInt128(accurateCastOrNull({constant_sql}, 'UUID'))"
-
     def _get_optimized_session_id_compare_operation(self, node: ast.CompareOperation) -> str | None:
         """Rewrite $session_id comparisons against UUID constants to use the $session_id_uuid column."""
-        if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq):
-            return self._get_optimized_session_id_eq_operation(node)
-        elif node.op in (ast.CompareOperationOp.In, ast.CompareOperationOp.NotIn):
-            return self._get_optimized_session_id_in_operation(node)
-        return None
+        op_name = {
+            ast.CompareOperationOp.Eq: "equals",
+            ast.CompareOperationOp.NotEq: "notEquals",
+            ast.CompareOperationOp.In: "in",
+            ast.CompareOperationOp.NotIn: "notIn",
+        }.get(node.op)
+        if op_name is None:
+            return None
 
-    def _get_optimized_session_id_eq_operation(self, node: ast.CompareOperation) -> str | None:
         session_id_table: ast.BaseTableType | None = None
-        constant: ast.Constant | None = None
+        constants: list[ast.Constant] = []
 
-        if (table := self._get_events_session_id_table_type(node.left)) and isinstance(node.right, ast.Constant):
-            session_id_table, constant = table, node.right
-        elif (table := self._get_events_session_id_table_type(node.right)) and isinstance(node.left, ast.Constant):
-            session_id_table, constant = table, node.left
+        if table := self._get_events_session_id_table_type(node.left):
+            session_id_table = table
+            constants = self._extract_uuid_constants(node.right)
+        elif node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq):
+            if table := self._get_events_session_id_table_type(node.right):
+                session_id_table = table
+                constants = self._extract_uuid_constants(node.left)
 
-        if session_id_table is None or constant is None:
+        if session_id_table is None or not constants:
             return None
 
-        if not UUIDT.is_valid_uuid(constant.value):
-            return None
+        field_sql = f"{self.visit(session_id_table)}.{self._print_identifier('$session_id_uuid')}"
+        wrapped = [f"toUInt128(accurateCastOrNull({self.visit(c)}, 'UUID'))" for c in constants]
 
-        table_sql = self.visit(session_id_table)
-        field_sql = f"{table_sql}.{self._print_identifier('$session_id_uuid')}"
-        constant_sql = self._wrap_constant_as_session_uuid(self.visit(constant))
+        if node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq):
+            return f"{op_name}({field_sql}, {wrapped[0]})"
+        return f"{op_name}({field_sql}, tuple({', '.join(wrapped)}))"
 
-        op_name = "equals" if node.op == ast.CompareOperationOp.Eq else "notEquals"
-        return f"{op_name}({field_sql}, {constant_sql})"
-
-    def _get_optimized_session_id_in_operation(self, node: ast.CompareOperation) -> str | None:
-        session_id_table = self._get_events_session_id_table_type(node.left)
-        if session_id_table is None:
-            return None
-
-        if isinstance(node.right, ast.Constant) and isinstance(node.right.value, str):
-            constants: list[ast.Constant] = [node.right]
-        elif isinstance(node.right, (ast.Tuple, ast.Array)):
-            constants = []
-            for expr in node.right.exprs:
-                if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
-                    constants.append(expr)
-                else:
-                    return None
-        else:
-            return None
-
-        if not constants or not all(UUIDT.is_valid_uuid(c.value) for c in constants):
-            return None
-
-        table_sql = self.visit(session_id_table)
-        field_sql = f"{table_sql}.{self._print_identifier('$session_id_uuid')}"
-        values_sql = ", ".join(self._wrap_constant_as_session_uuid(self.visit(c)) for c in constants)
-
-        op_name = "in" if node.op == ast.CompareOperationOp.In else "notIn"
-        return f"{op_name}({field_sql}, tuple({values_sql}))"
+    @staticmethod
+    def _extract_uuid_constants(node: ast.Expr) -> list[ast.Constant]:
+        """Extract UUID string constants from an expression. Returns empty list if any value is not a valid UUID."""
+        if isinstance(node, ast.Constant):
+            return [node] if UUIDT.is_valid_uuid(node.value) else []
+        if isinstance(node, (ast.Tuple, ast.Array)):
+            result: list[ast.Constant] = []
+            for expr in node.exprs:
+                if not isinstance(expr, ast.Constant) or not UUIDT.is_valid_uuid(expr.value):
+                    return []
+                result.append(expr)
+            return result
+        return []
 
     def _optimize_in_with_string_values(
         self, values: list[ast.Expr], property_source: PrintableMaterializedPropertyGroupItem

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3921,6 +3921,59 @@ class TestPrinter(BaseTest):
             context=context,
         )
 
+    @parameterized.expand(
+        [
+            (
+                "eq_direct_field",
+                "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'",
+                "equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')))",
+            ),
+            (
+                "neq_direct_field",
+                "$session_id != 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'",
+                "notEquals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')))",
+            ),
+            (
+                "eq_constant_on_left",
+                "'a1b2c3d4-e5f6-7890-abcd-ef1234567890' = $session_id",
+                "equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')))",
+            ),
+            (
+                "eq_property_access",
+                "properties.$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'",
+                "equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')))",
+            ),
+            (
+                "in_operation",
+                "$session_id IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'b2c3d4e5-f6a7-8901-bcde-f12345678901')",
+                "in(events.`$session_id_uuid`, tuple(toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')), toUInt128(accurateCastOrNull(%(hogql_val_1)s, 'UUID'))))",
+            ),
+            (
+                "not_in_operation",
+                "$session_id NOT IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'b2c3d4e5-f6a7-8901-bcde-f12345678901')",
+                "notIn(events.`$session_id_uuid`, tuple(toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')), toUInt128(accurateCastOrNull(%(hogql_val_1)s, 'UUID'))))",
+            ),
+            (
+                "eq_uppercase_uuid",
+                "$session_id = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890'",
+                "equals(events.`$session_id_uuid`, toUInt128(accurateCastOrNull(%(hogql_val_0)s, 'UUID')))",
+            ),
+        ]
+    )
+    def test_session_id_uuid_optimization(self, _name, expr, expected):
+        self.assertEqual(self._expr(expr), expected)
+
+    @parameterized.expand(
+        [
+            ("non_uuid_string", "$session_id = 'not-a-uuid'"),
+            ("non_string_constant", "$session_id = 123"),
+            ("in_with_non_uuid", "$session_id IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'not-a-uuid')"),
+        ]
+    )
+    def test_session_id_uuid_optimization_skipped(self, _name, expr):
+        result = self._expr(expr)
+        self.assertNotIn("$session_id_uuid", result)
+
 
 @snapshot_clickhouse_queries
 class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
@@ -4667,6 +4720,77 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
         with materialized("events", "test_prop", is_nullable=False) as mat_col:
             printed = self._expr("JSONExtractString(properties, 'test_prop')")
             assert printed == f"nullIf(nullIf(events.{mat_col.name}, ''), 'null')"
+
+
+class TestSessionIdUuidOptimization(ClickhouseTestMixin, APIBaseTest):
+    SESSION_UUID_1 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    SESSION_UUID_2 = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+    def setUp(self):
+        super().setUp()
+        _create_person(distinct_ids=["user1"], team_id=self.team.pk)
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="user1",
+            properties={"$session_id": self.SESSION_UUID_1, "color": "blue"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="user1",
+            properties={"$session_id": self.SESSION_UUID_2, "color": "red"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="user1",
+            properties={"$session_id": "not-a-uuid", "color": "green"},
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "eq_direct_field",
+                "SELECT properties.color FROM events WHERE $session_id = '{session_uuid_1}' ORDER BY properties.color",
+                [("blue",)],
+            ),
+            (
+                "eq_property_access",
+                "SELECT properties.color FROM events WHERE properties.$session_id = '{session_uuid_1}' ORDER BY properties.color",
+                [("blue",)],
+            ),
+            (
+                "neq_direct_field",
+                "SELECT properties.color FROM events WHERE $session_id != '{session_uuid_1}' AND $session_id = '{session_uuid_2}' ORDER BY properties.color",
+                [("red",)],
+            ),
+            (
+                "in_operation",
+                "SELECT properties.color FROM events WHERE $session_id IN ('{session_uuid_1}', '{session_uuid_2}') ORDER BY properties.color",
+                [("blue",), ("red",)],
+            ),
+            (
+                "not_in_operation",
+                "SELECT properties.color FROM events WHERE $session_id NOT IN ('{session_uuid_1}') AND $session_id = '{session_uuid_2}' ORDER BY properties.color",
+                [("red",)],
+            ),
+        ]
+    )
+    def test_session_id_uuid_query(self, _name, query_template, expected):
+        query = query_template.format(session_uuid_1=self.SESSION_UUID_1, session_uuid_2=self.SESSION_UUID_2)
+        response = execute_hogql_query(team=self.team, query=query)
+        self.assertEqual(response.results, expected)
+
+    # Remove xfail when we add a minmax index on $session_id_uuid (see events table in posthog/models/event/sql.py)
+    # see https://posthog.slack.com/archives/C076R4753Q8/p1772027599338529
+    @pytest.mark.xfail(strict=True, reason="No minmax index on $session_id_uuid yet")
+    def test_session_id_uuid_uses_minmax_index(self):
+        query = f"SELECT properties.color FROM events WHERE $session_id = '{self.SESSION_UUID_1}'"
+        response = execute_hogql_query(team=self.team, query=query)
+        assert response.clickhouse is not None
+        index_info = get_index_from_explain(response.clickhouse, "minmax_$session_id_uuid")
+        assert index_info, "Expected minmax_$session_id_uuid skip index to be used"
 
 
 class TestPrinted(APIBaseTest):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3968,6 +3968,14 @@ class TestPrinter(BaseTest):
             ("non_uuid_string", "$session_id = 'not-a-uuid'"),
             ("non_string_constant", "$session_id = 123"),
             ("in_with_non_uuid", "$session_id IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'not-a-uuid')"),
+            # SQL injection attempts — none of these are valid UUIDs, so the optimization is
+            # skipped and values go through the normal parameterized query path (%(hogql_val_N)s)
+            ("sqli_quote_escape", '$session_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890\' OR 1=1 --"'),
+            ("sqli_uuid_with_suffix", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890; DROP TABLE events'"),
+            ("sqli_uuid_with_parens", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef123456789()'"),
+            ("sqli_overlong_hex", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef12345678901'"),
+            ("sqli_short_hex", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef123456789'"),
+            ("sqli_embedded_sql", "$session_id = '00000000-0000-0000-0000-00000000000\\' OR \\'1\\'=\\'1'"),
         ]
     )
     def test_session_id_uuid_optimization_skipped(self, _name, expr):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3970,12 +3970,15 @@ class TestPrinter(BaseTest):
             ("in_with_non_uuid", "$session_id IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'not-a-uuid')"),
             # SQL injection attempts — none of these are valid UUIDs, so the optimization is
             # skipped and values go through the normal parameterized query path (%(hogql_val_N)s)
-            ("sqli_quote_escape", '$session_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890\' OR 1=1 --"'),
             ("sqli_uuid_with_suffix", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890; DROP TABLE events'"),
             ("sqli_uuid_with_parens", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef123456789()'"),
             ("sqli_overlong_hex", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef12345678901'"),
             ("sqli_short_hex", "$session_id = 'a1b2c3d4-e5f6-7890-abcd-ef123456789'"),
-            ("sqli_embedded_sql", "$session_id = '00000000-0000-0000-0000-00000000000\\' OR \\'1\\'=\\'1'"),
+            ("sqli_non_hex_chars", "$session_id = 'g1b2c3d4-e5f6-7890-abcd-ef1234567890'"),
+            (
+                "sqli_in_with_injection",
+                "$session_id IN ('a1b2c3d4-e5f6-7890-abcd-ef1234567890', '1; DROP TABLE events')",
+            ),
         ]
     )
     def test_session_id_uuid_optimization_skipped(self, _name, expr):

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -104,11 +104,14 @@ class UUIDT(uuid.UUID):
     def is_valid_uuid(cls, candidate: Any) -> bool:
         if not isinstance(candidate, str):
             return False
-        hex = candidate.replace("urn:", "").replace("uuid:", "")
-        hex = hex.strip("{}").replace("-", "")
-        if len(hex) != 32:
+        hex_str = candidate.replace("urn:", "").replace("uuid:", "")
+        hex_str = hex_str.strip("{}").replace("-", "")
+        if len(hex_str) != 32:
             return False
-        return 0 <= int(hex, 16) < 1 << 128
+        try:
+            return 0 <= int(hex_str, 16) < (1 << 128)
+        except ValueError:
+            return False
 
 
 # Delete this when we can use the version from the stdlib directly, see https://github.com/python/cpython/issues/102461


### PR DESCRIPTION
~Note: do not merge until we have an index on `$session_id_uuid`, see https://posthog.slack.com/archives/C076R4753Q8/p1772027599338529~

## Problem

When we compare session IDs, we do a simple string equality. This is inefficient, because we have already parsed the session ID as a UUID. This means that we could compare a 16-bit integer rather than a 32-character string. The string comparison is also case-sensitive when it shouldn't need to be. This has especially caused problems with iOS devices, which can generate UUIDs in all caps.

## Changes

Rewrite `equals` and `in` comparisons between the session ID column and constant UUID string, to parse the strings as UUID and compare as UUIDs instead (they are actually compared as UInt128s, as clickhouse has bat-shit insane ordering of UUID).

In a future PR, we'll add a minmax index to `$session_id_uuid`, without this, this may end up as a performance regression, as `$session_id` does have that index.

## How did you test this code?

Added many tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
