### PR TITLE
fix: ensure refresh token inherits same scopes as parent

### DIFF
--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -246,7 +246,9 @@ class OAuthValidator(OAuth2Validator):
             scoped_teams = grant.scoped_teams
             scoped_organizations = grant.scoped_organizations
 
-        if request.decoded_body:
+        # Only fall back to the authorization code when no other scope source exists,
+        # so a `code` param injected into a refresh request cannot escalate scopes.
+        if scoped_teams is None and scoped_organizations is None and request.decoded_body:
             try:
                 code = dict(request.decoded_body).get("code", None)
                 if code:


### PR DESCRIPTION
Previously, an OAuth refresh token request that included a `code` parameter from a broader-scope authorization grant could escalate the token's scopes beyond what was originally authorized.