### PR TITLE
fix(workflows): hit internal k8s url in batch workflows

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
@@ -47,7 +47,7 @@ describe('HogFlowBatchPersonQueryService', () => {
 
             expect(fetchMock).toHaveBeenCalledTimes(1)
             expect(fetchMock).toHaveBeenCalledWith({
-                url: 'http://localhost:8000/api/projects/123/internal/hog_flows/user_blast_radius',
+                urlPath: '/api/projects/123/internal/hog_flows/user_blast_radius',
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -69,7 +69,7 @@ describe('HogFlowBatchPersonQueryService', () => {
             await service.getBlastRadius(team, filters)
 
             expect(fetchMock).toHaveBeenCalledWith({
-                url: 'http://localhost:8000/api/projects/123/internal/hog_flows/user_blast_radius',
+                urlPath: '/api/projects/123/internal/hog_flows/user_blast_radius',
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -135,7 +135,7 @@ describe('HogFlowBatchPersonQueryService', () => {
 
             expect(fetchMock).toHaveBeenCalledTimes(2)
             expect(fetchMock).toHaveBeenNthCalledWith(1, {
-                url: 'http://localhost:8000/api/projects/123/internal/hog_flows/user_blast_radius_persons',
+                urlPath: '/api/projects/123/internal/hog_flows/user_blast_radius_persons',
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -146,7 +146,7 @@ describe('HogFlowBatchPersonQueryService', () => {
                 },
             })
             expect(fetchMock).toHaveBeenNthCalledWith(2, {
-                url: 'http://localhost:8000/api/projects/123/internal/hog_flows/user_blast_radius_persons',
+                urlPath: '/api/projects/123/internal/hog_flows/user_blast_radius_persons',
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -173,7 +173,7 @@ describe('HogFlowBatchPersonQueryService', () => {
             await service.getBlastRadiusPersons(team, filters)
 
             expect(fetchMock).toHaveBeenCalledWith({
-                url: 'http://localhost:8000/api/projects/123/internal/hog_flows/user_blast_radius_persons',
+                urlPath: '/api/projects/123/internal/hog_flows/user_blast_radius_persons',
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({

--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
@@ -35,11 +35,12 @@ export class HogFlowBatchPersonQueryService {
         filters: Pick<HogFunctionFilters, 'properties' | 'filter_test_accounts'>,
         groupTypeIndex?: number
     ): Promise<BlastRadiusResponse> {
-        const url = `${this.siteUrl}/api/projects/${team.id}/internal/hog_flows/user_blast_radius`
+        // The /internal endpoints aren't exposed publicly and require INTERNAL_API_SECRET for authentication
+        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius`
 
         try {
-            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
-                url,
+            const { fetchResponse, fetchError } = await this.hub.internalFetchService.fetch({
+                urlPath,
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -50,7 +51,7 @@ export class HogFlowBatchPersonQueryService {
             })
 
             if (!fetchResponse || fetchError) {
-                logger.error('Error fetching blast radius from Django', { error: fetchError, url })
+                logger.error('Error fetching blast radius from Django', { error: fetchError, urlPath })
                 throw fetchError
             }
 
@@ -59,7 +60,7 @@ export class HogFlowBatchPersonQueryService {
                 logger.error('Failed to fetch blast radius from Django', {
                     status: fetchResponse.status,
                     error: errorText,
-                    url,
+                    urlPath,
                 })
                 throw new Error(`Failed to fetch blast radius: ${fetchResponse.status} ${errorText}`)
             }
@@ -68,7 +69,7 @@ export class HogFlowBatchPersonQueryService {
 
             return data
         } catch (error) {
-            logger.error('Error calling blast radius endpoint', { error, url })
+            logger.error('Error calling blast radius endpoint', { error, urlPath })
             throw error
         }
     }
@@ -85,11 +86,11 @@ export class HogFlowBatchPersonQueryService {
         groupTypeIndex?: number,
         cursor?: string | null
     ): Promise<BlastRadiusPersonsResponse> {
-        const url = `${this.siteUrl}/api/projects/${team.id}/internal/hog_flows/user_blast_radius_persons`
+        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius_persons`
 
         try {
-            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
-                url,
+            const { fetchResponse, fetchError } = await this.hub.internalFetchService.fetch({
+                urlPath,
                 fetchParams: {
                     method: 'POST',
                     body: JSON.stringify({
@@ -101,7 +102,7 @@ export class HogFlowBatchPersonQueryService {
             })
 
             if (!fetchResponse || fetchError) {
-                logger.error('Error fetching blast radius persons from Django', { error: fetchError, url })
+                logger.error('Error fetching blast radius persons from Django', { error: fetchError, urlPath })
                 throw fetchError
             }
 
@@ -110,7 +111,7 @@ export class HogFlowBatchPersonQueryService {
                 logger.error('Failed to fetch blast radius persons from Django', {
                     status: fetchResponse.status,
                     error: errorText,
-                    url,
+                    urlPath,
                 })
                 throw new Error(`Failed to fetch blast radius persons: ${fetchResponse.status} ${errorText}`)
             }
@@ -119,7 +120,7 @@ export class HogFlowBatchPersonQueryService {
 
             return data
         } catch (error) {
-            logger.error('Error calling blast radius persons endpoint', { error, url })
+            logger.error('Error calling blast radius persons endpoint', { error, urlPath })
             throw error
         }
     }

--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
@@ -36,10 +36,10 @@ export class HogFlowBatchPersonQueryService {
         groupTypeIndex?: number
     ): Promise<BlastRadiusResponse> {
         // The /internal endpoints aren't exposed publicly and require INTERNAL_API_SECRET for authentication
-        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius`
+        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius` as const
 
         try {
-            const { fetchResponse, fetchError } = await this.hub.internalFetchService.fetch({
+            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
                 urlPath,
                 fetchParams: {
                     method: 'POST',
@@ -86,10 +86,10 @@ export class HogFlowBatchPersonQueryService {
         groupTypeIndex?: number,
         cursor?: string | null
     ): Promise<BlastRadiusPersonsResponse> {
-        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius_persons`
+        const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius_persons` as const
 
         try {
-            const { fetchResponse, fetchError } = await this.hub.internalFetchService.fetch({
+            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
                 urlPath,
                 fetchParams: {
                     method: 'POST',

--- a/nodejs/src/common/services/internal-fetch.test.ts
+++ b/nodejs/src/common/services/internal-fetch.test.ts
@@ -9,7 +9,10 @@ jest.mock('~/cdp/services/hog-executor.service', () => ({
 
 describe('InternalFetchService', () => {
     it('calls cdpTrackedFetch with internal auth header and templateId', async () => {
-        const internalFetchService = new InternalFetchService({ INTERNAL_API_SECRET: 'secret-123' })
+        const internalFetchService = new InternalFetchService({
+            INTERNAL_API_SECRET: 'secret-123',
+            INTERNAL_API_BASE_URL: 'https://internal.example.com',
+        })
         const mockedCdpTrackedFetch = jest.mocked(cdpTrackedFetch)
 
         mockedCdpTrackedFetch.mockResolvedValueOnce({
@@ -19,7 +22,7 @@ describe('InternalFetchService', () => {
         })
 
         await internalFetchService.fetch({
-            url: 'https://internal.example.com/health',
+            urlPath: '/health' as const,
             fetchParams: { method: 'POST', headers: { 'X-Test': 'abc' } } as any,
         })
 
@@ -38,14 +41,17 @@ describe('InternalFetchService', () => {
     })
 
     it('rethrows exceptions from cdpTrackedFetch', async () => {
-        const internalFetchService = new InternalFetchService({ INTERNAL_API_SECRET: 'secret-123' })
+        const internalFetchService = new InternalFetchService({
+            INTERNAL_API_SECRET: 'secret-123',
+            INTERNAL_API_BASE_URL: 'https://internal.example.com',
+        })
         const mockedCdpTrackedFetch = jest.mocked(cdpTrackedFetch)
 
         mockedCdpTrackedFetch.mockRejectedValueOnce(new Error('boom'))
 
         await expect(
             internalFetchService.fetch({
-                url: 'https://internal.example.com/boom',
+                urlPath: '/boom' as const,
                 fetchParams: { method: 'GET' } as any,
             })
         ).rejects.toThrow('boom')

--- a/nodejs/src/common/services/internal-fetch.ts
+++ b/nodejs/src/common/services/internal-fetch.ts
@@ -5,18 +5,21 @@ import { logger } from '~/utils/logger'
 import { FetchOptions, FetchResponse } from '~/utils/request'
 
 export class InternalFetchService {
-    constructor(private config: Pick<PluginsServerConfig, 'INTERNAL_API_SECRET'>) {}
+    constructor(private config: Pick<PluginsServerConfig, 'INTERNAL_API_SECRET' | 'INTERNAL_API_BASE_URL'>) {}
 
     async fetch({
-        url,
+        urlPath,
         fetchParams,
     }: {
-        url: string
+        urlPath: string
         fetchParams: FetchOptions
     }): Promise<{ fetchError: Error | null; fetchResponse: FetchResponse | null; fetchDuration: number }> {
-        logger.debug('Making internal fetch request', { url })
+        logger.debug('Making internal fetch request', { urlPath })
+
+        const internalUrl = `${this.config.INTERNAL_API_BASE_URL || 'http://localhost:8000'}${urlPath}`
+
         return await cdpTrackedFetch({
-            url,
+            url: internalUrl,
             fetchParams: {
                 ...fetchParams,
                 headers: {

--- a/nodejs/src/common/services/internal-fetch.ts
+++ b/nodejs/src/common/services/internal-fetch.ts
@@ -11,7 +11,7 @@ export class InternalFetchService {
         urlPath,
         fetchParams,
     }: {
-        urlPath: string
+        urlPath: `/${string}`
         fetchParams: FetchOptions
     }): Promise<{ fetchError: Error | null; fetchResponse: FetchResponse | null; fetchDuration: number }> {
         logger.debug('Making internal fetch request', { urlPath })

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -157,6 +157,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         OTEL_SERVICE_NAME: null,
         OTEL_SERVICE_ENVIRONMENT: null,
         // Internal API authentication
+        INTERNAL_API_BASE_URL: isProdEnv()
+            ? 'http://posthog-web-django.posthog.svc.cluster.local:8000'
+            : 'http://localhost:8000',
         INTERNAL_API_SECRET: isProdEnv() ? '' : 'posthog123',
 
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -501,7 +501,9 @@ export interface PluginsServerConfig
     // Super properties for internal analytics (matching Python posthoganalytics.super_properties)
     OTEL_SERVICE_NAME: string | null
     OTEL_SERVICE_ENVIRONMENT: string | null
+
     // Internal API authentication
+    INTERNAL_API_BASE_URL: string
     INTERNAL_API_SECRET: string
 
     // Destination Migration Diffing


### PR DESCRIPTION
## Problem

We are hitting this internal API in production by using the SITE_URL, which by design 403s

## Changes

Use the internal k8s service URL instead

## How did you test this code?

Verified the correct URL by exec-ing into a pod and curling the url being used here

## Publish to changelog?

No