### PR TITLE
fix(experiments): add metric_type to all experiment metric events

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1484,6 +1484,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 experiment_id: experimentId,
                 team_id: teamId,
                 query_id: queryId,
+                ...getEventPropertiesForMetric(metric),
                 metric,
             })
         },
@@ -1494,6 +1495,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 query_id: queryId,
                 error_code: errorCode,
                 error_message: errorMessage,
+                ...getEventPropertiesForMetric(metric),
                 metric,
             })
         },
@@ -1502,6 +1504,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 experiment_id: experimentId,
                 team_id: teamId,
                 query_id: queryId,
+                ...getEventPropertiesForMetric(metric),
                 metric,
                 ...context,
             })


### PR DESCRIPTION
## Problem

`metric_type` (mean, funnel, ratio, retention, etc.) was only sent on `experiment metric error` events. The other metric events (timeout, out of memory, finished) were missing it, making breakdown/filtering by metric type impossible in dashboards.

## Changes

Add `getEventPropertiesForMetric(metric)` to the three remaining metric events so they all include `metric_type`.