### PR TITLE
feat(flags): add management commands for flag definitions cache

### DIFF
--- a/posthog/management/commands/verify_flag_definitions_cache.py
+++ b/posthog/management/commands/verify_flag_definitions_cache.py
@@ -1,0 +1,107 @@
+"""
+Management command to verify flag definitions cache consistency.
+
+Compares cached flag definitions data against database to detect discrepancies.
+Verifies both cache variants (with and without cohorts) used for SDK local evaluation.
+
+Usage:
+    # Verify all teams
+    python manage.py verify_flag_definitions_cache
+
+    # Verify specific teams
+    python manage.py verify_flag_definitions_cache --team-ids 123 456 789
+
+    # Sample random teams
+    python manage.py verify_flag_definitions_cache --sample 100
+
+    # Verify only one variant
+    python manage.py verify_flag_definitions_cache --variant with-cohorts
+    python manage.py verify_flag_definitions_cache --variant without-cohorts
+
+    # Verbose output (show full diffs)
+    python manage.py verify_flag_definitions_cache --verbose
+
+    # Automatically fix cache issues
+    python manage.py verify_flag_definitions_cache --fix
+"""
+
+from typing import Any
+
+from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
+from posthog.models.feature_flag.local_evaluation import (
+    FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
+    FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
+    verify_team_flag_definitions,
+)
+from posthog.models.team import Team
+
+
+class Command(BaseHyperCacheCommand):
+    help = "Verify flag definitions cache consistency against database"
+
+    def add_arguments(self, parser):
+        self.add_common_team_arguments(parser)
+        self.add_verify_arguments(parser)
+        parser.add_argument(
+            "--variant",
+            type=str,
+            choices=["with-cohorts", "without-cohorts"],
+            help="Verify only the specified variant (default: both)",
+        )
+
+    def handle(self, *args, **options):
+        team_ids = options.get("team_ids")
+        sample_size = options.get("sample")
+        verbose = options.get("verbose", False)
+        fix = options.get("fix", False)
+        variant = options.get("variant")
+
+        # Validate input arguments to prevent resource exhaustion
+        if sample_size is not None:
+            if not self.validate_sample_size(sample_size):
+                return
+
+        # Determine which configs to verify
+        configs_to_verify = []
+        if variant == "with-cohorts":
+            configs_to_verify = [(FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts", True)]
+        elif variant == "without-cohorts":
+            configs_to_verify = [(FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts", False)]
+        else:
+            # Verify both variants
+            configs_to_verify = [
+                (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts", True),
+                (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts", False),
+            ]
+
+        # Verify each variant
+        for config, variant_name, include_cohorts in configs_to_verify:
+            self.stdout.write(f"\n{'=' * 70}")
+            self.stdout.write(self.style.SUCCESS(f"Verifying flag definitions cache ({variant_name})"))
+            self.stdout.write("=" * 70)
+
+            # Store config and include_cohorts for the verify_team method
+            # Note: Not thread-safe, but management commands run single-threaded
+            self._current_config = config
+            self._include_cohorts = include_cohorts
+
+            self.run_verification(
+                team_ids=team_ids,
+                sample_size=sample_size,
+                verbose=verbose,
+                fix=fix,
+            )
+
+    def get_hypercache_config(self):
+        """Return the HyperCache management configuration."""
+        return getattr(self, "_current_config", FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG)
+
+    def verify_team(self, team: Team, verbose: bool, batch_data: dict[int, Any] | None = None) -> dict[str, Any]:
+        """Verify a single team's flag definitions cache against the database."""
+        include_cohorts = getattr(self, "_include_cohorts", True)
+        return verify_team_flag_definitions(
+            team,
+            db_batch_data=batch_data,
+            include_cohorts=include_cohorts,
+            verbose=verbose,
+        )

--- a/posthog/management/commands/verify_flag_definitions_cache.py
+++ b/posthog/management/commands/verify_flag_definitions_cache.py
@@ -25,7 +25,7 @@ Usage:
     python manage.py verify_flag_definitions_cache --fix
 """
 
-from typing import Any
+from typing import Any, override
 
 from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
 from posthog.models.feature_flag.local_evaluation import (
@@ -49,7 +49,38 @@ class Command(BaseHyperCacheCommand):
             help="Verify only the specified variant (default: both)",
         )
 
+    @override
+    def format_verbose_diff(self, diff: dict):
+        """
+        Format and print a single diff for verbose verification output.
+
+        Handles the flag-definitions diff structure which uses:
+        - type: MISSING_IN_CACHE, STALE_IN_CACHE, or FIELD_MISMATCH
+        - flag_key: The flag key
+        - field_diffs: (for FIELD_MISMATCH) List of {field, db_value, cached_value}
+        """
+        diff_type = diff.get("type")
+        flag_key = diff.get("flag_key") or str(diff.get("flag_id"))
+
+        if diff_type == "MISSING_IN_CACHE":
+            self.stdout.write(f"  Flag '{flag_key}': exists in DB but missing from cache")
+        elif diff_type == "STALE_IN_CACHE":
+            self.stdout.write(f"  Flag '{flag_key}': exists in cache but deleted from DB")
+        elif diff_type == "FIELD_MISMATCH":
+            self.stdout.write(f"  Flag '{flag_key}': field values differ")
+            field_diffs = diff.get("field_diffs", [])
+            for field_diff in field_diffs:
+                field_name = field_diff.get("field", "unknown_field")
+                self.stdout.write(f"    Field: {field_name}")
+                self.stdout.write(f"      DB:    {field_diff.get('db_value')}")
+                self.stdout.write(f"      Cache: {field_diff.get('cached_value')}")
+        else:
+            # Fallback for unknown diff types (e.g., COHORTS_MISMATCH, GROUP_TYPE_MAPPING_MISMATCH)
+            self.stdout.write(f"  Flag '{flag_key}': {diff_type}")
+
     def handle(self, *args, **options):
+        # No check_dedicated_cache_configured() needed — flag definitions use the
+        # default cache (REDIS_URL), not the dedicated flags cache (FLAGS_REDIS_URL).
         team_ids = options.get("team_ids")
         sample_size = options.get("sample")
         verbose = options.get("verbose", False)

--- a/posthog/management/commands/warm_flag_definitions_cache.py
+++ b/posthog/management/commands/warm_flag_definitions_cache.py
@@ -42,6 +42,8 @@ class Command(BaseHyperCacheCommand):
         )
 
     def handle(self, *args, **options):
+        # No check_dedicated_cache_configured() needed — flag definitions use the
+        # default cache (REDIS_URL), not the dedicated flags cache (FLAGS_REDIS_URL).
         team_ids = options.get("team_ids")
         batch_size = options["batch_size"]
         invalidate_first = options["invalidate_first"]

--- a/posthog/management/commands/warm_flag_definitions_cache.py
+++ b/posthog/management/commands/warm_flag_definitions_cache.py
@@ -1,0 +1,93 @@
+"""
+Management command to warm the flag definitions cache.
+
+This warms both cache variants (with and without cohorts) used for SDK local evaluation.
+
+Usage:
+    # Initial cache warm (preserves existing caches)
+    python manage.py warm_flag_definitions_cache
+
+    # Warm specific teams
+    python manage.py warm_flag_definitions_cache --team-ids 12345 67890
+
+    # Schema changes (invalidates all caches first)
+    python manage.py warm_flag_definitions_cache --invalidate-first
+
+    # Warm only one variant
+    python manage.py warm_flag_definitions_cache --variant with-cohorts
+    python manage.py warm_flag_definitions_cache --variant without-cohorts
+
+    # Custom batch size and TTL range
+    python manage.py warm_flag_definitions_cache --batch-size 200 --min-ttl-days 6 --max-ttl-days 8
+"""
+
+from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
+from posthog.models.feature_flag.local_evaluation import (
+    FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
+    FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
+)
+
+
+class Command(BaseHyperCacheCommand):
+    help = "Warm flag definitions cache for all teams (initial build or schema migration)"
+
+    def add_arguments(self, parser):
+        self.add_common_team_arguments(parser)
+        self.add_warm_arguments(parser)
+        parser.add_argument(
+            "--variant",
+            type=str,
+            choices=["with-cohorts", "without-cohorts"],
+            help="Warm only the specified variant (default: both)",
+        )
+
+    def handle(self, *args, **options):
+        team_ids = options.get("team_ids")
+        batch_size = options["batch_size"]
+        invalidate_first = options["invalidate_first"]
+        stagger_ttl = not options["no_stagger"]
+        min_ttl_days = options["min_ttl_days"]
+        max_ttl_days = options["max_ttl_days"]
+        variant = options.get("variant")
+
+        # Validate input arguments to prevent resource exhaustion
+        if not self.validate_batch_size(batch_size):
+            return
+        if not self.validate_ttl_range(min_ttl_days, max_ttl_days):
+            return
+
+        # Determine which configs to warm
+        configs_to_warm = []
+        if variant == "with-cohorts":
+            configs_to_warm = [(FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts")]
+        elif variant == "without-cohorts":
+            configs_to_warm = [(FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts")]
+        else:
+            # Warm both variants
+            configs_to_warm = [
+                (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts"),
+                (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts"),
+            ]
+
+        # Warm each variant
+        for config, variant_name in configs_to_warm:
+            self.stdout.write(f"\n{'=' * 70}")
+            self.stdout.write(self.style.SUCCESS(f"Warming flag definitions cache ({variant_name})"))
+            self.stdout.write("=" * 70)
+
+            # Store the config for get_hypercache_config()
+            # Note: Not thread-safe, but management commands run single-threaded
+            self._current_config = config
+
+            self.run_warm(
+                team_ids=team_ids,
+                batch_size=batch_size,
+                invalidate_first=invalidate_first,
+                stagger_ttl=stagger_ttl,
+                min_ttl_days=min_ttl_days,
+                max_ttl_days=max_ttl_days,
+            )
+
+    def get_hypercache_config(self):
+        """Return the HyperCache management configuration."""
+        return getattr(self, "_current_config", FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG)

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import override_settings
 
 from parameterized import parameterized
@@ -1324,6 +1325,108 @@ class TestVerifyFlagDefinitions(BaseTest):
         assert "diffs" in result
         mapping_diff = [d for d in result["diffs"] if d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH"]
         assert len(mapping_diff) == 1
+
+
+@override_settings(
+    FLAGS_REDIS_URL="redis://test",
+    CACHES={
+        **settings.CACHES,
+        "flags_dedicated": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "flags-definitions-test",
+        },
+    },
+)
+class TestFlagDefinitionsManagementCommands(BaseTest):
+    """Tests for flag definitions cache management commands."""
+
+    def setUp(self):
+        super().setUp()
+        clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
+
+    def test_verify_command_specific_teams(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command("verify_flag_definitions_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        assert "Verification Results" in output
+        assert "Total teams verified: 1" in output
+
+    def test_verify_command_with_variant_flag(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command(
+            "verify_flag_definitions_cache",
+            f"--team-ids={self.team.id}",
+            "--variant=with-cohorts",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "with cohorts" in output
+        assert output.count("Verification Results") == 1
+
+    def test_warm_command_specific_teams(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command("warm_flag_definitions_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        assert "Flag definitions cache warm completed" in output or "Total teams: 1" in output
+
+    def test_warm_command_with_variant_flag(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command(
+            "warm_flag_definitions_cache",
+            f"--team-ids={self.team.id}",
+            "--variant=with-cohorts",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "with cohorts" in output
 
 
 @override_settings(FLAGS_REDIS_URL=None)

--- a/posthog/models/feature_flag/test/test_local_evaluation.py
+++ b/posthog/models/feature_flag/test/test_local_evaluation.py
@@ -1344,7 +1344,7 @@ class TestFlagDefinitionsManagementCommands(BaseTest):
         super().setUp()
         clear_flag_definition_caches(self.team, kinds=["redis", "s3"])
 
-    def test_verify_command_specific_teams(self):
+    def test_verify_command_processes_both_variants_by_default(self):
         from io import StringIO
 
         from django.core.management import call_command
@@ -1360,8 +1360,9 @@ class TestFlagDefinitionsManagementCommands(BaseTest):
         call_command("verify_flag_definitions_cache", f"--team-ids={self.team.id}", stdout=out)
 
         output = out.getvalue()
-        assert "Verification Results" in output
-        assert "Total teams verified: 1" in output
+        assert "with cohorts" in output
+        assert "without cohorts" in output
+        assert output.count("Verification Results") == 2
 
     def test_verify_command_with_variant_flag(self):
         from io import StringIO
@@ -1385,9 +1386,10 @@ class TestFlagDefinitionsManagementCommands(BaseTest):
 
         output = out.getvalue()
         assert "with cohorts" in output
+        assert "without cohorts" not in output
         assert output.count("Verification Results") == 1
 
-    def test_warm_command_specific_teams(self):
+    def test_warm_command_processes_both_variants_by_default(self):
         from io import StringIO
 
         from django.core.management import call_command
@@ -1403,7 +1405,9 @@ class TestFlagDefinitionsManagementCommands(BaseTest):
         call_command("warm_flag_definitions_cache", f"--team-ids={self.team.id}", stdout=out)
 
         output = out.getvalue()
-        assert "Flag definitions cache warm completed" in output or "Total teams: 1" in output
+        assert "with cohorts" in output
+        assert "without cohorts" in output
+        assert "Successful: 1" in output
 
     def test_warm_command_with_variant_flag(self):
         from io import StringIO
@@ -1427,6 +1431,7 @@ class TestFlagDefinitionsManagementCommands(BaseTest):
 
         output = out.getvalue()
         assert "with cohorts" in output
+        assert "without cohorts" not in output
 
 
 @override_settings(FLAGS_REDIS_URL=None)


### PR DESCRIPTION
## Problem

The flag definitions cache (`flags_with_cohorts.json` / `flags_without_cohorts.json`) used for SDK local evaluation has no operational tooling for manual recovery. Unlike the other caches (`flags.json`, `team_metadata`), operators have no way to:

1. **Manually warm the cache** — if the cache is cold (after a Redis flush, schema migration, or deployment), there's no command to populate it. Recovery requires waiting for Django signals or SDK requests to hit the database.
2. **Manually verify cache consistency** — if cache drift is suspected (stale data, missing entries), there's no command to compare what's in Redis against the database and report or fix discrepancies.

This matters during incident response, after infrastructure changes, or during initial rollout of the cache layer.

Part 3 of 3 splitting #44701 into reviewable pieces. Depends on #49154 (verification logic). Independent of #49155 (Celery tasks).

## Changes

Add two management commands:
- `warm_flag_definitions_cache`: warm both cache variants with support for specific teams, invalidation, TTL staggering, and batch sizing.
- `verify_flag_definitions_cache`: compare cached data against database with support for specific teams, sampling, variant selection, verbose diffs, and auto-fix.

## How did you test this code?

```bash
pytest posthog/models/feature_flag/test/test_local_evaluation.py -k "TestFlagDefinitionsManagementCommands" -x  # 4 passed
pytest posthog/models/feature_flag/test/test_local_evaluation.py -x  # 65 passed (full file)
```

`ruff check` passes on all changed files.

## Publish to changelog?

No