### PR TITLE
fix(experiments): Fix cases of warning banner shown in cases of 0 percent rollout

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -791,6 +791,15 @@ describe('experimentLogic', () => {
                 expected: { key: 'ended_but_multiple_variants_rolled_out' },
             },
             {
+                desc: 'ended experiment with flag active but zero group rollout',
+                overrides: {
+                    start_date: '2020-01-01',
+                    end_date: '2020-02-01',
+                    feature_flag: { id: 1, key: 'flag', active: true, filters: zeroRolloutFilters } as any,
+                },
+                expected: null,
+            },
+            {
                 desc: 'ended experiment with flag disabled',
                 overrides: {
                     start_date: '2020-01-01',
@@ -826,6 +835,15 @@ describe('experimentLogic', () => {
                     feature_flag: { id: 1, key: 'flag', active: true, filters: multivariantFilters } as any,
                 },
                 expected: { key: 'not_started_but_multiple_variants_rolled_out' },
+            },
+            {
+                desc: 'draft experiment with flag active but zero group rollout',
+                overrides: {
+                    start_date: undefined,
+                    end_date: undefined,
+                    feature_flag: { id: 1, key: 'flag', active: true, filters: zeroRolloutFilters } as any,
+                },
+                expected: null,
             },
             {
                 desc: 'draft experiment with flag disabled',

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -738,6 +738,16 @@ describe('experimentLogic', () => {
             },
         }
 
+        const zeroRolloutShippedVariantFilters = {
+            groups: [{ properties: [], rollout_percentage: 0 }],
+            multivariate: {
+                variants: [
+                    { key: 'control', rollout_percentage: 0 },
+                    { key: 'test', rollout_percentage: 100 },
+                ],
+            },
+        }
+
         const createExperiment = (overrides: Partial<Experiment>): Experiment =>
             ({
                 ...experiment,
@@ -778,6 +788,20 @@ describe('experimentLogic', () => {
                     start_date: '2020-01-01',
                     end_date: undefined,
                     feature_flag: { id: 1, key: 'flag', active: true, filters: zeroRolloutFilters } as any,
+                },
+                expected: { key: 'running_but_no_rollout' },
+            },
+            {
+                desc: 'running experiment with zero rollout takes priority over single variant shipped',
+                overrides: {
+                    start_date: '2020-01-01',
+                    end_date: undefined,
+                    feature_flag: {
+                        id: 1,
+                        key: 'flag',
+                        active: true,
+                        filters: zeroRolloutShippedVariantFilters,
+                    } as any,
                 },
                 expected: { key: 'running_but_no_rollout' },
             },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2601,10 +2601,10 @@ export const experimentLogic = kea<experimentLogicType>([
                 if (isExperimentRunning) {
                     if (!isFlagActive) {
                         return { key: 'running_but_flag_disabled' }
-                    } else if (singleVariantShipped) {
-                        return { key: 'running_but_single_variant_shipped', variantKey: shippedVariantKey }
                     } else if (hasZeroRollout(filters)) {
                         return { key: 'running_but_no_rollout' }
+                    } else if (singleVariantShipped) {
+                        return { key: 'running_but_single_variant_shipped', variantKey: shippedVariantKey }
                     }
                 } else if (hasEnded(experiment)) {
                     if (

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2607,12 +2607,17 @@ export const experimentLogic = kea<experimentLogicType>([
                         return { key: 'running_but_no_rollout' }
                     }
                 } else if (hasEnded(experiment)) {
-                    if (isFlagActive && hasMultipleVariantsActive(filters) && !singleVariantShipped) {
+                    if (
+                        isFlagActive &&
+                        hasMultipleVariantsActive(filters) &&
+                        !hasZeroRollout(filters) &&
+                        !singleVariantShipped
+                    ) {
                         return { key: 'ended_but_multiple_variants_rolled_out' }
                     }
                 } else if (isExperimentDraft) {
                     // The draft state is also reached again when resetting experiment measurements
-                    if (isFlagActive && hasMultipleVariantsActive(filters)) {
+                    if (isFlagActive && hasMultipleVariantsActive(filters) && !hasZeroRollout(filters)) {
                         return { key: 'not_started_but_multiple_variants_rolled_out' }
                     }
                 }


### PR DESCRIPTION
## Problem

We show a warning banner to users if the state between feature flag and experiment are inconsistent. In this logic, the case of feature flags with rollout 0% wasn't fully correct.

## Changes

- Fix considering active feature flags with 0% rollout as active in warning logic
- Fix case of a shipped variant but a total rollout of 0%

## How did you test this code?

Test suite

## Publish to changelog?

No