### PR TITLE
feat(flags): add device bucketing option to new flags UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -46,7 +46,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { tagsModel } from '~/models/tagsModel'
-import { FeatureFlagEvaluationRuntime } from '~/types'
+import { FeatureFlagBucketingIdentifier, FeatureFlagEvaluationRuntime } from '~/types'
 
 import { FeatureFlagCodeExample } from './FeatureFlagCodeExample'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
@@ -79,11 +79,13 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
         setShowImplementation,
         setOpenVariants,
         setPayloadExpanded,
+        setBucketingIdentifier,
     } = useActions(featureFlagLogic)
     const { tags: availableTags } = useValues(tagsModel)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const hasEvaluationTags = useFeatureFlag('FLAG_EVALUATION_TAGS')
     const featureFlagsV2Enabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAGS_V2]
+    const showBucketingIdentifierUI = !!featureFlags[FEATURE_FLAGS.FLAG_BUCKETING_IDENTIFIER]
 
     const isNewFeatureFlag = id === 'new' || id === undefined
     const implementationRef = useRef<HTMLDivElement>(null)
@@ -778,6 +780,15 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         onChange={setFeatureFlagFilters}
                                         variants={nonEmptyVariants}
                                         isDisabled={!featureFlag.active}
+                                        bucketingIdentifier={
+                                            showBucketingIdentifierUI ? featureFlag.bucketing_identifier : undefined
+                                        }
+                                        onBucketingIdentifierChange={
+                                            showBucketingIdentifierUI
+                                                ? (value: FeatureFlagBucketingIdentifier | null) =>
+                                                      setBucketingIdentifier(value)
+                                                : undefined
+                                        }
                                     />
                                 </div>
                             )}


### PR DESCRIPTION
## Problem

The new feature flags form (`FEATURE_FLAGS_V2`) only has User and Group in the "Match by" radio. The old form also supports Device bucketing (gated behind `FLAG_BUCKETING_IDENTIFIER`), which is needed for experiments on anonymous users. This means the new UI lacks parity with the old form.

## Changes

- **`FeatureFlagReleaseConditionsCollapsible.tsx`**: Added `bucketingIdentifier` and `onBucketingIdentifierChange` optional props. The "Match by" radio now shows when either groups are available or bucketing props are provided. Device appears as a second option between User and Group, conditionally based on `onBucketingIdentifierChange` being set. Each radio selection updates both the aggregation group type index and the bucketing identifier.
- **`FeatureFlagForm.tsx`**: Reads the `FLAG_BUCKETING_IDENTIFIER` feature flag and passes the bucketing identifier value and `setBucketingIdentifier` action to the collapsible component when enabled.

<img width="1212" height="604" alt="Screenshot 2026-02-26 at 12 49 00" src="https://github.com/user-attachments/assets/865f28a2-1110-4de9-be76-2031286c0f24" />

## Testing

1. Enable both `FLAG_BUCKETING_IDENTIFIER` and `FEATURE_FLAGS_V2` feature flags
2. Create or edit a feature flag — verify the Device option appears in the "Match by" radio
3. Select Device → `bucketing_identifier` should be `'device_id'`
4. Select User → `bucketing_identifier` should be `'distinct_id'`
5. Select Group → `bucketing_identifier` should be `null`, group type selector appears
6. Disable `FLAG_BUCKETING_IDENTIFIER` → Device option should not appear
7. Without groups configured, the "Match by" section should still show User and Device when bucketing is enabled