### PR TITLE
feat(flags): add flag definitions cache verification logic

### DIFF
--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -752,8 +752,8 @@ def verify_team_flag_definitions(
     cached_flags = cached_data.get("flags", []) if cached_data else []
 
     # Compare flags by key (flag definitions use key as primary identifier)
-    db_flags_by_key = {flag.get("key"): flag for flag in db_flags}
-    cached_flags_by_key = {flag.get("key"): flag for flag in cached_flags}
+    db_flags_by_key = {flag["key"]: flag for flag in db_flags}
+    cached_flags_by_key = {flag["key"]: flag for flag in cached_flags}
 
     diffs = []
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -702,6 +702,145 @@ FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementC
 )
 
 
+def verify_team_flag_definitions(
+    team: Team,
+    db_batch_data: dict | None = None,
+    cache_batch_data: dict | None = None,
+    include_cohorts: bool = True,
+    verbose: bool = False,
+) -> dict:
+    """
+    Verify a team's flag definitions cache against the database.
+
+    Args:
+        team: Team to verify
+        db_batch_data: Pre-loaded DB data from batch_load_fn (keyed by team.id)
+        cache_batch_data: Pre-loaded cache data from batch_get_from_cache (keyed by team.id)
+        include_cohorts: Which cache variant to verify (True for with-cohorts, False for without)
+        verbose: If True, include detailed diffs
+
+    Returns:
+        Dict with 'status' ("match", "miss", "mismatch") and 'issue' type.
+    """
+    hypercache = flag_definitions_hypercache if include_cohorts else flag_definitions_without_cohorts_hypercache
+
+    # Get cached data - use pre-loaded batch data if available
+    if cache_batch_data and team.id in cache_batch_data:
+        cached_data, source = cache_batch_data[team.id]
+    else:
+        cached_data, source = hypercache.get_from_cache_with_source(team)
+
+    # Get flag definitions from database
+    if db_batch_data and team.id in db_batch_data:
+        db_data = db_batch_data[team.id]
+    else:
+        db_data = _get_flags_response_for_local_evaluation(team, include_cohorts)
+
+    db_flags = db_data.get("flags", []) if isinstance(db_data, dict) else []
+
+    # Cache miss (source="db" or "miss" means data was not found in cache)
+    if source in ("db", "miss"):
+        return {
+            "status": "miss",
+            "issue": "CACHE_MISS",
+            "details": f"No cache entry found (team has {len(db_flags)} flags in DB)",
+        }
+
+    # Extract cached flags
+    cached_flags = cached_data.get("flags", []) if cached_data else []
+
+    # Compare flags by key (flag definitions use key as primary identifier)
+    db_flags_by_key = {flag.get("key"): flag for flag in db_flags}
+    cached_flags_by_key = {flag.get("key"): flag for flag in cached_flags}
+
+    diffs = []
+
+    # Find missing flags (in DB but not in cache)
+    for flag_key in db_flags_by_key:
+        if flag_key not in cached_flags_by_key:
+            diffs.append(
+                {
+                    "type": "MISSING_IN_CACHE",
+                    "flag_key": flag_key,
+                }
+            )
+
+    # Find stale flags (in cache but not in DB)
+    for flag_key in cached_flags_by_key:
+        if flag_key not in db_flags_by_key:
+            diffs.append(
+                {
+                    "type": "STALE_IN_CACHE",
+                    "flag_key": flag_key,
+                }
+            )
+
+    # Compare field values for flags that exist in both
+    for flag_key in db_flags_by_key:
+        if flag_key in cached_flags_by_key:
+            db_flag = db_flags_by_key[flag_key]
+            cached_flag = cached_flags_by_key[flag_key]
+            if db_flag != cached_flag:
+                field_diffs = _compare_flag_definition_fields(db_flag, cached_flag)
+                diff: dict = {
+                    "type": "FIELD_MISMATCH",
+                    "flag_key": flag_key,
+                    "diff_fields": [f["field"] for f in field_diffs],
+                }
+                if verbose:
+                    diff["field_diffs"] = field_diffs
+                diffs.append(diff)
+
+    # Also compare cohorts and group_type_mapping
+    if cached_data and db_data:
+        if cached_data.get("cohorts") != db_data.get("cohorts"):
+            diffs.append({"type": "COHORTS_MISMATCH", "flag_key": "cohorts"})
+        if cached_data.get("group_type_mapping") != db_data.get("group_type_mapping"):
+            diffs.append({"type": "GROUP_TYPE_MAPPING_MISMATCH", "flag_key": "group_type_mapping"})
+
+    if not diffs:
+        return {"status": "match", "issue": "", "details": ""}
+
+    # Summarize diffs
+    missing_count = sum(1 for d in diffs if d.get("type") == "MISSING_IN_CACHE")
+    stale_count = sum(1 for d in diffs if d.get("type") == "STALE_IN_CACHE")
+    mismatch_count = sum(1 for d in diffs if d.get("type") == "FIELD_MISMATCH")
+
+    summary_parts = []
+    if missing_count > 0:
+        summary_parts.append(f"{missing_count} missing")
+    if stale_count > 0:
+        summary_parts.append(f"{stale_count} stale")
+    if mismatch_count > 0:
+        summary_parts.append(f"{mismatch_count} mismatched")
+
+    result: dict = {
+        "status": "mismatch",
+        "issue": "DATA_MISMATCH",
+        "details": f"{', '.join(summary_parts)} flags" if summary_parts else "unknown differences",
+    }
+
+    if verbose:
+        result["diffs"] = diffs
+
+    return result
+
+
+def _compare_flag_definition_fields(db_flag: dict, cached_flag: dict) -> list[dict]:
+    """Compare field values between DB and cached versions of a flag."""
+    field_diffs = []
+    all_keys = set(db_flag.keys()) | set(cached_flag.keys())
+
+    for key in all_keys:
+        db_val = db_flag.get(key)
+        cached_val = cached_flag.get(key)
+
+        if db_val != cached_val:
+            field_diffs.append({"field": key, "db_value": db_val, "cached_value": cached_val})
+
+    return field_diffs
+
+
 # NOTE: All models that affect feature flag evaluation should have a signal to update the cache
 # GroupTypeMapping excluded as it's primarily managed by Node.js plugin-server
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -792,7 +792,7 @@ def verify_team_flag_definitions(
                 diffs.append(diff)
 
     # Also compare cohorts and group_type_mapping
-    if cached_data and db_data:
+    if cached_data is not None and db_data is not None:
         if cached_data.get("cohorts") != db_data.get("cohorts"):
             diffs.append({"type": "COHORTS_MISMATCH", "flag_key": "cohorts"})
         if cached_data.get("group_type_mapping") != db_data.get("group_type_mapping"):
@@ -805,6 +805,8 @@ def verify_team_flag_definitions(
     missing_count = sum(1 for d in diffs if d.get("type") == "MISSING_IN_CACHE")
     stale_count = sum(1 for d in diffs if d.get("type") == "STALE_IN_CACHE")
     mismatch_count = sum(1 for d in diffs if d.get("type") == "FIELD_MISMATCH")
+    cohorts_mismatch = any(d.get("type") == "COHORTS_MISMATCH" for d in diffs)
+    gtm_mismatch = any(d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH" for d in diffs)
 
     summary_parts = []
     if missing_count > 0:
@@ -814,10 +816,19 @@ def verify_team_flag_definitions(
     if mismatch_count > 0:
         summary_parts.append(f"{mismatch_count} mismatched")
 
+    flag_summary = f"{', '.join(summary_parts)} flags" if summary_parts else ""
+    extra_parts = []
+    if cohorts_mismatch:
+        extra_parts.append("cohorts mismatch")
+    if gtm_mismatch:
+        extra_parts.append("group_type_mapping mismatch")
+
+    details = "; ".join(filter(None, [flag_summary, ", ".join(extra_parts)]))
+
     result: dict = {
         "status": "mismatch",
         "issue": "DATA_MISMATCH",
-        "details": f"{', '.join(summary_parts)} flags" if summary_parts else "unknown differences",
+        "details": details or "unknown differences",
     }
 
     if verbose:

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -40,6 +40,7 @@ from posthog.models.cohort.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.util import get_nested_cohort_ids
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
+from posthog.models.feature_flag.flags_cache import _compare_flag_fields
 from posthog.models.feature_flag.types import FlagFilters, FlagProperty, PropertyFilterType
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.surveys.survey import Survey
@@ -744,6 +745,7 @@ def verify_team_flag_definitions(
             "status": "miss",
             "issue": "CACHE_MISS",
             "details": f"No cache entry found (team has {len(db_flags)} flags in DB)",
+            "db_data": db_data,
         }
 
     # Extract cached flags
@@ -781,7 +783,7 @@ def verify_team_flag_definitions(
             db_flag = db_flags_by_key[flag_key]
             cached_flag = cached_flags_by_key[flag_key]
             if db_flag != cached_flag:
-                field_diffs = _compare_flag_definition_fields(db_flag, cached_flag)
+                field_diffs = _compare_flag_fields(db_flag, cached_flag)
                 diff: dict = {
                     "type": "FIELD_MISMATCH",
                     "flag_key": flag_key,
@@ -829,27 +831,13 @@ def verify_team_flag_definitions(
         "status": "mismatch",
         "issue": "DATA_MISMATCH",
         "details": details or "unknown differences",
+        "db_data": db_data,
     }
 
     if verbose:
         result["diffs"] = diffs
 
     return result
-
-
-def _compare_flag_definition_fields(db_flag: dict, cached_flag: dict) -> list[dict]:
-    """Compare field values between DB and cached versions of a flag."""
-    field_diffs = []
-    all_keys = set(db_flag.keys()) | set(cached_flag.keys())
-
-    for key in all_keys:
-        db_val = db_flag.get(key)
-        cached_val = cached_flag.get(key)
-
-        if db_val != cached_val:
-            field_diffs.append({"field": key, "db_value": db_val, "cached_value": cached_val})
-
-    return field_diffs
 
 
 # NOTE: All models that affect feature flag evaluation should have a signal to update the cache

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -21,7 +21,9 @@ from posthog.models.feature_flag.local_evaluation import (
     get_flags_response_for_local_evaluation,
     update_flag_caches,
     update_flag_definitions_cache,
+    verify_team_flag_definitions,
 )
+from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.project import Project
 from posthog.models.surveys.survey import Survey
 from posthog.models.tag import Tag
@@ -317,6 +319,13 @@ class TestLocalEvaluationSignals(BaseTest):
 
 class TestSurveyFlagExclusion(BaseTest):
     """Tests for excluding survey-linked flags from local evaluation (GitHub issue #43631)."""
+
+    def setUp(self):
+        super().setUp()
+        # Clear existing flags and caches to ensure test isolation
+        FeatureFlag.objects.filter(team=self.team).delete()
+        Survey.objects.filter(team=self.team).delete()
+        clear_flag_definition_caches(self.team)
 
     @parameterized.expand(
         [
@@ -1147,6 +1156,144 @@ class TestFlagDefinitionsCache(BaseTest):
 
         mock_with.assert_called_once_with(self.team, ttl=3600)
         mock_without.assert_called_once_with(self.team, ttl=3600)
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestVerifyFlagDefinitions(BaseTest):
+    """Tests for flag definitions cache verification."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
+
+    def test_verify_returns_miss_when_cache_empty(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True)
+
+        assert result["status"] == "miss"
+        assert result["issue"] == "CACHE_MISS"
+
+    def test_verify_returns_match_when_cache_matches(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True)
+
+        assert result["status"] == "match"
+        assert result["issue"] == ""
+
+    def test_verify_returns_mismatch_when_flag_changed(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        flag.key = "modified-flag"
+        flag.save()
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "mismatch"
+        assert result["issue"] == "DATA_MISMATCH"
+        assert "diffs" in result
+
+    def test_verify_both_variants_independently(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        result_with = verify_team_flag_definitions(self.team, include_cohorts=True)
+        result_without = verify_team_flag_definitions(self.team, include_cohorts=False)
+
+        assert result_with["status"] == "match"
+        assert result_without["status"] == "match"
+
+    def test_verify_returns_mismatch_when_cohort_changed(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test Cohort",
+            groups=[{"properties": [{"key": "email", "value": "test@example.com", "type": "person"}]}],
+        )
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        cohort.groups = [{"properties": [{"key": "email", "value": "changed@example.com", "type": "person"}]}]
+        cohort.save()
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "mismatch"
+        assert result["issue"] == "DATA_MISMATCH"
+        assert "diffs" in result
+        cohorts_diff = [d for d in result["diffs"] if d.get("type") == "COHORTS_MISMATCH"]
+        assert len(cohorts_diff) == 1
+
+    def test_verify_returns_mismatch_when_group_type_mapping_changed(self):
+        GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type="company",
+            group_type_index=0,
+        )
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={
+                "aggregation_group_type_index": 0,
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+            },
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        mapping = GroupTypeMapping.objects.get(team=self.team, group_type_index=0)
+        mapping.group_type = "organization"
+        mapping.save()
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "mismatch"
+        assert result["issue"] == "DATA_MISMATCH"
+        assert "diffs" in result
+        mapping_diff = [d for d in result["diffs"] if d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH"]
+        assert len(mapping_diff) == 1
 
 
 @override_settings(FLAGS_REDIS_URL=None)

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1259,6 +1259,7 @@ class TestVerifyFlagDefinitions(BaseTest):
 
         assert result["status"] == "mismatch"
         assert result["issue"] == "DATA_MISMATCH"
+        assert "cohorts mismatch" in result["details"]
         assert "diffs" in result
         cohorts_diff = [d for d in result["diffs"] if d.get("type") == "COHORTS_MISMATCH"]
         assert len(cohorts_diff) == 1
@@ -1291,6 +1292,7 @@ class TestVerifyFlagDefinitions(BaseTest):
 
         assert result["status"] == "mismatch"
         assert result["issue"] == "DATA_MISMATCH"
+        assert "group_type_mapping mismatch" in result["details"]
         assert "diffs" in result
         mapping_diff = [d for d in result["diffs"] if d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH"]
         assert len(mapping_diff) == 1

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1194,7 +1194,7 @@ class TestVerifyFlagDefinitions(BaseTest):
         assert result["status"] == "match"
         assert result["issue"] == ""
 
-    def test_verify_returns_mismatch_when_flag_changed(self):
+    def test_verify_returns_mismatch_when_flag_key_renamed(self):
         flag = FeatureFlag.objects.create(
             team=self.team,
             key="test-flag",
@@ -1211,7 +1211,35 @@ class TestVerifyFlagDefinitions(BaseTest):
 
         assert result["status"] == "mismatch"
         assert result["issue"] == "DATA_MISMATCH"
-        assert "diffs" in result
+        assert "1 missing, 1 stale" in result["details"]
+        missing_diffs = [d for d in result["diffs"] if d["type"] == "MISSING_IN_CACHE"]
+        stale_diffs = [d for d in result["diffs"] if d["type"] == "STALE_IN_CACHE"]
+        assert len(missing_diffs) == 1
+        assert missing_diffs[0]["flag_key"] == "modified-flag"
+        assert len(stale_diffs) == 1
+        assert stale_diffs[0]["flag_key"] == "test-flag"
+
+    def test_verify_returns_field_mismatch_when_flag_filters_changed(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        update_flag_definitions_cache(self.team)
+
+        flag.filters = {"groups": [{"properties": [], "rollout_percentage": 50}]}
+        flag.save()
+
+        result = verify_team_flag_definitions(self.team, include_cohorts=True, verbose=True)
+
+        assert result["status"] == "mismatch"
+        assert result["issue"] == "DATA_MISMATCH"
+        assert "1 mismatched" in result["details"]
+        field_mismatch_diffs = [d for d in result["diffs"] if d["type"] == "FIELD_MISMATCH"]
+        assert len(field_mismatch_diffs) == 1
+        assert field_mismatch_diffs[0]["flag_key"] == "test-flag"
 
     def test_verify_both_variants_independently(self):
         FeatureFlag.objects.create(

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -258,6 +258,52 @@ class TestFixAndRecord(BaseTest):
         assert result.cache_miss_fixed == 0
         assert result.fix_failed == 1
 
+    def test_uses_db_data_when_available(self):
+        """Test that when verification provides db_data, it's used directly instead of calling update_fn."""
+        mock_config = MagicMock()
+        mock_config.hypercache.set_cache_value.return_value = None
+        mock_config.update_fn.return_value = True
+
+        result = VerificationResult()
+        db_data = {"flags": [{"id": 1, "key": "test-flag"}]}
+        verification = {"status": "miss", "issue": "CACHE_MISS", "db_data": db_data}
+
+        _fix_and_record(
+            team=self.team,
+            config=mock_config,
+            issue_type="cache_miss",
+            cache_type="test_cache",
+            result=result,
+            verification=verification,
+        )
+
+        # Should use set_cache_value with db_data instead of update_fn
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
+        mock_config.update_fn.assert_not_called()
+        assert result.cache_miss_fixed == 1
+        assert self.team.id in result.fixed_team_ids
+
+    def test_falls_back_to_update_fn_without_db_data(self):
+        """Test that when db_data is not available, update_fn is called as before."""
+        mock_config = MagicMock()
+        mock_config.update_fn.return_value = True
+
+        result = VerificationResult()
+        verification = {"status": "miss", "issue": "CACHE_MISS"}
+
+        _fix_and_record(
+            team=self.team,
+            config=mock_config,
+            issue_type="cache_miss",
+            cache_type="test_cache",
+            result=result,
+            verification=verification,
+        )
+
+        mock_config.update_fn.assert_called_once_with(self.team)
+        assert result.cache_miss_fixed == 1
+        assert self.team.id in result.fixed_team_ids
+
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestVerifyAndFixBatch(BaseTest):
@@ -468,6 +514,75 @@ class TestVerifyAndFixBatch(BaseTest):
 
         # Batch infrastructure injects db_data, so set_cache_value is used (not update_fn)
         mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": ["flag1", "flag2"]})
+        mock_config.update_fn.assert_not_called()
+        assert result.expiry_missing_fixed == 1
+
+    @parameterized.expand(
+        [
+            ("cache_miss", {"status": "miss", "issue": "CACHE_MISS"}, {}, "cache_miss_fixed"),
+            ("cache_mismatch", {"status": "mismatch", "issue": "DATA_MISMATCH"}, {}, "cache_mismatch_fixed"),
+        ]
+    )
+    def test_fix_uses_batch_data(self, _name, verification_result, expiry_status, result_attr):
+        """Test that fixes use preloaded batch data via set_cache_value when available."""
+        mock_config = MagicMock()
+        db_data = {"flags": ["flag1", "flag2"]}
+        mock_db_batch_data: dict = {self.team.id: db_data}
+        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+        mock_config.update_fn.return_value = True
+        mock_config.get_team_ids_to_skip_fix_fn = None
+
+        result = VerificationResult()
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            return verification_result
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value=expiry_status):
+            _verify_and_fix_batch(
+                teams=[self.team],
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                result=result,
+            )
+
+        # With batch data available, set_cache_value is used directly (avoiding redundant DB query)
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
+        mock_config.update_fn.assert_not_called()
+        assert getattr(result, result_attr) == 1
+
+    def test_expiry_missing_fix_uses_batch_data(self):
+        """Test that expiry_missing fixes use preloaded batch data via set_cache_value."""
+        mock_config = MagicMock()
+        db_data = {"flags": ["flag1", "flag2"]}
+        mock_db_batch_data: dict = {self.team.id: db_data}
+        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
+        mock_config.update_fn.return_value = True
+        mock_config.get_team_ids_to_skip_fix_fn = None
+
+        result = VerificationResult()
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            # Return match with no db_data - the batch infrastructure injects it
+            return {"status": "match", "issue": None}
+
+        # Expiry status shows this team is NOT tracked (False)
+        expiry_status = {str(self.team.id): False}
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value=expiry_status):
+            _verify_and_fix_batch(
+                teams=[self.team],
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                result=result,
+            )
+
+        # With batch data available, set_cache_value is used directly (avoiding redundant DB query)
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
         mock_config.update_fn.assert_not_called()
         assert result.expiry_missing_fixed == 1
 
@@ -737,9 +852,11 @@ class TestVerifyEmptyCacheTeam(BaseTest):
     """Test _verify_empty_cache_team fast-path verification."""
 
     def test_cache_miss_triggers_fix(self):
-        """Teams with no cache entry should be fixed with empty_cache_value."""
+        """Teams with no cache entry should be fixed via set_cache_value with empty data."""
         mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
+        empty_value = {"flags": []}
+        mock_config.empty_cache_value = empty_value
+        mock_config.update_fn.return_value = True
 
         result = VerificationResult()
         # Cache batch data has no entry for this team (cache miss)
@@ -755,9 +872,10 @@ class TestVerifyEmptyCacheTeam(BaseTest):
             team_ids_to_skip_fix=set(),
         )
 
-        # Should trigger cache_miss fix with empty_cache_value
         assert result.cache_miss_fixed == 1
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": []})
+        # Empty cache value is passed as db_data, so set_cache_value is used directly
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, empty_value)
+        mock_config.update_fn.assert_not_called()
 
     def test_cached_data_none_triggers_fix(self):
         """Teams with cached_data=None should be fixed."""
@@ -781,9 +899,11 @@ class TestVerifyEmptyCacheTeam(BaseTest):
         assert result.cache_miss_fixed == 1
 
     def test_cache_mismatch_triggers_fix(self):
-        """Teams with cached flags but expected empty should be fixed."""
+        """Teams with cached flags but expected empty should be fixed via set_cache_value with empty data."""
         mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
+        empty_value = {"flags": []}
+        mock_config.empty_cache_value = empty_value
+        mock_config.update_fn.return_value = True
 
         result = VerificationResult()
         # Cache has stale data (team used to have flags)
@@ -799,9 +919,10 @@ class TestVerifyEmptyCacheTeam(BaseTest):
             team_ids_to_skip_fix=set(),
         )
 
-        # Should trigger cache_mismatch fix
         assert result.cache_mismatch_fixed == 1
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": []})
+        # Empty cache value is passed as db_data, so set_cache_value is used directly
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, empty_value)
+        mock_config.update_fn.assert_not_called()
 
     def test_cache_match_no_fix(self):
         """Teams with correct empty cache should not trigger fix."""

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -854,7 +854,7 @@ class TestVerifyEmptyCacheTeam(BaseTest):
     def test_cache_miss_triggers_fix(self):
         """Teams with no cache entry should be fixed via set_cache_value with empty data."""
         mock_config = MagicMock()
-        empty_value = {"flags": []}
+        empty_value: dict = {"flags": []}
         mock_config.empty_cache_value = empty_value
         mock_config.update_fn.return_value = True
 
@@ -901,7 +901,7 @@ class TestVerifyEmptyCacheTeam(BaseTest):
     def test_cache_mismatch_triggers_fix(self):
         """Teams with cached flags but expected empty should be fixed via set_cache_value with empty data."""
         mock_config = MagicMock()
-        empty_value = {"flags": []}
+        empty_value: dict = {"flags": []}
         mock_config.empty_cache_value = empty_value
         mock_config.update_fn.return_value = True
 

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -258,52 +258,6 @@ class TestFixAndRecord(BaseTest):
         assert result.cache_miss_fixed == 0
         assert result.fix_failed == 1
 
-    def test_uses_db_data_when_available(self):
-        """Test that when verification provides db_data, it's used directly instead of calling update_fn."""
-        mock_config = MagicMock()
-        mock_config.hypercache.set_cache_value.return_value = None
-        mock_config.update_fn.return_value = True
-
-        result = VerificationResult()
-        db_data = {"flags": [{"id": 1, "key": "test-flag"}]}
-        verification = {"status": "miss", "issue": "CACHE_MISS", "db_data": db_data}
-
-        _fix_and_record(
-            team=self.team,
-            config=mock_config,
-            issue_type="cache_miss",
-            cache_type="test_cache",
-            result=result,
-            verification=verification,
-        )
-
-        # Should use set_cache_value with db_data instead of update_fn
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
-        mock_config.update_fn.assert_not_called()
-        assert result.cache_miss_fixed == 1
-        assert self.team.id in result.fixed_team_ids
-
-    def test_falls_back_to_update_fn_without_db_data(self):
-        """Test that when db_data is not available, update_fn is called as before."""
-        mock_config = MagicMock()
-        mock_config.update_fn.return_value = True
-
-        result = VerificationResult()
-        verification = {"status": "miss", "issue": "CACHE_MISS"}
-
-        _fix_and_record(
-            team=self.team,
-            config=mock_config,
-            issue_type="cache_miss",
-            cache_type="test_cache",
-            result=result,
-            verification=verification,
-        )
-
-        mock_config.update_fn.assert_called_once_with(self.team)
-        assert result.cache_miss_fixed == 1
-        assert self.team.id in result.fixed_team_ids
-
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestVerifyAndFixBatch(BaseTest):
@@ -514,75 +468,6 @@ class TestVerifyAndFixBatch(BaseTest):
 
         # Batch infrastructure injects db_data, so set_cache_value is used (not update_fn)
         mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": ["flag1", "flag2"]})
-        mock_config.update_fn.assert_not_called()
-        assert result.expiry_missing_fixed == 1
-
-    @parameterized.expand(
-        [
-            ("cache_miss", {"status": "miss", "issue": "CACHE_MISS"}, {}, "cache_miss_fixed"),
-            ("cache_mismatch", {"status": "mismatch", "issue": "DATA_MISMATCH"}, {}, "cache_mismatch_fixed"),
-        ]
-    )
-    def test_fix_uses_batch_data(self, _name, verification_result, expiry_status, result_attr):
-        """Test that fixes use preloaded batch data via set_cache_value when available."""
-        mock_config = MagicMock()
-        db_data = {"flags": ["flag1", "flag2"]}
-        mock_db_batch_data: dict = {self.team.id: db_data}
-        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
-        mock_config.hypercache.batch_get_from_cache.return_value = {}
-        mock_config.update_fn.return_value = True
-        mock_config.get_team_ids_to_skip_fix_fn = None
-
-        result = VerificationResult()
-
-        def verify_fn(team, db_batch_data, cache_batch_data):
-            return verification_result
-
-        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value=expiry_status):
-            _verify_and_fix_batch(
-                teams=[self.team],
-                config=mock_config,
-                verify_team_fn=verify_fn,
-                cache_type="test_cache",
-                result=result,
-            )
-
-        # With batch data available, set_cache_value is used directly (avoiding redundant DB query)
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
-        mock_config.update_fn.assert_not_called()
-        assert getattr(result, result_attr) == 1
-
-    def test_expiry_missing_fix_uses_batch_data(self):
-        """Test that expiry_missing fixes use preloaded batch data via set_cache_value."""
-        mock_config = MagicMock()
-        db_data = {"flags": ["flag1", "flag2"]}
-        mock_db_batch_data: dict = {self.team.id: db_data}
-        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
-        mock_config.hypercache.batch_get_from_cache.return_value = {}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
-        mock_config.update_fn.return_value = True
-        mock_config.get_team_ids_to_skip_fix_fn = None
-
-        result = VerificationResult()
-
-        def verify_fn(team, db_batch_data, cache_batch_data):
-            # Return match with no db_data - the batch infrastructure injects it
-            return {"status": "match", "issue": None}
-
-        # Expiry status shows this team is NOT tracked (False)
-        expiry_status = {str(self.team.id): False}
-
-        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value=expiry_status):
-            _verify_and_fix_batch(
-                teams=[self.team],
-                config=mock_config,
-                verify_team_fn=verify_fn,
-                cache_type="test_cache",
-                result=result,
-            )
-
-        # With batch data available, set_cache_value is used directly (avoiding redundant DB query)
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
         mock_config.update_fn.assert_not_called()
         assert result.expiry_missing_fixed == 1
 


### PR DESCRIPTION
## Problem

The flag definitions cache (`flags_with_cohorts.json` / `flags_without_cohorts.json`) used for SDK local evaluation has no verification mechanism. Unlike the flags cache (`flags.json`) and team metadata cache — which have `verify_team_flags()` and `verify_team_metadata()` — there's no way to detect when cached flag definitions drift from the database. If a Django signal fails or a cache entry expires without a flag change, the stale or missing data goes undetected until an SDK request triggers a database fallback.

Closes #44701 (when all 3 PRs are merged)

## Changes

- Add `verify_team_flag_definitions()` function that compares cached flag definitions against the database, detecting missing, stale, and mismatched flags (including cohorts and group_type_mapping).
- Reuse `_compare_flag_fields()` from `flags_cache.py` for field-level diff reporting.
- Include `db_data` in verification return dicts for consistency with the other verify functions, allowing `_fix_and_record()` to write directly to cache without a redundant DB query.
- Improve test coverage for the FIELD_MISMATCH code path and HyperCache verifier's `db_data` optimization path.
- Add `setUp` cleanup to `TestSurveyFlagExclusion` for better test isolation.

PRs 2 and 3 depend on this:
- PR 2: #49155 (Celery tasks + scheduling)
- PR 3: #49156 (Management commands)

## Review notes

`verify_team_flag_definitions()` follows the same pattern as `verify_team_flags()` in `flags_cache.py` and `verify_team_metadata()` in `team_metadata_cache.py`. Comparing any of the three side-by-side is the fastest way to review — the structure is identical (batch data lookup → cache miss check → diff detection → summary). The main differences from `verify_team_flags()` are:

- Flags are compared by `key` instead of `id` (keys are the stable identifier in local evaluation definitions)
- Cohorts and `group_type_mapping` are also compared (these are top-level fields alongside `flags` in the definitions payload)

## How did you test this code?

```bash
pytest posthog/models/feature_flag/test/test_local_evaluation.py -k "TestVerifyFlagDefinitions" -x  # 7 passed
pytest posthog/storage/test/test_hypercache_verifier.py -x  # 54 passed
pytest posthog/models/feature_flag/test/test_local_evaluation.py -x  # 62 passed (full file)
```

`ruff check` passes on all changed files.

## Publish to changelog?

No