### PR TITLE
fix(experiments): hardcode experiment type to 'product' in MCP

### DIFF
--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -708,12 +708,6 @@
                     "type": "string",
                     "description": "Feature flag key (letters, numbers, hyphens, underscores only). IMPORTANT: First search for existing feature flags that might be suitable using the feature-flags-get-all tool, then suggest reusing existing ones or creating a new key based on the experiment name"
                 },
-                "type": {
-                    "type": "string",
-                    "enum": ["product", "web"],
-                    "default": "product",
-                    "description": "Experiment type: 'product' for backend/API changes, 'web' for frontend UI changes"
-                },
                 "primary_metrics": {
                     "type": "array",
                     "items": {

--- a/services/mcp/src/schema/experiments.ts
+++ b/services/mcp/src/schema/experiments.ts
@@ -318,7 +318,7 @@ export const ExperimentCreatePayloadSchema = ToolExperimentCreateSchema.transfor
         name: input.name,
         description: input.description || null,
         feature_flag_key: input.feature_flag_key, // Maps to get_feature_flag_key in serializer
-        type: input.type || 'product',
+        type: 'product',
 
         // Metrics - ensure arrays are never null, always empty arrays when no metrics
         metrics: primaryMetrics,

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -171,11 +171,6 @@ export const ExperimentCreateSchema = z.object({
             'Feature flag key (letters, numbers, hyphens, underscores only). IMPORTANT: First search for existing feature flags that might be suitable using the feature-flags-get-all tool, then suggest reusing existing ones or creating a new key based on the experiment name'
         ),
 
-    type: z
-        .enum(['product', 'web'])
-        .default('product')
-        .describe("Experiment type: 'product' for backend/API changes, 'web' for frontend UI changes"),
-
     // Primary metrics with guidance
     primary_metrics: z
         .array(


### PR DESCRIPTION
## Problem

The MCP `experiment-create` tool exposed a `type` field with `'product'` and `'web'` options. LLMs frequently chose `'web'` because many experiments run on the web, but `'web'` actually means **no-code experiments** which the MCP should never create. The naming is misleading — `'web'` should really be called `'no-code'` and `'product'` should be `'code'`.

We should also improve the API layer. But for now, fix the MCP so the user experience is improved.

## Changes

- Removed the `type` field from `ExperimentCreateSchema` in `tool-inputs.ts` so LLMs no longer see it as an option
- Hardcoded `type: 'product'` in the payload transformation in `experiments.ts` instead of reading from input

## Testing

- Verify MCP `experiment-create` no longer accepts a `type` parameter
- Verify created experiments always have `type: 'product'`