### PR TITLE
feat: add strong CSP to non-html requests

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -733,6 +733,12 @@ class CSPMiddleware:
         # nonce must be added to request (above) before generating response
         response = self.get_response(request)
 
+        content_type = response.get("Content-Type", "")
+        # csp headers only matter on html documents, so for defense in depth, add strong csp to all other requests
+        if "text/html" not in content_type:
+            response.headers["Content-Security-Policy"] = "default-src 'none'"
+            return response
+
         is_admin_view = request.path.startswith("/admin/")
         if is_admin_view:
             django_loginas_inline_script_hash = "sha256-2bSkJXtgXFhxZUhgXzWsEsKImxJEQsqjns0vi3KiSrI="

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1355,6 +1355,20 @@ class TestActiveOrganizationMiddleware(APIBaseTest):
         self.assertIn(response.status_code, [status.HTTP_302_FOUND, status.HTTP_200_OK])
 
 
+class TestCSPMiddleware(APIBaseTest):
+    def test_non_html_response_gets_strict_csp(self):
+        response = self.client.get("/api/users/@me/")
+        assert response.status_code == 200
+        assert response["Content-Security-Policy"] == "default-src 'none'"
+        assert "Content-Security-Policy-Report-Only" not in response
+
+    def test_html_response_gets_report_only_csp(self):
+        response = self.client.get("/")
+        assert response.status_code == 200
+        assert "Content-Security-Policy-Report-Only" in response
+        assert "Content-Security-Policy" not in response
+
+
 class TestSocialAuthExceptionMiddleware(APIBaseTest):
     CONFIG_AUTO_LOGIN = False
 


### PR DESCRIPTION
Simple defense in depth measure, since these responses shouldn't be rendered by the browser.