### PR TITLE
fix: Move sleep to async part of the code

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -735,10 +735,12 @@ class BigQueryClient:
                     backoff=backoff,
                     error_code=err.code,
                 )
+
                 await asyncio.sleep(backoff)
                 attempt += 1
 
-        return result
+            else:
+                return result
 
     def _run_load_job(self, file, bq_table, job_config):
         """Run a BigQuery LoadJob and return its result.

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -747,20 +747,19 @@ class BigQueryClient:
 
         This method blocks and should only be run on an executor.
         """
-        while True:
-            try:
-                load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
-                result = load_job.result()
-            except Forbidden as err:
-                if err.reason == "quotaExceeded":
-                    self.external_logger.exception(
-                        "BigQuery quota long-term limit exceeded. We will attempt to retry the batch export with an exponential back-off, but it may take several minutes or longer until the quota is restored."
-                    )
-                    raise BigQueryQuotaExceededError(err.message) from err
+        try:
+            load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
+            result = load_job.result()
+        except Forbidden as err:
+            if err.reason == "quotaExceeded":
+                self.external_logger.exception(
+                    "BigQuery quota long-term limit exceeded. We will attempt to retry the batch export with an exponential back-off, but it may take several minutes or longer until the quota is restored."
+                )
+                raise BigQueryQuotaExceededError(err.message) from err
 
-                raise
-            else:
-                return result
+            raise
+        else:
+            return result
 
 
 class MissingRequiredPermissionsError(Exception):

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -710,17 +710,6 @@ class BigQueryClient:
 
         self.logger.info("Waiting for BigQuery load job", format=format, table_id=table.name)
 
-        result = await asyncio.to_thread(self._run_load_job, file, bq_table, job_config=job_config)
-
-        return result
-
-    def _run_load_job(self, file, bq_table, job_config):
-        """Run a BigQuery LoadJob and return its result.
-
-        This method blocks and should only be run on an executor.
-
-        Ensures we retry on transient ``TooManyRequests`` errors.
-        """
         initial_retry = 1
         backoff_factor = 2
         max_retry = 32
@@ -728,16 +717,7 @@ class BigQueryClient:
 
         while True:
             try:
-                load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
-                result = load_job.result()
-            except Forbidden as err:
-                if err.reason == "quotaExceeded":
-                    self.external_logger.exception(
-                        "BigQuery quota long-term limit exceeded. We will attempt to retry the batch export with an exponential back-off, but it may take several minutes or longer until the quota is restored."
-                    )
-                    raise BigQueryQuotaExceededError(err.message) from err
-
-                raise
+                result = await asyncio.to_thread(self._run_load_job, file, bq_table, job_config=job_config)
             except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError) as err:
                 backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
                 self.logger.exception(
@@ -755,8 +735,28 @@ class BigQueryClient:
                     backoff=backoff,
                     error_code=err.code,
                 )
-                time.sleep(backoff)
+                await asyncio.sleep(backoff)
                 attempt += 1
+
+        return result
+
+    def _run_load_job(self, file, bq_table, job_config):
+        """Run a BigQuery LoadJob and return its result.
+
+        This method blocks and should only be run on an executor.
+        """
+        while True:
+            try:
+                load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
+                result = load_job.result()
+            except Forbidden as err:
+                if err.reason == "quotaExceeded":
+                    self.external_logger.exception(
+                        "BigQuery quota long-term limit exceeded. We will attempt to retry the batch export with an exponential back-off, but it may take several minutes or longer until the quota is restored."
+                    )
+                    raise BigQueryQuotaExceededError(err.message) from err
+
+                raise
             else:
                 return result
 


### PR DESCRIPTION
## Problem

~`time.sleep` may be blocking.~ All resources I've found indicate this is likely not the issue.

However, having too many infinite loops could starve the executor's thread pool. So, we should still consider waiting outside the thread pool so that others can get a thread to run. The downside is more context switching when we retry a lot, but this should be rare to begin with (and we sleep up to 32 seconds, so plenty of time to run other stuff). 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Move wait loop outside blocking function.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
