### PR TITLE
fix(llma): fix cluster card border colors and reduce width

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -52,13 +52,12 @@ export function ClusterCard({
     return (
         <div
             className={`rounded-lg overflow-hidden transition-all border-y border-r ${
-                isOutlierCluster
-                    ? 'bg-surface-primary border-dashed border-warning-dark'
-                    : 'bg-surface-primary border-border'
+                isOutlierCluster ? 'bg-surface-primary border-dashed' : 'bg-surface-primary'
             }`}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
-                borderLeftWidth: 4,
+                borderColor: isOutlierCluster ? 'var(--warning-dark)' : 'var(--border)',
+                borderLeftWidth: 3,
                 borderLeftColor: clusterColor,
                 borderLeftStyle: isOutlierCluster ? 'dashed' : 'solid',
             }}


### PR DESCRIPTION
## Problem

Cluster card left borders were all grey instead of showing their series colors. The root cause was Tailwind's `important: true` config, which caused `border-border` and `border-warning-dark` utility classes to generate `!important` declarations that overrode the inline `borderLeftColor` style.

## Changes

- Moved border color from Tailwind classes (`border-border`, `border-warning-dark`) to inline styles so `borderLeftColor` is no longer overridden by `!important`
- Reduced left border width from 4px to 3px

## How did you test this code?

I am an agent and have not tested this manually. The change is a straightforward CSS fix - moving border-color from Tailwind classes to inline styles to avoid the `!important` override. Visual verification recommended.

## Publish to changelog?

No