### PR TITLE
fix(llma): disable spinner time capture on AIDataLoading

### DIFF
--- a/products/llm_analytics/frontend/components/AIDataLoading.tsx
+++ b/products/llm_analytics/frontend/components/AIDataLoading.tsx
@@ -4,7 +4,7 @@ export function AIDataLoading({ variant = 'inline' }: { variant?: 'inline' | 'bl
     if (variant === 'inline') {
         return (
             <div className="inline-flex items-center gap-1 text-muted-alt">
-                <Spinner className="text-sm" />
+                <Spinner className="text-sm" captureTime={false} />
                 <span className="text-xs">Loading...</span>
             </div>
         )
@@ -12,7 +12,7 @@ export function AIDataLoading({ variant = 'inline' }: { variant?: 'inline' | 'bl
 
     return (
         <div className="flex flex-col items-center justify-center p-8 text-muted-alt">
-            <Spinner className="text-2xl mb-2" />
+            <Spinner className="text-2xl mb-2" captureTime={false} />
             <p className="text-sm">Loading AI data...</p>
         </div>
     )


### PR DESCRIPTION
## Problem

The `AIDataLoading` component (used for lazy-loaded sentiment cells in the LLM analytics traces table) renders `<Spinner>` with the default `captureTime={true}`. This causes every sentiment cell to fire a `spinner_unloaded` event when it finishes loading.

Since sentiment loads lazily per-trace in batches, a single page load of the traces table can fire dozens of these events. The "LLM Analytics Traces - Spinner Load Times" insight filters on `event = 'spinner_unloaded' AND $current_url LIKE '%llm-analytics/traces%'`, so these per-cell spinner events get mixed in with the actual page-load spinner metrics, inflating and distorting the load time data.

## Changes

Set `captureTime={false}` on both `Spinner` instances in `AIDataLoading` (inline and block variants). These per-cell loading indicators are not meaningful page-load signals and should not contribute to spinner timing metrics.

## How did you test this code?

Code-only change — verified the `Spinner` component accepts `captureTime` prop and defaults to `true`. This is an agent-authored PR; no manual testing was performed.

## Publish to changelog?

No