### PR TITLE
fix(dwh): host validation

### DIFF
--- a/posthog/temporal/data_imports/sources/common/test_mixins.py
+++ b/posthog/temporal/data_imports/sources/common/test_mixins.py
@@ -1,0 +1,154 @@
+from dataclasses import dataclass
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from posthog.temporal.data_imports.sources.common.mixins import SSHTunnelMixin, ValidateDatabaseHostMixin, _is_host_safe
+
+
+class TestIsHostSafe(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("private_10", "10.0.0.1"),
+            ("private_172_16", "172.16.0.1"),
+            ("private_192_168", "192.168.1.1"),
+            ("loopback_127", "127.0.0.1"),
+            ("loopback_127_other", "127.0.0.2"),
+            ("localhost", "localhost"),
+            ("link_local_imds", "169.254.169.254"),
+            ("link_local", "169.254.1.1"),
+            ("ipv6_mapped_loopback", "::ffff:127.0.0.1"),
+            ("ipv6_mapped_imds", "::ffff:169.254.169.254"),
+            ("ipv6_mapped_private", "::ffff:10.0.0.1"),
+            ("ipv6_loopback", "::1"),
+            ("multicast", "224.0.0.1"),
+            ("reserved", "0.0.0.0"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_blocks_internal_ip(self, _name: str, host: str):
+        valid, error = _is_host_safe(host, team_id=999)
+        assert not valid
+        assert error is not None
+
+    @parameterized.expand(
+        [
+            ("public_ip", "8.8.8.8"),
+            ("public_ip_2", "1.1.1.1"),
+            ("public_ip_3", "52.0.0.1"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allows_public_ip(self, _name: str, host: str):
+        valid, _ = _is_host_safe(host, team_id=999)
+        assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allows_internal_ip_for_whitelisted_team_us(self):
+        valid, _ = _is_host_safe("10.0.0.1", team_id=2)
+        assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="EU")
+    def test_allows_internal_ip_for_whitelisted_team_eu(self):
+        valid, _ = _is_host_safe("10.0.0.1", team_id=1)
+        assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_dns_resolving_to_internal_ip_blocked(self):
+        with patch(
+            "posthog.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("10.0.0.1", 0))],
+        ):
+            valid, error = _is_host_safe("evil.example.com", team_id=999)
+            assert not valid
+            assert error == "Hosts with internal IP addresses are not allowed"
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_dns_resolving_to_public_ip_allowed(self):
+        with patch(
+            "posthog.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("52.1.2.3", 0))],
+        ):
+            valid, _ = _is_host_safe("good.example.com", team_id=999)
+            assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_unresolvable_host_blocked(self):
+        import socket
+
+        with patch(
+            "posthog.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            valid, error = _is_host_safe("nonexistent.invalid", team_id=999)
+            assert not valid
+            assert error == "Host could not be resolved"
+
+
+class TestValidateDatabaseHostMixin(SimpleTestCase):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_blocks_private_ip(self):
+        mixin = ValidateDatabaseHostMixin()
+        valid, error = mixin.is_database_host_valid("192.168.1.1", team_id=999)
+        assert not valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allows_public_ip(self):
+        mixin = ValidateDatabaseHostMixin()
+        valid, _ = mixin.is_database_host_valid("8.8.8.8", team_id=999)
+        assert valid
+
+
+@dataclass
+class FakeSSHTunnelConfig:
+    enabled: bool
+    host: str
+    port: int = 22
+
+
+@dataclass
+class FakeConfig:
+    host: str = "dbhost.example.com"
+    port: int = 5432
+    ssh_tunnel: FakeSSHTunnelConfig | None = None
+
+
+class TestSSHTunnelHostValidation(SimpleTestCase):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_ssh_tunnel_with_internal_host_blocked(self):
+        mixin = SSHTunnelMixin()
+        config = FakeConfig(ssh_tunnel=FakeSSHTunnelConfig(enabled=True, host="10.0.0.1"))
+        valid, error = mixin.ssh_tunnel_is_valid(config, team_id=999)
+        assert not valid
+        assert "SSH tunnel host not allowed" in error  # type: ignore
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_ssh_tunnel_disabled_skips_validation(self):
+        mixin = SSHTunnelMixin()
+        config = FakeConfig(ssh_tunnel=FakeSSHTunnelConfig(enabled=False, host="10.0.0.1"))
+        valid, _ = mixin.ssh_tunnel_is_valid(config, team_id=999)
+        assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_no_ssh_tunnel_skips_validation(self):
+        mixin = SSHTunnelMixin()
+        config = FakeConfig(ssh_tunnel=None)
+        valid, _ = mixin.ssh_tunnel_is_valid(config, team_id=999)
+        assert valid
+
+    @parameterized.expand(
+        [
+            ("imds", "169.254.169.254"),
+            ("loopback", "127.0.0.1"),
+            ("private_192", "192.168.0.1"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_ssh_tunnel_blocks_various_internal_hosts(self, _name: str, host: str):
+        mixin = SSHTunnelMixin()
+        config = FakeConfig(ssh_tunnel=FakeSSHTunnelConfig(enabled=True, host=host))
+        valid, _ = mixin.ssh_tunnel_is_valid(config, team_id=999)
+        assert not valid

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -77,10 +77,9 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         if not connection_params.get("database"):
             return False, "Database name is required in connection string"
 
-        if not connection_params.get("is_srv"):
-            valid_host, host_errors = self.is_database_host_valid(connection_params["host"], team_id, False)
-            if not valid_host:
-                return False, host_errors
+        valid_host, host_errors = self.is_database_host_valid(connection_params["host"], team_id)
+        if not valid_host:
+            return False, host_errors
 
         try:
             collection_names = get_collection_names(config)

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -141,12 +141,12 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
     ) -> tuple[bool, str | None]:
         from pymssql import OperationalError
 
-        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
+        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
 
         valid_host, host_errors = self.is_database_host_valid(
-            config.host, team_id, config.ssh_tunnel.enabled if config.ssh_tunnel else False
+            config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False
         )
         if not valid_host:
             return valid_host, host_errors

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -152,12 +152,12 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
     def validate_credentials(
         self, config: MySQLSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
+        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
 
         valid_host, host_errors = self.is_database_host_valid(
-            config.host, team_id, config.ssh_tunnel.enabled if config.ssh_tunnel else False
+            config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False
         )
         if not valid_host:
             return valid_host, host_errors

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -198,12 +198,12 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
     def validate_credentials(
         self, config: PostgresSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
+        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
 
         valid_host, host_errors = self.is_database_host_valid(
-            config.host, team_id, config.ssh_tunnel.enabled if config.ssh_tunnel else False
+            config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False
         )
         if not valid_host:
             return valid_host, host_errors

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -188,12 +188,12 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
     def validate_credentials(
         self, config: RedshiftSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
+        is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
 
         valid_host, host_errors = self.is_database_host_valid(
-            config.host, team_id, config.ssh_tunnel.enabled if config.ssh_tunnel else False
+            config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False
         )
         if not valid_host:
             return valid_host, host_errors

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -458,6 +458,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
         source_config: Config = source.parse_config(payload)
 
+        credentials_valid, credentials_error = source.validate_credentials(source_config, self.team_id)
+        if not credentials_valid:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": credentials_error or "Invalid credentials"},
+            )
+
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),
             connection_id=str(uuid.uuid4()),

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -1051,40 +1051,33 @@ class TestExternalDataSource(APIBaseTest):
         return_value={"table_1": [("id", "integer", True)]},
     )
     def test_blocks_internal_host(self, host, _patch_schemas):
-        endpoints = [
-            {
-                "url": f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
-                "data": {
-                    "source_type": "Postgres",
-                    "host": host,
-                    "port": int(settings.PG_PORT),
-                    "database": settings.PG_DATABASE,
-                    "user": settings.PG_USER,
-                    "password": settings.PG_PASSWORD,
-                    "schema": "public",
-                },
+        database_schema_url = f"/api/environments/{self.team.pk}/external_data_sources/database_schema/"
+        database_schema_data = {
+            "source_type": "Postgres",
+            "host": host,
+            "port": int(settings.PG_PORT),
+            "database": settings.PG_DATABASE,
+            "user": settings.PG_USER,
+            "password": settings.PG_PASSWORD,
+            "schema": "public",
+        }
+        create_url = f"/api/environments/{self.team.pk}/external_data_sources/"
+        create_data = {
+            "source_type": "Postgres",
+            "payload": {
+                "host": host,
+                "port": 5432,
+                "database": "mydb",
+                "user": "user",
+                "password": "pass",
+                "schema": "public",
             },
-            {
-                "url": f"/api/environments/{self.team.pk}/external_data_sources/",
-                "data": {
-                    "source_type": "Postgres",
-                    "payload": {
-                        "host": host,
-                        "port": 5432,
-                        "database": "mydb",
-                        "user": "user",
-                        "password": "pass",
-                        "schema": "public",
-                    },
-                    "schemas": [],
-                },
-            },
-        ]
+            "schemas": [],
+        }
         with override_settings(CLOUD_DEPLOYMENT="US"):
-            for endpoint in endpoints:
-                url: str = endpoint["url"]
-                response = self.client.post(url, data=endpoint["data"])
-                self.assertEqual(response.status_code, 400, f"Expected 400 for {host} on {endpoint['url']}")
+            for url, data in [(database_schema_url, database_schema_data), (create_url, create_data)]:
+                response = self.client.post(url, data=data)
+                self.assertEqual(response.status_code, 400, f"Expected 400 for {host} on {url}")
                 self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
 
             self.assertFalse(

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -1082,7 +1082,8 @@ class TestExternalDataSource(APIBaseTest):
         ]
         with override_settings(CLOUD_DEPLOYMENT="US"):
             for endpoint in endpoints:
-                response = self.client.post(endpoint["url"], data=endpoint["data"])
+                url: str = endpoint["url"]
+                response = self.client.post(url, data=endpoint["data"])
                 self.assertEqual(response.status_code, 400, f"Expected 400 for {host} on {endpoint['url']}")
                 self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
 

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.test import override_settings
 
 import psycopg
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team
@@ -1035,6 +1036,59 @@ class TestExternalDataSource(APIBaseTest):
             )
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
+
+    @parameterized.expand(
+        [
+            ("192.168.1.1",),
+            ("169.254.169.254",),
+            ("localhost",),
+            ("127.0.0.1",),
+            ("0.0.0.0",),
+        ]
+    )
+    @patch(
+        "posthog.temporal.data_imports.sources.postgres.source.get_postgres_schemas",
+        return_value={"table_1": [("id", "integer", True)]},
+    )
+    def test_blocks_internal_host(self, host, _patch_schemas):
+        endpoints = [
+            {
+                "url": f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+                "data": {
+                    "source_type": "Postgres",
+                    "host": host,
+                    "port": int(settings.PG_PORT),
+                    "database": settings.PG_DATABASE,
+                    "user": settings.PG_USER,
+                    "password": settings.PG_PASSWORD,
+                    "schema": "public",
+                },
+            },
+            {
+                "url": f"/api/environments/{self.team.pk}/external_data_sources/",
+                "data": {
+                    "source_type": "Postgres",
+                    "payload": {
+                        "host": host,
+                        "port": 5432,
+                        "database": "mydb",
+                        "user": "user",
+                        "password": "pass",
+                        "schema": "public",
+                    },
+                    "schemas": [],
+                },
+            },
+        ]
+        with override_settings(CLOUD_DEPLOYMENT="US"):
+            for endpoint in endpoints:
+                response = self.client.post(endpoint["url"], data=endpoint["data"])
+                self.assertEqual(response.status_code, 400, f"Expected 400 for {host} on {endpoint['url']}")
+                self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
+
+            self.assertFalse(
+                ExternalDataSource.objects.filter(team=self.team, source_type="Postgres").exists(),
+            )
 
     def test_source_jobs(self):
         source = self._create_external_data_source()

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -61,7 +61,11 @@ class TestExternalDataSource(APIBaseTest):
             name="Customers", team_id=self.team.pk, source_id=source_id, table=None
         )
 
-    def test_create_external_data_source(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -108,7 +112,11 @@ class TestExternalDataSource(APIBaseTest):
             len(STRIPE_ENDPOINTS),
         )
 
-    def test_create_external_data_source_delete_on_missing_schemas(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_delete_on_missing_schemas(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -123,7 +131,11 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 400
         assert ExternalDataSource.objects.count() == 0
 
-    def test_create_external_data_source_delete_on_bad_schema(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_delete_on_bad_schema(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -140,7 +152,11 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 400
         assert ExternalDataSource.objects.count() == 0
 
-    def test_prefix_external_data_source(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_prefix_external_data_source(self, _mock_validate):
         # Create no prefix
 
         response = self.client.post(
@@ -270,7 +286,11 @@ class TestExternalDataSource(APIBaseTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"message": "Prefix already exists"})
 
-    def test_create_external_data_source_incremental(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_incremental(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -333,7 +353,11 @@ class TestExternalDataSource(APIBaseTest):
         )
         self.assertEqual(response.status_code, 201)
 
-    def test_create_external_data_source_incremental_missing_field(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_incremental_missing_field(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -390,7 +414,11 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 400
         assert len(ExternalDataSource.objects.all()) == 0
 
-    def test_create_external_data_source_incremental_missing_type(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_incremental_missing_type(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -449,9 +477,15 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_bigquery_removes_project_id_prefix(self):
         """Test we remove the `project_id` prefix of a `dataset_id`."""
-        with patch(
-            "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
-        ) as mocked_get_bigquery_schemas:
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
+            ) as mocked_get_bigquery_schemas,
+            patch(
+                "posthog.temporal.data_imports.sources.bigquery.source.BigQuerySource.validate_credentials",
+                return_value=(True, None),
+            ),
+        ):
             mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE", False)]}
 
             response = self.client.post(
@@ -1202,7 +1236,11 @@ class TestExternalDataSource(APIBaseTest):
             assert len(data) == 1
             assert data[0]["id"] == str(job3.pk)
 
-    def test_trimming_payload(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_trimming_payload(self, _mock_validate):
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -1796,9 +1834,15 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_bigquery_create_and_update(self):
         """Test that we can create and update the config for a BigQuery source"""
-        with patch(
-            "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
-        ) as mocked_get_bigquery_schemas:
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.bigquery.source.BigQuerySource.validate_credentials",
+                return_value=(True, None),
+            ),
+            patch(
+                "posthog.temporal.data_imports.sources.bigquery.source.get_bigquery_schemas"
+            ) as mocked_get_bigquery_schemas,
+        ):
             mocked_get_bigquery_schemas.return_value = {"my_table": [("something", "DATE", False)]}
 
             # Create a BigQuery source
@@ -2103,7 +2147,11 @@ class TestExternalDataSource(APIBaseTest):
                     f"Expected error message about prefix validation for '{prefix}' ({reason}), got: {response.json()}",
                 )
 
-    def test_create_external_data_source_accepts_valid_prefix(self):
+    @patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_accepts_valid_prefix(self, _mock_validate):
         """Test that valid prefixes are accepted."""
         valid_prefixes = [
             "valid_prefix",

--- a/products/data_warehouse/backend/api/test/utils.py
+++ b/products/data_warehouse/backend/api/test/utils.py
@@ -1,34 +1,40 @@
 from typing import Any
 
+from unittest.mock import patch
+
 from django.test.client import Client as HttpClient
 
 
 def create_external_data_source_ok(client: HttpClient, team_id: int) -> int:
     """Create an external data source and return the id."""
-    response = client.post(
-        f"/api/environments/{team_id}/external_data_sources/",
-        data={
-            "source_type": "Stripe",
-            "payload": {
-                "stripe_secret_key": "sk_test_123",
-                "schemas": [
-                    {"name": "BalanceTransaction", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Subscription", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Customer", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Product", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Price", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Invoice", "should_sync": True, "sync_type": "full_refresh"},
-                    {
-                        "name": "Charge",
-                        "should_sync": False,
-                        "sync_type": "full_refresh",
-                        "sync_time_of_day": "01:00:00",
-                    },
-                ],
+    with patch(
+        "posthog.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    ):
+        response = client.post(
+            f"/api/environments/{team_id}/external_data_sources/",
+            data={
+                "source_type": "Stripe",
+                "payload": {
+                    "stripe_secret_key": "sk_test_123",
+                    "schemas": [
+                        {"name": "BalanceTransaction", "should_sync": True, "sync_type": "full_refresh"},
+                        {"name": "Subscription", "should_sync": True, "sync_type": "full_refresh"},
+                        {"name": "Customer", "should_sync": True, "sync_type": "full_refresh"},
+                        {"name": "Product", "should_sync": True, "sync_type": "full_refresh"},
+                        {"name": "Price", "should_sync": True, "sync_type": "full_refresh"},
+                        {"name": "Invoice", "should_sync": True, "sync_type": "full_refresh"},
+                        {
+                            "name": "Charge",
+                            "should_sync": False,
+                            "sync_type": "full_refresh",
+                            "sync_time_of_day": "01:00:00",
+                        },
+                    ],
+                },
             },
-        },
-        content_type="application/json",
-    )
+            content_type="application/json",
+        )
     payload: dict[str, Any] = response.json()
 
     assert response.status_code == 201


### PR DESCRIPTION
## changes

  - Rewrite is_database_host_valid() to use _is_safe_public_ip() with DNS resolution, blocking 192.168.*, 127.*, 169.254.* (IMDS), IPv6-mapped, multicast, and reserved ranges that were previously missed
  - Add SSH tunnel host validation in ssh_tunnel_is_valid() — the tunnel host is the actual outbound connection from our infra and was previously unvalidated
  - Fix MongoDB SRV bypass — mongodb+srv:// connections skipped host validation entirely, but SRV records can resolve to internal IPs
  - Validate credentials before creating ExternalDataSource in the create endpoint to block internal hosts early

This only impacts new sources

## How did you test this code?

tests

## Publish to changelog?

NO