### PR TITLE
fix(flags): link to remote config docs when remote config is selected

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
@@ -39,6 +39,7 @@ export const FF_ANCHOR = '#feature-flags'
 export const PAYLOADS_ANCHOR = '#feature-flag-payloads'
 export const LOCAL_EVAL_ANCHOR = '#local-evaluation'
 export const BOOTSTRAPPING_ANCHOR = '#bootstrapping-flags'
+export const REMOTE_CONFIG_DOC_URL = `${DOC_BASE_URL}feature-flags/remote-config`
 
 export interface InstructionOption {
     value: string

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -23,6 +23,7 @@ import {
     OPTIONS,
     PAYLOADS_ANCHOR,
     PAYLOAD_LIBRARIES,
+    REMOTE_CONFIG_DOC_URL,
     REMOTE_CONFIGURATION_LIBRARIES,
 } from './FeatureFlagCodeOptions'
 
@@ -88,6 +89,10 @@ export function CodeInstructions({
 
     const { reportFlagsCodeExampleInteraction, reportFlagsCodeExampleLanguage } = useActions(eventUsageLogic)
     const getDocumentationLink = (): string => {
+        if (remoteConfiguration) {
+            return REMOTE_CONFIG_DOC_URL
+        }
+
         const documentationLink = selectedOption.documentationLink
 
         if (showBootstrapCode) {


### PR DESCRIPTION
The "how to implement" section was linking to the generic feature flag payload docs instead of the remote config docs when remote configuration was selected. Now links to /docs/feature-flags/remote-config.

## How did you test this code?

locally

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
