### PR TITLE
feat(mcp): Track `report_user_action` from MCP separately if it's from the wizard

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -265,6 +265,7 @@ class EventSource(StrEnum):
     POSTHOG_AI = "posthog_ai"
     TERRAFORM = "terraform"
     MCP = "mcp"
+    WIZARD = "wizard"
 
 
 def get_event_source(request) -> EventSource:
@@ -272,6 +273,8 @@ def get_event_source(request) -> EventSource:
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     if "posthog/terraform-provider" in user_agent:
         return EventSource.TERRAFORM
+    if "posthog/wizard" in user_agent:
+        return EventSource.WIZARD
     if "posthog/mcp-server" in user_agent:
         return EventSource.MCP
     if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { USER_AGENT } from '@/lib/constants'
+import { getUserAgent } from '@/lib/constants'
 import { ErrorCode } from '@/lib/errors'
 import { getSearchParamsFromRecord } from '@/lib/utils.js'
 import {
@@ -125,6 +125,7 @@ export type Result<T, E = Error> = { success: true; data: T } | { success: false
 export interface ApiConfig {
     apiToken: string
     baseUrl: string
+    clientIdentifier?: string
 }
 
 type Endpoint = Record<string, any>
@@ -154,7 +155,7 @@ export class ApiClient {
         // TODO: should we move rate limiting from `fetchWithSchema` to here?
         const defaultHeaders: HeadersInit = {
             Authorization: `Bearer ${this.config.apiToken}`,
-            'User-Agent': USER_AGENT,
+            'User-Agent': getUserAgent(this.config.clientIdentifier),
         }
         if (options?.body) {
             defaultHeaders['Content-Type'] = 'application/json'

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -125,7 +125,7 @@ export type Result<T, E = Error> = { success: true; data: T } | { success: false
 export interface ApiConfig {
     apiToken: string
     baseUrl: string
-    clientIdentifier?: string
+    clientIdentifier?: string | undefined
 }
 
 type Endpoint = Record<string, any>

--- a/services/mcp/src/api/fetcher.ts
+++ b/services/mcp/src/api/fetcher.ts
@@ -1,4 +1,4 @@
-import { USER_AGENT } from '@/lib/constants'
+import { getUserAgent } from '@/lib/constants'
 
 import type { ApiConfig } from './client'
 import type { createApiClient } from './generated'
@@ -18,7 +18,7 @@ export const buildApiFetcher: (config: ApiConfig) => Parameters<typeof createApi
 
                 const headers = new Headers()
                 headers.set('Authorization', `Bearer ${config.apiToken}`)
-                headers.set('User-Agent', USER_AGENT)
+                headers.set('User-Agent', getUserAgent(config.clientIdentifier))
 
                 // Handle query parameters
                 if (input.urlSearchParams) {

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -202,12 +202,19 @@ const handleRequest = async (
         request.headers.get('x-posthog-organization-id') || url.searchParams.get('organization_id') || undefined
     const projectId = request.headers.get('x-posthog-project-id') || url.searchParams.get('project_id') || undefined
 
+    // Extract posthog/foo identifier from the client's User-Agent (e.g. "posthog/wizard")
+    // so we can forward it in outgoing API requests for source attribution
+    const clientUserAgent = request.headers.get('User-Agent') || ''
+    const clientIdentifierMatch = clientUserAgent.match(/posthog\/(\S+)/)
+    const clientIdentifier = clientIdentifierMatch ? clientIdentifierMatch[0] : undefined
+
     Object.assign(ctx.props, {
         apiToken: token,
         userHash: hash(token),
         sessionId: sessionId || undefined,
         organizationId,
         projectId,
+        clientIdentifier,
     })
 
     // Search params are used to build up the list of available tools. If no features are provided, all tools are available.

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -205,7 +205,7 @@ const handleRequest = async (
     // Extract posthog/foo identifier from the client's User-Agent (e.g. "posthog/wizard")
     // so we can forward it in outgoing API requests for source attribution
     const clientUserAgent = request.headers.get('User-Agent') || ''
-    const clientIdentifierMatch = clientUserAgent.match(/posthog\/(\S+)/)
+    const clientIdentifierMatch = clientUserAgent.match(/posthog\/([\w-]+)/)
     const clientIdentifier = clientIdentifierMatch ? clientIdentifierMatch[0] : undefined
 
     Object.assign(ctx.props, {

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -6,6 +6,13 @@ import packageJson from '../../package.json'
 
 export const USER_AGENT = `posthog/mcp-server; version: ${packageJson.version}`
 
+export function getUserAgent(clientIdentifier?: string): string {
+    if (clientIdentifier) {
+        return `${USER_AGENT}; for ${clientIdentifier}`
+    }
+    return USER_AGENT
+}
+
 // Region-specific PostHog API base URLs
 export const POSTHOG_US_BASE_URL = 'https://us.posthog.com'
 export const POSTHOG_EU_BASE_URL = 'https://eu.posthog.com'

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -41,6 +41,7 @@ export type RequestProperties = {
     version?: number
     organizationId?: string
     projectId?: string
+    clientIdentifier?: string
 }
 
 export class MCP extends McpAgent<Env> {
@@ -137,6 +138,7 @@ export class MCP extends McpAgent<Env> {
             this._api = new ApiClient({
                 apiToken: this.requestProperties.apiToken,
                 baseUrl,
+                clientIdentifier: this.requestProperties.clientIdentifier,
             })
         }
 


### PR DESCRIPTION
See https://github.com/PostHog/wizard/pull/291

## Problem

We need to track which client is making requests to the MCP server (e.g., PostHog Wizard) for better source attribution and analytics. Currently, we extract the client identifier from the User-Agent header but don't forward it in outgoing API requests.

## Changes

- Extract `posthog/foo` identifier from incoming User-Agent headers in the MCP request handler
- Store the client identifier in request context properties
- Pass client identifier through to the ApiClient configuration
- Update User-Agent headers in outgoing API requests to include the client identifier (e.g., `posthog/mcp-server; for posthog/wizard`)
- Add `WIZARD` event source to the Python event tracking system to properly categorize requests from PostHog Wizard
- Update `get_event_source()` to detect and classify wizard requests based on User-Agent

## How did you test this code?

The changes are straightforward data flow modifications:
- Client identifier extraction uses standard regex matching on User-Agent headers
- User-Agent header construction is a simple string concatenation
- Event source detection follows the existing pattern used for terraform-provider detection
- No new external dependencies or complex logic introduced

Existing tests should continue to pass as this is additive functionality that doesn't break existing behavior.

## Publish to changelog?

No

https://claude.ai/code/session_01AJEWnwWhZPuugRrFz9MgQ1