### PR TITLE
feat(gateway): add separate product for background agents

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -5,7 +5,15 @@ from django.conf import settings
 from openai import AsyncOpenAI, OpenAI
 
 Product = Literal[
-    "llm_gateway", "twig", "background_agents", "wizard", "django", "growth", "llma_translation", "llma_summarization", "llma_eval_summary"
+    "llm_gateway",
+    "twig",
+    "background_agents",
+    "wizard",
+    "django",
+    "growth",
+    "llma_translation",
+    "llma_summarization",
+    "llma_eval_summary",
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from openai import AsyncOpenAI, OpenAI
 
 Product = Literal[
-    "llm_gateway", "twig", "wizard", "django", "growth", "llma_translation", "llma_summarization", "llma_eval_summary"
+    "llm_gateway", "twig", "background_agents", "wizard", "django", "growth", "llma_translation", "llma_summarization", "llma_eval_summary"
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -21,12 +21,19 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "llm_gateway": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
     "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
     "twig": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
+    "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
 }
 
 DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
     "twig": UserCostLimit(
         burst_limit_usd=100.0,
-        burst_window_seconds=18000,
+        burst_window_seconds=86400,
+        sustained_limit_usd=1000.0,
+        sustained_window_seconds=2592000,
+    ),
+    "background_agents": UserCostLimit(
+        burst_limit_usd=100.0,
+        burst_window_seconds=86400,
         sustained_limit_usd=1000.0,
         sustained_window_seconds=2592000,
     ),

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -5,12 +5,12 @@ from pydantic import BaseModel, field_validator
 from pydantic_settings import BaseSettings
 
 
-class ProductCostLimit(BaseModel):
+class ProductCostLimit(BaseModel, frozen=True):
     limit_usd: float
     window_seconds: int
 
 
-class UserCostLimit(BaseModel):
+class UserCostLimit(BaseModel, frozen=True):
     burst_limit_usd: float
     burst_window_seconds: int
     sustained_limit_usd: float

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -17,6 +17,13 @@ class UserCostLimit(BaseModel):
     sustained_window_seconds: int
 
 
+DEFAULT_USER_COST_LIMIT = UserCostLimit(
+    burst_limit_usd=100.0,
+    burst_window_seconds=86400,
+    sustained_limit_usd=1000.0,
+    sustained_window_seconds=2592000,
+)
+
 DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "llm_gateway": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
     "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -42,6 +42,21 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         ),
         allow_api_keys=False,
     ),
+    "background_agents": ProductConfig(
+        allowed_application_ids=frozenset({TWIG_US_APP_ID, TWIG_EU_APP_ID}),
+        allowed_models=frozenset(
+            {
+                "claude-opus-4-5",
+                "claude-opus-4-6",
+                "claude-sonnet-4-5",
+                "claude-haiku-4-5",
+                "gpt-5.3-codex",
+                "gpt-5.2",
+                "gpt-5-mini",
+            }
+        ),
+        allow_api_keys=False,
+    ),
     "wizard": ProductConfig(
         allowed_application_ids=frozenset({WIZARD_US_APP_ID, WIZARD_EU_APP_ID}),
         allowed_models=None,

--- a/services/llm-gateway/src/llm_gateway/streaming/sse.py
+++ b/services/llm-gateway/src/llm_gateway/streaming/sse.py
@@ -37,8 +37,14 @@ async def format_sse_stream(llm_stream: AsyncGenerator[Any, None]) -> AsyncGener
 
         if not is_raw_passthrough:
             yield b"data: [DONE]\n\n"
-    except Exception:
+    except Exception as e:
         logger.exception("Error in LLM stream")
-        error_data = {"error": {"message": "An internal error has occurred.", "type": "internal_error"}}
+        error_data = {
+            "error": {
+                "message": getattr(e, "message", str(e)),
+                "type": getattr(e, "type", "internal_error"),
+                "code": getattr(e, "code", None),
+            }
+        }
         yield f"data: {json.dumps(error_data)}\n\n".encode()
         raise

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -3,11 +3,12 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.main import http_exception_handler
 from llm_gateway.rate_limiting.cost_throttles import (
     ProductCostThrottle,
     UserCostBurstThrottle,
@@ -38,6 +39,8 @@ def create_test_app(
         yield
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)
+    app.exception_handler(HTTPException)(http_exception_handler)
+
     app.include_router(health_router)
     app.include_router(router)
     return app

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -105,7 +105,9 @@ class TestAnthropicMessagesEndpoint:
         )
 
         assert response.status_code == error_status
-        assert "error" in response.json()["detail"]
+        data = response.json()
+        assert data["error"]["message"] == error_message
+        assert data["error"]["type"] == error_type
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_product_prefix_route(

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -166,16 +166,20 @@ class TestUserCostBurstThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_skips_for_products_without_config(self) -> None:
+    async def test_uses_default_for_products_without_config(self) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="llm_gateway")
 
-        await throttle.record_cost(context, 99999.0)
+        await throttle.record_cost(context, 99.0)
         result = await throttle.allow_request(context)
         assert result.allowed is True
+
+        await throttle.record_cost(context, 1.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -251,16 +255,20 @@ class TestUserCostSustainedThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_skips_for_products_without_config(self) -> None:
+    async def test_uses_default_for_products_without_config(self) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="llm_gateway")
 
-        await throttle.record_cost(context, 99999.0)
+        await throttle.record_cost(context, 999.0)
         result = await throttle.allow_request(context)
         assert result.allowed is True
+
+        await throttle.record_cost(context, 1.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -587,38 +595,45 @@ class TestTeamRateLimitMultipliers:
         get_settings.cache_clear()
 
 
-class TestUnconfiguredProductsNotLimitedPerUser:
-    """Products without user_cost_limits config must never be throttled or accumulate per-user cost."""
+class TestUnconfiguredProductsUseDefaults:
+    """Products without user_cost_limits config use default limits ($100/24h burst, $1000/30d sustained)."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("throttle_cls", ["UserCostBurstThrottle", "UserCostSustainedThrottle"])
-    async def test_unconfigured_product_always_allowed(self, throttle_cls: str) -> None:
+    async def test_unconfigured_product_uses_burst_default(self) -> None:
         get_settings.cache_clear()
-        import llm_gateway.rate_limiting.cost_throttles as mod
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
-        throttle = getattr(mod, throttle_cls)(redis=None)
+        throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="wizard")
 
-        await throttle.record_cost(context, 999_999.0)
+        await throttle.record_cost(context, 99.0)
         result = await throttle.allow_request(context)
         assert result.allowed is True
+
+        await throttle.record_cost(context, 1.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("throttle_cls", ["UserCostBurstThrottle", "UserCostSustainedThrottle"])
-    async def test_unconfigured_product_does_not_create_limiter(self, throttle_cls: str) -> None:
+    async def test_unconfigured_product_uses_sustained_default(self) -> None:
         get_settings.cache_clear()
-        import llm_gateway.rate_limiting.cost_throttles as mod
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
-        throttle = getattr(mod, throttle_cls)(redis=None)
+        throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="wizard")
 
-        await throttle.record_cost(context, 500.0)
-        assert len(throttle._limiters) == 0
+        await throttle.record_cost(context, 999.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+        await throttle.record_cost(context, 1.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_configured_product_limited_while_unconfigured_not(self) -> None:
+    async def test_configured_and_unconfigured_products_both_limited(self) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, UserCostSustainedThrottle
 
@@ -634,15 +649,13 @@ class TestUnconfiguredProductsNotLimitedPerUser:
         await sustained.record_cost(ctx_wizard, 1000.0)
 
         assert (await burst.allow_request(ctx_twig)).allowed is False
-        assert (await burst.allow_request(ctx_wizard)).allowed is True
+        assert (await burst.allow_request(ctx_wizard)).allowed is False
         assert (await sustained.allow_request(ctx_twig)).allowed is False
-        assert (await sustained.allow_request(ctx_wizard)).allowed is True
+        assert (await sustained.allow_request(ctx_wizard)).allowed is False
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_logs_warning_for_unconfigured_product_with_end_user(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    async def test_logs_info_for_unconfigured_product_with_end_user(self, capsys: pytest.CaptureFixture[str]) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle, _UserCostThrottleBase
 
@@ -653,12 +666,12 @@ class TestUnconfiguredProductsNotLimitedPerUser:
 
         await throttle.allow_request(context)
         captured = capsys.readouterr()
-        assert "user_cost_limits_missing_product" in captured.out
+        assert "user_cost_limits_using_default" in captured.out
         assert "wizard" in captured.out
 
         await throttle.allow_request(context)
         captured2 = capsys.readouterr()
-        assert "user_cost_limits_missing_product" not in captured2.out
+        assert "user_cost_limits_using_default" not in captured2.out
 
         _UserCostThrottleBase._warned_products = set()
         get_settings.cache_clear()
@@ -678,20 +691,20 @@ class TestUnconfiguredProductsNotLimitedPerUser:
 
         await throttle.allow_request(context)
         captured = capsys.readouterr()
-        assert "user_cost_limits_missing_product" not in captured.out
+        assert "user_cost_limits_using_default" not in captured.out
 
         _UserCostThrottleBase._warned_products = set()
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_dynamically_adding_product_config_enables_limits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_dynamically_adding_product_config_overrides_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="wizard")
 
-        await throttle.record_cost(context, 999.0)
+        await throttle.record_cost(context, 99.0)
         assert (await throttle.allow_request(context)).allowed is True
 
         monkeypatch.setenv(
@@ -751,15 +764,18 @@ class TestUserCostEdgeCases:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_require_config_raises_for_unconfigured_product(self) -> None:
+    async def test_get_config_returns_default_for_unconfigured_product(self) -> None:
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="wizard")
 
-        with pytest.raises(RuntimeError, match="No user_cost_limits config for product 'wizard'"):
-            throttle._require_config(context)
+        config = throttle._get_config(context)
+        assert config.burst_limit_usd == 100.0
+        assert config.burst_window_seconds == 86400
+        assert config.sustained_limit_usd == 1000.0
+        assert config.sustained_window_seconds == 2592000
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -59,7 +59,7 @@ class TestUserCostLimitConfig:
         assert "twig" in settings.user_cost_limits
         twig = settings.user_cost_limits["twig"]
         assert twig.burst_limit_usd == 100.0
-        assert twig.burst_window_seconds == 18000
+        assert twig.burst_window_seconds == 86400
         assert twig.sustained_limit_usd == 1000.0
         assert twig.sustained_window_seconds == 2592000
         get_settings.cache_clear()
@@ -389,7 +389,7 @@ class TestRetryAfterHeader:
         result = await throttle.allow_request(context)
 
         assert result.allowed is False
-        assert result.retry_after == 18000
+        assert result.retry_after == 86400
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/services/llm-gateway/tests/test_openai.py
+++ b/services/llm-gateway/tests/test_openai.py
@@ -111,4 +111,6 @@ class TestChatCompletionsEndpoint:
         )
 
         assert response.status_code == error_status
-        assert "error" in response.json()["detail"]
+        data = response.json()
+        assert data["error"]["message"] == error_message
+        assert data["error"]["type"] == error_type

--- a/services/llm-gateway/tests/test_rate_limiting.py
+++ b/services/llm-gateway/tests/test_rate_limiting.py
@@ -244,11 +244,9 @@ class TestRateLimitResponseHeaders:
             assert response.status_code == 429
             assert response.headers["retry-after"] == "3600"
             assert response.json() == {
-                "detail": {
-                    "error": {
-                        "message": "Rate limit exceeded",
-                        "type": "rate_limit_error",
-                        "reason": "Product rate limit exceeded",
-                    }
+                "error": {
+                    "message": "Rate limit exceeded",
+                    "type": "rate_limit_error",
+                    "reason": "Product rate limit exceeded",
                 }
             }


### PR DESCRIPTION
We want to track this usage seperately from twig, this adds it as its own product with its own rate limits.

Also reverts burst limits to be daily in Twig.