### PR TITLE
fix: context panel label wrapping + fix tooltips

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
@@ -2,6 +2,7 @@ import { Tabs } from '@base-ui/react/tabs'
 import { useActions, useValues } from 'kea'
 
 import { IconSparkles, IconX } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
 
 import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
@@ -55,42 +56,42 @@ export function SidePanelNavigation({ activeTab, onTabChange, children }: SidePa
                                   ? 'Discuss'
                                   : defaultLabel
                         return (
-                            <Tabs.Tab
-                                key={tab}
-                                value={tab}
-                                render={(props) => (
-                                    <ButtonPrimitive
-                                        {...props}
-                                        onClick={() => openSidePanel(tab as SidePanelTab)}
-                                        tooltip={defaultLabel}
-                                        data-attr={`context-panel-tab-${tab}`}
-                                        className="size-[33px] @[540px]/side-panel:w-auto hover:bg-transparent group justify-center @[540px]/side-panel:justify-normal"
-                                    >
-                                        {tab === SidePanelTab.Max ? (
-                                            <IconSparkles
+                            <Tooltip key={tab} title={defaultLabel} delayMs={100}>
+                                <Tabs.Tab
+                                    value={tab}
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            onClick={() => openSidePanel(tab as SidePanelTab)}
+                                            data-attr={`context-panel-tab-${tab}`}
+                                            className="size-[33px] @[660px]/side-panel:w-auto hover:bg-transparent group justify-center @[660px]/side-panel:justify-normal"
+                                        >
+                                            {tab === SidePanelTab.Max ? (
+                                                <IconSparkles
+                                                    className={cn(
+                                                        'text-ai size-4 -mt-[1px] ml-[2px] group-hover/button-primitive:animate-hue-rotate'
+                                                    )}
+                                                />
+                                            ) : (
+                                                <Icon
+                                                    className={cn(
+                                                        'size-4 text-tertiary group-hover:text-primary',
+                                                        activeTab === tab ? 'text-primary' : 'text-tertiary'
+                                                    )}
+                                                />
+                                            )}
+                                            <span
                                                 className={cn(
-                                                    'text-ai size-4 -mt-[1px] ml-[2px] group-hover/button-primitive:animate-hue-rotate'
-                                                )}
-                                            />
-                                        ) : (
-                                            <Icon
-                                                className={cn(
-                                                    'size-4 text-tertiary group-hover:text-primary',
+                                                    'hidden @[660px]/side-panel:block text-tertiary group-hover:text-primary',
                                                     activeTab === tab ? 'text-primary' : 'text-tertiary'
                                                 )}
-                                            />
-                                        )}
-                                        <span
-                                            className={cn(
-                                                'hidden @[540px]/side-panel:block text-tertiary group-hover:text-primary',
-                                                activeTab === tab ? 'text-primary' : 'text-tertiary'
-                                            )}
-                                        >
-                                            {label}
-                                        </span>
-                                    </ButtonPrimitive>
-                                )}
-                            />
+                                            >
+                                                {label}
+                                            </span>
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+                            </Tooltip>
                         )
                     })}
                 <Tabs.Indicator className="transform-gpu absolute top-1/2 left-0 z-[-1] h-[33px] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] -translate-y-1/2 rounded bg-[var(--color-bg-fill-button-tertiary-active)] transition-all duration-200 ease-in-out" />

--- a/frontend/src/layout/navigation-3000/sidepanel/components/SidePanelPaneHeader.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/components/SidePanelPaneHeader.tsx
@@ -33,7 +33,7 @@ export function SidePanelPaneHeader({
             )}
         >
             {title ? (
-                <h3 className="flex-1 flex items-center gap-1 font-semibold mb-0 truncate pr-1 flex-none pl-2">
+                <h3 className="flex items-center gap-1 font-semibold mb-0 truncate pr-1 pl-2 flex-none text-sm">
                     {title}
                 </h3>
             ) : null}


### PR DESCRIPTION
## Problem
* Adding team activity back into context panel broke the icon/icon+ label container query
* Tooltips weren't showing correctly nor respecting the no-delay when hover over subsequent tabs
* PHAI panel header is `text-sm` while others are `text-base`

## Changes
- fix those things.
- headers now `text-sm`

![2026-02-27 16 19 05](https://github.com/user-attachments/assets/40fd828e-a411-4885-a94f-964978fdf9f2)


## How did you test this code?
Locally

## Publish to changelog?
No