### PR TITLE
feat(llma): materialize ai experiment id

### DIFF
--- a/posthog/clickhouse/migrations/0218_materialize_ai_experiment_id.py
+++ b/posthog/clickhouse/migrations/0218_materialize_ai_experiment_id.py
@@ -1,0 +1,49 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+ADD_COLUMN_SHARDED_EVENTS = """
+ALTER TABLE sharded_events
+ADD COLUMN IF NOT EXISTS `mat_$ai_experiment_id` Nullable(String)
+MATERIALIZED JSONExtract(properties, '$ai_experiment_id', 'Nullable(String)')
+"""
+
+ADD_COLUMN_EVENTS = """
+ALTER TABLE events
+ADD COLUMN IF NOT EXISTS `mat_$ai_experiment_id` Nullable(String)
+COMMENT 'column_materializer::properties::$ai_experiment_id'
+"""
+
+ADD_BLOOM_FILTER_INDEX_SHARDED_EVENTS = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `bloom_filter_$ai_experiment_id` `mat_$ai_experiment_id`
+TYPE bloom_filter
+GRANULARITY 1
+"""
+
+ADD_MINMAX_INDEX_SHARDED_EVENTS = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `minmax_$ai_experiment_id` `mat_$ai_experiment_id`
+TYPE minmax
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_COLUMN_SHARDED_EVENTS, node_roles=[NodeRole.DATA], sharded=True, is_alter_on_replicated_table=True
+    ),
+    run_sql_with_exceptions(
+        ADD_COLUMN_EVENTS,
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    run_sql_with_exceptions(
+        ADD_BLOOM_FILTER_INDEX_SHARDED_EVENTS,
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        ADD_MINMAX_INDEX_SHARDED_EVENTS, node_roles=[NodeRole.DATA], sharded=True, is_alter_on_replicated_table=True
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0217_tophog
+0218_materialize_ai_experiment_id


### PR DESCRIPTION
## Problem

Offline eval queries need fast filtering on `$ai_experiment_id` as usage grows.

## Changes

- Added ClickHouse migration `0218_materialize_ai_experiment_id.py`.
- Materializes `mat_$ai_experiment_id` on `sharded_events` and `events`.
- Adds bloom and minmax indexes on `sharded_events.mat_$ai_experiment_id`.
- Updated `posthog/clickhouse/migrations/max_migration.txt` to `0218_materialize_ai_experiment_id`.


## Publish to changelog?

no
