### PR TITLE
fix(modeling): numbers() is not a parent for a model

### DIFF
--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -193,7 +193,11 @@ def get_parents_from_model_query(team: Team, model_name: str, model_query: str) 
                 queries.extend(list(extract_select_queries(join.table)))
                 break
 
-            if isinstance(join.table, ast.Placeholder):
+            if join.table_args is not None:
+                # Table functions like numbers(), s3(), etc. are not real parents
+                join = join.next_join
+                continue
+            elif isinstance(join.table, ast.Placeholder):
                 parent_name = join.table.field
             elif isinstance(join.table, ast.Field):
                 parent_name = ".".join(str(s) for s in join.table.chain)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
trying to mat numbers() fails with a parent not found error

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- skip nodes that have table_args (like numbers())
- update tests that were expecting numbers to be a parent
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- tests (though i changed some, so worth an extra patient look)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
