### PR TITLE
chore(flags): validate operators coming from mcp server

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -118,7 +118,7 @@ FEATURE_FLAG_SUPPORTED_OPERATORS: frozenset[str | None] = frozenset(
         "is_date_exact",
         "is_date_after",
         "is_date_before",
-        "in_",
+        "in",
         "not_in",
         "flag_evaluates_to",
     }

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -87,6 +87,48 @@ BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
 
 MAX_PROPERTY_VALUES = 1000
 
+# Operators the Rust feature-flag evaluation service supports (OperatorType in property_models.rs).
+# None means "no operator specified" which defaults to exact.
+FEATURE_FLAG_SUPPORTED_OPERATORS: frozenset[str | None] = frozenset(
+    {
+        None,
+        "exact",
+        "is_not",
+        "icontains",
+        "not_icontains",
+        "icontains_multi",
+        "not_icontains_multi",
+        "regex",
+        "not_regex",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "semver_gt",
+        "semver_gte",
+        "semver_lt",
+        "semver_lte",
+        "semver_eq",
+        "semver_neq",
+        "semver_tilde",
+        "semver_caret",
+        "semver_wildcard",
+        "is_set",
+        "is_not_set",
+        "is_date_exact",
+        "is_date_after",
+        "is_date_before",
+        "in_",
+        "not_in",
+        "flag_evaluates_to",
+    }
+)
+
+FEATURE_FLAG_OPERATOR_ALIASES: dict[str, str] = {
+    "min": "gte",
+    "max": "lte",
+}
+
 LOCAL_EVALUATION_REQUEST_COUNTER = Counter(
     "posthog_local_evaluation_request_total",
     "Local evaluation API requests",
@@ -779,12 +821,21 @@ class FeatureFlagSerializer(
                 raise serializers.ValidationError("Filters are not valid (variant override does not exist)")
 
             for property in condition.get("properties", []):
+                if property.get("operator") in FEATURE_FLAG_OPERATOR_ALIASES:
+                    property["operator"] = FEATURE_FLAG_OPERATOR_ALIASES[property["operator"]]
+
                 prop = Property(**property)
 
                 if prop.operator is not None and prop.operator not in PropertyOperator.__members__.values():
                     raise serializers.ValidationError(
                         detail=f"Invalid operator: {prop.operator}",
                         code="invalid_operator",
+                    )
+
+                if prop.operator not in FEATURE_FLAG_SUPPORTED_OPERATORS:
+                    raise serializers.ValidationError(
+                        detail=f"Unsupported operator for feature flags: {prop.operator}",
+                        code="unsupported_operator",
                     )
 
                 if isinstance(prop.value, list):
@@ -850,6 +901,8 @@ class FeatureFlagSerializer(
                         code="invalid_operator",
                     )
 
+                # Currently unreachable (between/not_between rejected by FEATURE_FLAG_SUPPORTED_OPERATORS),
+                # but kept so value validation is ready if Rust adds support for these operators.
                 if prop.operator in (PropertyOperator.BETWEEN, PropertyOperator.NOT_BETWEEN):
                     if not isinstance(prop.value, list) or len(prop.value) != 2:
                         raise serializers.ValidationError(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -4277,45 +4277,84 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
     @parameterized.expand(
         [
-            ("not_a_list", "between", "1,10", "between operator requires a two-element array [min, max]"),
-            ("wrong_length", "between", [1], "between operator requires a two-element array [min, max]"),
-            (
-                "three_elements",
-                "not_between",
-                [1, 2, 3],
-                "not_between operator requires a two-element array [min, max]",
-            ),
-            ("non_numeric", "between", ["a", "b"], "between operator requires numeric values"),
-            (
-                "min_gt_max",
-                "not_between",
-                [10, 1],
-                "not_between operator requires min value to be less than or equal to max value",
-            ),
+            ("between", "between"),
+            ("not_between", "not_between"),
+            ("is_cleaned_path_exact", "is_cleaned_path_exact"),
         ]
     )
-    def test_create_flag_with_invalid_between_value(self, _name, operator, value, expected_detail):
+    def test_cant_create_flag_with_unsupported_operator(self, _name, operator):
         resp = self._create_flag_with_properties(
-            "between-flag",
-            [{"key": "age", "type": "person", "value": value, "operator": operator}],
+            "unsupported-op-flag",
+            [{"key": "age", "type": "person", "value": "test", "operator": operator}],
             expected_status=status.HTTP_400_BAD_REQUEST,
         )
-        self.assertEqual(resp.json()["code"], "invalid_value")
-        self.assertEqual(resp.json()["detail"], expected_detail)
+        self.assertEqual(resp.json()["code"], "unsupported_operator")
+        self.assertIn(operator, resp.json()["detail"])
 
     @parameterized.expand(
         [
-            ("valid_between", "between", [1, 10]),
-            ("valid_not_between", "not_between", [0.5, 99.9]),
-            ("equal_bounds", "between", [5, 5]),
+            ("between", "between"),
+            ("not_between", "not_between"),
+            ("is_cleaned_path_exact", "is_cleaned_path_exact"),
         ]
     )
-    def test_create_flag_with_valid_between_value(self, _name, operator, value):
-        self._create_flag_with_properties(
-            f"between-flag-{_name}",
-            [{"key": "age", "type": "person", "value": value, "operator": operator}],
-            expected_status=status.HTTP_201_CREATED,
+    def test_cant_update_flag_with_unsupported_operator(self, _name, operator):
+        flag = self._create_flag_with_properties(
+            f"flag-to-update-{_name}",
+            [{"key": "age", "type": "person", "value": "test", "operator": "exact"}],
         )
+        resp = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.json()['id']}/",
+            {
+                "filters": {
+                    "groups": [
+                        {"properties": [{"key": "age", "type": "person", "value": "test", "operator": operator}]}
+                    ]
+                }
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.json()["code"], "unsupported_operator")
+        self.assertIn(operator, resp.json()["detail"])
+
+    @parameterized.expand(
+        [
+            ("min_to_gte", "min", "gte"),
+            ("max_to_lte", "max", "lte"),
+        ]
+    )
+    def test_create_flag_aliases_operator(self, _name, input_op, saved_op):
+        resp = self._create_flag_with_properties(
+            f"alias-flag-{_name}",
+            [{"key": "age", "type": "person", "value": "10", "operator": input_op}],
+        )
+        saved_operator = resp.json()["filters"]["groups"][0]["properties"][0]["operator"]
+        self.assertEqual(saved_operator, saved_op)
+
+    @parameterized.expand(
+        [
+            ("min_to_gte", "min", "gte"),
+            ("max_to_lte", "max", "lte"),
+        ]
+    )
+    def test_update_flag_aliases_operator(self, _name, input_op, saved_op):
+        flag = self._create_flag_with_properties(
+            f"flag-alias-update-{_name}",
+            [{"key": "age", "type": "person", "value": "5", "operator": "exact"}],
+        )
+        resp = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.json()['id']}/",
+            {
+                "filters": {
+                    "groups": [{"properties": [{"key": "age", "type": "person", "value": "10", "operator": input_op}]}]
+                }
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        saved_operator = resp.json()["filters"]["groups"][0]["properties"][0]["operator"]
+        self.assertEqual(saved_operator, saved_op)
 
     @parameterized.expand(
         [

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+// Keep in sync with FEATURE_FLAG_SUPPORTED_OPERATORS in posthog/api/feature_flag.py
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OperatorType {

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -1476,13 +1476,10 @@
                                                         "not_icontains",
                                                         "regex",
                                                         "not_regex",
-                                                        "is_cleaned_path_exact",
                                                         "gt",
                                                         "gte",
                                                         "lt",
-                                                        "lte",
-                                                        "min",
-                                                        "max"
+                                                        "lte"
                                                     ]
                                                 }
                                             },
@@ -1663,13 +1660,10 @@
                                                                 "not_icontains",
                                                                 "regex",
                                                                 "not_regex",
-                                                                "is_cleaned_path_exact",
                                                                 "gt",
                                                                 "gte",
                                                                 "lt",
-                                                                "lte",
-                                                                "min",
-                                                                "max"
+                                                                "lte"
                                                             ]
                                                         }
                                                     },
@@ -4126,13 +4120,10 @@
                                                         "not_icontains",
                                                         "regex",
                                                         "not_regex",
-                                                        "is_cleaned_path_exact",
                                                         "gt",
                                                         "gte",
                                                         "lt",
-                                                        "lte",
-                                                        "min",
-                                                        "max"
+                                                        "lte"
                                                     ]
                                                 }
                                             },
@@ -5013,13 +5004,10 @@
                                                         "not_icontains",
                                                         "regex",
                                                         "not_regex",
-                                                        "is_cleaned_path_exact",
                                                         "gt",
                                                         "gte",
                                                         "lt",
-                                                        "lte",
-                                                        "min",
-                                                        "max"
+                                                        "lte"
                                                     ]
                                                 }
                                             },

--- a/services/mcp/src/schema/flags.ts
+++ b/services/mcp/src/schema/flags.ts
@@ -10,9 +10,9 @@ export interface PostHogFlagsResponse {
     results?: PostHogFeatureFlag[]
 }
 const base = ['exact', 'is_not', 'is_set', 'is_not_set'] as const
-const stringOpsForSchema = ['icontains', 'not_icontains', 'regex', 'not_regex', 'is_cleaned_path_exact']
+const stringOpsForSchema = ['icontains', 'not_icontains', 'regex', 'not_regex']
 const stringOps = [...base, ...stringOpsForSchema] as const
-const numberOpsForSchema = ['gt', 'gte', 'lt', 'lte', 'min', 'max']
+const numberOpsForSchema = ['gt', 'gte', 'lt', 'lte']
 const numberOps = [...base, ...numberOpsForSchema] as const
 const booleanOps = [...base] as const
 


### PR DESCRIPTION
# Summary

Replaces #46598 

Creating a feature flag with an operator unsupported by the Rust evaluation service (e.g., `between`, `is_cleaned_path_exact`) causes team-wide 503 errors. The flag is accepted by Django but fails during Rust evaluation. The current validation only checks that operators exist in the Python `PropertyOperator` enum, which includes operators Rust doesn't support yet.

Operators in Python but not in Rust: `min`, `max`, `between`, `not_between`, `is_cleaned_path_exact`

## This PR:

- Adds a `FEATURE_FLAG_SUPPORTED_OPERATORS` allowlist matching the Rust `OperatorType` enum, and rejects unsupported operators with a clear error message
- Aliases `min` → `gte` and `max` → `lte` just in case for precaution, though they shouldn't happen anymore since we are also updating the MCP tool.
- Removes `min`, `max`, and `is_cleaned_path_exact` from the MCP tool schema so LLMs use the canonical operators going forward
- Adds a cross-reference comment in the Rust `OperatorType` enum pointing to the Python allowlist

  Ideally all Python operators would be supported in Rust too. This is a safety net to prevent 503s until that happens.

## Test plan

  - Parameterized tests: creating/updating flags with between, not_between, is_cleaned_path_exact → 400
  - Parameterized tests: creating/updating flags with min/max → succeeds, saved as gte/lte
  - MCP schema tests pass, tool-inputs.json no longer contains unsupported operators
