### PR TITLE
feat(llma): cache sentiment results in Temporal activity

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/activities.py
+++ b/posthog/temporal/llm_analytics/sentiment/activities.py
@@ -68,6 +68,16 @@ async def classify_sentiment_activity(input: ClassifySentimentInput) -> dict[str
         output[trace_id] = trace_result.to_dict()
         offset += consumed
 
+    # Cache results in the activity so they survive even if the HTTP caller disconnects.
+    # Uses the same key format and TTL as the API view.
+    from django.core.cache import cache
+
+    from posthog.temporal.llm_analytics.sentiment.constants import CACHE_KEY_PREFIX, CACHE_TTL
+
+    to_cache = {f"{CACHE_KEY_PREFIX}:{input.team_id}:{tid}": result for tid, result in output.items()}
+    if to_cache:
+        cache.set_many(to_cache, timeout=CACHE_TTL)
+
     logger.info(
         "Sentiment activity completed",
         team_id=input.team_id,

--- a/posthog/temporal/llm_analytics/sentiment/activities.py
+++ b/posthog/temporal/llm_analytics/sentiment/activities.py
@@ -76,7 +76,15 @@ async def classify_sentiment_activity(input: ClassifySentimentInput) -> dict[str
 
     to_cache = {f"{CACHE_KEY_PREFIX}:{input.team_id}:{tid}": result for tid, result in output.items()}
     if to_cache:
-        cache.set_many(to_cache, timeout=CACHE_TTL)
+        try:
+            cache.set_many(to_cache, timeout=CACHE_TTL)
+        except Exception:
+            logger.warning(
+                "Failed to cache sentiment results",
+                team_id=input.team_id,
+                trace_count=len(to_cache),
+                exc_info=True,
+            )
 
     logger.info(
         "Sentiment activity completed",

--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -26,8 +26,11 @@ ACTIVITY_TIMEOUT_SECONDS = 60  # start-to-close timeout for classify activity
 WORKFLOW_TIMEOUT_BATCH_SECONDS = 60  # task timeout for sentiment workflow
 MAX_RETRY_ATTEMPTS = 2  # retry policy for both workflow and activity
 
-# API config
+# Cache config
 CACHE_TTL = 60 * 60 * 24  # 24 hours — events are immutable once ingested
+CACHE_KEY_PREFIX = "llm_sentiment"  # key format: {prefix}:{team_id}:{trace_id}
+
+# API config
 BATCH_MAX_TRACE_IDS = 5
 
 # HogQL query template for fetching $ai_generation events.


### PR DESCRIPTION
## Problem

When a user opens the traces table, the frontend fires off sentiment classification requests. If the user navigates away (clicks into a trace, switches tabs) before the workflow completes, the HTTP request is dropped and the results are lost -- even though the Temporal workflow runs to completion on the worker. When the user navigates back, classification starts from scratch, wasting the work that was already done.

## Changes

- Move cache writes from the Django API view into the Temporal activity itself. The activity writes results to the Django cache (Redis) immediately after classification, using the same key format and TTL. This means results are persisted even if the HTTP caller disconnects.
- Extract the cache key prefix (`llm_sentiment`) into a shared `CACHE_KEY_PREFIX` constant in `constants.py` to prevent drift between the activity and API view.
- Remove the now-redundant `cache.set_many` from the API view (it only reads from cache now).

The API view's cache read path is unchanged -- it still checks cache first and only triggers a workflow on misses.

## How did you test this code?

All 40 existing sentiment backend tests pass. Constants-only change in `constants.py`, small addition in `activities.py`, and simplification in `sentiment.py`. The Temporal worker runs in a Django process so `django.core.cache` is available.

## Publish to changelog?

No