### PR TITLE
feat(llma): bump sentiment MAX_INPUT_CHARS from 50k to 300k

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -17,7 +17,7 @@ MAX_MESSAGE_CHARS = 2000
 CLASSIFY_BATCH_SIZE = 32  # texts per ONNX forward pass
 MAX_CLASSIFICATIONS_PER_TRACE = 200
 MAX_GENERATIONS_PER_TRACE = 10  # per-trace cap enforced by window function in ClickHouse
-MAX_INPUT_CHARS = 50_000  # skip $ai_input longer than this (accumulated conversation histories)
+MAX_INPUT_CHARS = 300_000  # skip $ai_input longer than this (covers p99; extraction truncates before inference)
 QUERY_LOOKBACK_DAYS = 30  # timestamp filter to enable partition pruning
 
 # Temporal workflow/activity config


### PR DESCRIPTION
## Summary

- Bumps `MAX_INPUT_CHARS` from 50,000 to 300,000 in the sentiment ClickHouse query filter
- The 50k limit was set conservatively during early dogfooding when CPU timeouts were the bottleneck — now activity p50 is ~20s with plenty of headroom
- Data from last 3h on team 2 shows **14.9% of all generations are being skipped** (no sentiment), including **61% of claude-sonnet-4-6** and **100% of o4-mini** generations
- 300k covers p99 (314k) and captures 98.6% of all generations
- Safe because the extraction code already truncates to 50 messages × 2000 chars before ONNX inference

### Input size distribution (team 2, last 3h, 75k generations)

| Percentile | Input length |
|-----------|-------------|
| p50 | 8K |
| p75 | 24K |
| p90 | 87K |
| p95 | 162K |
| p99 | 314K |
| max | 815K |

### Models most affected by 50k filter

| Model | % over 50K |
|-------|-----------|
| o4-mini | 100% |
| claude-haiku-4-5 | 82% |
| claude-opus-4-6 | 70% |
| claude-sonnet-4-6 | 61% |

## Test plan

- [ ] Verify sentiment now appears on Anthropic/large-input generations in team 2 traces
- [ ] Monitor Grafana LLMA Sentiment dashboard — activity latency should remain well under 60s timeout