### PR TITLE
fix(flags): enforce mandatory org membership for scoped personal API keys

### DIFF
--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1397,4 +1397,20 @@ impl TestContext {
         .await?;
         Ok(())
     }
+
+    pub async fn remove_user_from_organization(
+        &self,
+        user_id: i32,
+        org_id: &uuid::Uuid,
+    ) -> Result<(), Error> {
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        sqlx::query(
+            "DELETE FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2",
+        )
+        .bind(user_id)
+        .bind(org_id)
+        .execute(&mut *conn)
+        .await?;
+        Ok(())
+    }
 }

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -695,6 +695,89 @@ async fn test_personal_api_key_with_scoped_organizations_denied() {
 }
 
 #[tokio::test]
+async fn test_personal_api_key_with_scoped_organizations_removed_member() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_org_removed_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    let org_id_str = org_id.to_string();
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Org Removed",
+            vec!["feature_flag:read"],
+            None,
+            Some(vec![org_id_str]),
+        )
+        .await
+        .unwrap();
+
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_flag_definitions_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Verify access works while user is a member
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        200,
+        "Should authenticate while user is an org member"
+    );
+
+    // Remove user from organization
+    context
+        .remove_user_from_organization(user_id, &org_id)
+        .await
+        .unwrap();
+
+    // Should now fail because the user is no longer an org member
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        401,
+        "Should deny access after user is removed from organization"
+    );
+}
+
+#[tokio::test]
 async fn test_cache_miss_returns_503() {
     use feature_flags::{config::Config, utils::test_utils::TestContext};
     use reqwest;

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -593,6 +593,10 @@ async fn test_personal_api_key_with_scoped_organizations_allowed() {
         .create_user(&user_email, &org_id, team.id)
         .await
         .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
 
     // Create personal API key with scoped_organizations restriction that includes our org
     let org_id_str = org_id.to_string();

--- a/rust/feature-flags/tests/test_personal_api_key_scopes.rs
+++ b/rust/feature-flags/tests/test_personal_api_key_scopes.rs
@@ -94,6 +94,9 @@ async fn test_personal_api_key_scoped_organizations_allowed() {
         .create_user_with_options(&user_email, &org_id, Some(team.id), true)
         .await
         .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
     let (pak_id, secure_value) = ctx
         .create_personal_api_key(
             user_id,
@@ -357,6 +360,9 @@ async fn test_personal_api_key_mixed_scopes_both_valid() {
     let user_email = format!("test_{}@example.com", Uuid::new_v4());
     let user_id = ctx
         .create_user_with_options(&user_email, &org_id, Some(team.id), true)
+        .await
+        .unwrap();
+    ctx.add_user_to_organization(user_id, &org_id, 15)
         .await
         .unwrap();
     let (pak_id, secure_value) = ctx


### PR DESCRIPTION
## Summary

- Fix auth bypass where personal API keys with `scoped_organizations` could access teams in organizations the user was no longer a member of
- Previously, when `scoped_organizations` was set, only the scope list was checked — the organization membership DB query was skipped entirely
- Now both checks are enforced independently: scope list (if set) AND current org membership are always required

## Detail

The old code used a `match` on `scoped_organizations` that was either/or:
- If scoped orgs had entries → only check the scope list (no membership query)
- Otherwise → check membership via DB query

This meant a user removed from an organization could still access its teams through a personal API key scoped to that org.

The fix decouples the two checks:
1. If `scoped_organizations` is non-empty, verify the team's org is in the list (early return with error if not)
2. **Always** verify the user is a current org member via `posthog_organizationmembership` query

Tests updated to add explicit org membership setup where the old tests relied on the bypassed path.

## Test plan

- [x] Existing tests updated to set up org membership (`add_user_to_organization`)
- [x] `test_personal_api_key_scoped_organizations_allowed` passes
- [x] `test_personal_api_key_mixed_scopes_both_valid` passes
- [x] `test_personal_api_key_mixed_scopes_org_mismatch` still correctly returns 401 (no membership added, scope check rejects first)