### PR TITLE
fix: added missing feature flag for external MCP servers

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -348,6 +348,7 @@ export const SETTINGS_MAP: SettingSection[] = [
         id: 'mcp-servers',
         title: 'MCP servers',
         group: 'AI',
+        flag: 'MCP_SERVERS',
         settings: [
             {
                 id: 'mcp-servers-manage',


### PR DESCRIPTION
## Problem

I forgot to add a feature flag to the settings page.

## Changes

I added the feature flag.

## How did you test this code?

- Tested manually

## Publish to changelog?

no