### PR TITLE
fix(insights): show breakdown label only in single series charts

### DIFF
--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -679,6 +679,28 @@ describe('insightVizDataLogic', () => {
             }).toMatchValues({ isSingleSeriesDefinition: true })
         })
 
+        it('returns true for single series WITH breakdowns array', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource({
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            name: '$pageview',
+                            event: '$pageview',
+                        },
+                    ],
+                    breakdownFilter: {
+                        breakdowns: [
+                            {
+                                property: '$browser',
+                                type: 'event',
+                            },
+                        ],
+                    },
+                } as Partial<TrendsQuery>)
+            }).toMatchValues({ isSingleSeriesDefinition: true })
+        })
+
         it('returns true for multiple series with single formula', () => {
             expectLogic(builtInsightVizDataLogic, () => {
                 builtInsightVizDataLogic.actions.updateQuerySource({
@@ -699,6 +721,39 @@ describe('insightVizDataLogic', () => {
                     },
                 } as Partial<TrendsQuery>)
             }).toMatchValues({ isSingleSeriesDefinition: true })
+        })
+    })
+
+    describe('isBreakdownSeries', () => {
+        it('returns false without breakdown filter', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource({
+                    series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+                } as Partial<TrendsQuery>)
+            }).toMatchValues({ isBreakdownSeries: false })
+        })
+
+        it('returns true with singular breakdown object', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource({
+                    series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+                    breakdownFilter: {
+                        breakdown: '$browser',
+                        breakdown_type: 'event',
+                    },
+                } as Partial<TrendsQuery>)
+            }).toMatchValues({ isBreakdownSeries: true })
+        })
+
+        it('returns true with breakdowns array', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource({
+                    series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+                    breakdownFilter: {
+                        breakdowns: [{ property: '$browser', type: 'event' }],
+                    },
+                } as Partial<TrendsQuery>)
+            }).toMatchValues({ isBreakdownSeries: true })
         })
     })
 })

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -335,7 +335,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         isBreakdownSeries: [
             (s) => [s.breakdownFilter],
             (breakdownFilter): boolean => {
-                return !!breakdownFilter?.breakdown
+                return !!breakdownFilter?.breakdown || (breakdownFilter?.breakdowns?.length ?? 0) > 0
             },
         ],
 

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -99,6 +99,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 'isNonTimeSeriesDisplay',
                 'isSingleSeriesOutput',
                 'isSingleSeriesDefinition',
+                'isBreakdownSeries',
                 'hasLegend',
                 'showLegend',
                 'vizSpecificOptions',

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -38,6 +38,7 @@ export function ActionsHorizontalBar({
         querySource,
         breakdownFilter,
         isSingleSeriesDefinition,
+        isBreakdownSeries,
         getTrendsColor,
         getTrendsHidden,
         theme,
@@ -102,7 +103,7 @@ export function ActionsHorizontalBar({
             formula={formula}
             showValuesOnSeries={showValuesOnSeries}
             ignoreActionsInSeriesLabels={
-                context?.ignoreActionsInSeriesLabels || (isSingleSeriesDefinition && !!breakdownFilter?.breakdown)
+                context?.ignoreActionsInSeriesLabels || (isSingleSeriesDefinition && isBreakdownSeries)
             }
             isStacked={false}
             inCardView={inCardView}


### PR DESCRIPTION
## Problem

Showing the event label for insights that have only one series is redundant. Also, can break responsiveness and hide/trim the breakdown label, which is more meaningful to keep visible than the event.

https://posthog.slack.com/archives/C0ACRAMJUAG/p1771948555424389
Related to #47172 

<img width="1204" height="654" alt="Screenshot 2026-02-27 at 11 41 05" src="https://github.com/user-attachments/assets/e51f4148-b737-4d5e-9c15-6b77ad0182c7" />


## Changes

<img width="1187" height="641" alt="Screenshot 2026-02-27 at 11 40 17" src="https://github.com/user-attachments/assets/76d73463-3c44-4779-8ac3-ad0bf684c724" />


## How did you test this code?

Manually + added tests

## Publish to changelog?

No
