### PR TITLE
fix(insights): add confirmation dialog and dashboard redirect on insight delete

### DIFF
--- a/frontend/src/lib/utils/deleteWithUndo.tsx
+++ b/frontend/src/lib/utils/deleteWithUndo.tsx
@@ -54,7 +54,6 @@ export async function deleteInsightWithUndo({
     object: QueryBasedInsightModel
     idField?: keyof QueryBasedInsightModel
     callback?: (undo: boolean, object: QueryBasedInsightModel) => void
-    onError?: () => void
 }): Promise<void> {
     try {
         await api.update(`api/${props.endpoint}/${props.object[props.idField || 'id']}`, {
@@ -85,7 +84,7 @@ export async function deleteInsightWithUndo({
             }
         )
     } catch (error: any) {
-        props.onError?.()
+        // Show error toast with the error message from the API
         const errorMessage = error.detail || error.message || 'Failed to delete'
         lemonToast.error(errorMessage)
     }

--- a/frontend/src/lib/utils/deleteWithUndo.tsx
+++ b/frontend/src/lib/utils/deleteWithUndo.tsx
@@ -54,6 +54,7 @@ export async function deleteInsightWithUndo({
     object: QueryBasedInsightModel
     idField?: keyof QueryBasedInsightModel
     callback?: (undo: boolean, object: QueryBasedInsightModel) => void
+    onError?: () => void
 }): Promise<void> {
     try {
         await api.update(`api/${props.endpoint}/${props.object[props.idField || 'id']}`, {
@@ -84,7 +85,7 @@ export async function deleteInsightWithUndo({
             }
         )
     } catch (error: any) {
-        // Show error toast with the error message from the API
+        props.onError?.()
         const errorMessage = error.detail || error.message || 'Failed to delete'
         lemonToast.error(errorMessage)
     }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -45,7 +45,6 @@ import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { getInsightDefinitionUrl } from 'lib/utils/insightLinks'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
@@ -55,7 +54,6 @@ import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -107,7 +105,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insightLoading,
         derivedName,
     } = useValues(insightLogic(insightLogicProps))
-    const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight, duplicateInsight, reloadSavedInsights } =
+    const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight, duplicateInsight, deleteInsight } =
         useActions(insightLogic(insightLogicProps))
 
     // insightDataLogic
@@ -138,7 +136,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { tags: allExistingTags } = useValues(tagsModel)
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
-    const { currentProjectId } = useValues(projectLogic)
     const { push } = useActions(router)
     const [tags, setTags] = useState(insight.tags)
     const { posthogTablesMap, allTables } = useValues(databaseTableListLogic)
@@ -577,16 +574,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             disabled={!!disabledReason}
                                             {...(disabledReason && { tooltip: disabledReason })}
                                             data-attr={`${RESOURCE_TYPE}-delete`}
-                                            onClick={() =>
-                                                void deleteInsightWithUndo({
-                                                    object: insight as QueryBasedInsightModel,
-                                                    endpoint: `projects/${currentProjectId}/insights`,
-                                                    callback: () => {
-                                                        reloadSavedInsights()
-                                                        push(urls.savedInsights())
-                                                    },
-                                                })
-                                            }
+                                            onClick={() => deleteInsight(dashboardId ?? null)}
                                         >
                                             <IconTrash />
                                             Delete insight

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -744,52 +744,6 @@ describe('insightLogic', () => {
         })
     })
 
-    describe('setInsight name preservation', () => {
-        it('preserves user-edited name when loading new data for the same insight', async () => {
-            logic = insightLogic({ dashboardItemId: Insight42 })
-            logic.mount()
-            await expectLogic(logic).toDispatchActions(['loadInsight']).toFinishAllListeners()
-
-            // simulate user editing the name locally
-            logic.actions.setInsightMetadataLocal({ name: 'User Edited Name' })
-
-            await expectLogic(logic).toMatchValues({
-                insight: partial({ name: 'User Edited Name', short_id: Insight42 }),
-            })
-
-            // simulate reloading data for the same insight (e.g. query refresh) — name should be preserved
-            logic.actions.setInsight(
-                { ...logic.values.insight, name: '', short_id: Insight42 },
-                { fromPersistentApi: false, overrideQuery: false }
-            )
-
-            await expectLogic(logic).toMatchValues({
-                insight: partial({ name: 'User Edited Name' }),
-            })
-        })
-
-        it('does not preserve name when switching to a new insight', async () => {
-            logic = insightLogic({ dashboardItemId: Insight42 })
-            logic.mount()
-            await expectLogic(logic).toDispatchActions(['loadInsight']).toFinishAllListeners()
-
-            // confirm the loaded insight has a name
-            await expectLogic(logic).toMatchValues({
-                insight: partial({ name: 'original name', short_id: Insight42 }),
-            })
-
-            // simulate switching to a brand new insight (no short_id)
-            logic.actions.setInsight(
-                { ...createEmptyInsight('new'), query: logic.values.insight.query },
-                { fromPersistentApi: false, overrideQuery: true }
-            )
-
-            await expectLogic(logic).toMatchValues({
-                insight: partial({ name: '' }),
-            })
-        })
-    })
-
     describe('saving query based insights', () => {
         beforeEach(async () => {
             const insightProps: InsightLogicProps = { dashboardItemId: 'new' }

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -237,6 +237,10 @@ describe('insightLogic', () => {
                     )
                     return [200, response]
                 },
+                '/api/projects/:team/insights/:id': async (req) => {
+                    const payload = await req.json()
+                    return [200, { ...payload, id: req.params['id'] }]
+                },
             },
         })
         initKeaTests(true, { ...MOCK_DEFAULT_TEAM, test_account_filters_default_checked: true })
@@ -800,7 +804,12 @@ describe('insightLogic', () => {
 
             await expectLogic(logic, () => {
                 logic.actions.setInsight(
-                    { query: { kind: NodeKind.DataTableNode } as DataTableNode },
+                    {
+                        query: {
+                            kind: NodeKind.DataTableNode,
+                            source: { kind: NodeKind.EventsQuery, select: ['*'] },
+                        } as DataTableNode,
+                    },
                     { overrideQuery: true }
                 )
                 logic.actions.saveInsight()
@@ -811,23 +820,87 @@ describe('insightLogic', () => {
                 [
                     `api/environments/${MOCK_TEAM_ID}/insights`,
                     expect.objectContaining({
-                        derived_name: 'DataTableNode query',
+                        derived_name: '* from events',
                         query: {
                             kind: 'DataTableNode',
+                            source: { kind: 'EventsQuery', select: ['*'] },
                         },
                         saved: true,
                     }),
                     expect.objectContaining({
-                        data: {
-                            derived_name: 'DataTableNode query',
+                        data: expect.objectContaining({
+                            derived_name: '* from events',
                             query: {
                                 kind: 'DataTableNode',
+                                source: { kind: 'EventsQuery', select: ['*'] },
                             },
                             saved: true,
-                        },
+                        }),
                     }),
                 ],
             ])
+        })
+    })
+
+    describe('confirmDeleteInsight', () => {
+        beforeEach(async () => {
+            const insightProps: InsightLogicProps = { dashboardItemId: Insight42 }
+            logic = insightLogic(insightProps)
+            logic.mount()
+
+            await expectLogic(logic)
+                .toFinishAllListeners()
+                .toMatchValues({
+                    insight: partial({ id: 42 }),
+                })
+        })
+
+        it.each([
+            { scenario: 'with dashboardId', dashboardId: 5 },
+            { scenario: 'without dashboardId', dashboardId: null },
+        ])('$scenario navigates immediately and deletes via API', async ({ dashboardId }) => {
+            jest.spyOn(api, 'update')
+
+            logic.actions.confirmDeleteInsight(dashboardId)
+
+            const expectedUrl = dashboardId ? urls.dashboard(dashboardId) : urls.savedInsights()
+            await expectLogic(router).toDispatchActions([router.actionCreators.push(expectedUrl)])
+
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(api.update).toHaveBeenCalledWith(
+                expect.stringContaining('/insights/42'),
+                expect.objectContaining({ deleted: true })
+            )
+        })
+
+        it('optimistically removes insight from dashboard', async () => {
+            await expectLogic(dashboardsModel, () => {
+                logic.actions.confirmDeleteInsight(5)
+            }).toDispatchActions([
+                (action: any) =>
+                    action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
+                    action.payload.insight.deleted === true &&
+                    action.payload.extraDashboardIds?.[0] === 5,
+            ])
+        })
+
+        it('restores insight on dashboard when API fails', async () => {
+            jest.spyOn(api, 'update').mockRejectedValueOnce(new Error('Network error'))
+
+            await expectLogic(dashboardsModel, () => {
+                logic.actions.confirmDeleteInsight(5)
+            })
+                .toDispatchActions([
+                    (action: any) =>
+                        action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
+                        action.payload.insight.deleted === true,
+                ])
+                .toDispatchActions([
+                    (action: any) =>
+                        action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
+                        action.payload.insight.deleted === false,
+                ])
         })
     })
 })

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -744,6 +744,52 @@ describe('insightLogic', () => {
         })
     })
 
+    describe('setInsight name preservation', () => {
+        it('preserves user-edited name when loading new data for the same insight', async () => {
+            logic = insightLogic({ dashboardItemId: Insight42 })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadInsight']).toFinishAllListeners()
+
+            // simulate user editing the name locally
+            logic.actions.setInsightMetadataLocal({ name: 'User Edited Name' })
+
+            await expectLogic(logic).toMatchValues({
+                insight: partial({ name: 'User Edited Name', short_id: Insight42 }),
+            })
+
+            // simulate reloading data for the same insight (e.g. query refresh) — name should be preserved
+            logic.actions.setInsight(
+                { ...logic.values.insight, name: '', short_id: Insight42 },
+                { fromPersistentApi: false, overrideQuery: false }
+            )
+
+            await expectLogic(logic).toMatchValues({
+                insight: partial({ name: 'User Edited Name' }),
+            })
+        })
+
+        it('does not preserve name when switching to a new insight', async () => {
+            logic = insightLogic({ dashboardItemId: Insight42 })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadInsight']).toFinishAllListeners()
+
+            // confirm the loaded insight has a name
+            await expectLogic(logic).toMatchValues({
+                insight: partial({ name: 'original name', short_id: Insight42 }),
+            })
+
+            // simulate switching to a brand new insight (no short_id)
+            logic.actions.setInsight(
+                { ...createEmptyInsight('new'), query: logic.values.insight.query },
+                { fromPersistentApi: false, overrideQuery: true }
+            )
+
+            await expectLogic(logic).toMatchValues({
+                insight: partial({ name: '' }),
+            })
+        })
+    })
+
     describe('saving query based insights', () => {
         beforeEach(async () => {
             const insightProps: InsightLogicProps = { dashboardItemId: 'new' }

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -812,49 +812,38 @@ describe('insightLogic', () => {
         it.each([
             { scenario: 'with dashboardId', dashboardId: 5 },
             { scenario: 'without dashboardId', dashboardId: null },
-        ])('$scenario navigates immediately and deletes via API', async ({ dashboardId }) => {
+        ])('$scenario deletes via API then navigates', async ({ dashboardId }) => {
             jest.spyOn(api, 'update')
 
             logic.actions.confirmDeleteInsight(dashboardId)
-
-            const expectedUrl = dashboardId ? urls.dashboard(dashboardId) : urls.savedInsights()
-            await expectLogic(router).toDispatchActions([router.actionCreators.push(expectedUrl)])
-
             await expectLogic(logic).toFinishAllListeners()
 
             expect(api.update).toHaveBeenCalledWith(
                 expect.stringContaining('/insights/42'),
                 expect.objectContaining({ deleted: true })
             )
+
+            const expectedUrl = dashboardId ? urls.dashboard(dashboardId) : urls.savedInsights()
+            await expectLogic(router).toDispatchActions([router.actionCreators.push(expectedUrl)])
         })
 
-        it('optimistically removes insight from dashboard', async () => {
+        it('restores insight on undo from dashboard', async () => {
+            logic.actions.confirmDeleteInsight(5)
+            await expectLogic(logic).toFinishAllListeners()
+
+            // Simulate undo — the callback with undo=true should restore the insight
             await expectLogic(dashboardsModel, () => {
-                logic.actions.confirmDeleteInsight(5)
+                dashboardsModel
+                    .findMounted()
+                    ?.actions.updateDashboardInsight(
+                        { ...(logic.values.insight as QueryBasedInsightModel), deleted: false },
+                        [5]
+                    )
             }).toDispatchActions([
                 (action: any) =>
                     action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
-                    action.payload.insight.deleted === true &&
-                    action.payload.extraDashboardIds?.[0] === 5,
+                    action.payload.insight.deleted === false,
             ])
-        })
-
-        it('restores insight on dashboard when API fails', async () => {
-            jest.spyOn(api, 'update').mockRejectedValueOnce(new Error('Network error'))
-
-            await expectLogic(dashboardsModel, () => {
-                logic.actions.confirmDeleteInsight(5)
-            })
-                .toDispatchActions([
-                    (action: any) =>
-                        action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
-                        action.payload.insight.deleted === true,
-                ])
-                .toDispatchActions([
-                    (action: any) =>
-                        action.type === dashboardsModel.actionTypes.updateDashboardInsight &&
-                        action.payload.insight.deleted === false,
-                ])
         })
     })
 })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -713,36 +713,32 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 secondaryButton: { children: 'Cancel' },
             })
         },
-        confirmDeleteInsight: ({ dashboardId }) => {
+        confirmDeleteInsight: async ({ dashboardId }) => {
             const { insight, currentTeamId } = values
-            const insightModel = { ...(insight as QueryBasedInsightModel), deleted: true, dashboards: [] }
-            if (dashboardId) {
-                dashboardsModel.actions.updateDashboardInsight(insightModel, [dashboardId])
-                router.actions.push(urls.dashboard(dashboardId))
-            } else {
-                router.actions.push(urls.savedInsights())
-            }
-            const restoreInsight = (): void => {
-                if (dashboardId) {
-                    dashboardsModel.actions.updateDashboardInsight(
-                        { ...(insight as QueryBasedInsightModel), deleted: false },
-                        [dashboardId]
-                    )
-                }
-                actions.reloadSavedInsights()
-            }
-            void deleteInsightWithUndo({
+            await deleteInsightWithUndo({
                 object: insight as QueryBasedInsightModel,
                 endpoint: `projects/${currentTeamId}/insights`,
                 callback: (undo: boolean) => {
-                    if (undo) {
-                        restoreInsight()
-                    } else {
-                        actions.reloadSavedInsights()
+                    if (undo && dashboardId) {
+                        dashboardsModel
+                            .findMounted()
+                            ?.actions.updateDashboardInsight(
+                                { ...(insight as QueryBasedInsightModel), deleted: false },
+                                [dashboardId]
+                            )
                     }
+                    actions.reloadSavedInsights()
                 },
-                onError: restoreInsight,
             })
+            if (dashboardId) {
+                router.actions.push(urls.dashboard(dashboardId))
+                dashboardsModel.actions.updateDashboardInsight(
+                    { ...(insight as QueryBasedInsightModel), deleted: true, dashboards: [] },
+                    [dashboardId]
+                )
+            } else {
+                router.actions.push(urls.savedInsights())
+            }
         },
         setInsightFeedback: ({ feedback }) => {
             const eventName = `customer-analytics-insight-${feedback}`

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -281,8 +281,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                           query: null,
                       },
             setInsight: (state, { insight }) => {
-                // Preserve the user-edited name when loading new data
-                if (!insight.name && state.name) {
+                // Preserve the user-edited name when loading new data for the same insight,
+                // but not when switching to a brand new insight
+                const isSameInsight = insight.short_id && insight.short_id === state.short_id
+                if (!insight.name && state.name && isSameInsight) {
                     return {
                         ...insight,
                         name: state.name,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -737,8 +737,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 callback: (undo: boolean) => {
                     if (undo) {
                         restoreInsight()
+                    } else {
+                        actions.reloadSavedInsights()
                     }
-                    actions.reloadSavedInsights()
+                },
                 },
                 onError: restoreInsight,
             })

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -13,6 +13,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isEmptyObject, isObject, objectsEqual } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
@@ -156,6 +157,8 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             insight,
             redirectToInsight,
         }),
+        deleteInsight: (dashboardId: number | null) => ({ dashboardId }),
+        confirmDeleteInsight: (dashboardId: number | null) => ({ dashboardId }),
         setInsightFeedback: (feedback: 'liked' | 'disliked') => ({ feedback }),
     }),
     loaders(({ actions, values, props }) => ({
@@ -697,6 +700,48 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 logic.actions.addInsight(newInsight)
             }
             redirectToInsight && router.actions.push(urls.insightEdit(newInsight.short_id))
+        },
+        deleteInsight: ({ dashboardId }) => {
+            LemonDialog.open({
+                title: 'Delete insight?',
+                description: 'Are you sure you want to delete this insight? This action can be undone.',
+                primaryButton: {
+                    children: 'Delete',
+                    status: 'danger',
+                    onClick: () => actions.confirmDeleteInsight(dashboardId),
+                },
+                secondaryButton: { children: 'Cancel' },
+            })
+        },
+        confirmDeleteInsight: ({ dashboardId }) => {
+            const { insight, currentTeamId } = values
+            const insightModel = { ...(insight as QueryBasedInsightModel), deleted: true, dashboards: [] }
+            if (dashboardId) {
+                dashboardsModel.actions.updateDashboardInsight(insightModel, [dashboardId])
+                router.actions.push(urls.dashboard(dashboardId))
+            } else {
+                router.actions.push(urls.savedInsights())
+            }
+            const restoreInsight = (): void => {
+                if (dashboardId) {
+                    dashboardsModel.actions.updateDashboardInsight(
+                        { ...(insight as QueryBasedInsightModel), deleted: false },
+                        [dashboardId]
+                    )
+                }
+                actions.reloadSavedInsights()
+            }
+            void deleteInsightWithUndo({
+                object: insight as QueryBasedInsightModel,
+                endpoint: `projects/${currentTeamId}/insights`,
+                callback: (undo: boolean) => {
+                    if (undo) {
+                        restoreInsight()
+                    }
+                    actions.reloadSavedInsights()
+                },
+                onError: restoreInsight,
+            })
         },
         setInsightFeedback: ({ feedback }) => {
             const eventName = `customer-analytics-insight-${feedback}`

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -281,10 +281,8 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                           query: null,
                       },
             setInsight: (state, { insight }) => {
-                // Preserve the user-edited name when loading new data for the same insight,
-                // but not when switching to a brand new insight
-                const isSameInsight = insight.short_id && insight.short_id === state.short_id
-                if (!insight.name && state.name && isSameInsight) {
+                // Preserve the user-edited name when loading new data
+                if (!insight.name && state.name) {
                     return {
                         ...insight,
                         name: state.name,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -741,7 +741,6 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                         actions.reloadSavedInsights()
                     }
                 },
-                },
                 onError: restoreInsight,
             })
         },

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -44,6 +44,7 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconAction, IconTableChart } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
@@ -854,13 +855,26 @@ export function SavedInsights(): JSX.Element {
                                 >
                                     <LemonButton
                                         status="danger"
-                                        onClick={() =>
-                                            void deleteInsightWithUndo({
-                                                object: insight,
-                                                endpoint: `projects/${currentProjectId}/insights`,
-                                                callback: loadInsights,
+                                        onClick={() => {
+                                            LemonDialog.open({
+                                                title: 'Delete insight?',
+                                                description:
+                                                    'Are you sure you want to delete this insight? This action can be undone.',
+                                                primaryButton: {
+                                                    children: 'Delete',
+                                                    status: 'danger',
+                                                    onClick: () =>
+                                                        void deleteInsightWithUndo({
+                                                            object: insight,
+                                                            endpoint: `projects/${currentProjectId}/insights`,
+                                                            callback: loadInsights,
+                                                        }),
+                                                },
+                                                secondaryButton: {
+                                                    children: 'Cancel',
+                                                },
                                             })
-                                        }
+                                        }}
                                         data-attr={`insight-item-${insight.short_id}-dropdown-remove`}
                                         fullWidth
                                     >

--- a/playwright/e2e/product-analytics/dashboards.spec.ts
+++ b/playwright/e2e/product-analytics/dashboards.spec.ts
@@ -212,6 +212,44 @@ test.describe('Dashboards', () => {
         })
     })
 
+    test('Deleting an insight from dashboard redirects back', async ({ page }) => {
+        const dashboard = new DashboardPage(page)
+        const insight = new InsightPage(page)
+
+        await test.step('create a dashboard with an insight', async () => {
+            await dashboard.createNew()
+            await dashboard.addInsightToNewDashboard()
+            await expect(dashboard.insightCards).toBeVisible()
+        })
+
+        await test.step('open the insight from the dashboard', async () => {
+            await dashboard.openFirstTileMenu()
+            await dashboard.selectTileMenuOption('Edit')
+            await expect(page).toHaveURL(/edit/)
+        })
+
+        await test.step('open the info panel and click delete', async () => {
+            await insight.openInfoPanel()
+            await insight.clickDeleteInsight()
+            await expect(page.locator('.LemonModal').filter({ hasText: 'Delete insight?' })).toBeVisible()
+        })
+
+        await test.step('cancel the dialog and verify we stay on the insight', async () => {
+            await insight.cancelDeleteDialog()
+            await expect(page).toHaveURL(/edit/)
+        })
+
+        await test.step('click delete again and confirm', async () => {
+            await insight.clickDeleteInsight()
+            await insight.confirmDeleteDialog()
+        })
+
+        await test.step('verify redirect to the dashboard with no insight cards', async () => {
+            await expect(page).toHaveURL(/\/dashboard\//)
+            await expect(dashboard.insightCards).toHaveCount(0)
+        })
+    })
+
     test('Creating a dashboard from a template populates tiles', async ({ page }) => {
         const dashboard = new DashboardPage(page)
 

--- a/playwright/e2e/product-analytics/insights-list.spec.ts
+++ b/playwright/e2e/product-analytics/insights-list.spec.ts
@@ -63,6 +63,9 @@ test.describe('Insights list', () => {
             await page.locator('table tbody tr').first().hover()
             await page.locator('table tbody tr').first().getByTestId('more-button').click()
             await page.getByRole('button', { name: 'Delete' }).click()
+
+            const dialog = page.locator('.LemonModal').filter({ hasText: 'Delete insight?' })
+            await dialog.getByRole('button', { name: 'Delete' }).click()
         })
 
         await test.step('verify the insight is removed', async () => {

--- a/playwright/page-models/insightPage.ts
+++ b/playwright/page-models/insightPage.ts
@@ -100,6 +100,30 @@ export class InsightPage {
         await this.page.waitForSelector('[data-attr="persons-modal"]', { state: 'visible' })
     }
 
+    async openInfoPanel(): Promise<void> {
+        const inlineButton = this.page.getByTestId('info-actions-panel')
+        const sidePanelButton = this.page.locator('#main-content').getByTestId('open-context-panel-button')
+        await inlineButton.or(sidePanelButton).click()
+        await this.page.locator('.scene-panel-actions-section').first().waitFor({ state: 'visible' })
+    }
+
+    async clickDeleteInsight(): Promise<void> {
+        await this.page.getByTestId('insight-delete').click()
+    }
+
+    async confirmDeleteDialog(): Promise<void> {
+        const dialog = this.page.locator('.LemonModal').filter({ hasText: 'Delete insight?' })
+        await expect(dialog).toBeVisible()
+        await dialog.getByRole('button', { name: 'Delete' }).click()
+    }
+
+    async cancelDeleteDialog(): Promise<void> {
+        const dialog = this.page.locator('.LemonModal').filter({ hasText: 'Delete insight?' })
+        await expect(dialog).toBeVisible()
+        await dialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(dialog).not.toBeVisible()
+    }
+
     async saveAsNew(name: string): Promise<void> {
         const originalUrl = this.page.url()
         await this.page.locator('[data-attr="insight-save-dropdown"]').click()


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0ACRAMJUAG/p1771954132325999

When coming from a dashboard to delete an insight there are two problems:
- No confirmation 
- No feedback it's deleted and you don't return to dashboard. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Adds a confirmation dialog
- Redirect to dashboard on delete

https://github.com/user-attachments/assets/d48040b9-87e3-473d-a964-d6ba370ed69f


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Playwright test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
