### PR TITLE
feat(experiments): extracting experiment tab content component.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentTabContent.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent.tsx
@@ -14,13 +14,11 @@ import { Experiment, FeatureFlagType } from '~/types'
 
 type ExperimentTabContentProps = {
     featureFlag: FeatureFlagType
-    emptyStateBannerMessage: string
     multipleExperimentsBannerMessage: React.ReactNode
 }
 
 export const ExperimentTabContent = ({
     featureFlag,
-    emptyStateBannerMessage,
     multipleExperimentsBannerMessage,
 }: ExperimentTabContentProps): JSX.Element => {
     const { experiments } = useValues(experimentsLogic)
@@ -33,7 +31,7 @@ export const ExperimentTabContent = ({
             <div className="flex flex-col items-center pt-5">
                 <div className="w-full max-w-5xl">
                     <LemonBanner type="info" className="mb-6">
-                        {emptyStateBannerMessage}
+                        No experiments are using this feature flag yet. Create one to start testing variants.
                     </LemonBanner>
                     <div className="border rounded p-6 bg-bg-light flex flex-col items-center gap-4">
                         <div className="text-muted text-center">

--- a/frontend/src/scenes/experiments/ExperimentTabContent.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent.tsx
@@ -1,0 +1,90 @@
+import { useValues } from 'kea'
+
+import { LemonBanner, LemonButton, LemonTable } from '@posthog/lemon-ui'
+
+import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import type { LemonTableColumn } from 'lib/lemon-ui/LemonTable/types'
+import stringWithWBR from 'lib/utils/stringWithWBR'
+import { experimentsLogic, getExperimentStatus } from 'scenes/experiments/experimentsLogic'
+import { StatusTag } from 'scenes/experiments/ExperimentView/components'
+import { urls } from 'scenes/urls'
+
+import { Experiment, FeatureFlagType } from '~/types'
+
+type ExperimentTabContentProps = {
+    featureFlag: FeatureFlagType
+    emptyStateBannerMessage: string
+    multipleExperimentsBannerMessage: React.ReactNode
+}
+
+export const ExperimentTabContent = ({
+    featureFlag,
+    emptyStateBannerMessage,
+    multipleExperimentsBannerMessage,
+}: ExperimentTabContentProps): JSX.Element => {
+    const { experiments } = useValues(experimentsLogic)
+    const relatedExperiments = experiments.results.filter((exp) =>
+        featureFlag.experiment_set?.includes(exp.id as number)
+    )
+
+    if (relatedExperiments.length === 0) {
+        return (
+            <div className="flex flex-col items-center pt-5">
+                <div className="w-full max-w-5xl">
+                    <LemonBanner type="info" className="mb-6">
+                        {emptyStateBannerMessage}
+                    </LemonBanner>
+                    <div className="border rounded p-6 bg-bg-light flex flex-col items-center gap-4">
+                        <div className="text-muted text-center">
+                            No experiments are using this feature flag yet. Create one to start testing variants.
+                        </div>
+                        <LemonButton type="primary" to={urls.experiment('new')}>
+                            Create experiment
+                        </LemonButton>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-6">
+            <LemonBanner type="info">{multipleExperimentsBannerMessage}</LemonBanner>
+
+            <LemonTable
+                dataSource={relatedExperiments}
+                defaultSorting={{
+                    columnKey: 'created_at',
+                    order: -1,
+                }}
+                rowKey="id"
+                nouns={['experiment', 'experiments']}
+                data-attr="experiments-table"
+                columns={[
+                    {
+                        dataIndex: 'name',
+                        title: 'Name',
+                        render: function RenderName(_, experiment: Experiment) {
+                            return (
+                                <LemonTableLink
+                                    to={urls.experiment(experiment.id)}
+                                    title={stringWithWBR(experiment.name, 17)}
+                                />
+                            )
+                        },
+                    },
+                    {
+                        title: 'Status',
+                        dataIndex: 'id',
+                        render: function RenderStatus(_, experiment: Experiment) {
+                            const status = getExperimentStatus(experiment)
+                            return <StatusTag status={status} />
+                        },
+                    },
+                    createdAtColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
+                ]}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
@@ -1,86 +1,23 @@
-import { useValues } from 'kea'
-
 import { IconArrowRight } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonTable, Link } from '@posthog/lemon-ui'
+import { Link } from '@posthog/lemon-ui'
 
-import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
-import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import type { LemonTableColumn } from 'lib/lemon-ui/LemonTable/types'
-import stringWithWBR from 'lib/utils/stringWithWBR'
-import { experimentsLogic, getExperimentStatus } from 'scenes/experiments/experimentsLogic'
-import { StatusTag } from 'scenes/experiments/ExperimentView/components'
+import { ExperimentTabContent } from 'scenes/experiments/ExperimentTabContent'
 import { urls } from 'scenes/urls'
 
-import { Experiment, FeatureFlagType } from '~/types'
+import type { FeatureFlagType } from '~/types'
 
 export function ExperimentsTab({ featureFlag }: { featureFlag: FeatureFlagType }): JSX.Element {
-    const { experiments } = useValues(experimentsLogic)
-    const relatedExperiments = experiments.results.filter((exp) =>
-        featureFlag.experiment_set?.includes(exp.id as number)
-    )
-
-    if (relatedExperiments.length === 0) {
-        return (
-            <div className="flex flex-col items-center pt-5">
-                <div className="w-full max-w-5xl">
-                    <LemonBanner type="info" className="mb-6">
-                        Create an experiment using this feature flag to test different variants and measure their impact
-                    </LemonBanner>
-                    <div className="border rounded p-6 bg-bg-light flex flex-col items-center gap-4">
-                        <div className="text-muted text-center">
-                            No experiments are using this feature flag yet. Create one to start testing variants.
-                        </div>
-                        <LemonButton type="primary" to={urls.experiment('new')}>
-                            Create experiment
-                        </LemonButton>
-                    </div>
-                </div>
-            </div>
-        )
-    }
-
     return (
-        <div className="space-y-6">
-            <LemonBanner type="info">
-                Showing experiments associated with this feature flag.{' '}
-                <Link to={urls.experiments()}>
-                    See all experiments <IconArrowRight />
-                </Link>
-            </LemonBanner>
-
-            <LemonTable
-                dataSource={relatedExperiments}
-                defaultSorting={{
-                    columnKey: 'created_at',
-                    order: -1,
-                }}
-                rowKey="id"
-                nouns={['experiment', 'experiments']}
-                data-attr="experiments-table"
-                columns={[
-                    {
-                        dataIndex: 'name',
-                        title: 'Name',
-                        render: function RenderName(_, experiment: Experiment) {
-                            return (
-                                <LemonTableLink
-                                    to={urls.experiment(experiment.id)}
-                                    title={stringWithWBR(experiment.name, 17)}
-                                />
-                            )
-                        },
-                    },
-                    {
-                        title: 'Status',
-                        dataIndex: 'id',
-                        render: function RenderStatus(_, experiment: Experiment) {
-                            const status = getExperimentStatus(experiment)
-                            return <StatusTag status={status} />
-                        },
-                    },
-                    createdAtColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
-                ]}
-            />
-        </div>
+        <ExperimentTabContent
+            featureFlag={featureFlag}
+            multipleExperimentsBannerMessage={
+                <>
+                    Showing experiments associated with this feature flag.{' '}
+                    <Link to={urls.experiments()}>
+                        See all experiments <IconArrowRight />
+                    </Link>
+                </>
+            }
+        />
     )
 }


### PR DESCRIPTION
## Problem

We don't want to pollute the _Feature flag_ scene folder with a collection of experiment files. We need to make this easier to manage.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are extracting the existing content of the `ExperimentsTab` component (`FeatureFlagExperimentsTab.tsx`) into a new component on the _Experiments_ scene. Any new feature we add to the tab (and its components) will live in the experiments folder.

There are no code changes (those will come later), and there should be no regressions. This is hidden under a feature flag.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/3a3d7d99-6384-4f59-ae03-0d0ed7690071)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
