### PR TITLE
fix(cohorts): validate date values for date operators in cohort API

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -12,7 +12,6 @@ from django.db import DatabaseError
 from django.db.models import OuterRef, Prefetch, QuerySet, Subquery, prefetch_related_objects
 
 import structlog
-from dateutil import parser as date_parser
 from drf_spectacular.utils import extend_schema
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
@@ -74,7 +73,7 @@ from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT
 from posthog.queries.actor_base_query import get_serialized_people
-from posthog.queries.base import property_group_to_Q, relative_date_parse_for_feature_flag_matching
+from posthog.queries.base import determine_parsed_date_for_property_matching, property_group_to_Q
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.util import get_earliest_timestamp
 from posthog.renderers import SafeJSONRenderer
@@ -232,31 +231,9 @@ class CohortFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
 
 
 # Date operators that require date value validation
-DATE_OPERATORS = ("is_date_after", "is_date_before", "is_date_exact")
-
-
-def is_valid_date_value(value: Any) -> bool:
-    """
-    Validate that a value can be parsed as a date for date operators.
-    Accepts:
-    - Relative date strings: -7d, 30d, -1w, -1m, -1y, -1h, etc. (with overflow protection)
-    - ISO 8601 date/datetime strings: 2024-01-15, 2024-01-15T10:30:00Z, etc.
-    """
-    if value is None:
-        return False
-
-    str_value = str(value)
-
-    # Check relative date format using existing utility (includes overflow protection)
-    if relative_date_parse_for_feature_flag_matching(str_value) is not None:
-        return True
-
-    # Try parsing as a date/datetime
-    try:
-        date_parser.parse(str_value)
-        return True
-    except (ValueError, TypeError):
-        return False
+# Note: is_date_exact is not yet supported (see posthog/models/property/util.py)
+# Keep in sync with OperatorType in posthog/models/property/property.py
+DATE_OPERATORS = ("is_date_after", "is_date_before")
 
 
 class PersonFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
@@ -282,9 +259,13 @@ class PersonFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
         if missing:
             raise ValueError(f"Missing required keys for person filter: {', '.join(missing)}")
 
-        # Validate date values for date operators
+        return self
+
+    @model_validator(mode="after")
+    def _validate_date_value(self):
         if self.operator in DATE_OPERATORS and self.value is not None:
-            if not is_valid_date_value(self.value):
+            parsed_date = determine_parsed_date_for_property_matching(self.value)
+            if not parsed_date:
                 raise ValueError(
                     f"Invalid date value '{self.value}' for operator '{self.operator}'. "
                     f"Expected a relative date (e.g., '-7d', '30d') or an ISO 8601 date (e.g., '2024-01-15')."

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -12,6 +12,7 @@ from django.db import DatabaseError
 from django.db.models import OuterRef, Prefetch, QuerySet, Subquery, prefetch_related_objects
 
 import structlog
+from dateutil import parser as date_parser
 from drf_spectacular.utils import extend_schema
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
@@ -73,7 +74,7 @@ from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT
 from posthog.queries.actor_base_query import get_serialized_people
-from posthog.queries.base import property_group_to_Q
+from posthog.queries.base import property_group_to_Q, relative_date_parse_for_feature_flag_matching
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.util import get_earliest_timestamp
 from posthog.renderers import SafeJSONRenderer
@@ -230,6 +231,34 @@ class CohortFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
     negation: bool = False
 
 
+# Date operators that require date value validation
+DATE_OPERATORS = ("is_date_after", "is_date_before", "is_date_exact")
+
+
+def is_valid_date_value(value: Any) -> bool:
+    """
+    Validate that a value can be parsed as a date for date operators.
+    Accepts:
+    - Relative date strings: -7d, 30d, -1w, -1m, -1y, -1h, etc. (with overflow protection)
+    - ISO 8601 date/datetime strings: 2024-01-15, 2024-01-15T10:30:00Z, etc.
+    """
+    if value is None:
+        return False
+
+    str_value = str(value)
+
+    # Check relative date format using existing utility (includes overflow protection)
+    if relative_date_parse_for_feature_flag_matching(str_value) is not None:
+        return True
+
+    # Try parsing as a date/datetime
+    try:
+        date_parser.parse(str_value)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
 class PersonFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
     type: Literal["person"]
     key: str
@@ -252,6 +281,14 @@ class PersonFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
 
         if missing:
             raise ValueError(f"Missing required keys for person filter: {', '.join(missing)}")
+
+        # Validate date values for date operators
+        if self.operator in DATE_OPERATORS and self.value is not None:
+            if not is_valid_date_value(self.value):
+                raise ValueError(
+                    f"Invalid date value '{self.value}' for operator '{self.operator}'. "
+                    f"Expected a relative date (e.g., '-7d', '30d') or an ISO 8601 date (e.g., '2024-01-15')."
+                )
 
         return self
 

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3101,6 +3101,79 @@ email@example.org,
         self.assertEqual(response.status_code, 201)
         self.assertNotEqual(response.json()["id"], None)
 
+    @parameterized.expand(
+        [
+            ("is_date_after", "garbage"),
+            ("is_date_before", "garbage"),
+            ("is_date_exact", "garbage"),
+            ("is_date_after", "-99999d"),  # Overflow - numbers >= 10,000 are rejected
+            ("is_date_before", "10000d"),  # Overflow - exactly 10,000 is rejected
+        ]
+    )
+    @patch("posthog.api.cohort.report_user_action")
+    def test_cohort_property_validation_date_operator_invalid_value(self, operator, value, patch_capture):
+        # Test that date operators reject invalid date values
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": "cohort with invalid date",
+                "filters": {
+                    "properties": {
+                        "type": "OR",
+                        "values": [
+                            {
+                                "key": "created_at",
+                                "type": "person",
+                                "operator": operator,
+                                "value": value,
+                            }
+                        ],
+                    }
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid date value", response.json()["detail"])
+
+    @parameterized.expand(
+        [
+            ("is_date_after", "-7d"),  # Relative date
+            ("is_date_after", "30d"),  # Relative date without minus
+            ("is_date_before", "-1w"),  # Relative date weeks
+            ("is_date_before", "-1m"),  # Relative date months
+            ("is_date_exact", "-1y"),  # Relative date years
+            ("is_date_after", "-24h"),  # Relative date hours
+            ("is_date_after", "2024-01-15"),  # ISO date
+            ("is_date_before", "2024-01-15T10:30:00Z"),  # ISO datetime
+            ("is_date_exact", "2024-01-15T10:30:00+00:00"),  # ISO datetime with timezone
+            ("is_date_after", "January 15, 2024"),  # Human readable date
+        ]
+    )
+    @patch("posthog.api.cohort.report_user_action")
+    def test_cohort_property_validation_date_operator_valid_value(self, operator, value, patch_capture):
+        # Test that date operators accept valid date values
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": f"cohort with valid date {operator} {value}",
+                "filters": {
+                    "properties": {
+                        "type": "OR",
+                        "values": [
+                            {
+                                "key": "created_at",
+                                "type": "person",
+                                "operator": operator,
+                                "value": value,
+                            }
+                        ],
+                    }
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertNotEqual(response.json()["id"], None)
+
     @patch("posthog.api.cohort.report_user_action")
     def test_cohort_property_validation_cohort_filter(self, patch_capture):
         # First create a cohort to reference

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3105,9 +3105,10 @@ email@example.org,
         [
             ("is_date_after", "garbage"),
             ("is_date_before", "garbage"),
-            ("is_date_exact", "garbage"),
             ("is_date_after", "-99999d"),  # Overflow - numbers >= 10,000 are rejected
             ("is_date_before", "10000d"),  # Overflow - exactly 10,000 is rejected
+            ("is_date_after", ""),  # Empty string
+            ("is_date_before", "9999999999"),  # Very large numeric string causes OverflowError
         ]
     )
     @patch("posthog.api.cohort.report_user_action")
@@ -3141,11 +3142,12 @@ email@example.org,
             ("is_date_after", "30d"),  # Relative date without minus
             ("is_date_before", "-1w"),  # Relative date weeks
             ("is_date_before", "-1m"),  # Relative date months
-            ("is_date_exact", "-1y"),  # Relative date years
+            ("is_date_after", "-1y"),  # Relative date years
             ("is_date_after", "-24h"),  # Relative date hours
+            ("is_date_after", "9999d"),  # Boundary: 9999 is valid (10000 is rejected)
             ("is_date_after", "2024-01-15"),  # ISO date
             ("is_date_before", "2024-01-15T10:30:00Z"),  # ISO datetime
-            ("is_date_exact", "2024-01-15T10:30:00+00:00"),  # ISO datetime with timezone
+            ("is_date_after", "2024-01-15T10:30:00+00:00"),  # ISO datetime with timezone
             ("is_date_after", "January 15, 2024"),  # Human readable date
         ]
     )
@@ -3162,6 +3164,38 @@ email@example.org,
                         "values": [
                             {
                                 "key": "created_at",
+                                "type": "person",
+                                "operator": operator,
+                                "value": value,
+                            }
+                        ],
+                    }
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertNotEqual(response.json()["id"], None)
+
+    @parameterized.expand(
+        [
+            ("exact", "garbage"),  # Non-date operator accepts any string
+            ("icontains", "not-a-date"),  # Non-date operator accepts any string
+            ("regex", ".*"),  # Non-date operator accepts any string
+        ]
+    )
+    @patch("posthog.api.cohort.report_user_action")
+    def test_cohort_property_validation_non_date_operator_accepts_any_value(self, operator, value, patch_capture):
+        # Regression test: non-date operators should still accept non-date values
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": f"cohort with {operator} operator",
+                "filters": {
+                    "properties": {
+                        "type": "OR",
+                        "values": [
+                            {
+                                "key": "some_prop",
                                 "type": "person",
                                 "operator": operator,
                                 "value": value,


### PR DESCRIPTION
## Problem

The cohort API accepts invalid date values (like `"garbage"`) for date operators (`is_date_after`/`since`, `is_date_before`, `is_date_exact`) without validation, allowing malformed cohorts to be created.

Closes #47722

## Changes

- Added `is_valid_date_value()` helper function in `posthog/api/cohort.py` that validates date strings
- Updated `PersonFilter._missing_keys_check` Pydantic model validator to validate date values when the operator is a date operator
- Reuses existing `relative_date_parse_for_feature_flag_matching` function to ensure consistent behavior with feature flag date matching (including overflow protection for numbers >= 10,000)

**Valid date formats:**
- Relative dates: `-7d`, `30d`, `-1w`, `-1m`, `-1y`, `-1h` (with overflow protection)
- ISO 8601 dates/datetimes: `2024-01-15`, `2024-01-15T10:30:00Z`
- Human-readable dates parsed by `dateutil.parser`

**Error response for invalid dates:**
```json
{
  "detail": "Invalid date value 'garbage' for operator 'is_date_after'. Expected a relative date (e.g., '-7d', '30d') or an ISO 8601 date (e.g., '2024-01-15')."
}
```

## How did you test this code?

Added parameterized tests in `posthog/api/test/test_cohort.py`:
- 5 invalid value tests: `"garbage"`, overflow values (`-99999d`, `10000d`)
- 10 valid value tests: relative dates (h/d/w/m/y), ISO dates, ISO datetimes with timezones, human-readable dates

All 15 tests pass.

## Publish to changelog?

no