### PR TITLE
fix: Improve enum handling for google ads

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -1,6 +1,5 @@
 import typing
 import datetime as dt
-import operator
 import collections.abc
 
 from django.conf import settings
@@ -117,6 +116,33 @@ class GoogleAdsColumn(Column):
         self.is_enum = data_type == ga_enums.GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType.ENUM
         self.is_message = data_type == ga_enums.GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType.MESSAGE
         self.is_date = data_type == ga_enums.GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType.DATE
+
+    @staticmethod
+    def _safe_get_enum(enum_cls, value) -> str:
+        try:
+            return enum_cls(value).name
+        except ValueError:
+            return str(value)
+
+    def resolve_value(self, value):
+        """Coerce a raw protobuf value to the appropriate Python type."""
+        if self.is_enum:
+            enum_cls = _resolve_protobuf_message_type_url(self.type_url)
+            if self.is_repeatable:
+                return [self._safe_get_enum(enum_cls, v) for v in value]
+            return self._safe_get_enum(enum_cls, value)
+
+        if self.is_message:
+            if self.is_repeatable:
+                return list(map(MessageToJson, value))
+            return MessageToJson(value)
+
+        if self.is_date:
+            if self.is_repeatable:
+                return [dt.date.fromisoformat(v[:10]) if v else None for v in value]
+            return dt.date.fromisoformat(value[:10]) if value else None
+
+        return value
 
     def to_arrow_field(self):
         """Return the Arrow type associated with this column.
@@ -401,7 +427,6 @@ def _stream_response_as_dicts(
     resource we are querying, and everything else unset.
     """
     field_paths = response.field_mask.paths
-    get_enum_name = operator.attrgetter("name")
     path_to_column = {col.qualified_name: col for col in table}
 
     for row in response.results:
@@ -410,27 +435,6 @@ def _stream_response_as_dicts(
         for path in field_paths:
             value = _traverse_attributes(row, *path.split("."))
             column = path_to_column[path]
-
-            # TODO: Special type handling moved somewhere else.
-            if column.is_enum:
-                enum_cls = _resolve_protobuf_message_type_url(column.type_url)
-                if column.is_repeatable:
-                    value = list(map(get_enum_name, map(enum_cls, value)))
-                else:
-                    value = enum_cls(value).name
-
-            elif column.is_message:
-                if column.is_repeatable:
-                    value = list(map(MessageToJson, value))
-                else:
-                    value = MessageToJson(value)
-
-            elif column.is_date:
-                if column.is_repeatable:
-                    value = [dt.date.fromisoformat(v[:10]) if v else None for v in value]
-                else:
-                    value = dt.date.fromisoformat(value[:10]) if value else None
-
-            row_dict[column.name] = value
+            row_dict[column.name] = column.resolve_value(value)
 
         yield row_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "drf-spectacular~=0.28.0",
     "emoji==2.14.1",
     "geoip2==4.6.0",
-    "google-ads==29.0.0",
+    "google-ads==29.2.0",
     "google-cloud-bigquery==3.26",
     "google-genai==1.46.0",
     "granian[uvloop,reload,pname]==2.5.5",

--- a/uv.lock
+++ b/uv.lock
@@ -2370,7 +2370,7 @@ wheels = [
 
 [[package]]
 name = "google-ads"
-version = "29.0.0"
+version = "29.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -2382,9 +2382,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/d5/bdc19aa181af685fa17b904d69440ad8821ace603aae704004882db984dc/google_ads-29.0.0.tar.gz", hash = "sha256:f0ac0ac1cbe52c3387dd13fd337cf72667751d4474240b85b1eb0dd1ebc9f9e8", size = 9427948, upload-time = "2026-01-28T22:27:37.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/eb/92edcc232060fc3bdee6f3f147f986db844083b157794658e9bb6ff05cc9/google_ads-29.2.0.tar.gz", hash = "sha256:d2331f2a79447792f80ce2a17f46eebc4003d3e4228b2e580e20af313dce8ed0", size = 9628865, upload-time = "2026-02-25T21:37:44.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/de/5e3b5f3260bde4e54e7d8360ba2e9ee0faa3b326c8d3bfc9343a269bfb12/google_ads-29.0.0-py3-none-any.whl", hash = "sha256:133652c0bafc92591b06a991bc3500b188cdaeb046be2b3193c9ca1cb30f86df", size = 18109098, upload-time = "2026-01-28T22:27:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a3/4f3cef090c97dd307048b6e3075cdc45f913584c32c6a8d45de71ad31702/google_ads-29.2.0-py3-none-any.whl", hash = "sha256:264d98b5a08158702d91248be633e104436da522b2a513fc90f983e39553380d", size = 18308345, upload-time = "2026-02-25T21:37:41.956Z" },
 ]
 
 [[package]]
@@ -5089,7 +5089,7 @@ requires-dist = [
     { name = "geoip2", specifier = "==4.6.0" },
     { name = "gitpython", specifier = "~=3.1.44" },
     { name = "glom", specifier = "~=24.11.0" },
-    { name = "google-ads", specifier = "==29.0.0" },
+    { name = "google-ads", specifier = "==29.2.0" },
     { name = "google-cloud-bigquery", specifier = "==3.26" },
     { name = "google-genai", specifier = "==1.46.0" },
     { name = "granian", extras = ["uvloop", "reload", "pname"], specifier = "==2.5.5" },


### PR DESCRIPTION
## Problem

Google ad source syncs were [failing for a customer](https://posthoghelp.zendesk.com/agent/tickets/51838) because a new enum value was added:

```
ValueError: 24 is not a valid ConversionActionCategoryEnum.ConversionActionCategory
```

## Changes

- Fall back to using the raw value if it doesn't exist on the Enum - I believe this is safe because we don't use the value downstream, it just gets stored in the synced table
- Upgrade the google-ads library version - it was [added recently](https://github.com/googleads/google-ads-python/blame/8eef1d09c1c45c28ea81aae7d8f3a833b59e83c1/google/ads/googleads/v23/enums/types/conversion_action_category.py#L140). This includes the `v23_1` API release which adds the `YOUTUBE_FOLLOW_ON_VIEWS` enum value (which seems to be bundled under the same `v23` module, so no import changes needed)
- Cleaned up a TODO by moving the value resolution logic onto the `GoogleAdsColumn` class

I thought about possibly logging the failure, but wasn't sure there was a clean way of doing this without a lot of logging noise. It should be evident from the sync that something has changed because the raw enum will start appearing?

## How did you test this code?

Unit tests are still passing