### PR TITLE
fix(llma): bump sentiment timeout from 60s to 120s

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -22,8 +22,8 @@ QUERY_LOOKBACK_DAYS = 30  # timestamp filter to enable partition pruning
 
 # Temporal workflow/activity config
 WORKFLOW_NAME = "llma-sentiment-classify"
-ACTIVITY_TIMEOUT_SECONDS = 60  # start-to-close timeout for classify activity
-WORKFLOW_TIMEOUT_BATCH_SECONDS = 60  # task timeout for sentiment workflow
+ACTIVITY_TIMEOUT_SECONDS = 120  # start-to-close timeout for classify activity
+WORKFLOW_TIMEOUT_BATCH_SECONDS = 120  # task timeout for sentiment workflow
 MAX_RETRY_ATTEMPTS = 2  # retry policy for both workflow and activity
 
 # API config


### PR DESCRIPTION
## Problem

The sentiment classification activity timeout (60s) is too tight. Grafana dashboard shows:

- Activity execution latency P95 at 59.1s (right at the limit)
- Activity execution latency P99 at 1.78 min (well over the limit)
- 24h workflow success rate at 99.858% — the ~0.14% failures are timeout kills

Tail activities processing larger traces legitimately need more time for ONNX inference but are being killed at 60s.

## Changes

Bump both `ACTIVITY_TIMEOUT_SECONDS` and `WORKFLOW_TIMEOUT_BATCH_SECONDS` from 60s to 120s in `posthog/temporal/llm_analytics/sentiment/constants.py`.

This is safe because the cascading retry problem (where timed-out activities pile up zombie threads) was already solved by the query-level workload reduction in PR #48980. The 120s limit gives:
- Plenty of headroom for P95 (~59s)
- Coverage for most P99 cases (~107s)
- A 2x safety margin over the typical P50 (~7-13s)

## How did you test this code?

Constants-only change — verified the two constants are referenced in the expected places (`workflow.py` for activity timeout, `sentiment.py` for workflow timeout). No logic changes.

## Publish to changelog?

No