### PR TITLE
fix: retry capture errors on ingestion tests

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/workflows.py
+++ b/posthog/temporal/ingestion_acceptance_test/workflows.py
@@ -33,7 +33,7 @@ class IngestionAcceptanceTestWorkflow(PostHogWorkflow):
         """
         result = await temporalio.workflow.execute_activity(
             run_ingestion_acceptance_tests,
-            start_to_close_timeout=timedelta(minutes=5),
+            start_to_close_timeout=timedelta(minutes=10),
             retry_policy=RetryPolicy(
                 maximum_attempts=1,
             ),

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -72,7 +72,10 @@ class TestFetchEventByUuid:
             call_kwargs = mock_post.call_args[1]
 
             assert call_kwargs["headers"] == {"Authorization": "Bearer phx_personal_key"}
-            assert call_kwargs["timeout"] == PostHogClient.HTTP_TIMEOUT_SECONDS
+            assert call_kwargs["timeout"] == (
+                PostHogClient.HTTP_CONNECT_TIMEOUT_SECONDS,
+                PostHogClient.HTTP_READ_TIMEOUT_SECONDS,
+            )
 
             request_body = call_kwargs["json"]
             assert request_body["query"]["kind"] == "HogQLQuery"


### PR DESCRIPTION
## Problem

The SDK capture methods do not retry on errors for POST requests which leads to failed test runs

## Changes

Wrap capture calls in a retry mechanism

## How did you test this code?