### PR TITLE
fix(elapsed-time): handle undefined query in ElapsedTime component

### DIFF
--- a/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
+++ b/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
@@ -185,7 +185,7 @@ export function ElapsedTime({ showTimings }: { showTimings?: boolean }): JSX.Ele
         useValues(dataNodeLogic)
     const [, setTick] = useState(0)
 
-    if ('query' in query && query.query === '') {
+    if (!query || ('query' in query && query.query === '')) {
         return null
     }
 


### PR DESCRIPTION
## Problem

`ElapsedTime` crashes with `TypeError: Cannot use 'in' operator to search for 'query' in undefined` — **418 occurrences across 143 users in the last 7 days**. (but actually, they're since the SQL editor refactoring).

The `ElapsedTime` component reads `query` from `dataNodeLogic` via `useValues`, then immediately does `'query' in query` without guarding against `undefined`. The `in` operator requires an object on the right-hand side, so this throws when `query` is `undefined`.

This started after [#48220 ](https://github.com/PostHog/posthog/pull/48220) restructured the SQL editor rendering hierarchy. During state transitions (tab switches, insight loading), `sourceQuery.source` can briefly be `undefined`, which flows through to `dataNodeLogic.query`. The logic itself already guards against this in its loader and `propsChanged` handler — but `ElapsedTime` didn't.

Fixes https://us.posthog.com/error_tracking/019c9567-07ea-79a0-a0c7-c1d773ae880f

## Changes

One-line fix in `ElapsedTime`: add an explicit `!query` early return. If there's no query, there's no elapsed time to display. It follows an existing pattern.

## How did you test this code?

There are no existing tests for `ElapsedTime` to update. The fix matches the defensive pattern already used in `dataNodeLogic` itself (e.g., `propsChanged` on line 200: `if (!props.query) { return }`).

I didn't actually test this myself locally, but it looks like it should work.

## Publish to changelog?

No