### PR TITLE
fix(surveys): prevent targeting flags from reactivating when archiving a stopped survey

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -760,9 +760,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team,
             )
 
-        # Derive flag activation from the persisted instance, which now
-        # reflects the full effect of this update.
-        should_flag_be_active = bool(instance.start_date) and not instance.end_date and not instance.archived
+        should_flag_be_active = self._should_survey_flags_be_active(instance)
 
         if instance.targeting_flag:
             instance.targeting_flag.active = should_flag_be_active
@@ -814,8 +812,11 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         instance.actions.set(Action.objects.filter(team__project_id=self.context["project_id"], id__in=action_ids))
         instance.save()
 
+    def _should_survey_flags_be_active(self, instance: Survey) -> bool:
+        return bool(instance.start_date) and not instance.end_date and not instance.archived
+
     def _add_user_survey_interacted_filters(self, instance: Survey):
-        should_flag_be_active = bool(instance.start_date) and not instance.end_date and not instance.archived
+        should_flag_be_active = self._should_survey_flags_be_active(instance)
 
         survey_key = f"{instance.id}"
         if instance.iteration_count is not None and instance.iteration_count > 0:

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -691,16 +691,6 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 validated_data["targeting_flag_id"] = new_flag.id
             validated_data.pop("targeting_flag_filters")
 
-        end_date = validated_data.get("end_date")
-
-        if instance.targeting_flag:
-            # turn off feature flag if survey is completed
-            if end_date is None:
-                instance.targeting_flag.active = True
-            else:
-                instance.targeting_flag.active = False
-            instance.targeting_flag.save()
-
         iteration_count = validated_data.get("iteration_count", None)
         if (
             instance.current_iteration is not None
@@ -770,7 +760,15 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 team,
             )
 
-        self._add_user_survey_interacted_filters(instance, end_date)
+        # Derive flag activation from the persisted instance, which now
+        # reflects the full effect of this update.
+        should_flag_be_active = bool(instance.start_date) and not instance.end_date and not instance.archived
+
+        if instance.targeting_flag:
+            instance.targeting_flag.active = should_flag_be_active
+            instance.targeting_flag.save()
+
+        self._add_user_survey_interacted_filters(instance)
         self._associate_actions(instance, validated_data.get("conditions"))
         self._add_internal_response_sampling_filters(instance)
         return instance
@@ -816,7 +814,9 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         instance.actions.set(Action.objects.filter(team__project_id=self.context["project_id"], id__in=action_ids))
         instance.save()
 
-    def _add_user_survey_interacted_filters(self, instance: Survey, end_date=None):
+    def _add_user_survey_interacted_filters(self, instance: Survey):
+        should_flag_be_active = bool(instance.start_date) and not instance.end_date and not instance.archived
+
         survey_key = f"{instance.id}"
         if instance.iteration_count is not None and instance.iteration_count > 0:
             survey_key = f"{instance.id}/{instance.current_iteration or 1}"
@@ -891,7 +891,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 instance.internal_targeting_flag, serialized_data_filters, flag_name_suffix="-custom"
             )
 
-            internal_targeting_flag.active = bool(instance.start_date) and not end_date
+            internal_targeting_flag.active = should_flag_be_active
             internal_targeting_flag.save()
 
             instance.internal_targeting_flag_id = internal_targeting_flag.id
@@ -902,7 +902,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 None,
                 user_submitted_dismissed_filter,
                 instance.name,
-                bool(instance.start_date) and not end_date,
+                should_flag_be_active,
                 flag_name_suffix="-custom",
             )
             instance.internal_targeting_flag_id = new_flag.id

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -1251,6 +1251,290 @@ class TestSurvey(APIBaseTest):
         )
         assert FeatureFlag.objects.filter(id=survey.internal_targeting_flag.id).get().active is True
 
+    def test_archiving_stopped_survey_disables_targeting_flag(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "billing_plan",
+                                    "value": ["cloud"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        ).json()
+
+        survey = Survey.objects.get(id=survey_with_targeting["id"])
+        targeting_flag_id = survey_with_targeting["targeting_flag"]["id"]
+        assert survey.internal_targeting_flag is not None
+        internal_flag_id = survey.internal_targeting_flag.id
+
+        # launch survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": datetime.now() - timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
+        # stop survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"end_date": datetime.now() + timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+        # archive the already-stopped survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"archived": True},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+    def test_unrelated_patch_to_stopped_survey_keeps_flags_inactive(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "billing_plan",
+                                    "value": ["cloud"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        ).json()
+
+        survey = Survey.objects.get(id=survey_with_targeting["id"])
+        targeting_flag_id = survey_with_targeting["targeting_flag"]["id"]
+        assert survey.internal_targeting_flag is not None
+        internal_flag_id = survey.internal_targeting_flag.id
+
+        # launch survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": datetime.now() - timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
+        # stop survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"end_date": datetime.now() + timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+        # unrelated update — just rename the survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"name": "renamed survey"},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+    def test_archiving_running_survey_disables_targeting_flag(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "billing_plan",
+                                    "value": ["cloud"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        ).json()
+
+        survey = Survey.objects.get(id=survey_with_targeting["id"])
+        targeting_flag_id = survey_with_targeting["targeting_flag"]["id"]
+        assert survey.internal_targeting_flag is not None
+        internal_flag_id = survey.internal_targeting_flag.id
+
+        # launch survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": datetime.now() - timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
+        # archive while still running (frontend sends end_date + archived together)
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={
+                "archived": True,
+                "end_date": datetime.now().isoformat(),
+            },
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+    def test_unarchiving_stopped_survey_keeps_flags_inactive(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "billing_plan",
+                                    "value": ["cloud"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        ).json()
+
+        survey = Survey.objects.get(id=survey_with_targeting["id"])
+        targeting_flag_id = survey_with_targeting["targeting_flag"]["id"]
+        assert survey.internal_targeting_flag is not None
+        internal_flag_id = survey.internal_targeting_flag.id
+
+        # launch survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": datetime.now() - timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
+        # stop survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"end_date": datetime.now() + timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+        # archive the stopped survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"archived": True},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+        # unarchive the survey — flags stay inactive because the survey
+        # is still stopped (end_date is set)
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"archived": False},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+    def test_resuming_stopped_survey_reactivates_both_flags(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "billing_plan",
+                                    "value": ["cloud"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        ).json()
+
+        survey = Survey.objects.get(id=survey_with_targeting["id"])
+        targeting_flag_id = survey_with_targeting["targeting_flag"]["id"]
+        assert survey.internal_targeting_flag is not None
+        internal_flag_id = survey.internal_targeting_flag.id
+
+        # launch survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": datetime.now() - timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
+        # stop survey
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"end_date": datetime.now() + timedelta(days=1)},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is False
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is False
+
+        # resume survey by clearing end_date
+        self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"end_date": None},
+        )
+        assert FeatureFlag.objects.get(id=targeting_flag_id).active is True
+        assert FeatureFlag.objects.get(id=internal_flag_id).active is True
+
     def test_survey_with_wait_period_creates_targeting_flag_with_last_seen_date_check(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/surveys/",


### PR DESCRIPTION
## Problem

The survey update serializer used `validated_data.get("end_date")` to decide whether targeting flags should be active. This returns `None` for any PATCH that doesn't include `end_date`, which caused two bugs:

1. **Archiving a stopped survey reactivated its flags** — the archive PATCH doesn't include `end_date` (it's already set), so the serializer treated it as "no end date" and set flags back to `active=True`
2. **Any unrelated PATCH to a stopped survey reactivated its flags** — e.g., renaming a stopped survey would silently turn its targeting flags back on

> [!NOTE]
> I happened to discover this while investigating why an active survey flag for an archive survey depended on deleted flags.

## Steps to reproduce

1. Create a survey with targeting conditions
2. Launch the survey (flags become active)
3. Stop the survey (flags become inactive)
4. Either:
   - Archive the survey, **or**
   - Make any unrelated update (e.g., rename it)
5. Check the targeting flags — they are now **active again** (bug)

## Changes

- Move flag activation logic to run **after** `super().update()` so both `targeting_flag` and `internal_targeting_flag` use the same committed instance state
- Derive `should_flag_be_active` from the persisted instance: `bool(instance.start_date) and not instance.end_date and not instance.archived`
- The `_add_user_survey_interacted_filters` method no longer needs an `is_being_archived` parameter — it reads `instance.archived` directly, which handles both the "being archived" transition and the "already archived" steady state
- Unarchiving a stopped survey correctly keeps flags inactive (the survey is still stopped)

## How did you test this code?

Added five tests covering the full flag lifecycle:

- `test_archiving_stopped_survey_disables_targeting_flag` — launches, stops, then archives; verifies flags stay disabled
- `test_archiving_running_survey_disables_targeting_flag` — launches, then stop+archives together; verifies flags are disabled
- `test_unrelated_patch_to_stopped_survey_keeps_flags_inactive` — launches, stops, then renames; verifies flags stay disabled (new test for bug #2)
- `test_unarchiving_stopped_survey_keeps_flags_inactive` — launches, stops, archives, then unarchives; verifies flags stay disabled since the survey is still stopped
- `test_resuming_stopped_survey_reactivates_both_flags` — launches, stops, then resumes by clearing `end_date`; verifies both `targeting_flag` and `internal_targeting_flag` reactivate

## Open questions for the surveys team

- **`internal_response_sampling_flag`**: This third survey-managed flag is not disabled on archive. Its `active` state is never managed for any lifecycle event (stop or archive). Should it be?
- **Already-archived surveys receiving unrelated PATCHes**: The old code used `validated_data.get("archived")` which only detects the archive *transition*, not the steady state. If an already-archived survey received an unrelated PATCH, the flag could have been incorrectly reactivated. The new code uses `instance.archived` (persisted state) which handles both cases.

## Publish to changelog?

no