### PR TITLE
fix(vim-mode): Status bar input, match highlight and paste button

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.scss
+++ b/frontend/src/lib/monaco/CodeEditor.scss
@@ -20,6 +20,18 @@
     border-radius: 0;
 }
 
+.CodeEditor__vim-status-bar {
+    input[type='text'] {
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: inherit;
+        background: transparent;
+        border: none;
+        outline: none;
+    }
+}
+
 .CodeEditorResizeable,
 .CodeEditorInline {
     .monaco-editor {

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import './CodeEditor.scss'
 
 import MonacoEditor, { type EditorProps, Monaco, DiffEditor as MonacoDiffEditor, loader } from '@monaco-editor/react'
-import { BuiltLogic, useMountedLogic, useValues } from 'kea'
+import { BuiltLogic, useActions, useMountedLogic, useValues } from 'kea'
 import * as monacoModule from 'monaco-editor'
 import { IDisposable, editor, editor as importedEditor } from 'monaco-editor'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -167,6 +167,9 @@ export function CodeEditor({
     })
     useMountedLogic(builtCodeEditorLogic)
 
+    const { vimCommandHistory } = useValues(builtCodeEditorLogic)
+    const { appendVimCommand } = useActions(builtCodeEditorLogic)
+
     const { isVisible } = usePageVisibility()
 
     // Create DIV with .monaco-editor inside <body> for monaco's popups.
@@ -248,7 +251,10 @@ export function CodeEditor({
         }
 
         if (enableVimMode && vimStatusBarRef.current) {
-            vimModeRef.current = setupVimMode(editor, vimStatusBarRef.current)
+            vimModeRef.current = setupVimMode(editor, vimStatusBarRef.current, {
+                initialHistory: vimCommandHistory,
+                onCommandExecuted: appendVimCommand,
+            })
         } else if (vimModeRef.current) {
             vimModeRef.current.dispose()
             vimModeRef.current = null

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -4,7 +4,6 @@ import MonacoEditor, { type EditorProps, Monaco, DiffEditor as MonacoDiffEditor,
 import { BuiltLogic, useMountedLogic, useValues } from 'kea'
 import * as monacoModule from 'monaco-editor'
 import { IDisposable, editor, editor as importedEditor } from 'monaco-editor'
-import { VimMode, initVimMode } from 'monaco-vim'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
@@ -18,6 +17,7 @@ import { initHogJsonLanguage } from 'lib/monaco/languages/hogJson'
 import { initHogQLLanguage } from 'lib/monaco/languages/hogQL'
 import { initHogTemplateLanguage } from 'lib/monaco/languages/hogTemplate'
 import { initLiquidLanguage } from 'lib/monaco/languages/liquid'
+import { setupVimMode } from 'lib/monaco/vimMode'
 import { inStorybookTestRunner } from 'lib/utils'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -148,7 +148,7 @@ export function CodeEditor({
     // Keep a ref to the editor for cleanup - ensures we can dispose it even if state is stale
     const editorRef = useRef<importedEditor.IStandaloneCodeEditor | null>(null)
 
-    const vimModeRef = useRef<VimMode | null>(null)
+    const vimModeRef = useRef<{ dispose: () => void } | null>(null)
     const vimStatusBarRef = useRef<HTMLDivElement | null>(null)
 
     const [realKey] = useState(() => codeEditorIndex++)
@@ -247,47 +247,14 @@ export function CodeEditor({
             return
         }
 
-        let focusCleanup: (() => void) | null = null
-
         if (enableVimMode && vimStatusBarRef.current) {
-            vimModeRef.current = initVimMode(editor, vimStatusBarRef.current)
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const regController = (VimMode as any).Vim.getRegisterController()
-            const origPushText = regController.pushText.bind(regController)
-            regController.pushText = function (
-                registerName: string,
-                operator: string,
-                text: string,
-                linewise: boolean,
-                blockwise: boolean
-            ) {
-                origPushText(registerName, operator, text, linewise, blockwise)
-                if (text) {
-                    void navigator.clipboard.writeText(text).catch(() => {})
-                }
-            }
-
-            const domNode = editor.getDomNode()
-            if (domNode) {
-                const onFocus = async (): Promise<void> => {
-                    try {
-                        const text = await navigator.clipboard.readText()
-                        regController.getRegister('+').setText(text)
-                    } catch {
-                        // clipboard permission denied or unavailable
-                    }
-                }
-                domNode.addEventListener('focus', onFocus, true)
-                focusCleanup = () => domNode.removeEventListener('focus', onFocus, true)
-            }
+            vimModeRef.current = setupVimMode(editor, vimStatusBarRef.current)
         } else if (vimModeRef.current) {
             vimModeRef.current.dispose()
             vimModeRef.current = null
         }
 
         return () => {
-            focusCleanup?.()
             if (vimModeRef.current) {
                 vimModeRef.current.dispose()
                 vimModeRef.current = null

--- a/frontend/src/lib/monaco/vimMode.ts
+++ b/frontend/src/lib/monaco/vimMode.ts
@@ -58,6 +58,60 @@ function patchAddOverlay(cmAdapter: any): () => void {
     }
 }
 
+// monaco-vim's statusbar passes `closeInput` as the `close` callback to
+// onKeyDown/onKeyUp. But keymap_vim.ts calls `close(value)` with a string
+// to mean "update the input" (the CodeMirror dialog convention), while
+// closeInput() ignores arguments and always destroys the input. This breaks
+// command/search history navigation with Up/Down arrows.
+function patchCloseInput(statusBar: any): () => void {
+    const originalCloseInput = statusBar.closeInput
+
+    statusBar.closeInput = (newVal?: string): void => {
+        if (typeof newVal === 'string') {
+            if (statusBar.input?.node) {
+                statusBar.input.node.value = newVal
+            }
+            return
+        }
+        originalCloseInput()
+    }
+
+    return () => {
+        statusBar.closeInput = originalCloseInput
+    }
+}
+
+// monaco-vim's monacoToCmKey expects Monaco-style key names ("UpArrow",
+// "DownArrow") but the statusbar's input element fires native browser
+// KeyboardEvents with e.key = "ArrowUp", "ArrowDown", etc. The
+// endsWith("Arrow") check in monacoToCmKey fails for "ArrowUp", so
+// onPromptKeyDown never sees "Up"/"Down" and history navigation breaks.
+// Normalizing e.key on the status bar element in capture phase fixes this
+// before the statusbar's inputKeyDown/inputKeyUp handlers read it.
+const BROWSER_TO_MONACO_KEYS: Record<string, string> = {
+    ArrowUp: 'UpArrow',
+    ArrowDown: 'DownArrow',
+    ArrowLeft: 'LeftArrow',
+    ArrowRight: 'RightArrow',
+}
+
+function patchStatusBarArrowKeys(statusBarEl: HTMLElement): () => void {
+    const normalizeKey = (e: KeyboardEvent): void => {
+        const mapped = BROWSER_TO_MONACO_KEYS[e.key]
+        if (mapped) {
+            Object.defineProperty(e, 'key', { value: mapped, configurable: true })
+        }
+    }
+
+    statusBarEl.addEventListener('keydown', normalizeKey, true)
+    statusBarEl.addEventListener('keyup', normalizeKey, true)
+
+    return () => {
+        statusBarEl.removeEventListener('keydown', normalizeKey, true)
+        statusBarEl.removeEventListener('keyup', normalizeKey, true)
+    }
+}
+
 function patchSubstituteHighlight(cmAdapter: any, statusBar: any): () => void {
     const originalSetSec = statusBar.setSec.bind(statusBar)
     const substituteRegex = /s([^\w\s])(.*)/
@@ -148,6 +202,8 @@ export function setupVimMode(editor: monacoEditor.IStandaloneCodeEditor, statusB
     const cmAdapter = vimMode as any
 
     const restoreAddOverlay = patchAddOverlay(cmAdapter)
+    const restoreCloseInput = patchCloseInput(cmAdapter.statusBar)
+    const restoreArrowKeys = patchStatusBarArrowKeys(statusBarEl)
     const restoreSetSec = patchSubstituteHighlight(cmAdapter, cmAdapter.statusBar)
     const cleanupClipboard = setupClipboardSync(editor, statusBarEl)
 
@@ -156,6 +212,8 @@ export function setupVimMode(editor: monacoEditor.IStandaloneCodeEditor, statusB
         dispose: () => {
             cleanupClipboard()
             restoreSetSec()
+            restoreArrowKeys()
+            restoreCloseInput()
             restoreAddOverlay()
             vimMode.dispose()
         },

--- a/frontend/src/lib/monaco/vimMode.ts
+++ b/frontend/src/lib/monaco/vimMode.ts
@@ -1,9 +1,14 @@
 import { editor as monacoEditor } from 'monaco-editor'
 import { VimMode, initVimMode } from 'monaco-vim'
 
-interface VimModeHandle {
+export interface VimModeHandle {
     vimMode: VimMode
     dispose: () => void
+}
+
+export interface VimModeProps {
+    initialHistory?: string[]
+    onCommandExecuted?: (command: string) => void
 }
 
 function extractPatternBeforeSeparator(str: string, separator: string): string | null {
@@ -197,7 +202,49 @@ function setupClipboardSync(editor: monacoEditor.IStandaloneCodeEditor, statusBa
     return () => cleanups.forEach((fn) => fn())
 }
 
-export function setupVimMode(editor: monacoEditor.IStandaloneCodeEditor, statusBarEl: HTMLElement): VimModeHandle {
+// The pushInput patch is applied once globally since exCommandHistoryController
+// lives on vimGlobalState (shared across all vim instances). The callback ref
+// lets us swap listeners without re-patching.
+let commandHistoryCallbackRef: ((command: string) => void) | null = null
+let pushInputPatched = false
+
+function setupCommandHistoryPersistence(
+    initialHistory: string[],
+    onCommandExecuted: (command: string) => void
+): () => void {
+    const globalState = (VimMode as any).Vim.getVimGlobalState_()
+    const controller = globalState.exCommandHistoryController
+
+    if (!controller.historyBuffer.length && initialHistory.length) {
+        controller.historyBuffer = [...initialHistory]
+        controller.iterator = controller.historyBuffer.length
+    }
+
+    commandHistoryCallbackRef = onCommandExecuted
+
+    if (!pushInputPatched) {
+        const origPushInput = controller.pushInput.bind(controller)
+        controller.pushInput = function (input: string): void {
+            origPushInput(input)
+            if (input && commandHistoryCallbackRef) {
+                commandHistoryCallbackRef(input)
+            }
+        }
+        pushInputPatched = true
+    }
+
+    return () => {
+        if (commandHistoryCallbackRef === onCommandExecuted) {
+            commandHistoryCallbackRef = null
+        }
+    }
+}
+
+export function setupVimMode(
+    editor: monacoEditor.IStandaloneCodeEditor,
+    statusBarEl: HTMLElement,
+    options?: VimModeProps
+): VimModeHandle {
     const vimMode = initVimMode(editor, statusBarEl)
     const cmAdapter = vimMode as any
 
@@ -207,9 +254,18 @@ export function setupVimMode(editor: monacoEditor.IStandaloneCodeEditor, statusB
     const restoreSetSec = patchSubstituteHighlight(cmAdapter, cmAdapter.statusBar)
     const cleanupClipboard = setupClipboardSync(editor, statusBarEl)
 
+    let cleanupHistoryPersistence: (() => void) | undefined
+    if (options?.onCommandExecuted) {
+        cleanupHistoryPersistence = setupCommandHistoryPersistence(
+            options.initialHistory ?? [],
+            options.onCommandExecuted
+        )
+    }
+
     return {
         vimMode,
         dispose: () => {
+            cleanupHistoryPersistence?.()
             cleanupClipboard()
             restoreSetSec()
             restoreArrowKeys()

--- a/frontend/src/lib/monaco/vimMode.ts
+++ b/frontend/src/lib/monaco/vimMode.ts
@@ -1,0 +1,163 @@
+import { editor as monacoEditor } from 'monaco-editor'
+import { VimMode, initVimMode } from 'monaco-vim'
+
+interface VimModeHandle {
+    vimMode: VimMode
+    dispose: () => void
+}
+
+function extractPatternBeforeSeparator(str: string, separator: string): string | null {
+    let result = ''
+    for (let i = 0; i < str.length; i++) {
+        if (str[i] === '\\' && i + 1 < str.length) {
+            result += str[i] + str[i + 1]
+            i++
+        } else if (str[i] === separator) {
+            return result
+        } else {
+            result += str[i]
+        }
+    }
+    return result
+}
+
+function patchAddOverlay(cmAdapter: any): () => void {
+    const original = cmAdapter.addOverlay.bind(cmAdapter)
+
+    cmAdapter.addOverlay = function ({ query }: { query: RegExp }): void {
+        if (!query) {
+            return
+        }
+        let matchCase = false
+        let isRegex = false
+        let source: string
+
+        if (query instanceof RegExp) {
+            isRegex = true
+            matchCase = !query.ignoreCase
+            source = query.source
+        } else {
+            source = String(query)
+        }
+
+        const model = this.editor.getModel()
+        if (!model) {
+            return
+        }
+
+        const allMatches = model.findMatches(source, false, isRegex, matchCase, null, false) as any[]
+        if (!allMatches?.length) {
+            this.removeOverlay()
+            return
+        }
+        this.highlightRanges(allMatches.map((m: any) => m.range))
+    }
+
+    return () => {
+        cmAdapter.addOverlay = original
+    }
+}
+
+function patchSubstituteHighlight(cmAdapter: any, statusBar: any): () => void {
+    const originalSetSec = statusBar.setSec.bind(statusBar)
+    const substituteRegex = /s([^\w\s])(.*)/
+
+    let hasSubstituteHighlight = false
+
+    statusBar.setSec = function (text: string, callback: any, options: any): any {
+        if (!text && hasSubstituteHighlight) {
+            cmAdapter.removeOverlay()
+            hasSubstituteHighlight = false
+        }
+        if (options && !options.onKeyInput) {
+            options.onKeyInput = (_event: InputEvent, value: string): void => {
+                const match = value.match(substituteRegex)
+                if (match) {
+                    const pattern = extractPatternBeforeSeparator(match[2], match[1])
+                    if (pattern) {
+                        try {
+                            cmAdapter.addOverlay({ query: new RegExp(pattern, 'gim') })
+                            hasSubstituteHighlight = true
+                            return
+                        } catch {
+                            // invalid regex in progress
+                        }
+                    }
+                }
+                if (hasSubstituteHighlight) {
+                    cmAdapter.removeOverlay()
+                    hasSubstituteHighlight = false
+                }
+            }
+        }
+        return originalSetSec(text, callback, options)
+    }
+
+    return () => {
+        statusBar.setSec = originalSetSec
+    }
+}
+
+function setupClipboardSync(editor: monacoEditor.IStandaloneCodeEditor, statusBarEl: HTMLElement): () => void {
+    const regController = (VimMode as any).Vim.getRegisterController()
+    const origPushText = regController.pushText.bind(regController)
+    const cleanups: (() => void)[] = []
+
+    regController.pushText = function (
+        registerName: string,
+        operator: string,
+        text: string,
+        linewise: boolean,
+        blockwise: boolean
+    ): void {
+        origPushText(registerName, operator, text, linewise, blockwise)
+        if (text) {
+            void navigator.clipboard.writeText(text).catch(() => {})
+        }
+    }
+
+    let lastStatusBarBlurTime = 0
+    const onStatusBarFocusOut = (): void => {
+        lastStatusBarBlurTime = Date.now()
+    }
+    statusBarEl.addEventListener('focusout', onStatusBarFocusOut, true)
+    cleanups.push(() => statusBarEl.removeEventListener('focusout', onStatusBarFocusOut, true))
+
+    const domNode = editor.getDomNode()
+    if (domNode) {
+        const onFocus = async (): Promise<void> => {
+            if (Date.now() - lastStatusBarBlurTime < 100) {
+                return
+            }
+            try {
+                const text = await navigator.clipboard.readText()
+                regController.getRegister('+').setText(text)
+            } catch {
+                // clipboard permission denied or unavailable
+            }
+        }
+        domNode.addEventListener('focus', onFocus, true)
+        cleanups.push(() => domNode.removeEventListener('focus', onFocus, true))
+    }
+
+    return () => cleanups.forEach((fn) => fn())
+}
+
+export function setupVimMode(editor: monacoEditor.IStandaloneCodeEditor, statusBarEl: HTMLElement): VimModeHandle {
+    const vimMode = initVimMode(editor, statusBarEl)
+    const cmAdapter = vimMode as any
+
+    const restoreAddOverlay = patchAddOverlay(cmAdapter)
+    const restoreSetSec = patchSubstituteHighlight(cmAdapter, cmAdapter.statusBar)
+    const cleanupClipboard = setupClipboardSync(editor, statusBarEl)
+
+    return {
+        vimMode,
+        dispose: () => {
+            cleanupClipboard()
+            restoreSetSec()
+            restoreAddOverlay()
+            vimMode.dispose()
+        },
+    }
+}

--- a/frontend/src/lib/monaco/vimMode.ts
+++ b/frontend/src/lib/monaco/vimMode.ts
@@ -203,9 +203,10 @@ function setupClipboardSync(editor: monacoEditor.IStandaloneCodeEditor, statusBa
 }
 
 // The pushInput patch is applied once globally since exCommandHistoryController
-// lives on vimGlobalState (shared across all vim instances). The callback ref
-// lets us swap listeners without re-patching.
-let commandHistoryCallbackRef: ((command: string) => void) | null = null
+// lives on vimGlobalState (shared across all vim instances). Multiple editors
+// can be mounted concurrently (e.g. SQL editor tabs), so we fan out to all
+// registered callbacks.
+const commandHistoryCallbacks = new Set<(command: string) => void>()
 let pushInputPatched = false
 
 function setupCommandHistoryPersistence(
@@ -220,23 +221,21 @@ function setupCommandHistoryPersistence(
         controller.iterator = controller.historyBuffer.length
     }
 
-    commandHistoryCallbackRef = onCommandExecuted
+    commandHistoryCallbacks.add(onCommandExecuted)
 
     if (!pushInputPatched) {
         const origPushInput = controller.pushInput.bind(controller)
         controller.pushInput = function (input: string): void {
             origPushInput(input)
-            if (input && commandHistoryCallbackRef) {
-                commandHistoryCallbackRef(input)
+            if (input) {
+                commandHistoryCallbacks.forEach((cb) => cb(input))
             }
         }
         pushInputPatched = true
     }
 
     return () => {
-        if (commandHistoryCallbackRef === onCommandExecuted) {
-            commandHistoryCallbackRef = null
-        }
+        commandHistoryCallbacks.delete(onCommandExecuted)
     }
 }
 


### PR DESCRIPTION
## Problem

Users brought up some feedback:
* No highlighting for search patterns (https://posthoghelp.zendesk.com/agent/tickets/50608 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54065))
* No command history (https://posthoghelp.zendesk.com/agent/tickets/50609 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53368))
* Status bar input overlapping with content
* Exiting `/` show `paste` button

## Changes
https://www.loom.com/share/0a153fd562b5489b9dd85e9e51fad181

- **Search highlighting**: Added visual highlighting for search patterns when using `/` or `?` commands
- **Command history persistence**: Vim command history now persists across sessions and is stored in localStorage with a 50-command limit
- **Substitute preview**: Added real-time highlighting of patterns being replaced during substitute commands (`:s/pattern/replacement/`)
- **Arrow key navigation**: Fixed Up/Down arrow key navigation in command and search history by normalizing browser keyboard events to Monaco's expected format
- **Status bar styling**: Added CSS styling for the Vim status bar input to match the editor's appearance

The implementation extracts Vim mode setup into a dedicated `vimMode.ts` module with proper patching of monaco-vim's internal behavior to enable these features.

## How did you test this code?
Manual testing (loom above):
- Search highlighting works with `/pattern` and `?pattern`
- Command history persists across page refreshes
- Substitute commands show live preview highlighting
- Arrow keys navigate through command history

## Publish to changelog?

no