### PR TITLE
feat(data-warehouse): rename ducklake data imports schema and table naming

### DIFF
--- a/posthog/ducklake/README.md
+++ b/posthog/ducklake/README.md
@@ -131,7 +131,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
    Once the import workflow completes it automatically starts `ducklake-copy.data-imports` as a child run. You should see it listed in the same Temporal UI; wait for the run to complete.
 
 5. **Query the new DuckLake table**
-   The copy activity creates a table at `ducklake.posthog_data_imports.<prefix><table_name>`. From any DuckDB shell you can inspect it:
+   The copy activity creates a table at `ducklake.posthog_data_imports.<source_type>_<prefix>_<table_name>`. From any DuckDB shell you can inspect it:
 
    ```sql
    duckdb -c "
@@ -153,6 +153,6 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
      SELECT table_schema, table_name FROM information_schema.tables WHERE table_catalog = 'ducklake';
 
      -- Query a specific table
-     SELECT * FROM ducklake.posthog_data_imports.${PREFIX}${TABLE_NAME} LIMIT 10;
+     SELECT * FROM ducklake.posthog_data_imports.${SOURCE_TYPE}_${PREFIX}_${TABLE_NAME} LIMIT 10;
    "
    ```

--- a/posthog/ducklake/README.md
+++ b/posthog/ducklake/README.md
@@ -50,9 +50,9 @@ Every copy is written to a deterministic schema inside DuckLake. Each workflow n
 
 ### Data Modeling
 
-- **Schema**: `data_modeling_team_<team_id>`
+- **Schema**: `posthog_data_modeling`
 - **Table**: `<model_label>` (derived from saved query name)
-- **Example**: `ducklake.data_modeling_team_123.my_saved_query`
+- **Example**: `ducklake.posthog_data_modeling.my_saved_query`
 
 ### Data Imports
 
@@ -90,7 +90,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
    Once the modeling workflow completes it automatically starts `ducklake-copy.data-modeling` as a child run. You should see it listed in the same Temporal UI; wait for the run to complete.
 
 5. **Query the new DuckLake table**
-   The copy activity creates a table at `ducklake.data_modeling_team_<team_id>.<model_label>`. From any DuckDB shell you can inspect it, for example:
+   The copy activity creates a table at `ducklake.posthog_data_modeling.<model_label>`. From any DuckDB shell you can inspect it, for example:
 
    ```sql
    duckdb -c "
@@ -112,7 +112,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
      SELECT table_schema, table_name FROM information_schema.tables WHERE table_catalog = 'ducklake';
 
      -- Query a specific table
-     SELECT * FROM ducklake.data_modeling_team_${TEAM_ID}.${MODEL_LABEL} LIMIT 10;
+     SELECT * FROM ducklake.posthog_data_modeling.${MODEL_LABEL} LIMIT 10;
    "
    ```
 

--- a/posthog/ducklake/README.md
+++ b/posthog/ducklake/README.md
@@ -56,9 +56,9 @@ Every copy is written to a deterministic schema inside DuckLake. Each workflow n
 
 ### Data Imports
 
-- **Schema**: `data_imports_team_<team_id>`
-- **Table**: `<source_type>_<normalized_name>_<schema_id_hex[:8]>`
-- **Example**: `ducklake.data_imports_team_123.stripe_invoices_a1b2c3d4`
+- **Schema**: `posthog_data_imports`
+- **Table**: `<source_type>_<prefix>_<normalized_name>` (prefix is user-defined on the external data source)
+- **Example**: `ducklake.posthog_data_imports.stripe_prod_invoices`
 
 Re-running a copy simply overwrites the same table. Choose the bucket so its lifecycle/replication policies fit that structure.
 
@@ -131,7 +131,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
    Once the import workflow completes it automatically starts `ducklake-copy.data-imports` as a child run. You should see it listed in the same Temporal UI; wait for the run to complete.
 
 5. **Query the new DuckLake table**
-   The copy activity creates a table at `ducklake.data_imports_team_<team_id>.<source_type>_<table_name>_<schema_id_hex>`. From any DuckDB shell you can inspect it:
+   The copy activity creates a table at `ducklake.posthog_data_imports.<prefix><table_name>`. From any DuckDB shell you can inspect it:
 
    ```sql
    duckdb -c "
@@ -153,6 +153,6 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
      SELECT table_schema, table_name FROM information_schema.tables WHERE table_catalog = 'ducklake';
 
      -- Query a specific table
-     SELECT * FROM ducklake.data_imports_team_${TEAM_ID}.${SOURCE_TYPE}_${TABLE_NAME}_${SCHEMA_ID_HEX} LIMIT 10;
+     SELECT * FROM ducklake.posthog_data_imports.${PREFIX}${TABLE_NAME} LIMIT 10;
    "
    ```

--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -16,6 +16,7 @@ this branching so callers don't need to check the mode themselves.
 from __future__ import annotations
 
 import os
+import re
 from typing import TYPE_CHECKING, TypedDict
 
 import duckdb
@@ -309,6 +310,25 @@ def initialize_ducklake(config: dict[str, str] | None = None, *, alias: str = "d
         conn.close()
 
 
+_IDENTIFIER_SANITIZE_RE = re.compile(r"[^0-9a-zA-Z]+")
+
+
+def sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
+    """Normalize identifiers so they are safe for DuckDB (lowercase alnum + underscores).
+
+    Non-alphanumeric runs are collapsed into a single underscore.
+    If the result is empty, ``default_prefix`` is used as the identifier.
+    If the result starts with a digit, ``default_prefix`` is prepended.
+    Truncated to 63 characters (DuckDB identifier limit).
+    """
+    cleaned = _IDENTIFIER_SANITIZE_RE.sub("_", (raw or "").strip()).strip("_").lower()
+    if not cleaned:
+        cleaned = default_prefix
+    if cleaned[0].isdigit():
+        cleaned = f"{default_prefix}_{cleaned}"
+    return cleaned[:63]
+
+
 __all__ = [
     "attach_catalog",
     "escape",
@@ -323,4 +343,5 @@ __all__ = [
     "parse_postgres_dsn",
     "is_dev_mode",
     "run_smoke_check",
+    "sanitize_ducklake_identifier",
 ]

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -192,7 +192,9 @@ async def prepare_data_imports_ducklake_metadata_activity(
                 source_table_uri=source_table_uri,
                 ducklake_schema_name="posthog_data_imports",
                 ducklake_table_name=_sanitize_ducklake_identifier(
-                    f"{source_type}_{schema.source.prefix or ''}_{normalized_name}",
+                    f"{source_type}_{schema.source.prefix}_{normalized_name}"
+                    if schema.source.prefix
+                    else f"{source_type}_{normalized_name}",
                     default_prefix="data_imports",
                 ),
                 verification_queries=list(get_data_imports_verification_queries(normalized_name)),

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -1,4 +1,3 @@
-import re
 import json
 import uuid
 import typing
@@ -15,7 +14,13 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-from posthog.ducklake.common import attach_catalog, get_config, get_ducklake_catalog_for_team, is_dev_mode
+from posthog.ducklake.common import (
+    attach_catalog,
+    get_config,
+    get_ducklake_catalog_for_team,
+    is_dev_mode,
+    sanitize_ducklake_identifier,
+)
 from posthog.ducklake.storage import (
     configure_connection,
     configure_cross_account_connection,
@@ -42,8 +47,6 @@ from products.data_warehouse.backend.models.external_data_schema import External
 
 LOGGER = get_logger(__name__)
 DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX = "data_imports"
-
-_IDENTIFIER_SANITIZE_RE = re.compile(r"[^0-9a-zA-Z]+")
 
 
 @dataclasses.dataclass
@@ -191,11 +194,11 @@ async def prepare_data_imports_ducklake_metadata_activity(
                 source_normalized_name=normalized_name,
                 source_table_uri=source_table_uri,
                 ducklake_schema_name="posthog_data_imports",
-                ducklake_table_name=_sanitize_ducklake_identifier(
+                ducklake_table_name=sanitize_ducklake_identifier(
                     f"{source_type}_{schema.source.prefix}_{normalized_name}"
                     if schema.source.prefix
                     else f"{source_type}_{normalized_name}",
-                    default_prefix="data_imports",
+                    default_prefix="data_import",
                 ),
                 verification_queries=list(get_data_imports_verification_queries(normalized_name)),
                 source_partition_column=partition_column,
@@ -279,16 +282,6 @@ def _fetch_delta_partition_columns(table_uri: str) -> list[str]:
 
     partition_columns = getattr(metadata, "partition_columns", None) or []
     return [column for column in partition_columns if column]
-
-
-def _sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
-    """Normalize identifiers so they are safe for DuckDB (lowercase alnum + underscores)."""
-    cleaned = _IDENTIFIER_SANITIZE_RE.sub("_", (raw or "").strip()).strip("_").lower()
-    if not cleaned:
-        cleaned = default_prefix
-    if cleaned[0].isdigit():
-        cleaned = f"{default_prefix}_{cleaned}"
-    return cleaned[:63]
 
 
 def _attach_ducklake_catalog(conn: duckdb.DuckDBPyConnection, config: dict[str, str], alias: str) -> None:

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -190,12 +190,10 @@ async def prepare_data_imports_ducklake_metadata_activity(
                 source_schema_name=schema.name,
                 source_normalized_name=normalized_name,
                 source_table_uri=source_table_uri,
-                ducklake_schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
-                    default_prefix=DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX,
-                ),
+                ducklake_schema_name="posthog_data_imports",
                 ducklake_table_name=_sanitize_ducklake_identifier(
-                    f"{source_type}_{normalized_name}_{schema.id.hex[:8]}", default_prefix="data_imports"
+                    f"{source_type}_{schema.source.prefix or ''}_{normalized_name}",
+                    default_prefix="data_imports",
                 ),
                 verification_queries=list(get_data_imports_verification_queries(normalized_name)),
                 source_partition_column=partition_column,

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -1,4 +1,3 @@
-import re
 import json
 import datetime as dt
 import dataclasses
@@ -11,7 +10,13 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-from posthog.ducklake.common import attach_catalog, get_config, get_ducklake_catalog_for_team, is_dev_mode
+from posthog.ducklake.common import (
+    attach_catalog,
+    get_config,
+    get_ducklake_catalog_for_team,
+    is_dev_mode,
+    sanitize_ducklake_identifier,
+)
 from posthog.ducklake.storage import (
     configure_connection,
     configure_cross_account_connection,
@@ -151,7 +156,7 @@ async def prepare_data_modeling_ducklake_metadata_activity(
                 normalized_name=normalized_name,
                 source_table_uri=model.table_uri,
                 schema_name="posthog_data_modeling",
-                table_name=_sanitize_ducklake_identifier(model.model_label or normalized_name, default_prefix="model"),
+                table_name=sanitize_ducklake_identifier(model.model_label or normalized_name, default_prefix="model"),
                 verification_queries=list(get_data_modeling_verification_queries(model.model_label)),
                 partition_column=partition_column,
             )
@@ -451,19 +456,6 @@ def _attach_ducklake_catalog(conn: duckdb.DuckDBPyConnection, config: dict[str, 
     except duckdb.CatalogException as exc:
         if alias not in str(exc):
             raise
-
-
-_IDENTIFIER_SANITIZE_RE = re.compile(r"[^0-9a-zA-Z]+")
-
-
-def _sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
-    """Normalize identifiers so they are safe for DuckDB (lowercase alnum + underscores)."""
-    cleaned = _IDENTIFIER_SANITIZE_RE.sub("_", (raw or "").strip()).strip("_").lower()
-    if not cleaned:
-        cleaned = default_prefix
-    if cleaned[0].isdigit():
-        cleaned = f"{default_prefix}_{cleaned}"
-    return cleaned[:63]
 
 
 def _detect_partition_column_name(table_uri: str) -> str | None:

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -150,10 +150,7 @@ async def prepare_data_modeling_ducklake_metadata_activity(
                 saved_query_name=saved_query.name,
                 normalized_name=normalized_name,
                 source_table_uri=model.table_uri,
-                schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
-                    default_prefix=DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX,
-                ),
+                schema_name="posthog_data_modeling",
                 table_name=_sanitize_ducklake_identifier(model.model_label or normalized_name, default_prefix="model"),
                 verification_queries=list(get_data_modeling_verification_queries(model.model_label)),
                 partition_column=partition_column,

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
@@ -132,8 +132,8 @@ async def test_prepare_data_imports_ducklake_metadata_activity_basic(ateam, monk
     assert len(result) == 1
     metadata = result[0]
     assert metadata.source_normalized_name == "customers"
-    assert metadata.ducklake_schema_name == f"data_imports_team_{ateam.id}"
-    assert metadata.ducklake_table_name.startswith("postgres_customers_")
+    assert metadata.ducklake_schema_name == "posthog_data_imports"
+    assert metadata.ducklake_table_name == "postgres_customers"
     assert metadata.source_partition_column == "created_at"
 
 
@@ -182,6 +182,51 @@ async def test_prepare_data_imports_ducklake_metadata_activity_no_partition(atea
     assert metadata.source_normalized_name == "charges"
     # No partition column when Delta table has no partitions
     assert metadata.source_partition_column is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_prepare_data_imports_ducklake_metadata_activity_with_prefix(ateam, monkeypatch):
+    monkeypatch.setattr(ducklake_module, "_fetch_delta_partition_columns", lambda table_uri: [])
+
+    credential = await database_sync_to_async(DataWarehouseCredential.objects.create)(
+        team=ateam, access_key="test_key", access_secret="test_secret"
+    )
+    source = await database_sync_to_async(ExternalDataSource.objects.create)(
+        team=ateam,
+        source_id="test_source",
+        connection_id="test_connection",
+        source_type="Stripe",
+        status="Running",
+        prefix="prod_",
+    )
+    table = await database_sync_to_async(DataWarehouseTable.objects.create)(
+        team=ateam,
+        name="test_table",
+        format="Delta",
+        url_pattern="s3://bucket/path",
+        credential=credential,
+        external_data_source=source,
+        columns={
+            "id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+        },
+    )
+    schema = await database_sync_to_async(ExternalDataSchema.objects.create)(
+        team=ateam,
+        name="invoices",
+        source=source,
+        table=table,
+        sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+    )
+
+    inputs = DataImportsDuckLakeCopyInputs(team_id=ateam.id, job_id="job-prefix", schema_ids=[schema.id])
+
+    result = await prepare_data_imports_ducklake_metadata_activity(inputs)
+
+    assert len(result) == 1
+    metadata = result[0]
+    assert metadata.ducklake_schema_name == "posthog_data_imports"
+    assert metadata.ducklake_table_name == "stripe_prod_invoices"  # {source_type}_{prefix}_{name}
 
 
 @pytest.mark.asyncio
@@ -258,7 +303,7 @@ def test_copy_data_imports_to_ducklake_activity_executes_correct_sql(monkeypatch
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
     )
     inputs = DuckLakeCopyDataImportsActivityInputs(team_id=1, job_id="job-123", model=metadata)
@@ -287,7 +332,7 @@ def test_verify_data_imports_ducklake_copy_activity_returns_empty_when_no_querie
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
         verification_queries=[],
     )
@@ -357,7 +402,7 @@ def test_verify_data_imports_ducklake_copy_activity_executes_configured_query(mo
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
         verification_queries=[query],
     )
@@ -431,7 +476,7 @@ def test_verify_data_imports_ducklake_copy_activity_handles_query_failure(monkey
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
         verification_queries=[query],
     )
@@ -514,7 +559,7 @@ def test_verify_data_imports_ducklake_copy_activity_tolerance_comparison(monkeyp
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
         verification_queries=[query_pass, query_fail],
     )
@@ -573,7 +618,7 @@ def test_copy_data_imports_to_ducklake_activity_raises_when_no_catalog(monkeypat
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
     )
     inputs = DuckLakeCopyDataImportsActivityInputs(team_id=1, job_id="job-123", model=metadata)
@@ -622,7 +667,7 @@ def test_verify_data_imports_ducklake_copy_activity_raises_when_no_catalog(monke
         source_schema_name="customers",
         source_normalized_name="customers",
         source_table_uri="s3://bucket/team_1/customers",
-        ducklake_schema_name="data_imports_team_1",
+        ducklake_schema_name="posthog_data_imports",
         ducklake_table_name="postgres_customers_abc12345",
         verification_queries=[query],
     )
@@ -650,7 +695,7 @@ async def test_ducklake_copy_data_imports_workflow_skips_when_feature_flag_disab
                 source_schema_name="customers",
                 source_normalized_name="customers",
                 source_table_uri="s3://bucket/team_1/customers",
-                ducklake_schema_name="data_imports_team_1",
+                ducklake_schema_name="posthog_data_imports",
                 ducklake_table_name="postgres_customers_abc12345",
             )
         ]
@@ -712,7 +757,7 @@ async def test_ducklake_copy_data_imports_workflow_runs_when_feature_flag_enable
                 source_schema_name="customers",
                 source_normalized_name="customers",
                 source_table_uri="s3://bucket/team_1/customers",
-                ducklake_schema_name="data_imports_team_1",
+                ducklake_schema_name="posthog_data_imports",
                 ducklake_table_name="postgres_customers_abc12345",
             )
         ]

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
@@ -82,7 +82,7 @@ async def test_prepare_data_modeling_ducklake_metadata_activity_returns_models(
     assert model_metadata.model_label == saved_query.id.hex
     assert model_metadata.saved_query_name == saved_query.name
     assert model_metadata.source_table_uri == table_uri
-    assert model_metadata.schema_name == f"data_modeling_team_{ateam.pk}"
+    assert model_metadata.schema_name == "posthog_data_modeling"
     assert model_metadata.table_name == f"model_{saved_query.id.hex}"
     assert model_metadata.verification_queries
     assert model_metadata.verification_queries[0].name == "row_count_delta_vs_ducklake"
@@ -246,7 +246,7 @@ def test_copy_data_modeling_model_to_ducklake_activity_uses_duckdb(monkeypatch):
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_a",
         verification_queries=[],
     )
@@ -263,8 +263,8 @@ def test_copy_data_modeling_model_to_ducklake_activity_uses_duckdb(monkeypatch):
 
     assert configured["called"] is True
     assert ensured["called"] is True
-    assert schema_calls and "ducklake.data_modeling_team_1" in schema_calls[0]
-    assert table_calls and "ducklake.data_modeling_team_1.model_a" in table_calls[0][0]
+    assert schema_calls and "ducklake.posthog_data_modeling" in schema_calls[0]
+    assert table_calls and "ducklake.posthog_data_modeling.model_a" in table_calls[0][0]
     assert "delta_scan(?)" in table_calls[0][0]
     assert table_calls[0][1] == (metadata.source_table_uri,)
     assert any("ATTACH" in statement for statement in fake_conn.sql_statements), "Expected DuckLake catalog attach"
@@ -331,7 +331,7 @@ def test_verify_ducklake_copy_activity_runs_queries(monkeypatch):
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_a",
         verification_queries=[
             DuckLakeCopyVerificationQuery(
@@ -369,7 +369,7 @@ async def test_ducklake_copy_workflow_skips_when_feature_flag_disabled(monkeypat
                 saved_query_name="model",
                 normalized_name="model",
                 source_table_uri="s3://source/table",
-                schema_name="data_modeling_team_1",
+                schema_name="posthog_data_modeling",
                 table_name="model",
             )
         ]
@@ -480,7 +480,7 @@ def test_verify_ducklake_copy_activity_reports_failures(monkeypatch):
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_b",
         verification_queries=[
             DuckLakeCopyVerificationQuery(
@@ -519,7 +519,7 @@ def test_run_partition_verification_without_temporal_type():
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_partition_string",
         verification_queries=[],
         partition_column="event_id",
@@ -554,7 +554,7 @@ def test_run_partition_verification_with_temporal_type():
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_partition_time",
         verification_queries=[],
         partition_column="timestamp",
@@ -636,7 +636,7 @@ def test_verify_ducklake_copy_activity_respects_tolerance(monkeypatch, observed,
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_tolerance",
         verification_queries=[
             DuckLakeCopyVerificationQuery(
@@ -723,7 +723,7 @@ def test_verify_ducklake_copy_activity_includes_additional_checks(monkeypatch):
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_c",
         verification_queries=[
             DuckLakeCopyVerificationQuery(
@@ -769,7 +769,7 @@ def test_copy_data_modeling_model_to_ducklake_activity_raises_when_no_catalog(mo
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_a",
         verification_queries=[],
     )
@@ -818,7 +818,7 @@ def test_verify_ducklake_copy_activity_raises_when_no_catalog(monkeypatch):
         saved_query_name="ducklake_model",
         normalized_name="ducklake_model",
         source_table_uri="s3://source/table",
-        schema_name="data_modeling_team_1",
+        schema_name="posthog_data_modeling",
         table_name="model_a",
         verification_queries=[query],
     )
@@ -847,7 +847,7 @@ async def test_ducklake_copy_workflow_runs_when_feature_flag_enabled(monkeypatch
                 saved_query_name="model",
                 normalized_name="model",
                 source_table_uri="s3://source/table",
-                schema_name="data_modeling_team_1",
+                schema_name="posthog_data_modeling",
                 table_name="model",
             )
         ]


### PR DESCRIPTION
## Summary
- Renames the ducklake schema from `data_imports_team_{team_id}` to `posthog_data_imports` since each ducklake is single tenant and team_id uniqueness is unnecessary
- Changes table naming from `{source_type}_{name}_{schema_id_hex}` to `{source_type}_{prefix}_{name}` where prefix is the user-defined value from `ExternalDataSource.prefix`, guaranteeing uniqueness across similar source types
- Adds test coverage for the prefix behavior

## Test plan
- [x] Non-DB unit tests pass locally (9/9)
- [ ] DB-dependent tests pass in CI (require ClickHouse)
- [ ] Verify new schema/table names in a local DuckLake setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)