### PR TITLE
fix: dashboards mount a listener per insight to do the same thing, can just have one global listener

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -14,6 +14,16 @@ type TooltipInstance = {
 
 const tooltipInstances = new Map<string, TooltipInstance>()
 
+let globalScrollEndListenerActive = false
+
+function initGlobalScrollEndListener(): void {
+    if (globalScrollEndListenerActive) {
+        return
+    }
+    globalScrollEndListenerActive = true
+    document.addEventListener('scrollend', () => hideTooltip(), { capture: true, passive: true })
+}
+
 export function ensureTooltip(id: string): [Root, HTMLElement] {
     let instance = tooltipInstances.get(id)
 
@@ -155,14 +165,9 @@ export function useInsightTooltip(): {
 } {
     const tooltipId = useMemo(() => Math.random().toString(36).substring(2, 11), [])
 
-    // Hide tooltip on scroll and clean up on unmount
     useOnMountEffect(() => {
-        const handleScrollEnd = (): void => hideTooltip(tooltipId)
-        // Tooltips are absolutely positioned on document.body and don't move with their chart.
-        // Use capture to catch scrollend from any scrollable ancestor (main, AI chat, side panels, etc.)
-        document.addEventListener('scrollend', handleScrollEnd, true)
+        initGlobalScrollEndListener()
         return () => {
-            document.removeEventListener('scrollend', handleScrollEnd, true)
             cleanupTooltip(tooltipId)
         }
     })


### PR DESCRIPTION
spotted while investigating janky dashboard scroll in safari 

certain it isn't the cause but tidied to register one global listener that hides tooltips than have every insight do it themeselves