### PR TITLE
Context sidebar labels

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
@@ -82,7 +82,7 @@ export function SidePanelNavigation({ activeTab, onTabChange, children }: SidePa
                                         )}
                                         <span
                                             className={cn(
-                                                'hidden @[540px]/side-panel:block text-tertiary group-hover:text-primary',
+                                                'hidden @[540px]/side-panel:block text-tertiary group-hover:text-primary whitespace-nowrap',
                                                 activeTab === tab ? 'text-primary' : 'text-tertiary'
                                             )}
                                         >


### PR DESCRIPTION
## Problem

Tab labels in the context sidebar were wrapping onto multiple lines, causing UI inconsistencies and poor readability.

## Changes

Added the `whitespace-nowrap` utility class to the tab label span within `SidePanelNavigation.tsx` to ensure labels remain on a single line.

## How did you test this code?

As an agent, I have not manually tested this change. The fix involves a CSS utility class (`whitespace-nowrap`) to prevent text wrapping, which can be visually verified by navigating to a page with the context sidebar and observing tab labels.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1772205497796859?thread_ts=1772205497.796859&cid=C0ACRAMJUAG)

<p><a href="https://cursor.com/agents/bc-fc7fb1a3-474d-55c2-ab3b-cf59381ac0c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc7fb1a3-474d-55c2-ab3b-cf59381ac0c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

