### PR TITLE
chore(flags): add cross-language property operator consistency checks

### DIFF
--- a/.github/scripts/check-operator-parity.py
+++ b/.github/scripts/check-operator-parity.py
@@ -43,7 +43,11 @@ RUST_ONLY_ALLOWLIST: dict[str, str] = {}
 
 
 def pascal_to_snake(name: str) -> str:
-    """Convert PascalCase to snake_case, matching serde's rename_all = "snake_case"."""
+    """Convert PascalCase to snake_case, matching serde's rename_all = "snake_case".
+
+    Assumes no consecutive-uppercase acronyms (e.g. "URL" or "HTTP") — all current
+    OperatorType variants use single-capital word boundaries like IsNotSet, SemverGt.
+    """
     s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
     return s.lower()
 
@@ -63,6 +67,9 @@ def get_python_operators() -> set[str]:
     return set(values)
 
 
+MIN_EXPECTED_RUST_VARIANTS = 20
+
+
 def get_rust_operators() -> set[str]:
     """Parse OperatorType variants from the Rust source file."""
     content = RUST_OPERATOR_PATH.read_text()
@@ -75,10 +82,25 @@ def get_rust_operators() -> set[str]:
 
     enum_body = enum_match.group(1)
 
+    # Strip lines that are comments or attributes so they don't interfere
+    # with variant extraction (e.g. /// doc comments, #[serde(...)] attributes)
+    cleaned_lines = []
+    for line in enum_body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("//") or stripped.startswith("#["):
+            continue
+        cleaned_lines.append(line)
+    cleaned_body = "\n".join(cleaned_lines)
+
     # Extract variant names (PascalCase identifiers on their own lines)
-    variants = re.findall(r"^\s*(\w+)\s*,?\s*$", enum_body, re.MULTILINE)
+    variants = re.findall(r"^\s*(\w+)\s*,?\s*$", cleaned_body, re.MULTILINE)
     if not variants:
-        print(f"ERROR: Could not parse variants from OperatorType enum")
+        print("ERROR: Could not parse variants from OperatorType enum")
+        sys.exit(1)
+
+    if len(variants) < MIN_EXPECTED_RUST_VARIANTS:
+        print(f"ERROR: Only parsed {len(variants)} Rust variants (expected >= {MIN_EXPECTED_RUST_VARIANTS}).")
+        print("The enum parser may be broken — check for unexpected formatting in OperatorType.")
         sys.exit(1)
 
     return {pascal_to_snake(v) for v in variants}

--- a/.github/scripts/check-operator-parity.py
+++ b/.github/scripts/check-operator-parity.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201 allow print statements
+"""
+CI script to verify PropertyOperator (Python/TypeScript) and OperatorType (Rust)
+enum variants stay in sync across languages.
+
+When a new property filter operator is added to the TypeScript/Python schema,
+it must also be added to the Rust feature flags evaluator (or explicitly
+allowlisted here). Without this check, missing operators cause silent runtime
+failures — e.g. serde deserialization errors in the Rust flag evaluator.
+
+Usage:
+    python .github/scripts/check-operator-parity.py
+
+Exit codes:
+    0 - All operators accounted for
+    1 - Unexpected parity gap found (ERROR)
+"""
+
+import re
+import sys
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+SCHEMA_JSON_PATH = REPO_ROOT / "frontend" / "src" / "queries" / "schema.json"
+RUST_OPERATOR_PATH = REPO_ROOT / "rust" / "feature-flags" / "src" / "properties" / "property_models.rs"
+
+# Operators intentionally present in Python/TypeScript but not in Rust.
+# The Rust feature flag evaluator doesn't need these operators.
+PYTHON_ONLY_ALLOWLIST: dict[str, str] = {
+    "between": "Range comparison, only used in HogQL insights queries",
+    "not_between": "Range comparison, only used in HogQL insights queries",
+    "min": "Alias for gte, only used in HogQL insights queries",
+    "max": "Alias for lte, only used in HogQL insights queries",
+    "is_cleaned_path_exact": "Path normalization, only used in HogQL path analysis",
+}
+
+# Operators intentionally present in Rust but not in Python/TypeScript.
+# This should normally be empty — Rust consumes the Python-defined schema.
+RUST_ONLY_ALLOWLIST: dict[str, str] = {}
+
+
+def pascal_to_snake(name: str) -> str:
+    """Convert PascalCase to snake_case, matching serde's rename_all = "snake_case"."""
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    return s.lower()
+
+
+def get_python_operators() -> set[str]:
+    """Parse PropertyOperator values from the JSON schema (source of truth)."""
+    with open(SCHEMA_JSON_PATH) as f:
+        schema = json.load(f)
+
+    operator_def = schema.get("definitions", {}).get("PropertyOperator", {})
+    values = operator_def.get("enum", [])
+
+    if not values:
+        print(f"ERROR: Could not find PropertyOperator enum in {SCHEMA_JSON_PATH}")
+        sys.exit(1)
+
+    return set(values)
+
+
+def get_rust_operators() -> set[str]:
+    """Parse OperatorType variants from the Rust source file."""
+    content = RUST_OPERATOR_PATH.read_text()
+
+    # Find the OperatorType enum block
+    enum_match = re.search(r"pub\s+enum\s+OperatorType\s*\{([^}]+)\}", content, re.DOTALL)
+    if not enum_match:
+        print(f"ERROR: Could not find OperatorType enum in {RUST_OPERATOR_PATH}")
+        sys.exit(1)
+
+    enum_body = enum_match.group(1)
+
+    # Extract variant names (PascalCase identifiers on their own lines)
+    variants = re.findall(r"^\s*(\w+)\s*,?\s*$", enum_body, re.MULTILINE)
+    if not variants:
+        print(f"ERROR: Could not parse variants from OperatorType enum")
+        sys.exit(1)
+
+    return {pascal_to_snake(v) for v in variants}
+
+
+def main() -> int:
+    python_ops = get_python_operators()
+    rust_ops = get_rust_operators()
+
+    has_errors = False
+    has_warnings = False
+
+    # Check for operators in Python but not in Rust
+    python_only = python_ops - rust_ops
+    unexpected_python_only = python_only - set(PYTHON_ONLY_ALLOWLIST.keys())
+    expected_python_only = python_only & set(PYTHON_ONLY_ALLOWLIST.keys())
+
+    # Check for operators in Rust but not in Python
+    rust_only = rust_ops - python_ops
+    unexpected_rust_only = rust_only - set(RUST_ONLY_ALLOWLIST.keys())
+    expected_rust_only = rust_only & set(RUST_ONLY_ALLOWLIST.keys())
+
+    # Check for stale allowlist entries
+    stale_python_allowlist = set(PYTHON_ONLY_ALLOWLIST.keys()) - python_only
+    stale_rust_allowlist = set(RUST_ONLY_ALLOWLIST.keys()) - rust_only
+
+    print("=" * 60)
+    print("Property Operator Parity Check")
+    print("=" * 60)
+    print(f"\n  Python/TypeScript operators (schema.json): {len(python_ops)}")
+    print(f"  Rust operators (property_models.rs):        {len(rust_ops)}")
+    print(f"  Python-only allowlist:                      {len(PYTHON_ONLY_ALLOWLIST)}")
+    print(f"  Rust-only allowlist:                        {len(RUST_ONLY_ALLOWLIST)}")
+
+    if unexpected_python_only:
+        has_errors = True
+        print(f"\n  ERROR: Operators in Python but not in Rust (and not in allowlist):")
+        for op in sorted(unexpected_python_only):
+            print(f"     - {op}")
+
+    if unexpected_rust_only:
+        has_errors = True
+        print(f"\n  ERROR: Operators in Rust but not in Python (and not in allowlist):")
+        for op in sorted(unexpected_rust_only):
+            print(f"     - {op}")
+
+    if expected_python_only:
+        print(f"\n  Allowlisted Python-only operators:")
+        for op in sorted(expected_python_only):
+            print(f"     - {op}: {PYTHON_ONLY_ALLOWLIST[op]}")
+
+    if expected_rust_only:
+        print(f"\n  Allowlisted Rust-only operators:")
+        for op in sorted(expected_rust_only):
+            print(f"     - {op}: {RUST_ONLY_ALLOWLIST[op]}")
+
+    if stale_python_allowlist:
+        has_warnings = True
+        print(f"\n  WARNING: Stale entries in PYTHON_ONLY_ALLOWLIST (operator no longer Python-only):")
+        for op in sorted(stale_python_allowlist):
+            print(f"     - {op}")
+
+    if stale_rust_allowlist:
+        has_warnings = True
+        print(f"\n  WARNING: Stale entries in RUST_ONLY_ALLOWLIST (operator no longer Rust-only):")
+        for op in sorted(stale_rust_allowlist):
+            print(f"     - {op}")
+
+    if (
+        not unexpected_python_only
+        and not unexpected_rust_only
+        and not stale_python_allowlist
+        and not stale_rust_allowlist
+    ):
+        print("\n  All gaps accounted for")
+
+    print("\n" + "=" * 60)
+
+    if has_errors:
+        print("\nFAILED: Unexpected operator parity gap found.")
+        print("\nTo fix, either:")
+        print("  1. Add the missing operator to the other language's enum:")
+        print(f"     - Rust: {RUST_OPERATOR_PATH.relative_to(REPO_ROOT)}")
+        print(f"     - Python/TS: frontend/src/types.ts (then run: hogli build:schema)")
+        print("  2. Or add it to the appropriate allowlist in this script")
+        print(f"     ({Path(__file__).relative_to(REPO_ROOT)})")
+        print("     with a reason explaining why the gap is intentional.")
+        return 1
+
+    if has_warnings:
+        print("\nPASSED with warnings: Some allowlist entries may be stale.")
+
+    print("\nAll operators are in sync across languages.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -104,6 +104,7 @@ jobs:
                         - pytest.ini
                         - .test_durations # Used for pytest-split sharding
                         - frontend/src/queries/schema.json # Used for generating schema.py
+                        - rust/feature-flags/src/properties/property_models.rs # Operator parity check
                         - common/plugin_transpiler/src # Used for transpiling plugins
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -396,6 +396,21 @@ jobs:
             - name: Check IDOR model coverage
               run: python .github/scripts/check-idor-model-coverage.py
 
+    check-operator-parity:
+        needs: [changes]
+        if: needs.changes.outputs.backend == 'true'
+        timeout-minutes: 2
+        name: Check operator parity across languages
+        runs-on: depot-ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Set up Python
+              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              with:
+                  python-version: 3.12.12
+            - name: Check operator parity
+              run: python .github/scripts/check-operator-parity.py
+
     check-migrations:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.openapi_types == 'true'
@@ -1485,6 +1500,7 @@ jobs:
                 turbo-tests,
                 handle-snapshots,
                 check-idor-coverage,
+                check-operator-parity,
             ]
         name: Django Tests Pass
         runs-on: ubuntu-latest
@@ -1519,6 +1535,12 @@ jobs:
                   # Check IDOR coverage - must pass for Django Tests to be green
                   if [[ "${{ needs.check-idor-coverage.result }}" != "success" && "${{ needs.check-idor-coverage.result }}" != "skipped" ]]; then
                     echo "IDOR coverage check failed."
+                    exit 1
+                  fi
+
+                  # Check operator parity - must pass for Django Tests to be green
+                  if [[ "${{ needs.check-operator-parity.result }}" != "success" && "${{ needs.check-operator-parity.result }}" != "skipped" ]]; then
+                    echo "Operator parity check failed."
                     exit 1
                   fi
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -385,7 +385,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.12.12
             - name: Install uv
@@ -406,7 +406,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.12.12
             - name: Check operator parity
@@ -436,7 +436,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d &
 
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.12.12
 
@@ -1030,7 +1030,7 @@ jobs:
               run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -1599,7 +1599,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d &
 
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version-file: 'pyproject.toml'
 
@@ -1698,7 +1698,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Set up Python
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: '3.12'
 

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 from django.conf import settings
 
 from posthog.hogql.compiler.bytecode import create_bytecode
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import action_to_expr, ast, property_to_expr
 from posthog.hogql.visitor import TraversingVisitor
@@ -156,7 +157,12 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
         if SelectFinder.has_select(expr):
             raise Exception("Select queries are not allowed in filters")
 
-        filters["bytecode"] = create_bytecode(expr).bytecode
+        context = HogQLContext(team_id=team.id)
+        filters["bytecode"] = create_bytecode(expr, context=context).bytecode
+
+        if context.errors:
+            error_messages = "; ".join(e.message for e in context.errors if e.message)
+            raise Exception(f"Filter compilation errors: {error_messages}")
         if "bytecode_error" in filters:
             del filters["bytecode_error"]
     except Exception as e:

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -160,6 +160,9 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
         context = HogQLContext(team_id=team.id)
         filters["bytecode"] = create_bytecode(expr, context=context).bytecode
 
+        # context.errors here only contains "function not implemented" errors from the
+        # bytecode compiler (the resolver doesn't run during create_bytecode). These are
+        # genuinely fatal — the bytecode would reference a non-existent function at runtime.
         if context.errors:
             error_messages = "; ".join(e.message for e in context.errors if e.message)
             raise Exception(f"Filter compilation errors: {error_messages}")

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
-from posthog.schema import EmptyPropertyFilter, HogQLPropertyFilter, PropertyOperator, RetentionEntity
+from posthog.schema import (
+    EmptyPropertyFilter,
+    FlagPropertyFilter,
+    HogQLPropertyFilter,
+    PropertyOperator,
+    RetentionEntity,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.errors import QueryError
@@ -1429,7 +1435,7 @@ class TestProperty(BaseTest):
         PropertyOperator.NOT_ICONTAINS_MULTI: ["a", "b"],
     }
 
-    # FLAG_EVALUATES_TO is dispatched via FlagPropertyFilter before reaching _expr_to_compare_op
+    # FLAG_EVALUATES_TO is dispatched via FlagPropertyFilter, not _expr_to_compare_op
     @parameterized.expand([(op.value,) for op in PropertyOperator if op not in {PropertyOperator.FLAG_EVALUATES_TO}])
     def test_operator_coverage(self, operator_value: str):
         value = self.OPERATOR_TEST_VALUES.get(PropertyOperator(operator_value), "test_value")
@@ -1437,6 +1443,11 @@ class TestProperty(BaseTest):
             {"type": "event", "key": "test_prop", "value": value, "operator": operator_value}
         )
         self.assertIsInstance(result, ast.Expr)
+
+    def test_flag_evaluates_to_produces_neutral_expr(self):
+        prop = FlagPropertyFilter(type="flag", key="my-flag", value="true", operator="flag_evaluates_to")
+        result = property_to_expr([prop], self.team)
+        self.assertEqual(result, ast.Constant(value=1))
 
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
-from posthog.schema import EmptyPropertyFilter, HogQLPropertyFilter, RetentionEntity
+from posthog.schema import EmptyPropertyFilter, HogQLPropertyFilter, PropertyOperator, RetentionEntity
 
 from posthog.hogql import ast
 from posthog.hogql.errors import QueryError
@@ -1405,6 +1405,38 @@ class TestProperty(BaseTest):
                 "(sortableSemver(person.properties.app_version) >= sortableSemver('1.2.3.0') AND sortableSemver(person.properties.app_version) < sortableSemver('1.2.4.0'))"
             ),
         )
+
+    # -- Operator coverage: every PropertyOperator must be handled by property_to_expr --
+
+    # Test values appropriate for each operator type
+    OPERATOR_TEST_VALUES: dict[PropertyOperator, Any] = {
+        PropertyOperator.IS_SET: "",
+        PropertyOperator.IS_NOT_SET: "",
+        PropertyOperator.BETWEEN: [1, 10],
+        PropertyOperator.NOT_BETWEEN: [1, 10],
+        PropertyOperator.IN_: ["a", "b"],
+        PropertyOperator.NOT_IN: ["a", "b"],
+        PropertyOperator.SEMVER_EQ: "1.2.3",
+        PropertyOperator.SEMVER_NEQ: "1.2.3",
+        PropertyOperator.SEMVER_GT: "1.2.3",
+        PropertyOperator.SEMVER_GTE: "1.2.3",
+        PropertyOperator.SEMVER_LT: "1.2.3",
+        PropertyOperator.SEMVER_LTE: "1.2.3",
+        PropertyOperator.SEMVER_TILDE: "1.2.3",
+        PropertyOperator.SEMVER_CARET: "1.2.3",
+        PropertyOperator.SEMVER_WILDCARD: "1.*",
+        PropertyOperator.ICONTAINS_MULTI: ["a", "b"],
+        PropertyOperator.NOT_ICONTAINS_MULTI: ["a", "b"],
+    }
+
+    # FLAG_EVALUATES_TO is dispatched via FlagPropertyFilter before reaching _expr_to_compare_op
+    @parameterized.expand([(op.value,) for op in PropertyOperator if op not in {PropertyOperator.FLAG_EVALUATES_TO}])
+    def test_operator_coverage(self, operator_value: str):
+        value = self.OPERATOR_TEST_VALUES.get(PropertyOperator(operator_value), "test_value")
+        result = self._property_to_expr(
+            {"type": "event", "key": "test_prop", "value": value, "operator": operator_value}
+        )
+        self.assertIsInstance(result, ast.Expr)
 
 
 class TestPropertyIsSetIsNotSetWithData(APIBaseTest):


### PR DESCRIPTION
## Problem

Property filter operators are defined in TypeScript/Python and independently re-implemented in Rust (feature flag evaluator) and HogVM (workflows/CDP). When a new operator is added to one evaluation path but not another, things break at runtime with no warning. This happened twice in one week:

1. **Semver operators** worked in HogQL but the HogVM bytecode referenced `sortableSemver` which didn't exist in the STL, [breaking workflows](https://posthog.slack.com/archives/C07QD3LT8U9/p1771835574992179)
2. **`icontains_multi`** was added to Python/HogQL but missing from the Rust `OperatorType` enum, causing [deserialization failures in the flag evaluator](https://posthog.slack.com/archives/C07Q2U4BH4L/p1771986494052489) when cohorts used "contains any of"

## Changes

**CI script** (`.github/scripts/check-operator-parity.py`): Zero-dependency script that parses `PropertyOperator` from `schema.json` and `OperatorType` from the Rust source, diffs them with explicit allowlists for intentional gaps, and fails CI with actionable error messages when they drift.

**Bytecode compiler fix** (`posthog/cdp/filters.py`): `compile_filters_bytecode` now passes a `HogQLContext` to `create_bytecode` and checks `context.errors` after compilation. The compiler already detected unknown function references as soft errors — this makes them blocking so broken bytecode can't be saved.

**HogQL operator coverage test** (`posthog/hogql/test/test_property.py`): Parametrized test that feeds every `PropertyOperator` value through `property_to_expr` and asserts it produces a valid AST expression.

### Why a CI check instead of codegen?

Generating code across languages (e.g. auto-generating the Rust enum from the Python/TypeScript source of truth) would be a heavier lift. This CI check is intentionally lightweight — a safety net that catches drift without requiring cross-language codegen infrastructure. If this proves valuable, it could evolve into a codegen step later.

## How did you test this code?

- CI script passes locally and correctly fails when a fake operator is added to `schema.json` but not Rust (verified in CI: the intentionally-broken commit [failed the check](https://github.com/PostHog/posthog/actions/runs/22454890596/job/65035195877) with `ERROR: Operators in Python but not in Rust (and not in allowlist): test_break_parity_check`)
- All existing CDP filter tests pass (`pytest posthog/cdp/test/test_filters.py`)
- All 34 operator coverage tests pass (`pytest posthog/hogql/test/test_property.py -k test_operator_coverage`)

## Publish to changelog?

No