### PR TITLE
fix(product tours): fix autosave bug

### DIFF
--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -577,8 +577,13 @@ export const productTourLogic = kea<productTourLogicType>([
 
                 const formValues = tourToFormValues(productTour)
                 const incomingPayload = buildDraftPayload(formValues)
-                const isOwnEcho = values.isEditingProductTour && isEqual(incomingPayload, cache.lastDraftPayload)
-                if (!isOwnEcho) {
+                const hasUnsavedLocalChanges =
+                    values.draftSaveStatus === 'unsaved' || values.draftSaveStatus === 'saving'
+                const isOwnEcho =
+                    values.isEditingProductTour &&
+                    isEqual(incomingPayload, cache.lastSentDraftPayload ?? cache.lastDraftPayload)
+
+                if (!isOwnEcho && !hasUnsavedLocalChanges) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     ;(actions.setProductTourFormValues as any)(formValues)
                     cache.lastDraftPayload = incomingPayload
@@ -617,8 +622,10 @@ export const productTourLogic = kea<productTourLogicType>([
             await breakpoint(1000)
             if (values.isEditingProductTour && values.productTourForm.name && props.id && props.id !== 'new') {
                 actions.setDraftSaveStatus('saving')
+                const payload = buildDraftPayload(values.productTourForm)
+                cache.lastSentDraftPayload = payload
                 try {
-                    await api.productTours.saveDraft(props.id, buildDraftPayload(values.productTourForm))
+                    await api.productTours.saveDraft(props.id, payload)
                     actions.setDraftSaveStatus('saved')
                 } finally {
                     actions.setDraftActionInProgress(null)


### PR DESCRIPTION
## Problem

if a user is editing a tour during an in-flight polling request, the poll response overwrites their content

at first i was unable to reproduce this, it's a pretty small race window, but setting network throttling to something slow made it happen more often

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

added new `lastSentDraftPayload` to track the last payload actually sent to the draft endpoint, separate from `lastDraftPayload` which is updated on every editor change & replaced on polling responses

also added a guard to prevent polling response from overwriting local content when there are unsaved local changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->