### PR TITLE
feat(endpoints): UI for timestamp field bucketing when materializing & configuration tab overhaul

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2121,6 +2121,32 @@ const api = {
             }
             return await request.get()
         },
+        async getMaterializationPreview(
+            name: string,
+            version?: number,
+            bucketOverrides?: Record<string, string>
+        ): Promise<{
+            can_materialize: boolean
+            reason: string | null
+            transformed_query: string | null
+            range_pairs: { column: string; variables: string[]; bucket_fn: string }[]
+            aggregates: { expression: string; reaggregate_fn: string | null }[]
+        }> {
+            const params: Record<string, any> = {}
+            if (version !== undefined) {
+                params.version = version
+            }
+            if (bucketOverrides) {
+                for (const [col, fn] of Object.entries(bucketOverrides)) {
+                    params[`bucket_overrides[${col}]`] = fn
+                }
+            }
+            let request = new ApiRequest().endpointDetail(name).withAction('materialization_preview')
+            if (Object.keys(params).length > 0) {
+                request = request.withQueryString(params)
+            }
+            return await request.get()
+        },
         async listVersions(name: string): Promise<EndpointVersionType[]> {
             return await new ApiRequest().endpointDetail(name).withAction('versions').get()
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2274,6 +2274,7 @@ export interface EndpointType extends WithAccessControl {
     last_executed_at?: string
     materialization?: EndpointVersionMaterializationType
     columns?: { name: string; type: string }[]
+    bucket_overrides?: Record<string, string> | null
 }
 
 /** Extends EndpointType with version-specific fields when fetching a specific version */

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1280,6 +1280,8 @@ class TestMaterializationPreview(ClickhouseTestMixin, APIBaseTest):
                 format="json",
             )
             assert response.status_code == status.HTTP_200_OK, response.json()
+            version = EndpointVersion.objects.get(endpoint__name="trigger-bucket", endpoint__team=self.team, version=1)
+            assert version.bucket_overrides == {"timestamp": "hour"}
             mock_trigger.assert_called_once()
 
     def test_bucket_overrides_unchanged_does_not_trigger_refresh(self):

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { objectsEqual } from 'lib/utils'
+
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { EndpointRequest } from '~/queries/schema/schema-general'
 import { isInsightVizNode } from '~/queries/utils'
@@ -14,11 +16,19 @@ export interface EndpointSceneHeaderProps {
 }
 
 export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.Element => {
-    const { endpoint, endpointLoading, localQuery, cacheAge, syncFrequency, isMaterialized, viewingVersion } =
-        useValues(endpointSceneLogic({ tabId }))
+    const {
+        endpoint,
+        endpointLoading,
+        localQuery,
+        cacheAge,
+        syncFrequency,
+        isMaterialized,
+        viewingVersion,
+        bucketOverrides,
+    } = useValues(endpointSceneLogic({ tabId }))
     const { endpointName, endpointDescription } = useValues(endpointLogic({ tabId }))
     const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic({ tabId }))
-    const { setLocalQuery, setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(
+    const { setLocalQuery, setCacheAge, setSyncFrequency, setIsMaterialized, resetBucketOverrides } = useActions(
         endpointSceneLogic({ tabId })
     )
 
@@ -39,13 +49,16 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
     const hasSyncFrequencyChange = syncFrequency !== null && syncFrequency !== baseSyncFrequency
     const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint?.is_materialized
     const hasIsMaterializedChange = isMaterialized !== null && isMaterialized !== baseIsMaterialized
+    const baseBucketOverrides = viewingVersion?.bucket_overrides ?? endpoint?.bucket_overrides ?? {}
+    const hasBucketOverridesChange = objectsEqual(bucketOverrides, baseBucketOverrides)
     const hasChanges =
         hasNameChange ||
         hasDescriptionChange ||
         hasQueryChange ||
         hasCacheAgeChange ||
         hasSyncFrequencyChange ||
-        hasIsMaterializedChange
+        hasIsMaterializedChange ||
+        hasBucketOverridesChange
 
     const handleSave = (): void => {
         let queryToSave = (localQuery || endpoint?.query) as any
@@ -64,6 +77,7 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
             query: hasQueryChange ? queryToSave : undefined,
             is_materialized: hasIsMaterializedChange ? isMaterialized : undefined,
             sync_frequency: hasSyncFrequencyChange ? (syncFrequency ?? undefined) : undefined,
+            bucket_overrides: hasBucketOverridesChange ? bucketOverrides : undefined,
         }
 
         updateEndpoint(endpoint.name, updatePayload, targetVersion ? { version: targetVersion } : undefined)
@@ -83,6 +97,7 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
         setSyncFrequency(sourceSyncFrequency ?? null)
         setIsMaterialized(null)
         setLocalQuery(null)
+        resetBucketOverrides(viewingVersion?.bucket_overrides ?? endpoint.bucket_overrides ?? {})
     }
 
     return (

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -1,15 +1,25 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
-import { IconDatabase, IconRefresh } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonDivider, LemonSelect, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+import { IconClock, IconDatabase, IconInfo, IconRefresh } from '@posthog/icons'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonCollapse,
+    LemonSelect,
+    LemonSkeleton,
+    LemonSwitch,
+    LemonTag,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
-import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { DataWarehouseSyncInterval } from '~/types'
 
 import { endpointLogic } from '../endpointLogic'
-import { endpointSceneLogic } from '../endpointSceneLogic'
+import { endpointSceneLogic, MaterializationPreview } from '../endpointSceneLogic'
 
 interface EndpointConfigurationProps {
     tabId: string
@@ -27,12 +37,29 @@ const CACHE_AGE_OPTIONS: { value: CacheAgeOption; label: string }[] = [
     { value: 259200, label: '3 days' },
 ]
 
-const SYNC_FREQUENCY_OPTIONS: { value: DataWarehouseSyncInterval; label: string }[] = [
+const SYNC_FREQUENCY_OPTIONS: {
+    value: DataWarehouseSyncInterval
+    label: string
+}[] = [
     { value: '1hour', label: 'Every hour' },
     { value: '6hour', label: 'Every 6 hours' },
     { value: '24hour', label: 'Once a day' },
     { value: '7day', label: 'Once a week' },
 ]
+
+const BUCKET_OPTIONS: { value: string; label: string }[] = [
+    { value: 'hour', label: 'Hour' },
+    { value: 'day', label: 'Day' },
+    { value: 'week', label: 'Week' },
+    { value: 'month', label: 'Month' },
+]
+
+const BUCKET_FN_TO_KEY: Record<string, string> = {
+    toStartOfHour: 'hour',
+    toStartOfDay: 'day',
+    toStartOfWeek: 'week',
+    toStartOfMonth: 'month',
+}
 
 function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'warning' | 'default' {
     if (!status) {
@@ -51,84 +78,263 @@ function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'w
 }
 
 export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JSX.Element {
+    const { endpoint } = useValues(endpointLogic({ tabId }))
+    const { setCacheAge } = useActions(endpointSceneLogic({ tabId }))
+    const {
+        cacheAge,
+        viewingVersion,
+        materializationPreview,
+        materializationPreviewLoading,
+        isMaterialized: localIsMaterialized,
+    } = useValues(endpointSceneLogic({ tabId }))
+    const { loadMaterializationPreview } = useActions(endpointSceneLogic({ tabId }))
+    const [leftActiveKeys, setLeftActiveKeys] = useState<string[]>(['materialization'])
+
+    if (!endpoint) {
+        return <></>
+    }
+
+    const effectiveCacheAge = cacheAge ?? viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds
+    const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
+    const isMaterialized = localIsMaterialized ?? baseIsMaterialized
+    const materializationExpanded = leftActiveKeys.includes('materialization')
+
+    return (
+        <div className="flex gap-6">
+            {/* Left column — settings (fixed width) */}
+            <div className="w-120 shrink-0">
+                <LemonCollapse
+                    multiple
+                    activeKeys={leftActiveKeys}
+                    onChange={setLeftActiveKeys}
+                    panels={[
+                        {
+                            key: 'materialization',
+                            header: (
+                                <div className="flex items-center gap-2">
+                                    <IconDatabase className="text-lg" />
+                                    <span>Materialization</span>
+                                    <Tooltip title="We run your query on a schedule and store results in a table. When you execute this endpoint, we read from that stored table instead of running the full query again. You'll get results much faster, but data is only as fresh as the last time materialization happened.">
+                                        <IconInfo className="text-lg text-secondary" />
+                                    </Tooltip>
+                                </div>
+                            ),
+                            content: <MaterializationContent tabId={tabId} />,
+                        },
+                        {
+                            key: 'caching',
+                            header: (
+                                <div className="flex items-center gap-2">
+                                    <IconClock className="text-lg" />
+                                    <span>Caching</span>
+                                    <Tooltip title="Caching configuration will soon be removed and replaced with the concept of data freshness.">
+                                        <IconInfo className="text-lg text-secondary" />
+                                    </Tooltip>
+                                </div>
+                            ),
+                            content: (
+                                <div className="flex flex-col gap-4 max-w-md p-1">
+                                    <p className="text-sm text-secondary m-0">
+                                        Keep query results cached, so subsequent requests get served quickly and are not
+                                        waiting for another query execution.
+                                    </p>
+                                    <LemonField.Pure
+                                        label="Cache duration"
+                                        info="Shorter durations mean fresher data but more query load. Longer durations are faster but may serve stale results."
+                                    >
+                                        <LemonSelect
+                                            value={effectiveCacheAge}
+                                            onChange={setCacheAge}
+                                            options={CACHE_AGE_OPTIONS}
+                                        />
+                                    </LemonField.Pure>
+                                </div>
+                            ),
+                        },
+                    ]}
+                />
+            </div>
+
+            {/* Right column — query previews, visible when materialization is expanded and enabled */}
+            {materializationExpanded && isMaterialized && (
+                <div className="flex-1 min-w-0">
+                    <LemonCollapse
+                        multiple
+                        defaultActiveKeys={['materialized-query']}
+                        panels={[
+                            {
+                                key: 'materialized-query',
+                                header: 'Query we materialize',
+                                content: (
+                                    <div className="p-1">
+                                        <div className="flex items-center justify-between mb-4">
+                                            <p className="text-sm text-secondary m-0">
+                                                This is the query we run on a schedule and materialize results in S3.
+                                                Variables are removed and their columns are added to the output columns.
+                                            </p>
+                                            <LemonButton
+                                                size="xsmall"
+                                                icon={<IconRefresh />}
+                                                onClick={() => loadMaterializationPreview()}
+                                                loading={materializationPreviewLoading}
+                                                tooltip="Refresh preview"
+                                            />
+                                        </div>
+                                        {materializationPreviewLoading && !materializationPreview && (
+                                            <LemonSkeleton className="h-24 w-full" />
+                                        )}
+                                        {materializationPreview?.transformed_query && (
+                                            <CodeSnippet language={Language.SQL} wrap>
+                                                {materializationPreview.transformed_query}
+                                            </CodeSnippet>
+                                        )}
+                                    </div>
+                                ),
+                            },
+                            ...(materializationPreview?.execution_query
+                                ? [
+                                      {
+                                          key: 'execution-query',
+                                          header: 'Query we run',
+                                          content: (
+                                              <ExecutionQueryPanel materializationPreview={materializationPreview} />
+                                          ),
+                                      },
+                                  ]
+                                : []),
+                        ]}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}
+
+function ExecutionQueryPanel({
+    materializationPreview,
+}: {
+    materializationPreview: MaterializationPreview
+}): JSX.Element {
+    const displayQuery = materializationPreview.display_execution_query || materializationPreview.execution_query
+
+    const reaggregates = materializationPreview.aggregates.filter((a) => a.reaggregate_fn)
+
+    return (
+        <div className="p-1">
+            <p className="text-sm text-secondary mb-4">
+                When you execute this endpoint, this is the query we run against the pre-computed table instead of
+                scanning raw data. Variables from the request become filters in the WHERE clause.
+            </p>
+            <CodeSnippet language={Language.SQL} wrap>
+                {displayQuery ?? ''}
+            </CodeSnippet>
+            {reaggregates.length > 0 && (
+                <p className="text-xs text-secondary mt-3 m-0">
+                    Aggregates like <code className="text-xs">count(*)</code> are re-aggregated as{' '}
+                    <code className="text-xs">sum(count(*))</code> because results are pre-grouped into buckets.
+                </p>
+            )}
+        </div>
+    )
+}
+
+function MaterializationContent({ tabId }: { tabId: string }): JSX.Element {
     const { loadMaterializationStatus } = useActions(endpointLogic({ tabId }))
     const {
         endpoint,
         materializationStatus: loadedMaterializationStatus,
         materializationStatusLoading,
     } = useValues(endpointLogic({ tabId }))
-    const { setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(endpointSceneLogic({ tabId }))
+    const { setSyncFrequency, setIsMaterialized, setBucketOverride } = useActions(endpointSceneLogic({ tabId }))
     const {
-        cacheAge,
         syncFrequency,
         isMaterialized: localIsMaterialized,
         viewingVersion,
+        materializationPreview,
+        bucketOverrides,
     } = useValues(endpointSceneLogic({ tabId }))
 
     if (!endpoint) {
         return <></>
     }
 
-    // When viewing a specific version, show that version's values
-    // Local state overrides viewed version values (for pending changes)
-    // materializationStatus (from refresh) takes priority over initial version data
     const versionMaterialization = viewingVersion?.materialization ?? endpoint.materialization
     const freshMaterialization = loadedMaterializationStatus ?? versionMaterialization
 
     const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
-    const effectiveCacheAge = cacheAge ?? viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds
     const effectiveIsMaterialized = localIsMaterialized ?? baseIsMaterialized
     const effectiveMaterializationStatus = freshMaterialization?.status
     const effectiveLastMaterializedAt = freshMaterialization?.last_materialized_at
     const effectiveMaterializationError = freshMaterialization?.error
     const effectiveSyncFrequency = syncFrequency ?? freshMaterialization?.sync_frequency
 
-    const canMaterialize = freshMaterialization?.can_materialize ?? endpoint.materialization?.can_materialize ?? false
+    const hasUnsavedMaterializationChange = localIsMaterialized !== null && localIsMaterialized !== baseIsMaterialized
+
+    const canMaterialize =
+        materializationPreview?.can_materialize ??
+        freshMaterialization?.can_materialize ??
+        endpoint.materialization?.can_materialize ??
+        false
+    const cannotMaterializeReason =
+        materializationPreview?.reason ?? freshMaterialization?.reason ?? endpoint.materialization?.reason ?? null
     const isMaterialized = effectiveIsMaterialized || effectiveMaterializationStatus?.toLowerCase() === 'running'
-    const materializationStatus = effectiveMaterializationStatus
-    const lastMaterializedAt = effectiveLastMaterializedAt
 
     const handleToggleMaterialization = (): void => {
         setIsMaterialized(!isMaterialized)
     }
 
+    const rangePairs = materializationPreview?.range_pairs ?? []
+
     return (
-        <SceneSection
-            title="Configure this endpoint"
-            description="If your use case does not require real-time data, consider materializing your endpoint resulting in faster response times, at the cost of slightly less fresh data."
-        >
-            <div className="flex flex-col gap-4 max-w-2xl">
-                <LemonField.Pure
-                    label="Cache age"
-                    info="How long cached results are served before re-running the query. Longer cache times improve performance but may return stale data."
-                >
-                    <LemonSelect value={effectiveCacheAge} onChange={setCacheAge} options={CACHE_AGE_OPTIONS} />
-                </LemonField.Pure>
-                <LemonField.Pure
-                    label="Materialization"
-                    info="Pre-compute and store query results in S3 for faster response times. Best for queries that don't need real-time data. Enabled by default for new endpoints."
-                >
+        <div className="p-1">
+            <p className="text-sm text-secondary mb-6">
+                Pre-compute query results on a schedule for faster response times.
+            </p>
+
+            {!canMaterialize && cannotMaterializeReason && (
+                <LemonBanner type="info">{cannotMaterializeReason}</LemonBanner>
+            )}
+
+            {canMaterialize && (
+                <div className="flex flex-col gap-4">
                     <LemonSwitch
-                        label="Enable materialization"
+                        label={isMaterialized ? 'Materialization enabled' : 'Enable materialization'}
                         checked={isMaterialized}
                         onChange={handleToggleMaterialization}
-                        disabled={!canMaterialize}
-                        disabledReason={!canMaterialize ? endpoint.materialization?.reason : undefined}
                         bordered
                     />
-                </LemonField.Pure>
 
-                <div className="space-y-4">
+                    {hasUnsavedMaterializationChange && (
+                        <LemonBanner type="info">
+                            {isMaterialized
+                                ? 'Save your changes to start materialization.'
+                                : 'Save your changes to disable materialization.'}
+                        </LemonBanner>
+                    )}
+
                     {isMaterialized && (
+                        <LemonField.Pure
+                            label="Materialization frequency"
+                            info="How often we re-run your query and update the stored table. More frequent syncs give fresher data but use more compute."
+                        >
+                            <LemonSelect
+                                value={effectiveSyncFrequency || '24hour'}
+                                onChange={setSyncFrequency}
+                                options={SYNC_FREQUENCY_OPTIONS}
+                            />
+                        </LemonField.Pure>
+                    )}
+
+                    {isMaterialized && !hasUnsavedMaterializationChange && (
                         <div className="space-y-3 p-4 bg-accent-3000 border border-border rounded">
                             <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-2">
                                     <IconDatabase className="text-lg" />
-                                    <span className="font-medium">Materialization status</span>
+                                    <span className="font-medium">Status</span>
                                 </div>
                                 <div className="flex items-center gap-2">
-                                    <LemonTag type={getStatusTagType(materializationStatus)}>
-                                        {materializationStatus || 'Pending'}
+                                    <LemonTag type={getStatusTagType(effectiveMaterializationStatus)}>
+                                        {effectiveMaterializationStatus || 'Pending'}
                                     </LemonTag>
                                     <LemonButton
                                         size="xsmall"
@@ -149,10 +355,12 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
                                 </div>
                             </div>
 
-                            {lastMaterializedAt && (
+                            {effectiveLastMaterializedAt && (
                                 <div className="flex items-center gap-2 text-xs text-secondary">
                                     <IconRefresh className="text-base" />
-                                    <span>Last materialized: {new Date(lastMaterializedAt).toLocaleString()}</span>
+                                    <span>
+                                        Last materialized: {new Date(effectiveLastMaterializedAt).toLocaleString()}
+                                    </span>
                                 </div>
                             )}
 
@@ -164,22 +372,31 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
                         </div>
                     )}
 
-                    {isMaterialized && (
-                        <LemonField.Pure
-                            label="Sync frequency"
-                            info="How often the materialized data is refreshed with new query results. More frequent syncs = fresher data but higher costs."
-                        >
-                            <LemonSelect
-                                value={effectiveSyncFrequency || '24hour'}
-                                onChange={setSyncFrequency}
-                                options={SYNC_FREQUENCY_OPTIONS}
-                                disabledReason={!isMaterialized ? 'Requires materializing the endpoint.' : undefined}
-                            />
-                        </LemonField.Pure>
+                    {isMaterialized && rangePairs.length > 0 && (
+                        <div className="space-y-3">
+                            {rangePairs.map((pair) => (
+                                <LemonField.Pure
+                                    key={pair.column}
+                                    label={
+                                        <>
+                                            <code>{pair.column}</code> bucket size
+                                        </>
+                                    }
+                                    info="Your date range variables are bucketed into this interval in the stored materialized table. Smaller bucket - more precise results. Larger bucket - less granular results."
+                                >
+                                    <LemonSelect
+                                        value={
+                                            bucketOverrides[pair.column] || BUCKET_FN_TO_KEY[pair.bucket_fn] || 'day'
+                                        }
+                                        onChange={(value) => setBucketOverride(pair.column, value)}
+                                        options={BUCKET_OPTIONS}
+                                    />
+                                </LemonField.Pure>
+                            ))}
+                        </div>
                     )}
                 </div>
-            </div>
-            <LemonDivider />
-        </SceneSection>
+            )}
+        </div>
     )
 }

--- a/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
@@ -74,7 +74,7 @@ function EndpointHogQLQuery({
     query: HogQLQuery
 }): JSX.Element {
     const sqlEditorTabId = useMemo(() => `endpoint-query-${tabId}-${version ?? 'latest'}`, [tabId, version])
-    const { setLocalQuery } = useActions(endpointSceneLogic({ tabId }))
+    const { setLocalQuery, keepSqlEditorMounted } = useActions(endpointSceneLogic({ tabId }))
     const { queryInput, sourceQuery } = useValues(
         sqlEditorLogic({ tabId: sqlEditorTabId, mode: SQLEditorMode.Embedded })
     )
@@ -83,18 +83,27 @@ function EndpointHogQLQuery({
     )
 
     useEffect(() => {
-        setQueryInput(query.query)
-        setSourceQuery({
-            kind: NodeKind.DataVisualizationNode,
-            source: {
-                kind: NodeKind.HogQLQuery,
-                query: query.query,
-                variables: query.variables,
-            },
-            display: ChartDisplayType.ActionsLineGraph,
-        })
-        runQuery(query.query)
-    }, [query.query, query.variables]) // eslint-disable-line react-hooks/exhaustive-deps
+        // Keep the sqlEditorLogic mounted even when this component unmounts (tab switches)
+        keepSqlEditorMounted(sqlEditorTabId)
+    }, [sqlEditorTabId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        // queryInput is null when the logic is freshly mounted — initialize and run.
+        // On remount (tab switch back), the logic is still alive so queryInput is already set.
+        if (queryInput === null) {
+            setQueryInput(query.query)
+            setSourceQuery({
+                kind: NodeKind.DataVisualizationNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: query.query,
+                    variables: query.variables,
+                },
+                display: ChartDisplayType.ActionsLineGraph,
+            })
+            runQuery(query.query)
+        }
+    }, [query.query, query.variables, queryInput]) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         const sourceVariables = isHogQLQuery(sourceQuery.source) ? sourceQuery.source.variables : undefined

--- a/products/endpoints/frontend/endpoint-tabs/EndpointVersions.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointVersions.tsx
@@ -5,8 +5,9 @@ import { LemonButton, LemonTable, LemonTag } from '@posthog/lemon-ui'
 import type { LemonTableColumns } from '@posthog/lemon-ui'
 
 import { More } from 'lib/lemon-ui/LemonButton/More'
-import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { atColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
@@ -110,8 +111,20 @@ export function EndpointVersions({ tabId }: EndpointVersionsProps): JSX.Element 
                 )
             },
         },
-        createdAtColumn<EndpointVersionType>() as any,
-        createdByColumn<EndpointVersionType>() as any,
+        atColumn<EndpointVersionType>('version_created_at', 'Created') as any,
+        {
+            title: 'Created by',
+            dataIndex: 'version_created_by',
+            render: function RenderCreatedBy(_, record) {
+                return (
+                    <div className="flex flex-row items-center flex-nowrap">
+                        {record.version_created_by && (
+                            <ProfilePicture user={record.version_created_by} size="md" showName />
+                        )}
+                    </div>
+                )
+            },
+        },
         {
             key: 'actions',
             width: 0,

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -116,6 +116,13 @@ export const endpointLogic = kea<endpointLogicType>([
                 createEndpointSuccess: () => null,
             },
         ],
+        // Clear stale endpoint data immediately when loading a new endpoint
+        endpoint: [
+            null as EndpointVersionType | null,
+            {
+                loadEndpoint: () => null,
+            },
+        ],
         // Extend the loader reducer to clear on action
         materializationStatus: [
             null as EndpointType['materialization'] | null,

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
@@ -7,6 +7,8 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { getTabSceneParams, updateTabUrl } from 'lib/logic/scenes/tabSceneUtils'
+import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
+import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -100,6 +102,16 @@ export enum EndpointTab {
     HISTORY = 'history',
 }
 
+export interface MaterializationPreview {
+    can_materialize: boolean
+    reason: string | null
+    transformed_query: string | null
+    execution_query: string | null
+    display_execution_query: string | null
+    range_pairs: { column: string; variables: string[]; bucket_fn: string }[]
+    aggregates: { expression: string; reaggregate_fn: string | null }[]
+}
+
 export const endpointSceneLogic = kea<endpointSceneLogicType>([
     props({} as EndpointSceneLogicProps),
     path(['products', 'endpoints', 'frontend', 'endpointSceneLogic']),
@@ -128,6 +140,10 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setIsMaterialized: (isMaterialized: boolean | null) => ({ isMaterialized }),
         setEndpointName: (name: string | null) => ({ name }),
         setViewingVersion: (version: EndpointVersionType | null) => ({ version }),
+        setBucketOverride: (column: string, bucketFn: string) => ({ column, bucketFn }),
+        resetBucketOverrides: (overrides: Record<string, string>) => ({ overrides }),
+        loadMaterializationPreview: true,
+        keepSqlEditorMounted: (editorTabId: string) => ({ editorTabId }),
     }),
     reducers({
         localQuery: [
@@ -141,12 +157,14 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             EndpointTab.QUERY as EndpointTab,
             {
                 setActiveTab: (_, { tab }) => tab,
+                loadEndpoint: () => EndpointTab.QUERY,
             },
         ],
         payloadJson: [
             '' as string,
             {
                 setPayloadJson: (_, { value }) => value,
+                loadEndpoint: () => '',
             },
         ],
         payloadJsonError: [
@@ -154,18 +172,22 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             {
                 setPayloadJsonError: (_, { error }) => error,
                 setPayloadJson: () => null,
+                loadEndpoint: () => null,
+                updateEndpointSuccess: () => null,
             },
         ],
         cacheAge: [
             null as number | null,
             {
                 setCacheAge: (_, { cacheAge }) => cacheAge,
+                loadEndpoint: () => null,
             },
         ],
         syncFrequency: [
             '24hour' as DataWarehouseSyncInterval | null,
             {
                 setSyncFrequency: (_, { syncFrequency }) => syncFrequency,
+                loadEndpoint: () => null,
             },
         ],
         isMaterialized: [
@@ -173,6 +195,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             {
                 setIsMaterialized: (_, { isMaterialized }) => isMaterialized,
                 loadEndpointSuccess: (_, { endpoint }) => endpoint?.is_materialized ?? null,
+                loadEndpoint: () => null,
             },
         ],
         endpointName: [
@@ -185,11 +208,47 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             null as EndpointVersionType | null,
             {
                 setViewingVersion: (_, { version }) => version,
-                // Note: Don't reset on loadEndpointSuccess - the listener handles restoring from URL
+                // Reset when switching endpoints; loadEndpointSuccess listener restores from URL if needed
+                loadEndpoint: () => null,
+            },
+        ],
+        bucketOverrides: [
+            {} as Record<string, string>,
+            {
+                setBucketOverride: (state, { column, bucketFn }) => ({ ...state, [column]: bucketFn }),
+                resetBucketOverrides: (_, { overrides }) => overrides,
+                loadEndpointSuccess: (_, { endpoint }) => endpoint?.bucket_overrides ?? {},
+            },
+        ],
+        // Clear stale playground results when switching endpoints
+        endpointResult: [
+            null as string | null,
+            {
+                loadEndpoint: () => null,
+                updateEndpointSuccess: () => null,
+            },
+        ],
+        // Clear stale materialization preview when switching endpoints
+        materializationPreview: [
+            null as MaterializationPreview | null,
+            {
+                loadEndpoint: () => null,
             },
         ],
     }),
-    loaders(() => ({
+    loaders(({ values }) => ({
+        materializationPreview: {
+            __default: null as MaterializationPreview | null,
+            loadMaterializationPreview: async () => {
+                const endpoint = values.endpoint
+                if (!endpoint?.name) {
+                    return null
+                }
+                const version = values.viewingVersion?.version
+                const overrides = Object.keys(values.bucketOverrides).length > 0 ? values.bucketOverrides : undefined
+                return await api.endpoint.getMaterializationPreview(endpoint.name, version, overrides)
+            },
+        },
         endpointResult: {
             __default: null as string | null,
             loadEndpointResult: async ({ name, data }: { name: string; data: EndpointRunRequest }) => {
@@ -263,7 +322,21 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             ],
         ],
     }),
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions, values, props, cache }) => ({
+        keepSqlEditorMounted: ({ editorTabId }) => {
+            // Already holding a mount for this editor
+            if (cache.sqlEditorTabId === editorTabId) {
+                return
+            }
+            cache.unmountSqlEditor?.()
+            cache.sqlEditorTabId = editorTabId
+            cache.unmountSqlEditor = sqlEditorLogic({ tabId: editorTabId, mode: SQLEditorMode.Embedded }).mount()
+        },
+        loadEndpoint: () => {
+            cache.unmountSqlEditor?.()
+            cache.unmountSqlEditor = null
+            cache.sqlEditorTabId = null
+        },
         loadEndpointSuccess: async ({ endpoint }: { endpoint: EndpointVersionType | null; payload?: string }) => {
             const initialPayload = generateInitialPayloadJson(endpoint)
             actions.setPayloadJson(initialPayload)
@@ -272,9 +345,12 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
 
             const { searchParams, hashParams } = getTabSceneParams(props.tabId)
 
-            // Load versions if on versions tab
+            // Load tab-specific data
             if (searchParams.tab === EndpointTab.VERSIONS && endpoint?.name) {
                 actions.loadVersions(endpoint.name)
+            }
+            if (searchParams.tab === EndpointTab.CONFIGURATION && endpoint?.name) {
+                actions.loadMaterializationPreview()
             }
 
             // Handle version param from URL
@@ -303,6 +379,12 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             if (tab === EndpointTab.VERSIONS && values.endpoint?.name) {
                 actions.loadVersions(values.endpoint.name)
             }
+            if (tab === EndpointTab.CONFIGURATION && values.endpoint?.name) {
+                actions.loadMaterializationPreview()
+            }
+        },
+        setBucketOverride: () => {
+            actions.loadMaterializationPreview()
         },
         setViewingVersion: ({ version }) => {
             // Reset local state so viewed version's data shows through
@@ -311,6 +393,9 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             actions.setSyncFrequency(null)
             actions.setIsMaterialized(null)
             actions.clearMaterializationStatus()
+
+            // Reset bucket overrides to viewed version's values
+            actions.resetBucketOverrides(version?.bucket_overrides ?? values.endpoint?.bucket_overrides ?? {})
 
             // Reset description to viewed version's description (or endpoint's if going back to current)
             if (version) {
@@ -417,6 +502,13 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                     }
                 }
             }
+        },
+    })),
+    events(({ cache }) => ({
+        beforeUnmount: () => {
+            cache.unmountSqlEditor?.()
+            cache.unmountSqlEditor = null
+            cache.sqlEditorTabId = null
         },
     })),
 ])


### PR DESCRIPTION
## Problem

we support bucket_overrides, but not in the UI

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- slight overhaul of the Configuration tab

![image.png](https://app.graphite.com/user-attachments/assets/6c27c03c-c823-4360-b5c6-fd64a10ba8ca.png)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

- played around

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->