### PR TITLE
fix: Validate format of Mailchimp API key

### DIFF
--- a/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/mailchimp.py
@@ -20,7 +20,10 @@ def extract_data_center(api_key: str) -> str:
     """
     if "-" not in api_key:
         raise ValueError("Invalid Mailchimp API key format. Expected format: key-dc")
-    return api_key.split("-")[-1]
+    dc = api_key.split("-")[-1]
+    if not dc.isalnum():
+        raise ValueError("Invalid Mailchimp API key format. Expected format: key-dc")
+    return dc
 
 
 def _format_incremental_value(value: Any) -> str:

--- a/posthog/temporal/data_imports/sources/mailchimp/tests/test_mailchimp.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/tests/test_mailchimp.py
@@ -21,6 +21,21 @@ class TestExtractDataCenter:
         with pytest.raises(ValueError, match="Invalid Mailchimp API key format"):
             extract_data_center("invalidkey")
 
+    @pytest.mark.parametrize(
+        "malicious_key",
+        [
+            "key-evil.com/#",
+            "key-evil.com/path",
+            "key-us6.attacker.com",
+            "key-dc:8080",
+            "key-",
+            "key- spaces",
+        ],
+    )
+    def test_malicious_dc_values_raise(self, malicious_key):
+        with pytest.raises(ValueError, match="Invalid Mailchimp API key format"):
+            extract_data_center(malicious_key)
+
 
 class TestFormatIncrementalValue:
     def test_datetime(self):


### PR DESCRIPTION
Users could previously provide an invalid API key.