### PR TITLE
fix(flags): canonical log lines silenty no-op in parallle path

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1015,7 +1015,7 @@ impl FeatureFlagMatcher {
         // Each rayon thread accumulates evaluation counters in a thread-local
         // FlagsCanonicalLogLine. After evaluation, the per-flag deltas are sent
         // back through the oneshot channel and merged into the request's
-        // tokio task-local canonical log. See #47752.
+        // tokio task-local canonical log.
         let work = move || {
             flags_to_evaluate
                 .into_par_iter()

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -16,7 +16,8 @@ use crate::flags::flag_models::{
     FeatureFlag, FeatureFlagId, FeatureFlagList, FlagFilters, FlagPropertyGroup,
 };
 use crate::flags::flag_operations::flags_require_db_preparation;
-use crate::handler::{install_rayon_canonical_log, take_rayon_canonical_log, with_canonical_log};
+use crate::handler::canonical_log::{install_rayon_canonical_log, take_rayon_canonical_log};
+use crate::handler::with_canonical_log;
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_BATCH_EVALUATION_COUNTER,
     FLAG_BATCH_EVALUATION_TIME, FLAG_BATCH_SIZE, FLAG_DB_PROPERTIES_FETCH_TIME,
@@ -1020,7 +1021,7 @@ impl FeatureFlagMatcher {
             flags_to_evaluate
                 .into_par_iter()
                 .map(|flag| {
-                    install_rayon_canonical_log();
+                    let _guard = install_rayon_canonical_log();
                     let result = matcher.evaluate_single_flag(
                         &flag,
                         &precomputed_property_overrides,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1014,8 +1014,8 @@ impl FeatureFlagMatcher {
             .collect();
 
         // Each rayon thread accumulates evaluation counters in a thread-local
-        // FlagsCanonicalLogLine. After evaluation, the per-flag deltas are sent
-        // back through the oneshot channel and merged into the request's
+        // FlagsCanonicalLogLine. After evaluation, the per-flag deltas are
+        // returned alongside each flag result and merged into the request's
         // tokio task-local canonical log.
         let work = move || {
             flags_to_evaluate

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -16,7 +16,7 @@ use crate::flags::flag_models::{
     FeatureFlag, FeatureFlagId, FeatureFlagList, FlagFilters, FlagPropertyGroup,
 };
 use crate::flags::flag_operations::flags_require_db_preparation;
-use crate::handler::with_canonical_log;
+use crate::handler::{install_rayon_canonical_log, take_rayon_canonical_log, with_canonical_log};
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_BATCH_EVALUATION_COUNTER,
     FLAG_BATCH_EVALUATION_TIME, FLAG_BATCH_SIZE, FLAG_DB_PROPERTIES_FETCH_TIME,
@@ -1012,16 +1012,15 @@ impl FeatureFlagMatcher {
             .map(FlagSnapshot::from_flag)
             .collect();
 
-        // TODO: Canonical log counters (cohorts_evaluated, flags_device_id_bucketing,
-        // property_cache_hits/misses, hash_key_override_status) are silently lost on rayon
-        // threads because CANONICAL_LOG uses tokio::task_local!. Fix by adding a thread_local!
-        // fallback: install a fresh FlagsCanonicalLogLine per flag eval, take it after, send
-        // deltas back through the oneshot channel, and merge into the real canonical log here.
-        // See: https://github.com/PostHog/posthog/issues/47752
+        // Each rayon thread accumulates evaluation counters in a thread-local
+        // FlagsCanonicalLogLine. After evaluation, the per-flag deltas are sent
+        // back through the oneshot channel and merged into the request's
+        // tokio task-local canonical log. See #47752.
         let work = move || {
             flags_to_evaluate
                 .into_par_iter()
                 .map(|flag| {
+                    install_rayon_canonical_log();
                     let result = matcher.evaluate_single_flag(
                         &flag,
                         &precomputed_property_overrides,
@@ -1029,9 +1028,10 @@ impl FeatureFlagMatcher {
                         &hash_overrides,
                         &req_hash_override,
                     );
-                    (flag, result)
+                    let delta = take_rayon_canonical_log();
+                    (flag, result, delta)
                 })
-                .collect()
+                .collect::<Vec<_>>()
         };
 
         let result = match &self.rayon_dispatcher {
@@ -1049,10 +1049,23 @@ impl FeatureFlagMatcher {
             }
         };
 
-        result.unwrap_or_else(|| {
+        let results_with_deltas = result.unwrap_or_else(|| {
             error!("Rayon parallel evaluation task was dropped (likely panicked)");
             Self::build_panic_fallback(flag_snapshots, team_id)
-        })
+                .into_iter()
+                .map(|(flag, result)| (flag, result, None))
+                .collect()
+        });
+
+        results_with_deltas
+            .into_iter()
+            .map(|(flag, result, delta)| {
+                if let Some(delta) = delta {
+                    with_canonical_log(|log| log.merge_rayon_delta(&delta));
+                }
+                (flag, result)
+            })
+            .collect()
     }
 
     /// Constructs per-flag error results from lightweight snapshots when the

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -851,13 +851,15 @@ mod tests {
             let mut log = FlagsCanonicalLogLine::default();
 
             for &(device_id, cohorts, hits, misses, person, group) in deltas {
-                let mut delta = FlagsCanonicalLogLine::default();
-                delta.flags_device_id_bucketing = device_id;
-                delta.cohorts_evaluated = cohorts;
-                delta.property_cache_hits = hits;
-                delta.property_cache_misses = misses;
-                delta.person_properties_not_cached = person;
-                delta.group_properties_not_cached = group;
+                let delta = FlagsCanonicalLogLine {
+                    flags_device_id_bucketing: device_id,
+                    cohorts_evaluated: cohorts,
+                    property_cache_hits: hits,
+                    property_cache_misses: misses,
+                    person_properties_not_cached: person,
+                    group_properties_not_cached: group,
+                    ..Default::default()
+                };
                 log.merge_rayon_delta(&delta);
             }
 
@@ -875,10 +877,12 @@ mod tests {
             log.team_id = Some(123);
             log.flags_evaluated = 50;
 
-            let mut delta = FlagsCanonicalLogLine::default();
-            delta.team_id = Some(999);
-            delta.flags_evaluated = 42;
-            delta.property_cache_hits = 5;
+            let delta = FlagsCanonicalLogLine {
+                team_id: Some(999),
+                flags_evaluated: 42,
+                property_cache_hits: 5,
+                ..Default::default()
+            };
 
             log.merge_rayon_delta(&delta);
 
@@ -895,7 +899,7 @@ mod tests {
 
         #[test]
         fn test_install_and_take_round_trip() {
-            install_rayon_canonical_log();
+            let _guard = install_rayon_canonical_log();
 
             // Modify via with_canonical_log (outside tokio scope, falls back to thread-local)
             with_canonical_log(|log| {
@@ -919,7 +923,7 @@ mod tests {
 
         #[test]
         fn test_take_clears_the_thread_local() {
-            install_rayon_canonical_log();
+            let _guard = install_rayon_canonical_log();
             with_canonical_log(|log| log.property_cache_hits = 1);
 
             let first = take_rayon_canonical_log();
@@ -931,11 +935,11 @@ mod tests {
 
         #[test]
         fn test_install_replaces_previous() {
-            install_rayon_canonical_log();
+            let _guard = install_rayon_canonical_log();
             with_canonical_log(|log| log.property_cache_hits = 99);
 
             // Re-install should reset
-            install_rayon_canonical_log();
+            let _guard = install_rayon_canonical_log();
             let delta = take_rayon_canonical_log().unwrap();
             assert_eq!(delta.property_cache_hits, 0);
         }
@@ -952,7 +956,7 @@ mod tests {
         #[tokio::test]
         async fn test_tokio_scope_takes_precedence_over_thread_local() {
             // Install a rayon thread-local
-            install_rayon_canonical_log();
+            let _guard = install_rayon_canonical_log();
 
             // Run inside a tokio canonical log scope
             let log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
@@ -979,7 +983,7 @@ mod tests {
 
             let b1 = barrier.clone();
             rayon::spawn(move || {
-                install_rayon_canonical_log();
+                let _guard = install_rayon_canonical_log();
                 with_canonical_log(|log| log.property_cache_hits = 111);
                 b1.wait(); // sync so both threads are alive simultaneously
                 let delta = take_rayon_canonical_log().unwrap();
@@ -988,7 +992,7 @@ mod tests {
 
             let b2 = barrier.clone();
             rayon::spawn(move || {
-                install_rayon_canonical_log();
+                let _guard = install_rayon_canonical_log();
                 with_canonical_log(|log| log.property_cache_hits = 222);
                 b2.wait();
                 let delta = take_rayon_canonical_log().unwrap();

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -46,18 +46,30 @@ pub fn with_canonical_log(f: impl FnOnce(&mut FlagsCanonicalLogLine)) {
     }
 }
 
+#[must_use = "guard cleans up the thread-local on drop; dropping immediately is a no-op"]
+pub(crate) struct RayonCanonicalLogGuard;
+
+impl Drop for RayonCanonicalLogGuard {
+    fn drop(&mut self) {
+        drop(take_rayon_canonical_log());
+    }
+}
+
 /// Install a fresh canonical log on the current thread for rayon evaluation.
-/// Call before each flag evaluation on a rayon thread, then call
-/// [`take_rayon_canonical_log`] after to retrieve the accumulated counters.
-pub fn install_rayon_canonical_log() {
+/// Returns an RAII guard that clears the thread-local on drop, ensuring
+/// cleanup even if the evaluation panics. Call [`take_rayon_canonical_log`]
+/// before the guard is dropped to retrieve the accumulated counters.
+pub(crate) fn install_rayon_canonical_log() -> RayonCanonicalLogGuard {
     RAYON_CANONICAL_LOG.with(|cell| {
         *cell.borrow_mut() = Some(FlagsCanonicalLogLine::default());
     });
+
+    RayonCanonicalLogGuard
 }
 
 /// Take the accumulated canonical log from the current rayon thread.
 /// Returns `None` if no log was installed.
-pub fn take_rayon_canonical_log() -> Option<FlagsCanonicalLogLine> {
+pub(crate) fn take_rayon_canonical_log() -> Option<FlagsCanonicalLogLine> {
     RAYON_CANONICAL_LOG.with(|cell| cell.borrow_mut().take())
 }
 

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -356,6 +356,10 @@ impl FlagsCanonicalLogLine {
     /// which runs on the tokio task after rayon returns.
     ///
     /// Numeric counters are summed; boolean flags are OR'd.
+    ///
+    // TODO: consider splitting these eval counters into an `EvalCounters` sub-struct
+    // so that new counters are merged automatically and this field list doesn't drift.
+    // See https://github.com/PostHog/posthog/issues/49255
     pub fn merge_rayon_delta(&mut self, delta: &FlagsCanonicalLogLine) {
         self.flags_device_id_bucketing += delta.flags_device_id_bucketing;
         self.cohorts_evaluated += delta.cohorts_evaluated;
@@ -839,7 +843,7 @@ mod tests {
             &[(0, 0, 0, 0, true, false), (0, 0, 0, 0, false, true)],
             0, 0, 0, 0, true, true
         )]
-        fn test_merge_rayon_delta(
+        fn test_merge_rayon_delta_from_zero(
             #[case] deltas: &[(usize, usize, usize, usize, bool, bool)],
             #[case] expected_device_id: usize,
             #[case] expected_cohorts: usize,
@@ -869,6 +873,38 @@ mod tests {
             assert_eq!(log.property_cache_misses, expected_cache_misses);
             assert_eq!(log.person_properties_not_cached, expected_person_not_cached);
             assert_eq!(log.group_properties_not_cached, expected_group_not_cached);
+        }
+
+        #[test]
+        fn test_merge_into_preexisting_counters() {
+            let mut log = FlagsCanonicalLogLine {
+                property_cache_hits: 10,
+                property_cache_misses: 5,
+                cohorts_evaluated: 3,
+                flags_device_id_bucketing: 2,
+                person_properties_not_cached: true,
+                group_properties_not_cached: false,
+                ..Default::default()
+            };
+
+            let delta = FlagsCanonicalLogLine {
+                property_cache_hits: 7,
+                property_cache_misses: 3,
+                cohorts_evaluated: 2,
+                flags_device_id_bucketing: 1,
+                person_properties_not_cached: false,
+                group_properties_not_cached: true,
+                ..Default::default()
+            };
+
+            log.merge_rayon_delta(&delta);
+
+            assert_eq!(log.property_cache_hits, 17);
+            assert_eq!(log.property_cache_misses, 8);
+            assert_eq!(log.cohorts_evaluated, 5);
+            assert_eq!(log.flags_device_id_bucketing, 3);
+            assert!(log.person_properties_not_cached);
+            assert!(log.group_properties_not_cached);
         }
 
         #[test]
@@ -942,6 +978,27 @@ mod tests {
             let _guard = install_rayon_canonical_log();
             let delta = take_rayon_canonical_log().unwrap();
             assert_eq!(delta.property_cache_hits, 0);
+        }
+
+        #[test]
+        fn test_guard_cleans_up_on_panic() {
+            use std::panic::catch_unwind;
+
+            // Ensure clean state
+            drop(take_rayon_canonical_log());
+
+            let result = catch_unwind(|| {
+                let _guard = install_rayon_canonical_log();
+                with_canonical_log(|log| log.property_cache_hits = 42);
+                panic!("simulated evaluation panic");
+            });
+
+            assert!(result.is_err(), "should have caught the panic");
+            // The guard's Drop should have cleared the thread-local
+            assert!(
+                take_rayon_canonical_log().is_none(),
+                "thread-local should be clean after panic"
+            );
         }
 
         #[test]

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -12,8 +12,20 @@ tokio::task_local! {
     static CANONICAL_LOG: RefCell<FlagsCanonicalLogLine>;
 }
 
+// Thread-local fallback for rayon worker threads.
+// Rayon threads don't have access to tokio task-locals, so we use a
+// std::thread_local to capture evaluation counters during parallel flag
+// evaluation. The counters are then merged back into the request's
+// canonical log on the tokio side after rayon returns.
+std::thread_local! {
+    static RAYON_CANONICAL_LOG: RefCell<Option<FlagsCanonicalLogLine>> = const { RefCell::new(None) };
+}
+
 /// Safely modify the canonical log if one exists in scope.
 /// No-ops silently if called outside a canonical log scope.
+///
+/// Tries the tokio task-local first (normal async request path), then
+/// falls back to the std::thread_local (rayon parallel-eval path).
 ///
 /// # Example
 /// ```ignore
@@ -21,7 +33,32 @@ tokio::task_local! {
 /// with_canonical_log(|log| log.property_cache_hits += 1);
 /// ```
 pub fn with_canonical_log(f: impl FnOnce(&mut FlagsCanonicalLogLine)) {
-    let _ = CANONICAL_LOG.try_with(|log| f(&mut log.borrow_mut()));
+    // Probe whether the tokio task-local is accessible without consuming `f`.
+    // On rayon threads there is no tokio task context, so this returns Err.
+    if CANONICAL_LOG.try_with(|_| ()).is_ok() {
+        CANONICAL_LOG.with(|log| f(&mut log.borrow_mut()));
+    } else {
+        RAYON_CANONICAL_LOG.with(|cell| {
+            if let Some(ref mut log) = *cell.borrow_mut() {
+                f(log);
+            }
+        });
+    }
+}
+
+/// Install a fresh canonical log on the current thread for rayon evaluation.
+/// Call before each flag evaluation on a rayon thread, then call
+/// [`take_rayon_canonical_log`] after to retrieve the accumulated counters.
+pub fn install_rayon_canonical_log() {
+    RAYON_CANONICAL_LOG.with(|cell| {
+        *cell.borrow_mut() = Some(FlagsCanonicalLogLine::default());
+    });
+}
+
+/// Take the accumulated canonical log from the current rayon thread.
+/// Returns `None` if no log was installed.
+pub fn take_rayon_canonical_log() -> Option<FlagsCanonicalLogLine> {
+    RAYON_CANONICAL_LOG.with(|cell| cell.borrow_mut().take())
 }
 
 /// Run an async block with a canonical log in scope.
@@ -295,6 +332,22 @@ impl FlagsCanonicalLogLine {
                 self.static_cohort_queries as f64,
             );
         }
+    }
+
+    /// Merge evaluation counters accumulated on a rayon thread back into this log.
+    ///
+    /// Only merges fields that are written during per-flag evaluation inside
+    /// `evaluate_single_flag` and its callees. Request-level metadata (request_id,
+    /// team_id, ip, etc.) is intentionally not merged.
+    ///
+    /// Numeric counters are summed; boolean flags are OR'd.
+    pub fn merge_rayon_delta(&mut self, delta: &FlagsCanonicalLogLine) {
+        self.flags_device_id_bucketing += delta.flags_device_id_bucketing;
+        self.cohorts_evaluated += delta.cohorts_evaluated;
+        self.property_cache_hits += delta.property_cache_hits;
+        self.property_cache_misses += delta.property_cache_misses;
+        self.person_properties_not_cached |= delta.person_properties_not_cached;
+        self.group_properties_not_cached |= delta.group_properties_not_cached;
     }
 
     /// Populate error fields from a FlagError without emitting.
@@ -743,6 +796,192 @@ mod tests {
             .await;
 
             assert_eq!(final_log.hash_key_override_status, Some("empty"));
+        }
+    }
+
+    mod merge_rayon_delta_tests {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        // Single delta with all counter fields populated
+        #[case(
+            &[(3, 5, 10, 2, true, false)],
+            3, 5, 10, 2, true, false
+        )]
+        // Two deltas accumulate: counters sum, booleans OR
+        #[case(
+            &[(1, 2, 3, 1, false, false), (2, 3, 7, 4, false, true)],
+            3, 5, 10, 5, false, true
+        )]
+        // Empty delta is a no-op
+        #[case(
+            &[(0, 0, 0, 0, false, false)],
+            0, 0, 0, 0, false, false
+        )]
+        // Boolean fields OR across deltas
+        #[case(
+            &[(0, 0, 0, 0, true, false), (0, 0, 0, 0, false, true)],
+            0, 0, 0, 0, true, true
+        )]
+        fn test_merge_rayon_delta(
+            #[case] deltas: &[(usize, usize, usize, usize, bool, bool)],
+            #[case] expected_device_id: usize,
+            #[case] expected_cohorts: usize,
+            #[case] expected_cache_hits: usize,
+            #[case] expected_cache_misses: usize,
+            #[case] expected_person_not_cached: bool,
+            #[case] expected_group_not_cached: bool,
+        ) {
+            let mut log = FlagsCanonicalLogLine::default();
+
+            for &(device_id, cohorts, hits, misses, person, group) in deltas {
+                let mut delta = FlagsCanonicalLogLine::default();
+                delta.flags_device_id_bucketing = device_id;
+                delta.cohorts_evaluated = cohorts;
+                delta.property_cache_hits = hits;
+                delta.property_cache_misses = misses;
+                delta.person_properties_not_cached = person;
+                delta.group_properties_not_cached = group;
+                log.merge_rayon_delta(&delta);
+            }
+
+            assert_eq!(log.flags_device_id_bucketing, expected_device_id);
+            assert_eq!(log.cohorts_evaluated, expected_cohorts);
+            assert_eq!(log.property_cache_hits, expected_cache_hits);
+            assert_eq!(log.property_cache_misses, expected_cache_misses);
+            assert_eq!(log.person_properties_not_cached, expected_person_not_cached);
+            assert_eq!(log.group_properties_not_cached, expected_group_not_cached);
+        }
+
+        #[test]
+        fn test_merge_does_not_touch_request_fields() {
+            let mut log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+            log.team_id = Some(123);
+            log.flags_evaluated = 50;
+
+            let mut delta = FlagsCanonicalLogLine::default();
+            delta.team_id = Some(999);
+            delta.flags_evaluated = 42;
+            delta.property_cache_hits = 5;
+
+            log.merge_rayon_delta(&delta);
+
+            // Request-level fields are unchanged
+            assert_eq!(log.team_id, Some(123));
+            assert_eq!(log.flags_evaluated, 50);
+            // Evaluation counter is merged
+            assert_eq!(log.property_cache_hits, 5);
+        }
+    }
+
+    mod rayon_fallback_tests {
+        use super::*;
+
+        #[test]
+        fn test_install_and_take_round_trip() {
+            install_rayon_canonical_log();
+
+            // Modify via with_canonical_log (outside tokio scope, falls back to thread-local)
+            with_canonical_log(|log| {
+                log.property_cache_hits = 7;
+                log.cohorts_evaluated = 3;
+            });
+
+            let delta = take_rayon_canonical_log();
+            assert!(delta.is_some());
+            let delta = delta.unwrap();
+            assert_eq!(delta.property_cache_hits, 7);
+            assert_eq!(delta.cohorts_evaluated, 3);
+        }
+
+        #[test]
+        fn test_take_without_install_returns_none() {
+            // Ensure clean state
+            drop(take_rayon_canonical_log());
+            assert!(take_rayon_canonical_log().is_none());
+        }
+
+        #[test]
+        fn test_take_clears_the_thread_local() {
+            install_rayon_canonical_log();
+            with_canonical_log(|log| log.property_cache_hits = 1);
+
+            let first = take_rayon_canonical_log();
+            assert!(first.is_some());
+
+            let second = take_rayon_canonical_log();
+            assert!(second.is_none());
+        }
+
+        #[test]
+        fn test_install_replaces_previous() {
+            install_rayon_canonical_log();
+            with_canonical_log(|log| log.property_cache_hits = 99);
+
+            // Re-install should reset
+            install_rayon_canonical_log();
+            let delta = take_rayon_canonical_log().unwrap();
+            assert_eq!(delta.property_cache_hits, 0);
+        }
+
+        #[test]
+        fn test_with_canonical_log_noop_without_either_scope() {
+            // Ensure thread-local is clean
+            drop(take_rayon_canonical_log());
+
+            // Outside both tokio scope and rayon scope: should no-op without panic
+            with_canonical_log(|log| log.team_id = Some(123));
+        }
+
+        #[tokio::test]
+        async fn test_tokio_scope_takes_precedence_over_thread_local() {
+            // Install a rayon thread-local
+            install_rayon_canonical_log();
+
+            // Run inside a tokio canonical log scope
+            let log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+            let (_, final_log) = run_with_canonical_log(log, async {
+                with_canonical_log(|l| l.property_cache_hits = 42);
+            })
+            .await;
+
+            // The tokio scope should have received the update
+            assert_eq!(final_log.property_cache_hits, 42);
+
+            // The rayon thread-local should be untouched
+            let rayon_delta = take_rayon_canonical_log().unwrap();
+            assert_eq!(rayon_delta.property_cache_hits, 0);
+        }
+
+        #[test]
+        fn test_rayon_threads_are_isolated() {
+            use std::sync::{Arc, Barrier};
+
+            let barrier = Arc::new(Barrier::new(2));
+            let (tx1, rx1) = std::sync::mpsc::channel();
+            let (tx2, rx2) = std::sync::mpsc::channel();
+
+            let b1 = barrier.clone();
+            rayon::spawn(move || {
+                install_rayon_canonical_log();
+                with_canonical_log(|log| log.property_cache_hits = 111);
+                b1.wait(); // sync so both threads are alive simultaneously
+                let delta = take_rayon_canonical_log().unwrap();
+                tx1.send(delta.property_cache_hits).unwrap();
+            });
+
+            let b2 = barrier.clone();
+            rayon::spawn(move || {
+                install_rayon_canonical_log();
+                with_canonical_log(|log| log.property_cache_hits = 222);
+                b2.wait();
+                let delta = take_rayon_canonical_log().unwrap();
+                tx2.send(delta.property_cache_hits).unwrap();
+            });
+
+            assert_eq!(rx1.recv().unwrap(), 111);
+            assert_eq!(rx2.recv().unwrap(), 222);
         }
     }
 

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -340,6 +340,9 @@ impl FlagsCanonicalLogLine {
     /// `evaluate_single_flag` and its callees. Request-level metadata (request_id,
     /// team_id, ip, etc.) is intentionally not merged.
     ///
+    /// `flags_errored` is excluded because it is incremented in `process_flag_result`,
+    /// which runs on the tokio task after rayon returns.
+    ///
     /// Numeric counters are summed; boolean flags are OR'd.
     pub fn merge_rayon_delta(&mut self, delta: &FlagsCanonicalLogLine) {
         self.flags_device_id_bucketing += delta.flags_device_id_bucketing;

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -11,10 +11,7 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
-pub use canonical_log::{
-    install_rayon_canonical_log, run_with_canonical_log, take_rayon_canonical_log,
-    with_canonical_log, FlagsCanonicalLogLine,
-};
+pub use canonical_log::{run_with_canonical_log, with_canonical_log, FlagsCanonicalLogLine};
 pub use types::*;
 
 use crate::{

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -11,7 +11,10 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
-pub use canonical_log::{run_with_canonical_log, with_canonical_log, FlagsCanonicalLogLine};
+pub use canonical_log::{
+    install_rayon_canonical_log, run_with_canonical_log, take_rayon_canonical_log,
+    with_canonical_log, FlagsCanonicalLogLine,
+};
 pub use types::*;
 
 use crate::{


### PR DESCRIPTION
## Problem

Canonical log counters (`cohorts_evaluated`, `property_cache_hits/misses`, `flags_device_id_bucketing`, `person_properties_not_cached`, `group_properties_not_cached`) are silently lost when flag evaluation runs on the rayon thread pool.

`CANONICAL_LOG` is stored in a `tokio::task_local!`, which is only accessible from the originating tokio task. Rayon worker threads have no access to it, so all `with_canonical_log()` calls during parallel evaluation are silent no-ops. This means canonical log lines for high-flag-count requests (which trigger parallel eval) have zeroed-out evaluation counters, making them useless for debugging.

Sequential evaluation is unaffected — it runs on the tokio task where the task-local is in scope.

Closes https://github.com/PostHog/posthog/issues/47752

## Changes

**Thread-local fallback for rayon threads** (`canonical_log.rs`):
- Adds a `std::thread_local!` (`RAYON_CANONICAL_LOG`) that captures evaluation counters on rayon threads where the tokio task-local is inaccessible.
- `with_canonical_log()` now probes the tokio task-local first and falls back to the thread-local. Existing call sites are unchanged.
- `install_rayon_canonical_log()` installs a fresh `FlagsCanonicalLogLine` per flag evaluation and returns an RAII guard (`RayonCanonicalLogGuard`) that clears the thread-local on drop, ensuring cleanup even on panic.
- `take_rayon_canonical_log()` extracts the accumulated counters before the guard drops.
- `merge_rayon_delta()` merges per-flag deltas back into the request's canonical log (sums numeric counters, ORs boolean flags).

**Integration in parallel eval** (`flag_matching.rs`):
- Each rayon iteration installs a fresh thread-local, evaluates the flag, takes the delta, and sends it back alongside the result through the existing oneshot channel.
- After rayon returns, deltas are merged into the tokio task-local canonical log.

## What is NOT affected

- `flags_errored` is incremented in `process_flag_result`, which runs on the tokio task after rayon returns — it was never actually lost.
- DB query counters (`db_property_fetches`, `person_queries`, `group_queries`, etc.) run in async functions before the rayon dispatch and are unaffected.
- Flag evaluation results themselves were never affected — only observability data was lost.
