### PR TITLE
First event banner

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -284,6 +284,7 @@ export const FEATURE_FLAGS = {
     FLAG_EVALUATION_RUNTIMES: 'flag-evaluation-runtimes', // owner: @dmarticus #team-feature-flags
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
+    FIRST_EVENT_BANNER: 'growth.first_event_banner', // owner: #team-growth
     INSIGHT_OPTIONS_PAGE: 'insight-options-page', // owner: @rafaeelaudibert #team-growth multivariate=true
     PRODUCT_ANALYTICS_HOME_TAB: 'product-analytics-home-tab', // owner: @anirudhpillai #team-product-analytics
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -190,8 +190,8 @@ export function validateFeatureFlagKey(key: string): string | undefined {
         ? 'Please set a key'
         : key.length > 400
           ? 'Key must be 400 characters or less.'
-          : !key.match?.(/^[a-zA-Z0-9_-]+$/)
-            ? 'Only letters, numbers, hyphens (-) & underscores (_) are allowed.'
+          : !key.match?.(/^[a-zA-Z0-9_.-]+$/)
+            ? 'Only letters, numbers, periods (.), hyphens (-) & underscores (_) are allowed.'
             : undefined
 }
 

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -8,10 +8,13 @@ import { IconHome } from '@posthog/icons'
 
 import { SceneDashboardChoiceRequired } from 'lib/components/SceneDashboardChoice/SceneDashboardChoiceRequired'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { DashboardLogicProps, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { EventDefinitionModal } from 'scenes/data-management/events/EventDefinitionModal'
 import { NewTabScene } from 'scenes/new-tab/NewTabScene'
 import { projectHomepageLogic } from 'scenes/project-homepage/projectHomepageLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
@@ -29,8 +32,10 @@ export const scene: SceneExport = {
 }
 
 function HomePageContent(): JSX.Element {
-    const { dashboardLogicProps } = useValues(projectHomepageLogic)
+    const { dashboardLogicProps, isFirstEventCreateEventModalOpen, shouldShowFirstEventBanner } =
+        useValues(projectHomepageLogic)
     const { showInviteModal } = useActions(inviteLogic)
+    const { clickFirstEventBannerCTA, closeFirstEventCreateEventModal } = useActions(projectHomepageLogic)
     const { dashboard } = useValues(dashboardLogic(dashboardLogicProps as DashboardLogicProps))
     const [isConfigurePinnedTabsOpen, setIsConfigurePinnedTabsOpen] = useState(false)
 
@@ -45,6 +50,35 @@ function HomePageContent(): JSX.Element {
             <span className="hidden" data-attr="aa-test-flag-result">
                 AA test flag result: {String(aaTestBayesianLegacy)} {String(aaTestBayesianNew)}
             </span>
+
+            {shouldShowFirstEventBanner && (
+                <div className="my-4" data-attr="first-event-banner">
+                    <LemonBanner type="info">
+                        <div className="flex flex-col gap-3 @md:flex-row @md:items-center @md:justify-between">
+                            <div className="grow">
+                                Welcome to PostHog! Create your first event to start tracking user behavior.
+                            </div>
+                            <div className="flex items-center gap-3 shrink-0">
+                                <LemonButton
+                                    type="primary"
+                                    size="small"
+                                    onClick={clickFirstEventBannerCTA}
+                                    data-attr="first-event-banner-create-event"
+                                >
+                                    Create event
+                                </LemonButton>
+                                <Link
+                                    to="https://posthog.com/docs/data/events"
+                                    target="_blank"
+                                    data-attr="first-event-banner-learn-more"
+                                >
+                                    Learn more
+                                </Link>
+                            </div>
+                        </div>
+                    </LemonBanner>
+                </div>
+            )}
 
             <SceneTitleSection
                 name={dashboard?.name ?? 'Project Homepage'}
@@ -99,6 +133,7 @@ function HomePageContent(): JSX.Element {
                 isOpen={isConfigurePinnedTabsOpen}
                 onClose={() => setIsConfigurePinnedTabsOpen(false)}
             />
+            <EventDefinitionModal isOpen={isFirstEventCreateEventModalOpen} onClose={closeFirstEventCreateEventModal} />
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -1,8 +1,11 @@
-import { BuiltLogic, actions, beforeUnmount, connect, kea, path, reducers, selectors } from 'kea'
+import { BuiltLogic, actions, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardLogicProps, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
 import { projectLogic } from 'scenes/projectLogic'
@@ -16,11 +19,15 @@ import type { projectHomepageLogicType } from './projectHomepageLogicType'
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeam'], projectLogic, ['currentProjectId']],
+        values: [teamLogic, ['currentTeam'], projectLogic, ['currentProjectId'], featureFlagLogic, ['featureFlags']],
     })),
 
     actions({
         toggleInsightExpanded: (insightShortId: string) => ({ insightShortId }),
+        openFirstEventCreateEventModal: true,
+        closeFirstEventCreateEventModal: true,
+        clickFirstEventBannerCTA: true,
+        reportFirstEventBannerImpression: true,
     }),
 
     reducers({
@@ -32,6 +39,19 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
                     next.has(insightShortId) ? next.delete(insightShortId) : next.add(insightShortId)
                     return next
                 },
+            },
+        ],
+        isFirstEventCreateEventModalOpen: [
+            false,
+            {
+                openFirstEventCreateEventModal: () => true,
+                closeFirstEventCreateEventModal: () => false,
+            },
+        ],
+        hasSentFirstEventBannerImpression: [
+            false,
+            {
+                reportFirstEventBannerImpression: () => true,
             },
         ],
     }),
@@ -80,6 +100,18 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
                 },
             ],
         ],
+        isFirstEventBannerEligible: [
+            (s) => [s.currentTeam],
+            (currentTeam): boolean => !!currentTeam && !currentTeam.is_demo && !currentTeam.ingested_event,
+        ],
+        isFirstEventBannerEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => featureFlags[FEATURE_FLAGS.FIRST_EVENT_BANNER] === true,
+        ],
+        shouldShowFirstEventBanner: [
+            (s) => [s.isFirstEventBannerEligible, s.isFirstEventBannerEnabled],
+            (isEligible, isEnabled): boolean => isEligible && isEnabled,
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -94,6 +126,35 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
                 },
             },
         ],
+    })),
+
+    listeners(({ actions, values }) => ({
+        clickFirstEventBannerCTA: () => {
+            posthog.capture('banner.cta_click', {
+                banner: 'first_event',
+                location: 'project_homepage',
+                feature_flag: FEATURE_FLAGS.FIRST_EVENT_BANNER,
+            })
+            actions.openFirstEventCreateEventModal()
+        },
+        reportFirstEventBannerImpression: () => {
+            if (values.hasSentFirstEventBannerImpression) {
+                return
+            }
+            posthog.capture('banner.impression', {
+                banner: 'first_event',
+                location: 'project_homepage',
+                feature_flag: FEATURE_FLAGS.FIRST_EVENT_BANNER,
+            })
+        },
+    })),
+
+    subscriptions(({ actions, values }) => ({
+        shouldShowFirstEventBanner: (shouldShow) => {
+            if (shouldShow && !values.hasSentFirstEventBannerImpression) {
+                actions.reportFirstEventBannerImpression()
+            }
+        },
     })),
 
     subscriptions(({ cache }) => ({

--- a/playwright/e2e/first-event-banner.spec.ts
+++ b/playwright/e2e/first-event-banner.spec.ts
@@ -1,0 +1,120 @@
+import { Page } from '@playwright/test'
+
+import { expect, test } from '../utils/workspace-test-base'
+
+function extractEventNamesFromPostHogCapture(postData: string | null): string[] {
+    if (!postData) {
+        return []
+    }
+
+    // Most commonly, posthog-js sends a JSON payload with `batch`
+    try {
+        const json = JSON.parse(postData) as any
+        if (Array.isArray(json?.batch)) {
+            return json.batch.map((e: any) => e?.event).filter(Boolean)
+        }
+        if (typeof json?.event === 'string') {
+            return [json.event]
+        }
+    } catch {
+        // ignore
+    }
+
+    // Fallback: posthog-js can send urlencoded `data=<base64(json)>`
+    try {
+        const params = new URLSearchParams(postData)
+        const data = params.get('data')
+        if (data) {
+            const decoded = Buffer.from(data, 'base64').toString('utf8')
+            const json = JSON.parse(decoded) as any
+            if (Array.isArray(json?.batch)) {
+                return json.batch.map((e: any) => e?.event).filter(Boolean)
+            }
+            if (typeof json?.event === 'string') {
+                return [json.event]
+            }
+        }
+    } catch {
+        // ignore
+    }
+
+    return []
+}
+
+async function patchAppContext(page: Page, { hasIngestedEvent }: { hasIngestedEvent: boolean }): Promise<void> {
+    await page.addInitScript(
+        ({ hasIngestedEvent }) => {
+            const persistedFlag = 'growth.first_event_banner'
+            let _ctx: any
+
+            const patch = (ctx: any): any => {
+                if (!ctx) {
+                    return ctx
+                }
+
+                ctx.persisted_feature_flags = Array.from(
+                    new Set([...(ctx.persisted_feature_flags || []), persistedFlag])
+                )
+
+                if (ctx.current_team) {
+                    ctx.current_team = { ...ctx.current_team, ingested_event: hasIngestedEvent }
+                }
+
+                return ctx
+            }
+
+            Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
+                configurable: true,
+                get() {
+                    return _ctx
+                },
+                set(value) {
+                    _ctx = patch(value)
+                },
+            })
+        },
+        { hasIngestedEvent }
+    )
+}
+
+test.describe('First event banner', () => {
+    test('shows banner for new users and tracks impression + CTA click', async ({ page, playwrightSetup }) => {
+        const capturedEventNames: string[] = []
+
+        await page.route('**/e/**', async (route) => {
+            if (route.request().method() !== 'POST') {
+                await route.continue()
+                return
+            }
+
+            capturedEventNames.push(...extractEventNamesFromPostHogCapture(route.request().postData()))
+            await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+        })
+
+        const workspace = await playwrightSetup.createWorkspace({ no_demo_data: true })
+
+        await patchAppContext(page, { hasIngestedEvent: false })
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace)
+        await page.goto(`/project/${workspace.team_id}/home`)
+
+        await expect(page.locator('[data-attr=first-event-banner]')).toBeVisible()
+
+        await expect.poll(() => capturedEventNames.includes('banner.impression')).toBeTruthy()
+
+        await page.locator('[data-attr=first-event-banner-create-event]').click()
+
+        await expect.poll(() => capturedEventNames.includes('banner.cta_click')).toBeTruthy()
+
+        await expect(page.locator('[data-attr=event-definition-name-input]')).toBeVisible()
+    })
+
+    test('does not show banner once events have been ingested', async ({ page, playwrightSetup }) => {
+        const workspace = await playwrightSetup.createWorkspace({ no_demo_data: true })
+
+        await patchAppContext(page, { hasIngestedEvent: true })
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace)
+        await page.goto(`/project/${workspace.team_id}/home`)
+
+        await expect(page.locator('[data-attr=first-event-banner]')).not.toBeVisible()
+    })
+})

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -696,9 +696,9 @@ class FeatureFlagSerializer(
         ):
             raise serializers.ValidationError("There is already a feature flag with this key.", code="unique")
 
-        if not re.match(r"^[a-zA-Z0-9_-]+$", value):
+        if not re.match(r"^[a-zA-Z0-9_.-]+$", value):
             raise serializers.ValidationError(
-                "Only letters, numbers, hyphens (-) & underscores (_) are allowed.",
+                "Only letters, numbers, periods (.), hyphens (-) & underscores (_) are allowed.",
                 code="invalid_key",
             )
 

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -29,6 +29,10 @@ INACTIVE_FLAGS = [
     "ai-first",
 ]
 
+ROLLOUT_OVERRIDES: dict[str, int] = {
+    "growth.first_event_banner": 50,
+}
+
 
 class Command(BaseCommand):
     help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all projects"
@@ -98,13 +102,17 @@ class Command(BaseCommand):
                             },
                         )
                     else:
+                        rollout_percentage = ROLLOUT_OVERRIDES.get(flag, 100)
                         FeatureFlag.objects.create(
                             team=team,
                             name=flag,
                             key=flag,
                             created_by=first_user,
                             active=is_enabled,
-                            filters={"groups": [{"properties": [], "rollout_percentage": 100}], "payloads": {}},
+                            filters={
+                                "groups": [{"properties": [], "rollout_percentage": rollout_percentage}],
+                                "payloads": {},
+                            },
                         )
 
                     print(


### PR DESCRIPTION
## Problem

New users (who haven't yet created any events) often need guidance on how to get started with PostHog. This banner aims to improve their onboarding experience by directly prompting them to create their first event, which is crucial for understanding the product's core value.

## Changes

- Implemented an in-dashboard banner component on the `ProjectHomepage` for new users (teams with no ingested events).
- The banner displays "Welcome to PostHog! Create your first event to start tracking user behavior."
- Added a primary "Create event" button that opens the `EventDefinitionModal` and a secondary "Learn more" link to PostHog documentation.
- Gated the banner behind the `growth.first_event_banner` feature flag, configured for a 50% rollout to new users.
- Implemented tracking for `banner.impression` and `banner.cta_click` events.
- Updated feature flag key validation (frontend and backend) to allow periods, accommodating the `growth.first_event_banner` key.

## How did you test this code?

As an agent, I have not manually tested this.
Automated tests include:
- A new Playwright E2E test (`playwright/e2e/first-event-banner.spec.ts`) covering:
    - Banner visibility for eligible users.
    - Impression tracking.
    - CTA click tracking.
    - Correct modal opening upon CTA click.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

yes

---
<p><a href="https://cursor.com/agents/bc-a279d375-54af-49ab-9460-36b7844fe5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a279d375-54af-49ab-9460-36b7844fe5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

