### PR TITLE
fix(toolbar): filter out internal flags from my_flags endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1901,8 +1901,18 @@ class FeatureFlagViewSet(
         if not request.user.is_authenticated:  # for mypy
             raise exceptions.NotAuthenticated()
 
+        # Exclude internal flags (survey targeting and product tour internal flags)
+        # These are auto-generated and not user-editable, same as the main flags list
+        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.project_id)
+        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
+            team__project_id=self.project_id, internal_targeting_flag__isnull=False
+        ).values_list("internal_targeting_flag_id", flat=True)
+
         feature_flags = list(
-            FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False).order_by("-created_at")
+            FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False)
+            .exclude(Q(id__in=survey_flag_ids))
+            .exclude(Q(id__in=product_tour_internal_targeting_flags))
+            .order_by("-created_at")
         )
 
         if not feature_flags:


### PR DESCRIPTION
## Problem

The toolbar's feature flags list shows all flags including internal ones like `survey-targeting-*` and `product-tour-targeting-*` flags. These are auto-generated flags that are not user-editable and clutter the toolbar interface. The main flags UI already filters these out, but the toolbar's `/my_flags` endpoint does not.

## Changes

Applies the same filtering logic used by the main flags list endpoint to exclude survey targeting and product tour internal flags from the toolbar's `/my_flags` endpoint.

## How did you test this code?

The change follows the exact same pattern already used in the list endpoint (lines 1685-1691 of the same file), so it should work identically.

## Publish to changelog?

No
