### PR TITLE
fix(llma): dashboard-reorder-tiles MCP tool returns 500

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1502,6 +1502,28 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         other_tile.refresh_from_db()
         assert other_tile.dashboard_id == other_dashboard.id
 
+    def test_update_tile_with_nonexistent_id_returns_400(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="test dashboard", created_by=self.user)
+        insight = Insight.objects.create(team=self.team, last_refresh=now())
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        self.dashboard_api.update_dashboard(
+            dashboard.id,
+            {"tiles": [{"id": 99999, "layouts": {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}}]},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_update_tile_without_id_returns_400(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="test dashboard", created_by=self.user)
+        insight = Insight.objects.create(team=self.team, last_refresh=now())
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        self.dashboard_api.update_dashboard(
+            dashboard.id,
+            {"tiles": [{"layouts": {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}}]},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
     def test_relations_on_insights_when_dashboards_were_deleted(self) -> None:
         filter_dict = {
             "events": [{"id": "$pageview"}],

--- a/services/mcp/src/schema/dashboards.ts
+++ b/services/mcp/src/schema/dashboards.ts
@@ -1,24 +1,27 @@
 import { z } from 'zod'
 
 export const DashboardTileSchema = z.object({
-    insight: z.object({
-        short_id: z.string(),
-        name: z.string(),
-        derived_name: z.string().nullable(),
-        description: z.string().nullable(),
-        query: z.object({
-            kind: z.union([z.literal('InsightVizNode'), z.literal('DataVisualizationNode')]),
-            source: z
-                .any()
-                .describe(
-                    'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused.'
-                ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
-        }),
-        created_at: z.string().nullish(),
-        updated_at: z.string().nullish(),
-        favorited: z.boolean().nullish(),
-        tags: z.array(z.string()).nullish(),
-    }),
+    id: z.number(),
+    insight: z
+        .object({
+            short_id: z.string(),
+            name: z.string(),
+            derived_name: z.string().nullable(),
+            description: z.string().nullable(),
+            query: z.object({
+                kind: z.union([z.literal('InsightVizNode'), z.literal('DataVisualizationNode')]),
+                source: z
+                    .any()
+                    .describe(
+                        'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused.'
+                    ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
+            }),
+            created_at: z.string().nullish(),
+            updated_at: z.string().nullish(),
+            favorited: z.boolean().nullish(),
+            tags: z.array(z.string()).nullish(),
+        })
+        .nullable(),
     order: z.number(),
     color: z.string().nullish(),
     layouts: z.record(z.any()).nullish(),


### PR DESCRIPTION
## Problem

The MCP `dashboard-reorder-tiles` tool consistently failed with HTTP 500 Internal Server Error (100% failure rate). This was the only non-functional tool in the MCP suite.

## Root Causes

Three chained bugs:

1. **Missing tile IDs in `dashboard-get`**: The `DashboardTileSchema` Zod schema omitted the `id` field, so LLMs never learned actual tile IDs and fabricated them when calling `dashboard-reorder-tiles`
2. **Text tiles rejected by schema**: The `insight` field was non-nullable in the Zod schema, but text tiles have `insight: null`, causing `dashboard-get` to fail entirely on dashboards with text tiles
3. **Backend creates ghost tiles**: The `_update_tiles` method called `update_or_create` with fabricated tile IDs, attempting to INSERT new rows without `insight` or `text`, violating the `dash_tile_exactly_one_related_object` database check constraint → 500 error

## Changes

### MCP Schema (`services/mcp/src/schema/dashboards.ts`)
- Add `id: z.number()` to `DashboardTileSchema`
- Change `insight: z.object({...})` to `insight: z.object({...}).nullable()`

### Backend (`posthog/api/dashboards/dashboard.py`)
- Replace `update_or_create` in `_update_tiles` with explicit `get` + field-level update
- Return 400 with clear error message when tile ID doesn't exist, instead of 500 from DB constraint violation

### Tests (`posthog/api/test/dashboards/test_dashboard.py`)
- Add `test_update_tile_with_nonexistent_id_returns_400`
- Add `test_update_tile_without_id_returns_400`

## Verification

- `dashboard-get` now returns tile IDs and handles text tiles correctly
- `dashboard-reorder-tiles` with valid IDs works end-to-end
- `dashboard-reorder-tiles` with invalid IDs returns 400 (not 500)

Fixes #3877515679

🤖 Generated with [Claude Code](https://claude.com/claude-code)