### PR TITLE
fix: bump python-multipart in ingestion acceptance tests to address CVE-2024-24762

### DIFF
--- a/common/ingestion/acceptance_tests/requirements.txt
+++ b/common/ingestion/acceptance_tests/requirements.txt
@@ -4,5 +4,5 @@ requests==2.31.0
 requests-toolbelt==1.0.0
 boto3==1.29.7
 docker==6.1.3
-python-multipart>=0.0.7
+python-multipart==0.0.7
 posthog==6.7.6

--- a/common/ingestion/acceptance_tests/requirements.txt
+++ b/common/ingestion/acceptance_tests/requirements.txt
@@ -4,5 +4,5 @@ requests==2.31.0
 requests-toolbelt==1.0.0
 boto3==1.29.7
 docker==6.1.3
-python-multipart==0.0.7
+python-multipart>=0.0.7
 posthog==6.7.6

--- a/common/ingestion/acceptance_tests/requirements.txt
+++ b/common/ingestion/acceptance_tests/requirements.txt
@@ -4,5 +4,5 @@ requests==2.31.0
 requests-toolbelt==1.0.0
 boto3==1.29.7
 docker==6.1.3
-python-multipart==0.0.6
+python-multipart>=0.0.7
 posthog==6.7.6


### PR DESCRIPTION
## What

Bumps `python-multipart==0.0.6` to `python-multipart>=0.0.7` in `common/ingestion/acceptance_tests/requirements.txt`.

## Why

`python-multipart==0.0.6` is affected by CVE-2024-24762 (CVSS 7.5, ReDoS).

The vulnerability is in `parse_options_header()`. When processing a `Content-Type` header with a crafted unclosed quoted-string boundary (e.g. `multipart/form-data; boundary="\\\\...a`), the internal regex `(?:\\.|[^"])*` enters catastrophic backtracking. Response time grows exponentially with payload size, allowing an attacker to hang the server with a single HTTP request.

Verified with a local reproduction:

| Backslashes in payload | Response time |
|------------------------|---------------|
| 10                     | 2ms           |
| 30                     | 348ms         |
| 40                     | >10s (hang)   |

The main `pyproject.toml` already requires `python-multipart>=0.0.9`. This PR aligns the acceptance test requirements with the same lower bound.

## Change

```
- python-multipart==0.0.6
+ python-multipart>=0.0.7
```

Reference: https://github.com/advisories/GHSA-2jv5-9r88-3w3p