### PR TITLE
fix(replay): exclude deleted recordings from billing queries

### DIFF
--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -36,6 +36,7 @@ INSERT INTO sharded_session_replay_events (
     block_first_timestamps,
     block_last_timestamps,
     retention_period_days,
+    is_deleted,
     _timestamp
 )
 SELECT
@@ -60,6 +61,7 @@ SELECT
     %(block_first_timestamps)s,
     %(block_last_timestamps)s,
     %(retention_period_days)s,
+    %(is_deleted)s,
     %(_timestamp)s
 """
 
@@ -140,6 +142,7 @@ def produce_replay_summary(
     block_first_timestamps: list[datetime] | None = None,
     block_last_timestamps: list[datetime] | None = None,
     retention_period_days: int | None = None,
+    is_deleted: bool = False,
 ):
     """
     Creates a session replay event in ClickHouse for testing purposes.
@@ -174,6 +177,7 @@ def produce_replay_summary(
         "block_first_timestamps": block_first_timestamps or [],
         "block_last_timestamps": block_last_timestamps or [],
         "retention_period_days": retention_period_days or 30,
+        "is_deleted": 1 if is_deleted else 0,
     }
 
     if settings.TEST:

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -453,7 +453,8 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web'
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -489,7 +490,8 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING dateDiff('milliseconds', min(min_first_timestamp), max(max_last_timestamp)) = 0)
+     HAVING dateDiff('milliseconds', min(min_first_timestamp), max(max_last_timestamp)) = 0
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -512,7 +514,8 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web'
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -534,7 +537,8 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile'
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -557,7 +561,8 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile'
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -583,7 +588,8 @@
              AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios',
                                                                'posthog-android',
                                                                'posthog-react-native',
-                                                               'posthog-flutter')))
+                                                               'posthog-flutter'))
+     AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -710,6 +710,7 @@ def get_teams_with_recording_count_in_period(
             WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
+            AND max(is_deleted) = 0
         )
         WHERE session_id NOT IN (
             -- we want to exclude sessions that might have events with timestamps
@@ -751,6 +752,7 @@ def get_teams_with_zero_duration_recording_count_in_period(begin: datetime, end:
             WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING dateDiff('milliseconds', min(min_first_timestamp), max(max_last_timestamp)) = 0
+            AND max(is_deleted) = 0
         )
         WHERE session_id NOT IN (
             -- we want to exclude sessions that might have events with timestamps
@@ -788,6 +790,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
             GROUP BY session_id
             HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
             AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'))
+            AND max(is_deleted) = 0
         )
         WHERE session_id NOT IN (
             -- we want to exclude sessions that might have events with timestamps
@@ -1501,6 +1504,7 @@ def get_teams_with_recording_bytes_in_period(
             WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
             GROUP BY session_id
             HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
+            AND max(is_deleted) = 0
         )
         WHERE session_id NOT IN (
             -- we want to exclude sessions that might have events with timestamps


### PR DESCRIPTION
## Summary

- Four billing queries in `usage_report.py` counted deleted (crypto-shredded) recordings as usage/spend
- Added `AND max(is_deleted) = 0` to the `HAVING` clause of each inner subquery, matching the pattern already used in all other `session_replay_events` queries

Affected queries:
- `get_teams_with_recording_count_in_period` (web + mobile recording count)
- `get_teams_with_zero_duration_recording_count_in_period`
- `get_teams_with_mobile_billable_recording_count_in_period`
- `get_teams_with_recording_bytes_in_period`

## Test plan

- [ ] Verify billing queries exclude sessions with `is_deleted=1` in ClickHouse
- [ ] Confirm no impact on billing for teams that haven't deleted recordings (`is_deleted` defaults to 0)