### PR TITLE
chore(flags): add unscoped PAK removed-member test and audit log improvement

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -214,6 +214,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                 if let Some(orgs) = scoped_organizations.as_ref() {
                     if !orgs.is_empty() && !orgs.contains(&team_organization_id_str) {
                         warn!(
+                            user_id = user_id,
                             team_organization_id = %team_organization_id_str,
                             scoped_organizations = ?orgs,
                             "Personal API key scope does not include this organization"

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -778,6 +778,90 @@ async fn test_personal_api_key_with_scoped_organizations_removed_member() {
 }
 
 #[tokio::test]
+async fn test_personal_api_key_unscoped_removed_member() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+
+    let test_uuid = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    let user_email = format!("test_unscoped_removed_{test_uuid}@posthog.com");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+
+    // Create PAK without scoped_organizations to confirm the mandatory membership
+    // check works for all PAK configurations, not just those with explicit org scoping.
+    let (_pak_id, api_key_value) = context
+        .create_personal_api_key(
+            user_id,
+            "Test PAK Unscoped",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_flag_definitions_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Verify access works while user is a member
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        200,
+        "Should authenticate while user is an org member"
+    );
+
+    // Remove user from organization
+    context
+        .remove_user_from_organization(user_id, &org_id)
+        .await
+        .unwrap();
+
+    // Should fail because the user is no longer an org member, even without scoped_organizations
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {api_key_value}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        401,
+        "Should deny access after user is removed from organization, even without scoped_organizations"
+    );
+}
+
+#[tokio::test]
 async fn test_cache_miss_returns_503() {
     use feature_flags::{config::Config, utils::test_utils::TestContext};
     use reqwest;


### PR DESCRIPTION
## Summary

Follow-up to #49128. Two improvements I noticed while reviewing it, but I got distracted and didn't comment in time. 😄 

- **New test**: `test_personal_api_key_unscoped_removed_member` — confirms the mandatory org membership check works for PAKs *without* `scoped_organizations` set (`None`). This guards against future regressions where someone might accidentally gate the membership query behind `scoped_organizations.is_some()`.
- **Logging nit**: Added `user_id` to the scope-mismatch warning in `auth.rs` for audit trail completeness, matching the detail level of the membership-denial warning.

## Test plan

- [ ] CI passes for `test_personal_api_key_unscoped_removed_member`
- [ ] Existing PAK auth tests still pass