### PR TITLE
Add server-side billing context fetching for HogAI

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -11,9 +11,10 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables import RunnableConfig
 
-from posthog.schema import AssistantMessage, HumanMessage, MaxBillingContext, MaxBillingContextSubscriptionLevel
+from posthog.schema import AssistantMessage, HumanMessage, MaxBillingContextSubscriptionLevel
 
 from ee.hogai.chat_agent.slash_commands.commands import SlashCommand
+from ee.hogai.context.billing import fetch_server_billing_context
 from ee.hogai.core.agent_modes.compaction_manager import AnthropicConversationCompactionManager
 from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.utils.types import AssistantMessageUnion, AssistantState, PartialAssistantState
@@ -37,20 +38,17 @@ class TicketCommand(SlashCommand):
         months_since_creation = (timezone.now() - org_created_at).days / 30
         return months_since_creation < 3
 
-    def _can_create_ticket(self, config: RunnableConfig) -> bool:
-        """Check if user's subscription allows ticket creation."""
-        # Enable ticket creation in local dev
+    def _can_create_ticket(self) -> bool:
+        """Check if user's subscription allows ticket creation via server-side billing verification."""
         if settings.DEBUG:
             return True
 
         if self._is_organization_new():
             return True
 
-        billing_context_data = config.get("configurable", {}).get("billing_context")
-        if not billing_context_data:
+        billing_context = fetch_server_billing_context(self._team)
+        if not billing_context:
             return False
-
-        billing_context = MaxBillingContext.model_validate(billing_context_data)
 
         has_paid_subscription = billing_context.subscription_level in (
             MaxBillingContextSubscriptionLevel.PAID,
@@ -61,7 +59,7 @@ class TicketCommand(SlashCommand):
         return has_paid_subscription or has_active_trial
 
     async def execute(self, config: RunnableConfig, state: AssistantState) -> PartialAssistantState:
-        if not self._can_create_ticket(config):
+        if not self._can_create_ticket():
             return PartialAssistantState(
                 messages=[
                     AssistantMessage(

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
@@ -8,34 +8,43 @@ from django.utils import timezone
 
 from langchain_core.runnables import RunnableConfig
 
-from posthog.schema import AssistantMessage, HumanMessage
+from posthog.schema import (
+    AssistantMessage,
+    HumanMessage,
+    MaxBillingContext,
+    MaxBillingContextSettings,
+    MaxBillingContextSubscriptionLevel,
+    MaxBillingContextTrial,
+)
 
 from ee.hogai.chat_agent.slash_commands.commands.ticket import TicketCommand
 from ee.hogai.utils.types import AssistantState
 
 
-def _make_billing_context(subscription_level: str = "paid", trial_active: bool = False):
-    return {
-        "subscription_level": subscription_level,
-        "has_active_subscription": subscription_level != "free",
-        "products": [],
-        "settings": {"autocapture_on": True, "active_destinations": 0},
-        "trial": {"is_active": trial_active, "expires_at": None, "target": None} if trial_active else None,
-    }
+def _make_server_billing_context(subscription_level: str = "paid", trial_active: bool = False) -> MaxBillingContext:
+    return MaxBillingContext(
+        subscription_level=MaxBillingContextSubscriptionLevel(subscription_level),
+        has_active_subscription=subscription_level != "free",
+        products=[],
+        settings=MaxBillingContextSettings(autocapture_on=True, active_destinations=0),
+        trial=MaxBillingContextTrial(is_active=trial_active, expires_at=None, target=None) if trial_active else None,
+    )
 
 
 class TestTicketCommand(BaseTest):
     def setUp(self):
         super().setUp()
-        # Default to old organization (more than 3 months) for consistent test behavior
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
         self.team.organization.save()
         self.command = TicketCommand(self.team, self.user)
 
     @pytest.mark.asyncio
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
     @patch.object(TicketCommand, "_summarize_conversation")
-    async def test_execute_returns_summary(self, mock_summarize):
-        """Test that /ticket returns the conversation summary."""
+    async def test_execute_returns_summary(self, mock_summarize, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("paid")
         mock_summarize.return_value = "Summary of the conversation"
 
         state = AssistantState(
@@ -45,13 +54,7 @@ class TestTicketCommand(BaseTest):
                 HumanMessage(content="/ticket"),
             ]
         )
-        config = RunnableConfig(
-            configurable={
-                "thread_id": "test-conversation-id",
-                "trace_id": "test-trace-id",
-                "billing_context": _make_billing_context("paid"),
-            }
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id", "trace_id": "test-trace-id"})
 
         result = await self.command.execute(config, state)
 
@@ -63,16 +66,17 @@ class TestTicketCommand(BaseTest):
         mock_summarize.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_execute_first_message_prompts_for_input(self):
-        """Test that /ticket as first message prompts user to describe issue."""
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
+    async def test_execute_first_message_prompts_for_input(self, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("paid")
         state = AssistantState(
             messages=[
                 HumanMessage(content="/ticket"),
             ]
         )
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("paid")}
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
         result = await self.command.execute(config, state)
 
@@ -83,24 +87,11 @@ class TestTicketCommand(BaseTest):
         self.assertIn("describe your issue", message.content.lower())
 
     @pytest.mark.asyncio
-    async def test_execute_free_user_returns_upgrade_message(self):
-        """Test that /ticket returns upgrade message for free users."""
-        state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
-
-        result = await self.command.execute(config, state)
-
-        self.assertEqual(len(result.messages), 1)
-        message = result.messages[0]
-        assert isinstance(message, AssistantMessage)
-        assert isinstance(message.content, str)
-        self.assertIn("paid plans", message.content)
-
-    @pytest.mark.asyncio
-    async def test_execute_no_billing_context_returns_upgrade_message(self):
-        """Test that /ticket returns upgrade message when no billing context."""
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
+    async def test_execute_free_user_returns_upgrade_message(self, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("free")
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
         config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
@@ -113,9 +104,29 @@ class TestTicketCommand(BaseTest):
         self.assertIn("paid plans", message.content)
 
     @pytest.mark.asyncio
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
+    async def test_execute_billing_unavailable_returns_upgrade_message(self, mock_fetch_billing):
+        mock_fetch_billing.return_value = None
+        state = AssistantState(messages=[HumanMessage(content="/ticket")])
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
+
+        result = await self.command.execute(config, state)
+
+        self.assertEqual(len(result.messages), 1)
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        assert isinstance(message.content, str)
+        self.assertIn("paid plans", message.content)
+
+    @pytest.mark.asyncio
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
     @patch.object(TicketCommand, "_summarize_conversation")
-    async def test_execute_custom_subscription_allowed(self, mock_summarize):
-        """Test that /ticket works for custom subscription level."""
+    async def test_execute_custom_subscription_allowed(self, mock_summarize, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("custom")
         mock_summarize.return_value = "Summary"
         state = AssistantState(
             messages=[
@@ -124,9 +135,7 @@ class TestTicketCommand(BaseTest):
                 HumanMessage(content="/ticket"),
             ]
         )
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("custom")}
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
         result = await self.command.execute(config, state)
 
@@ -135,15 +144,13 @@ class TestTicketCommand(BaseTest):
         self.assertNotIn("paid plans", message.content)
 
     @pytest.mark.asyncio
-    async def test_execute_active_trial_allowed(self):
-        """Test that /ticket works for users with active trial."""
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
+    async def test_execute_active_trial_allowed(self, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("free", trial_active=True)
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={
-                "thread_id": "test-conversation-id",
-                "billing_context": _make_billing_context("free", trial_active=True),
-            }
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
         result = await self.command.execute(config, state)
 
@@ -153,12 +160,10 @@ class TestTicketCommand(BaseTest):
         self.assertIn("describe your issue", message.content.lower())
 
     def test_is_first_message_with_only_ticket_command(self):
-        """Test that _is_first_message returns True when only /ticket is present."""
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
         self.assertTrue(self.command._is_first_message(state))
 
     def test_is_first_message_with_prior_conversation(self):
-        """Test that _is_first_message returns False when there's prior conversation."""
         state = AssistantState(
             messages=[
                 HumanMessage(content="How do I create an insight?"),
@@ -169,13 +174,11 @@ class TestTicketCommand(BaseTest):
         self.assertFalse(self.command._is_first_message(state))
 
     def test_is_organization_new_returns_true_for_recent_org(self):
-        """Test that _is_organization_new returns True for org created less than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=30)
         self.team.organization.save()
         self.assertTrue(self.command._is_organization_new())
 
     def test_is_organization_new_returns_false_for_old_org(self):
-        """Test that _is_organization_new returns False for org created more than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
         self.team.organization.save()
         self.assertFalse(self.command._is_organization_new())
@@ -183,11 +186,8 @@ class TestTicketCommand(BaseTest):
     @pytest.mark.asyncio
     @patch.object(TicketCommand, "_is_organization_new", return_value=True)
     async def test_execute_new_org_free_user_allowed(self, mock_is_new):
-        """Test that /ticket works for free users in new organizations."""
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
         result = await self.command.execute(config, state)
 
@@ -197,13 +197,14 @@ class TestTicketCommand(BaseTest):
         self.assertIn("describe your issue", message.content.lower())
 
     @pytest.mark.asyncio
+    @patch(
+        "ee.hogai.chat_agent.slash_commands.commands.ticket.command.fetch_server_billing_context",
+    )
     @patch.object(TicketCommand, "_is_organization_new", return_value=False)
-    async def test_execute_old_org_free_user_blocked(self, mock_is_new):
-        """Test that /ticket returns upgrade message for free users in old organizations."""
+    async def test_execute_old_org_free_user_blocked(self, mock_is_new, mock_fetch_billing):
+        mock_fetch_billing.return_value = _make_server_billing_context("free")
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
-        config = RunnableConfig(
-            configurable={"thread_id": "test-conversation-id", "billing_context": _make_billing_context("free")}
-        )
+        config = RunnableConfig(configurable={"thread_id": "test-conversation-id"})
 
         result = await self.command.execute(config, state)
 

--- a/ee/hogai/context/billing.py
+++ b/ee/hogai/context/billing.py
@@ -1,0 +1,163 @@
+import structlog
+
+from posthog.schema import (
+    MaxAddonInfo,
+    MaxBillingContext,
+    MaxBillingContextBillingPeriod,
+    MaxBillingContextBillingPeriodInterval,
+    MaxBillingContextSettings,
+    MaxBillingContextSubscriptionLevel,
+    MaxBillingContextTrial,
+    MaxProductInfo,
+)
+
+from posthog.cloud_utils import get_cached_instance_license
+from posthog.models.hog_functions.hog_function import HogFunction
+from posthog.models.team.team import Team
+
+from ee.billing.billing_manager import BillingManager
+
+logger = structlog.get_logger(__name__)
+
+
+def _convert_addon(addon: dict) -> MaxAddonInfo:
+    current_usage = addon.get("current_usage") or 0
+    percentage_usage = addon.get("percentage_usage") or 0
+    return MaxAddonInfo(
+        type=addon.get("type", ""),
+        name=addon.get("name", ""),
+        description=addon.get("description", ""),
+        is_used=current_usage > 0,
+        has_exceeded_limit=percentage_usage > 1,
+        current_usage=current_usage,
+        usage_limit=addon.get("usage_limit"),
+        percentage_usage=percentage_usage,
+        docs_url=addon.get("docs_url"),
+        projected_amount_usd=addon.get("projected_amount_usd"),
+        projected_amount_usd_with_limit=addon.get("projected_amount_usd_with_limit"),
+    )
+
+
+def _convert_product(product: dict, custom_limits: dict | None, next_period_limits: dict | None) -> MaxProductInfo:
+    current_usage = product.get("current_usage") or 0
+    percentage_usage = product.get("percentage_usage") or 0
+    product_type = product.get("type", "")
+    usage_key = product.get("usage_key", "")
+
+    custom_limit = None
+    if custom_limits:
+        custom_limit = custom_limits.get(product_type) or custom_limits.get(usage_key)
+
+    next_period_limit = None
+    if next_period_limits:
+        next_period_limit = next_period_limits.get(product_type) or next_period_limits.get(usage_key)
+
+    addons = [_convert_addon(addon) for addon in product.get("addons", [])]
+
+    return MaxProductInfo(
+        type=product_type,
+        name=product.get("name", ""),
+        description=product.get("description", ""),
+        is_used=current_usage > 0,
+        has_exceeded_limit=percentage_usage > 1,
+        current_usage=current_usage,
+        usage_limit=product.get("usage_limit"),
+        percentage_usage=percentage_usage,
+        custom_limit_usd=custom_limit,
+        next_period_custom_limit_usd=next_period_limit,
+        projected_amount_usd=product.get("projected_amount_usd"),
+        projected_amount_usd_with_limit=product.get("projected_amount_usd_with_limit"),
+        docs_url=product.get("docs_url"),
+        addons=addons,
+    )
+
+
+def _convert_trial(trial: dict | None) -> MaxBillingContextTrial | None:
+    if not trial:
+        return None
+    return MaxBillingContextTrial(
+        is_active=trial.get("status") == "active",
+        expires_at=trial.get("expires_at"),
+        target=trial.get("target"),
+    )
+
+
+def _convert_billing_period(billing_period: dict | None) -> MaxBillingContextBillingPeriod | None:
+    if not billing_period:
+        return None
+    interval_str = billing_period.get("interval", "month")
+    interval = (
+        MaxBillingContextBillingPeriodInterval.YEAR
+        if interval_str == "year"
+        else MaxBillingContextBillingPeriodInterval.MONTH
+    )
+    return MaxBillingContextBillingPeriod(
+        current_period_start=billing_period.get("current_period_start", ""),
+        current_period_end=billing_period.get("current_period_end", ""),
+        interval=interval,
+    )
+
+
+def _get_settings(team: Team) -> MaxBillingContextSettings:
+    active_destinations = HogFunction.objects.filter(team=team, enabled=True, type="destination").count()
+    return MaxBillingContextSettings(
+        autocapture_on=not (team.autocapture_opt_out or False),
+        active_destinations=active_destinations,
+    )
+
+
+def billing_response_to_max_context(billing_data: dict, team: Team) -> MaxBillingContext:
+    """Convert a BillingManager.get_billing() response dict into a MaxBillingContext model."""
+    subscription_level_str = billing_data.get("subscription_level", "free")
+    try:
+        subscription_level = MaxBillingContextSubscriptionLevel(subscription_level_str)
+    except ValueError:
+        subscription_level = MaxBillingContextSubscriptionLevel.FREE
+
+    custom_limits = billing_data.get("custom_limits_usd")
+    next_period_limits = billing_data.get("next_period_custom_limits_usd")
+
+    products = [_convert_product(p, custom_limits, next_period_limits) for p in billing_data.get("products", [])]
+
+    license_data = billing_data.get("license")
+    billing_plan = license_data.get("plan") if isinstance(license_data, dict) else None
+
+    return MaxBillingContext(
+        has_active_subscription=billing_data.get("has_active_subscription", False),
+        subscription_level=subscription_level,
+        billing_plan=billing_plan,
+        is_deactivated=billing_data.get("deactivated"),
+        products=products,
+        billing_period=_convert_billing_period(billing_data.get("billing_period")),
+        total_current_amount_usd=billing_data.get("current_total_amount_usd"),
+        projected_total_amount_usd=billing_data.get("projected_total_amount_usd"),
+        projected_total_amount_usd_after_discount=billing_data.get("projected_total_amount_usd_after_discount"),
+        projected_total_amount_usd_with_limit=billing_data.get("projected_total_amount_usd_with_limit"),
+        projected_total_amount_usd_with_limit_after_discount=billing_data.get(
+            "projected_total_amount_usd_with_limit_after_discount"
+        ),
+        startup_program_label=billing_data.get("startup_program_label"),
+        startup_program_label_previous=billing_data.get("startup_program_label_previous"),
+        trial=_convert_trial(billing_data.get("trial")),
+        settings=_get_settings(team),
+        usage_history=None,
+        spend_history=None,
+    )
+
+
+def fetch_server_billing_context(team: Team) -> MaxBillingContext | None:
+    """Fetch billing data from the billing service and convert to MaxBillingContext.
+
+    Returns None if the billing service is unreachable or the organization has no billing set up.
+    """
+    try:
+        license = get_cached_instance_license()
+        if not license or not license.is_v2_license:
+            return None
+
+        billing_manager = BillingManager(license)
+        billing_data = billing_manager.get_billing(team.organization)
+        return billing_response_to_max_context(billing_data, team)
+    except Exception:
+        logger.exception("Failed to fetch server-side billing context")
+        return None

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -120,6 +120,15 @@ class AssistantContextManager(AssistantContextMixin):
             return None
         return MaxBillingContext.model_validate(billing_context)
 
+    @database_sync_to_async(thread_sensitive=False)
+    def get_server_billing_context(self) -> MaxBillingContext | None:
+        """
+        Fetches billing context server-side from BillingManager, independent of client-supplied data.
+        """
+        from ee.hogai.context.billing import fetch_server_billing_context
+
+        return fetch_server_billing_context(self._team)
+
     @database_sync_to_async
     def check_user_has_billing_access(self) -> bool:
         """

--- a/ee/hogai/context/test/test_billing.py
+++ b/ee/hogai/context/test/test_billing.py
@@ -1,0 +1,325 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import MaxBillingContextBillingPeriodInterval, MaxBillingContextSubscriptionLevel
+
+from ee.hogai.context.billing import billing_response_to_max_context, fetch_server_billing_context
+
+
+def _make_billing_response(
+    *,
+    subscription_level: str = "paid",
+    has_active_subscription: bool = True,
+    trial: dict | None = None,
+    products: list | None = None,
+    billing_period: dict | None = None,
+    deactivated: bool = False,
+) -> dict:
+    return {
+        "has_active_subscription": has_active_subscription,
+        "subscription_level": subscription_level,
+        "license": {"plan": "scale"},
+        "deactivated": deactivated,
+        "products": products or [],
+        "billing_period": billing_period,
+        "trial": trial,
+        "current_total_amount_usd": "100.00",
+        "projected_total_amount_usd": "200.00",
+        "startup_program_label": None,
+    }
+
+
+class TestBillingResponseToMaxContext(BaseTest):
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_paid_subscription(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 3
+        billing_data = _make_billing_response(subscription_level="paid", has_active_subscription=True)
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.PAID)
+        self.assertTrue(result.has_active_subscription)
+        self.assertEqual(result.billing_plan, "scale")
+        self.assertFalse(result.is_deactivated)
+        self.assertEqual(result.total_current_amount_usd, "100.00")
+        self.assertEqual(result.projected_total_amount_usd, "200.00")
+        self.assertIsNone(result.trial)
+        self.assertIsNone(result.usage_history)
+        self.assertIsNone(result.spend_history)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_free_subscription(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(subscription_level="free", has_active_subscription=False)
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.FREE)
+        self.assertFalse(result.has_active_subscription)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_custom_subscription(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(subscription_level="custom", has_active_subscription=True)
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.CUSTOM)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_unknown_subscription_level_defaults_to_free(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(subscription_level="unknown_level")
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.FREE)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_active_trial(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            subscription_level="free",
+            has_active_subscription=False,
+            trial={"status": "active", "expires_at": "2026-03-01", "target": "paid"},
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertIsNotNone(result.trial)
+        self.assertTrue(result.trial.is_active)
+        self.assertEqual(result.trial.expires_at, "2026-03-01")
+        self.assertEqual(result.trial.target, "paid")
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_expired_trial(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            trial={"status": "expired", "expires_at": "2025-01-01", "target": "paid"},
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertIsNotNone(result.trial)
+        self.assertFalse(result.trial.is_active)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_no_trial(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(trial=None)
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertIsNone(result.trial)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_billing_period_monthly(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            billing_period={
+                "current_period_start": "2026-01-01",
+                "current_period_end": "2026-01-31",
+                "interval": "month",
+            }
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertIsNotNone(result.billing_period)
+        self.assertEqual(result.billing_period.current_period_start, "2026-01-01")
+        self.assertEqual(result.billing_period.current_period_end, "2026-01-31")
+        self.assertEqual(result.billing_period.interval, MaxBillingContextBillingPeriodInterval.MONTH)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_billing_period_yearly(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            billing_period={
+                "current_period_start": "2025-01-01",
+                "current_period_end": "2026-01-01",
+                "interval": "year",
+            }
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.billing_period.interval, MaxBillingContextBillingPeriodInterval.YEAR)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_products_conversion(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            products=[
+                {
+                    "type": "product_analytics",
+                    "name": "Product analytics",
+                    "description": "Track events",
+                    "current_usage": 50000,
+                    "usage_limit": 100000,
+                    "percentage_usage": 0.5,
+                    "projected_amount_usd": "400.00",
+                    "docs_url": "https://posthog.com/docs",
+                    "addons": [
+                        {
+                            "type": "group_analytics",
+                            "name": "Group analytics",
+                            "description": "Analyze by groups",
+                            "current_usage": 1000,
+                            "usage_limit": 5000,
+                            "percentage_usage": 0.2,
+                            "docs_url": "https://posthog.com/docs/groups",
+                        }
+                    ],
+                }
+            ]
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(len(result.products), 1)
+        product = result.products[0]
+        self.assertEqual(product.type, "product_analytics")
+        self.assertEqual(product.name, "Product analytics")
+        self.assertTrue(product.is_used)
+        self.assertFalse(product.has_exceeded_limit)
+        self.assertEqual(product.current_usage, 50000)
+        self.assertEqual(product.percentage_usage, 0.5)
+
+        self.assertEqual(len(product.addons), 1)
+        addon = product.addons[0]
+        self.assertEqual(addon.type, "group_analytics")
+        self.assertTrue(addon.is_used)
+        self.assertFalse(addon.has_exceeded_limit)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_product_exceeded_limit(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            products=[
+                {
+                    "type": "analytics",
+                    "name": "Analytics",
+                    "description": "desc",
+                    "current_usage": 150000,
+                    "usage_limit": 100000,
+                    "percentage_usage": 1.5,
+                    "addons": [],
+                }
+            ]
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertTrue(result.products[0].has_exceeded_limit)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_product_not_used(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            products=[
+                {
+                    "type": "replay",
+                    "name": "Session replay",
+                    "description": "desc",
+                    "current_usage": 0,
+                    "percentage_usage": 0,
+                    "addons": [],
+                }
+            ]
+        )
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertFalse(result.products[0].is_used)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_custom_limits_applied_to_products(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(
+            products=[
+                {
+                    "type": "product_analytics",
+                    "name": "Product analytics",
+                    "description": "desc",
+                    "current_usage": 0,
+                    "percentage_usage": 0,
+                    "usage_key": "event_count_in_period",
+                    "addons": [],
+                }
+            ]
+        )
+        billing_data["custom_limits_usd"] = {"product_analytics": 500.0}
+        billing_data["next_period_custom_limits_usd"] = {"event_count_in_period": 600.0}
+
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.products[0].custom_limit_usd, 500.0)
+        self.assertEqual(result.products[0].next_period_custom_limit_usd, 600.0)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_settings_from_team(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 5
+        self.team.autocapture_opt_out = True
+        self.team.save()
+
+        billing_data = _make_billing_response()
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertFalse(result.settings.autocapture_on)
+        self.assertEqual(result.settings.active_destinations, 5)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_deactivated_account(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = _make_billing_response(deactivated=True)
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertTrue(result.is_deactivated)
+
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_minimal_response_no_optional_fields(self, mock_hog_function):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        billing_data = {
+            "has_active_subscription": False,
+            "products": [],
+        }
+        result = billing_response_to_max_context(billing_data, self.team)
+
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.FREE)
+        self.assertFalse(result.has_active_subscription)
+        self.assertIsNone(result.billing_plan)
+        self.assertIsNone(result.billing_period)
+        self.assertIsNone(result.trial)
+        self.assertEqual(result.products, [])
+
+
+class TestFetchServerBillingContext(BaseTest):
+    @patch("ee.hogai.context.billing.BillingManager")
+    @patch("ee.hogai.context.billing.get_cached_instance_license")
+    @patch("ee.hogai.context.billing.HogFunction")
+    def test_returns_billing_context_on_success(self, mock_hog_function, mock_license_fn, mock_billing_cls):
+        mock_hog_function.objects.filter.return_value.count.return_value = 0
+        mock_license = MagicMock(is_v2_license=True)
+        mock_license_fn.return_value = mock_license
+        mock_billing_cls.return_value.get_billing.return_value = {
+            "has_active_subscription": True,
+            "subscription_level": "paid",
+            "license": {"plan": "scale"},
+            "products": [],
+        }
+
+        result = fetch_server_billing_context(self.team)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.subscription_level, MaxBillingContextSubscriptionLevel.PAID)
+        self.assertTrue(result.has_active_subscription)
+
+    @patch("ee.hogai.context.billing.get_cached_instance_license")
+    def test_returns_none_when_no_license(self, mock_license_fn):
+        mock_license_fn.return_value = None
+        result = fetch_server_billing_context(self.team)
+        self.assertIsNone(result)
+
+    @patch("ee.hogai.context.billing.get_cached_instance_license")
+    def test_returns_none_when_not_v2_license(self, mock_license_fn):
+        mock_license_fn.return_value = MagicMock(is_v2_license=False)
+        result = fetch_server_billing_context(self.team)
+        self.assertIsNone(result)
+
+    @patch("ee.hogai.context.billing.BillingManager")
+    @patch("ee.hogai.context.billing.get_cached_instance_license")
+    def test_returns_none_on_billing_service_error(self, mock_license_fn, mock_billing_cls):
+        mock_license_fn.return_value = MagicMock(is_v2_license=True)
+        mock_billing_cls.return_value.get_billing.side_effect = Exception("Billing service error")
+
+        result = fetch_server_billing_context(self.team)
+
+        self.assertIsNone(result)

--- a/ee/hogai/tools/read_billing_tool/test/test_nodes.py
+++ b/ee/hogai/tools/read_billing_tool/test/test_nodes.py
@@ -40,12 +40,14 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
             context_manager=AssistantContextManager(self.team, self.user, {}),
         )
 
-    async def test_run_with_no_billing_context(self):
-        with patch.object(self.tool._context_manager, "get_billing_context", return_value=None):
-            result = await self.tool.execute()
-            self.assertEqual(result, "No billing information available")
+    @patch("ee.hogai.tools.read_billing_tool.tool.fetch_server_billing_context")
+    async def test_run_with_no_billing_context(self, mock_fetch_billing):
+        mock_fetch_billing.return_value = None
+        result = await self.tool.execute()
+        self.assertEqual(result, "No billing information available")
 
-    async def test_run_with_billing_context(self):
+    @patch("ee.hogai.tools.read_billing_tool.tool.fetch_server_billing_context")
+    async def test_run_with_billing_context(self, mock_fetch_billing):
         billing_context = MaxBillingContext(
             subscription_level=MaxBillingContextSubscriptionLevel.PAID,
             billing_plan="paid",
@@ -54,10 +56,8 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
             settings=MaxBillingContextSettings(autocapture_on=True, active_destinations=2),
             products=[],
         )
-        with (
-            patch.object(self.tool._context_manager, "get_billing_context", return_value=billing_context),
-            patch.object(self.tool, "_format_billing_context", return_value="Formatted Context"),
-        ):
+        mock_fetch_billing.return_value = billing_context
+        with patch.object(self.tool, "_format_billing_context", return_value="Formatted Context"):
             result = await self.tool.execute()
             self.assertEqual(result, "Formatted Context")
 

--- a/ee/hogai/tools/read_billing_tool/tool.py
+++ b/ee/hogai/tools/read_billing_tool/tool.py
@@ -9,6 +9,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.models import Team, User
 from posthog.sync import database_sync_to_async
 
+from ee.hogai.context.billing import fetch_server_billing_context
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.tool import MaxSubtool
 from ee.hogai.tool_errors import MaxToolFatalError
@@ -53,11 +54,10 @@ class ReadBillingTool(MaxSubtool):
         self._teams_map: dict[int, str] = {}
 
     async def execute(self) -> str:
-        billing_context = self._context_manager.get_billing_context()
+        billing_context = await database_sync_to_async(fetch_server_billing_context, thread_sensitive=False)(self._team)
         if not billing_context:
             return "No billing information available"
-        formatted_billing_context = await self._format_billing_context(billing_context)
-        return formatted_billing_context
+        return await self._format_billing_context(billing_context)
 
     @database_sync_to_async(thread_sensitive=False)
     def _format_billing_context(self, billing_context: MaxBillingContext) -> str:


### PR DESCRIPTION
## Problem

The HogAI system previously relied on client-supplied billing context passed through the RunnableConfig, which could be unreliable or missing. We need a robust server-side mechanism to fetch billing information directly from the BillingManager, ensuring accurate billing data is available for AI features like ticket creation and billing tool operations.

## Changes

- **New module `ee/hogai/context/billing.py`**: Implements server-side billing context fetching with:
  - `fetch_server_billing_context()`: Fetches billing data from BillingManager and converts to MaxBillingContext
  - `billing_response_to_max_context()`: Converts raw billing API responses to typed MaxBillingContext objects
  - Helper functions for converting products, addons, trials, and billing periods
  - Proper error handling and logging for billing service failures

- **Updated `TicketCommand`**: Modified to fetch billing context server-side via `fetch_server_billing_context()` instead of relying on config-supplied context, ensuring accurate subscription level checks for ticket creation eligibility

- **Updated `ReadBillingTool`**: Changed to use server-side billing context fetching instead of context manager's client-supplied data

- **Enhanced `AssistantContextManager`**: Added `get_server_billing_context()` method for async server-side billing context retrieval

- **Comprehensive test coverage**: Added 325 lines of tests covering:
  - Subscription level conversions (paid, free, custom)
  - Trial status handling (active, expired, none)
  - Billing period conversions (monthly, yearly)
  - Product and addon conversion with usage tracking
  - Custom limits application
  - Team settings integration
  - Error handling and edge cases

## How did you test this code?

Added comprehensive unit tests in `ee/hogai/context/test/test_billing.py` covering:
- All subscription level types and edge cases
- Trial status conversions
- Billing period interval handling
- Product/addon conversion with usage limits
- Custom limit application
- Team settings integration
- Error scenarios (missing license, non-v2 license, billing service errors)

Updated existing tests in `test_ticket.py` and `test_nodes.py` to use the new server-side billing context fetching approach with proper mocking.

All tests pass with the new implementation.

https://claude.ai/code/session_01MWSSe86ZAwWK7CR9fgBmWU