### PR TITLE
feat(mcp): use oauth.posthog.com as authorization server

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -141,8 +141,8 @@ const handleRequest = async (
         resourceUrl.pathname = resourcePath
         resourceUrl.search = ''
 
-        // Determine authorization server based on hostname or region param.
-        // POSTHOG_API_BASE_URL takes precedence for self-hosted, otherwise routes to US/EU.
+        // Determine authorization server for OAuth.
+        // POSTHOG_API_BASE_URL takes precedence for self-hosted, otherwise routes to oauth.posthog.com.
         const authorizationServer = getAuthorizationServerUrl()
 
         return new Response(

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -111,7 +111,7 @@ const handleRequest = async (
     // See: https://github.com/anthropics/claude-code/issues/2267
     const redirect = matchAuthServerRedirect(url.pathname)
     if (redirect) {
-        const authServer = getAuthorizationServerUrl(effectiveRegion)
+        const authServer = getAuthorizationServerUrl()
         const redirectTo = buildRedirectUrl(authServer, url.pathname, url.search, redirect)
 
         log.extend({ redirectTo })
@@ -143,7 +143,7 @@ const handleRequest = async (
 
         // Determine authorization server based on hostname or region param.
         // POSTHOG_API_BASE_URL takes precedence for self-hosted, otherwise routes to US/EU.
-        const authorizationServer = getAuthorizationServerUrl(effectiveRegion)
+        const authorizationServer = getAuthorizationServerUrl()
 
         return new Response(
             JSON.stringify({

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -40,13 +40,16 @@ export const getBaseUrlForRegion = (region: CloudRegion): string => {
  */
 export const CUSTOM_API_BASE_URL = env.POSTHOG_API_BASE_URL
 
-// Get the authorization server URL for OAuth, respecting CUSTOM_API_BASE_URL for self-hosted instances
-export const getAuthorizationServerUrl = (regionParam: string | null): string => {
+export const OAUTH_PROXY_URL = 'https://oauth.posthog.com'
+
+// Get the authorization server URL for OAuth
+// Uses the cross-region OAuth proxy for cloud, or CUSTOM_API_BASE_URL for self-hosted
+export const getAuthorizationServerUrl = (): string => {
     if (CUSTOM_API_BASE_URL) {
         return CUSTOM_API_BASE_URL
     }
 
-    return getBaseUrlForRegion(toCloudRegion(regionParam))
+    return OAUTH_PROXY_URL
 }
 
 // OAuth Authorization Server URL (where clients get tokens)

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -40,7 +40,7 @@ export const getBaseUrlForRegion = (region: CloudRegion): string => {
  */
 export const CUSTOM_API_BASE_URL = env.POSTHOG_API_BASE_URL
 
-export const OAUTH_PROXY_URL = 'https://oauth.posthog.com'
+const OAUTH_PROXY_URL = 'https://oauth.posthog.com'
 
 // Get the authorization server URL for OAuth
 // Uses the cross-region OAuth proxy for cloud, or CUSTOM_API_BASE_URL for self-hosted

--- a/services/mcp/tests/unit/oauth-region.test.ts
+++ b/services/mcp/tests/unit/oauth-region.test.ts
@@ -35,46 +35,6 @@ describe('OAuth Region Routing', () => {
         })
     })
 
-    describe('Protected Resource Metadata', () => {
-        const testCases = [
-            {
-                name: 'defaults to US when no region param',
-                params: '',
-                expectedServer: 'https://us.posthog.com',
-            },
-            {
-                name: 'returns EU server when region=eu',
-                params: '?region=eu',
-                expectedServer: 'https://eu.posthog.com',
-            },
-            {
-                name: 'returns EU server when region=EU (case insensitive)',
-                params: '?region=EU',
-                expectedServer: 'https://eu.posthog.com',
-            },
-            {
-                name: 'returns US server when region=us',
-                params: '?region=us',
-                expectedServer: 'https://us.posthog.com',
-            },
-            {
-                name: 'defaults to US for unknown region',
-                params: '?region=unknown',
-                expectedServer: 'https://us.posthog.com',
-            },
-        ]
-
-        it.each(testCases)('$name', ({ params, expectedServer }) => {
-            const url = new URL(`https://mcp.posthog.com/.well-known/oauth-protected-resource${params}`)
-            const regionParam = url.searchParams.get('region')
-
-            // Uses actual helpers from constants.ts
-            const authorizationServer = getBaseUrlForRegion(toCloudRegion(regionParam))
-
-            expect(authorizationServer).toBe(expectedServer)
-        })
-    })
-
     describe('401 Response Metadata URL (RFC 9728)', () => {
         // Per RFC 9728, the well-known URL is constructed by inserting the well-known path
         // between the host and the resource path:

--- a/services/mcp/tests/unit/oauth-region.test.ts
+++ b/services/mcp/tests/unit/oauth-region.test.ts
@@ -30,24 +30,8 @@ describe('OAuth Region Routing', () => {
     })
 
     describe('getAuthorizationServerUrl', () => {
-        it('returns EU URL when region is eu', () => {
-            expect(getAuthorizationServerUrl('eu')).toBe('https://eu.posthog.com')
-        })
-
-        it('returns EU URL when region is EU (case insensitive)', () => {
-            expect(getAuthorizationServerUrl('EU')).toBe('https://eu.posthog.com')
-        })
-
-        it('returns US URL when region is us', () => {
-            expect(getAuthorizationServerUrl('us')).toBe('https://us.posthog.com')
-        })
-
-        it('returns US URL when region is null', () => {
-            expect(getAuthorizationServerUrl(null)).toBe('https://us.posthog.com')
-        })
-
-        it('returns US URL for unknown region', () => {
-            expect(getAuthorizationServerUrl('unknown')).toBe('https://us.posthog.com')
+        it('returns oauth proxy URL', () => {
+            expect(getAuthorizationServerUrl()).toBe('https://oauth.posthog.com')
         })
     })
 


### PR DESCRIPTION
## Problem

MCP clients currently need to know which region (US/EU) a user is on before starting the OAuth flow. The MCP server advertises regional authorization servers (`us.posthog.com` or `eu.posthog.com`), requiring users to pick the right MCP endpoint upfront.

## Changes

Points the MCP server's OAuth authorization server at `oauth.posthog.com` (the cross-region OAuth proxy from #48838) instead of regional URLs. MCP clients no longer need to know the user's region — the proxy handles routing transparently via a region picker.

- `getAuthorizationServerUrl()` now returns `https://oauth.posthog.com` instead of regional URLs
- Removed the unused `regionParam` parameter since region routing is handled by the proxy
- Self-hosted (`CUSTOM_API_BASE_URL`) still works as before

## How did you test this code?

- Ran MCP server locally with `wrangler dev`, verified `.well-known/oauth-protected-resource/mcp` returns `oauth.posthog.com` as the authorization server
- Connected Claude Code to the local MCP server, completed full OAuth flow through `oauth.posthog.com` (region picker → US login → token exchange)
- Verified MCP tools work after auth (successfully queried projects via the authenticated connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)