### PR TITLE
chore(ph-ai): billing context for ticket command from billing be

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from uuid import uuid4
+
+import structlog
+
+if TYPE_CHECKING:
+    from posthog.models import Organization
 
 from django.conf import settings
 from django.utils import timezone
 
+from asgiref.sync import sync_to_async
 from langchain_core.messages import (
     AIMessage,
     HumanMessage as LangchainHumanMessage,
@@ -11,14 +20,19 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables import RunnableConfig
 
-from posthog.schema import AssistantMessage, HumanMessage, MaxBillingContext, MaxBillingContextSubscriptionLevel
+from posthog.schema import AssistantMessage, HumanMessage
 
+from posthog.cloud_utils import get_cached_instance_license
+
+from ee.billing.billing_manager import BillingManager
 from ee.hogai.chat_agent.slash_commands.commands import SlashCommand
 from ee.hogai.core.agent_modes.compaction_manager import AnthropicConversationCompactionManager
 from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.utils.types import AssistantMessageUnion, AssistantState, PartialAssistantState
 
 from .prompts import SUPPORT_SUMMARIZER_SYSTEM_PROMPT, SUPPORT_SUMMARIZER_USER_PROMPT
+
+logger = structlog.get_logger(__name__)
 
 
 class TicketCommand(SlashCommand):
@@ -37,31 +51,31 @@ class TicketCommand(SlashCommand):
         months_since_creation = (timezone.now() - org_created_at).days / 30
         return months_since_creation < 3
 
-    def _can_create_ticket(self, config: RunnableConfig) -> bool:
-        """Check if user's subscription allows ticket creation."""
-        # Enable ticket creation in local dev
+    async def _can_create_ticket(self) -> bool:
+        """Check if user's subscription allows ticket creation using server-side billing data."""
         if settings.DEBUG:
             return True
 
         if self._is_organization_new():
             return True
 
-        billing_context_data = config.get("configurable", {}).get("billing_context")
-        if not billing_context_data:
+        org = self._team.organization
+        if not org.customer_id:
             return False
 
-        billing_context = MaxBillingContext.model_validate(billing_context_data)
+        try:
+            return await sync_to_async(self._check_billing_subscription, thread_sensitive=False)(org)
+        except Exception:
+            logger.exception("failed_to_fetch_billing_for_ticket_command")
+            return False
 
-        has_paid_subscription = billing_context.subscription_level in (
-            MaxBillingContextSubscriptionLevel.PAID,
-            MaxBillingContextSubscriptionLevel.CUSTOM,
-        )
-        has_active_trial = billing_context.trial is not None and billing_context.trial.is_active
-
-        return has_paid_subscription or has_active_trial
+    def _check_billing_subscription(self, org: Organization) -> bool:
+        billing_manager = BillingManager(get_cached_instance_license())
+        billing = billing_manager.get_billing(org)
+        return billing.get("has_active_subscription", False)
 
     async def execute(self, config: RunnableConfig, state: AssistantState) -> PartialAssistantState:
-        if not self._can_create_ticket(config):
+        if not await self._can_create_ticket():
             return PartialAssistantState(
                 messages=[
                     AssistantMessage(

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
@@ -14,28 +14,29 @@ from ee.hogai.chat_agent.slash_commands.commands.ticket import TicketCommand
 from ee.hogai.utils.types import AssistantState
 
 
-def _make_billing_context(subscription_level: str = "paid", trial_active: bool = False):
-    return {
-        "subscription_level": subscription_level,
-        "has_active_subscription": subscription_level != "free",
-        "products": [],
-        "settings": {"autocapture_on": True, "active_destinations": 0},
-        "trial": {"is_active": trial_active, "expires_at": None, "target": None} if trial_active else None,
-    }
+def _make_config(**extra_configurable):
+    return RunnableConfig(configurable={"thread_id": "test-conversation-id", **extra_configurable})
 
 
-class TestTicketCommand(BaseTest):
+def _mock_billing_response(has_active_subscription: bool = True) -> dict:
+    return {"has_active_subscription": has_active_subscription, "products": []}
+
+
+class TestTicketCommandPaidOrg(BaseTest):
+    """Tests for /ticket with a paid organization (has active subscription)."""
+
     def setUp(self):
         super().setUp()
-        # Default to old organization (more than 3 months) for consistent test behavior
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
+        self.team.organization.customer_id = "cus_test123"
         self.team.organization.save()
         self.command = TicketCommand(self.team, self.user)
 
     @pytest.mark.asyncio
     @patch.object(TicketCommand, "_summarize_conversation")
-    async def test_execute_returns_summary(self, mock_summarize):
-        """Test that /ticket returns the conversation summary."""
+    @patch("ee.hogai.chat_agent.slash_commands.commands.ticket.command.BillingManager")
+    async def test_execute_returns_summary(self, MockBillingManager, mock_summarize):
+        MockBillingManager.return_value.get_billing.return_value = _mock_billing_response()
         mock_summarize.return_value = "Summary of the conversation"
 
         state = AssistantState(
@@ -45,15 +46,8 @@ class TestTicketCommand(BaseTest):
                 HumanMessage(content="/ticket"),
             ]
         )
-        config = RunnableConfig(
-            configurable={
-                "thread_id": "test-conversation-id",
-                "trace_id": "test-trace-id",
-                "billing_context": _make_billing_context("paid"),
-            }
-        )
 
-        result = await self.command.execute(config, state)
+        result = await self.command.execute(_make_config(), state)
 
         self.assertEqual(len(result.messages), 1)
         message = result.messages[0]
@@ -63,18 +57,13 @@ class TestTicketCommand(BaseTest):
         mock_summarize.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_execute_first_message_prompts_for_input(self):
-        """Test that /ticket as first message prompts user to describe issue."""
-        state = AssistantState(
-            messages=[
-                HumanMessage(content="/ticket"),
-            ]
-        )
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("paid")}
-        )
+    @patch("ee.hogai.chat_agent.slash_commands.commands.ticket.command.BillingManager")
+    async def test_execute_first_message_prompts_for_input(self, MockBillingManager):
+        MockBillingManager.return_value.get_billing.return_value = _mock_billing_response()
 
-        result = await self.command.execute(config, state)
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+
+        result = await self.command.execute(_make_config(), state)
 
         self.assertEqual(len(result.messages), 1)
         message = result.messages[0]
@@ -83,40 +72,12 @@ class TestTicketCommand(BaseTest):
         self.assertIn("describe your issue", message.content.lower())
 
     @pytest.mark.asyncio
-    async def test_execute_free_user_returns_upgrade_message(self):
-        """Test that /ticket returns upgrade message for free users."""
-        state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
-
-        result = await self.command.execute(config, state)
-
-        self.assertEqual(len(result.messages), 1)
-        message = result.messages[0]
-        assert isinstance(message, AssistantMessage)
-        assert isinstance(message.content, str)
-        self.assertIn("paid plans", message.content)
-
-    @pytest.mark.asyncio
-    async def test_execute_no_billing_context_returns_upgrade_message(self):
-        """Test that /ticket returns upgrade message when no billing context."""
-        state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
-
-        result = await self.command.execute(config, state)
-
-        self.assertEqual(len(result.messages), 1)
-        message = result.messages[0]
-        assert isinstance(message, AssistantMessage)
-        assert isinstance(message.content, str)
-        self.assertIn("paid plans", message.content)
-
-    @pytest.mark.asyncio
     @patch.object(TicketCommand, "_summarize_conversation")
-    async def test_execute_custom_subscription_allowed(self, mock_summarize):
-        """Test that /ticket works for custom subscription level."""
+    @patch("ee.hogai.chat_agent.slash_commands.commands.ticket.command.BillingManager")
+    async def test_execute_active_subscription_allowed(self, MockBillingManager, mock_summarize):
+        MockBillingManager.return_value.get_billing.return_value = _mock_billing_response(has_active_subscription=True)
         mock_summarize.return_value = "Summary"
+
         state = AssistantState(
             messages=[
                 HumanMessage(content="Issue"),
@@ -124,24 +85,46 @@ class TestTicketCommand(BaseTest):
                 HumanMessage(content="/ticket"),
             ]
         )
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("custom")}
-        )
 
-        result = await self.command.execute(config, state)
+        result = await self.command.execute(_make_config(), state)
 
         message = result.messages[0]
         assert isinstance(message, AssistantMessage)
         self.assertNotIn("paid plans", message.content)
 
+
+class TestTicketCommandFreeOrg(BaseTest):
+    """Tests for /ticket with a free organization."""
+
+    def setUp(self):
+        super().setUp()
+        self.team.organization.created_at = timezone.now() - timedelta(days=100)
+        self.team.organization.customer_id = None
+        self.team.organization.save()
+        self.command = TicketCommand(self.team, self.user)
+
     @pytest.mark.asyncio
-    async def test_execute_active_trial_allowed(self):
-        """Test that /ticket works for users with active trial."""
+    async def test_execute_no_customer_id_returns_upgrade_message(self):
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={
-                "thread_id": "test-conversation-id",
-                "billing_context": _make_billing_context("free", trial_active=True),
+
+        result = await self.command.execute(_make_config(), state)
+
+        self.assertEqual(len(result.messages), 1)
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        assert isinstance(message.content, str)
+        self.assertIn("paid plans", message.content)
+
+    @pytest.mark.asyncio
+    async def test_execute_spoofed_billing_context_blocked(self):
+        """Verify that client-supplied billing_context cannot bypass the authorization check."""
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+        config = _make_config(
+            billing_context={
+                "subscription_level": "paid",
+                "has_active_subscription": True,
+                "products": [],
+                "settings": {"autocapture_on": True, "active_destinations": 0},
             }
         )
 
@@ -150,15 +133,82 @@ class TestTicketCommand(BaseTest):
         message = result.messages[0]
         assert isinstance(message, AssistantMessage)
         assert isinstance(message.content, str)
+        self.assertIn("paid plans", message.content)
+
+
+class TestTicketCommandInactiveSubscription(BaseTest):
+    """Tests for /ticket with customer_id but inactive subscription."""
+
+    def setUp(self):
+        super().setUp()
+        self.team.organization.created_at = timezone.now() - timedelta(days=100)
+        self.team.organization.customer_id = "cus_cancelled123"
+        self.team.organization.save()
+        self.command = TicketCommand(self.team, self.user)
+
+    @pytest.mark.asyncio
+    @patch("ee.hogai.chat_agent.slash_commands.commands.ticket.command.BillingManager")
+    async def test_execute_inactive_subscription_blocked(self, MockBillingManager):
+        MockBillingManager.return_value.get_billing.return_value = _mock_billing_response(has_active_subscription=False)
+
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+
+        result = await self.command.execute(_make_config(), state)
+
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        assert isinstance(message.content, str)
+        self.assertIn("paid plans", message.content)
+
+    @pytest.mark.asyncio
+    @patch("ee.hogai.chat_agent.slash_commands.commands.ticket.command.BillingManager")
+    async def test_execute_billing_service_error_blocks(self, MockBillingManager):
+        MockBillingManager.return_value.get_billing.side_effect = Exception("billing service down")
+
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+
+        result = await self.command.execute(_make_config(), state)
+
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        assert isinstance(message.content, str)
+        self.assertIn("paid plans", message.content)
+
+
+class TestTicketCommandNewOrg(BaseTest):
+    """Tests for /ticket with a new organization (< 3 months, always allowed)."""
+
+    def setUp(self):
+        super().setUp()
+        self.team.organization.created_at = timezone.now() - timedelta(days=30)
+        self.team.organization.customer_id = None
+        self.team.organization.save()
+        self.command = TicketCommand(self.team, self.user)
+
+    @pytest.mark.asyncio
+    async def test_execute_new_org_free_user_allowed(self):
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+
+        result = await self.command.execute(_make_config(), state)
+
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        assert isinstance(message.content, str)
         self.assertIn("describe your issue", message.content.lower())
 
+
+class TestTicketCommandHelpers(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.organization.created_at = timezone.now() - timedelta(days=100)
+        self.team.organization.save()
+        self.command = TicketCommand(self.team, self.user)
+
     def test_is_first_message_with_only_ticket_command(self):
-        """Test that _is_first_message returns True when only /ticket is present."""
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
         self.assertTrue(self.command._is_first_message(state))
 
     def test_is_first_message_with_prior_conversation(self):
-        """Test that _is_first_message returns False when there's prior conversation."""
         state = AssistantState(
             messages=[
                 HumanMessage(content="How do I create an insight?"),
@@ -169,45 +219,11 @@ class TestTicketCommand(BaseTest):
         self.assertFalse(self.command._is_first_message(state))
 
     def test_is_organization_new_returns_true_for_recent_org(self):
-        """Test that _is_organization_new returns True for org created less than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=30)
         self.team.organization.save()
         self.assertTrue(self.command._is_organization_new())
 
     def test_is_organization_new_returns_false_for_old_org(self):
-        """Test that _is_organization_new returns False for org created more than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
         self.team.organization.save()
         self.assertFalse(self.command._is_organization_new())
-
-    @pytest.mark.asyncio
-    @patch.object(TicketCommand, "_is_organization_new", return_value=True)
-    async def test_execute_new_org_free_user_allowed(self, mock_is_new):
-        """Test that /ticket works for free users in new organizations."""
-        state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
-
-        result = await self.command.execute(config, state)
-
-        message = result.messages[0]
-        assert isinstance(message, AssistantMessage)
-        assert isinstance(message.content, str)
-        self.assertIn("describe your issue", message.content.lower())
-
-    @pytest.mark.asyncio
-    @patch.object(TicketCommand, "_is_organization_new", return_value=False)
-    async def test_execute_old_org_free_user_blocked(self, mock_is_new):
-        """Test that /ticket returns upgrade message for free users in old organizations."""
-        state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
-
-        result = await self.command.execute(config, state)
-
-        message = result.messages[0]
-        assert isinstance(message, AssistantMessage)
-        assert isinstance(message.content, str)
-        self.assertIn("paid plans", message.content)


### PR DESCRIPTION
## Problem

Handles veria report, moves check back to billing BE via their manager.

## How did you test this code?

- [x] manual tests
- [x] unit tests

## Publish to changelog?

no
