### PR TITLE
feat: Exponentially retry on BigQuery ServiceUnavailable

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -12,7 +12,15 @@ from django.conf import settings
 
 import pyarrow as pa
 import requests
-from google.api_core.exceptions import Forbidden, GoogleAPICallError, NotFound, ServiceUnavailable, TooManyRequests
+from google.api_core.exceptions import (
+    Forbidden,
+    GatewayTimeout,
+    GoogleAPICallError,
+    InternalServerError,
+    NotFound,
+    ServiceUnavailable,
+    TooManyRequests,
+)
 from google.cloud import bigquery
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
 from google.oauth2 import service_account
@@ -730,7 +738,7 @@ class BigQueryClient:
                     raise BigQueryQuotaExceededError(err.message) from err
 
                 raise
-            except (TooManyRequests, ServiceUnavailable):
+            except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError):
                 self.logger.exception(
                     "LoadJob rate limit exceeded",
                     attempt=attempt,

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -740,7 +740,7 @@ class BigQueryClient:
                 raise
             except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError):
                 self.logger.exception(
-                    "LoadJob rate limit exceeded",
+                    "LoadJob transient error encountered",
                     attempt=attempt,
                 )
                 time.sleep(min(max_retry, initial_retry * (backoff_factor**attempt)))

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -12,7 +12,7 @@ from django.conf import settings
 
 import pyarrow as pa
 import requests
-from google.api_core.exceptions import Forbidden, GoogleAPICallError, NotFound, TooManyRequests
+from google.api_core.exceptions import Forbidden, GoogleAPICallError, NotFound, ServiceUnavailable, TooManyRequests
 from google.cloud import bigquery
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
 from google.oauth2 import service_account
@@ -730,7 +730,7 @@ class BigQueryClient:
                     raise BigQueryQuotaExceededError(err.message) from err
 
                 raise
-            except TooManyRequests:
+            except (TooManyRequests, ServiceUnavailable):
                 self.logger.exception(
                     "LoadJob rate limit exceeded",
                     attempt=attempt,

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -738,12 +738,24 @@ class BigQueryClient:
                     raise BigQueryQuotaExceededError(err.message) from err
 
                 raise
-            except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError):
+            except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError) as err:
+                backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
                 self.logger.exception(
-                    "LoadJob transient error encountered",
-                    attempt=attempt,
+                    "LoadJob transient error encountered", attempt=attempt, backoff=backoff, error_code=err.code
                 )
-                time.sleep(min(max_retry, initial_retry * (backoff_factor**attempt)))
+                self.external_logger.error(  # noqa: TRY400
+                    "Encountered a service-side issue that will be retried in %d seconds, this is attempt number %d."
+                    " These type of errors indicate BigQuery may be under too much load from all sources. You may have"
+                    " to check with BigQuery if it keeps happening consistently."
+                    " Error: %s",
+                    backoff,
+                    attempt,
+                    err,
+                    attempt=attempt,
+                    backoff=backoff,
+                    error_code=err.code,
+                )
+                time.sleep(backoff)
                 attempt += 1
             else:
                 return result


### PR DESCRIPTION
## Problem

We have exponential retries for bigquery jobs that fail, but only on `TooManyRequests`. BigQuery also recommends retrying on 500, 503 and 504 errors.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Retry on `ServiceUnavailable` (`503`), `GatewayTimeout` (`504`) and `InternalServerError` (`500`) errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
