### PR TITLE
feat(personhog-replica): integrate common/lifecycle

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6062,7 +6062,7 @@ dependencies = [
  "common-database",
  "common-metrics",
  "envconfig",
- "health",
+ "lifecycle",
  "personhog-proto",
  "rand 0.8.5",
  "serde_json",

--- a/rust/personhog-replica/Cargo.toml
+++ b/rust/personhog-replica/Cargo.toml
@@ -9,7 +9,7 @@ personhog-proto = { path = "../personhog-proto" }
 common-database = { path = "../common/database" }
 common-metrics = { path = "../common/metrics" }
 common-alloc = { path = "../common/alloc" }
-health = { path = "../common/health" }
+lifecycle = { path = "../common/lifecycle" }
 
 async-trait = { workspace = true }
 axum = { workspace = true }


### PR DESCRIPTION
## Problem
Several of the new `personhog` Rust services are perfect candidates to integrate the new `common/lifecycle` library
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Integrate `common/lifecycle` management and component monitoring into `personhog-replica`
* TODO: I'll update dashboard with lifecycle metrics once this lands 🎗️ 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Can do smoke test deploy prior to prod rollout if desired 👍 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
