### PR TITLE
fix(flags): skip dependency extraction for inactive feature flags

### DIFF
--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -612,7 +612,7 @@ pub fn log_dependency_graph_construction_errors(
         );
     }
 
-    tracing::error!(
+    tracing::warn!(
         "There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}",
         team_id, errors
     );


### PR DESCRIPTION
## Problem

The `posthog_tombstone_total{operation="flag_dependency_missing"}` metric fires at ~800-1000/sec in prod-us. Investigation revealed this comes from a small number of inactive or orphaned survey-targeting flags that reference deleted feature flags. When the dependency graph is built, these stale references trigger `MissingDependency` errors and tombstone emissions on every request for those teams.

The root issue: `from_nodes()` extracts dependencies for ALL flags including inactive ones. Since inactive flags always evaluate to `false` regardless of their dependencies, extracting their deps is unnecessary work — and when those deps point to deleted flags, it generates noisy tombstone metrics.

## Changes

- In `FeatureFlag::extract_dependencies()`, return an empty set when `self.active` is false. Inactive flags don't need their dependencies resolved since they're short-circuited to `false` during evaluation anyway.
- Downgrade the dependency graph construction error log from `error!` to `warn!` since missing dependencies from deleted flags are a normal operational scenario, not an "impossible" failure.

**Why this approach:**
- No trait changes: `DependencyProvider` trait is unchanged; cohorts and test helpers unaffected
- No graph construction changes: `from_nodes()` stays generic; the fix is in the `FeatureFlag`-specific impl
- Inactive flags remain in the graph: Other active flags can still depend on them and find them in `id_map`
- Correct evaluation preserved: Inactive flags already short-circuit to `false` in `evaluate_single_flag`

## How did you test this code?

This was written by an AI agent. No manual testing was performed.

Automated tests added and run via `cargo test -p feature-flags`:

- `test_extract_dependencies_skips_inactive_flags` — inactive flag with a dependency returns empty set
- `test_extract_dependencies_includes_active_flag_deps` — active flag still extracts dependencies normally
- `test_inactive_flag_with_missing_dependency_produces_no_error` — graph build produces no errors for inactive flag referencing a deleted flag
- `test_active_flag_depending_on_inactive_flag_still_works` — active flag can depend on an inactive flag (it's still in `id_map`)
- `test_inactive_flag_with_missing_dep_does_not_affect_active_flags` — missing dep on inactive flag doesn't propagate to unrelated active flags
- `test_active_flag_with_missing_dependency_still_produces_error` — sanity check that active flags with missing deps still error

All existing `feature-flags` tests continue to pass.

## Publish to changelog?

no