### PR TITLE
feat(flags): add negative cache for invalid API tokens

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "bytes",
  "chrono",
  "common-alloc",
+ "common-cache",
  "common-compression",
  "common-continuous-profiling",
  "common-cookieless",

--- a/rust/common/cache/src/negative_cache.rs
+++ b/rust/common/cache/src/negative_cache.rs
@@ -46,15 +46,11 @@ impl NegativeCache {
         Self { cache }
     }
 
-    /// Check if a key is in the negative cache (was not found in database)
-    ///
-    /// # Arguments
-    /// * `key` - The key to check
-    ///
-    /// # Returns
-    /// `true` if the key is in the negative cache, `false` otherwise
+    /// Check if a key is in the negative cache (was not found in database).
+    /// Uses `get` instead of `contains_key` to refresh the entry's LRU position,
+    /// keeping frequently-hit entries (e.g., persistent bots) from being evicted.
     pub fn contains(&self, key: &str) -> bool {
-        self.cache.contains_key(key)
+        self.cache.get(key).is_some()
     }
 
     /// Add a key to the negative cache (marking it as not found in database)

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -409,17 +409,6 @@ impl HyperCacheReader {
             1,
         );
 
-        // Also increment the tombstone counter for hypercache misses - this should never happen
-        inc(
-            TOMBSTONE_COUNTER_NAME,
-            &[
-                ("namespace".to_string(), self.config.namespace.clone()),
-                ("operation".to_string(), "hypercache_miss".to_string()),
-                ("component".to_string(), self.config.value.clone()),
-            ],
-            1,
-        );
-
         Err(HyperCacheError::CacheMiss)
     }
 

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -39,6 +39,7 @@ fancy-regex.workspace = true
 base64.workspace = true
 sqlx = { workspace = true, features = ["rust_decimal"] }
 uuid = { workspace = true }
+common-cache = { path = "../common/cache" }
 common-compression = { path = "../common/compression" }
 common-hypercache = { path = "../common/hypercache" }
 common-alloc = { path = "../common/alloc" }

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -204,7 +204,7 @@ impl FlagError {
     pub fn is_token_not_found(&self) -> bool {
         matches!(
             self,
-            FlagError::TokenValidationError | FlagError::RowNotFound | FlagError::CacheMiss
+            FlagError::TokenValidationError | FlagError::RowNotFound
         )
     }
 
@@ -871,9 +871,9 @@ mod tests {
         // These errors mean the token definitively doesn't map to a team
         assert!(FlagError::TokenValidationError.is_token_not_found());
         assert!(FlagError::RowNotFound.is_token_not_found());
-        assert!(FlagError::CacheMiss.is_token_not_found());
 
         // Transient infrastructure errors should NOT be treated as "not found"
+        assert!(!FlagError::CacheMiss.is_token_not_found());
         assert!(!FlagError::RedisUnavailable.is_token_not_found());
         assert!(!FlagError::DatabaseUnavailable.is_token_not_found());
         assert!(!FlagError::TimeoutError(None).is_token_not_found());

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -198,6 +198,16 @@ impl FlagError {
         }
     }
 
+    /// Whether this error definitively means the token does not map to any team.
+    /// Transient infrastructure errors (timeouts, Redis/DB unavailable) return false
+    /// to avoid poisoning the negative cache with valid tokens during outages.
+    pub fn is_token_not_found(&self) -> bool {
+        matches!(
+            self,
+            FlagError::TokenValidationError | FlagError::RowNotFound | FlagError::CacheMiss
+        )
+    }
+
     /// Returns a short error code for canonical logging.
     pub fn error_code(&self) -> &'static str {
         self.error_metadata().0
@@ -854,6 +864,23 @@ mod tests {
                 "status_code() should be >= 500 for {error:?}, got {status}"
             );
         }
+    }
+
+    #[test]
+    fn test_is_token_not_found() {
+        // These errors mean the token definitively doesn't map to a team
+        assert!(FlagError::TokenValidationError.is_token_not_found());
+        assert!(FlagError::RowNotFound.is_token_not_found());
+        assert!(FlagError::CacheMiss.is_token_not_found());
+
+        // Transient infrastructure errors should NOT be treated as "not found"
+        assert!(!FlagError::RedisUnavailable.is_token_not_found());
+        assert!(!FlagError::DatabaseUnavailable.is_token_not_found());
+        assert!(!FlagError::TimeoutError(None).is_token_not_found());
+        assert!(!FlagError::TimeoutError(Some("pool_timeout".to_string())).is_token_not_found());
+        assert!(!FlagError::DatabaseError(sqlx::Error::PoolTimedOut, None).is_token_not_found());
+        assert!(!FlagError::Internal("serialization failed".to_string()).is_token_not_found());
+        assert!(!FlagError::DataParsingError.is_token_not_found());
     }
 
     #[test]

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -491,6 +491,14 @@ pub struct Config {
     // 0 = auto (use available_parallelism).
     #[envconfig(from = "THREAD_POOL_CORES", default = "0")]
     pub thread_pool_cores: usize,
+
+    // In-memory negative cache for invalid API tokens. Prevents repeated
+    // Redis/S3/PG lookups for tokens that don't correspond to any team.
+    #[envconfig(from = "TEAM_NEGATIVE_CACHE_CAPACITY", default = "10000")]
+    pub team_negative_cache_capacity: u64,
+
+    #[envconfig(from = "TEAM_NEGATIVE_CACHE_TTL_SECONDS", default = "300")]
+    pub team_negative_cache_ttl_seconds: u64,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -682,6 +690,8 @@ impl Config {
             max_concurrent_batch_evals: 0,
             skip_writes: FlexBool(false),
             thread_pool_cores: 0,
+            team_negative_cache_capacity: 10_000,
+            team_negative_cache_ttl_seconds: 300,
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -205,6 +205,7 @@ mod tests {
         setup_redis_client, setup_team_hypercache_reader,
     };
     use bytes::Bytes;
+    use common_cache::NegativeCache;
     use serde_json::json;
 
     #[test]
@@ -494,6 +495,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         match flag_service.verify_token_and_get_team(&token).await {
@@ -523,6 +525,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
         assert!(matches!(
             flag_service.verify_token_and_get_team(&result).await,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -3,10 +3,12 @@ use crate::{
     flags::flag_models::FeatureFlagList,
     handler::canonical_log::with_canonical_log,
     metrics::consts::{
-        DB_TEAM_READS_COUNTER, TEAM_CACHE_HIT_COUNTER, TOKEN_VALIDATION_ERRORS_COUNTER,
+        DB_TEAM_READS_COUNTER, TEAM_CACHE_HIT_COUNTER, TEAM_NEGATIVE_CACHE_HIT_COUNTER,
+        TOKEN_VALIDATION_ERRORS_COUNTER,
     },
     team::team_models::Team,
 };
+use common_cache::NegativeCache;
 use common_database::PostgresReader;
 use common_hypercache::{CacheSource, HyperCacheReader, KeyType};
 use common_metrics::inc;
@@ -34,6 +36,8 @@ pub struct FlagService {
     /// HyperCache reader for fetching flags from Redis/S3
     /// Arc-wrapped to allow sharing across requests
     flags_hypercache_reader: Arc<HyperCacheReader>,
+    /// In-memory negative cache for invalid API tokens
+    team_negative_cache: NegativeCache,
 }
 
 impl FlagService {
@@ -42,12 +46,14 @@ impl FlagService {
         pg_client: PostgresReader,
         team_hypercache_reader: Arc<HyperCacheReader>,
         flags_hypercache_reader: Arc<HyperCacheReader>,
+        team_negative_cache: NegativeCache,
     ) -> Self {
         Self {
             shared_redis_client,
             pg_client,
             team_hypercache_reader,
             flags_hypercache_reader,
+            team_negative_cache,
         }
     }
 
@@ -64,11 +70,27 @@ impl FlagService {
     ///
     /// This combines token verification with team fetching to avoid a redundant
     /// cache lookup — callers get the Team directly instead of re-fetching it.
+    /// Invalid tokens are tracked in a negative cache to avoid repeated lookups
+    /// against Redis/S3/PG for tokens that don't correspond to any team.
     pub async fn verify_token_and_get_team(&self, token: &str) -> Result<Team, FlagError> {
+        if self.team_negative_cache.contains(token) {
+            with_canonical_log(|log| log.team_cache_source = Some("negative_cache"));
+            inc(TEAM_NEGATIVE_CACHE_HIT_COUNTER, &[], 1);
+            inc(
+                TOKEN_VALIDATION_ERRORS_COUNTER,
+                &[("reason".to_string(), "token_not_found".to_string())],
+                1,
+            );
+            return Err(FlagError::TokenValidationError);
+        }
+
         match self.get_team_from_cache_or_pg(token).await {
             Ok(team) => Ok(team),
             Err(e) => {
                 tracing::warn!("Token validation failed for token '{}': {:?}", token, e);
+                if e.is_token_not_found() {
+                    self.team_negative_cache.insert(token.to_string());
+                }
                 inc(
                     TOKEN_VALIDATION_ERRORS_COUNTER,
                     &[("reason".to_string(), "token_not_found".to_string())],
@@ -163,6 +185,7 @@ impl FlagService {
 
 #[cfg(test)]
 mod tests {
+    use common_cache::NegativeCache;
     use serde_json::json;
 
     use crate::{
@@ -195,6 +218,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         // Test valid token returns the team
@@ -226,6 +250,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         // Test fetching from HyperCache
@@ -254,6 +279,7 @@ mod tests {
             context.non_persons_reader.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         // Test fetching from PostgreSQL (cache miss)
@@ -375,6 +401,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         // Test fetching from hypercache
@@ -514,6 +541,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -572,6 +600,7 @@ mod tests {
             pg_client.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         // Should fall back to PostgreSQL and succeed (returns empty list for new team)
@@ -613,6 +642,7 @@ mod tests {
             context.non_persons_reader.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -658,6 +688,7 @@ mod tests {
             context.non_persons_reader.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -706,6 +737,7 @@ mod tests {
             context.non_persons_reader.clone(),
             team_hypercache_reader,
             hypercache_reader,
+            NegativeCache::new(100, 300),
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -729,6 +761,127 @@ mod tests {
                 .any(|call| call.op == "set" || call.op == "set_bytes"),
             "Cache write detected after PG fallback. Rust should be read-only; \
              Django handles cache population via HyperCache. Found calls: {client_calls:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_returns_error_for_cached_invalid_token() {
+        let redis_client = setup_redis_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+        let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+
+        let negative_cache = NegativeCache::new(100, 300);
+        negative_cache.insert("known_bad_token".to_string());
+
+        let flag_service = FlagService::new(
+            redis_client.clone(),
+            pg_client.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache,
+        );
+
+        let result = flag_service
+            .verify_token_and_get_team("known_bad_token")
+            .await;
+        assert!(matches!(result, Err(FlagError::TokenValidationError)));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_populated_on_invalid_token() {
+        let redis_client = setup_redis_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+        let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+
+        let negative_cache = NegativeCache::new(100, 300);
+        assert!(!negative_cache.contains("nonexistent_token"));
+
+        let flag_service = FlagService::new(
+            redis_client.clone(),
+            pg_client.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache.clone(),
+        );
+
+        // First call should fail and populate the negative cache
+        let result = flag_service
+            .verify_token_and_get_team("nonexistent_token")
+            .await;
+        assert!(matches!(result, Err(FlagError::TokenValidationError)));
+        assert!(negative_cache.contains("nonexistent_token"));
+    }
+
+    #[tokio::test]
+    async fn test_negative_cache_does_not_affect_valid_tokens() {
+        let redis_client = setup_redis_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+        let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+        let team = insert_new_team_in_redis(redis_client.clone())
+            .await
+            .expect("Failed to insert team");
+
+        let negative_cache = NegativeCache::new(100, 300);
+
+        let flag_service = FlagService::new(
+            redis_client.clone(),
+            pg_client.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache.clone(),
+        );
+
+        // Valid token should succeed and not be added to negative cache
+        let result = flag_service
+            .verify_token_and_get_team(&team.api_token)
+            .await;
+        assert!(result.is_ok());
+        assert!(!negative_cache.contains(&team.api_token));
+    }
+
+    /// Verifies the full negative cache lifecycle: the first call for an invalid
+    /// token hits the backend and populates the cache, and the second call is
+    /// served from cache without making additional Redis calls.
+    #[tokio::test]
+    async fn test_second_call_for_invalid_token_skips_backends() {
+        use common_redis::MockRedisClient;
+
+        let mock_client = MockRedisClient::new();
+        let mock_redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
+        let team_hypercache_reader = setup_hypercache_reader_with_mock_redis(mock_redis.clone());
+        let hypercache_reader = setup_hypercache_reader_with_mock_redis(mock_redis.clone());
+        let context = TestContext::new(None).await;
+
+        let negative_cache = NegativeCache::new(100, 300);
+
+        let flag_service = FlagService::new(
+            mock_redis,
+            context.non_persons_reader.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache.clone(),
+        );
+
+        // First call: misses cache, hits Redis (mock) + PG fallback, fails, populates negative cache
+        let result = flag_service.verify_token_and_get_team("bad_token").await;
+        assert!(matches!(result, Err(FlagError::TokenValidationError)));
+        assert!(negative_cache.contains("bad_token"));
+        let calls_after_first = mock_client.get_calls().len();
+        assert!(
+            calls_after_first > 0,
+            "First call should have made Redis calls"
+        );
+
+        // Second call: should hit negative cache and return immediately
+        let result = flag_service.verify_token_and_get_team("bad_token").await;
+        assert!(matches!(result, Err(FlagError::TokenValidationError)));
+        let calls_after_second = mock_client.get_calls().len();
+        assert_eq!(
+            calls_after_first, calls_after_second,
+            "Second call should not make additional Redis calls (served from negative cache)"
         );
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -90,12 +90,12 @@ impl FlagService {
                 tracing::warn!("Token validation failed for token '{}': {:?}", token, e);
                 if e.is_token_not_found() {
                     self.team_negative_cache.insert(token.to_string());
+                    inc(
+                        TOKEN_VALIDATION_ERRORS_COUNTER,
+                        &[("reason".to_string(), "token_not_found".to_string())],
+                        1,
+                    );
                 }
-                inc(
-                    TOKEN_VALIDATION_ERRORS_COUNTER,
-                    &[("reason".to_string(), "token_not_found".to_string())],
-                    1,
-                );
                 Err(FlagError::TokenValidationError)
             }
         }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -111,6 +111,7 @@ async fn process_request_inner(
             context.state.database_pools.non_persons_reader.clone(),
             context.state.team_hypercache_reader.clone(),
             context.state.flags_hypercache_reader.clone(),
+            context.state.team_negative_cache.clone(),
         );
 
         let (original_distinct_id, team, request) =

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -27,6 +27,7 @@ use crate::{
 use axum::http::HeaderMap;
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
+use common_cache::NegativeCache;
 use common_database::Client;
 use common_geoip::GeoIpClient;
 use reqwest::header::CONTENT_TYPE;
@@ -1189,6 +1190,7 @@ async fn test_fetch_and_filter_flags() {
         reader.clone(),
         team_hypercache_reader,
         hypercache_reader,
+        NegativeCache::new(100, 300),
     );
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -5,6 +5,7 @@ pub const FLAG_HASH_KEY_RETRIES_COUNTER: &str = "flags_hash_key_retries_total";
 pub const TEAM_CACHE_HIT_COUNTER: &str = "flags_team_cache_hit_total";
 pub const DB_TEAM_READS_COUNTER: &str = "flags_db_team_reads_total";
 pub const TOKEN_VALIDATION_ERRORS_COUNTER: &str = "flags_token_validation_errors_total";
+pub const TEAM_NEGATIVE_CACHE_HIT_COUNTER: &str = "flags_team_negative_cache_hit_total";
 pub const DB_COHORT_READS_COUNTER: &str = "flags_db_cohort_reads_total";
 pub const DB_COHORT_ERRORS_COUNTER: &str = "flags_db_cohort_errors_total";
 pub const COHORT_CACHE_HIT_COUNTER: &str = "flags_cohort_cache_hit_total";

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use common_cache::NegativeCache;
 use common_database::get_pool;
 use common_hypercache::{HyperCacheConfig, HyperCacheReader};
 use common_redis::MockRedisClient;
@@ -328,6 +329,7 @@ impl ServerHandle {
                 team_hypercache_reader,
                 config_hypercache_reader,
                 RayonDispatcher::new(2),
+                NegativeCache::new(10_000, 300),
                 config,
             );
 


### PR DESCRIPTION
## Summary

- Remove the `posthog_tombstone_total{operation="hypercache_miss"}` metric from the hypercache that incorrectly fired for every invalid token lookup (~1% of traffic). The existing `result=missing` counter already tracks this case.
- Add an in-memory negative cache (Moka-based, bounded, TTL) to the feature-flags service that prevents repeated Redis/S3/PG lookups for API tokens that don't correspond to any team.

### Why

Grafana metrics showed that the tombstone fires at the same rate as `flags_token_validation_errors_total{reason="token_not_found"}` (~60-630/s), confirming these are simply invalid tokens, not a cache problem. The PG fallback never succeeds for these tokens either (`hit_fallback` is zero). Each invalid token request currently hits Redis, S3, and PG before failing — the negative cache short-circuits this on the second attempt.

### Configuration

| Env var | Default | Description |
|---|---|---|
| `TEAM_NEGATIVE_CACHE_CAPACITY` | 10,000 | Max entries (LRU eviction) |
| `TEAM_NEGATIVE_CACHE_TTL_SECONDS` | 300 | Time-to-live per entry |

### Cache poisoning mitigation

- **Bounded size**: LRU eviction prevents unbounded memory growth
- **Short TTL**: A re-created team isn't blocked for long
- **Pod isolation**: In-memory only, not shared across pods or written to Redis
- **Minimal memory**: ~1MB max at capacity

### Request flow after changes

```
Request with token → check NegativeCache
  ├─ Hit → return TokenValidationError immediately (no Redis/S3/PG)
  └─ Miss → proceed to HyperCache (Redis → S3 → PG fallback)
               ├─ Found → return team
               └─ Not found → insert token into NegativeCache, return error
```

## Test plan

- [x] 3 new unit tests for negative cache behavior (cached token rejected, failed token inserted, valid token unaffected)
- [x] All 1006 existing tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Monitor post-deploy:
  - `posthog_tombstone_total{operation="hypercache_miss"}` should drop to zero
  - `posthog_hypercache_get_from_cache{result="missing"}` should decrease
  - `flags_team_negative_cache_hit_total` should show cache hits
  - `flags_token_validation_errors_total` should stay the same