### PR TITLE
feat(endpoints): multiple breakdown support, vars in CTEs, sentinels

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -2,6 +2,7 @@ import re
 import uuid
 import builtins
 import dataclasses
+from collections.abc import Iterator
 from datetime import timedelta
 from typing import Optional, Union, cast
 
@@ -91,10 +92,20 @@ from common.hogvm.python.utils import HogVMException
 
 MIN_CACHE_AGE_SECONDS = 300
 MAX_CACHE_AGE_SECONDS = 86400
+ENDPOINT_BREAKDOWN_LIMIT = 10_000
+
 
 ENDPOINT_NAME_REGEX = r"^[a-zA-Z][a-zA-Z0-9_-]{0,127}$"
 
 logger = structlog.get_logger(__name__)
+
+
+def _add_where_condition(select_query: ast.SelectQuery, condition: ast.Expr) -> None:
+    """Append a condition to select_query.where with AND."""
+    if select_query.where:
+        select_query.where = ast.And(exprs=[select_query.where, condition])
+    else:
+        select_query.where = condition
 
 
 def _get_single_breakdown_property(breakdown_filter: dict) -> str | None:
@@ -114,27 +125,41 @@ def _get_single_breakdown_property(breakdown_filter: dict) -> str | None:
     return None
 
 
-def _get_single_breakdown_info(breakdown_filter: dict) -> tuple[str, str] | None:
-    """Extract the breakdown property name and type from either legacy or new format.
-
-    Returns (property_name, property_type) or None if not found.
-
-    Legacy: {"breakdown": "$browser", "breakdown_type": "event"}
-    New:    {"breakdowns": [{"property": "$browser", "type": "event"}]}
-    """
+def _iter_breakdowns(breakdown_filter: dict) -> Iterator[tuple[str, str]]:
+    """Yield (property_name, property_type) from legacy or new breakdown format."""
     breakdown = breakdown_filter.get("breakdown")
     if breakdown:
-        breakdown_type = breakdown_filter.get("breakdown_type", "event")
-        return (breakdown, breakdown_type)
-
-    breakdowns = breakdown_filter.get("breakdowns") or []
-    if len(breakdowns) == 1:
-        prop = breakdowns[0].get("property")
-        prop_type = breakdowns[0].get("type", "event")
+        yield (breakdown, breakdown_filter.get("breakdown_type", "event"))
+        return
+    for b in breakdown_filter.get("breakdowns") or []:
+        prop = b.get("property")
         if prop:
-            return (prop, prop_type)
+            yield (prop, b.get("type", "event"))
 
-    return None
+
+def _get_breakdown_properties(breakdown_filter: dict) -> list[str]:
+    """Extract all breakdown property names from either legacy or new format."""
+    return [name for name, _ in _iter_breakdowns(breakdown_filter)]
+
+
+def _get_breakdown_column_indices(breakdown_filter: dict) -> dict[str, int]:
+    """Map breakdown property names to their 1-based index in the breakdown_value array.
+
+    Single breakdown: {"$browser": 0}  (0 means use the whole array, not an index)
+    Multiple breakdowns: {"$browser": 1, "$os": 2}
+    """
+    props = _get_breakdown_properties(breakdown_filter)
+    if len(props) <= 1:
+        return {props[0]: 0} if props else {}
+    return {prop: i + 1 for i, prop in enumerate(props)}
+
+
+def _get_breakdown_infos(breakdown_filter: dict) -> list[tuple[str, str]]:
+    """Extract all breakdown property name and type pairs.
+
+    Returns list of (property_name, property_type) tuples.
+    """
+    return list(_iter_breakdowns(breakdown_filter))
 
 
 def _endpoint_refresh_mode_to_refresh_type(
@@ -866,7 +891,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
             )
 
-        hogql_query = convert_insight_query_to_hogql(version.query, self.team)
+        mat_query = _prepare_insight_query_for_endpoint(version.query)
+        hogql_query = convert_insight_query_to_hogql(mat_query, self.team)
 
         variable_infos: list = []
         if version.query.get("variables"):
@@ -874,6 +900,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
             if can_materialize and variable_infos:
                 hogql_query = transform_query_for_materialization(hogql_query, variable_infos, self.team)
+
+        hogql_query = _replace_breakdown_sentinels_in_query(hogql_query)
 
         saved_query.query = hogql_query
         saved_query.external_tables = saved_query.s3_tables
@@ -1032,14 +1060,14 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 if not request_var_codes.issubset(materialized_codes):
                     return False
             else:
-                # Materialized insight: only breakdown property allowed
+                # Materialized insight: only breakdown properties allowed
                 breakdown_filter = query.get("breakdownFilter") or {}
-                breakdown = _get_single_breakdown_property(breakdown_filter)
-                if not breakdown:
+                allowed_props = set(_get_breakdown_properties(breakdown_filter))
+                if not allowed_props:
                     return False
 
                 request_var_codes = set(data.variables.keys())
-                if not request_var_codes.issubset({breakdown}):
+                if not request_var_codes.issubset(allowed_props):
                     return False
 
         return True
@@ -1098,12 +1126,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         # Insight queries
         allowed: set[str] = set()
 
-        # Only allow breakdown property for query types that support it
+        # Only allow breakdown properties for query types that support it
         if query_kind in self.BREAKDOWN_SUPPORTED_QUERY_TYPES:
             breakdown_filter = query.get("breakdownFilter") or {}
-            breakdown = _get_single_breakdown_property(breakdown_filter)
-            if breakdown:
-                allowed.add(breakdown)
+            allowed.update(_get_breakdown_properties(breakdown_filter))
 
         if not is_materialized:
             # Non-materialized also allows date_from/date_to via filters_override
@@ -1123,11 +1149,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             materialized_vars = self._get_materialized_variables(version)
             return {v.code_name for v in materialized_vars}
 
-        # Insight queries: breakdown property is required if present
+        # Insight queries: all breakdown properties are required
         if query_kind in self.BREAKDOWN_SUPPORTED_QUERY_TYPES:
             breakdown_filter = query.get("breakdownFilter") or {}
-            prop = _get_single_breakdown_property(breakdown_filter)
-            return {prop} if prop else set()
+            return set(_get_breakdown_properties(breakdown_filter))
 
         return set()
 
@@ -1148,48 +1173,40 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             op=op,
             right=right_expr,
         )
-        if select_query.where:
-            select_query.where = ast.And(exprs=[select_query.where, condition])
-        else:
-            select_query.where = condition
+        _add_where_condition(select_query, condition)
 
-    def _build_breakdown_filter_condition(self, query_kind: str | None, value: str) -> ast.Expr | None:
+    def _build_breakdown_filter_condition(
+        self, query_kind: str | None, value: str, array_index: int = 0
+    ) -> ast.Expr | None:
         """Build the appropriate WHERE condition for breakdown filtering based on query type.
 
-        Different insight types store breakdowns in different columns:
-        - TrendsQuery, RetentionQuery: `breakdown_value` Array column
-        - FunnelsQuery: `final_prop` Array column
-        - LifecycleQuery, StickinessQuery, PathsQuery: No breakdown support
-
-        Both breakdown_value and final_prop are Array(Nullable(String)) columns,
-        so we use has() for array containment check.
+        array_index controls how to access the breakdown column:
+        - 0: single breakdown — use has() on the full array
+        - 1+: multiple breakdowns — use equality on breakdown_value[N]
         """
-        if query_kind == "FunnelsQuery":
-            return ast.Call(
-                name="has",
-                args=[ast.Field(chain=["final_prop"]), ast.Constant(value=value)],
-            )
-        elif query_kind in ("TrendsQuery", "RetentionQuery"):
-            return ast.Call(
-                name="has",
-                args=[ast.Field(chain=["breakdown_value"]), ast.Constant(value=value)],
-            )
-        elif query_kind in ("LifecycleQuery", "StickinessQuery", "PathsQuery"):
+        if query_kind in ("LifecycleQuery", "StickinessQuery", "PathsQuery"):
             logger.warning(
                 "Query type does not support breakdown filtering",
                 query_kind=query_kind,
             )
             return None
-        else:
-            logger.warning(
-                "Unknown query kind for breakdown filtering",
-                query_kind=query_kind,
-                falling_back_to="breakdown_value",
+
+        column_name = "final_prop" if query_kind == "FunnelsQuery" else "breakdown_value"
+
+        if array_index > 0:
+            return ast.CompareOperation(
+                left=ast.ArrayAccess(
+                    array=ast.Field(chain=[column_name]),
+                    property=ast.Constant(value=array_index),
+                ),
+                op=ast.CompareOperationOp.Eq,
+                right=ast.Constant(value=value),
             )
-            return ast.Call(
-                name="has",
-                args=[ast.Field(chain=["breakdown_value"]), ast.Constant(value=value)],
-            )
+
+        return ast.Call(
+            name="has",
+            args=[ast.Field(chain=[column_name]), ast.Constant(value=value)],
+        )
 
     def _execute_query_and_respond(
         self,
@@ -1252,6 +1269,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             pagination.process_results(result)
         elif "results" in result:
             result["hasMore"] = False
+
+        _clean_breakdown_sentinels(result)
 
         if "results" in result:
             results_value = result.pop("results")
@@ -1333,11 +1352,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                             value = prop.value[0] if isinstance(prop.value, list) else prop.value
                             condition = self._build_breakdown_filter_condition(query_kind, str(value))
                             if condition:
-                                if select_query.where:
-                                    select_query.where = ast.And(exprs=[select_query.where, condition])
-                                else:
-                                    select_query.where = condition
-                            break  # Only use first property filter for materialized
+                                _add_where_condition(select_query, condition)
+                            # filters_override is deprecated — only the first property is used
+                            break
             elif data.variables:
                 if query_kind == "HogQLQuery":
                     # HogQL: filter by all materialized variable columns
@@ -1353,18 +1370,17 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                                 value_wrapper_fns=mat_var.value_wrapper_fns,
                             )
                 else:
-                    # Insight: filter by breakdown property name
+                    # Insight: filter by breakdown property names
                     breakdown_filter = query.get("breakdownFilter") or {}
-                    breakdown_prop = _get_single_breakdown_property(breakdown_filter)  # e.g., "$browser"
+                    index_mapping = _get_breakdown_column_indices(breakdown_filter)
 
-                    if breakdown_prop and breakdown_prop in data.variables:
-                        value = data.variables[breakdown_prop]
-                        condition = self._build_breakdown_filter_condition(query_kind, value)
-                        if condition:
-                            if select_query.where:
-                                select_query.where = ast.And(exprs=[select_query.where, condition])
-                            else:
-                                select_query.where = condition
+                    for breakdown_prop, array_index in index_mapping.items():
+                        if breakdown_prop in data.variables:
+                            condition = self._build_breakdown_filter_condition(
+                                query_kind, data.variables[breakdown_prop], array_index=array_index
+                            )
+                            if condition:
+                                _add_where_condition(select_query, condition)
 
             materialized_hogql_query = HogQLQuery(
                 query=select_query.to_hogql(),
@@ -1506,33 +1522,46 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             )
         return variables_override
 
-    def _variables_to_filters(self, variables: dict[str, str], breakdown_info: tuple[str, str] | None = None):
+    def _variables_to_filters(
+        self,
+        variables: dict[str, str],
+        breakdown_infos: builtins.list[tuple[str, str]] | None = None,
+    ):
         """Convert insight magic variables to DashboardFilter.
 
         Args:
             variables: Dict of variable name -> value from the request
-            breakdown_info: Tuple of (property_name, property_type) from breakdown filter
+            breakdown_infos: List of (property_name, property_type) for breakdown filtering
         """
         from posthog.schema import DashboardFilter, PropertyOperator
 
         date_from = variables.get("date_from")
         date_to = variables.get("date_to")
 
-        # Build properties filter for breakdown
-        properties: list[dict] | None = None
-        if breakdown_info:
-            breakdown_prop, breakdown_type = breakdown_info
-            if breakdown_prop in variables:
-                breakdown_value = variables[breakdown_prop]
-                # Build filter dict - Pydantic will validate and convert to correct type
-                properties = [
-                    {
-                        "key": breakdown_prop,
-                        "value": breakdown_value,
-                        "type": breakdown_type if breakdown_type else "event",
-                        "operator": PropertyOperator.EXACT,
-                    }
-                ]
+        properties: list[dict] = []
+        for prop_name, prop_type in breakdown_infos or []:
+            if prop_name in variables:
+                value = variables[prop_name]
+                # Empty string means "null/unset" — match events where the property is missing.
+                # This keeps inline execution consistent with the materialized path,
+                # where null breakdown values are stored as '' in S3.
+                if value == "":
+                    properties.append(
+                        {
+                            "key": prop_name,
+                            "type": prop_type if prop_type else "event",
+                            "operator": PropertyOperator.IS_NOT_SET,
+                        }
+                    )
+                else:
+                    properties.append(
+                        {
+                            "key": prop_name,
+                            "value": value,
+                            "type": prop_type if prop_type else "event",
+                            "operator": PropertyOperator.EXACT,
+                        }
+                    )
 
         if not date_from and not date_to and not properties:
             return None
@@ -1623,6 +1652,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     ) -> Response:
         """Execute query directly against ClickHouse."""
         try:
+            query = _prepare_insight_query_for_endpoint(query)
+
             pagination: EndpointPagination | None = None
             if limit is not None:
                 query, pagination = self._apply_pagination_to_query(query, limit, offset or 0)
@@ -1645,8 +1676,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     variables_override = self._parse_variables(query, data.variables)
                 else:
                     breakdown_filter = query.get("breakdownFilter") or {}
-                    breakdown_info = _get_single_breakdown_info(breakdown_filter)
-                    filters_override = self._variables_to_filters(data.variables, breakdown_info)
+                    breakdown_infos = _get_breakdown_infos(breakdown_filter)
+                    filters_override = self._variables_to_filters(data.variables, breakdown_infos=breakdown_infos)
 
             query_request_data = {
                 "client_query_id": data.client_query_id,
@@ -2020,3 +2051,148 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
         spec = generate_openapi_spec(endpoint, self.team.id, request, version)
         return Response(spec, content_type="application/json")
+
+
+def _prepare_insight_query_for_endpoint(query: dict) -> dict:
+    """Prepare an insight query for endpoint execution.
+
+    We override the breakdown_limit to a high value so all values are returned
+    (the insight UI default of 25 would silently drop data). We keep
+    breakdown_hide_other_aggregation=False (default) so that if the limit IS
+    exceeded, the "Other" bucket appears in results and we can detect + alert.
+    """
+    breakdown_filter = query.get("breakdownFilter")
+    if not breakdown_filter:
+        return query
+
+    return {
+        **query,
+        "breakdownFilter": {
+            **breakdown_filter,
+            "breakdown_hide_other_aggregation": False,
+            "breakdown_limit": ENDPOINT_BREAKDOWN_LIMIT,
+        },
+    }
+
+
+def _replace_breakdown_sentinels_in_query(hogql_query: dict) -> dict:
+    """Replace breakdown sentinel string literals in HogQL query text.
+
+    Runs before the query is stored for materialization, so S3 data
+    never contains the internal sentinel strings. The "other" sentinel
+    is still embedded in the HogQL by the query builder (in if() and ORDER BY
+    expressions) even when breakdown_hide_other_aggregation is set, because
+    that flag only affects post-processing in the query runner.
+    """
+    from posthog.hogql_queries.insights.trends.breakdown import (
+        BREAKDOWN_NULL_STRING_LABEL,
+        BREAKDOWN_OTHER_STRING_LABEL,
+    )
+
+    query_text = hogql_query.get("query")
+    if not query_text or not isinstance(query_text, str):
+        return hogql_query
+
+    replacements = {
+        f"'{BREAKDOWN_NULL_STRING_LABEL}'": "''",
+        f"'{BREAKDOWN_OTHER_STRING_LABEL}'": "'Other'",
+    }
+    for old, new in replacements.items():
+        query_text = query_text.replace(old, new)
+
+    return {**hogql_query, "query": query_text}
+
+
+def _clean_breakdown_sentinels(result: dict) -> None:
+    """Replace breakdown sentinel strings in API response results in-place.
+
+    Handles both list-of-lists (materialized/HogQL) and list-of-dicts (inline insight).
+    If the "Other" sentinel is found, it means the breakdown_limit was exceeded —
+    we clean it to "Other" but also capture_exception for visibility.
+    """
+    from posthog.hogql_queries.insights.trends.breakdown import BREAKDOWN_OTHER_STRING_LABEL
+
+    rows = result.get("results")
+    if not rows:
+        return
+
+    found_other = False
+    columns = result.get("columns")
+    if columns:
+        # HogQL/materialized path: results are list[tuple] or list[list]
+        indices = [i for i, col in enumerate(columns) if col == "breakdown_value"]
+        if not indices:
+            return
+        for row_idx, row in enumerate(rows):
+            needs_clean = any(isinstance(row[i], (str, list)) or row[i] is None for i in indices)
+            if not needs_clean:
+                continue
+            if not found_other:
+                found_other = any(_value_contains_other(row[i], BREAKDOWN_OTHER_STRING_LABEL) for i in indices)
+            row_list = list(row)
+            for i in indices:
+                row_list[i] = _clean_sentinel_value(row_list[i])
+            rows[row_idx] = type(row)(row_list)
+    elif isinstance(rows[0], dict):
+        # Inline insight path: results are list[dict]
+        for row in rows:
+            if "breakdown_value" in row:
+                if not found_other:
+                    found_other = _value_contains_other(row["breakdown_value"], BREAKDOWN_OTHER_STRING_LABEL)
+                row["breakdown_value"] = _clean_sentinel_value(row["breakdown_value"])
+            if "label" in row:
+                if not found_other and isinstance(row["label"], str):
+                    found_other = BREAKDOWN_OTHER_STRING_LABEL in row["label"]
+                row["label"] = _clean_sentinel_label(row["label"])
+
+    if found_other:
+        capture_exception(
+            Exception(
+                f"Endpoint breakdown limit ({ENDPOINT_BREAKDOWN_LIMIT}) exceeded — 'Other' bucket appeared in results"
+            )
+        )
+
+
+def _value_contains_other(value: object, other_label: str) -> bool:
+    """Check if a breakdown value contains the 'Other' sentinel."""
+    if isinstance(value, str):
+        return value == other_label
+    if isinstance(value, list):
+        return any(item == other_label for item in value if isinstance(item, str))
+    return False
+
+
+def _clean_sentinel_value(value: object) -> object:
+    """Clean breakdown sentinel strings (null and other) in a value or list of values."""
+    from posthog.hogql_queries.insights.trends.breakdown import (
+        BREAKDOWN_NULL_STRING_LABEL,
+        BREAKDOWN_OTHER_STRING_LABEL,
+    )
+
+    if isinstance(value, str):
+        if value == BREAKDOWN_NULL_STRING_LABEL or value == "":
+            return None
+        if value == BREAKDOWN_OTHER_STRING_LABEL:
+            return "Other"
+    elif isinstance(value, list):
+        return [_clean_sentinel_value(item) for item in value]
+    return value
+
+
+def _clean_sentinel_label(label: object) -> object:
+    """Clean a label string containing ::-joined breakdown parts."""
+    from posthog.hogql_queries.insights.trends.breakdown import (
+        BREAKDOWN_NULL_STRING_LABEL,
+        BREAKDOWN_OTHER_STRING_LABEL,
+    )
+
+    if not isinstance(label, str):
+        return label
+    if BREAKDOWN_NULL_STRING_LABEL not in label and BREAKDOWN_OTHER_STRING_LABEL not in label:
+        return label
+    parts = label.split("::")
+    cleaned = [
+        "null" if p == BREAKDOWN_NULL_STRING_LABEL else "Other" if p == BREAKDOWN_OTHER_STRING_LABEL else p
+        for p in parts
+    ]
+    return "::".join(cleaned)

--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -52,6 +52,7 @@ class MaterializableVariable:
     operator: ast.CompareOperationOp = ast.CompareOperationOp.Eq
     column_ast: Optional[ast.Expr] = None
     value_wrapper_fns: Optional[list[str]] = None
+    cte_name: Optional[str] = None  # CTE containing the variable; None = top-level query
 
 
 @dataclass
@@ -122,15 +123,29 @@ def analyze_variables_for_materialization(
         seen_code_names.add(code_name)
 
         try:
-            variable_usage = find_variable_in_where(ast_node, placeholder)
+            all_usages = find_all_variable_usages(ast_node, placeholder)
         except VariableInHavingClauseError:
             return False, "Variable used in HAVING clause are not supported for materialization.", []
         except ValueError as e:
             capture_exception(e)
             return False, "Invalid variable usage in WHERE clause.", []
 
-        if not variable_usage:
+        if not all_usages:
             return False, "Variable not used in WHERE clause", []
+
+        # Determine CTE context for this variable
+        cte_names = {cte_name for cte_name, _ in all_usages}
+        if len(cte_names) > 1:
+            # Variable used in multiple different locations (e.g. two CTEs, or CTE + top-level)
+            has_top_level = None in cte_names
+            has_cte = any(n is not None for n in cte_names)
+            if has_top_level and has_cte:
+                return False, "Variable used in both CTE and top-level query is not yet supported", []
+            return False, "Variable used in multiple CTEs is not yet supported", []
+
+        cte_name = next(iter(cte_names))
+        # Use the first usage for column info (all usages of the same variable should be consistent)
+        variable_usage = all_usages[0][1]
 
         if variable_usage.operator not in SUPPORTED_MATERIALIZATION_OPS:
             return (
@@ -156,10 +171,24 @@ def analyze_variables_for_materialization(
                 operator=variable_usage.operator,
                 column_ast=variable_usage.column_ast,
                 value_wrapper_fns=variable_usage.value_wrapper_fns,
+                cte_name=cte_name,
             )
         )
 
+    # Safety check: CTE variables + top-level JOINs produce wrong results.
+    # Removing a CTE's WHERE changes its row cardinality, which changes JOIN
+    # output. Filtering after materialization can't recover the original semantics
+    # (e.g. LEFT JOIN non-matches get NULL for the variable column and are lost).
+    has_cte_vars = any(v.cte_name is not None for v in result_vars)
+    if has_cte_vars and isinstance(ast_node, ast.SelectQuery) and _has_joins(ast_node):
+        return False, "CTE variables with JOINs in the top-level query are not supported for materialization", []
+
     return True, "OK", result_vars
+
+
+def _has_joins(node: ast.SelectQuery) -> bool:
+    """Check if a SelectQuery has any JOINs (next_join on select_from)."""
+    return node.select_from is not None and node.select_from.next_join is not None
 
 
 class VariablePlaceholderFinder(TraversingVisitor):
@@ -188,14 +217,34 @@ def find_variable_in_where(
     return finder.result
 
 
+def find_all_variable_usages(
+    ast_node: ast.SelectQuery | ast.SelectSetQuery, placeholder: ast.Placeholder
+) -> list[tuple[Optional[str], VariableUsageInWhere]]:
+    """Find all usages of a variable in WHERE clauses, including inside CTEs.
+
+    Returns list of (cte_name, usage) tuples. cte_name is None for top-level query.
+    """
+    if not isinstance(ast_node, ast.SelectQuery):
+        return []
+    finder = VariableInWhereFinder(placeholder)
+    finder.visit(ast_node)
+    return finder.all_results
+
+
 class VariableInWhereFinder(TraversingVisitor):
-    """Find how a variable is used in WHERE clause"""
+    """Find how a variable is used in WHERE clause, including inside CTEs."""
 
     def __init__(self, target_placeholder: ast.Placeholder):
         super().__init__()
         self.target = target_placeholder
-        self.result: Optional[VariableUsageInWhere] = None
+        self.all_results: list[tuple[Optional[str], VariableUsageInWhere]] = []
         self.in_where = False
+        self._current_cte_name: Optional[str] = None
+
+    @property
+    def result(self) -> Optional[VariableUsageInWhere]:
+        """Backward-compat: return first match's usage."""
+        return self.all_results[0][1] if self.all_results else None
 
     def visit_select_query(self, node: ast.SelectQuery):
         if node.having:
@@ -203,6 +252,14 @@ class VariableInWhereFinder(TraversingVisitor):
             finder.visit(node.having)
             if any(p.chain == self.target.chain for p in finder.variable_placeholders):
                 raise VariableInHavingClauseError()
+
+        # Visit CTEs first (they're part of this SelectQuery)
+        if node.ctes:
+            for cte_name, cte in node.ctes.items():
+                prev_cte = self._current_cte_name
+                self._current_cte_name = cte_name
+                self.visit(cte.expr)
+                self._current_cte_name = prev_cte
 
         if node.where:
             self.in_where = True
@@ -229,20 +286,30 @@ class VariableInWhereFinder(TraversingVisitor):
 
         if isinstance(field_side, ast.Field):
             column_chain = [str(item) for item in field_side.chain]
-            self.result = VariableUsageInWhere(
-                column_chain=column_chain,
-                column_expression=".".join(column_chain),
-                operator=node.op,
-                value_wrapper_fns=wrapper_fns,
+            self.all_results.append(
+                (
+                    self._current_cte_name,
+                    VariableUsageInWhere(
+                        column_chain=column_chain,
+                        column_expression=".".join(column_chain),
+                        operator=node.op,
+                        value_wrapper_fns=wrapper_fns,
+                    ),
+                )
             )
         elif isinstance(field_side, ast.Call):
             column_chain = self._extract_column_chain_from_call(field_side)
-            self.result = VariableUsageInWhere(
-                column_chain=column_chain,
-                column_expression=".".join(column_chain) if column_chain else str(field_side),
-                operator=node.op,
-                column_ast=field_side if not column_chain else None,
-                value_wrapper_fns=wrapper_fns,
+            self.all_results.append(
+                (
+                    self._current_cte_name,
+                    VariableUsageInWhere(
+                        column_chain=column_chain,
+                        column_expression=".".join(column_chain) if column_chain else str(field_side),
+                        operator=node.op,
+                        column_ast=field_side if not column_chain else None,
+                        value_wrapper_fns=wrapper_fns,
+                    ),
+                )
             )
 
     def _contains_target_placeholder(self, node: ast.Expr) -> bool:
@@ -341,47 +408,135 @@ class MaterializationTransformer(CloningVisitor):
     Each variable gets an aliased column in SELECT (aliased by code_name).
     GROUP BY is deduplicated by column_chain to handle same-column range variables
     (e.g., hour >= start AND hour < end → GROUP BY hour, not GROUP BY hour, hour).
+
+    CTE-aware: when variables live in a CTE, the CTE gets the column addition + WHERE removal,
+    and the top-level query gets a passthrough column from the CTE.
     """
 
     def __init__(self, variable_infos: list[MaterializableVariable]):
         super().__init__()
         self.variable_infos = variable_infos
+        self._current_cte_name: Optional[str] = None
 
     def visit_select_query(self, node: ast.SelectQuery):
+        new_ctes = self._process_ctes(node)
+
+        # Visit the select query itself (without re-visiting CTEs)
+        original_ctes = node.ctes
+        node.ctes = None
         new_node = super().visit_select_query(node)
+        node.ctes = original_ctes  # Restore original
+        new_node.ctes = new_ctes
 
-        # Add aliased column per variable to SELECT
-        select_additions = [self._create_column_field(var) for var in self.variable_infos]
-        if new_node.select:
-            new_node.select = [*list(new_node.select), *select_additions]
+        # Add variable columns + remove variable WHERE clauses for current context
+        vars_for_context = self._vars_for_current_context()
+        if vars_for_context:
+            self._add_variable_columns(new_node, vars_for_context)
+
+        # Top-level query: add passthrough columns for CTE variables
+        cte_vars = [v for v in self.variable_infos if v.cte_name is not None]
+        if self._current_cte_name is None and cte_vars:
+            self._add_cte_passthrough_columns(new_node, cte_vars)
+
+        return new_node
+
+    def _process_ctes(self, node: ast.SelectQuery) -> Optional[dict[str, ast.CTE]]:
+        """Process CTEs with proper context tracking, returning transformed CTE dict."""
+        if not node.ctes:
+            return None
+        new_ctes: dict[str, ast.CTE] = {}
+        for cte_name, cte in node.ctes.items():
+            prev_cte = self._current_cte_name
+            self._current_cte_name = cte_name
+            new_expr = self.visit(cte.expr)
+            self._current_cte_name = prev_cte
+            new_ctes[cte_name] = ast.CTE(name=cte_name, expr=new_expr, cte_type=cte.cte_type)
+        return new_ctes
+
+    def _add_variable_columns(self, node: ast.SelectQuery, vars_for_context: list[MaterializableVariable]) -> None:
+        """Add aliased variable columns to SELECT, update GROUP BY, and remove variable WHERE clauses."""
+        select_additions = [self._create_column_field(var) for var in vars_for_context]
+        if node.select:
+            node.select = [*list(node.select), *select_additions]
         else:
-            new_node.select = select_additions
+            node.select = select_additions
 
-        # Add unique columns to GROUP BY (deduplicated by column_chain or expression string)
-        # Also skip columns that already exist in the GROUP BY from the original query
+        if node.group_by is not None or self._current_cte_name is None:
+            self._add_group_by(node, vars_for_context)
+
+        if node.where:
+            node.where = self._remove_variable_from_where(node.where)
+
+    def _add_cte_passthrough_columns(self, node: ast.SelectQuery, cte_vars: list[MaterializableVariable]) -> None:
+        """Add passthrough columns + GROUP BY at top level for CTE-resident variables."""
+        passthrough_additions: list[ast.Expr] = [ast.Field(chain=[var.code_name]) for var in cte_vars]
+        if node.select:
+            node.select = [*list(node.select), *passthrough_additions]
+        else:
+            node.select = passthrough_additions
+
+        if node.group_by is not None or self._has_aggregate_functions(node):
+            self._add_group_by(node, cte_vars, use_field_ref=True)
+
+    @staticmethod
+    def _has_aggregate_functions(node: ast.SelectQuery) -> bool:
+        """Check if any SELECT expression uses an aggregate function (sum, count, avg, etc.)."""
+        from posthog.hogql.functions.mapping import HOGQL_AGGREGATIONS
+
+        agg_names = set(HOGQL_AGGREGATIONS.keys())
+
+        class AggFinder(TraversingVisitor):
+            def __init__(self):
+                super().__init__()
+                self.found = False
+
+            def visit_call(self, node: ast.Call):
+                if node.name in agg_names:
+                    self.found = True
+                else:
+                    super().visit_call(node)
+
+        finder = AggFinder()
+        for expr in node.select or []:
+            finder.visit(expr)
+            if finder.found:
+                return True
+        return False
+
+    def _vars_for_current_context(self) -> list[MaterializableVariable]:
+        """Return variables that apply to the current CTE/top-level context."""
+        return [v for v in self.variable_infos if v.cte_name == self._current_cte_name]
+
+    def _add_group_by(
+        self,
+        node: ast.SelectQuery,
+        vars_to_add: list[MaterializableVariable],
+        use_field_ref: bool = False,
+    ) -> None:
+        """Add unique columns to GROUP BY, deduplicating by column_chain."""
         existing_keys: set[str] = set()
-        if new_node.group_by:
-            for expr in new_node.group_by:
+        if node.group_by:
+            for expr in node.group_by:
                 if isinstance(expr, ast.Field):
                     existing_keys.add(".".join(str(c) for c in expr.chain))
 
         seen_keys: set[str] = set()
         group_by_additions: list[ast.Expr] = []
-        for var in self.variable_infos:
+        for var in vars_to_add:
             dedup_key = ".".join(var.column_chain) if var.column_chain else var.column_expression
+            if use_field_ref:
+                dedup_key = var.code_name
             if dedup_key not in seen_keys and dedup_key not in existing_keys:
                 seen_keys.add(dedup_key)
-                group_by_additions.append(self._variable_expr(var))
+                if use_field_ref:
+                    group_by_additions.append(ast.Field(chain=[var.code_name]))
+                else:
+                    group_by_additions.append(self._variable_expr(var))
 
-        if new_node.group_by:
-            new_node.group_by = [*list(new_node.group_by), *group_by_additions]
-        else:
-            new_node.group_by = group_by_additions
-
-        if new_node.where:
-            new_node.where = self._remove_variable_from_where(new_node.where)
-
-        return new_node
+        if node.group_by:
+            node.group_by = [*list(node.group_by), *group_by_additions]
+        elif group_by_additions:
+            node.group_by = group_by_additions
 
     def _create_column_field(self, var: MaterializableVariable) -> ast.Expr:
         return ast.Alias(
@@ -399,27 +554,7 @@ class MaterializationTransformer(CloningVisitor):
         """
         if var.column_ast is not None:
             return CloningVisitor().visit(var.column_ast)
-
-        chain = var.column_chain
-
-        if len(chain) >= 2 and chain[0] == "properties":
-            properties_chain: list[str | int] = ["properties"]
-            return ast.Call(
-                name="JSONExtractString",
-                args=[
-                    ast.Field(chain=properties_chain),
-                    ast.Constant(value=chain[1]),
-                ],
-            )
-        elif len(chain) >= 3 and chain[1] == "properties":
-            field_chain: list[str | int] = list(chain[:2])
-            return ast.Call(
-                name="JSONExtractString",
-                args=[ast.Field(chain=field_chain), ast.Constant(value=chain[2])],
-            )
-        else:
-            simple_chain: list[str | int] = list(chain)
-            return ast.Field(chain=simple_chain)
+        return ast.Field(chain=list(var.column_chain))
 
     def _remove_variable_from_where(self, where_node: Optional[ast.Expr]) -> Optional[ast.Expr]:
         if where_node is None:

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -207,13 +207,6 @@ class EndpointVersion(models.Model):
                 f"Query type '{query_kind}' cannot be materialized. Supported types: {supported}",
             )
 
-        # Check for multiple breakdowns in insight queries
-        if query_kind != "HogQLQuery":
-            breakdown_filter = self.query.get("breakdownFilter") or {}
-            breakdowns = breakdown_filter.get("breakdowns") or []
-            if len(breakdowns) > 1:
-                return False, "Multiple breakdowns not supported for materialization"
-
         if self.query.get("variables"):
             from products.endpoints.backend.materialization import analyze_variables_for_materialization
 

--- a/products/endpoints/backend/tests/__snapshots__/test_variable_materialization.ambr
+++ b/products/endpoints/backend/tests/__snapshots__/test_variable_materialization.ambr
@@ -1,4 +1,186 @@
 # serializer version: 1
+# name: TestCTETransformSnapshots.test_cte_property_variable
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              properties.os AS os_name
+          FROM
+              events
+          GROUP BY
+              properties.os)
+  SELECT
+      cnt,
+      os_name
+  FROM
+      cte
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_range_variable_deduped_group_by
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              hour AS start_hour,
+              hour AS end_hour
+          FROM
+              events
+          GROUP BY
+              hour)
+  SELECT
+      cnt,
+      start_hour,
+      end_hour
+  FROM
+      cte
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_two_variables_same_cte
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              event AS event_name,
+              distinct_id AS user_id
+          FROM
+              events
+          GROUP BY
+              event,
+              distinct_id)
+  SELECT
+      cnt,
+      event_name,
+      user_id
+  FROM
+      cte
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_variable_preserves_non_variable_where
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              event AS event_name
+          FROM
+              events
+          WHERE
+              greater(timestamp, '2024-01-01')
+          GROUP BY
+              event)
+  SELECT
+      cnt,
+      event_name
+  FROM
+      cte
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_variable_top_level_no_group_by_passthrough
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              event,
+              event AS event_name
+          FROM
+              events
+          GROUP BY
+              event)
+  SELECT
+      sum(cnt),
+      event_name
+  FROM
+      cte
+  GROUP BY
+      event_name
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_variable_with_group_by
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              toStartOfDay(timestamp) AS date,
+              event AS event_name
+          FROM
+              events
+          GROUP BY
+              date,
+              event)
+  SELECT
+      cnt,
+      date,
+      event_name
+  FROM
+      cte
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_cte_variable_without_group_by
+  '''
+  WITH
+      cte AS (SELECT
+              uuid,
+              event,
+              properties,
+              timestamp,
+              distinct_id,
+              elements_chain,
+              created_at,
+              $session_id,
+              $window_id,
+              person_mode,
+              person_id,
+              $group_0,
+              $group_1,
+              $group_2,
+              $group_3,
+              $group_4,
+              elements_chain_href,
+              elements_chain_texts,
+              elements_chain_ids,
+              elements_chain_elements,
+              event_person_id,
+              event_issue_id,
+              issue_id,
+              event AS event_name
+          FROM
+              events)
+  SELECT
+      count(),
+      event_name
+  FROM
+      cte
+  GROUP BY
+      event_name
+  LIMIT 50000
+  '''
+# ---
+# name: TestCTETransformSnapshots.test_top_level_variable_with_cte_present
+  '''
+  WITH
+      cte AS (SELECT
+              count() AS cnt,
+              event
+          FROM
+              events
+          GROUP BY
+              event)
+  SELECT
+      cnt,
+      event,
+      event AS event_name
+  FROM
+      cte
+  GROUP BY
+      event
+  LIMIT 50000
+  '''
+# ---
 # name: TestTransformQuerySnapshots.test_all_where_conditions_are_variables
   '''
   SELECT
@@ -126,11 +308,11 @@
   '''
   SELECT
       count(),
-      JSONExtractString(person.properties, 'city') AS city
+      person.properties.city AS city
   FROM
       events
   GROUP BY
-      JSONExtractString(person.properties, 'city')
+      person.properties.city
   LIMIT 50000
   '''
 # ---
@@ -152,11 +334,11 @@
   '''
   SELECT
       count(),
-      JSONExtractString(properties, 'os') AS os_name
+      properties.os AS os_name
   FROM
       events
   GROUP BY
-      JSONExtractString(properties, 'os')
+      properties.os
   LIMIT 50000
   '''
 # ---

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -882,6 +882,108 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
             self.assertIn("has(breakdown_value", query_sql)
             self.assertIn("chrome", query_sql)
 
+    def test_materialized_insight_endpoint_filters_by_multiple_breakdowns(self):
+        endpoint = create_endpoint_with_version(
+            name="mat_trends_multi_bd",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter={
+                    "breakdowns": [
+                        {"property": "$browser", "type": "event"},
+                        {"property": "$os", "type": "event"},
+                    ]
+                },
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+        self._materialize_endpoint(endpoint)
+
+        with mock.patch.object(EndpointViewSet, "_execute_query_and_respond", return_value=Response({})) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {"variables": {"$browser": "Chrome", "$os": "Mac"}},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_exec.assert_called()
+            query_request_data = mock_exec.call_args[0][0]
+            query_sql = query_request_data["query"]["query"].lower()
+            # Multiple breakdowns use array index access on breakdown_value
+            self.assertIn("breakdown_value[1]", query_sql)
+            self.assertIn("breakdown_value[2]", query_sql)
+            self.assertNotIn("has(", query_sql)
+            self.assertIn("chrome", query_sql)
+            self.assertIn("mac", query_sql)
+
+    def test_materialized_insight_endpoint_filters_by_three_breakdowns(self):
+        endpoint = create_endpoint_with_version(
+            name="mat_trends_triple_bd",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter={
+                    "breakdowns": [
+                        {"property": "$browser", "type": "event"},
+                        {"property": "$os", "type": "event"},
+                        {"property": "$device_type", "type": "event"},
+                    ]
+                },
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+        self._materialize_endpoint(endpoint)
+
+        with mock.patch.object(EndpointViewSet, "_execute_query_and_respond", return_value=Response({})) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {"variables": {"$browser": "Chrome", "$os": "Mac", "$device_type": "Desktop"}},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_exec.assert_called()
+            query_request_data = mock_exec.call_args[0][0]
+            query_sql = query_request_data["query"]["query"].lower()
+            self.assertIn("breakdown_value[1]", query_sql)
+            self.assertIn("breakdown_value[2]", query_sql)
+            self.assertIn("breakdown_value[3]", query_sql)
+            self.assertNotIn("has(", query_sql)
+            self.assertIn("chrome", query_sql)
+            self.assertIn("mac", query_sql)
+            self.assertIn("desktop", query_sql)
+
+    def test_materialized_insight_endpoint_requires_all_multiple_breakdowns(self):
+        endpoint = create_endpoint_with_version(
+            name="mat_trends_multi_bd_req",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter={
+                    "breakdowns": [
+                        {"property": "$browser", "type": "event"},
+                        {"property": "$os", "type": "event"},
+                    ]
+                },
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+        self._materialize_endpoint(endpoint)
+
+        # Only providing one of the two required breakdown variables should fail
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {"$browser": "Chrome"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("required", response.json()["detail"].lower())
+
     def test_materialized_insight_endpoint_rejects_date_variables(self):
         endpoint = create_endpoint_with_version(
             name="mat_trends_dates",
@@ -1047,7 +1149,7 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         # is_materialized is derived from saved_query.table_id — False until Temporal creates the table
         self.assertFalse(response.json()["is_materialized"])
 
-    def test_endpoint_with_multiple_breakdowns_cannot_be_materialized(self):
+    def test_endpoint_with_multiple_breakdowns_can_be_materialized(self):
         endpoint = create_endpoint_with_version(
             name="multi_breakdown",
             team=self.team,
@@ -1064,18 +1166,16 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
             is_active=True,
         )
 
-        # Endpoint creation should succeed
         self.assertIsNotNone(endpoint.id)
 
-        # But enabling materialization should fail
         response = self.client.patch(
             f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
             {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("multiple breakdowns", response.json()["detail"].lower())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()["is_materialized"])  # not yet materialized until Temporal runs
 
     # =========================================================================
     # ENDPOINT EXECUTION WITHOUT VARIABLES (SIMPLE CASES)
@@ -1194,6 +1294,46 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
             self.assertTrue(
                 any(p.get("key") == "$browser" and p.get("value") == "Chrome" for p in filter_props),
                 "Breakdown property filter should be applied",
+            )
+
+    def test_non_materialized_insight_endpoint_accepts_multiple_breakdown_variables(self):
+        from posthog.schema import Breakdown, BreakdownFilter, BreakdownType
+
+        endpoint = create_endpoint_with_version(
+            name="trends_multi_breakdown_filter",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter=BreakdownFilter(
+                    breakdowns=[
+                        Breakdown(property="$browser", type=BreakdownType.EVENT),
+                        Breakdown(property="$os", type=BreakdownType.EVENT),
+                    ]
+                ),
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {"$browser": "Chrome", "$os": "Mac"}, "debug": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+
+        result = response_data["results"][0] if response_data.get("results") else {}
+        if "filter" in result:
+            filter_props = result["filter"].get("properties", [])
+            self.assertTrue(
+                any(p.get("key") == "$browser" and p.get("value") == "Chrome" for p in filter_props),
+                "Browser breakdown property filter should be applied",
+            )
+            self.assertTrue(
+                any(p.get("key") == "$os" and p.get("value") == "Mac" for p in filter_props),
+                "OS breakdown property filter should be applied",
             )
 
     # =========================================================================
@@ -1423,3 +1563,288 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
             format="json",
         )
         self.assertEqual(run_response.status_code, status.HTTP_200_OK)
+
+    # =========================================================================
+    # BREAKDOWN SENTINEL CLEANUP
+    # =========================================================================
+
+    @mock.patch("products.endpoints.backend.api.process_query_model")
+    def test_inline_insight_sentinel_null_cleaned_from_breakdown_value(self, mock_process):
+        mock_process.return_value = {
+            "results": [
+                {"breakdown_value": ["Chrome", "$$_posthog_breakdown_null_$$"], "count": 10, "label": "Chrome"},
+                {"breakdown_value": "$$_posthog_breakdown_null_$$", "count": 5, "label": "none"},
+            ],
+            "columns": None,
+        }
+
+        endpoint = create_endpoint_with_version(
+            name="sentinel-null",
+            team=self.team,
+            query=TrendsQuery(series=[EventsNode(event="$pageview")]).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(results[0]["breakdown_value"], ["Chrome", None])
+        self.assertIsNone(results[1]["breakdown_value"])
+
+    @mock.patch("products.endpoints.backend.api.process_query_model")
+    def test_inline_insight_sentinel_cleaned_from_label(self, mock_process):
+        mock_process.return_value = {
+            "results": [
+                {
+                    "breakdown_value": "Chrome",
+                    "count": 10,
+                    "label": "Chrome::$$_posthog_breakdown_null_$$",
+                },
+            ],
+            "columns": None,
+        }
+
+        endpoint = create_endpoint_with_version(
+            name="sentinel-label",
+            team=self.team,
+            query=TrendsQuery(series=[EventsNode(event="$pageview")]).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(results[0]["label"], "Chrome::null")
+
+    @mock.patch("products.endpoints.backend.api.process_query_model")
+    def test_hogql_result_sentinel_cleaned_from_breakdown_column(self, mock_process):
+        mock_process.return_value = {
+            "results": [
+                ("Chrome", 10),
+                ("$$_posthog_breakdown_null_$$", 5),
+            ],
+            "columns": ["breakdown_value", "count"],
+        }
+
+        endpoint = create_endpoint_with_version(
+            name="sentinel-hogql",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT breakdown_value, count() FROM events GROUP BY 1"},
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(results[0][0], "Chrome")
+        self.assertIsNone(results[1][0])
+
+    def test_inline_insight_cleans_other_sentinel_and_alerts(self):
+        from posthog.hogql_queries.insights.trends.breakdown import BREAKDOWN_OTHER_STRING_LABEL
+
+        for event_name in [f"event_{i}" for i in range(30)]:
+            _create_event(
+                event="$pageview",
+                distinct_id="user1",
+                team=self.team,
+                timestamp="2026-01-05 12:00:00",
+                properties={"unique_prop": event_name},
+            )
+        flush_persons_and_events()
+
+        endpoint = create_endpoint_with_version(
+            name="no-other-bucket",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+                breakdownFilter={"breakdown": "unique_prop", "breakdown_type": "event", "breakdown_limit": 5},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Patch the limit to a low value so the 30 distinct breakdown values exceed it
+        with (
+            mock.patch("products.endpoints.backend.api.ENDPOINT_BREAKDOWN_LIMIT", 5),
+            mock.patch("products.endpoints.backend.api.capture_exception") as mock_capture,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {"refresh": "force"},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertGreater(len(results), 0, "Expected non-empty results")
+
+            # Sentinels must be cleaned — no raw sentinel strings in the response
+            for row in results:
+                bv = row.get("breakdown_value", "")
+                label = row.get("label", "")
+                self.assertNotEqual(
+                    bv, BREAKDOWN_OTHER_STRING_LABEL, f"Found raw other sentinel in breakdown_value: {bv}"
+                )
+                self.assertNotIn(
+                    BREAKDOWN_OTHER_STRING_LABEL, str(label), f"Found raw other sentinel in label: {label}"
+                )
+
+            # The "Other" bucket should appear as a cleaned "Other" string
+            breakdown_values = [row.get("breakdown_value") for row in results]
+            self.assertIn("Other", breakdown_values, "Expected cleaned 'Other' value in results")
+
+            # capture_exception should have been called to alert about the limit being exceeded
+            mock_capture.assert_called_once()
+            exc = mock_capture.call_args[0][0]
+            self.assertIn("exceeded", str(exc))
+
+    # =========================================================================
+    # CTE VARIABLE TESTS — API-LEVEL END-TO-END
+    # =========================================================================
+
+    def test_hogql_cte_variable_inline_execution(self):
+        endpoint = create_endpoint_with_version(
+            name="cte_inline",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt, event FROM cte",
+                "variables": {
+                    str(self.event_name_var.id): {
+                        "variableId": str(self.event_name_var.id),
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    }
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {"event_name": "$pageview"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        # 10 $pageview events, grouped by event
+        self.assertEqual(results[0][0], 10)
+        self.assertEqual(results[0][1], "$pageview")
+
+    def test_hogql_cte_variable_materialized_execution(self):
+        endpoint = create_endpoint_with_version(
+            name="cte_materialized",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt, event FROM cte",
+                "variables": {
+                    str(self.event_name_var.id): {
+                        "variableId": str(self.event_name_var.id),
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    }
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+        self._materialize_endpoint(endpoint)
+
+        with mock.patch.object(EndpointViewSet, "_execute_query_and_respond", return_value=Response({})) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {"variables": {"event_name": "$pageview"}},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_exec.assert_called()
+            query_sql = mock_exec.call_args[0][0]["query"]["query"].lower()
+            # CTE variable should appear as a WHERE filter on the materialized table
+            self.assertIn("event_name", query_sql)
+            self.assertIn("$pageview", query_sql)
+
+    def test_hogql_cte_variable_missing_required_variable(self):
+        endpoint = create_endpoint_with_version(
+            name="cte_missing_var",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt, event FROM cte",
+                "variables": {
+                    str(self.event_name_var.id): {
+                        "variableId": str(self.event_name_var.id),
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    }
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+        self._materialize_endpoint(endpoint)
+
+        # Call without providing the required variable
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        detail = response.json()["detail"]
+        self.assertIn("event_name", detail)
+        self.assertIn("required", detail.lower())
+
+    def test_hogql_multiple_ctes_one_with_variable(self):
+        endpoint = create_endpoint_with_version(
+            name="multi_cte_one_var",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": (
+                    "WITH cte1 AS (SELECT count() as cnt FROM events GROUP BY event), "
+                    "cte2 AS (SELECT count() as cnt2 FROM events WHERE event = {variables.event_name} GROUP BY event) "
+                    "SELECT cnt2 FROM cte2"
+                ),
+                "variables": {
+                    str(self.event_name_var.id): {
+                        "variableId": str(self.event_name_var.id),
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    }
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Inline execution — verify the variable filters correctly
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {"event_name": "$pageleave"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        # cte2 filters by event_name, so should return count for $pageleave only
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][0], 10)

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1175,6 +1175,50 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Node.objects.filter(team=self.team, saved_query_id=saved_query_id).exists())
 
+    def test_materialization_replaces_breakdown_sentinels_in_hogql(self):
+        from posthog.hogql_queries.insights.trends.breakdown import (
+            BREAKDOWN_NULL_STRING_LABEL,
+            BREAKDOWN_OTHER_STRING_LABEL,
+        )
+
+        trends_query = {
+            "kind": "TrendsQuery",
+            "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+            "dateRange": {"date_from": "-7d"},
+            "breakdownFilter": {
+                "breakdown": "$browser",
+                "breakdown_type": "event",
+                "breakdown_limit": 5,
+            },
+        }
+
+        _create_event(team=self.team, event="$pageview", distinct_id="user1")
+        flush_persons_and_events()
+
+        endpoint = create_endpoint_with_version(
+            name="sentinel_mat_test",
+            team=self.team,
+            query=trends_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        version = endpoint.versions.first()
+        version.refresh_from_db()
+        saved_query = version.saved_query
+        assert saved_query is not None
+
+        hogql_text = saved_query.query.get("query", "")
+        self.assertNotIn(BREAKDOWN_NULL_STRING_LABEL, hogql_text)
+        self.assertNotIn(BREAKDOWN_OTHER_STRING_LABEL, hogql_text)
+
 
 @pytest.mark.asyncio
 class TestEndpointMaterializationTemporal:

--- a/products/endpoints/backend/tests/test_variable_materialization.py
+++ b/products/endpoints/backend/tests/test_variable_materialization.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 
 from posthog.hogql import ast
 
@@ -505,11 +505,9 @@ class TestQueryTransformation(APIBaseTest):
         assert len(var_infos) >= 1
         transformed = transform_query_for_materialization(query, var_infos, self.team)
 
-        # Should have JSONExtractString for properties.os
+        # Should have properties.os as a Field (not JSONExtractString)
         transformed_query = transformed["query"]
-        assert "JSONExtractString" in transformed_query
-        assert "properties" in transformed_query
-        assert "'os'" in transformed_query or '"os"' in transformed_query
+        assert "properties.os" in transformed_query
 
     def test_transform_removes_where_clause(self):
         query = {
@@ -708,9 +706,8 @@ class TestQueryTransformation(APIBaseTest):
         transformed = transform_query_for_materialization(query, var_infos, self.team)
 
         transformed_query = transformed["query"]
-        # Should use JSONExtractString for person.properties
-        assert "JSONExtractString" in transformed_query
-        assert "person" in transformed_query
+        # Should use person.properties.city as a Field
+        assert "person.properties.city" in transformed_query
 
     def test_transform_variable_first_in_and_chain(self):
         query = {
@@ -1337,3 +1334,454 @@ class TestMaterializedReadPath(APIBaseTest):
         )
 
         assert "toDate(toStartOfMonth('2024-01-15'))" in result
+
+
+class TestCTEVariableAnalysis(APIBaseTest):
+    """Test variable analysis for variables inside CTE WHERE clauses."""
+
+    def test_single_cte_with_variable_in_where(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt, event FROM cte",
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is True
+        assert reason == "OK"
+        assert len(var_infos) == 1
+        assert var_infos[0].code_name == "event_name"
+        assert var_infos[0].cte_name == "cte"
+
+    def test_variable_in_cte_with_or_condition_rejected(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "WITH cte AS (SELECT count() as cnt FROM events WHERE event = {variables.event_name} OR event = '$click' GROUP BY event) "
+                "SELECT cnt FROM cte"
+            ),
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        if can_materialize and var_infos:
+            with pytest.raises(ValueError, match="OR conditions not supported"):
+                transform_query_for_materialization(query, var_infos, self.team)
+
+    def test_two_ctes_one_variable_each_different_vars_allowed(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "WITH cte1 AS (SELECT count() as cnt1 FROM events WHERE event = {variables.event_name} GROUP BY event), "
+                "cte2 AS (SELECT count() as cnt2 FROM events WHERE distinct_id = {variables.user_id} GROUP BY distinct_id) "
+                "SELECT cnt1 FROM cte1"
+            ),
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+                "var-2": {"code_name": "user_id", "value": "user_0"},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        # Each variable is in its own single CTE — this should be allowed
+        assert can_materialize is True
+        assert reason == "OK"
+        assert len(var_infos) == 2
+        code_names = {v.code_name for v in var_infos}
+        assert code_names == {"event_name", "user_id"}
+
+    def test_variable_in_cte_and_top_level_rejected(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": "WITH cte AS (SELECT count() as cnt FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt FROM cte WHERE event = {variables.event_name}",
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, _ = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "both CTE and top-level" in reason
+
+    def test_variable_in_two_different_ctes_rejected(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "WITH cte1 AS (SELECT count() as cnt1 FROM events WHERE event = {variables.event_name} GROUP BY event), "
+                "cte2 AS (SELECT count() as cnt2 FROM events WHERE event = {variables.event_name} GROUP BY event) "
+                "SELECT cnt1, cnt2 FROM cte1 CROSS JOIN cte2"
+            ),
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, _ = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "multiple CTEs" in reason
+
+    def test_variable_in_cte_having_rejected(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": "WITH cte AS (SELECT count() as cnt, event FROM events GROUP BY event HAVING cnt > {variables.min_count}) SELECT * FROM cte",
+            "variables": {
+                "var-1": {"code_name": "min_count", "value": "10"},
+            },
+        }
+
+        can_materialize, reason, _ = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "HAVING" in reason
+
+    def test_cte_variable_with_top_level_join_rejected(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "WITH filtered AS (SELECT user_id FROM events WHERE event = {variables.event_name} GROUP BY user_id) "
+                "SELECT p.name FROM persons p LEFT JOIN filtered f ON p.id = f.user_id"
+            ),
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, _ = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "JOINs" in reason
+
+    def test_top_level_variable_with_join_still_allowed(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "WITH cte AS (SELECT count() as cnt, event FROM events GROUP BY event) "
+                "SELECT c.cnt, p.name FROM cte c JOIN persons p ON 1=1 WHERE c.event = {variables.event_name}"
+            ),
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is True
+        assert var_infos[0].cte_name is None
+
+    def test_top_level_variable_still_works(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": "WITH cte AS (SELECT count() as cnt, event FROM events GROUP BY event) SELECT cnt, event FROM cte WHERE event = {variables.event_name}",
+            "variables": {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is True
+        assert len(var_infos) == 1
+        assert var_infos[0].cte_name is None
+
+
+@pytest.mark.usefixtures("unittest_snapshot")
+class TestCTETransformSnapshots(APIBaseTest):
+    """Snapshot tests for CTE variable materialization query transforms.
+
+    Run `pytest --snapshot-update` to regenerate after intentional changes.
+    """
+
+    snapshot: Any
+
+    def _transform(self, query_str: str, variables: dict) -> str:
+        hogql_query = {"kind": "HogQLQuery", "query": query_str, "variables": variables}
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(hogql_query)
+        assert can_materialize, f"Expected materializable, got: {reason}"
+        transformed = transform_query_for_materialization(hogql_query, var_infos, self.team)
+        assert transformed["variables"] == {}
+        assert "{variables" not in transformed["query"]
+        return transformed["query"]
+
+    def test_cte_variable_with_group_by(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt, toStartOfDay(timestamp) as date FROM events WHERE event = {variables.event_name} GROUP BY date) SELECT cnt, date FROM cte",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            )
+            == self.snapshot
+        )
+
+    def test_cte_variable_without_group_by(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT * FROM events WHERE event = {variables.event_name}) SELECT count() FROM cte",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            )
+            == self.snapshot
+        )
+
+    def test_top_level_variable_with_cte_present(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt, event FROM events GROUP BY event) SELECT cnt, event FROM cte WHERE event = {variables.event_name}",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            )
+            == self.snapshot
+        )
+
+    def test_cte_two_variables_same_cte(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt FROM events WHERE event = {variables.event_name} AND distinct_id = {variables.user_id} GROUP BY event, distinct_id) SELECT cnt FROM cte",
+                {
+                    "var-1": {"code_name": "event_name", "value": "$pageview"},
+                    "var-2": {"code_name": "user_id", "value": "u1"},
+                },
+            )
+            == self.snapshot
+        )
+
+    def test_cte_variable_preserves_non_variable_where(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt FROM events WHERE timestamp > '2024-01-01' AND event = {variables.event_name} GROUP BY event) SELECT cnt FROM cte",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            )
+            == self.snapshot
+        )
+
+    def test_cte_range_variable_deduped_group_by(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt FROM events WHERE hour >= {variables.start_hour} AND hour < {variables.end_hour} GROUP BY hour) SELECT cnt FROM cte",
+                {
+                    "var-1": {"code_name": "start_hour", "value": "10"},
+                    "var-2": {"code_name": "end_hour", "value": "20"},
+                },
+            )
+            == self.snapshot
+        )
+
+    def test_cte_property_variable(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt FROM events WHERE properties.os = {variables.os_name} GROUP BY properties.os) SELECT cnt FROM cte",
+                {"var-1": {"code_name": "os_name", "value": "Mac"}},
+            )
+            == self.snapshot
+        )
+
+    def test_cte_variable_top_level_no_group_by_passthrough(self):
+        assert (
+            self._transform(
+                "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT sum(cnt) FROM cte",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            )
+            == self.snapshot
+        )
+
+
+class TestMaterializationEquivalence(ClickhouseTestMixin, APIBaseTest):
+    """Verify that querying a materialized table with variable filters returns
+    the same data as running the original query with variables substituted.
+
+    Strategy:
+      1. Insert real events into ClickHouse with varied property values.
+      2. Run the original query with the variable value hard-coded (the "inline" result).
+      3. Run the materialized-transformed query (variable removed from WHERE,
+         added as a column), then filter that result to the desired variable value.
+      4. Assert both results match on the data columns.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        for event_name in ("$pageview", "$click"):
+            for i in range(5):
+                _create_event(
+                    event=event_name,
+                    distinct_id=f"user_{i % 3}",
+                    team=self.team,
+                    timestamp=f"2026-01-{(i + 1):02d} 12:00:00",
+                    properties={"$browser": "Chrome" if i % 2 == 0 else "Safari", "$os": "Mac" if i < 3 else "Windows"},
+                )
+        flush_persons_and_events()
+
+    def _run_hogql(self, query_str: str) -> list[list]:
+        from posthog.schema import HogQLQuery
+
+        from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+
+        runner = HogQLQueryRunner(team=self.team, query=HogQLQuery(query=query_str))
+        response = runner.calculate()
+        return sorted([list(row) for row in response.results])
+
+    def _assert_equivalent(self, original_query: str, variables: dict, variable_values: dict):
+        """Run the original (with values substituted) and materialized+filtered queries, assert equality.
+
+        Args:
+            original_query: HogQL with {variables.X} placeholders
+            variables: variable metadata dict for analyze_variables_for_materialization
+            variable_values: dict of code_name -> value to substitute
+        """
+        # 1. Build the "inline" query by substituting variable values directly
+        inline_query = original_query
+        for code_name, value in variable_values.items():
+            inline_query = inline_query.replace("{variables." + code_name + "}", f"'{value}'")
+
+        inline_results = self._run_hogql(inline_query)
+
+        # 2. Transform for materialization
+        hogql_query = {"kind": "HogQLQuery", "query": original_query, "variables": variables}
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(hogql_query)
+        assert can_materialize, f"Expected materializable: {reason}"
+        transformed = transform_query_for_materialization(hogql_query, var_infos, self.team)
+
+        # 3. Run the materialized query (returns all permutations) and get column names
+        var_code_names = {v.code_name for v in var_infos}
+
+        from posthog.schema import HogQLQuery
+
+        from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+
+        runner = HogQLQueryRunner(team=self.team, query=HogQLQuery(query=transformed["query"]))
+        response = runner.calculate()
+        columns = response.columns or []
+
+        var_col_indices = {i for i, col in enumerate(columns) if col in var_code_names}
+        data_col_indices = [i for i in range(len(columns)) if i not in var_col_indices]
+
+        # Build index mapping: code_name -> column position
+        var_col_positions = {col: i for i, col in enumerate(columns) if col in var_code_names}
+
+        filtered_results = []
+        for row in response.results:
+            row_list = list(row)
+            # Check if this row matches all variable values
+            matches = all(row_list[var_col_positions[cn]] == val for cn, val in variable_values.items())
+            if matches:
+                filtered_results.append([row_list[i] for i in data_col_indices])
+
+        filtered_results = sorted(filtered_results)
+        assert inline_results == filtered_results, (
+            f"Inline vs materialized+filtered results differ.\n"
+            f"Inline:       {inline_results}\n"
+            f"Materialized: {filtered_results}"
+        )
+
+    def test_simple_equality_variable(self):
+        self._assert_equivalent(
+            "SELECT count() FROM events WHERE event = {variables.event_name}",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_two_variables(self):
+        self._assert_equivalent(
+            "SELECT count() FROM events WHERE event = {variables.event_name} AND distinct_id = {variables.user_id}",
+            {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+                "var-2": {"code_name": "user_id", "value": "user_0"},
+            },
+            {"event_name": "$pageview", "user_id": "user_0"},
+        )
+
+    def test_variable_with_group_by(self):
+        self._assert_equivalent(
+            "SELECT distinct_id, count() FROM events WHERE event = {variables.event_name} GROUP BY distinct_id",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_variable_with_non_variable_where(self):
+        self._assert_equivalent(
+            "SELECT count() FROM events WHERE distinct_id = 'user_0' AND event = {variables.event_name}",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_property_variable(self):
+        self._assert_equivalent(
+            "SELECT count() FROM events WHERE properties.$browser = {variables.browser}",
+            {"var-1": {"code_name": "browser", "value": "Chrome"}},
+            {"browser": "Chrome"},
+        )
+
+    def test_cte_variable(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt, distinct_id FROM events WHERE event = {variables.event_name} GROUP BY distinct_id) SELECT cnt, distinct_id FROM cte",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_variable_with_top_level_aggregation(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt, distinct_id FROM events WHERE event = {variables.event_name} GROUP BY distinct_id) SELECT sum(cnt) FROM cte",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_two_variables(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt FROM events WHERE event = {variables.event_name} AND distinct_id = {variables.user_id} GROUP BY event, distinct_id) SELECT cnt FROM cte",
+            {
+                "var-1": {"code_name": "event_name", "value": "$pageview"},
+                "var-2": {"code_name": "user_id", "value": "user_0"},
+            },
+            {"event_name": "$pageview", "user_id": "user_0"},
+        )
+
+    def test_cte_variable_preserves_non_variable_where(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt FROM events WHERE distinct_id = 'user_0' AND event = {variables.event_name} GROUP BY event) SELECT cnt FROM cte",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_property_variable(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt FROM events WHERE properties.$browser = {variables.browser} GROUP BY properties.$browser) SELECT cnt FROM cte",
+            {"var-1": {"code_name": "browser", "value": "Chrome"}},
+            {"browser": "Chrome"},
+        )
+
+    def test_cte_variable_without_group_by(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT event, distinct_id FROM events WHERE event = {variables.event_name}) SELECT event, distinct_id FROM cte",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_variable_with_order_by(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt, event FROM cte ORDER BY cnt DESC",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_variable_with_limit(self):
+        self._assert_equivalent(
+            "WITH cte AS (SELECT count() as cnt, event FROM events WHERE event = {variables.event_name} GROUP BY event) SELECT cnt FROM cte LIMIT 5",
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )
+
+    def test_cte_multiple_non_variable_ctes(self):
+        self._assert_equivalent(
+            (
+                "WITH cte1 AS (SELECT count() as cnt FROM events GROUP BY event), "
+                "cte2 AS (SELECT count() as cnt2 FROM events WHERE event = {variables.event_name} GROUP BY event) "
+                "SELECT cnt2 FROM cte2"
+            ),
+            {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+            {"event_name": "$pageview"},
+        )


### PR DESCRIPTION
## Problem

1. **Multiple breakdowns not supported** — Endpoints rejected insight queries with multiple breakdowns and only handled a single breakdown property throughout the execution and materialization paths.
2. **Variables inside CTEs ignored** — HogQL queries with variables in CTE WHERE clauses couldn't be materialized, because the variable analysis and transformation only looked at the top-level query.
3. **Sentinel string leakage** — Internal placeholder strings (`$$_posthog_breakdown_null_$$`, `$$_posthog_breakdown_other_$$`) leaked into endpoint API responses instead of clean `null` / `"Other"` values.
4. **"Other" bucket and breakdown limit silently drop data** — Insight breakdowns aggregate low-cardinality values into an "Other" bucket and default to 25 values, silently returning incomplete data from endpoints.
5. **Materialized vs inline inconsistency** — Passing `""` as a breakdown variable returned data on the materialized path but empty results on the inline path, because S3 stores nulls as `''` while ClickHouse uses `NULL`.

## Changes

- **Multiple breakdown support** — Supported now :P
    - Replaced single-breakdown helpers with multi-breakdown equivalents. Executing a materialized endpoint now filters using `breakdown_value[N]` indexing for multi-breakdown queries. 
- **CTE variable support** — Extended `VariableInWhereFinder` and `MaterializationTransformer` to track which CTE a variable lives in. Variables in a CTE get their column added inside the CTE with a passthrough column at the top level. Rejects unsupported cases (variable in multiple CTEs, CTE variable + top-level JOINs).
- **Sentinel cleanup at two layers** — Replace sentinel strings in HogQL at materialization time (so S3 data is clean), and clean any remaining sentinels in the API response for inline and legacy data.
- **Detect "Other" bucket instead of hiding it** — `_prepare_insight_query_for_endpoint()` sets `breakdown_limit: 10000` (arbitrary) and keeps `breakdown_hide_other_aggregation: false`. If the "Other" sentinel appears in results, `capture_exception` fires for visibility while the sentinel is still cleaned to `"Other"` in the response.
- **Empty string → IS_NOT_SET** — Treat `""` variable values as `IS_NOT_SET` operator so both execution paths match null/missing properties consistently.
- **Materialization equivalence tests** — New test class inserts real ClickHouse events and asserts that the materialized+filtered path returns identical data to the original query with variables substituted inline.
- **Simplified** **`_variable_expr`** — Removed manual `JSONExtractString` wrapping in favor of plain `ast.Field` chains, since HogQL already handles property access resolution.

## How did you test this code?

- Equivalence tests comparing inline vs materialized execution for all variable patterns (equality, range, property, CTE)
- Snapshot tests for CTE transform output
- Unit test for "Other" sentinel detection + cleaning with mocked breakdown limit
- Played around with insight-based endpoints and executing them
- Played with variables in CTEs

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no