### PR TITLE
feat(flags): add pushgateway duration metrics for hypercache verification tasks

### DIFF
--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -25,7 +25,7 @@ from posthog.models.feature_flag.local_evaluation import (
 )
 from posthog.models.team.team import Team
 from posthog.storage.hypercache_verifier import _run_verification_for_cache
-from posthog.tasks.utils import CeleryQueue
+from posthog.tasks.utils import CeleryQueue, PushGatewayTask
 
 logger = structlog.get_logger(__name__)
 
@@ -160,12 +160,14 @@ def _run_cache_verification(cache_type: CacheType, chunk_size: int) -> None:
 
 
 @shared_task(
+    bind=True,
+    base=PushGatewayTask,
     ignore_result=True,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )
-def verify_and_fix_flags_cache_task() -> None:
+def verify_and_fix_flags_cache_task(self: PushGatewayTask) -> None:
     """
     Periodic task to verify the flags HyperCache and fix issues.
 
@@ -181,12 +183,14 @@ def verify_and_fix_flags_cache_task() -> None:
 
 
 @shared_task(
+    bind=True,
+    base=PushGatewayTask,
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )
-def verify_and_fix_team_metadata_cache_task() -> None:
+def verify_and_fix_team_metadata_cache_task(self: PushGatewayTask) -> None:
     """
     Periodic task to verify the team metadata HyperCache and fix issues.
 
@@ -202,12 +206,14 @@ def verify_and_fix_team_metadata_cache_task() -> None:
 
 
 @shared_task(
+    bind=True,
+    base=PushGatewayTask,
     ignore_result=True,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=50 * 60,  # 50 min soft limit
     time_limit=60 * 60,  # 1 hour hard limit (distributed lock prevents overlap)
 )
-def verify_and_fix_flag_definitions_cache_task() -> None:
+def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
     """
     Periodic task to verify the flag definitions HyperCache and fix issues.
 

--- a/posthog/tasks/test/test_flag_definitions_cache_tasks.py
+++ b/posthog/tasks/test/test_flag_definitions_cache_tasks.py
@@ -2,29 +2,11 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from prometheus_client import CollectorRegistry
-
 from posthog.tasks.feature_flags import (
     cleanup_stale_flag_definitions_expiry_tracking_task,
     refresh_expiring_flag_definitions_cache_entries,
 )
-
-
-class PushGatewayTaskTestMixin:
-    """Sets up mocked PushGateway context so PushGatewayTask-based tasks can run in tests."""
-
-    def setUp(self) -> None:
-        super().setUp()  # type: ignore[misc]
-        self.registry = CollectorRegistry()
-        self.mock_context = MagicMock()
-        self.mock_context.__enter__ = MagicMock(return_value=self.registry)
-        self.mock_context.__exit__ = MagicMock(return_value=False)
-        self.patcher = patch("posthog.tasks.utils.pushed_metrics_registry", return_value=self.mock_context)
-        self.patcher.start()
-
-    def tearDown(self) -> None:
-        self.patcher.stop()
-        super().tearDown()  # type: ignore[misc]
+from posthog.tasks.test.utils import PushGatewayTaskTestMixin
 
 
 class TestRefreshExpiringFlagDefinitionsCacheEntries(PushGatewayTaskTestMixin, TestCase):

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -11,30 +11,12 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
-from prometheus_client import CollectorRegistry
-
 from posthog.tasks.hypercache_verification import (
     verify_and_fix_flag_definitions_cache_task,
     verify_and_fix_flags_cache_task,
     verify_and_fix_team_metadata_cache_task,
 )
-
-
-class PushGatewayTaskTestMixin:
-    """Sets up mocked PushGateway context so PushGatewayTask-based tasks can run in tests."""
-
-    def setUp(self) -> None:
-        super().setUp()  # type: ignore[misc]
-        self.registry = CollectorRegistry()
-        self.mock_context = MagicMock()
-        self.mock_context.__enter__ = MagicMock(return_value=self.registry)
-        self.mock_context.__exit__ = MagicMock(return_value=False)
-        self.patcher = patch("posthog.tasks.utils.pushed_metrics_registry", return_value=self.mock_context)
-        self.patcher.start()
-
-    def tearDown(self) -> None:
-        self.patcher.stop()
-        super().tearDown()  # type: ignore[misc]
+from posthog.tasks.test.utils import PushGatewayTaskTestMixin
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
@@ -92,7 +74,7 @@ class TestVerifyAndFixFlagsCacheTaskDisabled(TestCase):
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
-class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
+class TestVerifyAndFixTeamMetadataCacheTask(PushGatewayTaskTestMixin, TestCase):
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verifies_team_metadata_cache(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
@@ -124,6 +106,19 @@ class TestVerifyAndFixTeamMetadataCacheTask(TestCase):
 
         mock_run_verification.assert_called_once()
 
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_team_metadata_cache_task()
+
+        success = self.registry.get_sample_value("posthog_celery_verify_and_fix_team_metadata_cache_task_success")
+        duration = self.registry.get_sample_value(
+            "posthog_celery_verify_and_fix_team_metadata_cache_task_duration_seconds"
+        )
+        assert success == 1
+        assert duration is not None and duration >= 0
+
 
 @override_settings(FLAGS_REDIS_URL=None)
 class TestVerifyAndFixTeamMetadataCacheTaskDisabled(TestCase):
@@ -134,7 +129,7 @@ class TestVerifyAndFixTeamMetadataCacheTaskDisabled(TestCase):
         mock_run_verification.assert_not_called()
 
 
-class TestVerifyAndFixFlagDefinitionsCacheTask(TestCase):
+class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCase):
     """Tests for the flag definitions cache verification task."""
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
@@ -158,6 +153,19 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(TestCase):
 
         mock_capture.assert_called_once_with(error)
         assert context.exception is error
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_flag_definitions_cache_task()
+
+        success = self.registry.get_sample_value("posthog_celery_verify_and_fix_flag_definitions_cache_task_success")
+        duration = self.registry.get_sample_value(
+            "posthog_celery_verify_and_fix_flag_definitions_cache_task_duration_seconds"
+        )
+        assert success == 1
+        assert duration is not None and duration >= 0
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_skips_when_lock_already_held(self, mock_run_verification: MagicMock) -> None:

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
+from prometheus_client import CollectorRegistry
+
 from posthog.tasks.hypercache_verification import (
     verify_and_fix_flag_definitions_cache_task,
     verify_and_fix_flags_cache_task,
@@ -18,8 +20,25 @@ from posthog.tasks.hypercache_verification import (
 )
 
 
+class PushGatewayTaskTestMixin:
+    """Sets up mocked PushGateway context so PushGatewayTask-based tasks can run in tests."""
+
+    def setUp(self) -> None:
+        super().setUp()  # type: ignore[misc]
+        self.registry = CollectorRegistry()
+        self.mock_context = MagicMock()
+        self.mock_context.__enter__ = MagicMock(return_value=self.registry)
+        self.mock_context.__exit__ = MagicMock(return_value=False)
+        self.patcher = patch("posthog.tasks.utils.pushed_metrics_registry", return_value=self.mock_context)
+        self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+        super().tearDown()  # type: ignore[misc]
+
+
 @override_settings(FLAGS_REDIS_URL="redis://test")
-class TestVerifyAndFixFlagsCacheTask(TestCase):
+class TestVerifyAndFixFlagsCacheTask(PushGatewayTaskTestMixin, TestCase):
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verifies_flags_cache(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
@@ -50,6 +69,17 @@ class TestVerifyAndFixFlagsCacheTask(TestCase):
         verify_and_fix_flags_cache_task()
 
         mock_run_verification.assert_called_once()
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_flags_cache_task()
+
+        success = self.registry.get_sample_value("posthog_celery_verify_and_fix_flags_cache_task_success")
+        duration = self.registry.get_sample_value("posthog_celery_verify_and_fix_flags_cache_task_duration_seconds")
+        assert success == 1
+        assert duration is not None and duration >= 0
 
 
 @override_settings(FLAGS_REDIS_URL=None)

--- a/posthog/tasks/test/utils.py
+++ b/posthog/tasks/test/utils.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock, patch
+
+from prometheus_client import CollectorRegistry
+
+
+class PushGatewayTaskTestMixin:
+    """Sets up mocked PushGateway context so PushGatewayTask-based tasks can run in tests."""
+
+    def setUp(self) -> None:
+        super().setUp()  # type: ignore[misc]
+        self.registry = CollectorRegistry()
+        self.mock_context = MagicMock()
+        self.mock_context.__enter__ = MagicMock(return_value=self.registry)
+        self.mock_context.__exit__ = MagicMock(return_value=False)
+        self.patcher = patch("posthog.tasks.utils.pushed_metrics_registry", return_value=self.mock_context)
+        self.patcher.start()
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+        super().tearDown()  # type: ignore[misc]


### PR DESCRIPTION
## Problem

The hypercache verification Celery tasks (`verify_and_fix_flags_cache_task`, `verify_and_fix_team_metadata_cache_task`, `verify_and_fix_flag_definitions_cache_task`) currently don't report duration metrics to Pushgateway, making it difficult to monitor their execution time in Grafana.

## Changes

- Add `PushGatewayTask` as the base class for all three hypercache verification tasks
- Set `bind=True` so the task instance is passed as `self`, which `PushGatewayTask` requires to report metrics
- Import `PushGatewayTask` from `posthog.tasks.utils`

This enables automatic duration metric reporting to Pushgateway for these long-running tasks, consistent with other instrumented Celery tasks in the codebase.

## How did you test this code?

Some unit tests

## Publish to changelog?

No