### PR TITLE
fix(experiments): Add back note about incompatibilities in feature flag auth persistance

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -476,12 +476,13 @@ export const VariantsPanelCreateFeatureFlag = ({
                     }
                 />
                 <div className="text-secondary text-sm pl-6 mt-2">
-                    This is only relevant if your feature flag is shown to both logged out AND logged in users.{' '}
+                    This is only relevant if your feature flag is shown to both logged out AND logged in users. Note
+                    that this feature is not compatible with all setups,{' '}
                     <Link
                         to="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
                         target="_blank"
                     >
-                        Learn more
+                        learn more
                     </Link>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

Reintroducing a note about incompatibilities for feature flag auth persistance. A longer version got removed when simplifying the form, see https://github.com/PostHog/posthog/pull/46591/changes#diff-ba1ad25383ab2f322c1ff527a9672741d193e3ca336f66bc4f2361acfff64120L342 , this PR adds a smaller note back

## Changes

- Add text

## How did you test this code?

Manually