### PR TITLE
fix(scim): replace email domain check with org membership guard

### DIFF
--- a/ee/api/scim/test/test_scim_api.py
+++ b/ee/api/scim/test/test_scim_api.py
@@ -216,8 +216,8 @@ class TestSCIMAPI(APILicensedTest):
         assert Role.objects.filter(id=other_role.id).exists()
 
 
-class TestSCIMEmailDomainValidation(APILicensedTest):
-    """Security tests: SCIM must not adopt users from other orgs or bypass email domain verification."""
+class TestSCIMCrossTenantProtection(APILicensedTest):
+    """Security tests: SCIM must not adopt users from other orgs. Email changes allowed for own org's users."""
 
     def setUp(self):
         super().setUp()
@@ -251,116 +251,142 @@ class TestSCIMEmailDomainValidation(APILicensedTest):
             "active": True,
         }
 
+    def _create_scim_user(self, email: str = "testuser@example.com") -> str:
+        self.client.credentials(**self.scim_headers)
+        response = self.client.post(
+            f"/scim/v2/{self.domain.id}/Users",
+            self._scim_user_data(email),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        return response.json()["id"]
+
+    # ---- from_dict: cross-tenant adoption ----
+
     def test_from_dict_rejects_adopting_user_from_different_org(self):
         other_org = Organization.objects.create(name="OtherCorp")
         other_user = User.objects.create(email="alice@othercorp.com", first_name="Alice")
         OrganizationMembership.objects.create(user=other_user, organization=other_org)
 
-        with self.assertRaises(ValueError, msg="does not match organization domain"):
-            PostHogSCIMUser.from_dict(
-                self._scim_user_data("alice@othercorp.com"),
-                self.domain,
-            )
+        with self.assertRaises(ValueError, msg="belongs to another organization"):
+            PostHogSCIMUser.from_dict(self._scim_user_data("alice@othercorp.com"), self.domain)
 
         assert not OrganizationMembership.objects.filter(user=other_user, organization=self.organization).exists()
 
-    def test_from_dict_allows_adopting_user_with_matching_domain(self):
-        other_org = Organization.objects.create(name="OtherCorp")
-        existing_user = User.objects.create(email="bob@example.com", first_name="Bob")
-        OrganizationMembership.objects.create(user=existing_user, organization=other_org)
+    def test_from_dict_allows_provisioning_existing_member(self):
+        existing_user = User.objects.create(email="bob@partner.com", first_name="Bob")
+        OrganizationMembership.objects.create(user=existing_user, organization=self.organization)
 
-        scim_user = PostHogSCIMUser.from_dict(
-            self._scim_user_data("bob@example.com"),
-            self.domain,
-        )
+        scim_user = PostHogSCIMUser.from_dict(self._scim_user_data("bob@partner.com"), self.domain)
 
-        assert scim_user.obj.email == "bob@example.com"
-        assert OrganizationMembership.objects.filter(user=existing_user, organization=self.organization).exists()
+        assert scim_user.obj.email == "bob@partner.com"
 
-    def test_from_dict_allows_creating_new_user_with_matching_domain(self):
-        scim_user = PostHogSCIMUser.from_dict(
-            self._scim_user_data("newuser@example.com"),
-            self.domain,
-        )
-        assert scim_user.obj.email == "newuser@example.com"
+    def test_from_dict_allows_creating_new_user_any_domain(self):
+        scim_user = PostHogSCIMUser.from_dict(self._scim_user_data("newuser@ibm.com"), self.domain)
+        assert scim_user.obj.email == "newuser@ibm.com"
 
-    def test_from_dict_rejects_creating_new_user_with_non_matching_domain(self):
-        with self.assertRaises(ValueError, msg="does not match organization domain"):
-            PostHogSCIMUser.from_dict(
-                self._scim_user_data("newuser@evil.com"),
-                self.domain,
-            )
-        assert not User.objects.filter(email="newuser@evil.com").exists()
+    def test_from_dict_allows_provisioning_user_with_no_org(self):
+        orphan_user = User.objects.create(email="orphan@anywhere.com", first_name="Orphan")
 
-    def test_put_rejects_email_change_to_non_matching_domain(self):
-        self.client.credentials(**self.scim_headers)
+        scim_user = PostHogSCIMUser.from_dict(self._scim_user_data("orphan@anywhere.com"), self.domain)
 
-        # Create a valid SCIM user first
-        response = self.client.post(
-            f"/scim/v2/{self.domain.id}/Users",
-            self._scim_user_data("valid@example.com"),
-            format="json",
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        user_id = response.json()["id"]
+        assert scim_user.obj.email == "orphan@anywhere.com"
+        assert OrganizationMembership.objects.filter(user=orphan_user, organization=self.organization).exists()
+
+    # ---- put: email changes for own org's users ----
+
+    def test_put_allows_email_change_for_own_user(self):
+        user_id = self._create_scim_user("valid@example.com")
 
         response = self.client.put(
             f"/scim/v2/{self.domain.id}/Users/{user_id}",
+            self._scim_user_data("newemail@partner.com", "Updated", "Name"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        user = User.objects.get(id=user_id)
+        assert user.email == "newemail@partner.com"
+        assert user.first_name == "Updated"
+
+    def test_put_rejects_email_change_to_taken_email(self):
+        User.objects.create(email="taken@example.com")
+        user_id = self._create_scim_user("valid@example.com")
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Users/{user_id}",
+            self._scim_user_data("taken@example.com"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        user = User.objects.get(id=user_id)
+        assert user.email == "valid@example.com"
+
+    def test_put_returns_404_for_user_in_other_org(self):
+        other_org = Organization.objects.create(name="OtherCorp")
+        other_user = User.objects.create(email="other@othercorp.com", first_name="Other")
+        OrganizationMembership.objects.create(user=other_user, organization=other_org)
+
+        self.client.credentials(**self.scim_headers)
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Users/{other_user.id}",
             self._scim_user_data("hijacked@evil.com"),
             format="json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
-        user = User.objects.get(id=user_id)
-        assert user.email == "valid@example.com"
+        other_user.refresh_from_db()
+        assert other_user.email == "other@othercorp.com"
 
-    def test_handle_replace_rejects_email_change_to_non_matching_domain(self):
-        self.client.credentials(**self.scim_headers)
+    # ---- patch (handle_replace / handle_add): email changes for own org's users ----
 
-        response = self.client.post(
-            f"/scim/v2/{self.domain.id}/Users",
-            self._scim_user_data("valid@example.com"),
-            format="json",
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        user_id = response.json()["id"]
-
-        response = self.client.patch(
-            f"/scim/v2/{self.domain.id}/Users/{user_id}",
-            {
-                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-                "Operations": [{"op": "replace", "path": "emails", "value": [{"value": "hijacked@evil.com"}]}],
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-        user = User.objects.get(id=user_id)
-        assert user.email == "valid@example.com"
-
-    def test_handle_add_rejects_email_change_to_non_matching_domain(self):
-        self.client.credentials(**self.scim_headers)
-
-        response = self.client.post(
-            f"/scim/v2/{self.domain.id}/Users",
-            self._scim_user_data("valid@example.com"),
-            format="json",
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        user_id = response.json()["id"]
+    @parameterized.expand(
+        [
+            ("replace",),
+            ("add",),
+        ]
+    )
+    def test_patch_allows_email_change_for_own_user(self, op: str):
+        user_id = self._create_scim_user("valid@example.com")
 
         response = self.client.patch(
             f"/scim/v2/{self.domain.id}/Users/{user_id}",
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-                "Operations": [{"op": "add", "path": "emails", "value": [{"value": "hijacked@evil.com"}]}],
+                "Operations": [{"op": op, "path": "emails", "value": [{"value": "newemail@partner.com"}]}],
             },
             format="json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_200_OK
 
         user = User.objects.get(id=user_id)
-        assert user.email == "valid@example.com"
+        assert user.email == "newemail@partner.com"
+
+    @parameterized.expand(
+        [
+            ("replace",),
+            ("add",),
+        ]
+    )
+    def test_patch_returns_404_for_user_in_other_org(self, op: str):
+        other_org = Organization.objects.create(name="OtherCorp")
+        other_user = User.objects.create(email="other@othercorp.com", first_name="Other")
+        OrganizationMembership.objects.create(user=other_user, organization=other_org)
+
+        self.client.credentials(**self.scim_headers)
+        response = self.client.patch(
+            f"/scim/v2/{self.domain.id}/Users/{other_user.id}",
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [{"op": op, "path": "emails", "value": [{"value": "hijacked@evil.com"}]}],
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        other_user.refresh_from_db()
+        assert other_user.email == "other@othercorp.com"
 
 
 class TestSCIMAuditLogging(APILicensedTest):

--- a/ee/api/scim/user.py
+++ b/ee/api/scim/user.py
@@ -17,13 +17,11 @@ class SCIMUserConflict(Exception):
     """User is already SCIM-provisioned for this organization domain."""
 
 
-def _validate_email_domain_matches(email: str, organization_domain: OrganizationDomain) -> None:
-    """Ensure email domain matches the organization domain. Prevents cross-tenant user adoption."""
-    email_domain = email.split("@")[1].lower()
-    if organization_domain.domain.lower() != email_domain:
-        raise ValueError(
-            f"Email domain '{email_domain}' does not match organization domain '{organization_domain.domain}'"
-        )
+def _check_cross_tenant_adoption(user: User, organization_domain: OrganizationDomain) -> None:
+    """Block provisioning a user who already belongs to a different organization."""
+    is_member = OrganizationMembership.objects.filter(user=user, organization=organization_domain.organization).exists()
+    if not is_member and OrganizationMembership.objects.filter(user=user).exists():
+        raise ValueError("Cannot provision a user that belongs to another organization")
 
 
 class PostHogSCIMUser(SCIMUser):
@@ -175,11 +173,7 @@ class PostHogSCIMUser(SCIMUser):
                 raise SCIMUserConflict()
 
             if user:
-                is_member = OrganizationMembership.objects.filter(
-                    user=user, organization=organization_domain.organization
-                ).exists()
-                if not is_member:
-                    _validate_email_domain_matches(email, organization_domain)
+                _check_cross_tenant_adoption(user, organization_domain)
 
                 if first_name:
                     user.first_name = first_name
@@ -187,7 +181,6 @@ class PostHogSCIMUser(SCIMUser):
                     user.last_name = last_name
                 user.save()
             else:
-                _validate_email_domain_matches(email, organization_domain)
                 # Create new user with no password (they'll use SAML)
                 user = User.objects.create_user(
                     email=email, password=None, first_name=first_name, last_name=last_name, is_email_verified=True
@@ -233,12 +226,10 @@ class PostHogSCIMUser(SCIMUser):
             raise ValueError("Email is required")
 
         with transaction.atomic():
-            # Do not allow changing email to another user's email
-            existing_user_with_email = User.objects.filter(email__iexact=email).exclude(id=self.obj.id).first()
-            if existing_user_with_email:
-                raise ValueError("Email belongs to another user")
-
-            _validate_email_domain_matches(email, self._organization_domain)
+            if email.lower() != self.obj.email.lower():
+                existing_user_with_email = User.objects.filter(email__iexact=email).exclude(id=self.obj.id).first()
+                if existing_user_with_email:
+                    raise ValueError("Email belongs to another user")
 
             self.obj.first_name = name_data.get("givenName", "")
             self.obj.last_name = name_data.get("familyName", "")
@@ -343,7 +334,6 @@ class PostHogSCIMUser(SCIMUser):
                     email = self._extract_email_from_value(value)
 
                 if email:
-                    _validate_email_domain_matches(email, self._organization_domain)
                     self.obj.email = email
 
             elif attr_name == "userName" and isinstance(value, str):
@@ -405,7 +395,6 @@ class PostHogSCIMUser(SCIMUser):
                     email = self._extract_email_from_value(value)
 
                 if email:
-                    _validate_email_domain_matches(email, self._organization_domain)
                     self.obj.email = email
                     self.obj.save()
 


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/49160 introduced email domain validation via SCIM. The fix is too strict, it requires the provisioned user's email domain to exactly match the `OrganizationDomain.domain`. 

## Changes

- Replaced `_validate_email_domain_matches` with `_check_cross_tenant_adoption` to check if users belong to a different organization. 
- `from_dict` (POST): if a user with the given email already exists and is a member of another org, the request is rejected. New users and existing members of the requesting org are allowed regardless of email domain. Users with no org membership can be adopted freely.
- `put` (full replace): email changes are allowed for users in the requesting org. The existing "email belongs to another user" guard remains. Access to users in other orgs is blocked by `get_object`, which only returns users who are members of the requesting org.
- `handle_replace` / `handle_add` (PATCH): same as PUT, email changes allowed for own org's users, `get_object` prevents any mutation of users in other orgs.
- No changes to `delete` or `handle_remove` - these were already safe (get_object gates access, and mutations are scoped to the requesting org's membership).

## How did you test this code?
Tests

## Publish to changelog?

No