### PR TITLE
feat(nodejs): support scheduling multiple promises in PromiseScheduler

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -465,7 +465,8 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase<CdpSourceWebhooks
             : await this.executeHogFunction(req, hogFunction, hogFunctionState)
 
         void this.promiseScheduler.schedule(
-            Promise.all([this.hogFunctionMonitoringService.flush(), this.hogWatcher.observeResultsBuffered(result)])
+            this.hogFunctionMonitoringService.flush(),
+            this.hogWatcher.observeResultsBuffered(result)
         )
 
         return result

--- a/nodejs/src/ingestion/pipelines/side-effect-handling-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/side-effect-handling-pipeline.ts
@@ -3,6 +3,9 @@ import { sideEffectResultCounter } from './metrics'
 
 export interface PromiseSchedulerInterface {
     schedule<T>(promise: Promise<T>): Promise<T>
+    schedule<T extends readonly [Promise<unknown>, Promise<unknown>, ...Promise<unknown>[]]>(
+        ...promises: T
+    ): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }>
 }
 
 export type SideEffectHandlingConfig = {

--- a/nodejs/src/utils/promise-scheduler.test.ts
+++ b/nodejs/src/utils/promise-scheduler.test.ts
@@ -12,12 +12,11 @@ describe('PromiseScheduler', () => {
             let resolve: () => void
             const promise = new Promise<void>((r) => (resolve = r))
 
-            scheduler.schedule(promise)
+            void scheduler.schedule(promise)
             expect(scheduler.promises.size).toBe(1)
 
             resolve!()
             await promise
-            // .finally is async, need a tick for cleanup
             await Promise.resolve()
             expect(scheduler.promises.size).toBe(0)
         })
@@ -26,7 +25,7 @@ describe('PromiseScheduler', () => {
             let reject: (err: Error) => void
             const promise = new Promise<void>((_, r) => (reject = r))
 
-            scheduler.schedule(promise)
+            void scheduler.schedule(promise)
             expect(scheduler.promises.size).toBe(1)
 
             reject!(new Error('fail'))
@@ -49,7 +48,7 @@ describe('PromiseScheduler', () => {
             const p1 = new Promise<void>((r) => (resolve1 = r))
             const p2 = new Promise<void>((r) => (resolve2 = r))
 
-            scheduler.schedule(p1, p2)
+            void scheduler.schedule(p1, p2)
             expect(scheduler.promises.size).toBe(2)
 
             resolve1!()
@@ -99,8 +98,8 @@ describe('PromiseScheduler', () => {
             const p1 = new Promise<string>((r) => (resolve1 = r))
             const p2 = new Promise<string>((r) => (resolve2 = r))
 
-            scheduler.schedule(p1)
-            scheduler.schedule(p2)
+            void scheduler.schedule(p1)
+            void scheduler.schedule(p2)
 
             let allDone = false
             const waiting = scheduler.waitForAll().then(() => (allDone = true))
@@ -117,8 +116,8 @@ describe('PromiseScheduler', () => {
 
     describe('waitForAllSettled', () => {
         it('should resolve even when some promises reject', async () => {
-            scheduler.schedule(Promise.resolve('ok'))
-            scheduler.schedule(Promise.reject(new Error('fail')).catch(() => {}))
+            void scheduler.schedule(Promise.resolve('ok'))
+            void scheduler.schedule(Promise.reject(new Error('fail')).catch(() => {}))
 
             const results = await scheduler.waitForAllSettled()
             expect(results).toHaveLength(2)

--- a/nodejs/src/utils/promise-scheduler.test.ts
+++ b/nodejs/src/utils/promise-scheduler.test.ts
@@ -1,0 +1,127 @@
+import { PromiseScheduler } from './promise-scheduler'
+
+describe('PromiseScheduler', () => {
+    let scheduler: PromiseScheduler
+
+    beforeEach(() => {
+        scheduler = new PromiseScheduler()
+    })
+
+    describe('schedule with a single promise', () => {
+        it('should track the promise and remove it on resolve', async () => {
+            let resolve: () => void
+            const promise = new Promise<void>((r) => (resolve = r))
+
+            scheduler.schedule(promise)
+            expect(scheduler.promises.size).toBe(1)
+
+            resolve!()
+            await promise
+            // .finally is async, need a tick for cleanup
+            await Promise.resolve()
+            expect(scheduler.promises.size).toBe(0)
+        })
+
+        it('should remove the promise on rejection', async () => {
+            let reject: (err: Error) => void
+            const promise = new Promise<void>((_, r) => (reject = r))
+
+            scheduler.schedule(promise)
+            expect(scheduler.promises.size).toBe(1)
+
+            reject!(new Error('fail'))
+            await promise.catch(() => {})
+            await Promise.resolve()
+            expect(scheduler.promises.size).toBe(0)
+        })
+
+        it('should return the same promise', () => {
+            const original = Promise.resolve(42)
+            const returned = scheduler.schedule(original)
+            expect(returned).toBe(original)
+        })
+    })
+
+    describe('schedule with multiple promises', () => {
+        it('should track each promise individually', async () => {
+            let resolve1: () => void
+            let resolve2: () => void
+            const p1 = new Promise<void>((r) => (resolve1 = r))
+            const p2 = new Promise<void>((r) => (resolve2 = r))
+
+            scheduler.schedule(p1, p2)
+            expect(scheduler.promises.size).toBe(2)
+
+            resolve1!()
+            await p1
+            await Promise.resolve()
+            expect(scheduler.promises.size).toBe(1)
+
+            resolve2!()
+            await p2
+            await Promise.resolve()
+            expect(scheduler.promises.size).toBe(0)
+        })
+
+        it('should return a combined result like Promise.all', async () => {
+            const p1 = Promise.resolve('hello')
+            const p2 = Promise.resolve(42)
+
+            const result = await scheduler.schedule(p1, p2)
+            expect(result).toEqual(['hello', 42])
+        })
+
+        it('should reject if any promise rejects', async () => {
+            const p1 = Promise.resolve('ok')
+            const p2 = Promise.reject(new Error('boom'))
+
+            await expect(scheduler.schedule(p1, p2)).rejects.toThrow('boom')
+        })
+
+        it('should handle three or more promises', async () => {
+            const p1 = Promise.resolve(1)
+            const p2 = Promise.resolve('two')
+            const p3 = Promise.resolve(true)
+
+            const result = await scheduler.schedule(p1, p2, p3)
+            expect(result).toEqual([1, 'two', true])
+        })
+    })
+
+    describe('waitForAll', () => {
+        it('should resolve immediately when no promises are tracked', async () => {
+            await expect(scheduler.waitForAll()).resolves.toEqual([])
+        })
+
+        it('should wait for all scheduled promises', async () => {
+            let resolve1: (v: string) => void
+            let resolve2: (v: string) => void
+            const p1 = new Promise<string>((r) => (resolve1 = r))
+            const p2 = new Promise<string>((r) => (resolve2 = r))
+
+            scheduler.schedule(p1)
+            scheduler.schedule(p2)
+
+            let allDone = false
+            const waiting = scheduler.waitForAll().then(() => (allDone = true))
+
+            resolve1!('a')
+            await Promise.resolve()
+            expect(allDone).toBe(false)
+
+            resolve2!('b')
+            await waiting
+            expect(allDone).toBe(true)
+        })
+    })
+
+    describe('waitForAllSettled', () => {
+        it('should resolve even when some promises reject', async () => {
+            scheduler.schedule(Promise.resolve('ok'))
+            scheduler.schedule(Promise.reject(new Error('fail')).catch(() => {}))
+
+            const results = await scheduler.waitForAllSettled()
+            expect(results).toHaveLength(2)
+        })
+    })
+})

--- a/nodejs/src/utils/promise-scheduler.ts
+++ b/nodejs/src/utils/promise-scheduler.ts
@@ -1,10 +1,17 @@
 export class PromiseScheduler {
     public readonly promises: Set<Promise<any>> = new Set()
 
-    public schedule<T>(promise: Promise<T>): Promise<T> {
-        this.promises.add(promise)
-        void promise.finally(() => this.promises.delete(promise))
-        return promise
+    public schedule<T>(promise: Promise<T>): Promise<T>
+    public schedule<T extends readonly [Promise<unknown>, Promise<unknown>, ...Promise<unknown>[]]>(
+        ...promises: T
+    ): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }>
+    public schedule(...promises: Promise<unknown>[]): Promise<unknown> {
+        for (const promise of promises) {
+            this.promises.add(promise)
+            const cleanup = () => this.promises.delete(promise)
+            promise.then(cleanup, cleanup)
+        }
+        return promises.length === 1 ? promises[0] : Promise.all(promises)
     }
 
     public async waitForAll() {


### PR DESCRIPTION
## Problem

The `PromiseScheduler` class currently only supports scheduling a single promise at a time. When multiple promises need to be tracked together, callers must wrap them in `Promise.all()` manually, which is verbose and error-prone.

## Changes

Enhanced `PromiseScheduler.schedule()` to accept multiple promises as variadic arguments:

- Added overloaded type signatures to properly type single vs. multiple promise scheduling
- Single promise: returns the promise as-is with proper type inference
- Multiple promises: returns `Promise.all()` result with tuple type preservation
- Updated cleanup logic to use `.then(cleanup, cleanup)` instead of `.finally()` for better performance
- Updated `PromiseSchedulerInterface` to reflect the new overloaded signatures
- Simplified call site in `cdp-source-webhooks.consumer.ts` to pass promises directly instead of wrapping in `Promise.all()`

## How did you test this code?

Added comprehensive unit tests covering:
- Single promise scheduling with resolve/reject scenarios
- Multiple promise scheduling with proper tracking and cleanup
- Return value type correctness for single and multiple promises
- `waitForAll()` and `waitForAllSettled()` methods with multiple promises
- Edge cases like empty promise sets

All tests pass and provide full coverage of the new functionality.

## Publish to changelog?

no

https://claude.ai/code/session_01WAjH2YapKhJoQDPwpW2Njh