### PR TITLE
fix(phai): azure embeddings client failures

### DIFF
--- a/ee/hogai/utils/embeddings.py
+++ b/ee/hogai/utils/embeddings.py
@@ -8,17 +8,33 @@ from azure.ai.inference.aio import EmbeddingsClient as EmbeddingsClientAsync
 from azure.core.credentials import AzureKeyCredential
 
 
+def _validate_azure_config() -> tuple[str, str]:
+    endpoint = str(settings.AZURE_INFERENCE_ENDPOINT).strip()
+    credential = str(settings.AZURE_INFERENCE_CREDENTIAL).strip()
+    if not endpoint:
+        raise ValueError(
+            "AZURE_INFERENCE_ENDPOINT is not configured. The Azure embeddings client requires a valid endpoint URL."
+        )
+    if not credential:
+        raise ValueError(
+            "AZURE_INFERENCE_CREDENTIAL is not configured. The Azure embeddings client requires a valid API key."
+        )
+    return endpoint, credential
+
+
 def get_azure_embeddings_client() -> EmbeddingsClient:
+    endpoint, credential = _validate_azure_config()
     return EmbeddingsClient(
-        endpoint=settings.AZURE_INFERENCE_ENDPOINT,
-        credential=AzureKeyCredential(settings.AZURE_INFERENCE_CREDENTIAL),
+        endpoint=endpoint,
+        credential=AzureKeyCredential(credential),
     )
 
 
 def get_async_azure_embeddings_client() -> EmbeddingsClientAsync:
+    endpoint, credential = _validate_azure_config()
     return EmbeddingsClientAsync(
-        endpoint=settings.AZURE_INFERENCE_ENDPOINT,
-        credential=AzureKeyCredential(settings.AZURE_INFERENCE_CREDENTIAL),
+        endpoint=endpoint,
+        credential=AzureKeyCredential(credential),
     )
 
 

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -101,8 +101,8 @@ INKEEP_API_KEY = get_from_env("INKEEP_API_KEY", "")
 MISTRAL_API_KEY = get_from_env("MISTRAL_API_KEY", "")
 GEMINI_API_KEY = get_from_env("GEMINI_API_KEY", "")
 PPLX_API_KEY = get_from_env("PPLX_API_KEY", "")
-AZURE_INFERENCE_ENDPOINT = get_from_env("AZURE_INFERENCE_ENDPOINT", "")
-AZURE_INFERENCE_CREDENTIAL = get_from_env("AZURE_INFERENCE_CREDENTIAL", "")
+AZURE_INFERENCE_ENDPOINT = get_from_env("AZURE_INFERENCE_ENDPOINT", "", type_cast=str)
+AZURE_INFERENCE_CREDENTIAL = get_from_env("AZURE_INFERENCE_CREDENTIAL", "", type_cast=str)
 BRAINTRUST_API_KEY = get_from_env("BRAINTRUST_API_KEY", "")
 
 LLMA_EVAL_OPENAI_API_KEY = get_from_env("LLMA_EVAL_OPENAI_API_KEY", "")
@@ -122,9 +122,6 @@ SQS_QUEUES = {
         "type": "billing",
     },
 }
-
-AZURE_INFERENCE_ENDPOINT = get_from_env("AZURE_INFERENCE_ENDPOINT", "", type_cast=str)
-AZURE_INFERENCE_CREDENTIAL = get_from_env("AZURE_INFERENCE_CREDENTIAL", "", type_cast=str)
 
 # Salesforce API credentials
 SALESFORCE_USERNAME = get_from_env("SF_USERNAME", "", type_cast=str)


### PR DESCRIPTION
## Summary

Azure AI Inference SDK's `EmbeddingsClientConfiguration` only validates `if endpoint is None:` not empty strings.