### PR TITLE
fix(llma): Add tabId support to llmAnalyticsToolsLogic

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -51,6 +51,7 @@ import { llmAnalyticsDashboardLogic } from './tabs/llmAnalyticsDashboardLogic'
 import { llmAnalyticsErrorsLogic } from './tabs/llmAnalyticsErrorsLogic'
 import { getDefaultGenerationsColumns, llmAnalyticsGenerationsLogic } from './tabs/llmAnalyticsGenerationsLogic'
 import { llmAnalyticsSessionsViewLogic } from './tabs/llmAnalyticsSessionsViewLogic'
+import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 import { llmAnalyticsTracesTabLogic } from './tabs/llmAnalyticsTracesTabLogic'
 import { llmAnalyticsUsersLogic } from './tabs/llmAnalyticsUsersLogic'
 import { getTraceTimestamp, sanitizeTraceUrlSearchParams, truncateValue } from './utils'
@@ -411,7 +412,9 @@ export function LLMAnalyticsScene({ tabId }: { tabId?: string }): JSX.Element {
                                 <BindLogic logic={llmAnalyticsErrorsLogic} props={{ tabId }}>
                                     <BindLogic logic={llmAnalyticsUsersLogic} props={{ tabId }}>
                                         <BindLogic logic={llmAnalyticsSessionsViewLogic} props={{ tabId }}>
-                                            <LLMAnalyticsSceneContent />
+                                            <BindLogic logic={llmAnalyticsToolsLogic} props={{ tabId }}>
+                                                <LLMAnalyticsSceneContent />
+                                            </BindLogic>
                                         </BindLogic>
                                     </BindLogic>
                                 </BindLogic>

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
@@ -10,11 +10,17 @@ import toolsQueryTemplate from '../../backend/queries/tools.sql?raw'
 import { SortDirection, SortState, llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import type { llmAnalyticsToolsLogicType } from './llmAnalyticsToolsLogicType'
 
+export interface LLMAnalyticsToolsLogicProps {
+    tabId?: string
+}
+
 export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'tabs', 'llmAnalyticsToolsLogic']),
-    connect(() => ({
+    key((props: LLMAnalyticsToolsLogicProps) => props.tabId || 'default'),
+    props({} as LLMAnalyticsToolsLogicProps),
+    connect((props: LLMAnalyticsToolsLogicProps) => ({
         values: [
-            llmAnalyticsSharedLogic,
+            llmAnalyticsSharedLogic({ tabId: props.tabId }),
             ['dateFilter', 'shouldFilterTestAccounts', 'propertyFilters'],
             groupsModel,
             ['groupsTaxonomicTypes'],


### PR DESCRIPTION
## Problem

The `llmAnalyticsToolsLogic` was not properly scoped to individual tabs, unlike other analytics logics in the scene. This could cause state conflicts when multiple tabs are open simultaneously.

## Changes

- Added `LLMAnalyticsToolsLogicProps` interface with optional `tabId` parameter
- Updated `llmAnalyticsToolsLogic` to use `key()` for tab-specific logic instances
- Modified the `connect()` function to pass `tabId` to `llmAnalyticsSharedLogic`
- Wrapped `LLMAnalyticsSceneContent` with `BindLogic` for `llmAnalyticsToolsLogic` in `LLMAnalyticsScene`
- Added missing import for `llmAnalyticsToolsLogic` in the scene component

## How did you test this code?

This change follows the established pattern already used by other analytics logics in the scene (`llmAnalyticsErrorsLogic`, `llmAnalyticsUsersLogic`, `llmAnalyticsSessionsViewLogic`). The modifications are straightforward structural changes that align the tools logic with the existing architecture. Existing tests should continue to pass.

https://claude.ai/code/session_01RaA9FGT5GTwXqCVnsqqPVU