### PR TITLE
feat(capture): misc. prep for high key cardinality global limiter smoke test

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -90,7 +90,12 @@ pub struct Config {
     /// for particular keys.
     pub global_rate_limit_overrides_csv: Option<String>,
 
-    /// Optional dedicated Redis URL for global rate limiter (primary/writer).
+    /// Maximum entries in the local LRU cache for the global rate limiter.
+    /// Higher values use more memory but reduce Redis reads under high key cardinality.
+    #[envconfig(default = "300000")]
+    pub global_rate_limit_local_cache_max_entries: u64,
+
+    /// Optional dedicated Redis URL for global rate limiter.
     /// If set, creates a separate Redis client for the limiter.
     /// Falls back to the shared redis_url if unset.
     pub global_rate_limit_redis_url: Option<String>,

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -49,10 +49,7 @@ impl GlobalRateLimiter {
         config: &Config,
         redis_instances: Vec<Arc<dyn Client + Send + Sync>>,
     ) -> anyhow::Result<Self> {
-        let redis_prefix = format!(
-            "@posthog/capture/global_rate_limiter/{}",
-            config.capture_mode.as_tag()
-        );
+        let redis_prefix = format!("@posthog/capture/grl/{}", config.capture_mode.as_tag());
 
         let grl_config = GlobalRateLimiterConfig {
             global_threshold: config.global_rate_limit_threshold,
@@ -60,6 +57,7 @@ impl GlobalRateLimiter {
             bucket_interval: Duration::from_secs(config.global_rate_limit_bucket_interval_secs),
             redis_key_prefix: redis_prefix,
             custom_keys: Self::format_custom_keys(config.global_rate_limit_overrides_csv.as_ref()),
+            local_cache_max_entries: config.global_rate_limit_local_cache_max_entries,
             ..Default::default()
         };
 

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +14,20 @@ use tracing::{error, info};
 
 #[cfg(test)]
 use chrono::DateTime;
+
+pub enum GlobalRateLimitKey<'a> {
+    Token(&'a str),
+    TokenDistinctId(&'a str, &'a str),
+}
+
+impl<'a> GlobalRateLimitKey<'a> {
+    pub fn to_cache_key(&self) -> Cow<'a, str> {
+        match self {
+            Self::Token(t) => Cow::Borrowed(t),
+            Self::TokenDistinctId(t, d) => Cow::Owned(format!("{t}:{d}")),
+        }
+    }
+}
 
 pub struct GlobalRateLimiter {
     limiter: Box<dyn CommonGlobalRateLimiter>,
@@ -328,5 +343,33 @@ mod tests {
             vec!["is_custom_key", "check_custom_limit"],
             "must NOT call check_limit when key is registered as custom"
         );
+    }
+
+    #[test]
+    fn test_global_rate_limit_key_to_cache_key() {
+        let cases: Vec<(GlobalRateLimitKey, &str, bool)> = vec![
+            (GlobalRateLimitKey::Token("abc"), "abc", true),
+            (GlobalRateLimitKey::Token(""), "", true),
+            (
+                GlobalRateLimitKey::TokenDistinctId("abc", "xyz"),
+                "abc:xyz",
+                false,
+            ),
+            (
+                GlobalRateLimitKey::TokenDistinctId("abc", ""),
+                "abc:",
+                false,
+            ),
+        ];
+
+        for (key, expected, expect_borrowed) in cases {
+            let result = key.to_cache_key();
+            assert_eq!(&*result, expected, "key={expected}");
+            assert_eq!(
+                matches!(result, Cow::Borrowed(_)),
+                expect_borrowed,
+                "key={expected}: expected borrowed={expect_borrowed}"
+            );
+        }
     }
 }

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -136,18 +136,29 @@ pub async fn handle_event_payload(
     };
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "processing complete");
 
-    // Apply global rate limit per team (API token) if enabled
+    // Apply global rate limit per (token, distinct_id) if enabled
     if let Some(global_rate_limiter) = &state.global_rate_limiter {
-        let cache_key = GlobalRateLimitKey::Token(&context.token).to_cache_key();
-        if let Some(limited) = global_rate_limiter
-            .is_limited(&cache_key, events.len() as u64)
-            .await
-        {
-            debug_or_info!(chatty_debug_enabled,
-                context=?context,
-                event_count=?events.len(),
-                details=?limited,
-                "global rate limit applied");
+        let mut is_rate_limited = false;
+        for event in &events {
+            let maybe_distinct_id = event
+                .distinct_id
+                .as_ref()
+                .or_else(|| event.properties.get("distinct_id"))
+                .and_then(|v| v.as_str());
+            if let Some(distinct_id) = maybe_distinct_id {
+                let cache_key =
+                    GlobalRateLimitKey::TokenDistinctId(&context.token, distinct_id).to_cache_key();
+                if let Some(limited) = global_rate_limiter.is_limited(&cache_key, 1).await {
+                    debug_or_info!(chatty_debug_enabled,
+                        context=?context,
+                        distinct_id,
+                        details=?limited,
+                        "global rate limit applied");
+                    is_rate_limited = true;
+                }
+            }
+        }
+        if is_rate_limited {
             return Err(CaptureError::GlobalRateLimitExceeded());
         }
     }

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -16,6 +16,7 @@ use crate::{
     api::CaptureError,
     debug_or_info,
     extractors::extract_body_with_timeout,
+    global_rate_limiter::GlobalRateLimitKey,
     payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     utils::extract_and_verify_token,
@@ -137,8 +138,9 @@ pub async fn handle_event_payload(
 
     // Apply global rate limit per team (API token) if enabled
     if let Some(global_rate_limiter) = &state.global_rate_limiter {
+        let cache_key = GlobalRateLimitKey::Token(&context.token).to_cache_key();
         if let Some(limited) = global_rate_limiter
-            .is_limited(&context.token, events.len() as u64)
+            .is_limited(&cache_key, events.len() as u64)
             .await
         {
             debug_or_info!(chatty_debug_enabled,

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -16,6 +16,7 @@ use crate::{
     debug_or_info,
     events::recordings::RawRecording,
     extractors::extract_body_with_timeout,
+    global_rate_limiter::GlobalRateLimitKey,
     payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     v0_request::ProcessingContext,
@@ -131,8 +132,9 @@ pub async fn handle_recording_payload(
 
     // Apply global rate limit per team (API token) if enabled
     if let Some(global_rate_limiter) = &state.global_rate_limiter {
+        let cache_key = GlobalRateLimitKey::Token(&context.token).to_cache_key();
         if let Some(limited) = global_rate_limiter
-            .is_limited(&context.token, events.len() as u64)
+            .is_limited(&cache_key, events.len() as u64)
             .await
         {
             debug_or_info!(chatty_debug_enabled,

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -130,18 +130,29 @@ pub async fn handle_recording_payload(
         chatty_debug_enabled,
     };
 
-    // Apply global rate limit per team (API token) if enabled
+    // Apply global rate limit per (token, distinct_id) if enabled
     if let Some(global_rate_limiter) = &state.global_rate_limiter {
-        let cache_key = GlobalRateLimitKey::Token(&context.token).to_cache_key();
-        if let Some(limited) = global_rate_limiter
-            .is_limited(&cache_key, events.len() as u64)
-            .await
-        {
-            debug_or_info!(chatty_debug_enabled,
-                context=?context,
-                event_count=?events.len(),
-                details=?limited,
-                "global rate limit applied");
+        let mut is_rate_limited = false;
+        for event in &events {
+            let maybe_distinct_id = event
+                .distinct_id
+                .as_ref()
+                .or(event.properties.distinct_id.as_ref())
+                .and_then(|v| v.as_str());
+            if let Some(distinct_id) = maybe_distinct_id {
+                let cache_key =
+                    GlobalRateLimitKey::TokenDistinctId(&context.token, distinct_id).to_cache_key();
+                if let Some(limited) = global_rate_limiter.is_limited(&cache_key, 1).await {
+                    debug_or_info!(chatty_debug_enabled,
+                        context=?context,
+                        distinct_id,
+                        details=?limited,
+                        "global rate limit applied");
+                    is_rate_limited = true;
+                }
+            }
+        }
+        if is_rate_limited {
             return Err(CaptureError::GlobalRateLimitExceeded());
         }
     }

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -42,6 +42,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     global_rate_limit_threshold: 10_000,
     global_rate_limit_window_interval_secs: 60,
     global_rate_limit_bucket_interval_secs: 10,
+    global_rate_limit_local_cache_max_entries: 300_000,
     global_rate_limit_overrides_csv: None,
     global_rate_limit_redis_url: None,
     global_rate_limit_redis_reader_url: None,


### PR DESCRIPTION
## Problem
Prep for smoke testing high-cardinality key tracking (`token:distinct_id`) in `capture` GRL
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Abstract key builder in `capture`
* Update limit check loops (per event instead of 1-shot per token/batch)
* Expose `capture` cfg var for local LRU cache size (we'll need to dial this _up_) 
*  Related test updates

Keeping this simple so we can get testing ASAP. Will add multiple limiter instances to split `token` and `token:distinct_id` caches with their own thresholds, override lists (and _possibly_ their own Redises?!) once we know if this works well out of the box for the `token:distinct_id` variant.

If not, I have some changes staged to the underlying limiter to further reduce Redis load that I can smoke test using this rig 👍 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. 🚬  tests on the way 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
