### PR TITLE
fix(llma): add continue_as_new to coordinator workflows

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -4,6 +4,9 @@ Coordinator workflow for daily trace clustering.
 This workflow discovers teams dynamically via the team discovery activity
 and spawns child workflows to cluster traces for each team.
 
+Uses continue_as_new after each batch to keep the workflow history bounded
+(Temporal has a 50K event limit per execution).
+
 Per-team child workflows handle the case where a team has no traces
 gracefully (returning empty results).
 """
@@ -52,6 +55,16 @@ with temporalio.workflow.unsafe.imports_passed_through():
 logger = structlog.get_logger(__name__)
 
 
+def _empty_clustering_results() -> dict[str, Any]:
+    return {
+        "teams_succeeded": 0,
+        "teams_failed": 0,
+        "failed_team_ids": [],
+        "total_items": 0,
+        "total_clusters": 0,
+    }
+
+
 @dataclasses.dataclass
 class TraceClusteringCoordinatorInputs:
     """Inputs for the coordinator workflow."""
@@ -62,6 +75,11 @@ class TraceClusteringCoordinatorInputs:
     min_k: int = constants.DEFAULT_MIN_K
     max_k: int = constants.DEFAULT_MAX_K
     max_concurrent_teams: int = constants.DEFAULT_MAX_CONCURRENT_TEAMS
+    # Fields used by continue_as_new to carry state across continuations.
+    # When remaining_team_ids is set, team discovery is skipped.
+    remaining_team_ids: list[int] | None = None
+    per_team_filters: dict[str, list[dict[str, Any]]] | None = None
+    results_so_far: dict[str, Any] | None = None
 
 
 @temporalio.workflow.defn(name=COORDINATOR_WORKFLOW_NAME)
@@ -70,6 +88,8 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
     Coordinator workflow that discovers teams dynamically and spawns child
     workflows for each team. Teams with no traces will complete quickly
     with empty results.
+
+    Uses continue_as_new to keep history bounded when processing many teams.
     """
 
     @staticmethod
@@ -87,48 +107,62 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: TraceClusteringCoordinatorInputs) -> dict[str, Any]:
         """Execute coordinator workflow."""
-        logger.info(
-            "Starting trace clustering coordinator",
-            analysis_level=inputs.analysis_level,
-            lookback_days=inputs.lookback_days,
-            max_samples=inputs.max_samples,
-        )
 
-        # Discover teams dynamically via activity, falling back to guaranteed
-        # teams if the activity fails (e.g. ClickHouse timeout).
-        try:
-            team_ids = await temporalio.workflow.execute_activity(
-                get_team_ids_for_llm_analytics,
-                TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
-                start_to_close_timeout=DISCOVERY_ACTIVITY_TIMEOUT,
-                retry_policy=DISCOVERY_ACTIVITY_RETRY_POLICY,
+        # Phase A: resolve teams and filters.
+        # On continuation legs, these are passed in directly to avoid
+        # re-running expensive ClickHouse queries.
+        if inputs.remaining_team_ids is not None:
+            team_ids = inputs.remaining_team_ids
+            # Temporal JSON serialization converts int dict keys to strings
+            per_team_filters: dict[int, list[dict[str, Any]]] = (
+                {int(k): v for k, v in inputs.per_team_filters.items()} if inputs.per_team_filters else {}
             )
-        except Exception:
-            logger.warning("Team discovery activity failed, falling back to guaranteed teams", exc_info=True)
-            team_ids = sorted(GUARANTEED_TEAM_IDS)
-
-        logger.info("Processing discovered teams", team_count=len(team_ids), team_ids=team_ids)
-        record_teams_discovered(len(team_ids), "clustering", inputs.analysis_level)
-
-        # Fetch user-configured event filters for all teams
-        try:
-            per_team_filters: dict[int, list[dict[str, Any]]] = await temporalio.workflow.execute_activity(
-                fetch_all_clustering_filters_activity,
-                FetchAllClusteringFiltersInput(team_ids=team_ids),
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=2),
+            results_so_far = inputs.results_so_far or _empty_clustering_results()
+            logger.info(
+                "Resuming clustering coordinator after continue_as_new",
+                remaining_teams=len(team_ids),
+                teams_succeeded_so_far=results_so_far["teams_succeeded"],
             )
-        except Exception:
-            logger.warning("Failed to fetch clustering filters, proceeding without filters", exc_info=True)
-            per_team_filters = {}
+        else:
+            logger.info(
+                "Starting trace clustering coordinator",
+                analysis_level=inputs.analysis_level,
+                lookback_days=inputs.lookback_days,
+                max_samples=inputs.max_samples,
+            )
 
-        # Spawn child workflows for each team with concurrency limit
-        total_clusters = 0
-        total_items = 0
-        failed_teams: list[int] = []
-        successful_teams: list[int] = []
+            # Discover teams dynamically via activity, falling back to guaranteed
+            # teams if the activity fails (e.g. ClickHouse timeout).
+            try:
+                team_ids = await temporalio.workflow.execute_activity(
+                    get_team_ids_for_llm_analytics,
+                    TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
+                    start_to_close_timeout=DISCOVERY_ACTIVITY_TIMEOUT,
+                    retry_policy=DISCOVERY_ACTIVITY_RETRY_POLICY,
+                )
+            except Exception:
+                logger.warning("Team discovery activity failed, falling back to guaranteed teams", exc_info=True)
+                team_ids = sorted(GUARANTEED_TEAM_IDS)
 
-        # Process teams in batches for controlled parallelism
+            logger.info("Processing discovered teams", team_count=len(team_ids), team_ids=team_ids)
+            record_teams_discovered(len(team_ids), "clustering", inputs.analysis_level)
+
+            # Fetch user-configured event filters for all teams
+            try:
+                per_team_filters = await temporalio.workflow.execute_activity(
+                    fetch_all_clustering_filters_activity,
+                    FetchAllClusteringFiltersInput(team_ids=team_ids),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=2),
+                )
+            except Exception:
+                logger.warning("Failed to fetch clustering filters, proceeding without filters", exc_info=True)
+                per_team_filters = {}
+
+            results_so_far = _empty_clustering_results()
+
+        # Phase B: process teams in batches, using continue_as_new to keep
+        # the workflow history bounded.
         max_concurrent = inputs.max_concurrent_teams
         child_id_prefix = (
             GENERATION_CHILD_WORKFLOW_ID_PREFIX if inputs.analysis_level == "generation" else CHILD_WORKFLOW_ID_PREFIX
@@ -163,9 +197,9 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
             for team_id, handle in workflow_handles:
                 try:
                     workflow_result: ClusteringResult = await handle
-                    total_clusters += workflow_result.metrics.num_clusters
-                    total_items += workflow_result.metrics.total_items_analyzed
-                    successful_teams.append(team_id)
+                    results_so_far["total_clusters"] += workflow_result.metrics.num_clusters
+                    results_so_far["total_items"] += workflow_result.metrics.total_items_analyzed
+                    results_so_far["teams_succeeded"] += 1
                     increment_team_succeeded("clustering", inputs.analysis_level)
 
                     logger.info(
@@ -177,23 +211,51 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
 
                 except Exception:
                     logger.exception("Failed to cluster team", team_id=team_id)
-                    failed_teams.append(team_id)
+                    results_so_far["failed_team_ids"].append(team_id)
+                    results_so_far["teams_failed"] += 1
                     increment_team_failed("clustering", inputs.analysis_level)
 
+            # After each batch, check if Temporal suggests continuing as new
+            # to keep the history size bounded.
+            remaining = team_ids[batch_start + max_concurrent :]
+            if remaining and temporalio.workflow.info().is_continue_as_new_suggested():
+                logger.info(
+                    "Continuing as new to keep history bounded",
+                    teams_remaining=len(remaining),
+                    teams_processed_this_leg=batch_start + len(batch),
+                )
+                # Serialize per_team_filters with string keys for Temporal JSON
+                serializable_filters = {str(k): v for k, v in per_team_filters.items()}
+                temporalio.workflow.continue_as_new(
+                    TraceClusteringCoordinatorInputs(
+                        analysis_level=inputs.analysis_level,
+                        lookback_days=inputs.lookback_days,
+                        max_samples=inputs.max_samples,
+                        min_k=inputs.min_k,
+                        max_k=inputs.max_k,
+                        max_concurrent_teams=inputs.max_concurrent_teams,
+                        remaining_team_ids=remaining,
+                        per_team_filters=serializable_filters,
+                        results_so_far=results_so_far,
+                    )
+                )
+
+        # Final leg: return accumulated results
+        total_teams = results_so_far["teams_succeeded"] + results_so_far["teams_failed"]
         logger.info(
             "Trace clustering coordinator completed",
-            teams_processed=len(team_ids),
-            teams_succeeded=len(successful_teams),
-            teams_failed=len(failed_teams),
-            total_items=total_items,
-            total_clusters=total_clusters,
+            teams_processed=total_teams,
+            teams_succeeded=results_so_far["teams_succeeded"],
+            teams_failed=results_so_far["teams_failed"],
+            total_items=results_so_far["total_items"],
+            total_clusters=results_so_far["total_clusters"],
         )
 
         return {
-            "teams_processed": len(team_ids),
-            "teams_succeeded": len(successful_teams),
-            "teams_failed": len(failed_teams),
-            "failed_team_ids": failed_teams,
-            "total_items": total_items,
-            "total_clusters": total_clusters,
+            "teams_processed": total_teams,
+            "teams_succeeded": results_so_far["teams_succeeded"],
+            "teams_failed": results_so_far["teams_failed"],
+            "failed_team_ids": results_so_far["failed_team_ids"],
+            "total_items": results_so_far["total_items"],
+            "total_clusters": results_so_far["total_clusters"],
         }

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_coordinator.py
@@ -1,0 +1,101 @@
+"""Tests for trace clustering coordinator workflow."""
+
+import pytest
+
+from posthog.temporal.llm_analytics.trace_clustering import constants
+from posthog.temporal.llm_analytics.trace_clustering.coordinator import (
+    TraceClusteringCoordinatorInputs,
+    TraceClusteringCoordinatorWorkflow,
+    _empty_clustering_results,
+)
+
+
+class TestTraceClusteringCoordinatorWorkflow:
+    """Tests for TraceClusteringCoordinatorWorkflow."""
+
+    @pytest.mark.parametrize(
+        "inputs,expected",
+        [
+            pytest.param(
+                [],
+                TraceClusteringCoordinatorInputs(
+                    analysis_level="trace",
+                    lookback_days=constants.DEFAULT_LOOKBACK_DAYS,
+                    max_samples=constants.DEFAULT_MAX_SAMPLES,
+                    min_k=constants.DEFAULT_MIN_K,
+                    max_k=constants.DEFAULT_MAX_K,
+                    max_concurrent_teams=constants.DEFAULT_MAX_CONCURRENT_TEAMS,
+                ),
+                id="empty_inputs_uses_defaults",
+            ),
+            pytest.param(
+                ["generation"],
+                TraceClusteringCoordinatorInputs(
+                    analysis_level="generation",
+                    lookback_days=constants.DEFAULT_LOOKBACK_DAYS,
+                    max_samples=constants.DEFAULT_MAX_SAMPLES,
+                ),
+                id="generation_level",
+            ),
+            pytest.param(
+                ["trace", "14", "2000", "3", "15", "5"],
+                TraceClusteringCoordinatorInputs(
+                    analysis_level="trace",
+                    lookback_days=14,
+                    max_samples=2000,
+                    min_k=3,
+                    max_k=15,
+                    max_concurrent_teams=5,
+                ),
+                id="full_inputs",
+            ),
+        ],
+    )
+    def test_parse_inputs(self, inputs, expected):
+        result = TraceClusteringCoordinatorWorkflow.parse_inputs(inputs)
+
+        assert result.analysis_level == expected.analysis_level
+        assert result.lookback_days == expected.lookback_days
+        assert result.max_samples == expected.max_samples
+
+    def test_continuation_fields_default_to_none(self):
+        inputs = TraceClusteringCoordinatorInputs()
+
+        assert inputs.remaining_team_ids is None
+        assert inputs.per_team_filters is None
+        assert inputs.results_so_far is None
+
+    def test_continuation_fields_can_be_set(self):
+        inputs = TraceClusteringCoordinatorInputs(
+            remaining_team_ids=[100, 200, 300],
+            per_team_filters={"100": [{"event": "$ai_generation"}]},
+            results_so_far={
+                "teams_succeeded": 5,
+                "teams_failed": 1,
+                "failed_team_ids": [99],
+                "total_items": 50,
+                "total_clusters": 10,
+            },
+        )
+
+        assert inputs.remaining_team_ids == [100, 200, 300]
+        assert inputs.per_team_filters == {"100": [{"event": "$ai_generation"}]}
+        assert inputs.results_so_far["teams_succeeded"] == 5
+
+    def test_empty_clustering_results(self):
+        results = _empty_clustering_results()
+
+        assert results == {
+            "teams_succeeded": 0,
+            "teams_failed": 0,
+            "failed_team_ids": [],
+            "total_items": 0,
+            "total_clusters": 0,
+        }
+
+    def test_empty_results_returns_independent_instances(self):
+        r1 = _empty_clustering_results()
+        r2 = _empty_clustering_results()
+        r1["failed_team_ids"].append(123)
+
+        assert r2["failed_team_ids"] == []

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_coordinator.py
@@ -80,6 +80,7 @@ class TestTraceClusteringCoordinatorWorkflow:
 
         assert inputs.remaining_team_ids == [100, 200, 300]
         assert inputs.per_team_filters == {"100": [{"event": "$ai_generation"}]}
+        assert inputs.results_so_far is not None
         assert inputs.results_so_far["teams_succeeded"] == 5
 
     def test_empty_clustering_results(self):

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
@@ -12,6 +12,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
 from posthog.temporal.llm_analytics.trace_summarization.coordinator import (
     BatchTraceSummarizationCoordinatorInputs,
     BatchTraceSummarizationCoordinatorWorkflow,
+    _empty_summarization_results,
 )
 
 from products.llm_analytics.backend.summarization.models import SummarizationMode
@@ -82,3 +83,45 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
         assert result.mode == expected.mode
         assert result.window_minutes == expected.window_minutes
         assert result.model == expected.model
+
+    def test_continuation_fields_default_to_none(self):
+        inputs = BatchTraceSummarizationCoordinatorInputs()
+
+        assert inputs.remaining_team_ids is None
+        assert inputs.per_team_filters is None
+        assert inputs.results_so_far is None
+
+    def test_continuation_fields_can_be_set(self):
+        inputs = BatchTraceSummarizationCoordinatorInputs(
+            remaining_team_ids=[100, 200, 300],
+            per_team_filters={"100": [{"event": "$ai_generation"}]},
+            results_so_far={
+                "teams_succeeded": 5,
+                "teams_failed": 1,
+                "failed_team_ids": [99],
+                "total_items": 50,
+                "total_summaries": 40,
+            },
+        )
+
+        assert inputs.remaining_team_ids == [100, 200, 300]
+        assert inputs.per_team_filters == {"100": [{"event": "$ai_generation"}]}
+        assert inputs.results_so_far["teams_succeeded"] == 5
+
+    def test_empty_summarization_results(self):
+        results = _empty_summarization_results()
+
+        assert results == {
+            "teams_succeeded": 0,
+            "teams_failed": 0,
+            "failed_team_ids": [],
+            "total_items": 0,
+            "total_summaries": 0,
+        }
+
+    def test_empty_results_returns_independent_instances(self):
+        r1 = _empty_summarization_results()
+        r2 = _empty_summarization_results()
+        r1["failed_team_ids"].append(123)
+
+        assert r2["failed_team_ids"] == []

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
@@ -106,6 +106,7 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
 
         assert inputs.remaining_team_ids == [100, 200, 300]
         assert inputs.per_team_filters == {"100": [{"event": "$ai_generation"}]}
+        assert inputs.results_so_far is not None
         assert inputs.results_so_far["teams_succeeded"] == 5
 
     def test_empty_summarization_results(self):


### PR DESCRIPTION
## Problem

Both LLMA coordinator workflows (clustering and summarization) were being silently TERMINATED by Temporal because spawning ~1,900 child workflows from a single execution exceeded the 50K event history limit. This has been breaking all coordinator runs since ~Feb 14 when the team count crossed the threshold, meaning non-guaranteed teams were never getting processed for clustering or summarization.

## Changes

Added `continue_as_new` support to both coordinator workflows:

- After each batch of teams completes, checks `workflow.info().is_continue_as_new_suggested()` (Temporal's built-in hint for when history is getting large)
- If suggested, calls `continue_as_new` with remaining teams, per-team filters, and accumulated results
- Team discovery and filter fetching only run on the first leg -- continuation legs skip straight to processing
- New optional fields on coordinator input dataclasses (`remaining_team_ids`, `per_team_filters`, `results_so_far`) default to `None`, so existing schedule definitions work without changes

Files changed:
- `posthog/temporal/llm_analytics/trace_clustering/coordinator.py`
- `posthog/temporal/llm_analytics/trace_summarization/coordinator.py`
- `posthog/temporal/llm_analytics/trace_clustering/tests/test_coordinator.py` (new)
- `posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py`

## How did you test this code?

- Unit tests for input dataclass backward compatibility, continuation field handling, and result helper functions (15 tests, all passing)
- Verified on prod-us worker pod that team discovery returns 2,525 teams and all recent coordinator runs show status=TERMINATED
- Tested locally too.

## Publish to changelog?

No