### PR TITLE
fix: Handle more too much data responses from Meta

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -90,8 +90,9 @@ def get_schemas() -> dict[str, MetaAdsSchema]:
     return schemas
 
 
-# Error subcode indicating the request timed out due to too much data
-META_TIMEOUT_ERROR_SUBCODE = 1504018
+# Error subcodes indicating the request timed out due to too much data
+# https://developers.facebook.com/docs/marketing-api/insights/error-codes
+META_TIMEOUT_ERROR_SUBCODES = {1504018, 1504038}
 
 # Chunk sizes for adaptive time-range pagination (in days)
 # Start with 30-day chunks, fall back to smaller chunks on timeout
@@ -100,14 +101,17 @@ TIME_RANGE_CHUNK_SIZES = [30, 7, 1]
 
 def _is_timeout_error(response: requests.Response) -> bool:
     """Check if the response is a Meta API timeout error that can be resolved with smaller date ranges."""
-    if response.status_code != 400:
-        return False
     try:
-        error_data = response.json()
-        error_subcode = error_data.get("error", {}).get("error_subcode")
-        return error_subcode == META_TIMEOUT_ERROR_SUBCODE
+        error = response.json().get("error", {})
     except (ValueError, KeyError):
         return False
+
+    if error.get("error_subcode") in META_TIMEOUT_ERROR_SUBCODES:
+        return True
+
+    # This check is a bit fragile, but the Meta API has been observed to return a 500 response like this:
+    # {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}
+    return error.get("code") == 1 and "reduce the amount of data" in error.get("message", "").lower()
 
 
 def _fetch_time_range_chunk(

--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -103,15 +103,16 @@ def _is_timeout_error(response: requests.Response) -> bool:
     """Check if the response is a Meta API timeout error that can be resolved with smaller date ranges."""
     try:
         error = response.json().get("error", {})
-    except (ValueError, KeyError):
+
+        if error.get("error_subcode") in META_TIMEOUT_ERROR_SUBCODES:
+            return True
+
+        # This check is a bit fragile, but the Meta API has been observed to return a 500 response like this:
+        # {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}
+        message = str(error.get("message") or "").lower()
+        return error.get("code") == 1 and "reduce the amount of data" in message
+    except (ValueError, KeyError, AttributeError):
         return False
-
-    if error.get("error_subcode") in META_TIMEOUT_ERROR_SUBCODES:
-        return True
-
-    # This check is a bit fragile, but the Meta API has been observed to return a 500 response like this:
-    # {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}
-    return error.get("code") == 1 and "reduce the amount of data" in error.get("message", "").lower()
 
 
 def _fetch_time_range_chunk(


### PR DESCRIPTION
## Problem

Customers with high-volume Meta Ads accounts are seeing their `ad_stats` syncs fail with a 500 error:                                                                                                                                                                             
                                                          
```                                                                                                                                                                                                                      
  {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}                                                                                                                                                                    
 ```

We already have adaptive time-range chunking (30 → 7 → 1 day) to handle Meta's "too much data" errors, but it only triggers on HTTP 400 responses with `error_subcode`: 1504018. The 500 variant bypasses this entirely, so the sync fails instead of trying smaller chunks.

Meta suggests 500/code 1 errors may be transient and are worth retrying the requests - I've done that for the customer source impacted here, but still seeing the same error.

https://posthoghelp.zendesk.com/agent/tickets/51556 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/57566)

##  Changes

Honestly my fix feels a little fragile, but the Meta API isn't really helping us here and I think it should be a safe change to make.

Based on the documented error codes [here](https://developers.facebook.com/docs/marketing-api/insights/error-codes) and [here](https://developers.facebook.com/docs/marketing-api/insights/error-codes):

- Broadened `_is_timeout_error()` to also handle:
  - `error_subcode: 1504038` - look the same as 1504018 which we already handle
    - [HTTP 500 with] `code: 1` and "reduce the amount of data" message - I couldn't see this in Meta's docs, but we're seeing it happen
    - Removed the HTTP status code gate so subcode checks work regardless of whether Meta returns a 400 or 500 - the HTTP status code feels unimportant

## How did you test this code?

I haven't been able to test it directly