### PR TITLE
fix: add missing is_optional_in_types column to schema enforcement test

### DIFF
--- a/nodejs/src/utils/event-schema-enforcement-manager.test.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.test.ts
@@ -87,9 +87,9 @@ describe('EventSchemaEnforcementManager', () => {
         await postgres.query(
             PostgresUse.COMMON_WRITE,
             `INSERT INTO posthog_schemapropertygroupproperty
-                (id, property_group_id, name, property_type, is_required, description, created_at, updated_at)
+                (id, property_group_id, name, property_type, is_required, is_optional_in_types, description, created_at, updated_at)
              VALUES
-                (gen_random_uuid(), $1, $2, $3, $4, '', NOW(), NOW())`,
+                (gen_random_uuid(), $1, $2, $3, $4, false, '', NOW(), NOW())`,
             [propertyGroupId, propertyName, propertyType, isRequired],
             'create-test-property'
         )


### PR DESCRIPTION
## Summary
- fix failing test
- noticed in https://github.com/PostHog/posthog/actions/runs/22414146751/job/64895256931?pr=49088