### PR TITLE
feat(analytics-platform): Allow dots in PostHog client identifier parsing

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -205,7 +205,7 @@ const handleRequest = async (
     // Extract posthog/foo identifier from the client's User-Agent (e.g. "posthog/wizard")
     // so we can forward it in outgoing API requests for source attribution
     const clientUserAgent = request.headers.get('User-Agent') || ''
-    const clientIdentifierMatch = clientUserAgent.match(/posthog\/([\w-]+)/)
+    const clientIdentifierMatch = clientUserAgent.match(/posthog\/([\w.-]+)/)
     const clientIdentifier = clientIdentifierMatch ? clientIdentifierMatch[0] : undefined
 
     Object.assign(ctx.props, {


### PR DESCRIPTION
## Problem

The regex pattern used to extract the PostHog client identifier from the User-Agent header only matches word characters and hyphens (`[\w-]+`). This prevents client identifiers containing dots (e.g., "posthog/hog.dev") from being properly recognized and forwarded in API requests for source attribution.

## Changes

Updated the regex pattern in the User-Agent parsing logic from `/posthog\/([\w-]+)/` to `/posthog\/([\w.-]+)/` to include dots in the allowed character set for client identifiers.

## How did you test this code?

This is a straightforward regex pattern update. The change allows the existing parsing logic to handle a broader set of valid client identifier formats. No additional testing is required beyond verifying the regex pattern correctly matches identifiers with dots.

## Publish to changelog?

no

https://claude.ai/code/session_019t3JB5X9r8ox3zXmaKcpQE