### PR TITLE
fix(hogql): strip whitespace from property filter comparison values

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -218,6 +218,14 @@ class AggregationFinder(TraversingVisitor):
                 self.visit(arg)
 
 
+def _strip_value(value: ValueT) -> ValueT:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return [v.strip() if isinstance(v, str) else v for v in value]
+    return value
+
+
 def _handle_bool_values(value: ValueT, expr: ast.Expr, property: Property, team: Team) -> ValueT | bool:
     if value is True:
         value = "true"
@@ -413,32 +421,46 @@ def _expr_to_compare_op(
             left=expr,
             right=ast.Constant(value=_handle_bool_values(value, expr, property, team)),
         )
-    elif operator == PropertyOperator.LT or operator == PropertyOperator.IS_DATE_BEFORE:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value))
-    elif operator == PropertyOperator.GT or operator == PropertyOperator.IS_DATE_AFTER:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value))
-    elif operator == PropertyOperator.LTE or operator == PropertyOperator.MAX:
-        return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value))
-    elif operator == PropertyOperator.GTE or operator == PropertyOperator.MIN:
-        return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value))
-    elif operator == PropertyOperator.BETWEEN:
-        _validate_between_values(value, operator)
-        assert isinstance(value, list)
-        return ast.And(
-            exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value[1])),
-            ]
-        )
-    elif operator == PropertyOperator.NOT_BETWEEN:
-        _validate_between_values(value, operator)
-        assert isinstance(value, list)
-        return ast.Or(
-            exprs=[
-                ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value[0])),
-                ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value[1])),
-            ]
-        )
+    elif operator in (
+        PropertyOperator.LT,
+        PropertyOperator.GT,
+        PropertyOperator.LTE,
+        PropertyOperator.GTE,
+        PropertyOperator.IS_DATE_BEFORE,
+        PropertyOperator.IS_DATE_AFTER,
+        PropertyOperator.MIN,
+        PropertyOperator.MAX,
+        PropertyOperator.BETWEEN,
+        PropertyOperator.NOT_BETWEEN,
+    ):
+        value = _strip_value(value)
+
+        if operator == PropertyOperator.LT or operator == PropertyOperator.IS_DATE_BEFORE:
+            return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value))
+        elif operator == PropertyOperator.GT or operator == PropertyOperator.IS_DATE_AFTER:
+            return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value))
+        elif operator == PropertyOperator.LTE or operator == PropertyOperator.MAX:
+            return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value))
+        elif operator == PropertyOperator.GTE or operator == PropertyOperator.MIN:
+            return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value))
+        elif operator == PropertyOperator.BETWEEN:
+            _validate_between_values(value, operator)
+            assert isinstance(value, list)
+            return ast.And(
+                exprs=[
+                    ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value[0])),
+                    ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value[1])),
+                ]
+            )
+        else:  # NOT_BETWEEN
+            _validate_between_values(value, operator)
+            assert isinstance(value, list)
+            return ast.Or(
+                exprs=[
+                    ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value[0])),
+                    ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value[1])),
+                ]
+            )
     elif operator == PropertyOperator.IS_CLEANED_PATH_EXACT:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.Eq,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -23,6 +23,7 @@ from posthog.schema import (
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 from posthog.hogql_queries.experiments.test.experiment_query_runner.utils import create_standard_group_test_events
+from posthog.models import PropertyDefinition
 from posthog.models.action.action import Action
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.group.util import create_group
@@ -529,6 +530,78 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         self.assertEqual(test_variant.sum, 8)
         self.assertEqual(control_variant.number_of_samples, 10)
         self.assertEqual(test_variant.number_of_samples, 10)
+
+    def test_query_runner_with_whitespace_padded_numeric_exposure_filter_value(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2020, 1, 1), end_date=datetime(2020, 1, 31)
+        )
+        experiment.stats_config = {"method": "frequentist"}
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        PropertyDefinition.objects.get_or_create(
+            team=self.team,
+            type=PropertyDefinition.Type.EVENT,
+            name="registration_ts",
+            defaults={"property_type": "Numeric"},
+        )
+
+        for variant, count in [("control", 6), ("test", 8)]:
+            for i in range(count):
+                _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "registration_ts": "1771606800",
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+
+        flush_persons_and_events()
+
+        exposure_config = ExperimentEventExposureConfig(
+            event="$pageview",
+            properties=[
+                EventPropertyFilter(
+                    key="registration_ts", operator=PropertyOperator.GT, value="   1700000000", type="event"
+                ),
+            ],
+        )
+        experiment.exposure_criteria = {
+            "exposure_config": exposure_config.model_dump(mode="json"),
+        }
+        experiment.save()
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=ExperimentMeanMetric(
+                source=EventsNode(event="purchase"),
+            ),
+        )
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.calculate()
+
+        assert result.variant_results is not None
+        control_variant = result.baseline
+        assert control_variant is not None
+        test_variant = result.variant_results[0]
+        assert test_variant is not None
+
+        self.assertEqual(control_variant.number_of_samples, 6)
+        self.assertEqual(test_variant.number_of_samples, 8)
 
     @snapshot_clickhouse_queries
     def test_query_runner_with_custom_exposure_without_properties(self):


### PR DESCRIPTION
## Problem

When an exposure property filter value contains leading/trailing whitespace (e.g. `'   1700000000'`), ClickHouse throws `DB::Exception: Cannot convert string '    1700000000' to type Float64`. This happens because `PropertySwapper` wraps the left side with `accurateCastOrNull()` → returns Float64, then ClickHouse's `greater()` tries to implicitly cast the right-side string constant to Float64 — and that implicit cast is strict.

## Changes

Strips whitespace from string comparison values in `property_to_expr()` for GT/GTE/LT/LTE/BETWEEN/NOT_BETWEEN operators via a `_strip_value()` helper.

## Testing

- Integration test in experiments: creates events with a numeric exposure property filter where the filter value has leading whitespace, verifies the query succeeds and returns correct results
- `pytest posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py` — 36 passed
- `pytest posthog/hogql/transforms/test/test_property_types.py` — 10 passed