### PR TITLE
feat(capture): split reader-writer URLs and pass RW Redis Client to global limiter

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -90,10 +90,15 @@ pub struct Config {
     /// for particular keys.
     pub global_rate_limit_overrides_csv: Option<String>,
 
-    /// Optional dedicated Redis URL for global rate limiter.
+    /// Optional dedicated Redis URL for global rate limiter (primary/writer).
     /// If set, creates a separate Redis client for the limiter.
     /// Falls back to the shared redis_url if unset.
     pub global_rate_limit_redis_url: Option<String>,
+
+    /// Optional Redis reader URL for global rate limiter (replica).
+    /// When set alongside global_rate_limit_redis_url, creates a ReadWriteClient
+    /// that routes reads to replicas and writes to the primary.
+    pub global_rate_limit_redis_reader_url: Option<String>,
 
     /// Response timeout for dedicated global rate limiter Redis (milliseconds).
     /// Defaults to redis_response_timeout_ms if unset.

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -242,7 +242,9 @@ where
     );
 
     let global_rate_limiter = if config.global_rate_limit_enabled {
-        // Use dedicated Redis if configured, otherwise fall back to shared client
+        // Use dedicated Redis if configured, otherwise fall back to shared client.
+        // When a reader URL is also provided, construct a ReadWriteClient that routes
+        // reads (MGET) to replicas and writes (INCRBY+EXPIRE) to the primary.
         let grl_redis_client: Arc<dyn common_redis::Client + Send + Sync> =
             if let Some(ref grl_redis_url) = config.global_rate_limit_redis_url {
                 let response_timeout = config
@@ -251,26 +253,46 @@ where
                 let connection_timeout = config
                     .global_rate_limit_redis_connection_timeout_ms
                     .unwrap_or(config.redis_connection_timeout_ms);
+                let response_timeout_duration = if response_timeout == 0 {
+                    None
+                } else {
+                    Some(Duration::from_millis(response_timeout))
+                };
+                let connection_timeout_duration = if connection_timeout == 0 {
+                    None
+                } else {
+                    Some(Duration::from_millis(connection_timeout))
+                };
 
-                Arc::new(
-                    RedisClient::with_config(
+                if let Some(ref reader_url) = config.global_rate_limit_redis_reader_url {
+                    let rw_config = common_redis::ReadWriteClientConfig::new(
                         grl_redis_url.clone(),
+                        reader_url.clone(),
                         common_redis::CompressionConfig::disabled(),
                         common_redis::RedisValueFormat::default(),
-                        if response_timeout == 0 {
-                            None
-                        } else {
-                            Some(Duration::from_millis(response_timeout))
-                        },
-                        if connection_timeout == 0 {
-                            None
-                        } else {
-                            Some(Duration::from_millis(connection_timeout))
-                        },
+                        response_timeout_duration,
+                        connection_timeout_duration,
+                    );
+                    info!("Global rate limiter using read/write split Redis client");
+                    Arc::new(
+                        rw_config
+                            .build()
+                            .await
+                            .expect("failed to create global rate limiter read/write redis client"),
                     )
-                    .await
-                    .expect("failed to create global rate limiter redis client"),
-                )
+                } else {
+                    Arc::new(
+                        RedisClient::with_config(
+                            grl_redis_url.clone(),
+                            common_redis::CompressionConfig::disabled(),
+                            common_redis::RedisValueFormat::default(),
+                            response_timeout_duration,
+                            connection_timeout_duration,
+                        )
+                        .await
+                        .expect("failed to create global rate limiter redis client"),
+                    )
+                }
             } else {
                 redis_client.clone()
             };

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -242,63 +242,9 @@ where
     );
 
     let global_rate_limiter = if config.global_rate_limit_enabled {
-        // Use dedicated Redis if configured, otherwise fall back to shared client.
-        // When a reader URL is also provided, construct a ReadWriteClient that routes
-        // reads (MGET) to replicas and writes (INCRBY+EXPIRE) to the primary.
-        let grl_redis_client: Arc<dyn common_redis::Client + Send + Sync> =
-            if let Some(ref grl_redis_url) = config.global_rate_limit_redis_url {
-                let response_timeout = config
-                    .global_rate_limit_redis_response_timeout_ms
-                    .unwrap_or(config.redis_response_timeout_ms);
-                let connection_timeout = config
-                    .global_rate_limit_redis_connection_timeout_ms
-                    .unwrap_or(config.redis_connection_timeout_ms);
-                let response_timeout_duration = if response_timeout == 0 {
-                    None
-                } else {
-                    Some(Duration::from_millis(response_timeout))
-                };
-                let connection_timeout_duration = if connection_timeout == 0 {
-                    None
-                } else {
-                    Some(Duration::from_millis(connection_timeout))
-                };
-
-                if let Some(ref reader_url) = config.global_rate_limit_redis_reader_url {
-                    let rw_config = common_redis::ReadWriteClientConfig::new(
-                        grl_redis_url.clone(),
-                        reader_url.clone(),
-                        common_redis::CompressionConfig::disabled(),
-                        common_redis::RedisValueFormat::default(),
-                        response_timeout_duration,
-                        connection_timeout_duration,
-                    );
-                    info!("Global rate limiter using read/write split Redis client");
-                    Arc::new(
-                        rw_config
-                            .build()
-                            .await
-                            .expect("failed to create global rate limiter read/write redis client"),
-                    )
-                } else {
-                    Arc::new(
-                        RedisClient::with_config(
-                            grl_redis_url.clone(),
-                            common_redis::CompressionConfig::disabled(),
-                            common_redis::RedisValueFormat::default(),
-                            response_timeout_duration,
-                            connection_timeout_duration,
-                        )
-                        .await
-                        .expect("failed to create global rate limiter redis client"),
-                    )
-                }
-            } else {
-                redis_client.clone()
-            };
-
         Some(Arc::new(
-            GlobalRateLimiter::new(&config, vec![grl_redis_client])
+            GlobalRateLimiter::try_from_config(&config, redis_client.clone())
+                .await
                 .expect("failed to create global rate limiter"),
         ))
     } else {

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -44,6 +44,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     global_rate_limit_bucket_interval_secs: 10,
     global_rate_limit_overrides_csv: None,
     global_rate_limit_redis_url: None,
+    global_rate_limit_redis_reader_url: None,
     global_rate_limit_redis_response_timeout_ms: None,
     global_rate_limit_redis_connection_timeout_ms: None,
     event_restrictions_enabled: false,


### PR DESCRIPTION
## Problem
We can spread the read load on Redis better if we wire up the RW Redis client and reader URLs in prod before passing them into the global limiter as we intended originally! 🚀 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add optional global limiter Redis reader URL to capture cfg
* Add RW client bootstrap if reader is present, before passing Client list to `common` limiter wrapper
* Related test updates 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke testing to follow; based on earlier primary-only tests this will be a big, cheap win as you'd expect
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
