### PR TITLE
chore(err): make chunk id deterministic

### DIFF
--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -114,6 +114,17 @@ impl SourceMapFile {
     pub fn set_release_id(&mut self, release_id: Option<String>) {
         self.inner.content.release_id = release_id;
     }
+
+    /// Returns the source map content serialized without PostHog metadata (chunk_id, release_id).
+    /// Used to compute deterministic content-hash chunk IDs from the actual source map data.
+    pub fn clean_content_bytes(&self) -> Result<Vec<u8>> {
+        let clean = SourceMapContent {
+            release_id: None,
+            chunk_id: None,
+            fields: self.inner.content.fields.clone(),
+        };
+        Ok(serde_json::to_vec(&clean)?)
+    }
 }
 
 impl MinifiedSourceFile {
@@ -130,6 +141,22 @@ impl MinifiedSourceFile {
     pub fn get_chunk_id(&self) -> Option<String> {
         let patterns = ["//# chunkId="];
         self.get_comment_value(&patterns)
+    }
+
+    /// Returns the JS content with any existing chunk ID injection stripped.
+    /// Used to compute deterministic content-hash chunk IDs from pre-injection content.
+    pub fn clean_content(&self) -> String {
+        let content = &self.inner.content;
+        let Some(existing_id) = self.get_chunk_id() else {
+            return content.clone();
+        };
+
+        let mut result = content.clone();
+        let code_snippet = CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, &existing_id);
+        result = result.replace(&code_snippet, "");
+        let chunk_comment = CHUNKID_COMMENT_PREFIX.replace(CHUNKID_PLACEHOLDER, &existing_id);
+        result = result.replace(&chunk_comment, "");
+        result
     }
 
     pub fn set_chunk_id(&mut self, chunk_id: &str) -> Result<SourceMap> {

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -75,17 +75,18 @@ pub fn inject_pairs(
     created_release_id: Option<String>,
 ) -> Result<Vec<SourcePair>> {
     for pair in &mut pairs {
-        let current_release_id = pair.get_release_id();
-        // We only update release ids and chunk ids when the release id changed or is not present
-        if current_release_id != created_release_id || pair.get_chunk_id().is_none() {
-            pair.set_release_id(created_release_id.clone());
+        let chunk_id = pair.compute_chunk_id()?;
 
-            let chunk_id = uuid::Uuid::now_v7().to_string();
-            if let Some(previous_chunk_id) = pair.get_chunk_id() {
-                pair.update_chunk_id(previous_chunk_id, chunk_id)?;
-            } else {
-                pair.add_chunk_id(chunk_id)?;
+        pair.set_release_id(created_release_id.clone());
+
+        if let Some(previous_chunk_id) = pair.get_chunk_id() {
+            if previous_chunk_id == chunk_id {
+                // Content hasn't changed — skip re-injection
+                continue;
             }
+            pair.update_chunk_id(previous_chunk_id, chunk_id)?;
+        } else {
+            pair.add_chunk_id(chunk_id)?;
         }
     }
 

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::symbol_sets::SymbolSetUpload,
     sourcemaps::content::{MinifiedSourceFile, SourceMapFile},
+    utils::files::chunk_id_hash,
 };
 use anyhow::{anyhow, Context, Result};
 use posthog_symbol_data::{write_symbol_data, SourceAndMap};
@@ -71,6 +72,14 @@ impl SourcePair {
 
     pub fn set_release_id(&mut self, release_id: Option<String>) {
         self.sourcemap.set_release_id(release_id);
+    }
+
+    /// Computes a deterministic chunk ID from the pre-injection content.
+    /// Returns SHA-256(clean_js || clean_sourcemap) truncated to 32 hex chars.
+    pub fn compute_chunk_id(&self) -> Result<String> {
+        let clean_js = self.source.clean_content();
+        let clean_map = self.sourcemap.clean_content_bytes()?;
+        Ok(chunk_id_hash(clean_js.as_bytes(), &clean_map))
     }
 
     pub fn save(&self) -> Result<()> {

--- a/cli/src/utils/files/content.rs
+++ b/cli/src/utils/files/content.rs
@@ -89,3 +89,13 @@ where
     }
     format!("{:x}", hasher.finalize())
 }
+
+/// Computes a deterministic chunk ID from the pre-injection minified JS and source map content.
+/// Uses SHA-256(js_content || sourcemap_content) truncated to 32 hex chars.
+pub fn chunk_id_hash(js_content: &[u8], sourcemap_content: &[u8]) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(js_content);
+    hasher.update(sourcemap_content);
+    let hash = format!("{:x}", hasher.finalize());
+    hash[..32].to_string()
+}

--- a/cli/src/utils/files/content.rs
+++ b/cli/src/utils/files/content.rs
@@ -92,10 +92,24 @@ where
 
 /// Computes a deterministic chunk ID from the pre-injection minified JS and source map content.
 /// Uses SHA-256(js_content || sourcemap_content) truncated to 32 hex chars.
+/// Must match the JS implementation in @posthog/core/process/chunk-id.ts.
 pub fn chunk_id_hash(js_content: &[u8], sourcemap_content: &[u8]) -> String {
     let mut hasher = sha2::Sha256::new();
     hasher.update(js_content);
     hasher.update(sourcemap_content);
     let hash = format!("{:x}", hasher.finalize());
     hash[..32].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_id_hash_matches_js_implementation() {
+        // This value must match the output of the JS computeChunkId function
+        // in @posthog/core/src/process/chunk-id.ts with the same inputs.
+        let result = chunk_id_hash(b"var x = 1;", b"{\"mappings\":\"AAAA\"}");
+        assert_eq!(result, "c1b08c52e81d19e59bfcb02180762bea");
+    }
 }

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -229,10 +229,14 @@ fn test_reinject_without_new_release() {
     assert_eq!(pairs.len(), 1);
     let injected_pairs = inject_pairs(pairs, None).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
-    assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
+    let chunk_id = first_pair.source.get_chunk_id().unwrap();
+    assert_ne!(&chunk_id, "0");
+    // Chunk ID should be a 32-char hex string (content hash)
+    assert_eq!(chunk_id.len(), 32);
+    assert!(chunk_id.chars().all(|c| c.is_ascii_hexdigit()));
     assert_eq!(
         &first_pair.sourcemap.get_chunk_id().unwrap(),
-        &first_pair.source.get_chunk_id().unwrap()
+        &chunk_id
     );
     assert!(&first_pair.sourcemap.get_release_id().is_none());
 }
@@ -247,15 +251,56 @@ fn test_reinject_with_new_release() {
     let injected_pairs =
         inject_pairs(pairs, Some(release_id.clone())).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
-    assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
+    let chunk_id = first_pair.source.get_chunk_id().unwrap();
+    assert_ne!(&chunk_id, "0");
+    // Chunk ID should be a 32-char hex string (content hash)
+    assert_eq!(chunk_id.len(), 32);
+    assert!(chunk_id.chars().all(|c| c.is_ascii_hexdigit()));
     assert_eq!(
         &first_pair.sourcemap.get_chunk_id().unwrap(),
-        &first_pair.source.get_chunk_id().unwrap()
+        &chunk_id
     );
     assert_eq!(
         first_pair.sourcemap.get_release_id().unwrap(),
         release_id.clone()
     );
+}
+
+#[test]
+fn test_chunk_id_is_deterministic() {
+    let case_path = get_case_path("inject");
+
+    // First injection
+    let pairs1 =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected1 = inject_pairs(pairs1, None).expect("Failed to inject pairs");
+    let chunk_id_1 = injected1.first().unwrap().source.get_chunk_id().unwrap();
+
+    // Second injection of the same content
+    let pairs2 =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected2 = inject_pairs(pairs2, None).expect("Failed to inject pairs");
+    let chunk_id_2 = injected2.first().unwrap().source.get_chunk_id().unwrap();
+
+    assert_eq!(chunk_id_1, chunk_id_2);
+}
+
+#[test]
+fn test_chunk_id_differs_across_release_stays_same() {
+    let case_path = get_case_path("inject");
+
+    let pairs1 =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected1 = inject_pairs(pairs1, Some("release-a".to_string())).expect("Failed");
+    let chunk_id_1 = injected1.first().unwrap().source.get_chunk_id().unwrap();
+
+    let pairs2 =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected2 = inject_pairs(pairs2, Some("release-b".to_string())).expect("Failed");
+    let chunk_id_2 = injected2.first().unwrap().source.get_chunk_id().unwrap();
+
+    // Same content, different release — chunk ID should be the same
+    assert_eq!(chunk_id_1, chunk_id_2);
 }
 
 #[test]

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -234,10 +234,7 @@ fn test_reinject_without_new_release() {
     // Chunk ID should be a 32-char hex string (content hash)
     assert_eq!(chunk_id.len(), 32);
     assert!(chunk_id.chars().all(|c| c.is_ascii_hexdigit()));
-    assert_eq!(
-        &first_pair.sourcemap.get_chunk_id().unwrap(),
-        &chunk_id
-    );
+    assert_eq!(&first_pair.sourcemap.get_chunk_id().unwrap(), &chunk_id);
     assert!(&first_pair.sourcemap.get_release_id().is_none());
 }
 
@@ -256,10 +253,7 @@ fn test_reinject_with_new_release() {
     // Chunk ID should be a 32-char hex string (content hash)
     assert_eq!(chunk_id.len(), 32);
     assert!(chunk_id.chars().all(|c| c.is_ascii_hexdigit()));
-    assert_eq!(
-        &first_pair.sourcemap.get_chunk_id().unwrap(),
-        &chunk_id
-    );
+    assert_eq!(&first_pair.sourcemap.get_chunk_id().unwrap(), &chunk_id);
     assert_eq!(
         first_pair.sourcemap.get_release_id().unwrap(),
         release_id.clone()


### PR DESCRIPTION
## Problem

- On Hermes and iOS, the chunk id generation is deterministic but the same chunk ids cannot have two different releases. When there is a release version mismatch we just insert the symbol set without release data.
- Users have to rebuild and re-upload all their symbol sets, to change the release name associated with their sources. By making it deterministic, we can decouple the symbol set resolution from the release process and use cache on the first step to save on bandwidth. 

## Changes

- Make chunk ids generation deterministic
- Use a hash of the chunk + sourcemap content

Related JS PR: https://github.com/PostHog/posthog-js/pull/3159