### PR TITLE
refactor(insights): extract modals from InsightPageHeader

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -125,6 +125,7 @@ interface SaveToDashboardModalProps {
     closeModal: () => void
     insightProps: InsightLogicProps
     canEditInsight: boolean
+    'data-attr'?: string
 }
 
 export function AddToDashboardModal({
@@ -132,6 +133,7 @@ export function AddToDashboardModal({
     closeModal,
     insightProps,
     canEditInsight,
+    'data-attr': dataAttr,
 }: SaveToDashboardModalProps): JSX.Element {
     const logic = addToDashboardModalLogic(insightProps)
 
@@ -161,6 +163,7 @@ export function AddToDashboardModal({
             }}
             isOpen={isOpen}
             title="Add to dashboard"
+            data-attr={dataAttr}
             footer={
                 <>
                     <div className="flex-1">

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -84,6 +84,7 @@ export interface SharingModalProps extends SharingModalBaseProps {
     isOpen: boolean
     closeModal: () => void
     inline?: boolean
+    'data-attr'?: string
 }
 
 export function SharingModalContent({
@@ -631,13 +632,21 @@ function LegendCheckbox({ insightShortId }: { insightShortId: InsightShortId }):
     )
 }
 
-export function SharingModal({ closeModal, isOpen, inline, title, ...props }: SharingModalProps): JSX.Element {
+export function SharingModal({
+    closeModal,
+    isOpen,
+    inline,
+    title,
+    'data-attr': dataAttr,
+    ...props
+}: SharingModalProps): JSX.Element {
     return (
         <LemonModal
             onClose={closeModal}
             isOpen={isOpen}
             width={SHARING_MODAL_WIDTH}
             title={title ?? 'Sharing'}
+            data-attr={dataAttr}
             footer={
                 <LemonButton type="secondary" onClick={closeModal}>
                     Done

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
@@ -19,10 +19,11 @@ export interface SubscriptionsModalProps extends SubscriptionBaseProps {
     closeModal: () => void
     subscriptionId: number | 'new' | null
     inline?: boolean
+    'data-attr'?: string
 }
 
 export function SubscriptionsModal(props: SubscriptionsModalProps): JSX.Element {
-    const { closeModal, dashboardId, insightShortId, subscriptionId, isOpen, inline } = props
+    const { closeModal, dashboardId, insightShortId, subscriptionId, isOpen, inline, 'data-attr': dataAttr } = props
     const { push } = useActions(router)
     const { userLoading } = useValues(userLogic)
 
@@ -30,7 +31,15 @@ export function SubscriptionsModal(props: SubscriptionsModalProps): JSX.Element 
         return <Spinner className="text-2xl" />
     }
     return (
-        <LemonModal onClose={closeModal} isOpen={isOpen} width={600} simple title="" inline={inline}>
+        <LemonModal
+            onClose={closeModal}
+            isOpen={isOpen}
+            width={600}
+            simple
+            title=""
+            inline={inline}
+            data-attr={dataAttr}
+        >
             <PayGateMini
                 feature={AvailableFeature.SUBSCRIPTIONS}
                 handleSubmit={closeModal}

--- a/frontend/src/lib/components/TerraformExporter/TerraformExportModal.tsx
+++ b/frontend/src/lib/components/TerraformExporter/TerraformExportModal.tsx
@@ -20,6 +20,7 @@ interface TerraformExportModalProps {
     isOpen: boolean
     onClose: () => void
     resource: TerraformExportResource
+    'data-attr'?: string
 }
 
 function getBaseName(resource: TerraformExportResource): string {
@@ -64,7 +65,12 @@ function getDescription(resource: TerraformExportResource, result: TerraformExpo
     )
 }
 
-export function TerraformExportModal({ isOpen, onClose, resource }: TerraformExportModalProps): JSX.Element {
+export function TerraformExportModal({
+    isOpen,
+    onClose,
+    resource,
+    'data-attr': dataAttr,
+}: TerraformExportModalProps): JSX.Element {
     const baseName = getBaseName(resource)
     const state = useTerraformExport(resource, isOpen)
     const handleDownload = useTerraformDownload(state.result, baseName)
@@ -77,6 +83,7 @@ export function TerraformExportModal({ isOpen, onClose, resource }: TerraformExp
             isOpen={isOpen}
             onClose={onClose}
             title="Manage with Terraform"
+            data-attr={dataAttr}
             description={getDescription(resource, state.result)}
             footer={
                 <div className="flex justify-between w-full">

--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -6,6 +6,7 @@ import { AccessDenied } from 'lib/components/AccessDenied'
 import { DebugCHQueries } from 'lib/components/AppShortcuts/utils/DebugCHQueries'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { InsightModals } from 'scenes/insights/InsightModals'
 import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { ReloadInsight } from 'scenes/saved-insights/ReloadInsight'
@@ -79,6 +80,7 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
 
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
+            <InsightModals insightLogicProps={insightProps} />
             <SceneContent className="Insight">
                 <InsightPageHeader insightLogicProps={insightProps} />
 

--- a/frontend/src/scenes/insights/InsightModals.tsx
+++ b/frontend/src/scenes/insights/InsightModals.tsx
@@ -1,0 +1,174 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
+import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
+import { EditAlertModal } from 'lib/components/Alerts/views/EditAlertModal'
+import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
+import { SharingModal } from 'lib/components/Sharing/SharingModal'
+import { SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
+import { TerraformExportModal } from 'lib/components/TerraformExporter/TerraformExportModal'
+import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import { urls } from 'scenes/urls'
+
+import { HogQLQuery, InsightQueryNode } from '~/queries/schema/schema-general'
+import { InsightLogicProps, InsightShortId, ItemMode } from '~/types'
+
+import { EndpointFromInsightModal } from 'products/endpoints/frontend/EndpointFromInsightModal'
+
+import { insightModalsLogic } from './insightModalsLogic'
+
+export function InsightModals({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element | null {
+    const { hasDashboardItemId } = useValues(insightLogic(insightLogicProps))
+
+    return (
+        <>
+            {hasDashboardItemId && (
+                <>
+                    <InsightSubscriptionsModalWrapper insightLogicProps={insightLogicProps} />
+                    <InsightSharingModalWrapper insightLogicProps={insightLogicProps} />
+                    <InsightAddToDashboardModalWrapper insightLogicProps={insightLogicProps} />
+                    <InsightAlertsModals insightLogicProps={insightLogicProps} />
+                    <NewDashboardModal />
+                    <InsightEndpointModalWrapper insightLogicProps={insightLogicProps} />
+                </>
+            )}
+
+            <InsightTerraformModalWrapper insightLogicProps={insightLogicProps} />
+        </>
+    )
+}
+
+function InsightSubscriptionsModalWrapper({
+    insightLogicProps,
+}: {
+    insightLogicProps: InsightLogicProps
+}): JSX.Element {
+    const { insightMode, itemId } = useValues(insightSceneLogic)
+    const { insight } = useValues(insightLogic(insightLogicProps))
+    const { push } = useActions(router)
+
+    return (
+        <SubscriptionsModal
+            data-attr="insight-subscriptions-modal"
+            isOpen={insightMode === ItemMode.Subscriptions}
+            closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
+            insightShortId={insight.short_id}
+            subscriptionId={typeof itemId === 'number' || itemId === 'new' ? itemId : null}
+        />
+    )
+}
+
+function InsightSharingModalWrapper({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const { insightMode } = useValues(insightSceneLogic)
+    const theInsightLogic = insightLogic(insightLogicProps)
+    const { insightProps, insight } = useValues(theInsightLogic)
+    const { insightData } = useValues(insightDataLogic(insightProps))
+    const { push } = useActions(router)
+
+    return (
+        <SharingModal
+            data-attr="insight-sharing-modal"
+            title="Insight sharing"
+            isOpen={insightMode === ItemMode.Sharing}
+            closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
+            insightShortId={insight.short_id}
+            insight={insight}
+            cachedResults={insightData}
+            previewIframe
+            userAccessLevel={insight.user_access_level}
+        />
+    )
+}
+
+function InsightAlertsModals({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const { insightMode, alertId } = useValues(insightSceneLogic)
+    const { insightProps, insight } = useValues(insightLogic(insightLogicProps))
+    const { query } = useValues(insightDataLogic(insightProps))
+    const { push } = useActions(router)
+
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+
+    return (
+        <>
+            {insightMode === ItemMode.Alerts && (
+                <ManageAlertsModal
+                    onClose={() => push(urls.insightView(insight.short_id as InsightShortId))}
+                    isOpen={insightMode === ItemMode.Alerts}
+                    insightLogicProps={insightLogicProps}
+                    insightId={insight.id as number}
+                    insightShortId={insight.short_id as InsightShortId}
+                    canCreateAlertForInsight={canCreateAlertForInsight}
+                />
+            )}
+
+            {!!alertId && insight.id && (
+                <EditAlertModal
+                    onClose={() => push(urls.insightAlerts(insight.short_id as InsightShortId))}
+                    isOpen={!!alertId}
+                    alertId={alertId === null || alertId === 'new' ? undefined : alertId}
+                    insightShortId={insight.short_id as InsightShortId}
+                    insightId={insight.id}
+                    onEditSuccess={() => push(urls.insightAlerts(insight.short_id as InsightShortId))}
+                    insightLogicProps={insightLogicProps}
+                />
+            )}
+        </>
+    )
+}
+
+function InsightAddToDashboardModalWrapper({
+    insightLogicProps,
+}: {
+    insightLogicProps: InsightLogicProps
+}): JSX.Element {
+    const { insightProps, canEditInsight } = useValues(insightLogic(insightLogicProps))
+    const theInsightModalsLogic = insightModalsLogic(insightLogicProps)
+    const { isAddToDashboardModalOpen } = useValues(theInsightModalsLogic)
+    const { closeAddToDashboardModal } = useActions(theInsightModalsLogic)
+
+    return (
+        <AddToDashboardModal
+            data-attr="insight-add-to-dashboard-modal"
+            isOpen={isAddToDashboardModalOpen}
+            closeModal={closeAddToDashboardModal}
+            insightProps={insightProps}
+            canEditInsight={canEditInsight}
+        />
+    )
+}
+
+function InsightTerraformModalWrapper({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const theInsightLogic = insightLogic(insightLogicProps)
+    const { insightProps, insight, derivedName } = useValues(theInsightLogic)
+    const { query } = useValues(insightDataLogic(insightProps))
+    const theInsightModalsLogic = insightModalsLogic(insightLogicProps)
+    const { isTerraformModalOpen } = useValues(theInsightModalsLogic)
+    const { closeTerraformModal } = useActions(theInsightModalsLogic)
+
+    return (
+        <TerraformExportModal
+            data-attr="insight-terraform-modal"
+            isOpen={isTerraformModalOpen}
+            onClose={closeTerraformModal}
+            resource={{ type: 'insight', data: { ...insight, query, derived_name: derivedName } }}
+        />
+    )
+}
+
+function InsightEndpointModalWrapper({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const theInsightLogic = insightLogic(insightLogicProps)
+    const { insightProps, insight } = useValues(theInsightLogic)
+    const { insightQuery } = useValues(insightDataLogic(insightProps))
+
+    return (
+        <EndpointFromInsightModal
+            tabId={insightProps.tabId || ''}
+            insightQuery={insightQuery as HogQLQuery | InsightQueryNode}
+            insightShortId={insight.short_id}
+        />
+    )
+}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,14 +1,11 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { IconCode2, IconInfo, IconPencil, IconPeople, IconShare, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
 import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
-import { EditAlertModal } from 'lib/components/Alerts/views/EditAlertModal'
-import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { SceneAddToDashboardButton } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToDashboardButton'
 import { SceneAddToNotebookDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu'
@@ -22,15 +19,12 @@ import { SceneShareButton } from 'lib/components/Scenes/SceneShareButton'
 import { SceneSubscribeButton } from 'lib/components/Scenes/SceneSubscribeButton'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
-import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import {
     TEMPLATE_LINK_HEADING,
     TEMPLATE_LINK_PII_WARNING,
     TEMPLATE_LINK_TOOLTIP,
 } from 'lib/components/Sharing/templateLinkMessages'
 import { TemplateLinkSection } from 'lib/components/Sharing/TemplateLinkSection'
-import { SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
-import { TerraformExportModal } from 'lib/components/TerraformExporter/TerraformExportModal'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -43,7 +37,6 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { getInsightDefinitionUrl } from 'lib/utils/insightLinks'
-import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
@@ -63,7 +56,7 @@ import {
     ScenePanelInfoSection,
 } from '~/layout/scenes/SceneLayout'
 import { tagsModel } from '~/models/tagsModel'
-import { HogQLQuery, InsightQueryNode, NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { isDataTableNode, isDataVisualizationNode, isEventsQuery, isHogQLQuery } from '~/queries/utils'
 import {
     AccessControlLevel,
@@ -75,21 +68,17 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
-import { EndpointFromInsightModal } from 'products/endpoints/frontend/EndpointFromInsightModal'
 import { endpointLogic } from 'products/endpoints/frontend/endpointLogic'
 
+import { insightModalsLogic } from './insightModalsLogic'
 import { getInsightIconTypeFromQuery, getOverrideWarningPropsForButton } from './utils'
 
 const RESOURCE_TYPE = 'insight'
 
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
-    // insightSceneLogic
-    const { insightMode, itemId, alertId, filtersOverride, variablesOverride, dashboardId } =
-        useValues(insightSceneLogic)
-
+    const { insightMode, filtersOverride, variablesOverride, dashboardId } = useValues(insightSceneLogic)
     const { setInsightMode } = useActions(insightSceneLogic)
 
-    // insightLogic
     const {
         insightProps,
         canEditInsight,
@@ -99,12 +88,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         isSavingTags,
         hasDashboardItemId,
         insightLoading,
-        derivedName,
     } = useValues(insightLogic(insightLogicProps))
     const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight, duplicateInsight, deleteInsight } =
         useActions(insightLogic(insightLogicProps))
 
-    // insightDataLogic
     const {
         query,
         queryChanged,
@@ -114,7 +101,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         exportContext,
         hogQLVariables,
         insightQuery,
-        insightData,
         generatedInsightNameLoading,
     } = useValues(insightDataLogic(insightProps))
     const { toggleQueryEditorPanel, toggleDebugPanel, cancelChanges, generateInsightName } = useActions(
@@ -125,22 +111,18 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { featureFlags } = useValues(featureFlagLogic)
     const canAccessAutoname = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_AUTONAME_INSIGHTS_WITH_AI]
 
-    // endpointLogic
     const { openCreateFromInsightModal } = useActions(endpointLogic({ tabId: insightProps.tabId || '' }))
 
-    // other logics
+    const { openAddToDashboardModal, openTerraformModal } = useActions(insightModalsLogic(insightLogicProps))
+
     const { tags: allExistingTags } = useValues(tagsModel)
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
     const { push } = useActions(router)
-    const [tags, setTags] = useState(insight.tags)
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1]
     const defaultInsightName =
         typeof lastBreadcrumb?.name === 'string' ? lastBreadcrumb.name : insight.name || insight.derived_name
-
-    const [addToDashboardModalOpen, setAddToDashboardModalOpenModal] = useState<boolean>(false)
-    const [terraformModalOpen, setTerraformModalOpen] = useState<boolean>(false)
 
     const showCohortButton =
         isDataTableNode(query) || isDataVisualizationNode(query) || isHogQLQuery(query) || isEventsQuery(query)
@@ -164,78 +146,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     return (
         <>
-            {hasDashboardItemId && (
-                <>
-                    <SubscriptionsModal
-                        isOpen={insightMode === ItemMode.Subscriptions}
-                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
-                        insightShortId={insight.short_id}
-                        subscriptionId={typeof itemId === 'number' || itemId === 'new' ? itemId : null}
-                    />
-                    <SharingModal
-                        title="Insight sharing"
-                        isOpen={insightMode === ItemMode.Sharing}
-                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
-                        insightShortId={insight.short_id}
-                        insight={insight}
-                        cachedResults={insightData}
-                        previewIframe
-                        userAccessLevel={insight.user_access_level}
-                    />
-                    <AddToDashboardModal
-                        isOpen={addToDashboardModalOpen}
-                        closeModal={() => setAddToDashboardModalOpenModal(false)}
-                        insightProps={insightProps}
-                        canEditInsight={canEditInsight}
-                    />
-                    {insightMode === ItemMode.Alerts && (
-                        <ManageAlertsModal
-                            onClose={() => push(urls.insightView(insight.short_id as InsightShortId))}
-                            isOpen={insightMode === ItemMode.Alerts}
-                            insightLogicProps={insightLogicProps}
-                            insightId={insight.id as number}
-                            insightShortId={insight.short_id as InsightShortId}
-                            canCreateAlertForInsight={canCreateAlertForInsight}
-                        />
-                    )}
-
-                    {!!alertId && insight.id && (
-                        <EditAlertModal
-                            onClose={() => push(urls.insightAlerts(insight.short_id as InsightShortId))}
-                            isOpen={!!alertId}
-                            alertId={alertId === null || alertId === 'new' ? undefined : alertId}
-                            insightShortId={insight.short_id as InsightShortId}
-                            insightId={insight.id}
-                            onEditSuccess={() => {
-                                push(urls.insightAlerts(insight.short_id as InsightShortId))
-                            }}
-                            insightLogicProps={insightLogicProps}
-                        />
-                    )}
-                    <NewDashboardModal />
-                    <EndpointFromInsightModal
-                        tabId={insightProps.tabId || ''}
-                        insightQuery={insightQuery as HogQLQuery | InsightQueryNode}
-                        insightShortId={insight.short_id}
-                    />
-                </>
-            )}
-
-            <TerraformExportModal
-                isOpen={terraformModalOpen}
-                onClose={() => setTerraformModalOpen(false)}
-                resource={{ type: 'insight', data: { ...insight, query, derived_name: derivedName } }}
-            />
-
             <ScenePanel>
                 <>
                     <ScenePanelInfoSection>
                         <SceneTags
-                            onSave={(tags) => {
-                                setInsightMetadata({ tags })
-                                setTags(tags)
-                            }}
-                            tags={tags}
+                            onSave={(tags) => setInsightMetadata({ tags })}
+                            tags={insight.tags}
                             tagsAvailable={allExistingTags}
                             dataAttrKey={RESOURCE_TYPE}
                             canEdit={canEditInsight}
@@ -272,9 +188,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             dashboard={
                                 hasDashboardItemId
                                     ? {
-                                          onClick: () => {
-                                              setAddToDashboardModalOpenModal(true)
-                                          },
+                                          onClick: openAddToDashboardModal,
                                       }
                                     : undefined
                             }
@@ -365,7 +279,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         ) : null}
 
                         <ButtonPrimitive
-                            onClick={() => setTerraformModalOpen(true)}
+                            onClick={openTerraformModal}
                             menuItem
                             data-attr={`${RESOURCE_TYPE}-manage-terraform`}
                         >
@@ -539,7 +453,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 isLoading={insightLoading && !insight?.id}
                 forceEdit={insightMode === ItemMode.Edit}
                 renameDebounceMs={0}
-                // Use onBlur-only saves to prevent autosave while typing
                 saveOnBlur
                 actions={
                     <>

--- a/frontend/src/scenes/insights/insightModalsLogic.ts
+++ b/frontend/src/scenes/insights/insightModalsLogic.ts
@@ -1,0 +1,36 @@
+import { actions, kea, key, path, props, reducers } from 'kea'
+
+import { InsightLogicProps } from '~/types'
+
+import type { insightModalsLogicType } from './insightModalsLogicType'
+import { keyForInsightLogicProps } from './sharedUtils'
+
+export const insightModalsLogic = kea<insightModalsLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'insightModalsLogic', key]),
+
+    actions({
+        openAddToDashboardModal: true,
+        closeAddToDashboardModal: true,
+        openTerraformModal: true,
+        closeTerraformModal: true,
+    }),
+
+    reducers({
+        isAddToDashboardModalOpen: [
+            false,
+            {
+                openAddToDashboardModal: () => true,
+                closeAddToDashboardModal: () => false,
+            },
+        ],
+        isTerraformModalOpen: [
+            false,
+            {
+                openTerraformModal: () => true,
+                closeTerraformModal: () => false,
+            },
+        ],
+    }),
+])

--- a/playwright/e2e/product-analytics/insights/insight-side-panel.spec.ts
+++ b/playwright/e2e/product-analytics/insights/insight-side-panel.spec.ts
@@ -1,11 +1,30 @@
+import { NodeKind } from '../../../../frontend/src/queries/schema/schema-general'
 import { InsightPage } from '../../../page-models/insightPage'
 import { PlaywrightWorkspaceSetupResult, expect, test } from '../../../utils/workspace-test-base'
 
 test.describe('Insight side panel actions', () => {
     let workspace: PlaywrightWorkspaceSetupResult | null = null
+    let insightUrl: string
 
     test.beforeAll(async ({ playwrightSetup }) => {
-        workspace = await playwrightSetup.createWorkspace({ use_current_time: true, skip_onboarding: true })
+        workspace = await playwrightSetup.createWorkspace({
+            use_current_time: true,
+            skip_onboarding: true,
+            insights: [
+                {
+                    name: 'Side Panel Test Insight',
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        },
+                    },
+                },
+            ],
+        })
+        const shortId = workspace!.created_insights![0].short_id
+        insightUrl = `/project/${workspace!.team_id}/insights/${shortId}`
     })
 
     test.beforeEach(async ({ page, playwrightSetup }) => {
@@ -83,6 +102,67 @@ test.describe('Insight side panel actions', () => {
         await test.step('enters edit mode and shows query editor', async () => {
             await expect(insight.saveButton).toBeVisible()
             await expect(page.getByTestId('query-editor')).toBeVisible()
+        })
+    })
+
+    test('Open sharing modal from side panel', async ({ page }) => {
+        const insight = new InsightPage(page)
+
+        await test.step('navigate to seeded insight', async () => {
+            await page.goto(insightUrl)
+        })
+
+        await test.step('click share and verify sharing modal opens', async () => {
+            await insight.openInfoPanel()
+            await page.getByTestId('insight-share-button').click()
+            const modal = page.getByTestId('insight-sharing-modal')
+            await expect(modal).toBeVisible()
+            await expect(modal.getByTestId('sharing-switch')).toBeVisible()
+        })
+
+        await test.step('toggle sharing on and verify share link appears', async () => {
+            const modal = page.getByTestId('insight-sharing-modal')
+            await modal.getByTestId('sharing-switch').click()
+            await expect(modal.getByTestId('sharing-link-button')).toBeVisible()
+        })
+    })
+
+    test('Open subscriptions modal from side panel', async ({ page }) => {
+        const insight = new InsightPage(page)
+
+        await test.step('navigate to seeded insight', async () => {
+            await page.goto(insightUrl)
+        })
+
+        await test.step('click subscribe and verify subscriptions modal opens', async () => {
+            await insight.openInfoPanel()
+            await page.getByTestId('insight-subscribe-dropdown-menu-item').click()
+            const modal = page.getByTestId('insight-subscriptions-modal')
+            await expect(modal).toBeVisible()
+        })
+    })
+
+    test('Export insight as Terraform and download the file', async ({ page }) => {
+        const insight = new InsightPage(page)
+
+        await test.step('navigate to seeded insight', async () => {
+            await page.goto(insightUrl)
+        })
+
+        await test.step('open terraform modal and wait for HCL to load', async () => {
+            await insight.openInfoPanel()
+            await page.getByTestId('insight-manage-terraform').click()
+            const modal = page.getByTestId('insight-terraform-modal')
+            await expect(modal).toBeVisible()
+            await expect(modal.getByText('resource "posthog_')).toBeVisible({ timeout: 10_000 })
+        })
+
+        await test.step('click download and verify the .tf file', async () => {
+            const modal = page.getByTestId('insight-terraform-modal')
+            const downloadPromise = page.waitForEvent('download')
+            await modal.getByRole('button', { name: /Download.*\.tf/ }).click()
+            const download = await downloadPromise
+            expect(download.suggestedFilename()).toMatch(/\.tf$/)
         })
     })
 })


### PR DESCRIPTION
## Problem
`InsightPageHeader`:
- Is 726 lines and doing at least 5 jobs.
- Has 9 modals
- 200+ lines of side panel buttons
- business logic for delete/duplicate/cohort
- connects to 10+ kea logics
Plus it's the most frequently fixed file in the last 6 months, at least 13 times.

So I'm breaking up!

## Changes
I've pulled out all these modals into a central modal component, and dedicated logic that just handles insight related modals.
Rest is just extracting components from files, nothing actually changes here

## How did you test this code?
Playwright tests for the modals

## Publish to changelog?
no
