### PR TITLE
fix(experiments): Copy exposure_preaggregation_enabled when duplicating experiment

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -1023,6 +1023,7 @@ class EnterpriseExperimentsViewSet(
             "feature_flag_key": feature_flag_key,  # Use provided key or fall back to existing
             "primary_metrics_ordered_uuids": source_experiment.primary_metrics_ordered_uuids,
             "secondary_metrics_ordered_uuids": source_experiment.secondary_metrics_ordered_uuids,
+            "exposure_preaggregation_enabled": source_experiment.exposure_preaggregation_enabled,
             # Reset fields for new experiment
             "start_date": None,
             "end_date": None,


### PR DESCRIPTION
## Problem

When duplicating an experiment, the `exposure_preaggregation_enabled` field was not included in the data dict passed to the serializer.

## Changes

Add `exposure_preaggregation_enabled` in the duplication endpoint.