### PR TITLE
fix(experiments): Allow camelcase feature flag names

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -688,10 +688,15 @@ export function clearDOMTextSelection(): void {
 }
 
 // trimBothEnds=false is useful when the input is slugified as the user is typing to allow them hitting space and continue typing
-export function slugify(text: string, { trimBothEnds = true }: { trimBothEnds?: boolean } = {}): string {
-    return text
-        .toString() // Cast to string
-        .toLowerCase() // Convert the string to lowercase letters
+export function slugify(
+    text: string,
+    { trimBothEnds = true, lowercase = true }: { trimBothEnds?: boolean; lowercase?: boolean } = {}
+): string {
+    let result = text.toString()
+    if (lowercase) {
+        result = result.toLowerCase()
+    }
+    return result
         .normalize('NFD') // The normalize() method returns the Unicode Normalization Form of a given string.
         [trimBothEnds ? 'trim' : 'trimStart']()
         .replace(/\s+/g, '-') // Replace spaces with -

--- a/frontend/src/scenes/experiments/ExperimentWizard/steps/AboutStep.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/steps/AboutStep.tsx
@@ -6,7 +6,7 @@ import { LemonInput, Link } from '@posthog/lemon-ui'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { Spinner } from 'lib/lemon-ui/Spinner'
-import { slugify } from 'lib/utils'
+import { slugifyFeatureFlagKey } from 'scenes/feature-flags/featureFlagLogic'
 
 import { SelectExistingFeatureFlagModal } from '../../ExperimentForm/SelectExistingFeatureFlagModal'
 import { selectExistingFeatureFlagModalLogic } from '../../ExperimentForm/selectExistingFeatureFlagModalLogic'
@@ -53,8 +53,11 @@ export function AboutStep(): JSX.Element {
                     value={experiment.name}
                     onChange={(value) => {
                         setExperimentValue('name', value)
-                        if (!experiment.feature_flag_key || experiment.feature_flag_key === slugify(experiment.name)) {
-                            const newKey = slugify(value)
+                        if (
+                            !experiment.feature_flag_key ||
+                            experiment.feature_flag_key === slugifyFeatureFlagKey(experiment.name)
+                        ) {
+                            const newKey = slugifyFeatureFlagKey(value)
                             setExperimentValue('feature_flag_key', newKey)
                             debouncedValidateFeatureFlagKey(newKey)
                         }
@@ -106,7 +109,7 @@ export function AboutStep(): JSX.Element {
                         placeholder="e.g., new-checkout-flow-test"
                         value={experiment.feature_flag_key ?? ''}
                         onChange={(value) => {
-                            const normalizedValue = slugify(value, { trimBothEnds: false })
+                            const normalizedValue = slugifyFeatureFlagKey(value, { trimBothEnds: false })
                             setExperimentValue('feature_flag_key', normalizedValue)
                             debouncedValidateFeatureFlagKey(normalizedValue)
                         }}

--- a/frontend/src/scenes/experiments/ExperimentWizard/steps/AboutStep.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/steps/AboutStep.tsx
@@ -55,9 +55,10 @@ export function AboutStep(): JSX.Element {
                         setExperimentValue('name', value)
                         if (
                             !experiment.feature_flag_key ||
-                            experiment.feature_flag_key === slugifyFeatureFlagKey(experiment.name)
+                            experiment.feature_flag_key ===
+                                slugifyFeatureFlagKey(experiment.name, { fromTitleInput: true })
                         ) {
-                            const newKey = slugifyFeatureFlagKey(value)
+                            const newKey = slugifyFeatureFlagKey(value, { fromTitleInput: true })
                             setExperimentValue('feature_flag_key', newKey)
                             debouncedValidateFeatureFlagKey(newKey)
                         }
@@ -109,7 +110,7 @@ export function AboutStep(): JSX.Element {
                         placeholder="e.g., new-checkout-flow-test"
                         value={experiment.feature_flag_key ?? ''}
                         onChange={(value) => {
-                            const normalizedValue = slugifyFeatureFlagKey(value, { trimBothEnds: false })
+                            const normalizedValue = slugifyFeatureFlagKey(value)
                             setExperimentValue('feature_flag_key', normalizedValue)
                             debouncedValidateFeatureFlagKey(normalizedValue)
                         }}

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -170,9 +170,14 @@ export function hasMultipleVariantsActive(filters: FeatureFlagType['filters'] | 
 }
 
 // Normalize a value into a valid feature flag key: spaces to dashes, strip invalid chars.
-// Note that lowercase should not be enforced as users use camelCase as well
-export function slugifyFeatureFlagKey(value: string, { trimBothEnds = true }: { trimBothEnds?: boolean } = {}): string {
-    return slugify(value, { lowercase: false, trimBothEnds })
+// fromTitleInput: when auto-filling from a name field, downcase and trim both ends.
+// Direct key input preserves case and only trims the start (so users can can continue typing with spaces).
+// Note that lowercase should not be enforced as users do use camelCase or UPPERCASE
+export function slugifyFeatureFlagKey(
+    value: string,
+    { fromTitleInput = false }: { fromTitleInput?: boolean } = {}
+): string {
+    return slugify(value, { lowercase: fromTitleInput, trimBothEnds: fromTitleInput })
 }
 
 /** Check whether a string is a valid feature flag key. If not, a reason string is returned - otherwise undefined. */

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -23,6 +23,7 @@ import { Dayjs } from 'lib/dayjs'
 import { scrollToFormError } from 'lib/forms/scrollToFormError'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
+import { slugify } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { experimentLogic } from 'scenes/experiments/experimentLogic'
@@ -166,6 +167,12 @@ export function hasMultipleVariantsActive(filters: FeatureFlagType['filters'] | 
         return false
     }
     return variants.filter(({ rollout_percentage }) => rollout_percentage !== 0).length > 1
+}
+
+// Normalize a value into a valid feature flag key: spaces to dashes, strip invalid chars.
+// Note that lowercase should not be enforced as users use camelCase as well
+export function slugifyFeatureFlagKey(value: string, { trimBothEnds = true }: { trimBothEnds?: boolean } = {}): string {
+    return slugify(value, { lowercase: false, trimBothEnds })
 }
 
 /** Check whether a string is a valid feature flag key. If not, a reason string is returned - otherwise undefined. */


### PR DESCRIPTION
## Problem

A user uses gave us feedback they use camelcase feature flag names, which was not supported in experiment FF key normalization.

## Changes

- Allow uppercase when modifying the feature flag key in the experiment form
- Improve UX by not trimming last space when entering feature flag key field directly (better typing experience)

## How did you test this code?

Manually

## Publish to changelog?

No