### PR TITLE
fix(signals): Optimize session segment clustering queries

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a3_cluster_segments.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a3_cluster_segments.py
@@ -66,7 +66,7 @@ async def cluster_segments_activity(inputs: ClusterSegmentsActivityInputs) -> Cl
     team = await Team.objects.aget(id=inputs.team_id)
     document_ids, _ = await load_fetch_result(inputs.storage_key)
     # We fetch segments here instead of passing via Temporal, to avoid large Temporal payloads (each embedding is 3 KB)
-    segments = await _fetch_embeddings_by_document_ids(team, document_ids)
+    segments = await _fetch_embeddings(team, inputs.lookback_hours)
 
     # Run in to_thread as clustering is CPU-bound
     clustering_with_centroids = await asyncio.to_thread(_perform_clustering, segments)
@@ -74,14 +74,11 @@ async def cluster_segments_activity(inputs: ClusterSegmentsActivityInputs) -> Cl
     return clustering_with_centroids.result
 
 
-async def _fetch_embeddings_by_document_ids(
+async def _fetch_embeddings(
     team: Team,
-    document_ids: list[str],
+    lookback_hours: int,
 ) -> list[VideoSegment]:
-    if not document_ids:
-        return []
-
-    rows = await fetch_video_segment_embedding_rows(team, document_ids)
+    rows = await fetch_video_segment_embedding_rows(team, lookback_hours)
     segments: list[VideoSegment] = []
 
     for row in rows:

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -110,6 +110,7 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
                 ClusterSegmentsActivityInputs(
                     team_id=inputs.team_id,
                     storage_key=fetch_result.storage_key,
+                    lookback_hours=inputs.lookback_hours,
                 )
             ],
             start_to_close_timeout=timedelta(seconds=180),

--- a/posthog/temporal/ai/video_segment_clustering/data.py
+++ b/posthog/temporal/ai/video_segment_clustering/data.py
@@ -6,6 +6,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models.team import Team
+from posthog.temporal.ai.session_summary.activities.a5_embed_and_store_segments import SESSION_SEGMENTS_EMBEDDING_MODEL
 
 MAX_SEGMENTS_RETURNED = 50_000
 
@@ -45,8 +46,9 @@ def fetch_video_segment_metadata_rows(team: Team, lookback_hours: int):
                     content,
                     metadata,
                     timestamp
-                FROM raw_document_embeddings
+                FROM document_embeddings
                 WHERE timestamp >= now() - INTERVAL {lookback_hours} HOUR
+                    AND model_name = {model_name}
                     AND product = {product}
                     AND document_type = {document_type}
                     AND rendering = {rendering}
@@ -55,6 +57,7 @@ def fetch_video_segment_metadata_rows(team: Team, lookback_hours: int):
             ),
             placeholders={
                 "lookback_hours": ast.Constant(value=lookback_hours),
+                "model_name": ast.Constant(value=SESSION_SEGMENTS_EMBEDDING_MODEL.value),
                 "product": ast.Constant(value="session-replay"),
                 "document_type": ast.Constant(value="video-segment"),
                 "rendering": ast.Constant(value="video-analysis"),
@@ -66,42 +69,11 @@ def fetch_video_segment_metadata_rows(team: Team, lookback_hours: int):
 
 
 @sync_to_async
-def fetch_video_segment_metadata_by_document_ids(team: Team, document_ids: list[str]):
-    """Fetch segment metadata (no embeddings) for specific document_ids."""
-    if not document_ids:
-        return []
-    with tags_context(product=Product.SESSION_SUMMARY):
-        result = execute_hogql_query(
-            query_type="VideoSegmentMetadataByDocumentIds",
-            query=parse_select(
-                """
-                SELECT
-                    document_id,
-                    content,
-                    metadata,
-                    timestamp
-                FROM raw_document_embeddings
-                WHERE document_id IN {doc_ids}
-                    AND product = {product}
-                    AND document_type = {document_type}
-                    AND rendering = {rendering}
-                LIMIT {max_segments_returned}"""
-            ),
-            placeholders={
-                "doc_ids": ast.Constant(value=document_ids),
-                "product": ast.Constant(value="session-replay"),
-                "document_type": ast.Constant(value="video-segment"),
-                "rendering": ast.Constant(value="video-analysis"),
-                "max_segments_returned": ast.Constant(value=MAX_SEGMENTS_RETURNED),
-            },
-            team=team,
-        )
-    return result.results or []
+def fetch_video_segment_embedding_rows(team: Team, lookback_hours: int):
+    """Fetch video segment embeddings from ClickHouse - with embedding vectors included.
 
-
-@sync_to_async
-def fetch_video_segment_embedding_rows(team: Team, document_ids: list[str]):
-    """Fetch video segment embeddings from ClickHouse - specific segments, with embedding vectors included."""
+    Uses the same time-based filter as fetch_video_segment_metadata_rows, avoiding large IN clauses.
+    """
     with tags_context(product=Product.SESSION_SUMMARY):
         result = execute_hogql_query(
             query_type="VideoSegmentEmbeddingsForClustering",
@@ -113,15 +85,18 @@ def fetch_video_segment_embedding_rows(team: Team, document_ids: list[str]):
                     embedding,
                     metadata,
                     timestamp
-                FROM raw_document_embeddings
-                WHERE document_id IN {doc_ids}
+                FROM document_embeddings
+                WHERE timestamp >= now() - INTERVAL {lookback_hours} HOUR
+                    AND model_name = {model_name}
                     AND product = {product}
                     AND document_type = {document_type}
                     AND rendering = {rendering}
+                ORDER BY timestamp ASC
                 LIMIT {max_segments_returned}"""
             ),
             placeholders={
-                "doc_ids": ast.Constant(value=document_ids),
+                "lookback_hours": ast.Constant(value=lookback_hours),
+                "model_name": ast.Constant(value=SESSION_SEGMENTS_EMBEDDING_MODEL.value),
                 "product": ast.Constant(value="session-replay"),
                 "document_type": ast.Constant(value="video-segment"),
                 "rendering": ast.Constant(value="video-analysis"),

--- a/posthog/temporal/ai/video_segment_clustering/models.py
+++ b/posthog/temporal/ai/video_segment_clustering/models.py
@@ -111,6 +111,7 @@ class FetchSegmentsActivityInputs:
 class ClusterSegmentsActivityInputs:
     team_id: int
     storage_key: str
+    lookback_hours: int
 
 
 @dataclass

--- a/posthog/temporal/ai/video_segment_clustering/tests/test_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/tests/test_workflow.py
@@ -115,10 +115,9 @@ async def _mock_load_fetch_result(key: str) -> tuple[list[str], list[str]]:
     return document_ids, distinct_ids
 
 
-async def _mock_fetch_embeddings_by_document_ids(_team, document_ids: list[str]) -> list[VideoSegment]:
+async def _mock_fetch_embeddings(_team, lookback_hours: int) -> list[VideoSegment]:
     """Mock that returns pre-loaded VideoSegments with embeddings."""
-    doc_id_to_segment = {s.document_id: s for s in _test_video_segments}
-    return [doc_id_to_segment[doc_id] for doc_id in document_ids if doc_id in doc_id_to_segment]
+    return list(_test_video_segments)
 
 
 async def test_video_segment_clustering_workflow_emits_signals(ateam, test_segments_and_embeddings):
@@ -130,8 +129,8 @@ async def test_video_segment_clustering_workflow_emits_signals(ateam, test_segme
 
         with (
             patch(
-                "posthog.temporal.ai.video_segment_clustering.activities.a3_cluster_segments._fetch_embeddings_by_document_ids",
-                side_effect=_mock_fetch_embeddings_by_document_ids,
+                "posthog.temporal.ai.video_segment_clustering.activities.a3_cluster_segments._fetch_embeddings",
+                side_effect=_mock_fetch_embeddings,
             ),
             patch(
                 "posthog.temporal.ai.video_segment_clustering.activities.a3_cluster_segments.load_fetch_result",


### PR DESCRIPTION
## Problem

The video segment clustering workflow was doing `document_id IN (...)` in a query, which at 60k document UUIDs means "Query size exceeded" (literally the text of the query being too large, >1MB). Also, it was querying `raw_document_embeddings` (a UNION ALL view over all model-specific tables) rather than the more proepr `document_embeddings`.


Verified via HogQL query that our project has ~64K segments over 7 days (all in `text-embedding-3-large-3072`, all team 2) - this puts us over the limit.

## Changes

Replacing the `document_id IN (...)` approach in `fetch_video_segment_embedding_rows` with the same time-based filter used by the metadata query, eliminating large IN clause.

Switching both `fetch_video_segment_metadata_rows` and `fetch_video_segment_embedding_rows` from `raw_document_embeddings` to `document_embeddings` (the lazy table that routes to the correct model-specific table based on `model_name`).

## How did you test this code?

- Existing `video_segment_clustering` tests updated and passing.
- New parametrized test in `test_data.py` verifying both fetch functions use `document_embeddings` with `model_name` filter.

## Publish to changelog?

No.