### PR TITLE
chore: Upgrade posthog-node to 5.25.0

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -102,7 +102,7 @@
         "p-limit": "3.1.0",
         "pg": "^8.6.0",
         "pino": "^8.6.0",
-        "posthog-node": "5.24.17",
+        "posthog-node": "5.25.0",
         "pretty-bytes": "^5.6.0",
         "prom-client": "^14.2.0",
         "re2": "^1.22.1",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -102,7 +102,7 @@
         "p-limit": "3.1.0",
         "pg": "^8.6.0",
         "pino": "^8.6.0",
-        "posthog-node": "5.10.4",
+        "posthog-node": "5.24.17",
         "pretty-bytes": "^5.6.0",
         "prom-client": "^14.2.0",
         "re2": "^1.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1509,8 +1509,8 @@ importers:
         specifier: ^8.6.0
         version: 8.11.0
       posthog-node:
-        specifier: 5.10.4
-        version: 5.10.4
+        specifier: 5.24.17
+        version: 5.24.17
       pretty-bytes:
         specifier: ^5.6.0
         version: 5.6.0
@@ -2818,8 +2818,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       posthog-node:
-        specifier: ^5.10.4
-        version: 5.10.4
+        specifier: ^5.24.17
+        version: 5.24.17
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -7711,9 +7711,6 @@ packages:
 
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
-
-  '@posthog/core@1.4.0':
-    resolution: {integrity: sha512-jmW8/I//YOHAfjzokqas+Qtc2T57Ux8d2uIJu7FLcMGxywckHsl6od59CD18jtUzKToQdjQhV6Y3429qj+KeNw==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -17949,9 +17946,9 @@ packages:
   posthog-js@1.354.2:
     resolution: {integrity: sha512-6bfPjqxLmLoyXHDh0634Mx88Ub8mtekQoFazrQfpo4wrrf5+LSsfDnyR9adQhEnHtllbbBe3IFF2Zbdb5e+VCQ==}
 
-  posthog-node@5.10.4:
-    resolution: {integrity: sha512-sy020/Q4mt18eCkVo/cGEJD+wgdxeg5DTgNUaA85awBCbuEP43BOdCTOOw/K2Tvgw2oZfag3PFyhkVuQ6nJfBg==}
-    engines: {node: '>=20'}
+  posthog-node@5.24.17:
+    resolution: {integrity: sha512-mdb8TKt+YCRbGQdYar3AKNUPCyEiqcprScF4unYpGALF6HlBaEuO6wPuIqXXpCWkw4VclJYCKbb6lq6pH6bJeA==}
+    engines: {node: ^20.20.0 || >=22.22.0}
 
   posthtml-parser@0.11.0:
     resolution: {integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==}
@@ -28322,8 +28319,6 @@ snapshots:
   '@posthog/core@1.23.1':
     dependencies:
       cross-spawn: 7.0.6
-
-  '@posthog/core@1.4.0': {}
 
   '@posthog/core@1.7.1':
     dependencies:
@@ -41170,9 +41165,9 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.1.0
 
-  posthog-node@5.10.4:
+  posthog-node@5.24.17:
     dependencies:
-      '@posthog/core': 1.4.0
+      '@posthog/core': 1.23.1
 
   posthtml-parser@0.11.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1509,8 +1509,8 @@ importers:
         specifier: ^8.6.0
         version: 8.11.0
       posthog-node:
-        specifier: 5.24.17
-        version: 5.24.17
+        specifier: 5.25.0
+        version: 5.25.0
       pretty-bytes:
         specifier: ^5.6.0
         version: 5.6.0
@@ -2818,8 +2818,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       posthog-node:
-        specifier: ^5.24.17
-        version: 5.24.17
+        specifier: ^5.25.0
+        version: 5.25.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -17946,8 +17946,8 @@ packages:
   posthog-js@1.354.2:
     resolution: {integrity: sha512-6bfPjqxLmLoyXHDh0634Mx88Ub8mtekQoFazrQfpo4wrrf5+LSsfDnyR9adQhEnHtllbbBe3IFF2Zbdb5e+VCQ==}
 
-  posthog-node@5.24.17:
-    resolution: {integrity: sha512-mdb8TKt+YCRbGQdYar3AKNUPCyEiqcprScF4unYpGALF6HlBaEuO6wPuIqXXpCWkw4VclJYCKbb6lq6pH6bJeA==}
+  posthog-node@5.25.0:
+    resolution: {integrity: sha512-DFE5lZAoD6hk7RATuT8qVQ7KFgFP5YlFTJciMbU2qq6NX0A8eJxiJcmEsMnB3g30jJJ9suiwGIq4I8ESwf9bZg==}
     engines: {node: ^20.20.0 || >=22.22.0}
 
   posthtml-parser@0.11.0:
@@ -41165,7 +41165,7 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.1.0
 
-  posthog-node@5.24.17:
+  posthog-node@5.25.0:
     dependencies:
       '@posthog/core': 1.23.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
     - posthog-js
     - posthog-js-lite
+    - posthog-node
     - '@posthog/*'
     - kea@4.0.0-pre.5
     - chartjs-plugin-stacked100@1.7.1

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -38,7 +38,7 @@
         "ai": "^6.0.0",
         "fflate": "^0.8.2",
         "posthog-js-lite": "4.2.2",
-        "posthog-node": "^5.24.17",
+        "posthog-node": "^5.25.0",
         "uuid": "^11.1.0",
         "zod": "^3.24.4"
     },

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -38,7 +38,7 @@
         "ai": "^6.0.0",
         "fflate": "^0.8.2",
         "posthog-js-lite": "4.2.2",
-        "posthog-node": "^5.10.4",
+        "posthog-node": "^5.24.17",
         "uuid": "^11.1.0",
         "zod": "^3.24.4"
     },


### PR DESCRIPTION
## Problem

Keep PostHog Node SDK dependencies up-to-date across the monorepo to benefit from bug fixes, performance improvements, and security updates in the latest version.

Specifically wanted to merge in the recent fix for registering super properties which our node services use

## Changes

- Upgraded `posthog-node` from 5.10.4 to 5.25.0 in `nodejs/package.json`
- Upgraded `posthog-node` from ^5.10.4 to ^5.25.0 in `services/mcp/package.json`
- Added `posthog-node` to the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml` to allow faster updates for this dependency

## How did you test this code?

No manual testing needed. This is a straightforward dependency upgrade. The lockfile changes are transitive resolution artifacts. CI will verify that the updated dependencies resolve correctly and that the build succeeds.

## Publish to changelog?

No

https://claude.ai/code/session_014hcjuQ67XEWQRCHW3tqBZQ