### PR TITLE
feat: change personhog upsert API to accept distinct_ids and resolve …

### DIFF
--- a/proto/personhog/types/v1/feature_flag.proto
+++ b/proto/personhog/types/v1/feature_flag.proto
@@ -36,23 +36,15 @@ message GetHashKeyOverrideContextResponse {
   repeated HashKeyOverrideContext results = 1;
 }
 
-// HashKeyOverrideInput represents a single override to upsert.
-// The hash_key is specified at the request level since all overrides
-// in a batch share the same hash key (for experience continuity).
-message HashKeyOverrideInput {
-  int64 person_id = 1;
-  string feature_flag_key = 2;
-}
-
-// UpsertHashKeyOverridesRequest batch upserts hash key overrides.
-// All overrides in a batch share the same hash_key, which is used for
-// experience continuity - ensuring consistent flag values when a user
-// logs in with a new distinct_id.
+// UpsertHashKeyOverridesRequest resolves distinct_ids to person_ids server-side
+// and creates hash key overrides for all matching persons crossed with all
+// feature_flag_keys. This ensures experience continuity works even when
+// distinct_ids haven't been merged yet.
 message UpsertHashKeyOverridesRequest {
   int64 team_id = 1;
-  repeated HashKeyOverrideInput overrides = 2;
-  // The hash key to use for all overrides (typically the $anon_distinct_id)
+  repeated string distinct_ids = 2;
   string hash_key = 3;
+  repeated string feature_flag_keys = 4;
 }
 
 message UpsertHashKeyOverridesResponse {

--- a/rust/personhog-replica/src/service/mod.rs
+++ b/rust/personhog-replica/src/service/mod.rs
@@ -348,18 +348,14 @@ impl PersonHogReplica for PersonHogReplicaService {
     ) -> Result<Response<UpsertHashKeyOverridesResponse>, Status> {
         let req = request.into_inner();
 
-        let overrides: Vec<storage::HashKeyOverrideInput> = req
-            .overrides
-            .into_iter()
-            .map(|o| storage::HashKeyOverrideInput {
-                person_id: o.person_id,
-                feature_flag_key: o.feature_flag_key,
-            })
-            .collect();
-
         let inserted_count = self
             .storage
-            .upsert_hash_key_overrides(req.team_id, &overrides, &req.hash_key)
+            .upsert_hash_key_overrides(
+                req.team_id,
+                &req.distinct_ids,
+                &req.feature_flag_keys,
+                &req.hash_key,
+            )
             .await
             .map_err(|e| log_and_convert_error(e, "upsert_hash_key_overrides"))?;
 

--- a/rust/personhog-replica/src/service/tests/mocks.rs
+++ b/rust/personhog-replica/src/service/tests/mocks.rs
@@ -124,7 +124,8 @@ impl storage::FeatureFlagStorage for FailingStorage {
     async fn upsert_hash_key_overrides(
         &self,
         _team_id: i64,
-        _overrides: &[storage::HashKeyOverrideInput],
+        _distinct_ids: &[String],
+        _feature_flag_keys: &[String],
         _hash_key: &str,
     ) -> storage::StorageResult<i64> {
         Err(self.error.clone())
@@ -312,7 +313,8 @@ impl storage::FeatureFlagStorage for SuccessStorage {
     async fn upsert_hash_key_overrides(
         &self,
         _team_id: i64,
-        _overrides: &[storage::HashKeyOverrideInput],
+        _distinct_ids: &[String],
+        _feature_flag_keys: &[String],
         _hash_key: &str,
     ) -> storage::StorageResult<i64> {
         Ok(0)
@@ -528,7 +530,8 @@ impl storage::FeatureFlagStorage for ConsistencyTrackingStorage {
     async fn upsert_hash_key_overrides(
         &self,
         _team_id: i64,
-        _overrides: &[storage::HashKeyOverrideInput],
+        _distinct_ids: &[String],
+        _feature_flag_keys: &[String],
         _hash_key: &str,
     ) -> storage::StorageResult<i64> {
         Ok(0)

--- a/rust/personhog-replica/src/storage/mod.rs
+++ b/rust/personhog-replica/src/storage/mod.rs
@@ -7,7 +7,7 @@ pub use error::{StorageError, StorageResult};
 
 pub use types::{
     CohortMembership, DistinctIdMapping, DistinctIdWithVersion, Group, GroupIdentifier, GroupKey,
-    GroupTypeMapping, HashKeyOverride, HashKeyOverrideContext, HashKeyOverrideInput, Person,
+    GroupTypeMapping, HashKeyOverride, HashKeyOverrideContext, Person,
 };
 
 pub use traits::{CohortStorage, DistinctIdLookup, FeatureFlagStorage, GroupStorage, PersonLookup};

--- a/rust/personhog-replica/src/storage/traits/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/traits/feature_flag.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::storage::error::StorageResult;
 use crate::storage::postgres::ConsistencyLevel;
-use crate::storage::types::{HashKeyOverrideContext, HashKeyOverrideInput};
+use crate::storage::types::HashKeyOverrideContext;
 
 /// Feature flag hash key override operations
 #[async_trait]
@@ -36,15 +36,16 @@ pub trait FeatureFlagStorage: Send + Sync {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<HashKeyOverrideContext>>;
 
-    /// Batch upsert hash key overrides. Returns the number of inserted records.
+    /// Upsert hash key overrides by resolving distinct_ids to person_ids server-side.
     ///
-    /// All overrides in a batch share the same `hash_key`, which is used for
-    /// experience continuity - ensuring consistent flag values when a user
-    /// logs in with a new distinct_id.
+    /// Resolves all `distinct_ids` to person_ids via `posthog_persondistinctid`,
+    /// cross-joins with `feature_flag_keys`, and inserts overrides with the given
+    /// `hash_key`. Returns the number of inserted records.
     async fn upsert_hash_key_overrides(
         &self,
         team_id: i64,
-        overrides: &[HashKeyOverrideInput],
+        distinct_ids: &[String],
+        feature_flag_keys: &[String],
         hash_key: &str,
     ) -> StorageResult<i64>;
 

--- a/rust/personhog-replica/src/storage/types/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/types/feature_flag.rs
@@ -4,15 +4,6 @@ pub struct HashKeyOverride {
     pub hash_key: String,
 }
 
-/// Input for upserting a hash key override.
-/// The hash_key is specified separately at the batch level since all overrides
-/// share the same hash key (for experience continuity).
-#[derive(Debug, Clone)]
-pub struct HashKeyOverrideInput {
-    pub person_id: i64,
-    pub feature_flag_key: String,
-}
-
 /// Context for hash key override decisions. Contains the resolved person ID,
 /// existing overrides, and which flags already have overrides.
 #[derive(Debug, Clone)]

--- a/rust/personhog-router/tests/integration.rs
+++ b/rust/personhog-router/tests/integration.rs
@@ -8,8 +8,8 @@ use personhog_proto::personhog::types::v1::{
     GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByTeamIdRequest, GetGroupsRequest,
     GetHashKeyOverrideContextRequest, GetPersonByDistinctIdRequest, GetPersonRequest,
     GetPersonsByDistinctIdsInTeamRequest, Group, GroupIdentifier, GroupTypeMapping,
-    HashKeyOverride, HashKeyOverrideContext, HashKeyOverrideInput, Person, PersonWithDistinctIds,
-    ReadOptions, UpsertHashKeyOverridesRequest,
+    HashKeyOverride, HashKeyOverrideContext, Person, PersonWithDistinctIds, ReadOptions,
+    UpsertHashKeyOverridesRequest,
 };
 
 #[tokio::test]
@@ -261,21 +261,13 @@ async fn test_upsert_hash_key_overrides() {
     let response = client
         .upsert_hash_key_overrides(UpsertHashKeyOverridesRequest {
             team_id: 1,
-            overrides: vec![
-                HashKeyOverrideInput {
-                    person_id: 42,
-                    feature_flag_key: "flag-1".to_string(),
-                },
-                HashKeyOverrideInput {
-                    person_id: 42,
-                    feature_flag_key: "flag-2".to_string(),
-                },
-                HashKeyOverrideInput {
-                    person_id: 42,
-                    feature_flag_key: "flag-3".to_string(),
-                },
-            ],
+            distinct_ids: vec!["user@example.com".to_string()],
             hash_key: "consistent-hash".to_string(),
+            feature_flag_keys: vec![
+                "flag-1".to_string(),
+                "flag-2".to_string(),
+                "flag-3".to_string(),
+            ],
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Problem

The personhog upsert API (`UpsertHashKeyOverridesRequest`) required callers to pre-resolve distinct IDs to person IDs before sending the request. This meant the feature-flags service had to call `get_person_by_distinct_id` for the first distinct ID, then build `HashKeyOverrideInput { person_id, feature_flag_key }` entries to send.

The SQL path resolves **all** distinct IDs (typically `[identified_user, anon_hash_key]`) and writes overrides for every person found. But the personhog path only resolved the **first** distinct ID, silently skipping the anonymous user's person. When the two distinct IDs haven't been merged yet, this causes experience continuity to fail during the merge window.


## Changes

- **Proto**: Remove `HashKeyOverrideInput` message. Change `UpsertHashKeyOverridesRequest` to accept `distinct_ids` + `feature_flag_keys` + `hash_key` instead of pre-resolved `HashKeyOverrideInput` entries. Since personhog isn't live yet, no wire compatibility is needed.

- **Storage trait + impl**: Change `upsert_hash_key_overrides` to accept `distinct_ids: &[String]` and `feature_flag_keys: &[String]`. Replace the old UNNEST-based insert (which took `person_id[]` and `flag_key[]` arrays) with a single atomic query that resolves distinct IDs → person IDs via `posthog_persondistinctid`, cross-joins with flag keys, and includes a person existence check:

  ```sql
  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
  SELECT $1, p.person_id, f.flag_key, $2
  FROM posthog_persondistinctid p
  CROSS JOIN UNNEST($4::text[]) AS f(flag_key)
  WHERE p.team_id = $1 AND p.distinct_id = ANY($3)
    AND EXISTS (SELECT 1 FROM posthog_person WHERE id = p.person_id AND team_id = p.team_id)
  ON CONFLICT DO NOTHING
  ```

- **Service handler**: Simplified to pass `req.distinct_ids` and `req.feature_flag_keys` directly to storage — no more proto → storage type conversion.

- **Remove `HashKeyOverrideInput`**: Deleted from storage types, re-exports, and all test files.

- **Tests**: Updated storage tests, service tests, mock impls (FailingStorage, SuccessStorage, ConsistencyTrackingStorage), and router integration tests to use the new request shape.


## How did you test this code?

- `cargo check` passes on `personhog-replica`, `personhog-router`, and `feature-flags`
- `cargo clippy --all-targets --all-features -- -D warnings` passes clean across all crates
- `cargo fmt -- --check` passes with no formatting issues
- All existing tests updated to use the new API shape and compile successfully
- Storage tests exercise the new query against real Postgres (single override, multiple distinct IDs × flags, empty inputs, conflict handling)
- Service tests verify the RPC layer passes through correctly
- Router integration tests verify end-to-end passthrough with the new request shape