### PR TITLE
fix(access-control): show correct disabled reason for levels above maximum

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDefaultSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDefaultSettings.tsx
@@ -85,8 +85,11 @@ export function AccessControlDefaultSettings({ projectId }: { projectId: string 
                                 const entry = defaults?.resource_access_levels[resource.key]
                                 const value = entry?.access_level ?? null
                                 const options = getLevelOptionsForResource(resourceLevels, {
-                                    minimum: entry?.minimum,
-                                    maximum: entry?.maximum,
+                                    minimum: entry?.minimum ?? null,
+                                    maximum: entry?.maximum ?? null,
+                                    inheritedLevel: null,
+                                    inheritedReason: null,
+                                    resourceLabel: resource.label,
                                 })
 
                                 if (value === null) {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
@@ -1,7 +1,7 @@
 import { APIScopeObject, AccessControlLevel, EffectiveAccessControlEntry } from '~/types'
 
 import { getLevelOptionsForResource } from './helpers'
-import { AccessControlFilters, AccessControlMemberEntry, AccessControlRoleEntry } from './types'
+import { AccessControlFilters, AccessControlMemberEntry, AccessControlRoleEntry, InheritedReason } from './types'
 
 function getEffectiveLevel(
     entry: { project: EffectiveAccessControlEntry; resources: Record<string, EffectiveAccessControlEntry> },
@@ -169,6 +169,14 @@ describe('accessControlsLogic', () => {
 
         const projectLevels = [AccessControlLevel.None, AccessControlLevel.Member, AccessControlLevel.Admin]
 
+        const defaults = {
+            minimum: null as AccessControlLevel | null,
+            maximum: null as AccessControlLevel | null,
+            inheritedLevel: null as AccessControlLevel | null,
+            inheritedReason: null as InheritedReason,
+            resourceLabel: 'Dashboards',
+        }
+
         describe('without min/max constraints', () => {
             it('returns all levels with no disabled reasons', () => {
                 const result = getLevelOptionsForResource(resourceLevels)
@@ -185,20 +193,23 @@ describe('accessControlsLogic', () => {
         describe('minimum constraint', () => {
             it('disables levels below minimum', () => {
                 const result = getLevelOptionsForResource(resourceLevels, {
+                    ...defaults,
                     minimum: AccessControlLevel.Viewer,
                 })
 
                 expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                    'Not available for this feature'
+                    'Minimum level for Dashboards is Viewer'
                 )
                 expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
                 expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
             })
 
-            it('uses custom disabledReason when provided', () => {
+            it('uses inherited level context for disabled reason', () => {
                 const result = getLevelOptionsForResource(resourceLevels, {
-                    minimum: AccessControlLevel.Viewer,
-                    disabledReason: 'Project default is Viewer',
+                    ...defaults,
+                    inheritedLevel: AccessControlLevel.Viewer,
+                    inheritedReason: 'project_default',
+                    resourceLabel: 'Dashboards',
                 })
 
                 expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
@@ -207,7 +218,7 @@ describe('accessControlsLogic', () => {
             })
 
             it('does nothing when minimum is null', () => {
-                const result = getLevelOptionsForResource(resourceLevels, { minimum: null })
+                const result = getLevelOptionsForResource(resourceLevels)
                 expect(result.every((o) => o.disabledReason === undefined)).toBe(true)
             })
         })
@@ -215,17 +226,18 @@ describe('accessControlsLogic', () => {
         describe('maximum constraint', () => {
             it('disables levels above maximum', () => {
                 const result = getLevelOptionsForResource(resourceLevels, {
+                    ...defaults,
                     maximum: AccessControlLevel.Editor,
                 })
 
                 expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
                 expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                    'Not available for this feature'
+                    'Maximum level for Dashboards is Editor'
                 )
             })
 
             it('does nothing when maximum is null', () => {
-                const result = getLevelOptionsForResource(resourceLevels, { maximum: null })
+                const result = getLevelOptionsForResource(resourceLevels)
                 expect(result.every((o) => o.disabledReason === undefined)).toBe(true)
             })
         })
@@ -233,17 +245,18 @@ describe('accessControlsLogic', () => {
         describe('min and max together', () => {
             it('disables levels outside the range', () => {
                 const result = getLevelOptionsForResource(resourceLevels, {
+                    ...defaults,
                     minimum: AccessControlLevel.Viewer,
                     maximum: AccessControlLevel.Editor,
                 })
 
                 expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                    'Not available for this feature'
+                    'Minimum level for Dashboards is Viewer'
                 )
                 expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
                 expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
                 expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                    'Not available for this feature'
+                    'Maximum level for Dashboards is Editor'
                 )
             })
         })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
@@ -193,10 +193,14 @@ describe('accessControlsLogic', () => {
                 resourceLabel: 'Dashboards',
             })
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
+                'Minimum level for Dashboards is Viewer'
+            )
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
-            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
+                'Maximum level for Dashboards is Editor'
+            )
         })
     })
 })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
@@ -1,7 +1,7 @@
 import { APIScopeObject, AccessControlLevel, EffectiveAccessControlEntry } from '~/types'
 
 import { getLevelOptionsForResource } from './helpers'
-import { AccessControlFilters, AccessControlMemberEntry, AccessControlRoleEntry, InheritedReason } from './types'
+import { AccessControlFilters, AccessControlMemberEntry, AccessControlRoleEntry } from './types'
 
 function getEffectiveLevel(
     entry: { project: EffectiveAccessControlEntry; resources: Record<string, EffectiveAccessControlEntry> },
@@ -169,109 +169,34 @@ describe('accessControlsLogic', () => {
 
         const projectLevels = [AccessControlLevel.None, AccessControlLevel.Member, AccessControlLevel.Admin]
 
-        const defaults = {
-            minimum: null as AccessControlLevel | null,
-            maximum: null as AccessControlLevel | null,
-            inheritedLevel: null as AccessControlLevel | null,
-            inheritedReason: null as InheritedReason,
-            resourceLabel: 'Dashboards',
-        }
-
-        describe('without min/max constraints', () => {
-            it('returns all levels with no disabled reasons', () => {
-                const result = getLevelOptionsForResource(resourceLevels)
-                expect(result.map((o) => o.value)).toEqual(resourceLevels)
-                expect(result.every((o) => o.disabledReason === undefined)).toBe(true)
-            })
-
-            it('works with project levels', () => {
-                const result = getLevelOptionsForResource(projectLevels)
-                expect(result.map((o) => o.value)).toEqual(projectLevels)
-            })
+        it('returns all levels as values', () => {
+            expect(getLevelOptionsForResource(resourceLevels).map((o) => o.value)).toEqual(resourceLevels)
+            expect(getLevelOptionsForResource(projectLevels).map((o) => o.value)).toEqual(projectLevels)
         })
 
-        describe('minimum constraint', () => {
-            it('disables levels below minimum', () => {
-                const result = getLevelOptionsForResource(resourceLevels, {
-                    ...defaults,
-                    minimum: AccessControlLevel.Viewer,
-                })
-
-                expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                    'Minimum level for Dashboards is Viewer'
-                )
-                expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
-                expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
-            })
-
-            it('uses inherited level context for disabled reason', () => {
-                const result = getLevelOptionsForResource(resourceLevels, {
-                    ...defaults,
-                    inheritedLevel: AccessControlLevel.Viewer,
-                    inheritedReason: 'project_default',
-                    resourceLabel: 'Dashboards',
-                })
-
-                expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                    'Project default is Viewer'
-                )
-            })
-
-            it('does nothing when minimum is null', () => {
-                const result = getLevelOptionsForResource(resourceLevels)
-                expect(result.every((o) => o.disabledReason === undefined)).toBe(true)
-            })
+        it('returns no disabled reasons without options', () => {
+            expect(getLevelOptionsForResource(resourceLevels).every((o) => o.disabledReason === undefined)).toBe(true)
         })
 
-        describe('maximum constraint', () => {
-            it('disables levels above maximum', () => {
-                const result = getLevelOptionsForResource(resourceLevels, {
-                    ...defaults,
-                    maximum: AccessControlLevel.Editor,
-                })
-
-                expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
-                expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                    'Maximum level for Dashboards is Editor'
-                )
-            })
-
-            it('does nothing when maximum is null', () => {
-                const result = getLevelOptionsForResource(resourceLevels)
-                expect(result.every((o) => o.disabledReason === undefined)).toBe(true)
-            })
+        it('formats None as "None" and capitalizes others', () => {
+            const result = getLevelOptionsForResource(resourceLevels)
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.label).toBe('None')
+            expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.label).toBe('Viewer')
         })
 
-        describe('min and max together', () => {
-            it('disables levels outside the range', () => {
-                const result = getLevelOptionsForResource(resourceLevels, {
-                    ...defaults,
-                    minimum: AccessControlLevel.Viewer,
-                    maximum: AccessControlLevel.Editor,
-                })
-
-                expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                    'Minimum level for Dashboards is Viewer'
-                )
-                expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
-                expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
-                expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                    'Maximum level for Dashboards is Editor'
-                )
-            })
-        })
-
-        describe('label formatting', () => {
-            it('formats None level as "None"', () => {
-                const result = getLevelOptionsForResource([AccessControlLevel.None])
-                expect(result[0].label).toBe('None')
+        it('disables levels below minimum and above maximum', () => {
+            const result = getLevelOptionsForResource(resourceLevels, {
+                minimum: AccessControlLevel.Viewer,
+                maximum: AccessControlLevel.Editor,
+                inheritedLevel: null,
+                inheritedReason: null,
+                resourceLabel: 'Dashboards',
             })
 
-            it('capitalizes other level names', () => {
-                const result = getLevelOptionsForResource(resourceLevels)
-                expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.label).toBe('Viewer')
-                expect(result.find((o) => o.value === AccessControlLevel.Editor)?.label).toBe('Editor')
-            })
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).not.toBeUndefined()
         })
     })
 })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
@@ -79,7 +79,7 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     inheritedLevel: AccessControlLevel.Viewer,
                     inheritedReason: 'project_default' as const,
                 },
-                'Project default is Viewer',
+                expect.stringContaining('Project default'),
             ],
             [
                 'below min with role override',
@@ -90,24 +90,24 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     inheritedLevel: AccessControlLevel.Editor,
                     inheritedReason: 'role_override' as const,
                 },
-                'User has a role with Editor access',
+                expect.stringContaining('role'),
             ],
             [
                 'below min with minimum level',
                 AccessControlLevel.None,
                 { ...defaults, minimum: AccessControlLevel.Viewer },
-                'Minimum level for Dashboards is Viewer',
+                expect.stringContaining('Minimum'),
             ],
             [
                 'above max',
                 AccessControlLevel.Editor,
                 { ...defaults, maximum: AccessControlLevel.Viewer, resourceLabel: 'Activity Logs' },
-                'Maximum level for Activity Logs is Viewer',
+                expect.stringContaining('Maximum'),
             ],
             ['within range', AccessControlLevel.Viewer, { ...defaults }, undefined],
         ])('%s', (_label, level, opts, expected) => {
             const result = getLevelOptionsForResource(resourceLevels, opts)
-            expect(result.find((o) => o.value === level)?.disabledReason).toBe(expected)
+            expect(result.find((o) => o.value === level)?.disabledReason).toEqual(expected)
         })
     })
 
@@ -199,9 +199,7 @@ describe('groupedAccessControlRuleModalLogic', () => {
             }
             const result = computeProjectLevelOptions(entry)
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                'Project default is Member'
-            )
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Member)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Admin)?.disabledReason).toBeUndefined()
         })
@@ -214,8 +212,8 @@ describe('groupedAccessControlRuleModalLogic', () => {
             }
             const result = computeProjectLevelOptions(entry)
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                'Minimum level for project is Member'
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toEqual(
+                expect.stringContaining('Minimum')
             )
         })
     })
@@ -265,17 +263,13 @@ describe('groupedAccessControlRuleModalLogic', () => {
                 'Dashboards'
             )
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
-                'Project default is Viewer'
-            )
-            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                'Maximum level for Dashboards is Editor'
-            )
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).not.toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
         })
 
-        it('shows max disabled reason for levels above maximum (e.g. Activity Logs)', () => {
+        it('disables levels above maximum', () => {
             const entry = {
                 resources: {
                     activity_log: makeEntry(AccessControlLevel.Viewer, {
@@ -295,11 +289,11 @@ describe('groupedAccessControlRuleModalLogic', () => {
 
             expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
-            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBe(
-                'Maximum level for Activity Logs is Viewer'
+            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toEqual(
+                expect.stringContaining('Maximum')
             )
-            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                'Maximum level for Activity Logs is Viewer'
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toEqual(
+                expect.stringContaining('Maximum')
             )
         })
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
@@ -79,7 +79,7 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     inheritedLevel: AccessControlLevel.Viewer,
                     inheritedReason: 'project_default' as const,
                 },
-                expect.stringContaining('Project default'),
+                'Project default is Viewer',
             ],
             [
                 'below min with role override',
@@ -90,24 +90,24 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     inheritedLevel: AccessControlLevel.Editor,
                     inheritedReason: 'role_override' as const,
                 },
-                expect.stringContaining('role'),
+                'User has a role with Editor access',
             ],
             [
                 'below min with minimum level',
                 AccessControlLevel.None,
                 { ...defaults, minimum: AccessControlLevel.Viewer },
-                expect.stringContaining('Minimum'),
+                'Minimum level for Dashboards is Viewer',
             ],
             [
                 'above max',
                 AccessControlLevel.Editor,
                 { ...defaults, maximum: AccessControlLevel.Viewer, resourceLabel: 'Activity Logs' },
-                expect.stringContaining('Maximum'),
+                'Maximum level for Activity Logs is Viewer',
             ],
             ['within range', AccessControlLevel.Viewer, { ...defaults }, undefined],
         ])('%s', (_label, level, opts, expected) => {
             const result = getLevelOptionsForResource(resourceLevels, opts)
-            expect(result.find((o) => o.value === level)?.disabledReason).toEqual(expected)
+            expect(result.find((o) => o.value === level)?.disabledReason).toBe(expected)
         })
     })
 
@@ -199,7 +199,9 @@ describe('groupedAccessControlRuleModalLogic', () => {
             }
             const result = computeProjectLevelOptions(entry)
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
+                'Project default is Member'
+            )
             expect(result.find((o) => o.value === AccessControlLevel.Member)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Admin)?.disabledReason).toBeUndefined()
         })
@@ -212,8 +214,8 @@ describe('groupedAccessControlRuleModalLogic', () => {
             }
             const result = computeProjectLevelOptions(entry)
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toEqual(
-                expect.stringContaining('Minimum')
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
+                'Minimum level for project is Member'
             )
         })
     })
@@ -263,8 +265,12 @@ describe('groupedAccessControlRuleModalLogic', () => {
                 'Dashboards'
             )
 
-            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).not.toBeUndefined()
-            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).not.toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
+                'Project default is Viewer'
+            )
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
+                'Maximum level for Dashboards is Editor'
+            )
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
         })
@@ -289,11 +295,11 @@ describe('groupedAccessControlRuleModalLogic', () => {
 
             expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
-            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toEqual(
-                expect.stringContaining('Maximum')
+            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBe(
+                'Maximum level for Activity Logs is Viewer'
             )
-            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toEqual(
-                expect.stringContaining('Maximum')
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
+                'Maximum level for Activity Logs is Viewer'
             )
         })
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.test.ts
@@ -1,6 +1,6 @@
 import { APIScopeObject, AccessControlLevel, EffectiveAccessControlEntry } from '~/types'
 
-import { getEntryId, getInheritedReasonTooltip, getLevelOptionsForResource, getMinLevelDisabledReason } from './helpers'
+import { getEntryId, getInheritedReasonTooltip, getLevelOptionsForResource } from './helpers'
 import { AccessControlMemberEntry, AccessControlRoleEntry, FormAccessLevel } from './types'
 
 const makeEntry = (
@@ -60,33 +60,54 @@ describe('groupedAccessControlRuleModalLogic', () => {
         })
     })
 
-    describe('getMinLevelDisabledReason', () => {
-        it('returns org admin reason when inherited reason is organization_admin', () => {
-            expect(getMinLevelDisabledReason(null, 'organization_admin', null, 'dashboard')).toBe(
-                'User is an organization admin'
-            )
-        })
+    describe('getLevelOptionsForResource disabled reasons', () => {
+        const defaults = {
+            minimum: AccessControlLevel.None,
+            maximum: AccessControlLevel.Manager,
+            inheritedLevel: null,
+            inheritedReason: null,
+            resourceLabel: 'Dashboards',
+        } as const
 
-        it('returns project default reason', () => {
-            expect(getMinLevelDisabledReason(AccessControlLevel.Viewer, 'project_default', null, 'dashboard')).toBe(
-                'Project default is Viewer'
-            )
-        })
-
-        it('returns role override reason', () => {
-            expect(getMinLevelDisabledReason(AccessControlLevel.Editor, 'role_override', null, 'dashboard')).toBe(
-                'User has a role with Editor access'
-            )
-        })
-
-        it('returns minimum level reason when no inherited level', () => {
-            expect(getMinLevelDisabledReason(null, null, AccessControlLevel.Viewer, 'Dashboards')).toBe(
-                'Minimum level for Dashboards is Viewer'
-            )
-        })
-
-        it('returns undefined when nothing applies', () => {
-            expect(getMinLevelDisabledReason(null, null, null, 'dashboard')).toBeUndefined()
+        it.each([
+            [
+                'below min with project default',
+                AccessControlLevel.None,
+                {
+                    ...defaults,
+                    minimum: AccessControlLevel.Viewer,
+                    inheritedLevel: AccessControlLevel.Viewer,
+                    inheritedReason: 'project_default' as const,
+                },
+                'Project default is Viewer',
+            ],
+            [
+                'below min with role override',
+                AccessControlLevel.None,
+                {
+                    ...defaults,
+                    minimum: AccessControlLevel.Editor,
+                    inheritedLevel: AccessControlLevel.Editor,
+                    inheritedReason: 'role_override' as const,
+                },
+                'User has a role with Editor access',
+            ],
+            [
+                'below min with minimum level',
+                AccessControlLevel.None,
+                { ...defaults, minimum: AccessControlLevel.Viewer },
+                'Minimum level for Dashboards is Viewer',
+            ],
+            [
+                'above max',
+                AccessControlLevel.Editor,
+                { ...defaults, maximum: AccessControlLevel.Viewer, resourceLabel: 'Activity Logs' },
+                'Maximum level for Activity Logs is Viewer',
+            ],
+            ['within range', AccessControlLevel.Viewer, { ...defaults }, undefined],
+        ])('%s', (_label, level, opts, expected) => {
+            const result = getLevelOptionsForResource(resourceLevels, opts)
+            expect(result.find((o) => o.value === level)?.disabledReason).toBe(expected)
         })
     })
 
@@ -155,6 +176,19 @@ describe('groupedAccessControlRuleModalLogic', () => {
     })
 
     describe('projectLevelOptions (selector logic)', () => {
+        function computeProjectLevelOptions(entry: {
+            project: EffectiveAccessControlEntry
+        }): { value: AccessControlLevel; label: string; disabledReason?: string }[] {
+            const { inherited_access_level, inherited_access_level_reason, minimum, maximum } = entry.project
+            return getLevelOptionsForResource(projectLevels, {
+                minimum,
+                maximum,
+                inheritedLevel: inherited_access_level,
+                inheritedReason: inherited_access_level_reason,
+                resourceLabel: 'project',
+            })
+        }
+
         it('uses inherited_access_level as minimum when present', () => {
             const entry = {
                 project: makeEntry(AccessControlLevel.Member, {
@@ -163,15 +197,7 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     minimum: AccessControlLevel.None,
                 }),
             }
-            const result = getLevelOptionsForResource(projectLevels, {
-                minimum: entry.project.inherited_access_level ?? entry.project.minimum,
-                disabledReason: getMinLevelDisabledReason(
-                    entry.project.inherited_access_level,
-                    entry.project.inherited_access_level_reason,
-                    entry.project.minimum,
-                    'project'
-                ),
-            })
+            const result = computeProjectLevelOptions(entry)
 
             expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
                 'Project default is Member'
@@ -186,15 +212,7 @@ describe('groupedAccessControlRuleModalLogic', () => {
                     minimum: AccessControlLevel.Member,
                 }),
             }
-            const result = getLevelOptionsForResource(projectLevels, {
-                minimum: entry.project.inherited_access_level ?? entry.project.minimum,
-                disabledReason: getMinLevelDisabledReason(
-                    entry.project.inherited_access_level,
-                    entry.project.inherited_access_level_reason,
-                    entry.project.minimum,
-                    'project'
-                ),
-            })
+            const result = computeProjectLevelOptions(entry)
 
             expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBe(
                 'Minimum level for project is Member'
@@ -213,14 +231,11 @@ describe('groupedAccessControlRuleModalLogic', () => {
             const { access_level, inherited_access_level, inherited_access_level_reason, minimum, maximum } = entry
                 .resources[resource] as EffectiveAccessControlEntry
             const levelOptions = getLevelOptionsForResource(availableResourceLevels, {
-                minimum: inherited_access_level ?? minimum,
-                maximum: maximum,
-                disabledReason: getMinLevelDisabledReason(
-                    inherited_access_level,
-                    inherited_access_level_reason,
-                    minimum,
-                    resourceLabel
-                ),
+                minimum,
+                maximum,
+                inheritedLevel: inherited_access_level,
+                inheritedReason: inherited_access_level_reason,
+                resourceLabel,
             })
             const hasFormOverride = formResourceLevels[resource] !== null
             const hasSavedOverride = access_level !== null && formResourceLevels[resource] !== null
@@ -254,10 +269,38 @@ describe('groupedAccessControlRuleModalLogic', () => {
                 'Project default is Viewer'
             )
             expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
-                'Project default is Viewer'
+                'Maximum level for Dashboards is Editor'
             )
             expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
             expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBeUndefined()
+        })
+
+        it('shows max disabled reason for levels above maximum (e.g. Activity Logs)', () => {
+            const entry = {
+                resources: {
+                    activity_log: makeEntry(AccessControlLevel.Viewer, {
+                        maximum: AccessControlLevel.Viewer,
+                    }),
+                },
+            }
+            const formLevels = { activity_log: AccessControlLevel.Viewer } as Record<APIScopeObject, FormAccessLevel>
+
+            const result = computeResourceLevelOptions(
+                resourceLevels,
+                entry,
+                formLevels,
+                'activity_log' as APIScopeObject,
+                'Activity Logs'
+            )
+
+            expect(result.find((o) => o.value === AccessControlLevel.None)?.disabledReason).toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Viewer)?.disabledReason).toBeUndefined()
+            expect(result.find((o) => o.value === AccessControlLevel.Editor)?.disabledReason).toBe(
+                'Maximum level for Activity Logs is Viewer'
+            )
+            expect(result.find((o) => o.value === AccessControlLevel.Manager)?.disabledReason).toBe(
+                'Maximum level for Activity Logs is Viewer'
+            )
         })
 
         it('prepends "No override" when no inherited level and form has override', () => {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/groupedAccessControlRuleModalLogic.ts
@@ -4,7 +4,7 @@ import { APIScopeObject, AccessControlLevel, EffectiveAccessControlEntry } from 
 
 import { accessControlsLogic } from './accessControlsLogic'
 import type { groupedAccessControlRuleModalLogicType } from './groupedAccessControlRuleModalLogicType'
-import { getEntryId, getInheritedReasonTooltip, getLevelOptionsForResource, getMinLevelDisabledReason } from './helpers'
+import { getEntryId, getInheritedReasonTooltip, getLevelOptionsForResource } from './helpers'
 import { FormAccessLevel, GroupedAccessControlRuleModalLogicProps } from './types'
 
 export const groupedAccessControlRuleModalLogic = kea<groupedAccessControlRuleModalLogicType>([
@@ -102,15 +102,13 @@ export const groupedAccessControlRuleModalLogic = kea<groupedAccessControlRuleMo
         projectLevelOptions: [
             (s) => [s.availableProjectLevels, s.entry],
             (availableProjectLevels, entry) => {
-                const { inherited_access_level, inherited_access_level_reason, minimum } = entry.project
+                const { inherited_access_level, inherited_access_level_reason, minimum, maximum } = entry.project
                 return getLevelOptionsForResource(availableProjectLevels, {
-                    minimum: inherited_access_level ?? minimum,
-                    disabledReason: getMinLevelDisabledReason(
-                        inherited_access_level,
-                        inherited_access_level_reason,
-                        minimum,
-                        'project'
-                    ),
+                    minimum,
+                    maximum,
+                    inheritedLevel: inherited_access_level,
+                    inheritedReason: inherited_access_level_reason,
+                    resourceLabel: 'project',
                 })
             },
         ],
@@ -157,14 +155,11 @@ export const groupedAccessControlRuleModalLogic = kea<groupedAccessControlRuleMo
                     const { access_level, inherited_access_level, inherited_access_level_reason, minimum, maximum } =
                         entry.resources[resource] as EffectiveAccessControlEntry
                     const levelOptions = getLevelOptionsForResource(availableResourceLevels, {
-                        minimum: inherited_access_level ?? minimum,
-                        maximum: maximum,
-                        disabledReason: getMinLevelDisabledReason(
-                            inherited_access_level,
-                            inherited_access_level_reason,
-                            minimum,
-                            resourceLabel
-                        ),
+                        minimum,
+                        maximum,
+                        inheritedLevel: inherited_access_level,
+                        inheritedReason: inherited_access_level_reason,
+                        resourceLabel,
                     })
                     // Show "No override" option when there's no inherited level and the user has set an override
                     const hasFormOverride = formResourceLevels[resource] !== null

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.ts
@@ -73,52 +73,48 @@ export function getInheritedReasonTooltip(reason: InheritedReason): string | und
     }
 }
 
-export function getMinLevelDisabledReason(
-    inheritedLevel: AccessControlLevel | null,
-    inheritedReason: InheritedReason,
-    minimum: AccessControlLevel | null,
-    resourceLabel: string
-): string | undefined {
-    if (inheritedReason === 'organization_admin') {
-        return 'User is an organization admin'
-    }
-    if (inheritedLevel) {
-        switch (inheritedReason) {
-            case 'project_default':
-                return `Project default is ${toSentenceCase(inheritedLevel)}`
-            case 'role_override':
-                return `User has a role with ${toSentenceCase(inheritedLevel)} access`
-        }
-    }
-    if (minimum) {
-        return `Minimum level for ${resourceLabel} is ${toSentenceCase(minimum)}`
-    }
-    return undefined
-}
-
 export function getLevelOptionsForResource(
     availableLevels: AccessControlLevel[],
     options?: {
-        minimum?: AccessControlLevel | null
-        maximum?: AccessControlLevel | null
-        disabledReason?: string
+        minimum: AccessControlLevel | null
+        maximum: AccessControlLevel | null
+        inheritedLevel: AccessControlLevel | null
+        inheritedReason: InheritedReason
+        resourceLabel: string
     }
 ): { value: AccessControlLevel; label: string; disabledReason?: string }[] {
-    const minimum = options?.minimum
-    const maximum = options?.maximum
-    const customDisabledReason = options?.disabledReason
+    const { minimum, maximum, inheritedLevel, inheritedReason, resourceLabel } = options ?? {}
+    const effectiveMinimum = inheritedLevel ?? minimum
 
-    const minIndex = minimum ? availableLevels.indexOf(minimum) : -1
+    const minIndex = effectiveMinimum ? availableLevels.indexOf(effectiveMinimum) : -1
     const maxIndex = maximum ? availableLevels.indexOf(maximum) : availableLevels.length
 
     return availableLevels.map((level) => {
         const currentIndex = availableLevels.indexOf(level)
-        const isDisabled = (minIndex >= 0 && currentIndex < minIndex) || (maxIndex >= 0 && currentIndex > maxIndex)
+        const isBelowMin = minIndex >= 0 && currentIndex < minIndex
+        const isAboveMax = maxIndex >= 0 && currentIndex > maxIndex
+
+        let disabledReason: string | undefined
+        if (isBelowMin) {
+            if (inheritedReason === 'organization_admin') {
+                disabledReason = 'User is an organization admin'
+            } else if (inheritedReason === 'project_default' && inheritedLevel) {
+                disabledReason = `Project default is ${toSentenceCase(inheritedLevel)}`
+            } else if (inheritedReason === 'role_override' && inheritedLevel) {
+                disabledReason = `User has a role with ${toSentenceCase(inheritedLevel)} access`
+            } else if (minimum) {
+                disabledReason = `Minimum level for ${resourceLabel} is ${toSentenceCase(minimum)}`
+            }
+        } else if (isAboveMax && maximum) {
+            disabledReason = `Maximum level for ${resourceLabel} is ${toSentenceCase(maximum)}`
+        } else {
+            disabledReason = undefined // not disabled
+        }
 
         return {
             value: level,
             label: level === AccessControlLevel.None ? 'None' : toSentenceCase(level),
-            disabledReason: isDisabled ? (customDisabledReason ?? 'Not available for this feature') : undefined,
+            disabledReason,
         }
     })
 }


### PR DESCRIPTION
## Problem

Follow-up to: https://github.com/PostHog/posthog/pull/48380

Disabled reason tooltip for access control dropdowns showed incorrect text for levels above the maximum. For example, Activity Logs (max=Viewer) showed "Minimum level for Activity Logs is None" on Editor/Manager options instead of a message about the maximum. 

![Screenshot 2026-02-25 at 21.32.37.png](https://app.graphite.com/user-attachments/assets/1c938cf0-9871-4115-8597-b9b2b33e210e.png)

## Changes

This PR simplifies how disabled reason is calculated. 

Moved the logic to `getLevelOptionsForResource`

## How did you test this code?

Logic tests + Clicked around

![2026-02-25 23.15.10.gif](https://app.graphite.com/user-attachments/assets/fabfd789-7e1a-4e34-bede-d3faff131952.gif)



## Publish to changelog?

No