### PR TITLE
fix(insights): do not use preserved insight name for newly created insights

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -278,8 +278,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                           query: null,
                       },
             setInsight: (state, { insight }) => {
-                // Preserve the user-edited name when loading new data
-                if (!insight.name && state.name) {
+                // Preserve the user-edited name when loading new data for the same insight,
+                // but not when switching to a brand new insight
+                const isSameInsight = insight.short_id && insight.short_id === state.short_id
+                if (!insight.name && state.name && isSameInsight) {
                     return {
                         ...insight,
                         name: state.name,


### PR DESCRIPTION
## Problem

We use the previously created insight name when creating a new one, instead of generating a new one based on the series/steps/etc.

https://posthog.slack.com/archives/C094YKVCT29/p1772062793212859?thread_ts=1772062144.498579&cid=C094YKVCT29

https://github.com/user-attachments/assets/dedb82a9-c263-4d76-8ff7-11b145bb0a96

## Changes

Check if updates the same insights


https://github.com/user-attachments/assets/97eafa56-4014-44b0-9264-bd10e476b8d3


## How did you test this code?

Manually + added tests

## Publish to changelog?

No
