### PR TITLE
fix: improve dashboard tile visibility interactions on scroll which are super expensive in safari

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -44,6 +44,8 @@ import {
 import { ResizeHandle1D, ResizeHandle2D } from '../handles'
 import { InsightMeta } from './InsightMeta'
 
+const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
+
 export interface InsightCardProps extends Resizeable {
     /** Insight to display. */
     insight: QueryBasedInsightModel
@@ -140,7 +142,7 @@ function InsightCardInternal(
     ref: React.Ref<HTMLDivElement>
 ): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { ref: inViewRef, inView } = useInView()
+    const { ref: inViewRef, inView } = useInView({ rootMargin: '500px' })
     const { isVisible: isPageVisible } = usePageVisibility()
 
     /** Wether the page is active and the line graph is currently in view. Used to free resources, by not rendering
@@ -149,9 +151,9 @@ function InsightCardInternal(
      * We add an extra check to make sure all insights are visible in Storybook.
      */
     const isVisible =
-        featureFlags[FEATURE_FLAGS.EXPERIMENTAL_DASHBOARD_ITEM_RENDERING] === true
-            ? (inView && isPageVisible) || inStorybook() || inStorybookTestRunner()
-            : true
+        featureFlags[FEATURE_FLAGS.EXPERIMENTAL_DASHBOARD_ITEM_RENDERING] === false
+            ? true
+            : IS_STORYBOOK || placement === DashboardPlacement.Export || (inView && isPageVisible)
 
     const mergedRefs = useMergeRefs([ref, inViewRef])
 


### PR DESCRIPTION
scrolling the posthog home dashboard is super janky in safari

this is hard to reproduce locally

with prod open running:

```
document.querySelectorAll('.InsightCard__viz canvas').forEach(el => el.style.display = 'none')
```

removed the janky scrolling all together

running: 

```
document.querySelectorAll('.react-grid-item').forEach(el => new IntersectionObserver((entries) => { entries.forEach(e => e.target.querySelectorAll('canvas').forEach(c => c.style.display = e.isIntersecting ? '' : 'none')) }, { rootMargin: '500px' }).observe(el)
```

also worked

so, let's codify that