### PR TITLE
fix: auto-recover stale heatmap screenshots stuck in processing

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5834,6 +5834,10 @@ const api = {
         ): Promise<HeatmapScreenshotType> {
             return await new ApiRequest().heatmapScreenshotSaved(id).update({ data })
         },
+
+        async regenerate(id: number | string): Promise<HeatmapScreenshotType> {
+            return await new ApiRequest().heatmapScreenshotSaved(id).withAction('regenerate').create()
+        },
     },
 
     sessionSummaries: {

--- a/frontend/src/scenes/heatmaps/components/HeatmapHeader.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapHeader.tsx
@@ -7,7 +7,7 @@ import { heatmapLogic } from 'scenes/heatmaps/scenes/heatmap/heatmapLogic'
 
 export function HeatmapHeader(): JSX.Element {
     const { dataUrl, displayUrl, isBrowserUrlAuthorized, screenshotError } = useValues(heatmapLogic)
-    const { setDataUrl } = useActions(heatmapLogic)
+    const { setDataUrl, regenerateScreenshot } = useActions(heatmapLogic)
 
     return (
         <>
@@ -35,7 +35,15 @@ export function HeatmapHeader(): JSX.Element {
                         {/* Screenshot display section */}
                         {screenshotError && (
                             <div className="mt-2">
-                                <LemonBanner type="error">{screenshotError}</LemonBanner>
+                                <LemonBanner
+                                    type="error"
+                                    action={{
+                                        children: 'Retry',
+                                        onClick: regenerateScreenshot,
+                                    }}
+                                >
+                                    {screenshotError}
+                                </LemonBanner>
                             </div>
                         )}
                     </div>

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -57,6 +57,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
         pollScreenshotStatus: (id: number, width?: number) => ({ id, width }),
         setHeatmapId: (id: number | null) => ({ id }),
         setScreenshotLoaded: (screenshotLoaded: boolean) => ({ screenshotLoaded }),
+        regenerateScreenshot: true,
         exportHeatmap: true,
         setContainerWidth: (containerWidth: number | null) => ({ containerWidth }),
     }),
@@ -161,7 +162,22 @@ export const heatmapLogic = kea<heatmapLogicType>([
             }
 
             if (attempts >= maxAttempts) {
+                actions.setGeneratingScreenshot(false)
                 actions.setScreenshotError('Screenshot generation timed out')
+            }
+        },
+        regenerateScreenshot: async () => {
+            if (!props.id || !values.heatmapId) {
+                return
+            }
+            actions.setScreenshotError(null)
+            actions.setScreenshotUrl(null)
+            actions.setScreenshotLoaded(false)
+            try {
+                await api.savedHeatmaps.regenerate(props.id)
+                actions.pollScreenshotStatus(values.heatmapId, values.widthOverride)
+            } catch (error: any) {
+                actions.setScreenshotError(error.detail || 'Failed to regenerate screenshot')
             }
         },
         createHeatmap: async () => {

--- a/posthog/heatmaps/test/test_heatmap_screenshots.py
+++ b/posthog/heatmaps/test/test_heatmap_screenshots.py
@@ -1,5 +1,9 @@
+from datetime import timedelta
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
+
+from django.utils import timezone
 
 from rest_framework.test import APIClient
 
@@ -79,3 +83,74 @@ class TestHeatmapsAPI(APIBaseTest):
         other = SavedHeatmap.objects.create(team=other_team, url="https://example.com")
         r = self.client.get(f"/api/environments/{self.team.id}/heatmap_screenshots/{other.id}/content/")
         self.assertEqual(r.status_code, 404)
+
+    @patch("posthog.heatmaps.heatmaps_api.generate_heatmap_screenshot")
+    def test_retrieve_auto_recovers_stale_processing_heatmap(self, mock_task):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.PROCESSING,
+            type=SavedHeatmap.Type.SCREENSHOT,
+        )
+        HeatmapSnapshot.objects.create(heatmap=saved, width=1024, content=b"old")
+
+        # Force updated_at to 15 minutes ago
+        SavedHeatmap.objects.filter(id=saved.id).update(updated_at=timezone.now() - timedelta(minutes=15))
+
+        r = self.client.get(f"/api/environments/{self.team.id}/saved/{saved.short_id}/")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data["status"], "processing")
+
+        # Task was re-enqueued
+        mock_task.delay.assert_called_once_with(saved.id)
+
+        # Old snapshots were cleaned up
+        self.assertEqual(HeatmapSnapshot.objects.filter(heatmap=saved).count(), 0)
+
+    @patch("posthog.heatmaps.heatmaps_api.generate_heatmap_screenshot")
+    def test_retrieve_does_not_recover_recent_processing_heatmap(self, mock_task):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.PROCESSING,
+            type=SavedHeatmap.Type.SCREENSHOT,
+        )
+
+        r = self.client.get(f"/api/environments/{self.team.id}/saved/{saved.short_id}/")
+        self.assertEqual(r.status_code, 200)
+
+        # Task was NOT re-enqueued (still within threshold)
+        mock_task.delay.assert_not_called()
+
+    @patch("posthog.heatmaps.heatmaps_api.generate_heatmap_screenshot")
+    def test_regenerate_endpoint_re_enqueues_task(self, mock_task):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.FAILED,
+            type=SavedHeatmap.Type.SCREENSHOT,
+            exception="previous error",
+        )
+        HeatmapSnapshot.objects.create(heatmap=saved, width=1024, content=b"old")
+
+        r = self.client.post(f"/api/environments/{self.team.id}/saved/{saved.short_id}/regenerate/")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data["status"], "processing")
+        self.assertIsNone(r.data["exception"])
+
+        mock_task.delay.assert_called_once_with(saved.id)
+        self.assertEqual(HeatmapSnapshot.objects.filter(heatmap=saved).count(), 0)
+
+    def test_regenerate_rejects_non_screenshot_type(self):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            type=SavedHeatmap.Type.IFRAME,
+        )
+
+        r = self.client.post(f"/api/environments/{self.team.id}/saved/{saved.short_id}/regenerate/")
+        self.assertEqual(r.status_code, 400)

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -211,7 +211,7 @@ def generate_heatmap_screenshot(screenshot_id: str) -> None:
         except Exception as e:
             screenshot.status = SavedHeatmap.Status.FAILED
             screenshot.exception = str(e)
-            screenshot.save()
+            screenshot.save(update_fields=["status", "exception"])
 
             logger.exception(
                 "heatmap_screenshot.failed",


### PR DESCRIPTION
## Problem

Users reported "Screenshot generation timed out" when viewing heatmap screenshots. The root cause: when a heatmap is created, a Celery task generates the screenshot. The frontend polls for up to 2 minutes waiting for it to complete. If the task doesn't finish in time (worker crash, queue loss, server restart), the `SavedHeatmap` record stays in `status='processing'` forever, and every subsequent visit triggers the same 2-minute polling timeout.

**Why it affects one user but not another for the same URL:** the affected user visits an *existing* heatmap stuck in `processing`, while creating a *new* heatmap enqueues a fresh Celery task that completes successfully.

**How we reproduced it locally:**
1. Created a heatmap screenshot
2. Forced `status='processing'` via Django shell
3. Restarted the server (killing the Celery worker)
4. Visited the heatmap page — frontend polled for 2 minutes then showed "Screenshot generation timed out"

## Changes

### Backend: auto-recovery of stale heatmaps (`heatmaps_api.py`)
- In `retrieve()`, if a screenshot heatmap has been in `processing` for >10 minutes, automatically clear old snapshots and re-enqueue the Celery task — transparent to the user
- Added `POST /saved/{short_id}/regenerate/` endpoint for explicit manual retry
- Added `_regenerate()` helper that resets status, clears old snapshots, and re-enqueues the task

### Frontend: retry button (`heatmapLogic.ts`, `HeatmapHeader.tsx`, `api.ts`)
- Added `regenerateScreenshot` action that calls the new `regenerate` endpoint and restarts polling
- Error banner now includes a "Retry" button
- Fixed bug where `generatingScreenshot` stayed `true` after polling timeout

### Backend: observability (`heatmap_screenshot.py`)
- Added `update_fields` to the failure save for efficiency

## How did you test this code?

**Automated:** 12 tests covering task success/failure, auto-recovery, regenerate endpoint, and edge cases.

**Manual reproduction:**
1. Created heatmap, forced `status='processing'`, killed worker → confirmed auto-recovery re-enqueues task after 10 min threshold
2. Created heatmap with `https://thiswillneverresolve.invalid` → task exhausted retries, status=FAILED, error banner with Retry button appeared
3. Clicked Retry → task re-enqueued, polling restarted

I was able to repro with those steps (before adding retry button):
<img width="1304" height="427" alt="Screenshot 2026-02-27 at 12 34 31 PM" src="https://github.com/user-attachments/assets/a0dc9ffa-518d-4087-a7e4-509ad9816084" />

The retry button:
<img width="1298" height="591" alt="Screenshot 2026-02-27 at 1 11 49 PM" src="https://github.com/user-attachments/assets/e609549c-145b-4b08-af38-02e54c774594" />

## Publish to changelog?

no