### PR TITLE
fix(toolbar): fix broken links

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -52,7 +52,7 @@ import { WebVitalsToolbarMenu } from '~/toolbar/web-vitals/WebVitalsToolbarMenu'
 
 import { ToolbarButton } from './ToolbarButton'
 
-const HELP_URL = 'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
+const HELP_URL = 'https://posthog.com/docs/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
 
 function EnabledStatusItem({ label, value }: { label: string; value: boolean }): JSX.Element {
     return (

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -228,7 +228,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                 <div className="flex items-center gap-1">
                                     <LemonLabel
                                         info="Sampling computes the result on a proportion of data of the users in the dataset, making click maps load significantly faster."
-                                        infoLink="https://posthog.com/docs/product-analytics/sampling"
+                                        infoLink="https://posthog.com/docs/toolbar/heatmaps"
                                     >
                                         Sampling
                                     </LemonLabel>


### PR DESCRIPTION
## Problem

Documentation links in the toolbar were pointing to outdated or incorrect URLs that don't match the current documentation structure.

## Changes

Updated two documentation links in the toolbar:

1. **Toolbar.tsx**: Changed the help button link from `/docs/user-guides/toolbar` to `/docs/toolbar` to match the current documentation URL structure
2. **HeatmapToolbarMenu.tsx**: Updated the sampling info link from `/docs/product-analytics/sampling` to `/docs/toolbar/heatmaps` to point to the relevant heatmap documentation

## How did you test this code?

No testing needed - these are straightforward URL updates that will be validated when users click the help links in the toolbar.

## Publish to changelog?

No

https://claude.ai/code/session_015f4NQqGgwnfJW5tWcipwJC