### PR TITLE
fix(replay): apply cohort filter when navigating from cohorts page

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1568,9 +1568,27 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
     }),
 
     // NOTE: It is important this comes after urlToAction, as it will override the default behavior
-    afterMount(({ actions, props }) => {
-        if (!props.onlyPinned) {
-            actions.loadSessionRecordings()
+    afterMount(({ actions, props, values }) => {
+        if (props.onlyPinned) {
+            return
         }
+
+        // If updateSearchParams is enabled and URL has filters different from current state,
+        // skip the initial load here. The urlToAction handler will apply the URL filters and
+        // trigger loadSessionRecordings with the correct filters. This prevents a race condition
+        // where we load with default filters first, then load again with URL filters.
+        if (props.updateSearchParams) {
+            const searchParams = router.values.searchParams
+            if (
+                searchParams?.filters &&
+                isValidRecordingFilters(searchParams.filters) &&
+                !equal(searchParams.filters, values.filters)
+            ) {
+                // URL has valid filters different from current state - let urlToAction handle the initial load
+                return
+            }
+        }
+
+        actions.loadSessionRecordings()
     }),
 ])


### PR DESCRIPTION
## Problem

When clicking "View Session Recordings" from the cohorts page, the cohort filter was not being applied to the session recordings list. Users would see all recordings instead of just those from users in the selected cohort.

Closes #43513

## Changes

Fixed a race condition in `sessionRecordingsPlaylistLogic`:

**Root cause:**
1. Logic mounted with default filters
2. `afterMount` immediately called `loadSessionRecordings()` with default filters
3. `urlToAction` then fired and applied the cohort filter from URL
4. This triggered another `loadSessionRecordings()` with correct filters

The first API call (without cohort filter) would often complete first, making it appear filters were not applied.

**Fix:** Check in `afterMount` whether URL has filters that will be applied by `urlToAction`. If so, skip the initial load - `urlToAction` will trigger the load with correct filters.

## How did you test this code?

- All 35 existing `sessionRecordingsPlaylistLogic` tests pass
- Manual testing should verify: Navigate to Cohorts → click "View Session Recordings" → verify cohort filter is shown and applied in the recordings list

## Publish to changelog?

No