### PR TITLE
feat: add filter for channels to tickets + fixes

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -294,28 +294,35 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         </div>
                     </LemonCard>
 
-                    {/* Session Recording Panel */}
-                    <SessionRecordingPanel sessionContext={ticket?.session_context} distinctId={ticket?.distinct_id} />
+                    {ticket?.channel_source === 'widget' && (
+                        <>
+                            {/* Session Recording Panel */}
+                            <SessionRecordingPanel
+                                sessionContext={ticket?.session_context}
+                                distinctId={ticket?.distinct_id}
+                            />
 
-                    {/* Recent Events Panel */}
-                    <RecentEventsPanel
-                        eventsQuery={eventsQuery}
-                        distinctId={ticket?.distinct_id}
-                        sessionId={ticket?.session_id}
-                    />
+                            {/* Recent Events Panel */}
+                            <RecentEventsPanel
+                                eventsQuery={eventsQuery}
+                                distinctId={ticket?.distinct_id}
+                                sessionId={ticket?.session_id}
+                            />
 
-                    {/* Exceptions Panel */}
-                    <ExceptionsPanel
-                        exceptionsQuery={exceptionsQuery}
-                        sessionId={ticket?.session_id}
-                        distinctId={ticket?.distinct_id}
-                    />
+                            {/* Exceptions Panel */}
+                            <ExceptionsPanel
+                                exceptionsQuery={exceptionsQuery}
+                                sessionId={ticket?.session_id}
+                                distinctId={ticket?.distinct_id}
+                            />
 
-                    {/* Previous Tickets Panel */}
-                    <PreviousTicketsPanel
-                        previousTickets={previousTickets}
-                        previousTicketsLoading={previousTicketsLoading}
-                    />
+                            {/* Previous Tickets Panel */}
+                            <PreviousTicketsPanel
+                                previousTickets={previousTickets}
+                                previousTicketsLoading={previousTicketsLoading}
+                            />
+                        </>
+                    )}
                 </div>
             </div>
         </SceneContent>

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../components/Assignee'
 import { ChannelsTag } from '../../components/Channels/ChannelsTag'
 import { ScenesTabs } from '../../components/ScenesTabs'
-import { type Ticket, priorityMultiselectOptions, statusMultiselectOptions } from '../../types'
+import { type Ticket, channelOptions, priorityMultiselectOptions, statusMultiselectOptions } from '../../types'
 import { SUPPORT_TICKETS_PAGE_SIZE, supportTicketsSceneLogic } from './supportTicketsSceneLogic'
 
 export const scene: SceneExport = {
@@ -41,6 +41,7 @@ export function SupportTicketsScene(): JSX.Element {
         filteredTickets,
         statusFilter,
         priorityFilter,
+        channelFilter,
         assigneeFilter,
         dateFrom,
         dateTo,
@@ -48,8 +49,15 @@ export function SupportTicketsScene(): JSX.Element {
         currentPage,
         totalCount,
     } = useValues(logic)
-    const { setStatusFilter, setPriorityFilter, setAssigneeFilter, setDateRange, setCurrentPage, loadTickets } =
-        useActions(logic)
+    const {
+        setStatusFilter,
+        setPriorityFilter,
+        setChannelFilter,
+        setAssigneeFilter,
+        setDateRange,
+        setCurrentPage,
+        loadTickets,
+    } = useActions(logic)
     const { push } = useActions(router)
 
     return (
@@ -141,6 +149,29 @@ export function SupportTicketsScene(): JSX.Element {
                                 : priorityFilter.length === 1
                                   ? priorityMultiselectOptions.find((o) => o.key === priorityFilter[0])?.label
                                   : `${priorityFilter.length} priorities`}
+                        </LemonButton>
+                    </LemonDropdown>
+                    <LemonDropdown
+                        closeOnClickInside
+                        overlay={
+                            <div className="space-y-px p-1">
+                                {channelOptions.map((option) => (
+                                    <LemonButton
+                                        key={option.value}
+                                        type="tertiary"
+                                        size="small"
+                                        fullWidth
+                                        onClick={() => setChannelFilter(option.value)}
+                                        active={channelFilter === option.value}
+                                    >
+                                        {option.label}
+                                    </LemonButton>
+                                ))}
+                            </div>
+                        }
+                    >
+                        <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                            {channelOptions.find((o) => o.value === channelFilter)?.label ?? 'All channels'}
                         </LemonButton>
                     </LemonDropdown>
                     <AssigneeSelect

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -148,7 +148,7 @@ export const channelOptions: { value: TicketChannel | 'all'; label: string }[] =
     { value: 'all', label: 'All channels' },
     { value: 'widget', label: 'Widget' },
     { value: 'slack', label: 'Slack' },
-    { value: 'email', label: 'Email' },
+    /*{ value: 'email', label: 'Email' }, commented out because we don't support email yet*/
 ]
 
 export const slaOptions: { value: TicketSlaState | 'all'; label: string }[] = [


### PR DESCRIPTION
2 things:
1. add filter by channel to the tickets list
2. do not show additional info in the ticket for slack channel

<img width="475" height="254" alt="Screenshot 2026-02-26 at 10 00 22" src="https://github.com/user-attachments/assets/16a7585d-892f-4cb1-9527-d6009bd3b646" />
