### PR TITLE
fix(approvals): add META and headers to RequestContext

### DIFF
--- a/posthog/approvals/services.py
+++ b/posthog/approvals/services.py
@@ -27,6 +27,8 @@ class RequestContext:
         self.user = user
         self.data = data
         self.session: dict[str, Any] = {}
+        self.META: dict[str, str] = {}
+        self.headers: dict[str, str] = {}
 
 
 def apply_change_request(change_request: ChangeRequest) -> Any:


### PR DESCRIPTION
## Problem

- Missing fields caused the apply method to fail on successful approve.

## Changes

- Added the missing fields during `apply` and introduced a bunch of integration tests to make sure such issues are caught early.
