### PR TITLE
feat(livestream): Migrate Livestream stats from in-memory to Redis

### DIFF
--- a/bin/start-go-service
+++ b/bin/start-go-service
@@ -38,6 +38,9 @@ case "$GO_SVC" in
     export LIVESTREAM_KAFKA_SESSION_TIMEOUT_MS=6000
     export LIVESTREAM_KAFKA_HEARTBEAT_INTERVAL_MS=1000
     export LIVESTREAM_KAFKA_MAX_POLL_INTERVAL_MS=6000
+    export LIVESTREAM_REDIS_ADDRESS=localhost
+    export LIVESTREAM_REDIS_PORT=6379
+    export LIVESTREAM_REDIS_TLS=false
 
     # MMDB path, relative to livestream directory where air runs
     export LIVESTREAM_MMDB_PATH=../share/GeoLite2-City.mmdb

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -24,6 +24,12 @@ type SessionRecordingConfig struct {
 	MaxLRUEntries int `mapstructure:"max_lru_entries"`
 }
 
+type RedisConfig struct {
+	Address string `mapstructure:"address"`
+	Port    string `mapstructure:"port"`
+	TLS     bool   `mapstructure:"tls"`
+}
+
 type Config struct {
 	Debug            bool `mapstructure:"debug"`
 	MMDB             MMDBConfig
@@ -33,6 +39,7 @@ type Config struct {
 	Postgres         PostgresConfig
 	JWT              JWTConfig
 	SessionRecording SessionRecordingConfig `mapstructure:"session_recording"`
+	Redis            RedisConfig
 }
 
 type KafkaConfig struct {
@@ -98,6 +105,11 @@ func InitConfigs(filename, configPath string) {
 
 	// Session recording settings
 	_ = viper.BindEnv("session_recording.max_lru_entries") // LIVESTREAM_SESSION_RECORDING_MAX_LRU_ENTRIES
+
+	// Redis settings
+	_ = viper.BindEnv("redis.address") // LIVESTREAM_REDIS_ADDRESS
+	_ = viper.BindEnv("redis.port")    // LIVESTREAM_REDIS_PORT
+	_ = viper.BindEnv("redis.tls")     // LIVESTREAM_REDIS_TLS
 }
 
 func LoadConfig() (*Config, error) {

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -46,6 +46,10 @@ func TestLoadConfig(t *testing.T) {
 				SessionRecording: SessionRecordingConfig{
 					MaxLRUEntries: 2_000_000_000,
 				},
+				Redis: RedisConfig{
+					Address: "localhost",
+					Port:    "6379",
+				},
 			},
 			wantErr: false,
 		},

--- a/livestream/events/live_stats.go
+++ b/livestream/events/live_stats.go
@@ -30,7 +30,7 @@ type Stats struct {
 	// Counter keeps all events count in the last COUNTER_TTL
 	Counter *SlidingWindowCounter
 
-	RedisWriter *RedisStatsWriter
+	RedisStore *StatsInRedis
 
 	mu sync.RWMutex // guards store
 }
@@ -73,10 +73,12 @@ func (ts *Stats) KeepStats(statsChan chan CountEvent) {
 		ts.GlobalStore.Add(event.DistinctID, NoSpaceType{})
 		metrics.HandledEvents.Inc()
 
-		if ts.RedisWriter != nil {
-			if err := ts.RedisWriter.AddUser(context.Background(), event.Token, event.DistinctID); err != nil {
+		if ts.RedisStore != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := ts.RedisStore.AddUser(ctx, event.Token, event.DistinctID); err != nil {
 				log.Printf("Redis AddUser error: %v", err)
 			}
+			cancel()
 		}
 	}
 }

--- a/livestream/events/live_stats.go
+++ b/livestream/events/live_stats.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"log"
 	"sync"
 	"time"
@@ -28,6 +29,8 @@ type Stats struct {
 	GlobalStore *expirable.LRU[string, NoSpaceType]
 	// Counter keeps all events count in the last COUNTER_TTL
 	Counter *SlidingWindowCounter
+
+	RedisWriter *RedisStatsWriter
 
 	mu sync.RWMutex // guards store
 }
@@ -69,5 +72,11 @@ func (ts *Stats) KeepStats(statsChan chan CountEvent) {
 		ts.GetStoreForToken(event.Token).Add(event.DistinctID, NoSpaceType{})
 		ts.GlobalStore.Add(event.DistinctID, NoSpaceType{})
 		metrics.HandledEvents.Inc()
+
+		if ts.RedisWriter != nil {
+			if err := ts.RedisWriter.AddUser(context.Background(), event.Token, event.DistinctID); err != nil {
+				log.Printf("Redis AddUser error: %v", err)
+			}
+		}
 	}
 }

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -1,0 +1,153 @@
+package events
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/posthog/posthog/livestream/configs"
+	"github.com/posthog/posthog/livestream/metrics"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	userKeyTTL    = 60 * time.Second
+	sessionKeyTTL = 5 * time.Minute
+)
+
+type RedisStatsWriter struct {
+	client  redis.Cmdable
+
+	// Needed for testing.
+	// By default, nowFunc will be nil and RedisStatsWriter will use Redis' Time so all workers use the same clock
+	// When testing, this can be set to a fake clock to allow time manipulation
+	nowFunc func(ctx context.Context) (time.Time, error)
+}
+
+func (w *RedisStatsWriter) now(ctx context.Context) (time.Time, error) {
+	if w.nowFunc != nil {
+		return w.nowFunc(ctx)
+	}
+	return w.client.Time(ctx).Result()
+}
+
+func NewRedisStatsWriter(cfg configs.RedisConfig) (*RedisStatsWriter, error) {
+	if cfg.Address == "" {
+		return nil, fmt.Errorf("redis: address not configured")
+	}
+
+	addr := fmt.Sprintf("%s:%s", cfg.Address, cfg.Port)
+
+	var client redis.Cmdable
+	if cfg.TLS {
+		client = redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:     []string{addr},
+			TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		})
+	} else {
+		client = redis.NewClient(&redis.Options{
+			Addr: addr,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var pingErr error
+	switch c := client.(type) {
+	case *redis.Client:
+		pingErr = c.Ping(ctx).Err()
+	case *redis.ClusterClient:
+		pingErr = c.Ping(ctx).Err()
+	}
+	if pingErr != nil {
+		return nil, fmt.Errorf("redis ping failed: %w", pingErr)
+	}
+
+	return &RedisStatsWriter{client: client}, nil
+}
+
+func userKey(token string) string {
+	return fmt.Sprintf("livestream:users:%s", token)
+}
+
+func sessionKey(token string) string {
+	return fmt.Sprintf("livestream:sessions:%s", token)
+}
+
+func (w *RedisStatsWriter) AddUser(ctx context.Context, token, distinctId string) error {
+	key := userKey(token)
+	return w.AddKey(ctx, key, distinctId, userKeyTTL, "add_user")
+}
+
+func (w *RedisStatsWriter) AddSession(ctx context.Context, token, sessionId string) error {
+	key := sessionKey(token)
+	return w.AddKey(ctx, key, sessionId, sessionKeyTTL, "add_session")
+}
+
+func (w *RedisStatsWriter) GetUserCount(ctx context.Context, token string) (int64, error) {
+	key := userKey(token)
+	return w.GetCount(ctx, key, userKeyTTL, "user_count")
+}
+
+func (w *RedisStatsWriter) GetSessionCount(ctx context.Context, token string) (int64, error) {
+	key := sessionKey(token)
+	return w.GetCount(ctx, key, sessionKeyTTL, "session_count")
+}
+
+func (w *RedisStatsWriter) AddKey(ctx context.Context, key string, memberId string, ttl time.Duration, metricsLabel string) error {
+	start := time.Now()
+
+	now, err := w.now(ctx)
+	if err != nil {
+		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
+		return err
+	}
+
+	pipe := w.client.Pipeline()
+	pipe.ZAdd(ctx, key, redis.Z{Score: float64(now.Unix()), Member: memberId})
+	pipe.Expire(ctx, key, ttl)
+	_, err = pipe.Exec(ctx)
+
+	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(start).Seconds())
+	if err != nil {
+		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
+	}
+	return err
+}
+
+func (w *RedisStatsWriter) GetCount(ctx context.Context, key string, ttl time.Duration, metricsLabel string) (int64, error) {
+	start := time.Now()
+
+	now, err := w.now(ctx)
+	if err != nil {
+		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
+		return 0, err
+	}
+	cutoff := float64(now.Add(-ttl).Unix())
+
+	pipe := w.client.Pipeline()
+	pipe.ZRemRangeByScore(ctx, key, "-inf", fmt.Sprintf("%f", cutoff))
+	cardCmd := pipe.ZCard(ctx, key)
+	_, err = pipe.Exec(ctx)
+
+	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(start).Seconds())
+	if err != nil {
+		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
+		return 0, err
+	}
+	return cardCmd.Val(), nil
+}
+
+func (w *RedisStatsWriter) Close() error {
+	if c, ok := w.client.(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// Testing helper
+func NewRedisStatsWriterFromClient(client redis.Cmdable) *RedisStatsWriter {
+	return &RedisStatsWriter{client: client}
+}

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -1,3 +1,13 @@
+/*
+	StatsInRedis provides a shared storage backed by Redis.
+	It enables the /stats endpoint to serve consistent user
+	and session counts across multiple service instances by
+	adding tokens to a sorted set with a short-lived TTL.
+
+	Redis pipelines are used to batch multiple commands into a single round-trip.
+	Each pipeline targets a single key, so all commands hit the same hash slot
+	and are safe by default in cluster mode.
+*/
 package events
 
 import (
@@ -16,23 +26,12 @@ const (
 	sessionKeyTTL = 5 * time.Minute
 )
 
-type RedisStatsWriter struct {
-	client  redis.Cmdable
-
-	// Needed for testing.
-	// By default, nowFunc will be nil and RedisStatsWriter will use Redis' Time so all workers use the same clock
-	// When testing, this can be set to a fake clock to allow time manipulation
-	nowFunc func(ctx context.Context) (time.Time, error)
+type StatsInRedis struct {
+	client redis.Cmdable
 }
 
-func (w *RedisStatsWriter) now(ctx context.Context) (time.Time, error) {
-	if w.nowFunc != nil {
-		return w.nowFunc(ctx)
-	}
-	return w.client.Time(ctx).Result()
-}
-
-func NewRedisStatsWriter(cfg configs.RedisConfig) (*RedisStatsWriter, error) {
+// Creates a Redis-backed stats store from the given config.
+func NewStatsInRedis(cfg configs.RedisConfig) (*StatsInRedis, error) {
 	if cfg.Address == "" {
 		return nil, fmt.Errorf("redis: address not configured")
 	}
@@ -65,7 +64,41 @@ func NewRedisStatsWriter(cfg configs.RedisConfig) (*RedisStatsWriter, error) {
 		return nil, fmt.Errorf("redis ping failed: %w", pingErr)
 	}
 
-	return &RedisStatsWriter{client: client}, nil
+	return &StatsInRedis{client: client}, nil
+}
+
+// Adds a distinct user to a Redis sorted set for the given project token,
+// scored by the current timestamp. The key auto-expires after userKeyTTL.
+func (s *StatsInRedis) AddUser(ctx context.Context, token, distinctId string) error {
+	key := userKey(token)
+	return s.addKey(ctx, key, distinctId, userKeyTTL, "add_user")
+}
+
+// Adds a session ID to a Redis sorted set for the given project token,
+// scored by the current timestamp. The key auto-expires after sessionKeyTTL.
+func (s *StatsInRedis) AddSession(ctx context.Context, token, sessionId string) error {
+	key := sessionKey(token)
+	return s.addKey(ctx, key, sessionId, sessionKeyTTL, "add_session")
+}
+
+// Returns the number of distinct users seen within the last userKeyTTL window for the given token.
+func (s *StatsInRedis) GetUserCount(ctx context.Context, token string) (int64, error) {
+	key := userKey(token)
+	return s.getCount(ctx, key, userKeyTTL, "user_count")
+}
+
+// Returns the number of active sessions within the last sessionKeyTTL window for the given token.
+func (s *StatsInRedis) GetSessionCount(ctx context.Context, token string) (int64, error) {
+	key := sessionKey(token)
+	return s.getCount(ctx, key, sessionKeyTTL, "session_count")
+}
+
+// Close closes the underlying Redis connection if the client supports it.
+func (s *StatsInRedis) Close() error {
+	if c, ok := s.client.(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 func userKey(token string) string {
@@ -76,63 +109,33 @@ func sessionKey(token string) string {
 	return fmt.Sprintf("livestream:sessions:%s", token)
 }
 
-func (w *RedisStatsWriter) AddUser(ctx context.Context, token, distinctId string) error {
-	key := userKey(token)
-	return w.AddKey(ctx, key, distinctId, userKeyTTL, "add_user")
-}
+// Adds a member to a sorted set scored by the current timestamp, then sets the key expiry. 
+func (s *StatsInRedis) addKey(ctx context.Context, key string, memberId string, ttl time.Duration, metricsLabel string) error {
+	now := time.Now()
 
-func (w *RedisStatsWriter) AddSession(ctx context.Context, token, sessionId string) error {
-	key := sessionKey(token)
-	return w.AddKey(ctx, key, sessionId, sessionKeyTTL, "add_session")
-}
-
-func (w *RedisStatsWriter) GetUserCount(ctx context.Context, token string) (int64, error) {
-	key := userKey(token)
-	return w.GetCount(ctx, key, userKeyTTL, "user_count")
-}
-
-func (w *RedisStatsWriter) GetSessionCount(ctx context.Context, token string) (int64, error) {
-	key := sessionKey(token)
-	return w.GetCount(ctx, key, sessionKeyTTL, "session_count")
-}
-
-func (w *RedisStatsWriter) AddKey(ctx context.Context, key string, memberId string, ttl time.Duration, metricsLabel string) error {
-	start := time.Now()
-
-	now, err := w.now(ctx)
-	if err != nil {
-		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
-		return err
-	}
-
-	pipe := w.client.Pipeline()
+	pipe := s.client.Pipeline()
 	pipe.ZAdd(ctx, key, redis.Z{Score: float64(now.Unix()), Member: memberId})
 	pipe.Expire(ctx, key, ttl)
-	_, err = pipe.Exec(ctx)
+	_, err := pipe.Exec(ctx)
 
-	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(start).Seconds())
+	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(now).Seconds())
 	if err != nil {
 		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
 	}
 	return err
 }
 
-func (w *RedisStatsWriter) GetCount(ctx context.Context, key string, ttl time.Duration, metricsLabel string) (int64, error) {
-	start := time.Now()
-
-	now, err := w.now(ctx)
-	if err != nil {
-		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
-		return 0, err
-	}
+// Returns a sliding-window count by first pruning entries older than the TTL then counting survivors
+func (s *StatsInRedis) getCount(ctx context.Context, key string, ttl time.Duration, metricsLabel string) (int64, error) {
+	now := time.Now()
 	cutoff := float64(now.Add(-ttl).Unix())
 
-	pipe := w.client.Pipeline()
+	pipe := s.client.Pipeline()
 	pipe.ZRemRangeByScore(ctx, key, "-inf", fmt.Sprintf("%f", cutoff))
 	cardCmd := pipe.ZCard(ctx, key)
-	_, err = pipe.Exec(ctx)
+	_, err := pipe.Exec(ctx)
 
-	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(start).Seconds())
+	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(now).Seconds())
 	if err != nil {
 		metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
 		return 0, err
@@ -140,14 +143,7 @@ func (w *RedisStatsWriter) GetCount(ctx context.Context, key string, ttl time.Du
 	return cardCmd.Val(), nil
 }
 
-func (w *RedisStatsWriter) Close() error {
-	if c, ok := w.client.(interface{ Close() error }); ok {
-		return c.Close()
-	}
-	return nil
-}
-
 // Testing helper
-func NewRedisStatsWriterFromClient(client redis.Cmdable) *RedisStatsWriter {
-	return &RedisStatsWriter{client: client}
+func NewStatsInRedisFromClient(client redis.Cmdable) *StatsInRedis {
+	return &StatsInRedis{client: client}
 }

--- a/livestream/events/redis_stats_test.go
+++ b/livestream/events/redis_stats_test.go
@@ -33,7 +33,7 @@ func setupMiniredis(t *testing.T) (*RedisStatsWriter, *fakeClock) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() })
 	clk := &fakeClock{t: time.Now()}
 	w := NewRedisStatsWriterFromClient(client)
 	w.nowFunc = clk.now

--- a/livestream/events/redis_stats_test.go
+++ b/livestream/events/redis_stats_test.go
@@ -1,0 +1,244 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now(_ context.Context) (time.Time, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t, nil
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func setupMiniredis(t *testing.T) (*RedisStatsWriter, *fakeClock) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { client.Close() })
+	clk := &fakeClock{t: time.Now()}
+	w := NewRedisStatsWriterFromClient(client)
+	w.nowFunc = clk.now
+	return w, clk
+}
+
+func TestAddUser_GetUserCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		users     []struct{ token, distinctID string }
+		queryTkn  string
+		wantCount int64
+	}{
+		{
+			name: "single user counted once",
+			users: []struct{ token, distinctID string }{
+				{"token_a", "user1"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 1,
+		},
+		{
+			name: "duplicate distinct ID is deduplicated",
+			users: []struct{ token, distinctID string }{
+				{"token_a", "user1"},
+				{"token_a", "user1"},
+				{"token_a", "user1"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 1,
+		},
+		{
+			name: "multiple distinct users counted",
+			users: []struct{ token, distinctID string }{
+				{"token_a", "user1"},
+				{"token_a", "user2"},
+				{"token_a", "user3"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 3,
+		},
+		{
+			name:      "unknown token returns zero",
+			users:     nil,
+			queryTkn:  "token_unknown",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, _ := setupMiniredis(t)
+			ctx := context.Background()
+
+			for _, u := range tt.users {
+				require.NoError(t, w.AddUser(ctx, u.token, u.distinctID))
+			}
+
+			count, err := w.GetUserCount(ctx, tt.queryTkn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+func TestAddSession_GetSessionCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		sessions  []struct{ token, sessionID string }
+		queryTkn  string
+		wantCount int64
+	}{
+		{
+			name: "single session counted",
+			sessions: []struct{ token, sessionID string }{
+				{"token_a", "session_1"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 1,
+		},
+		{
+			name: "duplicate session ID is deduplicated",
+			sessions: []struct{ token, sessionID string }{
+				{"token_a", "session_1"},
+				{"token_a", "session_1"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 1,
+		},
+		{
+			name: "multiple sessions counted",
+			sessions: []struct{ token, sessionID string }{
+				{"token_a", "session_1"},
+				{"token_a", "session_2"},
+				{"token_a", "session_3"},
+			},
+			queryTkn:  "token_a",
+			wantCount: 3,
+		},
+		{
+			name:      "unknown token returns zero",
+			sessions:  nil,
+			queryTkn:  "token_unknown",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, _ := setupMiniredis(t)
+			ctx := context.Background()
+
+			for _, s := range tt.sessions {
+				require.NoError(t, w.AddSession(ctx, s.token, s.sessionID))
+			}
+
+			count, err := w.GetSessionCount(ctx, tt.queryTkn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+func TestSessionExpiry(t *testing.T) {
+	w, clk := setupMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, w.AddSession(ctx, "token_a", "session_1"))
+	require.NoError(t, w.AddSession(ctx, "token_a", "session_2"))
+
+	count, err := w.GetSessionCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	clk.advance(6 * time.Minute)
+
+	count, err = w.GetSessionCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestUserExpiry(t *testing.T) {
+	w, clk := setupMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, w.AddUser(ctx, "token_a", "user1"))
+	require.NoError(t, w.AddUser(ctx, "token_a", "user2"))
+
+	count, err := w.GetUserCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	clk.advance(userKeyTTL + time.Second)
+
+	count, err = w.GetUserCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestUserNaturalDecay(t *testing.T) {
+	w, clk := setupMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, w.AddUser(ctx, "token_a", "user1"))
+
+	clk.advance(30 * time.Second)
+
+	require.NoError(t, w.AddUser(ctx, "token_a", "user2"))
+
+	count, err := w.GetUserCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	clk.advance(40 * time.Second)
+
+	count, err = w.GetUserCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "only user2 should remain after user1 ages out")
+}
+
+func TestCrossTokenIsolation(t *testing.T) {
+	w, _ := setupMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, w.AddUser(ctx, "token_a", "user1"))
+	require.NoError(t, w.AddUser(ctx, "token_a", "user2"))
+	require.NoError(t, w.AddUser(ctx, "token_b", "user3"))
+
+	require.NoError(t, w.AddSession(ctx, "token_a", "session_1"))
+	require.NoError(t, w.AddSession(ctx, "token_b", "session_2"))
+	require.NoError(t, w.AddSession(ctx, "token_b", "session_3"))
+
+	countA, err := w.GetUserCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), countA)
+
+	countB, err := w.GetUserCount(ctx, "token_b")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countB)
+
+	sessA, err := w.GetSessionCount(ctx, "token_a")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), sessA)
+
+	sessB, err := w.GetSessionCount(ctx, "token_b")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), sessB)
+}

--- a/livestream/events/redis_stats_test.go
+++ b/livestream/events/redis_stats_test.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -12,32 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeClock struct {
-	mu sync.Mutex
-	t  time.Time
-}
-
-func (c *fakeClock) now(_ context.Context) (time.Time, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.t, nil
-}
-
-func (c *fakeClock) advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.t = c.t.Add(d)
-}
-
-func setupMiniredis(t *testing.T) (*RedisStatsWriter, *fakeClock) {
+func setupMiniredis(t *testing.T) (*StatsInRedis, redis.Cmdable) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = client.Close() })
-	clk := &fakeClock{t: time.Now()}
-	w := NewRedisStatsWriterFromClient(client)
-	w.nowFunc = clk.now
-	return w, clk
+	w := NewStatsInRedisFromClient(client)
+	return w, client
 }
 
 func TestAddUser_GetUserCount(t *testing.T) {
@@ -158,58 +138,42 @@ func TestAddSession_GetSessionCount(t *testing.T) {
 }
 
 func TestSessionExpiry(t *testing.T) {
-	w, clk := setupMiniredis(t)
+	w, client := setupMiniredis(t)
 	ctx := context.Background()
+	key := sessionKey("token_a")
+	oldScore := float64(time.Now().Add(-6 * time.Minute).Unix())
 
-	require.NoError(t, w.AddSession(ctx, "token_a", "session_1"))
-	require.NoError(t, w.AddSession(ctx, "token_a", "session_2"))
+	client.ZAdd(ctx, key, redis.Z{Score: oldScore, Member: "session_1"})
+	client.ZAdd(ctx, key, redis.Z{Score: oldScore, Member: "session_2"})
 
 	count, err := w.GetSessionCount(ctx, "token_a")
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), count)
-
-	clk.advance(6 * time.Minute)
-
-	count, err = w.GetSessionCount(ctx, "token_a")
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 }
 
 func TestUserExpiry(t *testing.T) {
-	w, clk := setupMiniredis(t)
+	w, client := setupMiniredis(t)
 	ctx := context.Background()
+	key := userKey("token_a")
+	oldScore := float64(time.Now().Add(-61 * time.Second).Unix())
 
-	require.NoError(t, w.AddUser(ctx, "token_a", "user1"))
-	require.NoError(t, w.AddUser(ctx, "token_a", "user2"))
+	client.ZAdd(ctx, key, redis.Z{Score: oldScore, Member: "user1"})
+	client.ZAdd(ctx, key, redis.Z{Score: oldScore, Member: "user2"})
 
 	count, err := w.GetUserCount(ctx, "token_a")
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), count)
-
-	clk.advance(userKeyTTL + time.Second)
-
-	count, err = w.GetUserCount(ctx, "token_a")
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 }
 
 func TestUserNaturalDecay(t *testing.T) {
-	w, clk := setupMiniredis(t)
+	w, client := setupMiniredis(t)
 	ctx := context.Background()
+	key := userKey("token_a")
 
-	require.NoError(t, w.AddUser(ctx, "token_a", "user1"))
-
-	clk.advance(30 * time.Second)
-
-	require.NoError(t, w.AddUser(ctx, "token_a", "user2"))
+	client.ZAdd(ctx, key, redis.Z{Score: float64(time.Now().Add(-70 * time.Second).Unix()), Member: "user1"})
+	client.ZAdd(ctx, key, redis.Z{Score: float64(time.Now().Unix()), Member: "user2"})
 
 	count, err := w.GetUserCount(ctx, "token_a")
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), count)
-
-	clk.advance(40 * time.Second)
-
-	count, err = w.GetUserCount(ctx, "token_a")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count, "only user2 should remain after user1 ages out")
 }

--- a/livestream/events/session_stats.go
+++ b/livestream/events/session_stats.go
@@ -28,7 +28,7 @@ type SessionStats struct {
 	// Mutex for Add operations to prevent race between existence check and counter increment
 	addMu sync.Mutex
 
-	RedisWriter *RedisStatsWriter
+	RedisStore *StatsInRedis
 }
 
 // NewSessionStatsKeeper creates a new SessionStats with the specified max LRU entries.
@@ -152,10 +152,12 @@ func (ss *SessionStats) KeepStats(ctx context.Context, statsChan chan SessionRec
 			ss.Add(event.Token, event.SessionId)
 			metrics.SessionRecordingHandledEvents.Inc()
 
-			if ss.RedisWriter != nil {
-				if err := ss.RedisWriter.AddSession(ctx, event.Token, event.SessionId); err != nil {
+			if ss.RedisStore != nil {
+				rCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				if err := ss.RedisStore.AddSession(rCtx, event.Token, event.SessionId); err != nil {
 					log.Printf("Redis AddSession error: %v", err)
 				}
+				cancel()
 			}
 		}
 	}

--- a/livestream/events/session_stats.go
+++ b/livestream/events/session_stats.go
@@ -27,6 +27,8 @@ type SessionStats struct {
 
 	// Mutex for Add operations to prevent race between existence check and counter increment
 	addMu sync.Mutex
+
+	RedisWriter *RedisStatsWriter
 }
 
 // NewSessionStatsKeeper creates a new SessionStats with the specified max LRU entries.
@@ -149,6 +151,12 @@ func (ss *SessionStats) KeepStats(ctx context.Context, statsChan chan SessionRec
 		case event := <-statsChan:
 			ss.Add(event.Token, event.SessionId)
 			metrics.SessionRecordingHandledEvents.Inc()
+
+			if ss.RedisWriter != nil {
+				if err := ss.RedisWriter.AddSession(ctx, event.Token, event.SessionId); err != nil {
+					log.Printf("Redis AddSession error: %v", err)
+				}
+			}
 		}
 	}
 }

--- a/livestream/go.mod
+++ b/livestream/go.mod
@@ -3,6 +3,7 @@ module github.com/posthog/posthog/livestream
 go 1.25.5
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -16,6 +17,7 @@ require (
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.22.0
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -34,6 +36,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -74,6 +77,8 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect

--- a/livestream/go.sum
+++ b/livestream/go.sum
@@ -14,6 +14,8 @@ github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exY
 github.com/Microsoft/hcsshim v0.11.5/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
@@ -46,6 +48,10 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
 github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -97,6 +103,8 @@ github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHf
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/buildx v0.15.1 h1:1cO6JIc0rOoC8tlxfXoh1HH1uxaNvYH1q7J7kv5enhw=
@@ -204,6 +212,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -306,6 +316,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/r3labs/sse v0.0.0-20210224172625-26fe804710bc h1:zAsgcP8MhzAbhMnB1QQ2O7ZhWYVGYSR2iVcjzQuPV+o=
 github.com/r3labs/sse v0.0.0-20210224172625-26fe804710bc/go.mod h1:S8xSOnV3CgpNrWd0GQ/OoQfMtlg2uPRSuTzcSGrzwK8=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
@@ -375,8 +387,12 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.46.1 h1:gbhw/u49SS3gkPWiYweQNJGm/uJN5GkI/FrosxSHT7A=
@@ -407,6 +423,8 @@ go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -33,7 +34,7 @@ func ServedHandler(stats *events.Stats) func(c echo.Context) error {
 	}
 }
 
-func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats) func(c echo.Context) error {
+func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisWriter *events.RedisStatsWriter) func(c echo.Context) error {
 	return func(c echo.Context) error {
 
 		type resp struct {
@@ -47,6 +48,27 @@ func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats) func(c
 			return c.JSON(http.StatusUnauthorized, resp{Error: "wrong token claims"})
 		}
 
+		if redisWriter != nil {
+			ctx := c.Request().Context()
+			userCount, userErr := redisWriter.GetUserCount(ctx, token)
+			sessionCount, sessionErr := redisWriter.GetSessionCount(ctx, token)
+
+			if userErr == nil && sessionErr == nil {
+				if userCount == 0 && sessionCount == 0 {
+					return c.JSON(http.StatusOK, resp{Error: "no stats"})
+				}
+
+				siteStats := resp{}
+				siteStats.UsersOnProduct = int(userCount)
+				siteStats.ActiveRecordings = int(sessionCount)
+
+				return c.JSON(http.StatusOK, siteStats)
+			}
+
+			log.Printf("Redis read failed, falling back to local LRU: users_err=%v sessions_err=%v", userErr, sessionErr)
+		}
+
+		// Fallback to local LRU until V2 migration is complete
 		userStore := stats.GetExistingStoreForToken(token)
 		sessionCount := sessionStats.CountForToken(token)
 

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -34,7 +34,7 @@ func ServedHandler(stats *events.Stats) func(c echo.Context) error {
 	}
 }
 
-func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisWriter *events.RedisStatsWriter) func(c echo.Context) error {
+func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisStore *events.StatsInRedis) func(c echo.Context) error {
 	return func(c echo.Context) error {
 
 		type resp struct {
@@ -48,10 +48,10 @@ func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisW
 			return c.JSON(http.StatusUnauthorized, resp{Error: "wrong token claims"})
 		}
 
-		if redisWriter != nil {
+		if redisStore != nil {
 			ctx := c.Request().Context()
-			userCount, userErr := redisWriter.GetUserCount(ctx, token)
-			sessionCount, sessionErr := redisWriter.GetSessionCount(ctx, token)
+			userCount, userErr := redisStore.GetUserCount(ctx, token)
+			sessionCount, sessionErr := redisStore.GetSessionCount(ctx, token)
 
 			if userErr == nil && sessionErr == nil {
 				if userCount == 0 && sessionCount == 0 {

--- a/livestream/handlers/handlers_test.go
+++ b/livestream/handlers/handlers_test.go
@@ -2,15 +2,18 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/posthog/posthog/livestream/auth"
 	"github.com/posthog/posthog/livestream/events"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,4 +162,90 @@ func createJWTToken(audience string, claims jwt.MapClaims) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, newClaims)
 	tokenString, _ := token.SignedString([]byte(viper.GetString("jwt.secret")))
 	return tokenString
+}
+
+func TestStatsHandler_ReadsFromRedis(t *testing.T) {
+	viper.Set("jwt.secret", "test-secret-for-stats")
+	apiToken := "phx_test_token"
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { client.Close() })
+	rw := events.NewRedisStatsWriterFromClient(client)
+
+	ctx := context.Background()
+	require.NoError(t, rw.AddUser(ctx, apiToken, "user1"))
+	require.NoError(t, rw.AddUser(ctx, apiToken, "user2"))
+	require.NoError(t, rw.AddSession(ctx, apiToken, "sess1"))
+
+	stats := events.NewStatsKeeper()
+	sessionStats := events.NewSessionStatsKeeper(0, 0)
+
+	handler := StatsHandler(stats, sessionStats, rw)
+
+	token := createJWTToken(auth.ExpectedScope, jwt.MapClaims{
+		"team_id":   1,
+		"api_token": apiToken,
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		UsersOnProduct   int    `json:"users_on_product"`
+		ActiveRecordings int    `json:"active_recordings"`
+		Error            string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.UsersOnProduct)
+	assert.Equal(t, 1, resp.ActiveRecordings)
+	assert.Empty(t, resp.Error)
+}
+
+func TestStatsHandler_FallsBackToLocal(t *testing.T) {
+	viper.Set("jwt.secret", "test-secret-for-stats")
+	apiToken := "phx_test_token"
+
+	stats := events.NewStatsKeeper()
+	stats.GetStoreForToken(apiToken).Add("user1", events.NoSpaceType{})
+	stats.GetStoreForToken(apiToken).Add("user2", events.NoSpaceType{})
+	stats.GetStoreForToken(apiToken).Add("user3", events.NoSpaceType{})
+
+	sessionStats := events.NewSessionStatsKeeper(0, 0)
+	sessionStats.Add(apiToken, "sess1")
+	sessionStats.Add(apiToken, "sess2")
+
+	handler := StatsHandler(stats, sessionStats, nil)
+
+	token := createJWTToken(auth.ExpectedScope, jwt.MapClaims{
+		"team_id":   1,
+		"api_token": apiToken,
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		UsersOnProduct   int    `json:"users_on_product"`
+		ActiveRecordings int    `json:"active_recordings"`
+		Error            string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.UsersOnProduct)
+	assert.Equal(t, 2, resp.ActiveRecordings)
+	assert.Empty(t, resp.Error)
 }

--- a/livestream/handlers/handlers_test.go
+++ b/livestream/handlers/handlers_test.go
@@ -170,7 +170,7 @@ func TestStatsHandler_ReadsFromRedis(t *testing.T) {
 
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() })
 	rw := events.NewRedisStatsWriterFromClient(client)
 
 	ctx := context.Background()

--- a/livestream/handlers/handlers_test.go
+++ b/livestream/handlers/handlers_test.go
@@ -171,7 +171,7 @@ func TestStatsHandler_ReadsFromRedis(t *testing.T) {
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = client.Close() })
-	rw := events.NewRedisStatsWriterFromClient(client)
+	rw := events.NewStatsInRedisFromClient(client)
 
 	ctx := context.Background()
 	require.NoError(t, rw.AddUser(ctx, apiToken, "user1"))

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -57,21 +57,19 @@ func main() {
 
 	stats := events.NewStatsKeeper()
 	sessionStats := events.NewSessionStatsKeeper(config.SessionRecording.MaxLRUEntries, 0)
-	redisWriter, err := events.NewRedisStatsWriter(config.Redis)
+	statsRedis, err := events.NewStatsInRedis(config.Redis)
 
-	if err != nil {
+	if err != nil || statsRedis == nil {
 		log.Printf("WARNING: Redis connection failed, continuing without Redis: %v", err)
-	}
-	
-	if redisWriter != nil {
+	} else {
 		defer func() {
-			if err := redisWriter.Close(); err != nil {
-				log.Printf("ERROR: Failed to close Redis writer: %v", err)
+			if err := statsRedis.Close(); err != nil {
+				log.Printf("ERROR: Failed to close Redis store: %v", err)
 			}
 		}()
-		stats.RedisWriter = redisWriter
-		sessionStats.RedisWriter = redisWriter
-		log.Printf("Redis stats writer enabled (address: %s:%s)", config.Redis.Address, config.Redis.Port)
+		stats.RedisStore = statsRedis
+		sessionStats.RedisStore = statsRedis
+		log.Printf("Redis stats store enabled (address: %s:%s)", config.Redis.Address, config.Redis.Port)
 	}
 
 	phEventChan := make(chan events.PostHogEvent, 10000)
@@ -194,7 +192,7 @@ func main() {
 		promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true}),
 	)))
 
-	e.GET("/stats", handlers.StatsHandler(stats, sessionStats, redisWriter))
+	e.GET("/stats", handlers.StatsHandler(stats, sessionStats, statsRedis))
 
 	e.GET("/events", handlers.StreamEventsHandler(e.Logger, subChan, filter))
 

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -57,6 +57,18 @@ func main() {
 
 	stats := events.NewStatsKeeper()
 	sessionStats := events.NewSessionStatsKeeper(config.SessionRecording.MaxLRUEntries, 0)
+	redisWriter, err := events.NewRedisStatsWriter(config.Redis)
+
+	if err != nil {
+		log.Printf("WARNING: Redis connection failed, continuing without Redis: %v", err)
+	}
+	
+	if redisWriter != nil {
+		defer redisWriter.Close()
+		stats.RedisWriter = redisWriter
+		sessionStats.RedisWriter = redisWriter
+		log.Printf("Redis stats writer enabled (address: %s:%s)", config.Redis.Address, config.Redis.Port)
+	}
 
 	phEventChan := make(chan events.PostHogEvent, 10000)
 	statsChan := make(chan events.CountEvent, 10000)
@@ -178,7 +190,7 @@ func main() {
 		promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true}),
 	)))
 
-	e.GET("/stats", handlers.StatsHandler(stats, sessionStats))
+	e.GET("/stats", handlers.StatsHandler(stats, sessionStats, redisWriter))
 
 	e.GET("/events", handlers.StreamEventsHandler(e.Logger, subChan, filter))
 

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -64,7 +64,11 @@ func main() {
 	}
 	
 	if redisWriter != nil {
-		defer redisWriter.Close()
+		defer func() {
+			if err := redisWriter.Close(); err != nil {
+				log.Printf("ERROR: Failed to close Redis writer: %v", err)
+			}
+		}()
 		stats.RedisWriter = redisWriter
 		sessionStats.RedisWriter = redisWriter
 		log.Printf("Redis stats writer enabled (address: %s:%s)", config.Redis.Address, config.Redis.Port)

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -109,4 +109,20 @@ var (
 		Help:    "Distribution of event lag in seconds",
 		Buckets: []float64{1, 2, 5, 10, 30, 60, 120, 300, 600, 900, 1800, 3600},
 	})
+
+	RedisErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "livestream_redis_errors_total",
+			Help: "Total number of Redis operation errors",
+		},
+		[]string{"operation"},
+	)
+	RedisLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "livestream_redis_latency_seconds",
+			Help:    "Redis operation latency in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"operation"},
+	)
 )


### PR DESCRIPTION
## Problem
As a part of the Livestream V2 migration, the service will switch from storing stats in memory to storing stats in redis so we can scale horizontally.

This PR adds reading / writing stats to Redis and intentionally falls back to in memory if there is any issues.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add redis configurations
Add stats writer that handles adding / getting counts from redis
Dual write to in memory and redis


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Tests, locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
