### PR TITLE
fix(llm-gateway): use shorter cache TTL for OAuth tokens to handle token refresh

### DIFF
--- a/services/llm-gateway/src/llm_gateway/auth/authenticators.py
+++ b/services/llm-gateway/src/llm_gateway/auth/authenticators.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import asyncpg
 
 from llm_gateway.auth.models import AuthenticatedUser, has_required_scope
+from llm_gateway.config import get_settings
 from llm_gateway.db.postgres import acquire_connection
 
 
@@ -15,6 +16,12 @@ class Authenticator(ABC):
     @abstractmethod
     def auth_type(self) -> str:
         """Identifier for this auth type (used in metrics)."""
+        ...
+
+    @property
+    @abstractmethod
+    def cache_ttl(self) -> int:
+        """How long successful auth results should be cached (seconds)."""
         ...
 
     @abstractmethod
@@ -39,6 +46,10 @@ class PersonalApiKeyAuthenticator(Authenticator):
     @property
     def auth_type(self) -> str:
         return "personal_api_key"
+
+    @property
+    def cache_ttl(self) -> int:
+        return get_settings().auth_cache_ttl
 
     def matches(self, token: str) -> bool:
         return token.startswith("phx_")
@@ -81,6 +92,10 @@ class OAuthAccessTokenAuthenticator(Authenticator):
     @property
     def auth_type(self) -> str:
         return "oauth_access_token"
+
+    @property
+    def cache_ttl(self) -> int:
+        return get_settings().auth_cache_ttl_oauth
 
     def matches(self, token: str) -> bool:
         return token.startswith("pha_")

--- a/services/llm-gateway/src/llm_gateway/auth/cache.py
+++ b/services/llm-gateway/src/llm_gateway/auth/cache.py
@@ -38,7 +38,7 @@ class AuthCache:
         return True, user
 
     def set(self, key: str, user: AuthenticatedUser | None, ttl: int | None = None) -> None:
-        effective_ttl = ttl if ttl is not None else self._ttl
+        effective_ttl: float = ttl if ttl is not None else self._ttl
 
         if user and user.token_expires_at:
             remaining = (user.token_expires_at - datetime.now(UTC)).total_seconds()

--- a/services/llm-gateway/src/llm_gateway/auth/cache.py
+++ b/services/llm-gateway/src/llm_gateway/auth/cache.py
@@ -37,8 +37,17 @@ class AuthCache:
 
         return True, user
 
-    def set(self, key: str, user: AuthenticatedUser | None) -> None:
-        expires_at = time.monotonic() + self._ttl
+    def set(self, key: str, user: AuthenticatedUser | None, ttl: int | None = None) -> None:
+        effective_ttl = ttl if ttl is not None else self._ttl
+
+        if user and user.token_expires_at:
+            remaining = (user.token_expires_at - datetime.now(UTC)).total_seconds()
+            if remaining > 0:
+                effective_ttl = min(effective_ttl, remaining)
+            else:
+                return
+
+        expires_at = time.monotonic() + effective_ttl
         self._cache[key] = CachedAuthEntry(user=user, expires_at=expires_at)
 
     def invalidate(self, key: str) -> None:

--- a/services/llm-gateway/src/llm_gateway/auth/service.py
+++ b/services/llm-gateway/src/llm_gateway/auth/service.py
@@ -50,7 +50,7 @@ class AuthService:
             AUTH_CACHE_MISSES.labels(auth_type=auth.auth_type).inc()
 
             user = await auth.authenticate(token_hash, pool)
-            self._cache.set(token_hash, user)
+            self._cache.set(token_hash, user, ttl=auth.cache_ttl)
 
             if user is None:
                 AUTH_INVALID.labels(auth_type=auth.auth_type).inc()

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -94,7 +94,8 @@ class Settings(BaseSettings):
 
     # ~600 bytes per entry (key + AuthenticatedUser + LRU overhead), 10000 entries ≈ 6 MB
     auth_cache_max_size: int = 10000
-    auth_cache_ttl: int = 900  # 15 minutes
+    auth_cache_ttl: int = 900  # 15 minutes — used for personal API keys
+    auth_cache_ttl_oauth: int = 60  # OAuth tokens can be revoked on refresh, keep short
 
     team_rate_limit_multipliers: dict[int, int] = {}
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -95,7 +95,7 @@ class Settings(BaseSettings):
     # ~600 bytes per entry (key + AuthenticatedUser + LRU overhead), 10000 entries ≈ 6 MB
     auth_cache_max_size: int = 10000
     auth_cache_ttl: int = 900  # 15 minutes — used for personal API keys
-    auth_cache_ttl_oauth: int = 60  # OAuth tokens can be revoked on refresh, keep short
+    auth_cache_ttl_oauth: int = 300  # 5 minutes — OAuth tokens can be revoked on refresh, keep short
 
     team_rate_limit_multipliers: dict[int, int] = {}
 


### PR DESCRIPTION
## Problem

OAuth tokens in the LLM gateway were cached for 15 minutes (`auth_cache_ttl = 900`). When a token refresh occurred, the old access token was deleted from the database, so the main Django API correctly returned 401. However, the LLM gateway's in-memory cache still held the old token as valid — the only expiration check on cache hits was against `token_expires_at` (the token's original lifetime), not whether it had been revoked/deleted by a refresh.

This meant revoked OAuth tokens could continue working in the LLM gateway for up to 15 minutes after refresh.

## Changes

- Added per-entry TTL support to `AuthCache.set()` so different token types can have different cache lifetimes
- Added `cache_ttl` abstract property to `Authenticator` base class
  - Personal API keys (`phx_`): 900s (unchanged, these don't get refreshed)
  - OAuth tokens (`pha_`): 60s (new `auth_cache_ttl_oauth` setting)
- Cache TTL is also clamped to the token's remaining lifetime — a token expiring in 20s won't be cached for 60s
- Already-expired tokens are not cached at all

The 60s TTL was chosen based on LLM generation latency data: it covers the P95 of all models, giving ~89% cache hit rate during agentic workflows (~7 hits per miss for the most common models) while limiting the revocation window to 1 minute.

## How did you test this code?

- All 66 existing auth tests pass
- Added 3 new tests:
  - `test_per_entry_ttl_overrides_default` — verifies per-entry TTL is respected
  - `test_ttl_clamped_to_token_remaining_lifetime` — verifies TTL is clamped to token expiry
  - `test_already_expired_token_not_cached` — verifies expired tokens are not inserted into cache

## Publish to changelog?

no