### PR TITLE
fix(max): show disabled reason in full-screen suggestion buttons

### DIFF
--- a/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
+++ b/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
@@ -57,6 +57,7 @@ function useSuggestionHandling(): {
 
 interface FloatingSuggestionsDisplayProps {
     dataProcessingAccepted: boolean
+    dataProcessingApprovalDisabledReason?: string | null
     suggestionsData: readonly SuggestionGroup[]
     type?: 'primary' | 'secondary' | 'tertiary'
     additionalSuggestions?: React.ReactNode[]
@@ -65,6 +66,7 @@ interface FloatingSuggestionsDisplayProps {
 export function FloatingSuggestionsDisplay({
     type = 'secondary',
     dataProcessingAccepted,
+    dataProcessingApprovalDisabledReason,
     suggestionsData,
     additionalSuggestions,
 }: FloatingSuggestionsDisplayProps): JSX.Element | null {
@@ -75,7 +77,13 @@ export function FloatingSuggestionsDisplay({
         <div className={cn('mt-1 mx-1', activeSuggestionGroup && 'fade-out pointer-events-none')}>
             {/* Main suggestion groups */}
             <>
-                <Tooltip title={!dataProcessingAccepted ? 'Please accept OpenAI processing data' : undefined}>
+                <Tooltip
+                    title={
+                        !dataProcessingAccepted
+                            ? dataProcessingApprovalDisabledReason || 'Please accept OpenAI processing data'
+                            : undefined
+                    }
+                >
                     <ul className="flex items-center justify-center flex-wrap gap-1.5">
                         {suggestionsData.map((group) => (
                             <li key={group.label}>

--- a/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
+++ b/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
@@ -80,7 +80,7 @@ export function FloatingSuggestionsDisplay({
                 <Tooltip
                     title={
                         !dataProcessingAccepted
-                            ? dataProcessingApprovalDisabledReason || 'Please accept OpenAI processing data'
+                            ? dataProcessingApprovalDisabledReason || 'Please accept AI data processing'
                             : undefined
                     }
                 >

--- a/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
@@ -21,7 +21,7 @@ export function SidebarQuestionInputWithSuggestions({
 }: {
     hideSuggestions?: boolean
 }): JSX.Element {
-    const { dataProcessingAccepted, activeSuggestionGroup } = useValues(maxLogic)
+    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason, activeSuggestionGroup } = useValues(maxLogic)
     const { setActiveGroup } = useActions(maxLogic)
     const { agentMode } = useValues(maxThreadLogic)
     const { coreMemory, coreMemoryLoading } = useValues(maxSettingsLogic)
@@ -60,6 +60,7 @@ export function SidebarQuestionInputWithSuggestions({
                 <FloatingSuggestionsDisplay
                     type="secondary"
                     dataProcessingAccepted={dataProcessingAccepted}
+                    dataProcessingApprovalDisabledReason={dataProcessingApprovalDisabledReason}
                     suggestionsData={
                         agentMode === AgentMode.Research ? RESEARCH_SUGGESTIONS_DATA : QUESTION_SUGGESTIONS_DATA
                     }

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -127,7 +127,14 @@ export const maxLogic = kea<maxLogicType>([
             router,
             ['searchParams'],
             maxGlobalLogic,
-            ['dataProcessingAccepted', 'tools', 'toolSuggestions', 'conversationHistory', 'conversationHistoryLoading'],
+            [
+                'dataProcessingAccepted',
+                'dataProcessingApprovalDisabledReason',
+                'tools',
+                'toolSuggestions',
+                'conversationHistory',
+                'conversationHistoryLoading',
+            ],
             maxSettingsLogic,
             ['coreMemory'],
             // Actions are lazy-loaded. In order to display their names in the UI, we're loading them here.


### PR DESCRIPTION
## Problem

When an admin hasn't approved running AI yet, non-admin users see disabled suggestion buttons in the full-page PostHog AI screen but without an explanation. This fix passes the dataProcessingApprovalDisabledReason to the FloatingSuggestionsDisplay component so the tooltip shows "Ask an admin or owner of <org> to approve this" instead of a generic "Please accept OpenAI processing data" message.

<img width="1208" height="789" alt="Screenshot 2026-02-27 at 18 11 12" src="https://github.com/user-attachments/assets/dffe970a-fe53-4ef7-81c7-381f10d87fea" />


## Changes

[<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->](https://claude.ai/code/session_01Cyfd8BBuNh6NwVdUpxSejd)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
