### PR TITLE
chore(oauth-proxy): set KV namespace ID

### DIFF
--- a/services/oauth-proxy/wrangler.jsonc
+++ b/services/oauth-proxy/wrangler.jsonc
@@ -26,7 +26,7 @@
     "kv_namespaces": [
         {
             "binding": "AUTH_KV",
-            "id": "TODO_REPLACE_WITH_KV_NAMESPACE_ID"
+            "id": "3ac9a85816994f3ea94f98364de4732a"
         }
     ]
 }


### PR DESCRIPTION
## Problem

The oauth-proxy worker (`services/oauth-proxy/`) was merged with a placeholder KV namespace ID that needs to be replaced with the real one before deployment.

## Changes

Sets the KV namespace ID to the one created in Cloudflare (`3ac9a85816994f3ea94f98364de4732a`).

## How did you test this code?

Config-only change — verified the ID matches the namespace created in Cloudflare dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)