### PR TITLE
Improve scroll tracking in heatmaps with event listeners

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -207,6 +207,11 @@ export function HeatmapCanvas({
     }
 
     if (heatmapFilters.type === 'scrolldepth') {
+        // In toolbar mode, ScrollDepth component in Elements.tsx handles scroll depth rendering
+        // with proper toolbar-specific mouse info and scroll sync
+        if (isToolbar) {
+            return null
+        }
         return (
             <ScrollDepthCanvas
                 key={`scrolldepth-${heatmapFilters.type}-${exportToken ? 'export' : `${widthOverride ?? windowWidth}x${windowHeight}`}`}

--- a/frontend/src/lib/components/heatmaps/useScrollSync.ts
+++ b/frontend/src/lib/components/heatmaps/useScrollSync.ts
@@ -26,8 +26,21 @@ export function useScrollSync(enabled: boolean = true): {
         let rafId: number | undefined
         let lastScrollY = -1
 
-        const onFrame = (): void => {
-            const scrollY = posthogInstance?.scrollManager?.scrollY() ?? window.scrollY
+        const getScrollY = (): number => {
+            // Try posthog scroll manager first — it handles pages with custom scroll containers
+            try {
+                const managed = posthogInstance?.scrollManager?.scrollY()
+                if (typeof managed === 'number' && !isNaN(managed)) {
+                    return managed
+                }
+            } catch {
+                // scrollManager unavailable or errored
+            }
+            return document.scrollingElement?.scrollTop ?? window.scrollY ?? 0
+        }
+
+        const applyScroll = (): void => {
+            const scrollY = getScrollY()
             if (scrollY !== lastScrollY) {
                 lastScrollY = scrollY
                 scrollYRef.current = scrollY
@@ -36,15 +49,25 @@ export function useScrollSync(enabled: boolean = true): {
                     inner.style.transform = `translateY(${-scrollY}px)`
                 }
             }
+        }
+
+        const onFrame = (): void => {
+            applyScroll()
             rafId = requestAnimationFrame(onFrame)
         }
 
         rafId = requestAnimationFrame(onFrame)
 
+        // Also listen for scroll events for immediate response.
+        // Capture phase catches events from nested scrollable containers too.
+        const onScroll = (): void => applyScroll()
+        document.addEventListener('scroll', onScroll, true)
+
         return () => {
             if (rafId !== undefined) {
                 cancelAnimationFrame(rafId)
             }
+            document.removeEventListener('scroll', onScroll, true)
         }
     }, [enabled])
 

--- a/frontend/src/toolbar/elements/ScrollDepth.tsx
+++ b/frontend/src/toolbar/elements/ScrollDepth.tsx
@@ -2,14 +2,12 @@ import { useValues } from 'kea'
 
 import { ScrollDepthMouseCanvas, scrollDepthColor } from 'lib/components/heatmaps/ScrollDepthCanvas'
 import { useMousePosition } from 'lib/components/heatmaps/useMousePosition'
+import { useScrollSync } from 'lib/components/heatmaps/useScrollSync'
 import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
 
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 
-import { toolbarConfigLogic } from '../toolbarConfigLogic'
-
-function ScrollDepthMouseInfo(): JSX.Element | null {
-    const { posthog } = useValues(toolbarConfigLogic)
+function ScrollDepthMouseInfo({ scrollYRef }: { scrollYRef: React.MutableRefObject<number> }): JSX.Element | null {
     const { heatmapElements, rawHeatmapLoading } = useValues(heatmapToolbarMenuLogic)
 
     const shiftPressed = useShiftKeyPressed()
@@ -19,8 +17,7 @@ function ScrollDepthMouseInfo(): JSX.Element | null {
         return null
     }
 
-    const scrollOffset = (posthog as any).scrollManager.scrollY()
-    const scrolledMouseY = mouseY + scrollOffset
+    const scrolledMouseY = mouseY + scrollYRef.current
 
     const elementInMouseY = heatmapElements.find((x, i) => {
         const lastY = heatmapElements[i - 1]?.y ?? 0
@@ -42,10 +39,12 @@ function ScrollDepthMouseInfo(): JSX.Element | null {
 }
 
 export function ScrollDepth(): JSX.Element | null {
-    const { posthog } = useValues(toolbarConfigLogic)
-
     const { heatmapEnabled, heatmapFilters, heatmapElements, scrollDepthPosthogJsError, heatmapColorPalette } =
         useValues(heatmapToolbarMenuLogic)
+
+    const { innerRef, scrollYRef } = useScrollSync(
+        heatmapEnabled && heatmapFilters.enabled && heatmapFilters.type === 'scrolldepth'
+    )
 
     if (!heatmapEnabled || !heatmapFilters.enabled || heatmapFilters.type !== 'scrolldepth') {
         return null
@@ -55,18 +54,16 @@ export function ScrollDepth(): JSX.Element | null {
         return null
     }
 
-    const scrollOffset = (posthog as any).scrollManager.scrollY()
-
-    // We want to have a fading color from red to orange to green to blue to grey, fading from the highest count to the lowest
     const maxCount = heatmapElements[0]?.count ?? 0
 
     return (
         <div className="fixed inset-0 overflow-hidden">
             <div
+                ref={innerRef}
                 className="absolute top-0 left-0 right-0"
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{
-                    transform: `translateY(${-scrollOffset}px)`,
+                    willChange: 'transform',
                 }}
             >
                 {heatmapElements.map(({ y, count }, i) => (
@@ -82,7 +79,7 @@ export function ScrollDepth(): JSX.Element | null {
                     />
                 ))}
             </div>
-            <ScrollDepthMouseInfo />
+            <ScrollDepthMouseInfo scrollYRef={scrollYRef} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The scroll depth heatmap tracking relies on PostHog's scroll manager, which may not be available or reliable in all contexts. Additionally, scroll synchronization only updates on animation frames, which can cause visual lag when scrolling quickly.

## Changes

### `useScrollSync.ts`
- Refactored scroll detection into a new `getScrollY()` function that:
  - Attempts to use PostHog's scroll manager first (handles custom scroll containers)
  - Falls back to `document.scrollingElement?.scrollTop` then `window.scrollY` with proper error handling
  - Returns 0 as a safe default instead of potentially undefined values
- Split frame logic into `applyScroll()` to separate scroll application from RAF scheduling
- Added a `scroll` event listener (capture phase) for immediate scroll response, complementing the RAF-based updates
- Properly cleans up the scroll event listener on unmount

### `ScrollDepth.tsx`
- Integrated `useScrollSync()` hook to manage scroll state consistently
- Removed direct dependency on `toolbarConfigLogic` and PostHog's scroll manager
- Updated `ScrollDepthMouseInfo` to receive `scrollYRef` as a prop instead of accessing PostHog directly
- Simplified scroll offset calculation to use the ref from `useScrollSync`
- Added `willChange: 'transform'` CSS hint for better rendering performance

### `HeatmapCanvas.tsx`
- Added early return for scroll depth heatmaps in toolbar mode, since `ScrollDepth.tsx` component handles rendering with proper scroll sync

## How did you test this code?

Code review of the changes:
- Verified scroll detection fallback chain handles missing/errored scroll manager gracefully
- Confirmed event listener is properly cleaned up to prevent memory leaks
- Checked that scroll depth rendering in toolbar mode uses the new unified scroll sync mechanism
- Validated that both RAF and event-based scroll updates work together for responsive tracking

https://claude.ai/code/session_01GPbSWkedsRYnGeWW7a5jeV