### PR TITLE
fix(web-analytics): trying to fix url filters loop state

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2163,8 +2163,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
     tabAwareActionToUrl(({ values }) => {
         const stateToUrl = (): string => {
-            const searchParams = { ...router.values.searchParams }
-            const urlParams = new URLSearchParams(searchParams)
+            const urlParams = new URLSearchParams(router.values.location.search)
 
             const {
                 rawWebAnalyticsFilters,


### PR DESCRIPTION
## Problem

When a user applies a pathname filter on the Web analytics dashboard, it can trigger an infinite URL update loop that eventually causes an OOM crash in the browser tab.

The root cause is in the `stateToUrl` function within `webAnalyticsLogic`. It was constructing `URLSearchParams` from `router.values.searchParams`, which contains **already-parsed JavaScript values** (arrays, objects) from kea-router's automatic JSON parsing. `URLSearchParams()` expects string values — when it receives an object or array, it calls `.toString()` on it, producing `"[object Object]"` instead of the proper JSON representation.

This corrupted URL then triggers `urlToAction`, which detects the values differ from the current state, dispatches actions to update state, which triggers `actionToUrl` again — creating the infinite loop.

## Changes

Use `router.values.location.search` (the raw URL search string) instead of `router.values.searchParams` (the parsed object with JS values) when constructing `URLSearchParams`. This avoids the object-to-string corruption entirely since the raw search string is already properly encoded.

## How did you test this code?

- Verified that `URLSearchParams(rawSearchString)` correctly preserves all URL parameter values without corruption
- Verified that the explicit `.set()` calls in `stateToUrl` correctly overwrite parameters with their current state values

## Publish to changelog?

no