### PR TITLE
fix(surveys): fix filtering on survey notification list

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -20,7 +20,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType, ActivityScope } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ActivityScope, SurveyEventName } from '~/types'
 
 import { SURVEY_CREATED_SOURCE } from './constants'
 import { DuplicateToProjectModal } from './DuplicateToProjectModal'
@@ -178,7 +178,11 @@ function Surveys(): JSX.Element {
             {tab === SurveysTabs.Notifications && (
                 <>
                     <p>Get notified whenever a survey result is submitted</p>
-                    <LinkedHogFunctions type="destination" subTemplateIds={['survey-response']} />
+                    <LinkedHogFunctions
+                        type="destination"
+                        subTemplateIds={['survey-response']}
+                        forceFilterGroups={[{ events: [{ id: SurveyEventName.SENT, type: 'events' }] }]}
+                    />
                 </>
             )}
 


### PR DESCRIPTION
## Problem

survey notifications page filters destinations that have `survey sent` events and a `$survey_response` filter, but the default creation does not include `$survey_response`, so they never appear in the list

- https://posthoghelp.zendesk.com/agent/tickets/51433 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52826)
- https://posthog.com/questions/survey-slack-notifications-not-saving-no-destinations-found

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

overrides filters on the survey list view to only filter on destinations with `survey sent` events

the individual survey page still filters on `survey sent` + `$survey_id = {the current survey}`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
