### PR TITLE
fix(groups): apply group filter on dashboard in view mode

### DIFF
--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -19,24 +19,23 @@ function GroupDetailDashboard({
     groupData: Group
 }): JSX.Element {
     const { groupTypeName } = useValues(groupLogic)
-    const { setProperties, setLoadLayoutFromServerOnPreview } = useActions(
-        dashboardLogic({ id: groupTypeDetailDashboard })
-    )
+    const { setExternalFilters } = useActions(dashboardLogic({ id: groupTypeDetailDashboard }))
 
     useEffect(() => {
         if (groupTypeDetailDashboard && groupData) {
-            setLoadLayoutFromServerOnPreview(true)
-            setProperties([
-                {
-                    type: PropertyFilterType.EventMetadata,
-                    key: `$group_${groupData.group_type_index}`,
-                    label: groupTypeName,
-                    value: groupData.group_key,
-                    operator: PropertyOperator.Exact,
-                },
-            ])
+            setExternalFilters({
+                properties: [
+                    {
+                        type: PropertyFilterType.EventMetadata,
+                        key: `$group_${groupData.group_type_index}`,
+                        label: groupTypeName,
+                        value: groupData.group_key,
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            })
         }
-    }, [groupTypeDetailDashboard, groupData, groupTypeName, setProperties, setLoadLayoutFromServerOnPreview])
+    }, [groupTypeDetailDashboard, groupData, groupTypeName, setExternalFilters])
 
     return (
         <div className="flex flex-col gap-0">


### PR DESCRIPTION
## Problem

When viewing a group's dashboard template from the group page, the automatic group filter is not applied to insights in view mode. The dashboard shows aggregated data for all groups instead of filtering to the selected group. This affects dashboards with 5+ tiles.

## Changes

`GroupDashboardCard` was using `setProperties()` to set the group filter, which stored it in `intermittentFilters`. These are intentionally excluded from `effectiveRefreshFilters` (used for insight refresh) because they're designed for temporary edit-bar preview changes. The filter only appeared to work because an `actionToUrl` side-effect encoded properties into the URL — but this was gated by `canAutoPreview`, which is `false` when the dashboard has >= 5 tiles (`MAX_TILES_FOR_AUTOPREVIEW`).

Switched to `setExternalFilters()` which correctly includes the filter in both `filtersOverrideForLoad` (initial API call) and `effectiveRefreshFilters` (insight refresh), regardless of tile count. Also removed the now-unnecessary `setLoadLayoutFromServerOnPreview(true)` call.

## How did you test this code?

Not tested yet, but here's my plan:
1. Navigate to a group page with a dashboard template that has 5+ tiles
2. Open the Overview tab and verify insights are filtered to the selected group
3. Switch to a different group and verify the filter updates
4. Check a dashboard template with < 5 tiles still works correctly

## Publish to changelog?
No