### PR TITLE
chore(mcp): clean up cohort tools descriptions and add integration tests

### DIFF
--- a/services/mcp/definitions/cohorts.yaml
+++ b/services/mcp/definitions/cohorts.yaml
@@ -24,9 +24,8 @@ tools:
         list: true
         title: List all cohorts
         description: >
-            List all cohorts in the project. Cohorts are groups of users that share common properties or behaviors.
-            Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based
-            on filters). Use the 'type' parameter to filter by cohort type.
+            List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic
+            cohorts (automatically updated based on property filters).
         mcp_version: 1
     cohorts-create:
         operation: cohorts_create
@@ -40,10 +39,9 @@ tools:
         enrich_url: '{id}'
         title: Create cohort
         description: >
-            Create a new cohort. For dynamic cohorts, provide 'filters' with property conditions. For static cohorts,
-            set 'is_static: true', then use 'cohorts-add-persons-to-static-cohort' to add person UUIDs. Dynamic cohort
-            filters use a nested structure with AND/OR groups containing person property filters (type: "person"),
-            behavioral filters (type: "behavioral"), or references to other cohorts (type: "cohort").
+            Create a new cohort. For dynamic cohorts, provide 'filters' with AND/OR groups of property conditions
+            (person properties, behavioral filters, or cohort references). For static cohorts, set 'is_static: true'
+            then use the 'cohorts-add-persons-to-static-cohort-partial-update' tool to add person UUIDs.
         exclude_params:
             - groups
             - deleted
@@ -70,8 +68,8 @@ tools:
         enrich_url: '{id}'
         title: Get cohort
         description: >
-            Get a specific cohort by ID. Returns the cohort configuration including name, description, filters (for
-            dynamic cohorts), count of matching users, and calculation status.
+            Get a specific cohort by ID. Returns the cohort name, description, filters (for dynamic cohorts), count
+            of matching users, and calculation status.
         mcp_version: 1
     cohorts-update:
         operation: cohorts_update
@@ -88,9 +86,8 @@ tools:
         enrich_url: '{id}'
         title: Update cohort
         description: >
-            Update an existing cohort. Can update name, description, and filters. For dynamic cohorts, changing filters
-            will trigger a recalculation of matching users. Note: cohorts used in active feature flags cannot have
-            behavioral filters added. To delete a cohort, set 'deleted: true' (soft delete).
+            Update an existing cohort's name, description, or filters. Changing filters on a dynamic cohort triggers
+            recalculation. To soft-delete a cohort, set 'deleted: true'.
         exclude_params:
             - groups
             - version
@@ -122,8 +119,7 @@ tools:
         enrich_url: '{id}'
         title: Add persons to static cohort
         description: >
-            Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true). Provide a
-            list of person UUIDs in 'person_ids'. Maximum batch size is limited.
+            Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true).
         mcp_version: 1
     cohorts-calculation-history-retrieve:
         operation: cohorts_calculation_history_retrieve
@@ -143,8 +139,8 @@ tools:
         enrich_url: '{id}'
         title: Remove person from static cohort
         description: >
-            Remove a person from a static cohort by their UUID. Only works for static cohorts (is_static: true). This
-            operation is idempotent - removing a person who isn't in the cohort will succeed without error.
+            Remove a person from a static cohort by their UUID. Only works for static cohorts (is_static: true).
+            Idempotent: removing a person not in the cohort succeeds silently.
         mcp_version: 1
     persons-cohorts-retrieve:
         operation: persons_cohorts_retrieve

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -75,7 +75,7 @@
         }
     },
     "cohorts-list": {
-        "description": "List all cohorts in the project. Cohorts are groups of users that share common properties or behaviors. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on filters). Use the 'type' parameter to filter by cohort type.",
+        "description": "List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on property filters).",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "List all cohorts",
@@ -90,7 +90,7 @@
         }
     },
     "cohorts-create": {
-        "description": "Create a new cohort. For dynamic cohorts, provide 'filters' with property conditions. For static cohorts, set 'is_static: true', then use 'cohorts-add-persons-to-static-cohort' to add person UUIDs. Dynamic cohort filters use a nested structure with AND/OR groups containing person property filters (type: \"person\"), behavioral filters (type: \"behavioral\"), or references to other cohorts (type: \"cohort\").",
+        "description": "Create a new cohort. For dynamic cohorts, provide 'filters' with AND/OR groups of property conditions (person properties, behavioral filters, or cohort references). For static cohorts, set 'is_static: true' then use the 'cohorts-add-persons-to-static-cohort-partial-update' tool to add person UUIDs.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "Create cohort",
@@ -105,7 +105,7 @@
         }
     },
     "cohorts-retrieve": {
-        "description": "Get a specific cohort by ID. Returns the cohort configuration including name, description, filters (for dynamic cohorts), count of matching users, and calculation status.",
+        "description": "Get a specific cohort by ID. Returns the cohort name, description, filters (for dynamic cohorts), count of matching users, and calculation status.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "Get cohort",
@@ -120,7 +120,7 @@
         }
     },
     "cohorts-partial-update": {
-        "description": "Update an existing cohort. Can update name, description, and filters. For dynamic cohorts, changing filters will trigger a recalculation of matching users. Note: cohorts used in active feature flags cannot have behavioral filters added. To delete a cohort, set 'deleted: true' (soft delete).",
+        "description": "Update an existing cohort's name, description, or filters. Changing filters on a dynamic cohort triggers recalculation. To soft-delete a cohort, set 'deleted: true'.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "Update cohort",
@@ -135,7 +135,7 @@
         }
     },
     "cohorts-add-persons-to-static-cohort-partial-update": {
-        "description": "Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true). Provide a list of person UUIDs in 'person_ids'. Maximum batch size is limited.",
+        "description": "Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true).",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "Add persons to static cohort",
@@ -150,7 +150,7 @@
         }
     },
     "cohorts-remove-person-from-static-cohort-partial-update": {
-        "description": "Remove a person from a static cohort by their UUID. Only works for static cohorts (is_static: true). This operation is idempotent - removing a person who isn't in the cohort will succeed without error.",
+        "description": "Remove a person from a static cohort by their UUID. Only works for static cohorts (is_static: true). Idempotent: removing a person not in the cohort succeeds silently.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "Remove person from static cohort",

--- a/services/mcp/tests/shared/test-utils.ts
+++ b/services/mcp/tests/shared/test-utils.ts
@@ -16,6 +16,7 @@ export interface CreatedResources {
     dashboards: number[]
     surveys: string[]
     actions: number[]
+    cohorts: number[]
 }
 
 export function validateEnvironmentVariables(): void {
@@ -109,6 +110,19 @@ export async function cleanupResources(
         }
     }
     resources.actions = []
+
+    for (const cohortId of resources.cohorts) {
+        try {
+            await client.request({
+                method: 'PATCH',
+                path: `/api/projects/${projectId}/cohorts/${cohortId}/`,
+                body: { deleted: true },
+            })
+        } catch (error) {
+            console.warn(`Failed to cleanup cohort ${cohortId}:`, error)
+        }
+    }
+    resources.cohorts = []
 }
 
 export function parseToolResponse(result: any): any {

--- a/services/mcp/tests/tools/actions.integration.test.ts
+++ b/services/mcp/tests/tools/actions.integration.test.ts
@@ -27,6 +27,7 @@ describe('Actions', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/cohorts.integration.test.ts
+++ b/services/mcp/tests/tools/cohorts.integration.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    type CreatedResources,
+    TEST_ORG_ID,
+    TEST_PROJECT_ID,
+    cleanupResources,
+    createTestClient,
+    createTestContext,
+    generateUniqueKey,
+    parseToolResponse,
+    setActiveProjectAndOrg,
+    validateEnvironmentVariables,
+} from '@/shared/test-utils'
+import { GENERATED_TOOLS } from '@/tools/generated/cohorts'
+import type { Context } from '@/tools/types'
+
+describe('Cohorts', { concurrent: false }, () => {
+    let context: Context
+    const createdResources: CreatedResources = {
+        featureFlags: [],
+        insights: [],
+        dashboards: [],
+        surveys: [],
+        actions: [],
+        cohorts: [],
+    }
+
+    beforeAll(async () => {
+        validateEnvironmentVariables()
+        const client = createTestClient()
+        context = createTestContext(client)
+        await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
+    })
+
+    afterEach(async () => {
+        await cleanupResources(context.api, TEST_PROJECT_ID!, createdResources)
+    })
+
+    describe('cohorts-list tool', () => {
+        const listTool = GENERATED_TOOLS['cohorts-list']!()
+
+        it('should list cohorts', async () => {
+            const result = await listTool.handler(context, {})
+            const cohorts = parseToolResponse(result)
+
+            expect(Array.isArray(cohorts)).toBe(true)
+        })
+
+        it('should support pagination', async () => {
+            const result = await listTool.handler(context, { limit: 5, offset: 0 })
+            const cohorts = parseToolResponse(result)
+
+            expect(Array.isArray(cohorts)).toBe(true)
+            expect(cohorts.length).toBeLessThanOrEqual(5)
+        })
+    })
+
+    describe('cohorts-create tool', () => {
+        const createTool = GENERATED_TOOLS['cohorts-create']!()
+
+        it('should create a dynamic cohort with filters', async () => {
+            const name = `Dynamic Cohort ${generateUniqueKey('dynamic')}`
+            const result = await createTool.handler(context, {
+                name,
+                description: 'Integration test dynamic cohort',
+                filters: {
+                    properties: {
+                        type: 'OR',
+                        values: [
+                            {
+                                type: 'person',
+                                key: '$browser',
+                                value: 'Chrome',
+                                operator: 'exact',
+                            },
+                        ],
+                    },
+                },
+            })
+            const cohort = parseToolResponse(result)
+
+            expect(cohort.id).toBeTruthy()
+            expect(cohort.name).toBe(name)
+            expect(cohort.description).toBe('Integration test dynamic cohort')
+            expect(cohort.url).toContain('/cohorts/')
+
+            createdResources.cohorts.push(cohort.id)
+        })
+
+        it('should create a static cohort', async () => {
+            const name = `Static Cohort ${generateUniqueKey('static')}`
+            const result = await createTool.handler(context, {
+                name,
+                is_static: true,
+            })
+            const cohort = parseToolResponse(result)
+
+            expect(cohort.id).toBeTruthy()
+            expect(cohort.name).toBe(name)
+            expect(cohort.is_static).toBe(true)
+            expect(cohort.url).toContain('/cohorts/')
+
+            createdResources.cohorts.push(cohort.id)
+        })
+    })
+
+    describe('cohorts-retrieve tool', () => {
+        const createTool = GENERATED_TOOLS['cohorts-create']!()
+        const retrieveTool = GENERATED_TOOLS['cohorts-retrieve']!()
+
+        it('should retrieve a specific cohort by ID', async () => {
+            const name = `Retrieve Test ${generateUniqueKey('retrieve')}`
+            const createResult = await createTool.handler(context, {
+                name,
+                description: 'For retrieve test',
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+            createdResources.cohorts.push(created.id)
+
+            const result = await retrieveTool.handler(context, { id: created.id })
+            const cohort = parseToolResponse(result)
+
+            expect(cohort.id).toBe(created.id)
+            expect(cohort.name).toBe(name)
+            expect(cohort.description).toBe('For retrieve test')
+            expect(cohort.url).toContain('/cohorts/')
+        })
+    })
+
+    describe('cohorts-partial-update tool', () => {
+        const createTool = GENERATED_TOOLS['cohorts-create']!()
+        const updateTool = GENERATED_TOOLS['cohorts-partial-update']!()
+
+        it('should update cohort name and description', async () => {
+            const createResult = await createTool.handler(context, {
+                name: `Original ${generateUniqueKey('orig')}`,
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+            createdResources.cohorts.push(created.id)
+
+            const updatedName = `Updated ${generateUniqueKey('upd')}`
+            const result = await updateTool.handler(context, {
+                id: created.id,
+                name: updatedName,
+                description: 'Updated description',
+            })
+            const updated = parseToolResponse(result)
+
+            expect(updated.id).toBe(created.id)
+            expect(updated.name).toBe(updatedName)
+            expect(updated.description).toBe('Updated description')
+        })
+
+        it('should soft-delete a cohort', async () => {
+            const createResult = await createTool.handler(context, {
+                name: `Delete Test ${generateUniqueKey('delete')}`,
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+
+            const result = await updateTool.handler(context, {
+                id: created.id,
+                deleted: true,
+            })
+            const deleted = parseToolResponse(result)
+
+            expect(deleted.id).toBe(created.id)
+
+            const listTool = GENERATED_TOOLS['cohorts-list']!()
+            const listResult = await listTool.handler(context, {})
+            const cohorts = parseToolResponse(listResult)
+            expect(cohorts.some((c: { id: number }) => c.id === created.id)).toBe(false)
+        })
+    })
+
+    describe('static cohort person management', () => {
+        const createTool = GENERATED_TOOLS['cohorts-create']!()
+        const addPersonsTool = GENERATED_TOOLS['cohorts-add-persons-to-static-cohort-partial-update']!()
+        const removePersonTool = GENERATED_TOOLS['cohorts-remove-person-from-static-cohort-partial-update']!()
+
+        it('should add persons to a static cohort', async () => {
+            const createResult = await createTool.handler(context, {
+                name: `Add Persons Test ${generateUniqueKey('add')}`,
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+            createdResources.cohorts.push(created.id)
+
+            const testUuid = '00000000-0000-4000-8000-000000000001'
+            const result = await addPersonsTool.handler(context, {
+                id: created.id,
+                person_ids: [testUuid],
+            })
+            const response = parseToolResponse(result)
+
+            expect(response).toBeTruthy()
+        })
+
+        it('should remove a person from a static cohort', async () => {
+            const createResult = await createTool.handler(context, {
+                name: `Remove Person Test ${generateUniqueKey('remove')}`,
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+            createdResources.cohorts.push(created.id)
+
+            const testUuid = '00000000-0000-4000-8000-000000000002'
+
+            await addPersonsTool.handler(context, {
+                id: created.id,
+                person_ids: [testUuid],
+            })
+
+            const result = await removePersonTool.handler(context, {
+                id: created.id,
+                person_id: testUuid,
+            })
+            const response = parseToolResponse(result)
+
+            expect(response).toBeTruthy()
+        })
+    })
+
+    describe('cohort workflow', () => {
+        it('should support create, list, retrieve, update workflow', async () => {
+            const createTool = GENERATED_TOOLS['cohorts-create']!()
+            const listTool = GENERATED_TOOLS['cohorts-list']!()
+            const retrieveTool = GENERATED_TOOLS['cohorts-retrieve']!()
+            const updateTool = GENERATED_TOOLS['cohorts-partial-update']!()
+
+            const name = `Workflow Test ${generateUniqueKey('workflow')}`
+            const createResult = await createTool.handler(context, {
+                name,
+                is_static: true,
+            })
+            const created = parseToolResponse(createResult)
+            createdResources.cohorts.push(created.id)
+
+            const listResult = await listTool.handler(context, {})
+            const cohorts = parseToolResponse(listResult)
+            expect(cohorts.some((c: { id: number }) => c.id === created.id)).toBe(true)
+
+            const retrieveResult = await retrieveTool.handler(context, { id: created.id })
+            const retrieved = parseToolResponse(retrieveResult)
+            expect(retrieved.name).toBe(name)
+
+            const updatedName = `Updated Workflow ${generateUniqueKey('upd-wf')}`
+            const updateResult = await updateTool.handler(context, {
+                id: created.id,
+                name: updatedName,
+            })
+            const updated = parseToolResponse(updateResult)
+            expect(updated.name).toBe(updatedName)
+        })
+    })
+})

--- a/services/mcp/tests/tools/dashboards.integration.test.ts
+++ b/services/mcp/tests/tools/dashboards.integration.test.ts
@@ -31,6 +31,7 @@ describe('Dashboards', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/dataSchema.integration.test.ts
+++ b/services/mcp/tests/tools/dataSchema.integration.test.ts
@@ -21,6 +21,7 @@ describe('read-data-schema', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/dataWarehouseSchema.integration.test.ts
+++ b/services/mcp/tests/tools/dataWarehouseSchema.integration.test.ts
@@ -21,6 +21,7 @@ describe('read-data-warehouse-schema', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/documentation.integration.test.ts
+++ b/services/mcp/tests/tools/documentation.integration.test.ts
@@ -21,6 +21,7 @@ describe('Documentation', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -24,6 +24,7 @@ describe('Error Tracking', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/executeSql.integration.test.ts
+++ b/services/mcp/tests/tools/executeSql.integration.test.ts
@@ -21,6 +21,7 @@ describe('execute-sql', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -28,6 +28,7 @@ describe('Experiments', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
     const createdExperiments: number[] = []
 

--- a/services/mcp/tests/tools/featureFlags.integration.test.ts
+++ b/services/mcp/tests/tools/featureFlags.integration.test.ts
@@ -27,6 +27,7 @@ describe('Feature Flags', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/insights.integration.test.ts
+++ b/services/mcp/tests/tools/insights.integration.test.ts
@@ -30,6 +30,7 @@ describe('Insights', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/llmAnalytics.integration.test.ts
+++ b/services/mcp/tests/tools/llmAnalytics.integration.test.ts
@@ -22,6 +22,7 @@ describe('LLM Analytics', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/logs.integration.test.ts
+++ b/services/mcp/tests/tools/logs.integration.test.ts
@@ -24,6 +24,7 @@ describe('Logs', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/organizations.integration.test.ts
+++ b/services/mcp/tests/tools/organizations.integration.test.ts
@@ -24,6 +24,7 @@ describe.skip('Organizations', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/projects.integration.test.ts
+++ b/services/mcp/tests/tools/projects.integration.test.ts
@@ -27,6 +27,7 @@ describe('Projects', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/tests/tools/query.integration.test.ts
+++ b/services/mcp/tests/tools/query.integration.test.ts
@@ -96,6 +96,7 @@ describe('Query Integration Tests', () => {
             dashboards: [],
             surveys: [],
             actions: [],
+            cohorts: [],
         }
     })
 

--- a/services/mcp/tests/tools/surveys.integration.test.ts
+++ b/services/mcp/tests/tools/surveys.integration.test.ts
@@ -29,6 +29,7 @@ describe('Surveys', { concurrent: false }, () => {
         dashboards: [],
         surveys: [],
         actions: [],
+        cohorts: [],
     }
 
     beforeAll(async () => {


### PR DESCRIPTION
## Summary

Cleanup PR stacked on #49141:
- Tighten YAML and JSON tool descriptions to be more concise
- Fix `cohorts-create` description to reference the correct tool name (`cohorts-add-persons-to-static-cohort-partial-update`)
- Add cohorts integration tests covering all 6 enabled tools (list, create, retrieve, partial-update, add-persons, remove-person)
- Add `cohorts` to `CreatedResources` interface and cleanup function across all test files

## Test plan

- [x] MCP unit tests pass (171 tests)
- [x] TypeScript compiles clean
- [ ] Integration tests pass against local PostHog instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)