### PR TITLE
feat(workflows): auto-disable workflows after bounce/complaint thresholds breach

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -104,7 +104,9 @@ export class CdpApi {
         this.emailTrackingService = new EmailTrackingService(
             this.hogFunctionManager,
             this.hogFlowManager,
-            this.hogFunctionMonitoringService
+            this.hogFunctionMonitoringService,
+            services.redis,
+            hub.teamManager
         )
     }
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
@@ -103,6 +103,54 @@ describe('HogFlowManager', () => {
         })
     })
 
+    describe('disableHogFlow', () => {
+        it('disables an active hog flow and returns true', async () => {
+            const updated = await manager.disableHogFlow(hogFlows[0].id)
+            expect(updated).toBe(true)
+
+            const res = await hub.postgres.query(
+                PostgresUse.COMMON_READ,
+                `SELECT status FROM posthog_hogflow WHERE id = $1`,
+                [hogFlows[0].id],
+                'testKey'
+            )
+            expect(res.rows[0].status).toEqual('draft')
+        })
+
+        it('returns false when the hog flow is not active', async () => {
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `UPDATE posthog_hogflow SET status='archived', updated_at = NOW() WHERE id = $1`,
+                [hogFlows[1].id],
+                'testKey'
+            )
+
+            const updated = await manager.disableHogFlow(hogFlows[1].id)
+            expect(updated).toBe(false)
+        })
+
+        it('only updates the specified hog flow id', async () => {
+            const updated = await manager.disableHogFlow(hogFlows[0].id)
+            expect(updated).toBe(true)
+
+            const res = await hub.postgres.query(
+                PostgresUse.COMMON_READ,
+                `SELECT id, status FROM posthog_hogflow WHERE id = ANY($1)`,
+                [[hogFlows[0].id, hogFlows[1].id, hogFlows[2].id]],
+                'testKey'
+            )
+
+            const statusMap: Record<string, string> = {}
+            for (const row of res.rows) {
+                statusMap[row.id] = row.status
+            }
+
+            expect(statusMap[hogFlows[0].id]).toEqual('draft')
+            expect(statusMap[hogFlows[1].id]).toEqual('active')
+            expect(statusMap[hogFlows[2].id]).toEqual('active')
+        })
+    })
+
     describe('getHogFlowIdsForTeam', () => {
         it('returns function IDs', async () => {
             const result = await manager.getHogFlowIdsForTeams([teamId1, teamId2])

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -107,6 +107,25 @@ export class HogFlowManagerService {
         return await this.lazyLoader.getMany(ids)
     }
 
+    /**
+     * Set the status of a HogFlow to 'draft'.
+     * Only transitions from 'active' — leaves 'archived' flows untouched.
+     * Invalidates the cache so workers pick up the change immediately.
+     */
+    public async setStatusDraft(id: HogFlow['id']): Promise<boolean> {
+        const result = await this.postgres.query<{ id: string }>(
+            PostgresUse.COMMON_WRITE,
+            `UPDATE posthog_hogflow SET status = 'draft', updated_at = NOW() WHERE id = $1 AND status = 'active' RETURNING id`,
+            [id],
+            'setHogFlowStatusDraft'
+        )
+        const updated = result.rows.length > 0
+        if (updated) {
+            this.lazyLoader.markForRefresh([id])
+        }
+        return updated
+    }
+
     private onHogFlowsReloaded(teamId: Team['id'], hogFlowIds: HogFlow['id'][]): void {
         this.lazyLoaderByTeam.markForRefresh(teamId.toString())
         this.lazyLoader.markForRefresh(hogFlowIds)

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -107,12 +107,7 @@ export class HogFlowManagerService {
         return await this.lazyLoader.getMany(ids)
     }
 
-    /**
-     * Set the status of a HogFlow to 'draft'.
-     * Only transitions from 'active' — leaves 'archived' flows untouched.
-     * Invalidates the cache so workers pick up the change immediately.
-     */
-    public async setStatusDraft(id: HogFlow['id']): Promise<boolean> {
+    public async disableHogFlow(id: HogFlow['id']): Promise<boolean> {
         const result = await this.postgres.query<{ id: string }>(
             PostgresUse.COMMON_WRITE,
             `UPDATE posthog_hogflow SET status = 'draft', updated_at = NOW() WHERE id = $1 AND status = 'active' RETURNING id`,

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -187,16 +187,21 @@ export class EmailTrackingService {
 
         // Use SETNX as a distributed once-per-window guard — only the first call within the TTL fires the event
         const alertKey = this.reputationKey(hogFlowId, 'alerted')
+
         const isFirstAlert = await this.redis.useClient(
             { name: 'email-reputation-alert', failOpen: true },
             async (client) => {
-                const set = await client.setnx(alertKey, '1')
-                if (set === 1) {
-                    await client.expire(alertKey, REPUTATION_TTL_SECONDS)
-                }
-                return set === 1
+                const script = `
+                    local set = redis.call('SETNX', KEYS[1], ARGV[1])
+                    if set == 1 then
+                        redis.call('EXPIRE', KEYS[1], ARGV[2])
+                    end
+                    return set
+                `
+                return (await client.eval(script, 1, alertKey, '1', REPUTATION_TTL_SECONDS)) === 1
             }
         )
+
 
         if (!isFirstAlert) {
             return

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -142,16 +142,22 @@ export class EmailTrackingService {
         return `${REPUTATION_REDIS_PREFIX}/${hogFlowId}/${counter}`
     }
 
+
     private async incrementWithTtl(key: string): Promise<number> {
         const count = await this.redis.useClient({ name: 'email-reputation-incr', failOpen: true }, async (client) => {
-            const newVal = await client.incr(key)
-            if (newVal === 1) {
-                await client.expire(key, REPUTATION_TTL_SECONDS)
-            }
-            return newVal
+            // Use Lua script to atomically incr and set expire on first write
+            const script = `
+                local val = redis.call('INCR', KEYS[1])
+                if val == 1 then
+                    redis.call('EXPIRE', KEYS[1], ARGV[1])
+                end
+                return val
+            `
+            return await client.eval(script, 1, key, REPUTATION_TTL_SECONDS)
         })
         return count ?? 0
     }
+
 
     private async checkAndMaybeDisableWorkflow(hogFlowId: string, teamId: number): Promise<void> {
         const [sendsRaw, bouncesRaw, complaintsRaw] = (await this.redis.useClient(

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -173,7 +173,7 @@ export class EmailTrackingService {
 
         const rateBreach =
             sends >= MIN_SENDS_FOR_RATE_CHECK &&
-            (bounceRate > BOUNCE_RATE_THRESHOLD || complaintRate > COMPLAINT_RATE_THRESHOLD)
+            (bounceRate >= BOUNCE_RATE_THRESHOLD || complaintRate >= COMPLAINT_RATE_THRESHOLD)
 
         if (!rateBreach) {
             return

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -3,9 +3,11 @@ import express from 'ultimate-express'
 
 import { ModifiedRequest } from '~/api/router'
 import { CyclotronJobInvocationHogFunction, MinimalAppMetric } from '~/cdp/types'
+import { RedisV2 } from '~/common/redis/redis-v2'
 import { defaultConfig } from '~/config/config'
 import { parseJSON } from '~/utils/json-parse'
-import { captureException } from '~/utils/posthog'
+import { captureException, captureTeamEvent } from '~/utils/posthog'
+import { TeamManager } from '~/utils/team-manager'
 
 import { logger } from '../../../utils/logger'
 import { HogFlowManagerService } from '../hogflows/hogflow-manager.service'
@@ -53,13 +55,25 @@ export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocat
     return html
 }
 
+const REPUTATION_REDIS_PREFIX =
+    process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
+const REPUTATION_TTL_SECONDS = 86400 // 24h sliding window
+
+const BOUNCE_RATE_THRESHOLD = 0.02 // 2% — Google/Yahoo enforcement threshold
+const COMPLAINT_RATE_THRESHOLD = 0.001 // 0.1% — SES suspension threshold
+const MIN_SENDS_FOR_RATE_CHECK = 50 // avoid false positives on low volume
+const MAX_BOUNCES_ABSOLUTE = 5 // pause regardless of rate below min sends
+const MAX_COMPLAINTS_ABSOLUTE = 3
+
 export class EmailTrackingService {
     private sesWebhookHandler: SesWebhookHandler
 
     constructor(
         private hogFunctionManager: HogFunctionManagerService,
         private hogFlowManager: HogFlowManagerService,
-        private hogFunctionMonitoringService: HogFunctionMonitoringService
+        private hogFunctionMonitoringService: HogFunctionMonitoringService,
+        private redis: RedisV2,
+        private teamManager: TeamManager
     ) {
         this.sesWebhookHandler = new SesWebhookHandler()
     }
@@ -126,6 +140,110 @@ export class EmailTrackingService {
         })
     }
 
+    private reputationKey(hogFlowId: string, counter: 'sends' | 'bounces' | 'complaints' | 'alerted'): string {
+        return `${REPUTATION_REDIS_PREFIX}/${hogFlowId}/${counter}`
+    }
+
+    private async incrementWithTtl(key: string): Promise<number> {
+        const count = await this.redis.useClient({ name: 'email-reputation-incr', failOpen: true }, async (client) => {
+            const newVal = await client.incr(key)
+            if (newVal === 1) {
+                await client.expire(key, REPUTATION_TTL_SECONDS)
+            }
+            return newVal
+        })
+        return count ?? 0
+    }
+
+    private async checkAndMaybeDisableWorkflow(hogFlowId: string, teamId: number): Promise<void> {
+        const [sendsRaw, bouncesRaw, complaintsRaw] = (await this.redis.useClient(
+            { name: 'email-reputation-check', failOpen: true },
+            async (client) =>
+                client.mget(
+                    this.reputationKey(hogFlowId, 'sends'),
+                    this.reputationKey(hogFlowId, 'bounces'),
+                    this.reputationKey(hogFlowId, 'complaints')
+                )
+        )) ?? [null, null, null]
+
+        const sends = parseInt(sendsRaw ?? '0', 10)
+        const bounces = parseInt(bouncesRaw ?? '0', 10)
+        const complaints = parseInt(complaintsRaw ?? '0', 10)
+
+        const bounceRate = sends > 0 ? bounces / sends : 0
+        const complaintRate = sends > 0 ? complaints / sends : 0
+
+        const rateBreach =
+            sends >= MIN_SENDS_FOR_RATE_CHECK &&
+            (bounceRate > BOUNCE_RATE_THRESHOLD || complaintRate > COMPLAINT_RATE_THRESHOLD)
+        const absoluteBreach = bounces >= MAX_BOUNCES_ABSOLUTE || complaints >= MAX_COMPLAINTS_ABSOLUTE
+
+        if (!rateBreach && !absoluteBreach) {
+            return
+        }
+
+        // Use SETNX as a distributed once-per-window guard — only the first call within the TTL fires the event
+        const alertKey = this.reputationKey(hogFlowId, 'alerted')
+        const isFirstAlert = await this.redis.useClient(
+            { name: 'email-reputation-alert', failOpen: true },
+            async (client) => {
+                const set = await client.setnx(alertKey, '1')
+                if (set === 1) {
+                    await client.expire(alertKey, REPUTATION_TTL_SECONDS)
+                }
+                return set === 1
+            }
+        )
+
+        if (!isFirstAlert) {
+            return
+        }
+
+        const team = await this.teamManager.getTeam(teamId)
+        if (!team) {
+            logger.error('[EmailTrackingService] checkAndMaybeDisableWorkflow: team not found', { teamId, hogFlowId })
+            return
+        }
+
+        const disabled = await this.hogFlowManager.disableHogFlow(hogFlowId)
+
+        captureTeamEvent(team, 'email_workflow_paused_for_reputation', {
+            workflow_id: hogFlowId,
+            bounce_rate: bounceRate,
+            complaint_rate: complaintRate,
+            bounces,
+            complaints,
+            sends,
+            disabled,
+        })
+
+        logger.info('[EmailTrackingService] Email reputation threshold breached', {
+            hogFlowId,
+            teamId,
+            bounces,
+            complaints,
+            sends,
+            bounceRate,
+            complaintRate,
+        })
+    }
+
+    private async trackReputation(
+        hogFlowId: string,
+        teamId: number,
+        metricName: MinimalAppMetric['metric_name']
+    ): Promise<void> {
+        if (metricName === 'email_sent') {
+            await this.incrementWithTtl(this.reputationKey(hogFlowId, 'sends'))
+        } else if (metricName === 'email_bounced') {
+            await this.incrementWithTtl(this.reputationKey(hogFlowId, 'bounces'))
+            await this.checkAndMaybeDisableWorkflow(hogFlowId, teamId)
+        } else if (metricName === 'email_blocked') {
+            await this.incrementWithTtl(this.reputationKey(hogFlowId, 'complaints'))
+            await this.checkAndMaybeDisableWorkflow(hogFlowId, teamId)
+        }
+    }
+
     public async handleSesWebhook(req: ModifiedRequest): Promise<{ status: number; message?: string }> {
         if (!req.body) {
             return { status: 403, message: 'Missing request body' }
@@ -145,6 +263,13 @@ export class EmailTrackingService {
                     metricName: metric.metricName,
                     source: 'ses',
                 })
+
+                if (metric.functionId) {
+                    const hogFlow = await this.hogFlowManager.getHogFlow(metric.functionId).catch(() => null)
+                    if (hogFlow) {
+                        await this.trackReputation(hogFlow.id, hogFlow.team_id, metric.metricName)
+                    }
+                }
             }
 
             return { status, message: body as string }

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -61,7 +61,7 @@ const REPUTATION_TTL_SECONDS = 86400 // 24h sliding window
 
 const BOUNCE_RATE_THRESHOLD = 0.02 // 2% — Google/Yahoo enforcement threshold
 const COMPLAINT_RATE_THRESHOLD = 0.001 // 0.1% — SES suspension threshold
-const MIN_SENDS_FOR_RATE_CHECK = 100 // avoid false positives on low volume
+const MIN_SENDS_FOR_RATE_CHECK = 250 // avoid false positives on low volume
 
 export class EmailTrackingService {
     private sesWebhookHandler: SesWebhookHandler

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -61,9 +61,7 @@ const REPUTATION_TTL_SECONDS = 86400 // 24h sliding window
 
 const BOUNCE_RATE_THRESHOLD = 0.02 // 2% — Google/Yahoo enforcement threshold
 const COMPLAINT_RATE_THRESHOLD = 0.001 // 0.1% — SES suspension threshold
-const MIN_SENDS_FOR_RATE_CHECK = 50 // avoid false positives on low volume
-const MAX_BOUNCES_ABSOLUTE = 5 // pause regardless of rate below min sends
-const MAX_COMPLAINTS_ABSOLUTE = 3
+const MIN_SENDS_FOR_RATE_CHECK = 100 // avoid false positives on low volume
 
 export class EmailTrackingService {
     private sesWebhookHandler: SesWebhookHandler
@@ -176,9 +174,8 @@ export class EmailTrackingService {
         const rateBreach =
             sends >= MIN_SENDS_FOR_RATE_CHECK &&
             (bounceRate > BOUNCE_RATE_THRESHOLD || complaintRate > COMPLAINT_RATE_THRESHOLD)
-        const absoluteBreach = bounces >= MAX_BOUNCES_ABSOLUTE || complaints >= MAX_COMPLAINTS_ABSOLUTE
 
-        if (!rateBreach && !absoluteBreach) {
+        if (!rateBreach) {
             return
         }
 

--- a/nodejs/src/cdp/services/messaging/email-tracking.ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.ses.test.ts
@@ -37,9 +37,9 @@ describe('EmailTrackingService (SES reputation - rate breaches)', () => {
     }
 
     beforeEach(() => {
-        const hogFunctionManager = { getHogFunction: () => null }
+        const hogFunctionManager = { getHogFunction: jest.fn().mockResolvedValue(null) }
         const hogFlowManager = {
-            getHogFlow: jest.fn((id: string) => (id === hogFlow.id ? hogFlow : null)),
+            getHogFlow: jest.fn((id: string) => Promise.resolve(id === hogFlow.id ? hogFlow : null)),
             disableHogFlow: jest.fn(() => true),
         }
         const hogFunctionMonitoringService = { queueAppMetric: jest.fn(), flush: jest.fn() }
@@ -62,8 +62,8 @@ describe('EmailTrackingService (SES reputation - rate breaches)', () => {
 
         // Pre-seed sends >= MIN_SENDS_FOR_RATE_CHECK and bounces such that bounceRate > BOUNCE_RATE_THRESHOLD
         const initial: any = {}
-        initial[`${prefix}/${hogFlow.id}/sends`] = '100' // MIN_SENDS_FOR_RATE_CHECK
-        initial[`${prefix}/${hogFlow.id}/bounces`] = '3' // bounceRate = 3/100 = 0.03 (> 0.02)
+        initial[`${prefix}/${hogFlow.id}/sends`] = '250' // MIN_SENDS_FOR_RATE_CHECK
+        initial[`${prefix}/${hogFlow.id}/bounces`] = '10' // bounceRate = 10/250 = 0.04 (> 0.02)
         initial[`${prefix}/${hogFlow.id}/complaints`] = '0'
         ;(service as any).redis = createRedisMock(initial) as any
         ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
@@ -100,9 +100,9 @@ describe('EmailTrackingService (SES reputation - rate breaches)', () => {
         const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
 
         const initial: any = {}
-        initial[`${prefix}/${hogFlow.id}/sends`] = '100' // MIN_SENDS_FOR_RATE_CHECK
+        initial[`${prefix}/${hogFlow.id}/sends`] = '250' // MIN_SENDS_FOR_RATE_CHECK
         initial[`${prefix}/${hogFlow.id}/bounces`] = '0'
-        initial[`${prefix}/${hogFlow.id}/complaints`] = '1' // complaintRate = 1/100 = 0.01 (> 0.001)
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '1' // complaintRate = 1/250 = 0.004 (> 0.001)
         ;(service as any).redis = createRedisMock(initial) as any
         ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
             status: 200,
@@ -119,9 +119,9 @@ describe('EmailTrackingService (SES reputation - rate breaches)', () => {
         const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
 
         const initial: Record<string, string> = {}
-        initial[`${prefix}/${hogFlow.id}/sends`] = '100'
+        initial[`${prefix}/${hogFlow.id}/sends`] = '100000'
         initial[`${prefix}/${hogFlow.id}/bounces`] = '0'
-        initial[`${prefix}/${hogFlow.id}/complaints`] = '0' // complaintRate = 0
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '0'
         ;(service as any).redis = createRedisMock(initial) as any
         ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
             status: 200,

--- a/nodejs/src/cdp/services/messaging/email-tracking.ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.ses.test.ts
@@ -1,0 +1,136 @@
+import { EmailTrackingService } from '~/cdp/services/messaging/email-tracking.service'
+
+jest.mock('~/utils/posthog', () => ({
+    captureTeamEvent: jest.fn(),
+    captureException: jest.fn(),
+}))
+
+describe('EmailTrackingService (SES reputation - rate breaches)', () => {
+    let service: EmailTrackingService
+    const hogFlow = { id: 'flow-1', team_id: 123 }
+    const team = { id: hogFlow.team_id }
+
+    function createRedisMock(initial: Record<string, string> = {}) {
+        const store = new Map<string, string>(Object.entries(initial))
+
+        const client = {
+            incr: (key: string) => {
+                const v = parseInt(store.get(key) ?? '0', 10) + 1
+                store.set(key, String(v))
+                return v
+            },
+            expire: () => 1,
+            mget: (...keys: string[]) => keys.map((k) => store.get(k) ?? null),
+            setnx: (key: string, val: string) => {
+                if (!store.has(key)) {
+                    store.set(key, val)
+                    return 1
+                }
+                return 0
+            },
+        }
+
+        return {
+            useClient: (_opts: any, cb: any) => cb(client),
+            __store: store,
+        }
+    }
+
+    beforeEach(() => {
+        const hogFunctionManager = { getHogFunction: () => null }
+        const hogFlowManager = {
+            getHogFlow: jest.fn((id: string) => (id === hogFlow.id ? hogFlow : null)),
+            disableHogFlow: jest.fn(() => true),
+        }
+        const hogFunctionMonitoringService = { queueAppMetric: jest.fn(), flush: jest.fn() }
+        const teamManager = { getTeam: jest.fn(() => team) }
+
+        // default redis (can be replaced per-test)
+        const redis = createRedisMock()
+
+        service = new EmailTrackingService(
+            hogFunctionManager as any,
+            hogFlowManager as any,
+            hogFunctionMonitoringService as any,
+            redis as any,
+            teamManager as any
+        )
+    })
+
+    it('disables flow when bounce rate breaches the configured threshold', async () => {
+        const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
+
+        // Pre-seed sends >= MIN_SENDS_FOR_RATE_CHECK and bounces such that bounceRate > BOUNCE_RATE_THRESHOLD
+        const initial: any = {}
+        initial[`${prefix}/${hogFlow.id}/sends`] = '100' // MIN_SENDS_FOR_RATE_CHECK
+        initial[`${prefix}/${hogFlow.id}/bounces`] = '3' // bounceRate = 3/100 = 0.03 (> 0.02)
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '0'
+        ;(service as any).redis = createRedisMock(initial) as any
+        ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
+            status: 200,
+            body: 'ok',
+            metrics: [{ functionId: hogFlow.id, invocationId: 'inv-1', metricName: 'email_bounced' }],
+        })
+
+        await service.handleSesWebhook({ body: '{}', headers: {} } as any)
+
+        expect((service as any).hogFlowManager.disableHogFlow).toHaveBeenCalledWith(hogFlow.id)
+    })
+
+    it('does not disable flow when sends below the MIN_SENDS_FOR_RATE_CHECK', async () => {
+        const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
+
+        const initial: Record<string, string> = {}
+        initial[`${prefix}/${hogFlow.id}/sends`] = '10' // below MIN_SENDS_FOR_RATE_CHECK
+        initial[`${prefix}/${hogFlow.id}/bounces`] = '1'
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '0'
+        ;(service as any).redis = createRedisMock(initial) as any
+        ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
+            status: 200,
+            body: 'ok',
+            metrics: [{ functionId: hogFlow.id, invocationId: 'inv-2', metricName: 'email_bounced' }],
+        })
+
+        await service.handleSesWebhook({ body: '{}', headers: {} } as any)
+
+        expect((service as any).hogFlowManager.disableHogFlow).not.toHaveBeenCalled()
+    })
+
+    it('disables flow when complaint rate breaches the configured threshold', async () => {
+        const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
+
+        const initial: any = {}
+        initial[`${prefix}/${hogFlow.id}/sends`] = '100' // MIN_SENDS_FOR_RATE_CHECK
+        initial[`${prefix}/${hogFlow.id}/bounces`] = '0'
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '1' // complaintRate = 1/100 = 0.01 (> 0.001)
+        ;(service as any).redis = createRedisMock(initial) as any
+        ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
+            status: 200,
+            body: 'ok',
+            metrics: [{ functionId: hogFlow.id, invocationId: 'inv-3', metricName: 'email_blocked' }],
+        })
+
+        await service.handleSesWebhook({ body: '{}', headers: {} } as any)
+
+        expect((service as any).hogFlowManager.disableHogFlow).toHaveBeenCalledWith(hogFlow.id)
+    })
+
+    it('does not disable flow when complaint rate is below threshold', async () => {
+        const prefix = process.env.NODE_ENV === 'test' ? '@posthog-test/email-reputation' : '@posthog/email-reputation'
+
+        const initial: Record<string, string> = {}
+        initial[`${prefix}/${hogFlow.id}/sends`] = '100'
+        initial[`${prefix}/${hogFlow.id}/bounces`] = '0'
+        initial[`${prefix}/${hogFlow.id}/complaints`] = '0' // complaintRate = 0
+        ;(service as any).redis = createRedisMock(initial) as any
+        ;(service as any).sesWebhookHandler.handleWebhook = jest.fn().mockResolvedValue({
+            status: 200,
+            body: 'ok',
+            metrics: [{ functionId: hogFlow.id, invocationId: 'inv-4', metricName: 'email_blocked' }],
+        })
+
+        await service.handleSesWebhook({ body: '{}', headers: {} } as any)
+
+        expect((service as any).hogFlowManager.disableHogFlow).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Problem

Currently SES can automatically disable tenants based on their reputation policies, but if/when this happens it would be pretty transparent to customers

## Changes

- Track complaint/bounce rates internally
- automatically disable a workflow if rate thresholds are breached
- emit an event that we'll use to send an email alert to the customer to let them know what happened

## How did you test this code?

Added tests for all new code

## Publish to changelog?

Yes