### PR TITLE
fix(backfill): adjust timeout calculation for backfill duration

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -762,16 +762,13 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
                 # if we release this to customers.
                 start_to_close_timeout = dt.timedelta(days=31)
             else:
-                # Allocate 5 minutes per expected number of runs to backfill as a timeout.
-                # The 5 minutes are just an assumption and we may tweak this in the future
-                backfill_duration = dt.datetime.fromisoformat(end_at) - dt.datetime.fromisoformat(start_at)
-                number_of_expected_runs = backfill_duration / dt.timedelta(seconds=interval_seconds)
-                start_to_close_timeout = dt.timedelta(minutes=5 * number_of_expected_runs)
+                # Else, allocate the duration of the backfill as a timeout (eg we assume backilling 3 hours of data should take less than 3 hours)
+                start_to_close_timeout = dt.datetime.fromisoformat(end_at) - dt.datetime.fromisoformat(start_at)
 
             backfill_schedule_inputs = BackfillScheduleInputs(
                 schedule_id=inputs.batch_export_id,
-                start_at=backfill_info.adjusted_start_at,
-                end_at=inputs.end_at,
+                start_at=start_at,
+                end_at=end_at,
                 frequency_seconds=interval_seconds,
                 start_delay=inputs.start_delay,
                 backfill_id=backfill_id,


### PR DESCRIPTION
## Problem

The Temporal start to close timeout for the `backfill_schedule` activity is set to 5 mins x number of runs. This is very optimistic for backfills with an interval of hourly or daily.

## Changes

Updated the timeout logic to allocate the duration of the backfill as a timeout instead of a fixed 5 minutes per expected run. This change ensures that the timeout reflects the actual backfill duration based on the start and end times.

## How did you test this code?

Relying on existing tests.

