### PR TITLE
feat: Kafka-Deduplicator fail open

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -282,6 +282,13 @@ pub struct Config {
     pub checkpoint_partition_import_timeout_secs: u64,
 
     //// End checkpoint configuration ////
+    /// Fail-open mode: bypass all deduplication and forward events directly to output topic.
+    /// When enabled, the deduplicator skips store operations, checkpoint import/export,
+    /// and treats all events as unique. Use as an emergency kill switch when the
+    /// deduplication store is causing issues.
+    #[envconfig(default = "false")]
+    pub fail_open: bool,
+
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -205,3 +205,7 @@ pub const KAFKA_PRODUCER_SEND_DURATION_MS: &str = "kafka_producer_send_duration_
 
 /// Histogram for event parsing duration using rayon (in milliseconds)
 pub const EVENT_PARSING_DURATION_MS: &str = "event_parsing_duration_ms";
+
+// ==== Fail-open mode metrics ====
+/// Counter for events passed through in fail-open mode (deduplication bypassed)
+pub const FAIL_OPEN_EVENTS_PASSED_THROUGH: &str = "fail_open_events_passed_through_total";

--- a/rust/kafka-deduplicator/src/pipelines/mod.rs
+++ b/rust/kafka-deduplicator/src/pipelines/mod.rs
@@ -78,4 +78,6 @@ pub use results::{DedupFieldName, EnrichedEvent, EventSimilarity, PropertyDiffer
 pub use timestamp_deduplicator::{
     DeduplicatableEvent, PublisherConfig, TimestampDeduplicator, TimestampDeduplicatorConfig,
 };
-pub use traits::{DeduplicationKeyExtractor, DeduplicationMetadata, EventParser};
+pub use traits::{
+    DeduplicationKeyExtractor, DeduplicationMetadata, EventParser, FailOpenProcessor,
+};

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -57,6 +57,9 @@ pub struct PipelineBuilder {
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     rebalance_cleanup_parallelism: usize,
 
+    // Fail-open mode: bypass deduplication and forward events directly
+    fail_open: bool,
+
     // Ingestion events specific
     dedup_config: Option<DeduplicationConfig>,
     main_producer: Option<Arc<FutureProducer<KafkaContext>>>,
@@ -76,6 +79,7 @@ impl PipelineBuilder {
         commit_interval: std::time::Duration,
         seek_timeout: std::time::Duration,
         rebalance_cleanup_parallelism: usize,
+        fail_open: bool,
     ) -> Self {
         Self {
             pipeline_type,
@@ -89,6 +93,7 @@ impl PipelineBuilder {
             seek_timeout,
             checkpoint_importer: None,
             rebalance_cleanup_parallelism,
+            fail_open,
             dedup_config: None,
             main_producer: None,
             duplicate_producer: None,
@@ -197,6 +202,7 @@ impl PipelineBuilder {
 
         let ch_config = ClickHouseEventsConfig {
             store_config: self.store_manager.config().clone(),
+            fail_open: self.fail_open,
         };
 
         let processor = Arc::new(ClickHouseEventsBatchProcessor::new(


### PR DESCRIPTION
## Problem

As the kafka deduplicator is in the hot path, this is just a fail safe mechanism to allow it to fail open based on a configuration flag. This just redirects messages from the input topic to the output topic

## Changes

- Added `FAIL_OPEN` env var (defaults to `false`) to bypass all deduplication
- Created `FailOpenProcessor<T>` trait in `pipelines/traits.rs` that all pipeline processors must implement
- Ingestion events: forwards all raw messages to the output topic without parsing or dedup
- `process_batch()` on both processors checks `fail_open` and dispatches to the trait method
- Service skips cleanup task, checkpoint export/import when fail-open is active
- Added `fail_open_events_passed_through_total` metric counter

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
