### PR TITLE
fix: return default project level when there're no overrides

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -415,7 +415,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
 
         default_access_controls = AccessControl.objects.filter(team=team, organization_member=None, role=None)
 
-        project_access_level = None
+        project_access_level: AccessControlLevel = default_access_level("project")
         saved_resource_levels: dict[str, str] = {}
 
         for ac in default_access_controls:

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1319,11 +1319,13 @@ class TestAccessControlDefaultsEndpoint(BaseAccessControlTest):
         assert expected_resource_entry_keys <= set(data["resource_access_levels"]["dashboard"].keys())
         assert data["resource_access_levels"]["dashboard"]["access_level"] == "viewer"
 
-    def test_no_overrides_returns_nulls(self):
-        """Without explicit defaults, access_level is null."""
+    def test_no_overrides_returns_default_project_level(self):
+        """Without explicit defaults, project uses system default; resources have no saved level."""
         res = self.client.get("/api/projects/@current/access_control_defaults")
         data = res.json()
-        assert data["project_access_level"] is None
+        from posthog.rbac.user_access_control import default_access_level
+
+        assert data["project_access_level"] == default_access_level("project")
         for entry in data["resource_access_levels"].values():
             assert entry["access_level"] is None
 


### PR DESCRIPTION
## Problem

The access control defaults endpoint was returning `null` for `project_access_level` when no explicit overrides were configured. 

![Screenshot 2026-02-25 at 18.28.07.png](https://app.graphite.com/user-attachments/assets/f9daea05-5c3a-4a42-8044-c7396bf8fa19.png)

## Changes

- Modified `project_access_level` initialization to use `default_access_level("project")` instead of `None`

## How did you test this code?
Tests

## Publish to changelog?

No