### PR TITLE
fix(ci): add pnpm-workspace.yaml to storybook filter paths

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -41,6 +41,7 @@ jobs:
                         - 'ee/frontend/**'
                         - '.storybook/**'
                         - 'package.json'
+                        - 'pnpm-workspace.yaml'
                         - '.github/workflows/ci-storybook.yml'
                         - 'playwright.config.ts'
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -42,6 +42,7 @@ jobs:
                         - '.storybook/**'
                         - 'package.json'
                         - 'pnpm-workspace.yaml'
+                        - 'pnpm-lock.yaml'
                         - '.github/workflows/ci-storybook.yml'
                         - 'playwright.config.ts'
 


### PR DESCRIPTION
## Summary

- The posthog-js 1.354.2 upgrade (#49122) broke visual regression snapshots on master (`TrendsLine` stories — 18% pixel diff, height changed from 926px to 958px)
- The upgrade PR only changed `pnpm-workspace.yaml` and `pnpm-lock.yaml`, neither of which was in the storybook CI filter paths, so visual regression tests were **skipped entirely** on the PR
- The breakage was only detected after merge to master, where push events run all tests regardless of filter
- This PR adds `pnpm-workspace.yaml` to the filter, and since the CI workflow file itself is in the filter, this PR will trigger the visual regression suite, which will auto-update the stale snapshots

## Test plan

- [ ] CI runs the visual regression suite (triggered by the workflow file change)
- [ ] `handle-snapshots` job auto-commits updated snapshot images
- [ ] After merge, master visual regression tests pass again