### PR TITLE
fix: replay json import

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -77,7 +77,7 @@ function Header(): JSX.Element {
                     <ScenePanel>
                         <ScenePanelActionsSection>
                             <Link
-                                to={urls.replaySettings()}
+                                to={urls.replayFilePlayback()}
                                 buttonProps={{
                                     menuItem: true,
                                 }}


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/51699 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53703) 

Replay imports are broken, link to the wrong place 

## Changes

side panel changes broke the import. 

## How did you test this code?

ran locally, imported a json replay.


## Publish to changelog?
no 