### PR TITLE
feat: Add batch exports hog function invocation endpoint

### DIFF
--- a/nodejs/src/cdp/_tests/fixtures.ts
+++ b/nodejs/src/cdp/_tests/fixtures.ts
@@ -341,3 +341,32 @@ export const insertCohortMemberships = async (
     }
     return results
 }
+
+export const insertBatchExport = async (postgres: PostgresRouter, team_id: Team['id'], id: string): Promise<any> => {
+    const destination = await insertBatchExportDestination(postgres)
+    const res = await insertRow(postgres, 'posthog_batchexport', {
+        id: id,
+        team_id: team_id,
+        destination_id: destination.id,
+        name: 'test-batch-export',
+        interval: 'hour',
+        paused: false,
+        deleted: false,
+        created_at: new Date().toISOString(),
+        last_updated_at: new Date().toISOString(),
+        timezone: 'UTC',
+    })
+    return res
+}
+
+export const insertBatchExportDestination = async (postgres: PostgresRouter): Promise<any> => {
+    const res = await insertRow(postgres, 'posthog_batchexportdestination', {
+        id: new UUIDT().toString(),
+        type: 'S3',
+        config: {},
+        integration_id: null,
+        created_at: new Date().toISOString(),
+        last_updated_at: new Date().toISOString(),
+    })
+    return res
+}

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -16,7 +16,6 @@ import { closeHub, createHub } from '../utils/db/hub'
 import { UUIDT } from '../utils/utils'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from './_tests/examples'
 import { insertHogFunction as _insertHogFunction, createHogFunction } from './_tests/fixtures'
-import { insertBatchExport } from './_tests/fixtures'
 import { insertHogFlow as _insertHogFlow } from './_tests/fixtures-hogflows'
 import { deleteKeysWithPrefix } from './_tests/redis'
 import { CdpApi } from './cdp-api'
@@ -778,125 +777,6 @@ describe('CDP API', () => {
 
             expect(res.status).toEqual(500)
             expect(res.body.error).toEqual('Kafka producer not available')
-        })
-    })
-    describe('batch export hog function invocations', () => {
-        let batchExportId: string
-        let batchExportHogFunction: HogFunctionType
-        let clickhouseEvent: Record<string, any>
-
-        beforeEach(async () => {
-            clickhouseEvent = {
-                uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-                event: '$pageview',
-                team_id: team.id,
-                distinct_id: '123',
-                timestamp: '2021-09-28T14:00:00Z',
-                created_at: '2021-09-28T14:00:00Z',
-                properties: JSON.stringify({ $lib_version: '1.0.0' }),
-                elements_chain: '',
-            }
-
-            batchExportId = new UUIDT().toString()
-            await insertBatchExport(hub.postgres, team.id, batchExportId)
-
-            batchExportHogFunction = await insertHogFunction({
-                name: 'test batch export hog function',
-                ...HOG_EXAMPLES.simple_fetch,
-                ...HOG_INPUTS_EXAMPLES.simple_fetch,
-                ...HOG_FILTERS_EXAMPLES.no_filters,
-                batch_export_id: batchExportId,
-            })
-        })
-
-        it('errors if missing team', async () => {
-            const nonExistentTeamId = new UUIDT().toString()
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${nonExistentTeamId}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent })
-
-            expect(res.status).toEqual(404)
-            expect(res.body.errors[0]).toContain(nonExistentTeamId)
-        })
-
-        it('errors if missing hog function', async () => {
-            const nonExistentHogFunctionId = new UUIDT().toString()
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${nonExistentHogFunctionId}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent })
-
-            expect(res.status).toEqual(404)
-            expect(res.body.errors[0]).toContain(nonExistentHogFunctionId)
-        })
-
-        it('errors if missing batch export', async () => {
-            const nonExistentBatchExportId = new UUIDT().toString()
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${nonExistentBatchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent })
-
-            expect(res.status).toEqual(404)
-            expect(res.body.errors[0]).toContain(batchExportHogFunction.id)
-        })
-
-        it('errors if missing event', async () => {
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({})
-
-            expect(res.status).toEqual(400)
-            expect(res.body.errors[0]).toEqual('Invalid event')
-        })
-
-        it('errors if invocation_id is not a valid UUID', async () => {
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent, invocation_id: 'not-a-uuid' })
-
-            expect(res.status).toEqual(400)
-            expect(res.body.errors[0]).toEqual('Invalid UUID: not-a-uuid')
-        })
-
-        it('can invoke a batch export mocked hog function via the API', async () => {
-            mockFetch.mockImplementationOnce(() =>
-                Promise.resolve({
-                    status: 200,
-                    headers: { 'Content-Type': 'application/json' },
-                    json: () => Promise.resolve({ ok: true }),
-                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
-                    dump: () => Promise.resolve(),
-                })
-            )
-
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent })
-
-            expect(res.status).toEqual(200)
-            expect(res.body.status).toEqual('success')
-            expect(res.body.errors).toEqual([])
-            expect(res.body.logs).toMatchObject([
-                {
-                    level: 'info',
-                    message: expect.stringContaining('Fetch response:'),
-                },
-                {
-                    level: 'debug',
-                    message: expect.stringContaining('Function completed in'),
-                },
-            ])
         })
     })
 })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -779,4 +779,100 @@ describe('CDP API', () => {
             expect(res.body.error).toEqual('Kafka producer not available')
         })
     })
+    describe('batch export hog function invocations', () => {
+        const batchExportId = new UUIDT().toString()
+        let batchExportHogFunction: HogFunctionType
+
+        const clickhouseEvent = {
+            uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+            event: '$pageview',
+            team_id: team.id,
+            distinct_id: '123',
+            timestamp: '2021-09-28T14:00:00Z',
+            created_at: '2021-09-28T14:00:00Z',
+            properties: '{"$lib_version":"1.0.0"}',
+            elements_chain: '',
+        }
+
+        beforeEach(async () => {
+            batchExportHogFunction = await insertHogFunction({
+                name: 'test batch export hog function',
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+                batch_export_id: batchExportId,
+            })
+        })
+
+        it('errors if missing team', async () => {
+            const nonExistentTeamId = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${nonExistentTeamId}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Team not found')
+        })
+
+        it('errors if missing hog function', async () => {
+            const nonExistentHogFunctionId = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${nonExistentHogFunctionId}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Hog function not found')
+        })
+
+        it('errors if hog function belongs to a different team', async () => {
+            // hogFunction (from outer beforeEach) has no batch_export_id and belongs to team.id,
+            // but we're requesting it under a different team's path
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${new UUIDT().toString()}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Team not found')
+        })
+
+        it('errors if hog function belongs to a different batch export', async () => {
+            const differentBatchExportId = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${team.id}/batch_exports/${differentBatchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Hog function not found')
+        })
+
+        it('errors if missing event', async () => {
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({})
+
+            expect(res.status).toEqual(400)
+            expect(res.body.error).toEqual('Missing event')
+        })
+
+        it('errors if invocation_id is not a valid UUID', async () => {
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent, invocation_id: 'not-a-uuid' })
+
+            expect(res.status).toEqual(400)
+            expect(res.body.error).toEqual('Invalid invocation ID')
+        })
+    })
 })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -818,7 +818,7 @@ describe('CDP API', () => {
                 .send({ clickhouse_event: clickhouseEvent })
 
             expect(res.status).toEqual(404)
-            expect(res.body.error).toEqual('Team not found')
+            expect(res.body.errors[0]).toContain(nonExistentTeamId)
         })
 
         it('errors if missing hog function', async () => {
@@ -830,30 +830,19 @@ describe('CDP API', () => {
                 .send({ clickhouse_event: clickhouseEvent })
 
             expect(res.status).toEqual(404)
-            expect(res.body.error).toEqual('Hog function not found')
+            expect(res.body.errors[0]).toContain(nonExistentHogFunctionId)
         })
 
-        it('errors if hog function belongs to a different team', async () => {
+        it('errors if missing batch export', async () => {
+            const nonExistentBatchExportId = new UUIDT().toString()
             const res = await supertest(app)
                 .post(
-                    `/api/projects/${new UUIDT().toString()}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                    `/api/projects/${team.id}/batch_exports/${nonExistentBatchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
                 )
                 .send({ clickhouse_event: clickhouseEvent })
 
             expect(res.status).toEqual(404)
-            expect(res.body.error).toEqual('Team not found')
-        })
-
-        it('errors if hog function belongs to a different batch export', async () => {
-            const differentBatchExportId = new UUIDT().toString()
-            const res = await supertest(app)
-                .post(
-                    `/api/projects/${team.id}/batch_exports/${differentBatchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
-                )
-                .send({ clickhouse_event: clickhouseEvent })
-
-            expect(res.status).toEqual(404)
-            expect(res.body.error).toEqual('Hog function not found')
+            expect(res.body.errors[0]).toContain(batchExportHogFunction.id)
         })
 
         it('errors if missing event', async () => {
@@ -863,8 +852,8 @@ describe('CDP API', () => {
                 )
                 .send({})
 
-            expect(res.status).toEqual(400)
-            expect(res.body.error).toEqual('Missing event')
+            expect(res.status).toEqual(404)
+            expect(res.body.errors[0]).toEqual('Empty event')
         })
 
         it('errors if invocation_id is not a valid UUID', async () => {
@@ -875,7 +864,7 @@ describe('CDP API', () => {
                 .send({ clickhouse_event: clickhouseEvent, invocation_id: 'not-a-uuid' })
 
             expect(res.status).toEqual(400)
-            expect(res.body.error).toEqual('Invalid invocation ID')
+            expect(res.body.errors[0]).toEqual('Invalid UUID: not-a-uuid')
         })
 
         it('can invoke a batch export mocked hog function via the API', async () => {

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -877,5 +877,18 @@ describe('CDP API', () => {
             expect(res.status).toEqual(400)
             expect(res.body.error).toEqual('Invalid invocation ID')
         })
+
+        it('can invoke a batch export hog function mocked', async () => {
+            const res = await supertest(app)
+                .post(
+                    `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
+                )
+                .send({ clickhouse_event: clickhouseEvent, mock_async_functions: true })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.errors).toEqual([])
+            expect(res.body.logs.map((log: any) => log.message)).toMatchInlineSnapshot(`...`)
+        })
     })
 })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -878,17 +878,36 @@ describe('CDP API', () => {
             expect(res.body.error).toEqual('Invalid invocation ID')
         })
 
-        it('can invoke a batch export hog function mocked', async () => {
+        it('can invoke a batch export mocked hog function via the API', async () => {
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
             const res = await supertest(app)
                 .post(
                     `/api/projects/${team.id}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`
                 )
-                .send({ clickhouse_event: clickhouseEvent, mock_async_functions: true })
+                .send({ clickhouse_event: clickhouseEvent })
 
             expect(res.status).toEqual(200)
             expect(res.body.status).toEqual('success')
             expect(res.body.errors).toEqual([])
-            expect(res.body.logs.map((log: any) => log.message)).toMatchInlineSnapshot(`...`)
+            expect(res.body.logs).toMatchObject([
+                {
+                    level: 'info',
+                    message: expect.stringContaining('Fetch response:'),
+                },
+                {
+                    level: 'debug',
+                    message: expect.stringContaining('Function completed in'),
+                },
+            ])
         })
     })
 })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -16,6 +16,7 @@ import { closeHub, createHub } from '../utils/db/hub'
 import { UUIDT } from '../utils/utils'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from './_tests/examples'
 import { insertHogFunction as _insertHogFunction, createHogFunction } from './_tests/fixtures'
+import { insertBatchExport } from './_tests/fixtures'
 import { insertHogFlow as _insertHogFlow } from './_tests/fixtures-hogflows'
 import { deleteKeysWithPrefix } from './_tests/redis'
 import { CdpApi } from './cdp-api'
@@ -780,21 +781,25 @@ describe('CDP API', () => {
         })
     })
     describe('batch export hog function invocations', () => {
-        const batchExportId = new UUIDT().toString()
+        let batchExportId: string
         let batchExportHogFunction: HogFunctionType
-
-        const clickhouseEvent = {
-            uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-            event: '$pageview',
-            team_id: team.id,
-            distinct_id: '123',
-            timestamp: '2021-09-28T14:00:00Z',
-            created_at: '2021-09-28T14:00:00Z',
-            properties: '{"$lib_version":"1.0.0"}',
-            elements_chain: '',
-        }
+        let clickhouseEvent: Record<string, any>
 
         beforeEach(async () => {
+            clickhouseEvent = {
+                uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+                event: '$pageview',
+                team_id: team.id,
+                distinct_id: '123',
+                timestamp: '2021-09-28T14:00:00Z',
+                created_at: '2021-09-28T14:00:00Z',
+                properties: JSON.stringify({ $lib_version: '1.0.0' }),
+                elements_chain: '',
+            }
+
+            batchExportId = new UUIDT().toString()
+            await insertBatchExport(hub.postgres, team.id, batchExportId)
+
             batchExportHogFunction = await insertHogFunction({
                 name: 'test batch export hog function',
                 ...HOG_EXAMPLES.simple_fetch,
@@ -829,8 +834,6 @@ describe('CDP API', () => {
         })
 
         it('errors if hog function belongs to a different team', async () => {
-            // hogFunction (from outer beforeEach) has no batch_export_id and belongs to team.id,
-            // but we're requesting it under a different team's path
             const res = await supertest(app)
                 .post(
                     `/api/projects/${new UUIDT().toString()}/batch_exports/${batchExportId}/hog_functions/${batchExportHogFunction.id}/invocations`

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -852,8 +852,8 @@ describe('CDP API', () => {
                 )
                 .send({})
 
-            expect(res.status).toEqual(404)
-            expect(res.body.errors[0]).toEqual('Empty event')
+            expect(res.status).toEqual(400)
+            expect(res.body.errors[0]).toEqual('Invalid event')
         })
 
         it('errors if invocation_id is not a valid UUID', async () => {

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -109,6 +109,7 @@ export class CdpApi {
             this.hogFunctionMonitoringService
         )
         this.batchExportHogFunctionService = new BatchExportHogFunctionService(
+            hub.SITE_URL,
             hub.teamManager,
             this.hogFunctionManager,
             this.hogExecutor,
@@ -168,7 +169,7 @@ export class CdpApi {
         router.post('/api/messaging/generate_preferences_token', asyncHandler(this.generatePreferencesToken()))
         router.get('/api/messaging/validate_preferences_token/:token', asyncHandler(this.validatePreferencesToken()))
         router.post(
-            '/api/projects/:team_id/batch_exports/:id/hog_functions/:hog_function_id/invocations',
+            '/api/projects/:team_id/hog_functions/:hog_function_id/batch_export_invocations',
             asyncHandler(this.handleBatchExportHogFunction())
         )
 
@@ -735,16 +736,13 @@ export class CdpApi {
         () =>
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             try {
-                const request = await this.batchExportHogFunctionService.parseRequest(
+                const result = await this.batchExportHogFunctionService.execute(
                     {
-                        batch_export_id: req.params.id,
                         team_id: req.params.team_id,
                         hog_function_id: req.params.hog_function_id,
                     },
-                    req.body,
-                    this.hub.SITE_URL
+                    req.body
                 )
-                const result = await this.batchExportHogFunctionService.handleRequest(request)
 
                 return res.json({
                     status: result.error ? 'error' : 'success',

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -154,6 +154,10 @@ export class CdpApi {
         router.get('/api/hog_function_templates', this.getHogFunctionTemplates)
         router.post('/api/messaging/generate_preferences_token', asyncHandler(this.generatePreferencesToken()))
         router.get('/api/messaging/validate_preferences_token/:token', asyncHandler(this.validatePreferencesToken()))
+        router.post(
+            '/api/projects/:team_id/batch_exports/:id/hog_functions/:hog_function_id/invocations',
+            asyncHandler(this.handleBatchExportHogFunction())
+        )
 
         const publicBodySizeLimit = (req: ModifiedRequest, res: express.Response, next: express.NextFunction): void => {
             if (req.rawBody && req.rawBody.length > 512_000) {
@@ -711,6 +715,93 @@ export class CdpApi {
             } catch (error) {
                 logger.error('[CdpApi] Error validating preferences token', error)
                 return res.status(500).json({ error: 'Failed to validate token' })
+            }
+        }
+
+    private handleBatchExportHogFunction =
+        () =>
+        async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+            try {
+                const { team_id, id, hog_function_id } = req.params
+                const { clickhouse_event, invocation_id } = req.body
+
+                logger.info('⚡️', 'Received batch export invocation', { team_id, batch_export_id: id })
+
+                const invocationID = invocation_id ?? new UUIDT().toString()
+                if (!UUID.validateString(invocationID)) {
+                    return res.status(400).json({ error: 'Invalid invocation ID' })
+                }
+
+                const team = await this.hub.teamManager.getTeam(parseInt(team_id)).catch(() => null)
+                if (!team) {
+                    return res.status(404).json({ error: 'Team not found' })
+                }
+
+                let globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.hub.SITE_URL)
+                if (!globals.event) {
+                    return res.status(400).json({ error: 'Missing event' })
+                }
+
+                const hogFunction = await this.hogFunctionManager.fetchHogFunction(hog_function_id).catch(() => null)
+                if (!hogFunction || hogFunction.team_id !== team.id || hogFunction.batch_export_id !== id) {
+                    return res.status(404).json({ error: 'Hog function not found' })
+                }
+
+                let logs: MinimalLogEntry[] = []
+                const errors: any[] = []
+
+                const {
+                    invocations,
+                    logs: filterLogs,
+                    metrics: filterMetrics,
+                } = await this.hogExecutor.buildHogFunctionInvocations([hogFunction], globals)
+
+                // Add metrics to the logs
+                filterMetrics.forEach((metric) => {
+                    if (metric.metric_name === 'filtered') {
+                        logs.push({
+                            level: 'info',
+                            timestamp: DateTime.now(),
+                            message: `Mapping trigger not matching filters was ignored.`,
+                        })
+                    }
+                })
+
+                filterLogs.forEach((log) => {
+                    logs.push(log)
+                })
+
+                for (const invocation of invocations) {
+                    invocation.id = invocationID
+
+                    const options: HogExecutorExecuteAsyncOptions = buildHogExecutorAsyncOptions(false, logs)
+
+                    let response: any = null
+                    if (isNativeHogFunction(hogFunction)) {
+                        response = await this.nativeDestinationExecutorService.execute(invocation)
+                    } else if (isSegmentPluginHogFunction(hogFunction)) {
+                        response = await this.segmentDestinationExecutorService.execute(invocation)
+                    } else {
+                        response = await this.hogExecutor.executeWithAsyncFunctions(invocation, options)
+                    }
+
+                    logs = logs.concat(response.logs)
+                    if (response.error) {
+                        errors.push(response.error)
+                    }
+                }
+
+                const wasSkipped = invocations.length === 0
+
+                return res.json({
+                    status: errors.length > 0 ? 'error' : wasSkipped ? 'skipped' : 'success',
+                    errors: errors.map((e) => String(e)),
+                    logs: logs,
+                })
+            } catch (e) {
+                return res.status(500).json({ errors: [e.message] })
+            } finally {
+                await this.hogFunctionMonitoringService.flush()
             }
         }
 }

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -728,7 +728,11 @@ export class CdpApi {
                 logger.info('⚡️', 'Received batch export invocation', { team_id, batch_export_id: id })
 
                 const invocationID = invocation_id ?? new UUIDT().toString()
-                if (!UUID.validateString(invocationID)) {
+                try {
+                    if (!UUID.validateString(invocationID)) {
+                        return res.status(400).json({ error: 'Invalid invocation ID' })
+                    }
+                } catch {
                     return res.status(400).json({ error: 'Invalid invocation ID' })
                 }
 
@@ -737,6 +741,9 @@ export class CdpApi {
                     return res.status(404).json({ error: 'Team not found' })
                 }
 
+                if (!clickhouse_event) {
+                    return res.status(400).json({ error: 'Missing event' })
+                }
                 const globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.hub.SITE_URL)
                 if (!globals.event) {
                     return res.status(400).json({ error: 'Missing event' })
@@ -799,6 +806,7 @@ export class CdpApi {
                     logs: logs,
                 })
             } catch (e) {
+                console.error(e)
                 return res.status(500).json({ errors: [e.message] })
             } finally {
                 await this.hogFunctionMonitoringService.flush()

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -723,7 +723,7 @@ export class CdpApi {
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             try {
                 const { team_id, id, hog_function_id } = req.params
-                const { clickhouse_event, invocation_id } = req.body
+                const { clickhouse_event, mock_async_functions, invocation_id } = req.body
 
                 logger.info('⚡️', 'Received batch export invocation', { team_id, batch_export_id: id })
 
@@ -781,7 +781,10 @@ export class CdpApi {
                 for (const invocation of invocations) {
                     invocation.id = invocationID
 
-                    const options: HogExecutorExecuteAsyncOptions = buildHogExecutorAsyncOptions(false, logs)
+                    const options: HogExecutorExecuteAsyncOptions = buildHogExecutorAsyncOptions(
+                        mock_async_functions,
+                        logs
+                    )
 
                     let response: any = null
                     if (isNativeHogFunction(hogFunction)) {

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -41,6 +41,7 @@ import { HOG_FUNCTION_TEMPLATES } from './templates'
 import { HogFunctionInvocationGlobals, HogFunctionType, MinimalLogEntry } from './types'
 import { convertToHogFunctionInvocationGlobals, isNativeHogFunction, isSegmentPluginHogFunction } from './utils'
 import { convertToHogFunctionFilterGlobal } from './utils/hog-function-filtering'
+import { createInvocation } from './utils/invocation-utils'
 
 /**
  * Hub type for CdpApi.
@@ -723,16 +724,18 @@ export class CdpApi {
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             try {
                 const { team_id, id, hog_function_id } = req.params
-                const { clickhouse_event, mock_async_functions, invocation_id } = req.body
-
+                const { clickhouse_event, invocation_id } = req.body
                 logger.info('⚡️', 'Received batch export invocation', { team_id, batch_export_id: id })
 
                 const invocationID = invocation_id ?? new UUIDT().toString()
-                try {
-                    if (!UUID.validateString(invocationID)) {
-                        return res.status(400).json({ error: 'Invalid invocation ID' })
+                const isValidUUID = (() => {
+                    try {
+                        return UUID.validateString(invocationID)
+                    } catch {
+                        return false
                     }
-                } catch {
+                })()
+                if (!isValidUUID) {
                     return res.status(400).json({ error: 'Invalid invocation ID' })
                 }
 
@@ -754,62 +757,18 @@ export class CdpApi {
                     return res.status(404).json({ error: 'Hog function not found' })
                 }
 
-                let logs: MinimalLogEntry[] = []
-                const errors: any[] = []
+                const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(hogFunction, globals)
+                const invocation = createInvocation(globalsWithInputs, hogFunction)
+                invocation.id = invocationID
 
-                const {
-                    invocations,
-                    logs: filterLogs,
-                    metrics: filterMetrics,
-                } = await this.hogExecutor.buildHogFunctionInvocations([hogFunction], globals)
-
-                // Add metrics to the logs
-                filterMetrics.forEach((metric) => {
-                    if (metric.metric_name === 'filtered') {
-                        logs.push({
-                            level: 'info',
-                            timestamp: DateTime.now(),
-                            message: `Mapping trigger not matching filters was ignored.`,
-                        })
-                    }
-                })
-
-                filterLogs.forEach((log) => {
-                    logs.push(log)
-                })
-
-                for (const invocation of invocations) {
-                    invocation.id = invocationID
-
-                    const options: HogExecutorExecuteAsyncOptions = buildHogExecutorAsyncOptions(
-                        mock_async_functions,
-                        logs
-                    )
-
-                    let response: any = null
-                    if (isNativeHogFunction(hogFunction)) {
-                        response = await this.nativeDestinationExecutorService.execute(invocation)
-                    } else if (isSegmentPluginHogFunction(hogFunction)) {
-                        response = await this.segmentDestinationExecutorService.execute(invocation)
-                    } else {
-                        response = await this.hogExecutor.executeWithAsyncFunctions(invocation, options)
-                    }
-
-                    logs = logs.concat(response.logs)
-                    if (response.error) {
-                        errors.push(response.error)
-                    }
-                }
-
-                const wasSkipped = invocations.length === 0
+                const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
 
                 return res.json({
-                    status: errors.length > 0 ? 'error' : wasSkipped ? 'skipped' : 'success',
-                    errors: errors.map((e) => String(e)),
-                    logs: logs,
+                    status: result.error ? 'error' : 'success',
+                    errors: result.error ? [String(result.error)] : [],
+                    logs: result.logs,
                 })
             } catch (e) {
-                console.error(e)
                 return res.status(500).json({ errors: [e.message] })
             } finally {
                 await this.hogFunctionMonitoringService.flush()

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -737,7 +737,7 @@ export class CdpApi {
                     return res.status(404).json({ error: 'Team not found' })
                 }
 
-                let globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.hub.SITE_URL)
+                const globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.hub.SITE_URL)
                 if (!globals.event) {
                     return res.status(400).json({ error: 'Missing event' })
                 }

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -111,7 +111,9 @@ export class CdpApi {
         this.batchExportHogFunctionService = new BatchExportHogFunctionService(
             hub.teamManager,
             this.hogFunctionManager,
-            this.hogExecutor
+            this.hogExecutor,
+            this.hogWatcher,
+            this.hogFunctionMonitoringService
         )
     }
 
@@ -132,7 +134,11 @@ export class CdpApi {
     }
 
     async stop(): Promise<void> {
-        await Promise.all([this.cdpWarehouseKafkaProducer?.disconnect(), this.cdpSourceWebhooksConsumer.stop()])
+        await Promise.all([
+            this.cdpWarehouseKafkaProducer?.disconnect(),
+            this.cdpSourceWebhooksConsumer.stop(),
+            this.batchExportHogFunctionService.stop(),
+        ])
     }
 
     isHealthy(): HealthCheckResult {

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -23,6 +23,7 @@ import {
     HogTransformerServiceDeps,
     createHogTransformerService,
 } from './hog-transformations/hog-transformer.service'
+import { BatchExportHogFunctionService, NotFoundError, ParseError } from './services/batch-export-hog-function.service'
 import { HogExecutorExecuteAsyncOptions, HogExecutorService, MAX_ASYNC_STEPS } from './services/hog-executor.service'
 import { HogFlowExecutorService, createHogFlowInvocation } from './services/hogflows/hogflow-executor.service'
 import { HogFlowFunctionsService } from './services/hogflows/hogflow-functions.service'
@@ -41,7 +42,6 @@ import { HOG_FUNCTION_TEMPLATES } from './templates'
 import { HogFunctionInvocationGlobals, HogFunctionType, MinimalLogEntry } from './types'
 import { convertToHogFunctionInvocationGlobals, isNativeHogFunction, isSegmentPluginHogFunction } from './utils'
 import { convertToHogFunctionFilterGlobal } from './utils/hog-function-filtering'
-import { createInvocation } from './utils/invocation-utils'
 
 /**
  * Hub type for CdpApi.
@@ -81,6 +81,7 @@ export class CdpApi {
     private recipientPreferencesService: RecipientPreferencesService
     private recipientTokensService: RecipientTokensService
     private cdpWarehouseKafkaProducer?: KafkaProducerWrapper
+    private batchExportHogFunctionService: BatchExportHogFunctionService
 
     constructor(private hub: CdpApiHub) {
         const services = createCdpCoreServices(hub, 'cdp-api-redis')
@@ -106,6 +107,11 @@ export class CdpApi {
             this.hogFunctionManager,
             this.hogFlowManager,
             this.hogFunctionMonitoringService
+        )
+        this.batchExportHogFunctionService = new BatchExportHogFunctionService(
+            hub.teamManager,
+            this.hogFunctionManager,
+            this.hogExecutor
         )
     }
 
@@ -723,45 +729,16 @@ export class CdpApi {
         () =>
         async (req: ModifiedRequest, res: express.Response): Promise<any> => {
             try {
-                const { team_id, id, hog_function_id } = req.params
-                const { clickhouse_event, invocation_id } = req.body
-                logger.info('⚡️', 'Received batch export invocation', { team_id, batch_export_id: id })
-
-                const invocationID = invocation_id ?? new UUIDT().toString()
-                const isValidUUID = (() => {
-                    try {
-                        return UUID.validateString(invocationID)
-                    } catch {
-                        return false
-                    }
-                })()
-                if (!isValidUUID) {
-                    return res.status(400).json({ error: 'Invalid invocation ID' })
-                }
-
-                const team = await this.hub.teamManager.getTeam(parseInt(team_id)).catch(() => null)
-                if (!team) {
-                    return res.status(404).json({ error: 'Team not found' })
-                }
-
-                if (!clickhouse_event) {
-                    return res.status(400).json({ error: 'Missing event' })
-                }
-                const globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.hub.SITE_URL)
-                if (!globals.event) {
-                    return res.status(400).json({ error: 'Missing event' })
-                }
-
-                const hogFunction = await this.hogFunctionManager.fetchHogFunction(hog_function_id).catch(() => null)
-                if (!hogFunction || hogFunction.team_id !== team.id || hogFunction.batch_export_id !== id) {
-                    return res.status(404).json({ error: 'Hog function not found' })
-                }
-
-                const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(hogFunction, globals)
-                const invocation = createInvocation(globalsWithInputs, hogFunction)
-                invocation.id = invocationID
-
-                const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
+                const request = await this.batchExportHogFunctionService.parseRequest(
+                    {
+                        batch_export_id: req.params.id,
+                        team_id: req.params.team_id,
+                        hog_function_id: req.params.hog_function_id,
+                    },
+                    req.body,
+                    this.hub.SITE_URL
+                )
+                const result = await this.batchExportHogFunctionService.handleRequest(request)
 
                 return res.json({
                     status: result.error ? 'error' : 'success',
@@ -769,9 +746,14 @@ export class CdpApi {
                     logs: result.logs,
                 })
             } catch (e) {
-                return res.status(500).json({ errors: [e.message] })
-            } finally {
-                await this.hogFunctionMonitoringService.flush()
+                if (e instanceof NotFoundError) {
+                    return res.status(404).json({ errors: [e.message] })
+                } else if (e instanceof ParseError) {
+                    return res.status(400).json({ errors: [e.message] })
+                } else {
+                    console.error(e)
+                    return res.status(500).json({ errors: [e.message] })
+                }
             }
         }
 }

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -1,0 +1,270 @@
+import { mockProducerObserver } from '~/tests/helpers/mocks/producer.mock'
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
+import { Server } from 'http'
+import supertest from 'supertest'
+import express from 'ultimate-express'
+
+import { setupExpressApp } from '~/api/router'
+import { insertBatchExport, insertHogFunction as _insertHogFunction } from '~/cdp/_tests/fixtures'
+import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '~/cdp/_tests/examples'
+import { CdpApi } from '~/cdp/cdp-api'
+import { HogFunctionType } from '~/cdp/types'
+import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
+import { Hub, Team } from '~/types'
+import { closeHub, createHub } from '~/utils/db/hub'
+import { UUIDT } from '~/utils/utils'
+
+describe('BatchExportHogFunctionService', () => {
+    let hub: Hub
+    let team: Team
+    let api: CdpApi
+    let app: express.Application
+    let server: Server
+
+    let batchExportId: string
+    let hogFunction: HogFunctionType
+    let clickhouseEvent: Record<string, any>
+
+    const insertHogFunction = async (hogFunction: Partial<HogFunctionType>) => {
+        const item = await _insertHogFunction(hub.postgres, team.id, hogFunction)
+        api['hogFunctionManager']['onHogFunctionsReloaded'](team.id, [item.id])
+        return item
+    }
+
+    const invocationUrl = () =>
+        `/api/projects/${team.id}/hog_functions/${hogFunction.id}/batch_export_invocations`
+
+    const postInvocation = (body: any) => supertest(app).post(invocationUrl()).send(body)
+
+    beforeAll(async () => {
+        hub = await createHub({ SITE_URL: 'http://localhost:8000' })
+        team = await getFirstTeam(hub)
+
+        api = new CdpApi(hub)
+        app = setupExpressApp()
+        app.use('/', api.router())
+        server = app.listen(0, () => {})
+    })
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        mockFetch.mockClear()
+
+        clickhouseEvent = {
+            uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+            event: '$pageview',
+            team_id: team.id,
+            distinct_id: '123',
+            timestamp: '2021-09-28T14:00:00Z',
+            created_at: '2021-09-28T14:00:00Z',
+            properties: JSON.stringify({ $lib_version: '1.0.0' }),
+            elements_chain: '',
+        }
+
+        batchExportId = new UUIDT().toString()
+        await insertBatchExport(hub.postgres, team.id, batchExportId)
+
+        hogFunction = await insertHogFunction({
+            name: 'test batch export hog function',
+            ...HOG_EXAMPLES.simple_fetch,
+            ...HOG_INPUTS_EXAMPLES.simple_fetch,
+            ...HOG_FILTERS_EXAMPLES.no_filters,
+            batch_export_id: batchExportId,
+        })
+    })
+
+    afterAll(async () => {
+        await api.stop()
+        server.close()
+        await closeHub(hub)
+    })
+
+    describe('request body validation', () => {
+        it.each([
+            ['empty body', {}, 'clickhouse_event'],
+            ['missing event uuid', { clickhouse_event: { event: '$pageview', team_id: 1, distinct_id: 'x', timestamp: 't' } }, 'uuid'],
+            ['missing event name', { clickhouse_event: { uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0', team_id: 1, distinct_id: 'x', timestamp: 't' } }, 'event'],
+        ])('rejects %s', async (_label, body, expectedField) => {
+            const res = await postInvocation(body)
+            expect(res.status).toEqual(400)
+            expect(res.body.errors[0]).toContain('Invalid request body')
+            expect(res.body.errors[0]).toContain(expectedField)
+        })
+
+        it('rejects non-string invocation_id', async () => {
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent, invocation_id: 12345 })
+            expect(res.status).toEqual(400)
+            expect(res.body.errors[0]).toContain('Invalid request body')
+            expect(res.body.errors[0]).toContain('invocation_id')
+        })
+
+        it('rejects invalid uuid invocation_id', async () => {
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent, invocation_id: 'not-a-uuid' })
+            expect(res.status).toEqual(400)
+            expect(res.body.errors[0]).toContain('Invalid request body')
+            expect(res.body.errors[0]).toContain('invocation_id')
+        })
+    })
+
+    describe('resource lookup errors', () => {
+        it('returns 404 for non-existent team', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/99999/hog_functions/${hogFunction.id}/batch_export_invocations`)
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.errors[0]).toContain('99999')
+        })
+
+        it('returns 404 for non-existent hog function', async () => {
+            const fakeId = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/${fakeId}/batch_export_invocations`)
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.errors[0]).toContain(fakeId)
+        })
+
+        it('returns 404 for hog function without batch_export_id', async () => {
+            const nonBatchFunction = await insertHogFunction({
+                name: 'non-batch hog function',
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+            })
+
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/${nonBatchFunction.id}/batch_export_invocations`)
+                .send({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(404)
+            expect(res.body.errors[0]).toContain(nonBatchFunction.id)
+        })
+    })
+
+    describe('successful invocation', () => {
+        it('executes the hog function and returns success', async () => {
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.errors).toEqual([])
+            expect(res.body.logs).toMatchObject([
+                { level: 'info', message: expect.stringContaining('Fetch response:') },
+                { level: 'debug', message: expect.stringContaining('Function completed in') },
+            ])
+        })
+
+        it('uses provided invocation_id', async () => {
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const invocationId = new UUIDT().toString()
+            const res = await postInvocation({
+                clickhouse_event: clickhouseEvent,
+                invocation_id: invocationId,
+            })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+        })
+
+        it('generates globals with source metadata', async () => {
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+            const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+            expect(fetchBody).toMatchObject({
+                event: expect.objectContaining({
+                    uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+                    event: '$pageview',
+                    distinct_id: '123',
+                }),
+            })
+        })
+
+        it('produces monitoring metrics', async () => {
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            await postInvocation({ clickhouse_event: clickhouseEvent })
+            await api['batchExportHogFunctionService'].stop()
+
+            const metrics = mockProducerObserver
+                .getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                .map((x) => x.value) as any[]
+
+            expect(metrics).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        metric_name: 'succeeded',
+                    }),
+                ])
+            )
+        })
+    })
+
+    describe('execution errors', () => {
+        it('returns error log when fetch returns 500', async () => {
+            mockFetch.mockImplementation(() =>
+                Promise.resolve({
+                    status: 500,
+                    headers: { 'Content-Type': 'text/plain' },
+                    json: () => Promise.reject(new Error('not json')),
+                    text: () => Promise.resolve('Internal Server Error'),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.logs).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        level: 'error',
+                        message: expect.stringContaining('HTTP fetch failed'),
+                    }),
+                ])
+            )
+        })
+    })
+})

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -6,14 +6,16 @@ import supertest from 'supertest'
 import express from 'ultimate-express'
 
 import { setupExpressApp } from '~/api/router'
-import { insertBatchExport, insertHogFunction as _insertHogFunction } from '~/cdp/_tests/fixtures'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '~/cdp/_tests/examples'
+import { insertHogFunction as _insertHogFunction, insertBatchExport } from '~/cdp/_tests/fixtures'
 import { CdpApi } from '~/cdp/cdp-api'
 import { HogFunctionType } from '~/cdp/types'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
 import { UUIDT } from '~/utils/utils'
+
+import { parseJSON } from '../../utils/json-parse'
 
 describe('BatchExportHogFunctionService', () => {
     let hub: Hub
@@ -32,8 +34,7 @@ describe('BatchExportHogFunctionService', () => {
         return item
     }
 
-    const invocationUrl = () =>
-        `/api/projects/${team.id}/hog_functions/${hogFunction.id}/batch_export_invocations`
+    const invocationUrl = () => `/api/projects/${team.id}/hog_functions/${hogFunction.id}/batch_export_invocations`
 
     const postInvocation = (body: any) => supertest(app).post(invocationUrl()).send(body)
 
@@ -83,8 +84,23 @@ describe('BatchExportHogFunctionService', () => {
     describe('request body validation', () => {
         it.each([
             ['empty body', {}, 'clickhouse_event'],
-            ['missing event uuid', { clickhouse_event: { event: '$pageview', team_id: 1, distinct_id: 'x', timestamp: 't' } }, 'uuid'],
-            ['missing event name', { clickhouse_event: { uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0', team_id: 1, distinct_id: 'x', timestamp: 't' } }, 'event'],
+            [
+                'missing event uuid',
+                { clickhouse_event: { event: '$pageview', team_id: 1, distinct_id: 'x', timestamp: 't' } },
+                'uuid',
+            ],
+            [
+                'missing event name',
+                {
+                    clickhouse_event: {
+                        uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+                        team_id: 1,
+                        distinct_id: 'x',
+                        timestamp: 't',
+                    },
+                },
+                'event',
+            ],
         ])('rejects %s', async (_label, body, expectedField) => {
             const res = await postInvocation(body)
             expect(res.status).toEqual(400)
@@ -204,7 +220,7 @@ describe('BatchExportHogFunctionService', () => {
             expect(res.status).toEqual(200)
 
             expect(mockFetch).toHaveBeenCalledTimes(1)
-            const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+            const fetchBody = parseJSON(mockFetch.mock.calls[0][1].body)
             expect(fetchBody).toMatchObject({
                 event: expect.objectContaining({
                     uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -1,11 +1,14 @@
+import { DateTime } from 'luxon'
+
 import { TeamManager } from '~/utils/team-manager'
 
 import { RawClickHouseEvent, Team } from '../../types'
+import { parseJSON } from '../../utils/json-parse'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
-import { UUID, UUIDT } from '../../utils/utils'
+import { UUID, UUIDT, clickHouseTimestampToISO } from '../../utils/utils'
 import { HogFunctionInvocationGlobals, HogFunctionType } from '../types'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
-import { convertToHogFunctionInvocationGlobals } from '../utils'
+import { getPersonDisplayName } from '../utils'
 import { createInvocation } from '../utils/invocation-utils'
 import { HogExecutorService } from './hog-executor.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
@@ -62,22 +65,28 @@ export class BatchExportHogFunctionService {
             throw new NotFoundError('Missing team with id: ' + params.team_id)
         }
 
-        let globals: HogFunctionInvocationGlobals
-        try {
-            globals = convertToHogFunctionInvocationGlobals(body.clickhouse_event as RawClickHouseEvent, team, siteUrl)
-        } catch (e) {
-            throw new ParseError('Invalid event')
-        }
-        if (!globals.event) {
-            throw new ParseError('Empty event')
-        }
-
         const hogFunction = await this.hogFunctionManager.getHogFunction(params.hog_function_id)
         if (!hogFunction) {
             throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
         }
         if (hogFunction.team_id !== team.id || hogFunction.batch_export_id !== params.batch_export_id) {
             throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
+        }
+
+        let globals: HogFunctionInvocationGlobals
+        try {
+            globals = this.buildRequestGlobals(
+                body.clickhouse_event as RawClickHouseEvent,
+                hogFunction,
+                params.batch_export_id,
+                team,
+                siteUrl
+            )
+        } catch (e) {
+            throw new ParseError('Invalid event')
+        }
+        if (!globals.event) {
+            throw new ParseError('Empty event')
         }
 
         return {
@@ -87,6 +96,67 @@ export class BatchExportHogFunctionService {
             invocationId,
             team,
         }
+    }
+
+    private buildRequestGlobals(
+        event: RawClickHouseEvent,
+        hogFunction: HogFunctionType,
+        batchExportId: string,
+        team: Team,
+        siteUrl: string
+    ) {
+        const properties = event.properties ? parseJSON(event.properties) : {}
+        const projectUrl = `${siteUrl}/project/${team.id}`
+
+        let person: HogFunctionInvocationGlobals['person']
+
+        if (event.person_id) {
+            const personProperties = event.person_properties ? parseJSON(event.person_properties) : {}
+            const personDisplayName = getPersonDisplayName(team, event.distinct_id, personProperties)
+
+            person = {
+                id: event.person_id,
+                properties: personProperties,
+                name: personDisplayName,
+                url: `${projectUrl}/person/${encodeURIComponent(event.distinct_id)}`,
+            }
+        }
+        const eventTimestamp = DateTime.fromISO(event.timestamp).isValid
+            ? event.timestamp
+            : clickHouseTimestampToISO(event.timestamp)
+
+        const eventCapturedAt = event.captured_at
+            ? DateTime.fromISO(event.captured_at).isValid
+                ? event.captured_at
+                : clickHouseTimestampToISO(event.captured_at)
+            : null
+
+        const context: HogFunctionInvocationGlobals = {
+            project: {
+                id: team.id,
+                name: team.name,
+                url: projectUrl,
+            },
+            source: {
+                name: `Batch export: ${batchExportId}`,
+                url: `${projectUrl}/batch_exports/${batchExportId}/hog_functions/${hogFunction.id}`,
+            },
+            event: {
+                uuid: event.uuid,
+                event: event.event!,
+                elements_chain: event.elements_chain,
+                distinct_id: event.distinct_id,
+                properties,
+                timestamp: eventTimestamp,
+                captured_at: eventCapturedAt,
+                url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
+            },
+            // TODO: Should this be set or not?
+            groups: {},
+            person,
+        }
+
+        return context
     }
 
     /**

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -1,0 +1,123 @@
+import { TeamManager } from '~/utils/team-manager'
+
+import { RawClickHouseEvent, Team } from '../../types'
+import { UUID, UUIDT } from '../../utils/utils'
+import { HogFunctionInvocationGlobals, HogFunctionType } from '../types'
+import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
+import { convertToHogFunctionInvocationGlobals } from '../utils'
+import { createInvocation } from '../utils/invocation-utils'
+import { HogExecutorService } from './hog-executor.service'
+import { HogFunctionManagerService } from './managers/hog-function-manager.service'
+
+export interface ExecutionRequest {
+    batchExportId: string
+    globals: HogFunctionInvocationGlobals
+    hogFunction: HogFunctionType
+    invocationId: UUID
+    team: Team
+}
+
+export class BatchExportHogFunctionService {
+    constructor(
+        private teamManager: TeamManager,
+        private hogFunctionManager: HogFunctionManagerService,
+        private hogExecutor: HogExecutorService
+    ) {}
+
+    /**
+     * Parses and validates all inputs required to execute a batch export hog function.
+     * Returns a fully-typed HogFunctionExecutionRequest when successful, or throws
+     * otherwise.
+     *
+     * @param params - Route parameters from the request
+     * @param body - Request body containing the event and invocation ID
+     * @param siteUrl - Required by convertToHogFunctionInvocationGlobals
+     * @returns A validated batch export hog function execution request
+     * @throws {ParseError} if any issues arise while parsing provided inputs
+     * @throws {NotFoundError} if any required look-ups result in no findings
+     */
+    async parseRequest(
+        params: { team_id: string; batch_export_id: string; hog_function_id: string },
+        body: { clickhouse_event?: unknown; invocation_id?: unknown },
+        siteUrl: string
+    ): Promise<ExecutionRequest> {
+        const invocationId = parseInvocationId(body.invocation_id)
+
+        let team: Team | null
+        try {
+            team = await this.teamManager.getTeam(parseInt(params.team_id))
+        } catch (e) {
+            throw new ParseError('Invalid team_id: ' + params.team_id)
+        }
+        if (!team) {
+            throw new NotFoundError('Missing team with id: ' + params.team_id)
+        }
+
+        let globals: HogFunctionInvocationGlobals
+        try {
+            globals = convertToHogFunctionInvocationGlobals(body.clickhouse_event as RawClickHouseEvent, team, siteUrl)
+        } catch (e) {
+            throw new ParseError('Invalid event')
+        }
+        if (!globals.event) {
+            throw new ParseError('Empty event')
+        }
+
+        const hogFunction = await this.hogFunctionManager.getHogFunction(params.hog_function_id)
+        if (!hogFunction) {
+            throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
+        }
+        if (hogFunction.team_id !== team.id || hogFunction.batch_export_id !== params.batch_export_id) {
+            throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
+        }
+
+        return {
+            batchExportId: params.batch_export_id,
+            globals,
+            hogFunction,
+            invocationId,
+            team,
+        }
+    }
+
+    /**
+     * Handles a HogFunctionExecutionRequest by executing the associated hog function.
+     *
+     * @param request - The request to handle
+     * @returns The result of the invocation
+     */
+    async handleRequest(
+        request: ExecutionRequest
+    ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
+        const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(request.hogFunction, request.globals)
+        const invocation = createInvocation(globalsWithInputs, request.hogFunction)
+        invocation.id = request.invocationId.toString()
+
+        return await this.hogExecutor.executeWithAsyncFunctions(invocation)
+    }
+}
+
+function parseInvocationId(raw: unknown): UUID {
+    try {
+        const uuid = typeof raw === 'string' ? new UUID(raw) : new UUIDT()
+        return uuid
+    } catch (e) {
+        throw new ParseError('Invalid UUID: ' + raw)
+    }
+}
+
+export class NotFoundError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'NotFoundError'
+        Object.setPrototypeOf(this, NotFoundError.prototype)
+    }
+}
+
+export class ParseError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ParseError'
+        Object.setPrototypeOf(this, NotFoundError.prototype)
+    }
+}

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -1,32 +1,45 @@
-import { DateTime } from 'luxon'
+import { z } from 'zod'
 
 import { TeamManager } from '~/utils/team-manager'
 
 import { RawClickHouseEvent, Team } from '../../types'
-import { parseJSON } from '../../utils/json-parse'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
-import { UUID, UUIDT, clickHouseTimestampToISO } from '../../utils/utils'
-import { HogFunctionInvocationGlobals, HogFunctionType } from '../types'
-import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
-import { getPersonDisplayName } from '../utils'
+import { UUID, UUIDT } from '../../utils/utils'
+import {
+    CyclotronJobInvocationHogFunction,
+    CyclotronJobInvocationResult,
+    HogFunctionInvocationGlobals,
+    HogFunctionType,
+} from '../types'
+import { convertToHogFunctionInvocationGlobals } from '../utils'
 import { createInvocation } from '../utils/invocation-utils'
 import { HogExecutorService } from './hog-executor.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
 import { HogWatcherService } from './monitoring/hog-watcher.service'
 
-export interface ExecutionRequest {
-    batchExportId: string
-    globals: HogFunctionInvocationGlobals
-    hogFunction: HogFunctionType
-    invocationId: UUID
-    team: Team
-}
+// TODO: This might be too strict so we need to validate that it matches well what we would expect to get from batch exports
+const batchExportRequestBodySchema = z.object({
+    clickhouse_event: z.object({
+        uuid: z.string(),
+        event: z.string(),
+        team_id: z.number(),
+        distinct_id: z.string(),
+        person_id: z.string().optional(),
+        timestamp: z.string(),
+        captured_at: z.string().nullish(),
+        properties: z.string().optional(),
+        elements_chain: z.string().default(''),
+        person_properties: z.string().optional(),
+    }),
+    invocation_id: z.string().uuid().optional(),
+})
 
 export class BatchExportHogFunctionService {
     private promiseScheduler: PromiseScheduler
 
     constructor(
+        private siteUrl: string,
         private teamManager: TeamManager,
         private hogFunctionManager: HogFunctionManagerService,
         private hogExecutor: HogExecutorService,
@@ -36,24 +49,17 @@ export class BatchExportHogFunctionService {
         this.promiseScheduler = new PromiseScheduler()
     }
 
-    /**
-     * Parses and validates all inputs required to execute a batch export hog function.
-     * Returns a fully-typed HogFunctionExecutionRequest when successful, or throws
-     * otherwise.
-     *
-     * @param params - Route parameters from the request
-     * @param body - Request body containing the event and invocation ID
-     * @param siteUrl - Required by convertToHogFunctionInvocationGlobals
-     * @returns A validated batch export hog function execution request
-     * @throws {ParseError} if any issues arise while parsing provided inputs
-     * @throws {NotFoundError} if any required look-ups result in no findings
-     */
-    async parseRequest(
-        params: { team_id: string; batch_export_id: string; hog_function_id: string },
-        body: { clickhouse_event?: unknown; invocation_id?: unknown },
-        siteUrl: string
-    ): Promise<ExecutionRequest> {
-        const invocationId = parseInvocationId(body.invocation_id)
+    async execute(
+        params: { team_id: string; hog_function_id: string },
+        body: unknown
+    ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
+        const parsed = batchExportRequestBodySchema.safeParse(body)
+        if (!parsed.success) {
+            throw new ParseError('Invalid request body: ' + parsed.error.message)
+        }
+
+        const { clickhouse_event, invocation_id } = parsed.data
+        const invocationId = invocation_id ? new UUID(invocation_id) : new UUIDT()
 
         let team: Team | null
         try {
@@ -69,108 +75,15 @@ export class BatchExportHogFunctionService {
         if (!hogFunction) {
             throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
         }
-        if (hogFunction.team_id !== team.id || hogFunction.batch_export_id !== params.batch_export_id) {
+        if (hogFunction.team_id !== team.id || !hogFunction.batch_export_id) {
             throw new NotFoundError('Missing hog function with id: ' + params.hog_function_id)
         }
 
-        let globals: HogFunctionInvocationGlobals
-        try {
-            globals = this.buildRequestGlobals(
-                body.clickhouse_event as RawClickHouseEvent,
-                hogFunction,
-                params.batch_export_id,
-                team,
-                siteUrl
-            )
-        } catch (e) {
-            throw new ParseError('Invalid event')
-        }
-        if (!globals.event) {
-            throw new ParseError('Empty event')
-        }
+        const globals = this.buildRequestGlobals(clickhouse_event as RawClickHouseEvent, hogFunction, team)
 
-        return {
-            batchExportId: params.batch_export_id,
-            globals,
-            hogFunction,
-            invocationId,
-            team,
-        }
-    }
-
-    private buildRequestGlobals(
-        event: RawClickHouseEvent,
-        hogFunction: HogFunctionType,
-        batchExportId: string,
-        team: Team,
-        siteUrl: string
-    ) {
-        const properties = event.properties ? parseJSON(event.properties) : {}
-        const projectUrl = `${siteUrl}/project/${team.id}`
-
-        let person: HogFunctionInvocationGlobals['person']
-
-        if (event.person_id) {
-            const personProperties = event.person_properties ? parseJSON(event.person_properties) : {}
-            const personDisplayName = getPersonDisplayName(team, event.distinct_id, personProperties)
-
-            person = {
-                id: event.person_id,
-                properties: personProperties,
-                name: personDisplayName,
-                url: `${projectUrl}/person/${encodeURIComponent(event.distinct_id)}`,
-            }
-        }
-        const eventTimestamp = DateTime.fromISO(event.timestamp).isValid
-            ? event.timestamp
-            : clickHouseTimestampToISO(event.timestamp)
-
-        const eventCapturedAt = event.captured_at
-            ? DateTime.fromISO(event.captured_at).isValid
-                ? event.captured_at
-                : clickHouseTimestampToISO(event.captured_at)
-            : null
-
-        const context: HogFunctionInvocationGlobals = {
-            project: {
-                id: team.id,
-                name: team.name,
-                url: projectUrl,
-            },
-            source: {
-                name: `Batch export: ${batchExportId}`,
-                url: `${projectUrl}/batch_exports/${batchExportId}/hog_functions/${hogFunction.id}`,
-            },
-            event: {
-                uuid: event.uuid,
-                event: event.event!,
-                elements_chain: event.elements_chain,
-                distinct_id: event.distinct_id,
-                properties,
-                timestamp: eventTimestamp,
-                captured_at: eventCapturedAt,
-                url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
-            },
-            // TODO: Should this be set or not?
-            groups: {},
-            person,
-        }
-
-        return context
-    }
-
-    /**
-     * Handles a HogFunctionExecutionRequest by executing the associated hog function.
-     *
-     * @param request - The request to handle
-     * @returns The result of the invocation
-     */
-    async handleRequest(
-        request: ExecutionRequest
-    ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
-        const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(request.hogFunction, request.globals)
-        const invocation = createInvocation(globalsWithInputs, request.hogFunction)
-        invocation.id = request.invocationId.toString()
+        const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(hogFunction, globals)
+        const invocation = createInvocation(globalsWithInputs, hogFunction)
+        invocation.id = invocationId.toString()
 
         const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
 
@@ -182,17 +95,27 @@ export class BatchExportHogFunctionService {
         return result
     }
 
+    private buildRequestGlobals(
+        event: RawClickHouseEvent,
+        hogFunction: HogFunctionType,
+        team: Team
+    ): HogFunctionInvocationGlobals {
+        const globals = convertToHogFunctionInvocationGlobals(event, team, this.siteUrl)
+        const projectUrl = `${this.siteUrl}/project/${team.id}`
+
+        return {
+            ...globals,
+            source: {
+                name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
+                url: `${projectUrl}/functions/${hogFunction.id}`,
+            },
+            // NOTE: Groups are currently not added - we could load them the same way we do for normal hog functions via the GroupsManagerService
+            groups: {},
+        }
+    }
+
     public async stop(): Promise<void> {
         await this.promiseScheduler.waitForAllSettled()
-    }
-}
-
-function parseInvocationId(raw: unknown): UUID {
-    try {
-        const uuid = typeof raw === 'string' ? new UUID(raw) : new UUIDT()
-        return uuid
-    } catch (e) {
-        throw new ParseError('Invalid UUID: ' + raw)
     }
 }
 
@@ -200,7 +123,6 @@ export class NotFoundError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'NotFoundError'
-        Object.setPrototypeOf(this, NotFoundError.prototype)
     }
 }
 
@@ -208,6 +130,5 @@ export class ParseError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'ParseError'
-        Object.setPrototypeOf(this, ParseError.prototype)
     }
 }

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -87,6 +87,10 @@ export class BatchExportHogFunctionService {
 
         const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
 
+        // TODO: Follow up - we might want to more accuratelt link an execution to the fact it came from a batch export
+        // We have the parent_id but that overrides the function id which is not always what we want
+        // Likely after v0 we will want to add an extra field or concept depending on whether it is a backfill vs a standard run
+
         await this.hogFunctionMonitoringService.queueInvocationResults([result])
         void this.promiseScheduler.schedule(
             Promise.all([this.hogFunctionMonitoringService.flush(), this.hogWatcher.observeResultsBuffered(result)])

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -1,6 +1,7 @@
 import { TeamManager } from '~/utils/team-manager'
 
 import { RawClickHouseEvent, Team } from '../../types'
+import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { UUID, UUIDT } from '../../utils/utils'
 import { HogFunctionInvocationGlobals, HogFunctionType } from '../types'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
@@ -8,6 +9,8 @@ import { convertToHogFunctionInvocationGlobals } from '../utils'
 import { createInvocation } from '../utils/invocation-utils'
 import { HogExecutorService } from './hog-executor.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
+import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
+import { HogWatcherService } from './monitoring/hog-watcher.service'
 
 export interface ExecutionRequest {
     batchExportId: string
@@ -18,11 +21,17 @@ export interface ExecutionRequest {
 }
 
 export class BatchExportHogFunctionService {
+    private promiseScheduler: PromiseScheduler
+
     constructor(
         private teamManager: TeamManager,
         private hogFunctionManager: HogFunctionManagerService,
-        private hogExecutor: HogExecutorService
-    ) {}
+        private hogExecutor: HogExecutorService,
+        private hogWatcher: HogWatcherService,
+        private hogFunctionMonitoringService: HogFunctionMonitoringService
+    ) {
+        this.promiseScheduler = new PromiseScheduler()
+    }
 
     /**
      * Parses and validates all inputs required to execute a batch export hog function.
@@ -93,7 +102,18 @@ export class BatchExportHogFunctionService {
         const invocation = createInvocation(globalsWithInputs, request.hogFunction)
         invocation.id = request.invocationId.toString()
 
-        return await this.hogExecutor.executeWithAsyncFunctions(invocation)
+        const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
+
+        await this.hogFunctionMonitoringService.queueInvocationResults([result])
+        void this.promiseScheduler.schedule(
+            Promise.all([this.hogFunctionMonitoringService.flush(), this.hogWatcher.observeResultsBuffered(result)])
+        )
+
+        return result
+    }
+
+    public async stop(): Promise<void> {
+        await this.promiseScheduler.waitForAllSettled()
     }
 }
 
@@ -118,6 +138,6 @@ export class ParseError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'ParseError'
-        Object.setPrototypeOf(this, NotFoundError.prototype)
+        Object.setPrototypeOf(this, ParseError.prototype)
     }
 }

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -324,7 +324,7 @@ describe('Hog Executor', () => {
 
             expect(results.invocations[0].state.globals.source).toEqual({
                 name: 'Hog Function',
-                url: `http://localhost:8000/projects/1/pipeline/destinations/hog-${fn.id}/configuration/`,
+                url: `http://localhost:8000/projects/1/functions/${fn.id}/configuration/`,
             })
         })
 

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -27,8 +27,7 @@ import {
     MinimalAppMetric,
     MinimalLogEntry,
 } from '../types'
-import { destinationE2eLagMsSummary } from '../utils'
-import { createAddLogFunction, sanitizeLogMessage } from '../utils'
+import { createAddLogFunction, destinationE2eLagMsSummary, sanitizeLogMessage } from '../utils'
 import { execHog } from '../utils/hog-exec'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'
 import { createInvocation, createInvocationResult } from '../utils/invocation-utils'
@@ -219,7 +218,7 @@ export class HogExecutorService {
                     ...triggerGlobals,
                     source: {
                         name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
-                        url: `${triggerGlobals.project.url}/pipeline/destinations/hog-${hogFunction.id}/configuration/`,
+                        url: `${triggerGlobals.project.url}/functions/${hogFunction.id}/configuration/`,
                     },
                 }
 

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -392,7 +392,7 @@ export type HogFunctionType = {
     created_at: string
     updated_at: string
     metadata?: Record<string, any>
-    batch_export_id: string | null
+    batch_export_id?: string | null
 }
 
 export type HogFunctionMappingTemplate = HogFunctionMappingType & {

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -392,6 +392,7 @@ export type HogFunctionType = {
     created_at: string
     updated_at: string
     metadata?: Record<string, any>
+    batch_export_id: string | null
 }
 
 export type HogFunctionMappingTemplate = HogFunctionMappingType & {


### PR DESCRIPTION
## Problem

Adds a new endpoint to the CDP API so that batch exports can invoke hog functions.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The new endpoint takes a request (Coming from a batch export) to execute a certain hog function. We validate the hog function belongs to the right team and batch export, and execute it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Included tests for the service.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
