### PR TITLE
feat(deduplicator): raise LimitStore caps 

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -105,8 +105,8 @@ impl Default for CheckpointConfig {
             s3_attempt_timeout: Duration::from_secs(20),
             s3_max_retries: 3,
             checkpoint_import_attempt_depth: 10,
-            max_concurrent_checkpoint_file_downloads: 100,
-            max_concurrent_checkpoint_file_uploads: 100,
+            max_concurrent_checkpoint_file_downloads: 1000,
+            max_concurrent_checkpoint_file_uploads: 1000,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
         }
     }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -267,12 +267,12 @@ pub struct Config {
     // Limits memory usage by bounding the number of in-flight HTTP connections
     // Critical during rebalance when many partitions are assigned simultaneously
     // Higher values speed up rebalance; streaming bounds memory per download to ~8KB
-    #[envconfig(default = "100")]
+    #[envconfig(default = "1000")]
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export
     // Less critical than downloads since uploads are bounded by max_concurrent_checkpoints
-    #[envconfig(default = "100")]
+    #[envconfig(default = "1000")]
     pub max_concurrent_checkpoint_file_uploads: usize,
 
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).


### PR DESCRIPTION
## Problem
With our new path prefix strategy, we should be unblocked to greatly increase `LimitStore` caps on S3 upload/downloads.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* 10x both configs
* Observe and if this has the desired effect
* Increase further until bottlenecks surface 🚀 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and CI. PoC env smoke tests on the way when this lands
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
