### PR TITLE
fix: prevent unnecessary reloads when clearing search in property filters

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -426,7 +426,9 @@ export function LemonInputSelect<T = string>({
     }
 
     const _addItem = (item: string, atIndex?: number | null, currentValues: T[] = values): void => {
-        setInputValue('')
+        if (mode === 'single') {
+            setInputValue('')
+        }
         // Convert string key back to typed value
         const actualTypedValue = getTypedValue(item)
         if (mode === 'single') {


### PR DESCRIPTION
the taxonomic filter reloads suggested values when the filter is cleared

when trying to use the multiselect checkboxes in the taxonomic filter this means you would click one, we would clear the search value, you would move your mouse to click a second, we would load new suggested values, and all the results would move around

now...

when you select in a multi-select we do not clear the input

this means that the content in suggested values does not move and change as you interact with it  


suggested values accumulates values and filters them with fuse so if you clear the text box the results appear to change and will move under your mouse



![CleanShot 2026-02-25 at 19.47.14.gif](https://app.graphite.com/user-attachments/assets/049521ad-c968-42c7-9b6c-25e06f6bb03a.gif)

