### PR TITLE
chore: remove pyright-lsp plugin from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,4 @@
 {
-    "enabledPlugins": {
-        "pyright-lsp@claude-plugins-official": true,
-        "typescript-lsp@claude-plugins-official": true
-    },
     "hooks": {
         "SessionStart": [
             {
@@ -14,5 +10,8 @@
                 ]
             }
         ]
+    },
+    "enabledPlugins": {
+        "typescript-lsp@claude-plugins-official": true
     }
 }


### PR DESCRIPTION
Removes the pyright-lsp plugin from the shared project `.claude/settings.json`.

**Why:** On a monorepo this size, pyright LSP consumes significant context tokens — diagnostics get injected on every file operation, and reference lookups on common symbols can return hundreds of results. There are also known upstream issues: false-positive hint-level diagnostics eating context ([anthropics/claude-code#26634](https://github.com/anthropics/claude-code/issues/26634)) and a memory leak with diagnostic data in long sessions that was recently patched.

**Impact:** Anyone who wants pyright LSP can still enable it in their user-level settings (`~/.claude/settings.json`). This just stops it from being forced on everyone by default.