### PR TITLE
fix: egress proxy fails when using Chromium

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -16,6 +16,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.proxy import Proxy, ProxyType
 from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.os_manager import ChromeType
@@ -73,7 +74,11 @@ def get_driver() -> webdriver.Chrome:
     )  # Removes the "Chrome is being controlled by automated test software" bar
 
     if settings.OUTBOUND_PROXY_ENABLED and settings.OUTBOUND_PROXY_URL:
-        options.add_argument(f"--proxy-server={settings.OUTBOUND_PROXY_URL}")
+        proxy = Proxy()
+        proxy.proxy_type = ProxyType.MANUAL
+        proxy.http_proxy = settings.OUTBOUND_PROXY_URL
+        proxy.ssl_proxy = settings.OUTBOUND_PROXY_URL
+        options.proxy = proxy
 
     # Create a unique prefix for the temporary directory
     pid = os.getpid()

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -256,12 +256,14 @@ def _generate_screenshots(screenshot: SavedHeatmap) -> None:
             "--no-sandbox",
             "--disable-gpu",
         ]
+        proxy_config = None
         if settings.OUTBOUND_PROXY_ENABLED and settings.OUTBOUND_PROXY_URL:
-            launch_args.append(f"--proxy-server={settings.OUTBOUND_PROXY_URL}")
+            proxy_config = {"server": settings.OUTBOUND_PROXY_URL}
 
         browser = p.chromium.launch(
             headless=True,  # TIP: for debugging, set to False
             args=launch_args,
+            proxy=proxy_config,
         )
         try:
             for w in widths:

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -5,6 +5,7 @@ import posthoganalytics
 from celery import shared_task
 from playwright.sync_api import (
     Page,
+    ProxySettings,
     TimeoutError as PlaywrightTimeoutError,
     sync_playwright,
 )
@@ -256,9 +257,9 @@ def _generate_screenshots(screenshot: SavedHeatmap) -> None:
             "--no-sandbox",
             "--disable-gpu",
         ]
-        proxy_config = None
+        proxy_config: ProxySettings | None = None
         if settings.OUTBOUND_PROXY_ENABLED and settings.OUTBOUND_PROXY_URL:
-            proxy_config = {"server": settings.OUTBOUND_PROXY_URL}
+            proxy_config = ProxySettings(server=settings.OUTBOUND_PROXY_URL)
 
         browser = p.chromium.launch(
             headless=True,  # TIP: for debugging, set to False


### PR DESCRIPTION
Follow up to #49170. The proxy worked for the Slack webhook and the Hog function, but not for heatmap screenshots or image exporter.