### PR TITLE
feat(personhog-router): add retries

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6090,6 +6090,7 @@ dependencies = [
  "metrics",
  "personhog-proto",
  "pin-project",
+ "rand 0.8.5",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",

--- a/rust/personhog-router/Cargo.toml
+++ b/rust/personhog-router/Cargo.toml
@@ -16,6 +16,7 @@ envconfig = { workspace = true }
 http = { workspace = true }
 metrics = { workspace = true }
 pin-project = "1.1"
+rand = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }

--- a/rust/personhog-router/src/backend/mod.rs
+++ b/rust/personhog-router/src/backend/mod.rs
@@ -1,5 +1,5 @@
 mod replica;
-pub mod retry;
+mod retry;
 
 pub use replica::ReplicaBackend;
 

--- a/rust/personhog-router/src/backend/mod.rs
+++ b/rust/personhog-router/src/backend/mod.rs
@@ -1,4 +1,5 @@
 mod replica;
+pub mod retry;
 
 pub use replica::ReplicaBackend;
 

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -19,11 +19,14 @@ use std::time::Duration;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
 
+use super::retry::with_retry;
 use super::PersonHogBackend;
+use crate::config::RetryConfig;
 
 /// Backend implementation that forwards requests to a personhog-replica service.
 pub struct ReplicaBackend {
     client: PersonHogReplicaClient<Channel>,
+    retry_config: RetryConfig,
 }
 
 impl ReplicaBackend {
@@ -31,6 +34,7 @@ impl ReplicaBackend {
     pub fn new(
         url: &str,
         timeout: Duration,
+        retry_config: RetryConfig,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let channel = Channel::from_shared(url.to_string())?
             .timeout(timeout)
@@ -38,8 +42,26 @@ impl ReplicaBackend {
 
         Ok(Self {
             client: PersonHogReplicaClient::new(channel),
+            retry_config,
         })
     }
+}
+
+/// Wraps a gRPC call with retry logic. Clones the request for each attempt.
+macro_rules! retry_call {
+    ($self:expr, $method:ident, $request:expr) => {
+        with_retry(&$self.retry_config, stringify!($method), || {
+            let mut client = $self.client.clone();
+            let req = $request.clone();
+            async move {
+                client
+                    .$method(Request::new(req))
+                    .await
+                    .map(|r| r.into_inner())
+            }
+        })
+        .await
+    };
 }
 
 #[async_trait]
@@ -47,41 +69,25 @@ impl PersonHogBackend for ReplicaBackend {
     // Person lookups by ID
 
     async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
-        self.client
-            .clone()
-            .get_person(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_person, request)
     }
 
     async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
-        self.client
-            .clone()
-            .get_persons(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_persons, request)
     }
 
     async fn get_person_by_uuid(
         &self,
         request: GetPersonByUuidRequest,
     ) -> Result<GetPersonResponse, Status> {
-        self.client
-            .clone()
-            .get_person_by_uuid(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_person_by_uuid, request)
     }
 
     async fn get_persons_by_uuids(
         &self,
         request: GetPersonsByUuidsRequest,
     ) -> Result<PersonsResponse, Status> {
-        self.client
-            .clone()
-            .get_persons_by_uuids(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_persons_by_uuids, request)
     }
 
     // Person lookups by distinct ID
@@ -90,33 +96,21 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetPersonByDistinctIdRequest,
     ) -> Result<GetPersonResponse, Status> {
-        self.client
-            .clone()
-            .get_person_by_distinct_id(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_person_by_distinct_id, request)
     }
 
     async fn get_persons_by_distinct_ids_in_team(
         &self,
         request: GetPersonsByDistinctIdsInTeamRequest,
     ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
-        self.client
-            .clone()
-            .get_persons_by_distinct_ids_in_team(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_persons_by_distinct_ids_in_team, request)
     }
 
     async fn get_persons_by_distinct_ids(
         &self,
         request: GetPersonsByDistinctIdsRequest,
     ) -> Result<PersonsByDistinctIdsResponse, Status> {
-        self.client
-            .clone()
-            .get_persons_by_distinct_ids(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_persons_by_distinct_ids, request)
     }
 
     // Distinct ID operations
@@ -125,22 +119,14 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetDistinctIdsForPersonRequest,
     ) -> Result<GetDistinctIdsForPersonResponse, Status> {
-        self.client
-            .clone()
-            .get_distinct_ids_for_person(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_distinct_ids_for_person, request)
     }
 
     async fn get_distinct_ids_for_persons(
         &self,
         request: GetDistinctIdsForPersonsRequest,
     ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
-        self.client
-            .clone()
-            .get_distinct_ids_for_persons(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_distinct_ids_for_persons, request)
     }
 
     // Feature flag hash key override support
@@ -149,33 +135,21 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetHashKeyOverrideContextRequest,
     ) -> Result<GetHashKeyOverrideContextResponse, Status> {
-        self.client
-            .clone()
-            .get_hash_key_override_context(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_hash_key_override_context, request)
     }
 
     async fn upsert_hash_key_overrides(
         &self,
         request: UpsertHashKeyOverridesRequest,
     ) -> Result<UpsertHashKeyOverridesResponse, Status> {
-        self.client
-            .clone()
-            .upsert_hash_key_overrides(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, upsert_hash_key_overrides, request)
     }
 
     async fn delete_hash_key_overrides_by_teams(
         &self,
         request: DeleteHashKeyOverridesByTeamsRequest,
     ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
-        self.client
-            .clone()
-            .delete_hash_key_overrides_by_teams(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, delete_hash_key_overrides_by_teams, request)
     }
 
     // Cohort membership
@@ -184,40 +158,24 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: CheckCohortMembershipRequest,
     ) -> Result<CohortMembershipResponse, Status> {
-        self.client
-            .clone()
-            .check_cohort_membership(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, check_cohort_membership, request)
     }
 
     // Groups
 
     async fn get_group(&self, request: GetGroupRequest) -> Result<GetGroupResponse, Status> {
-        self.client
-            .clone()
-            .get_group(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_group, request)
     }
 
     async fn get_groups(&self, request: GetGroupsRequest) -> Result<GroupsResponse, Status> {
-        self.client
-            .clone()
-            .get_groups(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_groups, request)
     }
 
     async fn get_groups_batch(
         &self,
         request: GetGroupsBatchRequest,
     ) -> Result<GetGroupsBatchResponse, Status> {
-        self.client
-            .clone()
-            .get_groups_batch(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_groups_batch, request)
     }
 
     // Group type mappings
@@ -226,43 +184,27 @@ impl PersonHogBackend for ReplicaBackend {
         &self,
         request: GetGroupTypeMappingsByTeamIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        self.client
-            .clone()
-            .get_group_type_mappings_by_team_id(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_group_type_mappings_by_team_id, request)
     }
 
     async fn get_group_type_mappings_by_team_ids(
         &self,
         request: GetGroupTypeMappingsByTeamIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        self.client
-            .clone()
-            .get_group_type_mappings_by_team_ids(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_group_type_mappings_by_team_ids, request)
     }
 
     async fn get_group_type_mappings_by_project_id(
         &self,
         request: GetGroupTypeMappingsByProjectIdRequest,
     ) -> Result<GroupTypeMappingsResponse, Status> {
-        self.client
-            .clone()
-            .get_group_type_mappings_by_project_id(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_group_type_mappings_by_project_id, request)
     }
 
     async fn get_group_type_mappings_by_project_ids(
         &self,
         request: GetGroupTypeMappingsByProjectIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
-        self.client
-            .clone()
-            .get_group_type_mappings_by_project_ids(Request::new(request))
-            .await
-            .map(|r| r.into_inner())
+        retry_call!(self, get_group_type_mappings_by_project_ids, request)
     }
 }

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -114,11 +114,7 @@ mod tests {
 
     #[tokio::test]
     async fn retries_transient_then_succeeds() {
-        let transient_codes = vec![
-            Code::Unavailable,
-            Code::DeadlineExceeded,
-            Code::Internal,
-        ];
+        let transient_codes = vec![Code::Unavailable, Code::DeadlineExceeded, Code::Internal];
         for code in transient_codes {
             let calls = AtomicU32::new(0);
             let result = with_retry(&test_config(), "test", || {
@@ -135,7 +131,11 @@ mod tests {
             .await;
 
             assert_eq!(result.unwrap(), "recovered", "should recover from {code:?}");
-            assert_eq!(calls.load(Ordering::SeqCst), 3, "should take 3 attempts for {code:?}");
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                3,
+                "should take 3 attempts for {code:?}"
+            );
         }
     }
 

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -73,7 +73,8 @@ where
                     "retrying after transient error"
                 );
 
-                let jittered_ms = rand::thread_rng().gen_range(0..=delay_ms);
+                let base = delay_ms / 2;
+                let jittered_ms = base + rand::thread_rng().gen_range(0..=base);
                 tokio::time::sleep(Duration::from_millis(jittered_ms)).await;
                 delay_ms = (delay_ms * 2).min(config.max_backoff_ms);
             }
@@ -113,21 +114,29 @@ mod tests {
 
     #[tokio::test]
     async fn retries_transient_then_succeeds() {
-        let calls = AtomicU32::new(0);
-        let result = with_retry(&test_config(), "test", || {
-            let attempt = calls.fetch_add(1, Ordering::SeqCst);
-            async move {
-                if attempt < 2 {
-                    Err(Status::unavailable("backend down"))
-                } else {
-                    Ok("recovered")
+        let transient_codes = vec![
+            Code::Unavailable,
+            Code::DeadlineExceeded,
+            Code::Internal,
+        ];
+        for code in transient_codes {
+            let calls = AtomicU32::new(0);
+            let result = with_retry(&test_config(), "test", || {
+                let attempt = calls.fetch_add(1, Ordering::SeqCst);
+                let status = Status::new(code, "transient");
+                async move {
+                    if attempt < 2 {
+                        Err(status)
+                    } else {
+                        Ok("recovered")
+                    }
                 }
-            }
-        })
-        .await;
+            })
+            .await;
 
-        assert_eq!(result.unwrap(), "recovered");
-        assert_eq!(calls.load(Ordering::SeqCst), 3);
+            assert_eq!(result.unwrap(), "recovered", "should recover from {code:?}");
+            assert_eq!(calls.load(Ordering::SeqCst), 3, "should take 3 attempts for {code:?}");
+        }
     }
 
     #[tokio::test]

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -1,0 +1,203 @@
+use std::future::Future;
+use std::time::Duration;
+
+use metrics::counter;
+use rand::Rng;
+use tonic::{Code, Status};
+use tracing::warn;
+
+use crate::config::RetryConfig;
+
+fn is_retryable(code: Code) -> bool {
+    matches!(
+        code,
+        Code::Unavailable | Code::DeadlineExceeded | Code::Internal
+    )
+}
+
+fn code_as_str(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::NotFound => "not_found",
+        Code::AlreadyExists => "already_exists",
+        Code::PermissionDenied => "permission_denied",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::FailedPrecondition => "failed_precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out_of_range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data_loss",
+        Code::Unauthenticated => "unauthenticated",
+    }
+}
+
+/// Executes an async operation with exponential backoff and jitter on transient gRPC errors.
+///
+/// Only retries on `Unavailable`, `DeadlineExceeded`, and `Internal` status codes.
+/// Permanent errors (e.g. `InvalidArgument`, `NotFound`) are returned immediately.
+pub async fn with_retry<F, Fut, T>(
+    config: &RetryConfig,
+    method: &'static str,
+    mut make_call: F,
+) -> Result<T, Status>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Status>>,
+{
+    let mut delay_ms = config.initial_backoff_ms;
+
+    for attempt in 0..=config.max_retries {
+        match make_call().await {
+            Ok(value) => return Ok(value),
+            Err(status) if attempt < config.max_retries && is_retryable(status.code()) => {
+                let code_str = code_as_str(status.code());
+
+                counter!(
+                    "personhog_router_backend_retries_total",
+                    "method" => method,
+                    "status_code" => code_str
+                )
+                .increment(1);
+
+                warn!(
+                    method = method,
+                    attempt = attempt + 1,
+                    max_retries = config.max_retries,
+                    status_code = code_str,
+                    "retrying after transient error"
+                );
+
+                let jittered_ms = rand::thread_rng().gen_range(0..=delay_ms);
+                tokio::time::sleep(Duration::from_millis(jittered_ms)).await;
+                delay_ms = (delay_ms * 2).min(config.max_backoff_ms);
+            }
+            Err(status) => return Err(status),
+        }
+    }
+
+    unreachable!("loop runs max_retries + 1 times and always returns")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    fn test_config() -> RetryConfig {
+        RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+        }
+    }
+
+    #[tokio::test]
+    async fn succeeds_on_first_attempt() {
+        let calls = AtomicU32::new(0);
+        let result = with_retry(&test_config(), "test", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Ok::<_, Status>("ok") }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), "ok");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_transient_then_succeeds() {
+        let calls = AtomicU32::new(0);
+        let result = with_retry(&test_config(), "test", || {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if attempt < 2 {
+                    Err(Status::unavailable("backend down"))
+                } else {
+                    Ok("recovered")
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), "recovered");
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_permanent_errors() {
+        let calls = AtomicU32::new(0);
+        let result = with_retry(&test_config(), "test", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err::<&str, _>(Status::invalid_argument("bad request")) }
+        })
+        .await;
+
+        assert_eq!(result.unwrap_err().code(), Code::InvalidArgument);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exhausts_retries_on_persistent_transient_error() {
+        let calls = AtomicU32::new(0);
+        let result = with_retry(&test_config(), "test", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err::<&str, _>(Status::unavailable("still down")) }
+        })
+        .await;
+
+        assert_eq!(result.unwrap_err().code(), Code::Unavailable);
+        // 1 initial + 3 retries = 4 total attempts
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn no_retries_when_max_retries_is_zero() {
+        let config = RetryConfig {
+            max_retries: 0,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+        };
+        let calls = AtomicU32::new(0);
+        let result = with_retry(&config, "test", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err::<&str, _>(Status::unavailable("down")) }
+        })
+        .await;
+
+        assert_eq!(result.unwrap_err().code(), Code::Unavailable);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_all_transient_codes() {
+        let cases = vec![
+            (Code::Unavailable, "unavailable"),
+            (Code::DeadlineExceeded, "deadline_exceeded"),
+            (Code::Internal, "internal"),
+        ];
+        for (code, msg) in cases {
+            let calls = AtomicU32::new(0);
+            let config = RetryConfig {
+                max_retries: 1,
+                initial_backoff_ms: 1,
+                max_backoff_ms: 1,
+            };
+            let result = with_retry(&config, "test", || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let status = Status::new(code, msg);
+                async move { Err::<&str, _>(status) }
+            })
+            .await;
+
+            assert_eq!(result.unwrap_err().code(), code);
+            assert_eq!(calls.load(Ordering::SeqCst), 2, "should retry {code:?}");
+        }
+    }
+}

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -17,10 +17,37 @@ pub struct Config {
 
     #[envconfig(default = "9101")]
     pub metrics_port: u16,
+
+    /// Maximum number of retry attempts for transient backend errors (0 = no retries)
+    #[envconfig(default = "3")]
+    pub max_retries: u32,
+
+    /// Initial backoff delay in milliseconds before the first retry
+    #[envconfig(default = "25")]
+    pub initial_backoff_ms: u64,
+
+    /// Maximum backoff delay in milliseconds (caps exponential growth)
+    #[envconfig(default = "500")]
+    pub max_backoff_ms: u64,
 }
 
 impl Config {
     pub fn backend_timeout(&self) -> Duration {
         Duration::from_millis(self.backend_timeout_ms)
     }
+
+    pub fn retry_config(&self) -> RetryConfig {
+        RetryConfig {
+            max_retries: self.max_retries,
+            initial_backoff_ms: self.initial_backoff_ms,
+            max_backoff_ms: self.max_backoff_ms,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
 }

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -45,7 +45,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct RetryConfig {
     pub max_retries: u32,
     pub initial_backoff_ms: u64,

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -23,6 +23,7 @@ use personhog_proto::personhog::types::v1::{
     UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
 };
 use personhog_router::backend::ReplicaBackend;
+use personhog_router::config::RetryConfig;
 use personhog_router::router::PersonHogRouter;
 use personhog_router::service::PersonHogRouterService;
 use tokio::net::TcpListener;
@@ -306,7 +307,12 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
     let addr = listener.local_addr().unwrap();
 
     let replica_url = format!("http://{}", replica_addr);
-    let backend = ReplicaBackend::new(&replica_url, Duration::from_secs(5)).unwrap();
+    let retry_config = RetryConfig {
+        max_retries: 3,
+        initial_backoff_ms: 25,
+        max_backoff_ms: 500,
+    };
+    let backend = ReplicaBackend::new(&replica_url, Duration::from_secs(5), retry_config).unwrap();
     let router = PersonHogRouter::new(Arc::new(backend));
     let service = PersonHogRouterService::new(Arc::new(router));
 

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -308,9 +308,9 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
 
     let replica_url = format!("http://{}", replica_addr);
     let retry_config = RetryConfig {
-        max_retries: 3,
-        initial_backoff_ms: 25,
-        max_backoff_ms: 500,
+        max_retries: 1,
+        initial_backoff_ms: 1,
+        max_backoff_ms: 1,
     };
     let backend = ReplicaBackend::new(&replica_url, Duration::from_secs(5), retry_config).unwrap();
     let router = PersonHogRouter::new(Arc::new(backend));


### PR DESCRIPTION
## Problem

The personhog-router makes single-shot gRPC calls to personhog-replica with no retry logic.
Any transient failure (connection blip, backend restart, brief overload) propagates directly to the caller.
As we migrate feature-flags to use personhog-router instead of direct SQL queries,
the router needs to absorb transient backend failures transparently — the same way
feature-flags currently has exponential backoff on its SQL path via `tokio-retry`.


## Changes

**Retry helper** (`src/backend/retry.rs`):

- Retries only transient gRPC status codes: `Unavailable`, `DeadlineExceeded`, `Internal`
- Returns immediately on permanent errors: `InvalidArgument`, `NotFound`, `PermissionDenied`, etc.
- Full jitter (`rand(0..=delay)`) to decorrelate concurrent retries and avoid thundering herd
- Emits `personhog_router_backend_retries_total` counter with `method` and `status_code` labels
- Logs each retry at `warn` level with attempt number

**Config** (`src/config.rs`):
Three new env-configurable fields with defaults tuned for the hot path:

| Variable | Default | Purpose |
|---|---|---|
| `MAX_RETRIES` | 3 | Max retry attempts (0 = disabled) |
| `INITIAL_BACKOFF_MS` | 25 | Base delay before first retry |
| `MAX_BACKOFF_MS` | 500 | Cap on exponential backoff growth |

Worst-case added latency is ~175ms (25 + 50 + 100), well within the 5s backend timeout.

**ReplicaBackend** (`src/backend/replica.rs`):
All 21 gRPC methods now use a `retry_call!` macro that wraps each call with the retry helper.
Each attempt clones the request and gets a fresh client handle.


## How did you test this code?

- 6 unit tests in `src/backend/retry.rs`:
  - First-attempt success (no unnecessary retries)
  - Transient errors retried then succeeds (2 failures → 3rd attempt OK)
  - Permanent errors not retried (`InvalidArgument` returns immediately)
  - Retry exhaustion on persistent transient errors (verifies attempt count = max_retries + 1)
  - Zero-retry config disables retries entirely
  - All three transient codes (`Unavailable`, `DeadlineExceeded`, `Internal`) are retried
- All 13 existing integration tests pass (end-to-end gRPC through router to mock replica)
- All 8 existing routing/service unit tests pass
- Full lint suite: `cargo fmt`, `cargo clippy -D warnings`, `cargo check`, `cargo shear` — all clean
