### PR TITLE
feat(replay): add Prometheus counter for recording deletions

### DIFF
--- a/nodejs/src/session-replay/recording-api/metrics.ts
+++ b/nodejs/src/session-replay/recording-api/metrics.ts
@@ -19,6 +19,12 @@ export class RecordingApiMetrics {
         this.getBlockDuration.labels({ result, session_state: sessionState }).observe(seconds)
     }
 
+    private static readonly recordingsDeleted = new Counter({
+        name: 'recording_api_recordings_deleted_total',
+        help: 'Number of recordings deleted via the recording API',
+        labelNames: ['status'],
+    })
+
     private static readonly cleanupFailures = new Counter({
         name: 'recording_api_delete_cleanup_failures_total',
         help: 'Cleanup step failures after successful key shred',
@@ -27,6 +33,13 @@ export class RecordingApiMetrics {
 
     public static observeDeleteRecordings(result: string, seconds: number): void {
         this.deleteRecordingsDuration.labels({ result }).observe(seconds)
+    }
+
+    public static incrementRecordingsDeleted(
+        status: 'deleted' | 'already_deleted' | 'failed',
+        count: number = 1
+    ): void {
+        this.recordingsDeleted.labels({ status }).inc(count)
     }
 
     public static incrementCleanupFailure(step: 'kafka' | 'postgres' | 'activity_log'): void {

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -137,7 +137,18 @@ export class RecordingService {
         )
 
         const deleted = results.filter((r) => r.ok && r.status === 'deleted')
+        const alreadyDeleted = results.filter((r) => r.ok && r.status === 'already_deleted')
         const failed = results.filter((r) => !r.ok)
+
+        if (deleted.length > 0) {
+            RecordingApiMetrics.incrementRecordingsDeleted('deleted', deleted.length)
+        }
+        if (alreadyDeleted.length > 0) {
+            RecordingApiMetrics.incrementRecordingsDeleted('already_deleted', alreadyDeleted.length)
+        }
+        if (failed.length > 0) {
+            RecordingApiMetrics.incrementRecordingsDeleted('failed', failed.length)
+        }
 
         await this.propagateDeletion(
             deleted.map((r) => r.sessionId),


### PR DESCRIPTION
## Summary

- Adds `recording_api_recordings_deleted_total` Prometheus counter with `status` label
- Tracks per-session outcomes: `deleted`, `already_deleted`, `failed`
- Incremented in `deleteRecordings` alongside the existing duration histogram

## Test plan

- [ ] Existing recording-api tests pass (32/32)
- [ ] Verify counter appears in `/metrics` endpoint after a delete request