### PR TITLE
feat(deduplicator): integrate common/lifecycle library

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2094,6 +2094,7 @@ name = "common-kafka"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "common-liveness",
  "envconfig",
  "health",
  "rdkafka",
@@ -2105,6 +2106,10 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "common-liveness"
+version = "0.1.0"
 
 [[package]]
 name = "common-metrics"
@@ -3742,6 +3747,7 @@ name = "health"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "common-liveness",
  "time",
  "tokio",
  "tracing",
@@ -4937,6 +4943,7 @@ name = "lifecycle"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "common-liveness",
  "metrics",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "der"
@@ -4630,9 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.89"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4714,8 +4714,8 @@ dependencies = [
  "envconfig",
  "futures",
  "futures-util",
- "health",
  "itertools 0.14.0",
+ "lifecycle",
  "metrics",
  "metrics-exporter-prometheus",
  "object_store",
@@ -4729,7 +4729,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "serve-metrics",
  "sha2",
  "strum 0.27.2",
  "strum_macros 0.27.2",
@@ -4898,7 +4897,7 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.2",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -6249,18 +6248,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6269,9 +6268,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -7255,9 +7254,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7457,9 +7456,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -8043,9 +8042,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -8062,9 +8061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -9977,9 +9976,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.112"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9990,9 +9989,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.62"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee85afca410ac4abba5b584b12e77ea225db6ee5471d0aebaae0861166f9378a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -10004,9 +10003,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.112"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10014,9 +10013,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.112"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10027,9 +10026,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.112"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -10107,9 +10106,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.89"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10053fbf9a374174094915bbce141e87a6bf32ecd9a002980db4b638405e8962"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10657,18 +10656,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "common/dns",
     "common/health",
     "common/kafka",
+    "common/liveness",
     "common/lifecycle",
     "common/limiters",
     "common/metrics",

--- a/rust/common/health/Cargo.toml
+++ b/rust/common/health/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+common-liveness = { path = "../liveness" }
 axum = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -201,6 +201,16 @@ impl HealthHandle {
     }
 }
 
+impl common_liveness::SyncLivenessReporter for HealthHandle {
+    fn report_healthy(&self) {
+        self.report_healthy_blocking();
+    }
+
+    fn report_unhealthy(&self) {
+        self.report_status_blocking(ComponentStatus::Unhealthy);
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum HealthStrategy {
     /// All components must be healthy for the registry to be healthy

--- a/rust/common/kafka/Cargo.toml
+++ b/rust/common/kafka/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+common-liveness = { path = "../liveness" }
 envconfig = { workspace = true }
 health = { path = "../health" }
 rdkafka = { workspace = true }

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -1,6 +1,7 @@
-use crate::config::KafkaConfig;
+use std::sync::Arc;
 
-use health::HealthHandle;
+use crate::config::KafkaConfig;
+use common_liveness::SyncLivenessReporter;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::{ClientConfig, ClientContext};
@@ -10,28 +11,39 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 
 pub struct KafkaContext {
-    liveness: HealthHandle,
+    liveness: Arc<dyn SyncLivenessReporter>,
 }
 
-impl From<HealthHandle> for KafkaContext {
-    fn from(value: HealthHandle) -> Self {
-        KafkaContext { liveness: value }
+impl KafkaContext {
+    pub fn new(liveness: impl SyncLivenessReporter + Clone + 'static) -> Self {
+        Self {
+            liveness: Arc::new(liveness),
+        }
+    }
+}
+
+impl From<health::HealthHandle> for KafkaContext {
+    fn from(value: health::HealthHandle) -> Self {
+        Self::new(value)
     }
 }
 
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, _: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
-        self.liveness.report_healthy_blocking();
+        self.liveness.report_healthy();
 
         // TODO: Take stats recording pieces that we want from `capture-rs`.
     }
 }
 
-pub async fn create_kafka_producer(
+pub async fn create_kafka_producer<L>(
     config: &KafkaConfig,
-    liveness: HealthHandle,
-) -> Result<FutureProducer<KafkaContext>, KafkaError> {
+    liveness: L,
+) -> Result<FutureProducer<KafkaContext>, KafkaError>
+where
+    L: SyncLivenessReporter + Clone + 'static,
+{
     let mut client_config = ClientConfig::new();
     client_config
         .set("bootstrap.servers", &config.kafka_hosts)
@@ -61,7 +73,8 @@ pub async fn create_kafka_producer(
     };
 
     debug!("rdkafka configuration: {:?}", client_config);
-    let api: FutureProducer<KafkaContext> = client_config.create_with_context(liveness.into())?;
+    let api: FutureProducer<KafkaContext> =
+        client_config.create_with_context(KafkaContext::new(liveness))?;
 
     // "Ping" the Kafka brokers by requesting metadata
     match api

--- a/rust/common/lifecycle/Cargo.toml
+++ b/rust/common/lifecycle/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+common-liveness = { path = "../liveness" }
 axum = { workspace = true }
 metrics = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -106,6 +106,7 @@ All options except `name` have sensible defaults.
 | `.with_prestop_check(bool)`               | Poll for pre-stop shutdown file (K8s pre-stop hook pattern).                                                                                                                                                   | `true`          |
 | `.with_prestop_path(path)`                | Override the pre-stop file path.                                                                                                                                                                               | `/tmp/shutdown` |
 | `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`            |
+| `.with_test_shutdown(receiver)`           | Inject a test shutdown trigger. When the oneshot receiver resolves (e.g. test sends on the paired sender), the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)` in tests. (see test `test_shutdown_trigger_initiates_shutdown`) | `None`          |
 | `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —               |
 
 ### register() / ComponentOptions
@@ -256,7 +257,7 @@ The crate emits metrics via the `metrics` facade (no recorder installed by this 
 | `lifecycle_shutdown_completed_total`            | Counter   | `service_name`, `clean`                               | Once when monitor returns successfully         |
 | `lifecycle_component_healthy`                   | Gauge     | `service_name`, `component`                           | Continuously during normal operation           |
 
-Label values: `trigger_reason` = `signal`, `prestop`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
+Label values: `trigger_reason` = `signal`, `prestop`, `test`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
 
 `lifecycle_shutdown_completed_total` is **not** emitted on global timeout or if the process is killed; that asymmetry with `lifecycle_shutdown_initiated_total` is how incomplete shutdowns (e.g. SIGKILL) are detected.
 
@@ -291,6 +292,24 @@ by `component`, `result`.
 - Incomplete shutdown count > 0 over 1h:
 `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h]) > 0`
 - Component unhealthy for > 2 consecutive scrapes: e.g. alert when `lifecycle_component_healthy{service_name="$service_name"}` is 0 for a given component for 2 scrape intervals.
+
+## Testing
+
+For deterministic shutdown in tests, use `with_trap_signals(false)`, `with_prestop_check(false)`, and `with_test_shutdown`:
+
+```rust
+let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+let mut manager = Manager::builder("test-service")
+    .with_trap_signals(false)
+    .with_prestop_check(false)
+    .with_test_shutdown(shutdown_rx)
+    .build();
+
+// ... register components, spawn monitor_background, spawn component tasks ...
+
+shutdown_tx.send(()).ok(); // test triggers shutdown
+guard.wait().await?;
+```
 
 ## SIGKILL detection
 

--- a/rust/common/lifecycle/src/handle.rs
+++ b/rust/common/lifecycle/src/handle.rs
@@ -210,3 +210,13 @@ impl Drop for HandleInner {
         }
     }
 }
+
+impl common_liveness::SyncLivenessReporter for Handle {
+    fn report_healthy(&self) {
+        Handle::report_healthy(self);
+    }
+
+    fn report_unhealthy(&self) {
+        Handle::report_unhealthy(self);
+    }
+}

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -22,7 +22,7 @@ use crate::signals;
 
 /// Builder for [`Manager`]. Start with [`Manager::builder("name")`](Manager::builder),
 /// chain `.with_*()` calls, then call [`.build()`](ManagerBuilder::build).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ManagerBuilder {
     name: String,
     global_shutdown_timeout: Duration,
@@ -30,6 +30,7 @@ pub struct ManagerBuilder {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
+    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
 }
 
 impl ManagerBuilder {
@@ -68,6 +69,16 @@ impl ManagerBuilder {
         self
     }
 
+    /// Inject a test shutdown trigger. When the receiver resolves (e.g. test sends on the paired sender),
+    /// the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)`
+    /// in tests for deterministic, signal-free shutdown control.
+    ///
+    /// (see test `test_shutdown_trigger_initiates_shutdown`)
+    pub fn with_test_shutdown(mut self, receiver: oneshot::Receiver<()>) -> Self {
+        self.test_shutdown_receiver = Some(receiver);
+        self
+    }
+
     /// Consume the builder and produce a [`Manager`].
     pub fn build(self) -> Manager {
         Manager {
@@ -77,6 +88,7 @@ impl ManagerBuilder {
             enable_prestop_check: self.enable_prestop_check,
             prestop_path: self.prestop_path,
             health_poll_interval: self.health_poll_interval,
+            test_shutdown_receiver: self.test_shutdown_receiver,
             shutdown_token: CancellationToken::new(),
             event_tx_slot: Arc::new(OnceLock::new()),
             components: HashMap::new(),
@@ -178,6 +190,7 @@ pub struct Manager {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
+    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
     shutdown_token: CancellationToken,
     event_tx_slot: Arc<OnceLock<mpsc::Sender<ComponentEvent>>>,
     components: HashMap<String, ComponentState>,
@@ -196,6 +209,7 @@ impl Manager {
             enable_prestop_check: true,
             prestop_path: PathBuf::from(DEFAULT_PRESTOP_PATH),
             health_poll_interval: Duration::from_secs(5),
+            test_shutdown_receiver: None,
         }
     }
 
@@ -373,6 +387,20 @@ impl Manager {
                         break;
                     }
                 }
+            });
+        }
+
+        if let Some(test_rx) = self.test_shutdown_receiver.take() {
+            let token = shutdown_token.clone();
+            let name_for_metrics = name.clone();
+            tokio::spawn(async move {
+                let _ = test_rx.await;
+                info!(
+                    trigger_reason = "test",
+                    "Lifecycle: shutdown initiated from test trigger"
+                );
+                metrics::emit_shutdown_initiated(&name_for_metrics, "test", "test");
+                token.cancel();
             });
         }
 

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -840,3 +840,35 @@ async fn mixed_component_timeout_outcomes() {
         .expect("timed out");
     assert!(result.is_ok());
 }
+
+/// Test shutdown trigger initiates shutdown. Use with_trap_signals(false) and
+/// with_prestop_check(false) for deterministic, signal-free shutdown control.
+#[tokio::test]
+async fn test_shutdown_trigger_initiates_shutdown() {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_test_shutdown(shutdown_rx)
+        .build();
+
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    let comp = ComponentA {
+        handle: handle.clone(),
+    };
+    tokio::spawn(async move {
+        comp.process().await;
+    });
+    drop(handle);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    shutdown_tx.send(()).ok();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}

--- a/rust/common/liveness/Cargo.toml
+++ b/rust/common/liveness/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "common-liveness"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/rust/common/liveness/src/lib.rs
+++ b/rust/common/liveness/src/lib.rs
@@ -1,0 +1,7 @@
+//! Sync liveness reporting for components that must signal "I'm alive" from sync contexts
+//! (e.g. rdkafka stats callbacks). Both health::HealthHandle and lifecycle::Handle implement this.
+
+pub trait SyncLivenessReporter: Send + Sync {
+    fn report_healthy(&self);
+    fn report_unhealthy(&self);
+}

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -10,6 +10,7 @@ default = []
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
+lifecycle = { path = "../common/lifecycle" }
 bincode = { version = "2.0.1", features = ["serde"] }
 bytesize = "1.3"
 chrono = { workspace = true }
@@ -21,7 +22,6 @@ dashmap = "6.1"
 envconfig = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
-health = { path = "../common/health" }
 itertools = "0.14"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
@@ -37,7 +37,6 @@ rocksdb = "0.24.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-serve-metrics = { path = "../common/serve_metrics" }
 sha2 = "0.10.9"
 strum = "0.27.0"
 strum_macros = "0.27.2"
@@ -52,6 +51,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
+lifecycle = { path = "../common/lifecycle" }
 tempfile = "3.8"
 
 [package.metadata.cargo-shear]

--- a/rust/kafka-deduplicator/README.md
+++ b/rust/kafka-deduplicator/README.md
@@ -92,6 +92,13 @@ The service includes a comprehensive checkpoint system for backup, recovery, and
 | `FULL_UPLOAD_INTERVAL` | Incremental uploads before full | `10` |
 | `MAX_LOCAL_CHECKPOINTS` | Local checkpoints to retain | `5` |
 
+## Lifecycle and Health Probes
+
+The service uses the [lifecycle](rust/common/lifecycle/) library for unified shutdown coordination and K8s probes:
+
+- **`/_readiness`** — Returns 200 while running; 503 after shutdown begins. K8s uses this to stop routing traffic.
+- **`/_liveness`** — Always returns 200 (process reachability). Component health is monitored internally; stalled components trigger coordinated graceful shutdown rather than K8s killing the pod.
+
 ## Architecture Components
 
 - **StatefulKafkaConsumer**: Main consumer orchestrating message processing

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -11,11 +11,10 @@
 
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 use std::time::Duration;
+
+use lifecycle::Handle;
 
 use crate::checkpoint::{
     CheckpointConfig, CheckpointExporter, CheckpointMetadata, CheckpointWorker,
@@ -125,14 +124,13 @@ impl CheckpointManager {
         }
     }
 
-    /// Start the periodic flush task, returning the inner worker
-    /// threads' health reporter flag for bubbling up failures
-    pub fn start(&mut self) -> Option<Arc<AtomicBool>> {
+    /// Start the periodic flush task. Uses the lifecycle handle for shutdown
+    /// coordination and health reporting.
+    pub fn start(&mut self, lifecycle_handle: Handle) {
         if self.checkpoint_task.is_some() {
             warn!("Checkpoint manager already started");
-            return None;
+            return;
         }
-        let health_reporter = Arc::new(AtomicBool::new(true));
 
         info!(
             "Starting checkpoint manager with interval: {:?}",
@@ -155,9 +153,10 @@ impl CheckpointManager {
         // Track checkpoint counter and metadata per partition in a single map for atomic updates
         let checkpoint_state: Arc<DashMap<Partition, (u32, CheckpointMetadata)>> =
             Arc::new(DashMap::new());
-        let checkpoint_health_reporter = health_reporter.clone();
+        let cancel_token = self.cancel_token.clone();
 
         let checkpoint_task_handle = tokio::spawn(async move {
+            let _guard = lifecycle_handle.process_scope();
             let mut interval = tokio::time::interval(submit_loop_config.checkpoint_interval);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -166,6 +165,11 @@ impl CheckpointManager {
 
             'outer: loop {
                 tokio::select! {
+                    _ = lifecycle_handle.shutdown_recv() => {
+                        info!("Checkpoint manager: submit loop shutting down");
+                        cancel_token.cancel();
+                        break 'outer;
+                    }
                     _ = cancel_submit_loop_token.cancelled() => {
                         info!("Checkpoint manager: submit loop shutting down");
                         break 'outer;
@@ -183,9 +187,11 @@ impl CheckpointManager {
                         let store_count = candidates.len();
                         if store_count == 0 {
                             debug!("No stores to flush");
+                            lifecycle_handle.report_healthy();
                             continue;
                         }
 
+                        lifecycle_handle.report_healthy();
                         info!("Checkpoint manager: attempting checkpoint submission for {} stores", store_count);
 
                         // Attempt to checkpoint each partitions' backing store in
@@ -397,11 +403,8 @@ impl CheckpointManager {
             } // end 'outer loop
 
             info!("Checkpoint manager: exiting submit loop");
-            checkpoint_health_reporter.store(false, Ordering::SeqCst);
         });
         self.checkpoint_task = Some(checkpoint_task_handle);
-
-        Some(health_reporter.clone())
     }
 
     /// Stop the checkpoint manager
@@ -621,6 +624,17 @@ mod tests {
         }
     }
 
+    fn create_test_lifecycle_handle() -> Handle {
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut manager = lifecycle::Manager::builder("test-checkpoint")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .with_test_shutdown(rx)
+            .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+            .build();
+        manager.register("checkpoint-manager", lifecycle::ComponentOptions::new())
+    }
+
     fn find_local_checkpoint_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
         let mut checkpoint_files = Vec::new();
         let mut stack = vec![base_dir.to_path_buf()];
@@ -674,7 +688,7 @@ mod tests {
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
 
         // Start the manager
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
         assert!(manager.checkpoint_task.is_some());
 
         // Stop the manager
@@ -752,7 +766,7 @@ mod tests {
 
         // Should fail for non-existent topic partition.
         // run the manager checkpoint loop for a few cycles
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
         tokio::time::sleep(Duration::from_millis(200)).await;
         manager.stop().await;
 
@@ -801,17 +815,13 @@ mod tests {
             CheckpointManager::new(config.clone(), store_manager.clone(), Some(exporter));
 
         // Start the manager
-        let health_reporter = manager.start();
-        assert!(health_reporter.is_some());
+        manager.start(create_test_lifecycle_handle());
 
         // Wait for a few flush cycles
         tokio::time::sleep(Duration::from_millis(800)).await;
 
         // Stop the manager
         manager.stop().await;
-
-        // service task threads are still healthy and running
-        assert!(health_reporter.unwrap().load(Ordering::SeqCst));
 
         // Verify that files were exported to the export directory
         let export_files = find_local_checkpoint_files(tmp_export_dir.path()).unwrap();
@@ -852,14 +862,12 @@ mod tests {
         };
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
 
-        // Start once - should return reporter
-        let health_reporter = manager.start();
-        assert!(health_reporter.is_some());
+        // Start once
+        manager.start(create_test_lifecycle_handle());
         assert!(manager.checkpoint_task.is_some());
 
         // Start again - should warn but not panic
-        let health_reporter = manager.start();
-        assert!(health_reporter.is_none());
+        manager.start(create_test_lifecycle_handle());
         assert!(manager.checkpoint_task.is_some());
 
         manager.stop().await;
@@ -877,7 +885,7 @@ mod tests {
         };
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
 
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
         let cancel_token = manager.cancel_token.clone();
 
         assert!(!cancel_token.is_cancelled());
@@ -923,7 +931,7 @@ mod tests {
         // start the manager and produce some exported checkpoint files
         let mut manager =
             CheckpointManager::new(config.clone(), store_manager.clone(), Some(exporter));
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
 
         // Give the manager time to start checkpointing
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -995,7 +1003,7 @@ mod tests {
         store_manager.rebalance_tracker().start_rebalancing();
 
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
 
         // Let the manager run a few cycles
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1037,7 +1045,7 @@ mod tests {
         };
 
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
 
         // Wait briefly for the manager to pick up the partition
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1081,7 +1089,7 @@ mod tests {
         };
 
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
 
         // Wait for the first checkpoint cycle to potentially start
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1173,7 +1181,7 @@ mod tests {
         };
 
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
-        manager.start();
+        manager.start(create_test_lifecycle_handle());
 
         // The manager should be running
         assert!(manager.checkpoint_task.is_some());

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -16,6 +16,7 @@ use crate::kafka::types::Partition;
 use anyhow::{Context, Result};
 use axum::async_trait;
 use futures_util::StreamExt;
+use lifecycle::Handle;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{CommitMode, Consumer, MessageStream, StreamConsumer};
 use rdkafka::error::KafkaResult;
@@ -23,7 +24,6 @@ use rdkafka::message::Message;
 use rdkafka::TopicPartitionList;
 use serde::Deserialize;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot::Receiver;
 use tracing::{error, info, warn};
 
 #[async_trait]
@@ -49,10 +49,8 @@ pub struct BatchConsumer<T> {
     // tracks processed offsets per partition for safe commits
     offset_tracker: Arc<OffsetTracker>,
 
-    // shutdown signal from parent process which
-    // we assume will be wrapping start_consumption
-    // in a spawned thread
-    shutdown_rx: Receiver<()>,
+    // shutdown signal from lifecycle manager
+    shutdown_handle: Handle,
 
     // receiver for consumer commands (e.g., seek partitions after checkpoint import, resume partitions)
     consumer_command_rx: ConsumerCommandReceiver,
@@ -71,7 +69,7 @@ where
         rebalance_handler: Arc<dyn RebalanceHandler>,
         processor: Arc<dyn BatchConsumerProcessor<T>>,
         offset_tracker: Arc<OffsetTracker>,
-        shutdown_rx: Receiver<()>,
+        shutdown_handle: Handle,
         topic: &str,
         batch_size: usize,
         batch_timeout: Duration,
@@ -97,7 +95,7 @@ where
             batch_timeout,
             processor,
             offset_tracker,
-            shutdown_rx,
+            shutdown_handle,
             consumer_command_rx,
             seek_timeout,
         })
@@ -117,7 +115,7 @@ where
         loop {
             tokio::select! {
                 // Check for shutdown signal
-                _ = &mut self.shutdown_rx => {
+                _ = self.shutdown_handle.shutdown_recv() => {
                     info!("Shutdown signal received, starting graceful shutdown");
                     break;
                 }

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -3,16 +3,14 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use axum::{routing::get, Router};
 use futures::future::ready;
-use health::HealthRegistry;
+use lifecycle::{ComponentOptions, Manager};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use opentelemetry::{KeyValue, Value};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::{BatchConfig, RandomIdGenerator, Sampler, Tracer};
 use opentelemetry_sdk::{runtime, Resource};
-use serve_metrics::serve;
-use tokio::task::JoinHandle;
+use tracing::info;
 use tracing::level_filters::LevelFilter;
-use tracing::{error, info};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -54,13 +52,10 @@ pub async fn index() -> &'static str {
 }
 
 /// Setup metrics recorder with optimized histogram buckets for kafka-deduplicator
-/// Using fewer buckets to reduce cardinality
 fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[
         0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
     ];
-    // similarity scores are all in the range [0.0, 1.0] so we want
-    // granular bucket ranges for higher fidelity metrics
     const SIMILARITY_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
     const CHECKPOINT_FILE_COUNT_BUCKETS: &[f64] = &[
@@ -81,7 +76,6 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
         100.0 * 1024.0 * 1024.0 * 1024.0,
     ];
 
-    // Buckets for counting unique items (UUIDs, timestamps)
     const COUNT_BUCKETS: &[f64] = &[
         1.0, 2.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0,
     ];
@@ -115,56 +109,13 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
         .unwrap()
 }
 
-fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
-    let router = Router::new()
-        .route("/", get(index))
-        .route("/_readiness", get(index))
-        .route(
-            "/_liveness",
-            get(move || async move {
-                let status = liveness.get_status();
-                if !status.healthy {
-                    let unhealthy_components: Vec<String> = status
-                        .components
-                        .iter()
-                        .filter(|(_, component_status)| !component_status.is_healthy())
-                        .map(|(name, component_status)| format!("{name}: {component_status:?}"))
-                        .collect();
-                    error!(
-                        "Health check FAILED - unhealthy components: [{}]",
-                        unhealthy_components.join(", ")
-                    );
-                }
-                status
-            }),
-        );
-
-    // Don't install metrics unless asked to
-    // Installing a global recorder when capture is used as a library (during tests etc)
-    // does not work well.
-    let router = if config.export_prometheus {
-        let recorder_handle = setup_kafka_deduplicator_metrics();
-        router.route("/metrics", get(move || ready(recorder_handle.render())))
-    } else {
-        router
-    };
-
-    let bind = config.bind_address();
-
-    tokio::task::spawn(async move {
-        serve(router, &bind)
-            .await
-            .expect("failed to start serving metrics");
-    })
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Load configuration first to get OTEL settings
     let config = Config::init_with_defaults()
         .context("Failed to load configuration from environment variables. Please check your environment setup.")?;
 
-    // Initialize tracing with structured output similar to feature-flags
+    // Initialize tracing
     let log_layer = {
         let base = fmt::layer()
             .with_target(true)
@@ -172,7 +123,6 @@ async fn main() -> Result<()> {
             .with_level(true);
 
         if config.otel_log_level == tracing::Level::DEBUG {
-            // local dev: pretty-print output to console
             base.with_span_events(
                 FmtSpan::NEW | FmtSpan::CLOSE | FmtSpan::ENTER | FmtSpan::EXIT | FmtSpan::ACTIVE,
             )
@@ -185,7 +135,6 @@ async fn main() -> Result<()> {
             )
             .boxed()
         } else {
-            // production: use JSON format Loki/Grafana can extract useful filter tags from
             base.json()
                 .flatten_event(true)
                 .with_span_list(true)
@@ -200,7 +149,6 @@ async fn main() -> Result<()> {
         }
     };
 
-    // OpenTelemetry layer if configured
     let otel_layer = if let Some(ref otel_url) = config.otel_url {
         Some(
             OpenTelemetryLayer::new(init_tracer(
@@ -219,16 +167,12 @@ async fn main() -> Result<()> {
         .with(otel_layer)
         .init();
 
-    // Create a root span with pod hostname for all logs
-    // This adds "pod" field to every log line for Loki/Grafana filtering
     let pod = config
         .pod_hostname
         .clone()
         .unwrap_or_else(|| "unknown".to_string());
     let _root_span = tracing::info_span!("service", pod = %pod).entered();
 
-    // Start continuous profiling if enabled (keep _agent alive for the duration of the program)
-    // NOTE: Must be after tracing is initialized so logs are visible
     let _profiling_agent = match config.continuous_profiling.start_agent() {
         Ok(agent) => agent,
         Err(e) => {
@@ -238,26 +182,65 @@ async fn main() -> Result<()> {
     };
 
     info!("Starting Kafka Deduplicator service");
-
     info!("Configuration loaded: {:?}", config);
 
-    // Create health registry for liveness checks
-    let liveness = HealthRegistry::new("liveness");
+    let mut manager = Manager::builder("kafka-deduplicator")
+        .with_global_shutdown_timeout(config.shutdown_timeout())
+        .build();
 
-    // Start HTTP server with metrics endpoint
-    let server_handle = start_server(&config, liveness.clone());
-    info!("Started metrics server on {}", config.bind_address());
+    let metrics_handle = manager.register(
+        "metrics-server",
+        ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(15)),
+    );
 
-    // Create and run the service
-    let service = KafkaDeduplicatorService::new(config, liveness)
+    let readiness = manager.readiness_handler();
+    let liveness = manager.liveness_handler();
+    let shutdown_signal = manager.shutdown_signal();
+
+    let mut service = KafkaDeduplicatorService::new(config.clone(), &mut manager)
         .await
         .with_context(|| "Failed to create Kafka Deduplicator service. Check your Kafka connection and RocksDB configuration.".to_string())?;
 
-    // Run the service (this blocks until shutdown)
-    service.run().await?;
+    service.initialize(&mut manager).await?;
 
-    // Clean up metrics server
-    server_handle.abort();
+    let bind = config.bind_address();
+    let mut router = Router::new()
+        .route("/", get(index))
+        .route(
+            "/_readiness",
+            get({
+                let r = readiness.clone();
+                move || {
+                    let r = r.clone();
+                    async move { r.check().await }
+                }
+            }),
+        )
+        .route("/_liveness", get(move || async move { liveness.check() }));
+
+    if config.export_prometheus {
+        let recorder_handle = setup_kafka_deduplicator_metrics();
+        router = router.route("/metrics", get(move || ready(recorder_handle.render())));
+    }
+
+    let monitor_guard = manager.monitor_background();
+
+    info!("Started metrics server on {}", bind);
+
+    tokio::spawn(async move {
+        let _guard = metrics_handle.process_scope();
+        let listener = tokio::net::TcpListener::bind(&bind)
+            .await
+            .expect("failed to bind metrics port");
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal)
+            .await
+            .expect("failed to start serving metrics");
+    });
+
+    service.spawn_consumer_task()?;
+
+    monitor_guard.wait().await?;
 
     Ok(())
 }

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use common_kafka::kafka_producer::KafkaContext;
 use common_types::{CapturedEvent, ClickHouseEvent};
+use lifecycle::Handle;
 use rdkafka::producer::FutureProducer;
 use rdkafka::ClientConfig;
-use tokio::sync::oneshot;
 use tracing::info;
 
 use crate::checkpoint::import::CheckpointImporter;
@@ -114,16 +114,16 @@ impl PipelineBuilder {
     }
 
     /// Build the pipeline consumer
-    pub fn build(self, shutdown_rx: oneshot::Receiver<()>) -> Result<PipelineConsumer> {
+    pub fn build(self, shutdown_handle: Handle) -> Result<PipelineConsumer> {
         let rebalance_tracker = self.store_manager.rebalance_tracker().clone();
         let offset_tracker = Arc::new(OffsetTracker::new(rebalance_tracker.clone()));
 
         match self.pipeline_type {
             PipelineType::IngestionEvents => {
-                self.build_ingestion_events(rebalance_tracker, offset_tracker, shutdown_rx)
+                self.build_ingestion_events(rebalance_tracker, offset_tracker, shutdown_handle)
             }
             PipelineType::ClickhouseEvents => {
-                self.build_clickhouse_events(rebalance_tracker, offset_tracker, shutdown_rx)
+                self.build_clickhouse_events(rebalance_tracker, offset_tracker, shutdown_handle)
             }
         }
     }
@@ -132,7 +132,7 @@ impl PipelineBuilder {
         self,
         rebalance_tracker: Arc<RebalanceTracker>,
         offset_tracker: Arc<OffsetTracker>,
-        shutdown_rx: oneshot::Receiver<()>,
+        shutdown_handle: Handle,
     ) -> Result<PipelineConsumer> {
         info!("Building ingestion_events pipeline");
 
@@ -175,7 +175,7 @@ impl PipelineBuilder {
             rebalance_handler,
             routing_processor,
             offset_tracker,
-            shutdown_rx,
+            shutdown_handle,
             &self.topic,
             self.batch_size,
             self.batch_timeout,
@@ -191,7 +191,7 @@ impl PipelineBuilder {
         self,
         rebalance_tracker: Arc<RebalanceTracker>,
         offset_tracker: Arc<OffsetTracker>,
-        shutdown_rx: oneshot::Receiver<()>,
+        shutdown_handle: Handle,
     ) -> Result<PipelineConsumer> {
         info!("Building clickhouse_events pipeline");
 
@@ -229,7 +229,7 @@ impl PipelineBuilder {
             rebalance_handler,
             routing_processor,
             offset_tracker,
-            shutdown_rx,
+            shutdown_handle,
             &self.topic,
             self.batch_size,
             self.batch_timeout,

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -1,14 +1,10 @@
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use common_kafka::config::KafkaConfig;
 use common_kafka::kafka_producer::create_kafka_producer;
-
-use health::{HealthHandle, HealthRegistry};
-use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
+use lifecycle::{ComponentOptions, Handle, Manager};
 use tracing::{error, info};
 
 use crate::config::PipelineType;
@@ -31,15 +27,11 @@ use crate::{
 pub struct KafkaDeduplicatorService {
     config: Config,
     consumer: Option<PipelineConsumer>,
+    consumer_handle: Option<Handle>,
     store_manager: Arc<StoreManager>,
     checkpoint_manager: Option<CheckpointManager>,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     cleanup_task_handle: Option<CleanupTaskHandle>,
-    shutdown_tx: Option<oneshot::Sender<()>>,
-    liveness: HealthRegistry,
-    service_health: Option<HealthHandle>,
-    health_task_cancellation: CancellationToken,
-    health_task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 impl KafkaDeduplicatorService {
@@ -80,8 +72,8 @@ impl KafkaDeduplicatorService {
         Ok(())
     }
 
-    /// Create a new service from configuration
-    pub async fn new(config: Config, liveness: HealthRegistry) -> Result<Self> {
+    /// Create a new service from configuration. Registers lifecycle components on the manager.
+    pub async fn new(config: Config, manager: &mut Manager) -> Result<Self> {
         // Validate configuration
         config.validate().with_context(|| format!("Configuration validation failed for service with consumer topic '{}' and group '{}'", config.kafka_consumer_topic, config.kafka_consumer_group))?;
 
@@ -104,11 +96,17 @@ impl KafkaDeduplicatorService {
 
         // Start periodic cleanup task if max_capacity is configured
         let cleanup_task_handle = if store_config.max_capacity > 0 {
+            let cleanup_handle = manager.register(
+                "cleanup-task",
+                ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(5)),
+            );
             let cleanup_interval = config.cleanup_interval();
             let orphan_min_staleness = config.orphan_cleanup_min_staleness();
-            let handle = store_manager
-                .clone()
-                .start_periodic_cleanup(cleanup_interval, orphan_min_staleness);
+            let handle = store_manager.clone().start_periodic_cleanup(
+                cleanup_interval,
+                orphan_min_staleness,
+                cleanup_handle,
+            );
             info!(
                 "Started periodic cleanup task with interval: {:?} for max capacity: {} bytes",
                 cleanup_interval, store_config.max_capacity
@@ -197,20 +195,16 @@ impl KafkaDeduplicatorService {
         Ok(Self {
             config,
             consumer: None,
+            consumer_handle: None,
             store_manager,
             checkpoint_manager: Some(checkpoint_manager),
             checkpoint_importer: importer,
             cleanup_task_handle,
-            shutdown_tx: None,
-            liveness,
-            service_health: None,
-            health_task_cancellation: CancellationToken::new(),
-            health_task_handles: Vec::new(),
         })
     }
 
-    /// Initialize the Kafka consumer and prepare for running
-    pub async fn initialize(&mut self) -> Result<()> {
+    /// Initialize the Kafka consumer and prepare for running. Registers lifecycle components.
+    pub async fn initialize(&mut self, manager: &mut Manager) -> Result<()> {
         if self.consumer.is_some() {
             return Err(anyhow::anyhow!("Service already initialized"));
         }
@@ -224,42 +218,18 @@ impl KafkaDeduplicatorService {
             },
         };
 
-        // Create shutdown channel
-        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-        self.shutdown_tx = Some(shutdown_tx);
-
-        // start checkpoint manager and async work loop threads, register health monitor
-        let checkpoint_health_reporter = self.checkpoint_manager.as_mut().unwrap().start();
-
-        // if health reporter is Some, this is the first time initializing
-        // the checkpoint manager, and we should start the health monitor thread
-        if checkpoint_health_reporter.is_some() {
-            let checkpoint_health_handle = self
-                .liveness
-                .register("checkpoint_manager".to_string(), Duration::from_secs(30))
-                .await;
-            let cancellation = self.health_task_cancellation.child_token();
-            let handle = tokio::spawn(async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(10));
-                loop {
-                    tokio::select! {
-                        _ = cancellation.cancelled() => {
-                            break;
-                        }
-                        _ = interval.tick() => {
-                            if checkpoint_health_reporter.as_ref().unwrap().load(Ordering::SeqCst) {
-                                checkpoint_health_handle.report_healthy().await;
-                            } else {
-                                // Explicitly report unhealthy when a worker dies
-                                checkpoint_health_handle.report_status(health::ComponentStatus::Unhealthy).await;
-                                error!("Checkpoint manager is unhealthy - checkpoint and/or cleanup loops died");
-                            }
-                        }
-                    }
-                }
-            });
-            self.health_task_handles.push(handle);
-        }
+        // Register checkpoint manager and start it
+        let checkpoint_handle = manager.register(
+            "checkpoint-manager",
+            ComponentOptions::new()
+                .with_graceful_shutdown(self.config.checkpoint_worker_shutdown_timeout())
+                .with_liveness_deadline(Duration::from_secs(30))
+                .with_stall_threshold(2),
+        );
+        self.checkpoint_manager
+            .as_mut()
+            .unwrap()
+            .start(checkpoint_handle);
 
         info!(
             "Started checkpoint manager (export enabled = {:?}, checkpoint interval = {:?})",
@@ -284,8 +254,9 @@ impl KafkaDeduplicatorService {
 
         // Configure pipeline-specific options for ingestion events
         if self.config.pipeline_type == PipelineType::IngestionEvents {
-            let (main_producer, duplicate_producer) =
-                self.create_producers_for_ingestion_pipeline().await?;
+            let (main_producer, duplicate_producer) = self
+                .create_producers_for_ingestion_pipeline(manager)
+                .await?;
 
             // Normalize empty strings to None for optional topic configs
             let output_topic = self
@@ -315,20 +286,22 @@ impl KafkaDeduplicatorService {
                 builder.with_ingestion_config(dedup_config, main_producer, duplicate_producer);
         }
 
-        let pipeline_consumer = builder.build(shutdown_rx)?;
+        let consumer_handle = manager.register(
+            "consumer",
+            ComponentOptions::new()
+                .with_graceful_shutdown(self.config.shutdown_timeout())
+                .with_liveness_deadline(Duration::from_secs(30))
+                .with_stall_threshold(2),
+        );
+
+        let pipeline_consumer = builder.build(consumer_handle.clone())?;
 
         info!(
             "Initialized {:?} pipeline for topic '{}'",
             self.config.pipeline_type, self.config.kafka_consumer_topic
         );
 
-        // Register health check for the service
-        self.service_health = Some(
-            self.liveness
-                .register("kafka_deduplicator".to_string(), Duration::from_secs(30))
-                .await,
-        );
-
+        self.consumer_handle = Some(consumer_handle);
         self.consumer = Some(pipeline_consumer);
         Ok(())
     }
@@ -336,6 +309,7 @@ impl KafkaDeduplicatorService {
     /// Create Kafka producers for the ingestion events pipeline
     async fn create_producers_for_ingestion_pipeline(
         &self,
+        manager: &mut Manager,
     ) -> Result<(
         Option<Arc<rdkafka::producer::FutureProducer<common_kafka::kafka_producer::KafkaContext>>>,
         Option<DuplicateEventProducerWrapper>,
@@ -372,14 +346,13 @@ impl KafkaDeduplicatorService {
             Some(topic) => {
                 info!("Creating Kafka producer for output topic: {}", topic);
 
-                // Create a health handle for the main producer
-                let main_producer_health = self
-                    .liveness
-                    .register(format!("main_producer_{topic}"), Duration::from_secs(30))
-                    .await;
+                let tag = format!("main_producer_{topic}");
+                let main_producer_handle = manager.register(
+                    &tag,
+                    ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(15)),
+                );
 
-                // Create the producer using common module's function
-                let producer = create_kafka_producer(&kafka_config, main_producer_health)
+                let producer = create_kafka_producer(&kafka_config, main_producer_handle)
                     .await
                     .with_context(|| {
                         format!("Failed to create Kafka producer for output topic '{topic}'")
@@ -401,17 +374,13 @@ impl KafkaDeduplicatorService {
                     topic
                 );
 
-                // Create a health handle for the duplicate producer
-                let duplicate_producer_health = self
-                    .liveness
-                    .register(
-                        format!("duplicate_producer_{topic}"),
-                        Duration::from_secs(30),
-                    )
-                    .await;
+                let tag = format!("duplicate_producer_{topic}");
+                let duplicate_producer_handle = manager.register(
+                    &tag,
+                    ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(15)),
+                );
 
-                // Create the producer using common module's function
-                let producer = create_kafka_producer(&kafka_config, duplicate_producer_health)
+                let producer = create_kafka_producer(&kafka_config, duplicate_producer_handle)
                     .await
                     .with_context(|| {
                         format!(
@@ -419,7 +388,6 @@ impl KafkaDeduplicatorService {
                         )
                     })?;
 
-                // Wrap in DuplicateEventProducerWrapper
                 Some(DuplicateEventProducerWrapper::new(
                     topic.clone(),
                     Arc::new(producer),
@@ -436,176 +404,45 @@ impl KafkaDeduplicatorService {
         Ok((main_producer, duplicate_producer))
     }
 
-    /// Run the service (blocking until shutdown)
-    pub async fn run(mut self) -> Result<()> {
-        // Initialize if not already done
-        if self.consumer.is_none() {
-            self.initialize().await?;
-        }
-
+    /// Spawn the consumer task with lifecycle coordination. The consumer runs until shutdown,
+    /// then performs teardown (checkpoint stop, cleanup stop, store shutdown).
+    pub fn spawn_consumer_task(mut self) -> Result<()> {
         let consumer = self
             .consumer
             .take()
             .ok_or_else(|| anyhow::anyhow!("Consumer not initialized"))?;
 
-        info!("Starting Kafka Deduplicator service");
-
-        // Start health reporting task for the main service
-        if let Some(health_handle) = self.service_health.clone() {
-            let cancellation = self.health_task_cancellation.child_token();
-            let handle = tokio::spawn(async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(10));
-                loop {
-                    tokio::select! {
-                        _ = cancellation.cancelled() => {
-                            break;
-                        }
-                        _ = interval.tick() => {
-                            health_handle.report_healthy().await;
-                        }
-                    }
-                }
-            });
-            self.health_task_handles.push(handle);
-        }
-
-        // Start consumption
-        let consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
-
-        // Wait for SIGTERM signal (Kubernetes graceful shutdown)
-        use tokio::signal::unix::{signal, SignalKind};
-        let mut sigterm = signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
-
-        sigterm.recv().await;
-        info!("Received SIGTERM signal, shutting down gracefully...");
-
-        // Send shutdown signal
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-
-        // Cancel health reporting tasks
-        self.health_task_cancellation.cancel();
-        for handle in self.health_task_handles.drain(..) {
-            let _ = handle.await;
-        }
-
-        // Stop the checkpoint manager
-        if let Some(mut checkpoint_manager) = self.checkpoint_manager.take() {
-            checkpoint_manager.stop().await;
-        }
-
-        // Wait for consumer to finish with timeout
-        match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
-            Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
-            Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
-            Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
-            Err(_) => error!(
-                "Consumer shutdown timed out after {:?}",
-                self.config.shutdown_timeout()
-            ),
-        }
-
-        // Shutdown all stores cleanly
-        self.store_manager.shutdown().await;
-
-        info!("Kafka Deduplicator service stopped");
-        Ok(())
-    }
-
-    /// Run the service with a custom shutdown signal (useful for testing)
-    pub async fn run_with_shutdown(
-        mut self,
-        shutdown_signal: impl std::future::Future<Output = ()>,
-    ) -> Result<()> {
-        // Initialize if not already done
-        if self.consumer.is_none() {
-            self.initialize().await?;
-        }
-
-        let consumer = self
-            .consumer
+        let consumer_handle = self
+            .consumer_handle
             .take()
-            .ok_or_else(|| anyhow::anyhow!("Consumer not initialized"))?;
+            .ok_or_else(|| anyhow::anyhow!("Consumer handle not initialized"))?;
+
+        let store_manager = self.store_manager.clone();
+        let mut checkpoint_manager = self.checkpoint_manager.take();
+        let cleanup_task_handle = self.cleanup_task_handle.take();
 
         info!("Starting Kafka Deduplicator service");
 
-        // Start health reporting task for the main service
-        if let Some(health_handle) = self.service_health.clone() {
-            let cancellation = self.health_task_cancellation.child_token();
-            let handle = tokio::spawn(async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(10));
-                loop {
-                    tokio::select! {
-                        _ = cancellation.cancelled() => {
-                            break;
-                        }
-                        _ = interval.tick() => {
-                            health_handle.report_healthy().await;
-                        }
-                    }
-                }
-            });
-            self.health_task_handles.push(handle);
-        }
+        tokio::spawn(async move {
+            let _guard = consumer_handle.process_scope();
 
-        // Start consumption
-        let consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
+            match consumer.start_consumption().await {
+                Ok(()) => info!("Consumer stopped normally"),
+                Err(e) => error!("Consumer stopped with error: {e:#}"),
+            }
 
-        // Wait for shutdown signal
-        shutdown_signal.await;
+            if let Some(mut cm) = checkpoint_manager.take() {
+                cm.stop().await;
+            }
 
-        info!("Received shutdown signal, shutting down gracefully...");
+            if let Some(handle) = cleanup_task_handle {
+                info!("Stopping cleanup task...");
+                handle.stop().await;
+            }
 
-        // Send shutdown signal
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-
-        // Cancel health reporting tasks
-        self.health_task_cancellation.cancel();
-        for handle in self.health_task_handles.drain(..) {
-            let _ = handle.await;
-        }
-
-        // Stop the checkpoint manager
-        if let Some(mut checkpoint_manager) = self.checkpoint_manager.take() {
-            checkpoint_manager.stop().await;
-        }
-
-        // Wait for consumer to finish with timeout
-        match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
-            Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
-            Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
-            Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
-            Err(_) => error!(
-                "Consumer shutdown timed out after {:?}",
-                self.config.shutdown_timeout()
-            ),
-        }
-
-        // Shutdown all stores cleanly
-        self.store_manager.shutdown().await;
-
-        Ok(())
-    }
-
-    /// Shutdown the service gracefully
-    pub async fn shutdown(&mut self) -> Result<()> {
-        info!("Shutting down service...");
-
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-
-        // Stop cleanup task if running
-        if let Some(handle) = self.cleanup_task_handle.take() {
-            info!("Stopping cleanup task...");
-            handle.stop().await;
-        }
-
-        // Give some time for graceful shutdown
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            store_manager.shutdown().await;
+            info!("Kafka Deduplicator service stopped");
+        });
 
         Ok(())
     }
@@ -629,13 +466,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let checkpoint_dir = temp_dir.path().join("checkpoints");
 
-        // Directory doesn't exist yet
         assert!(!checkpoint_dir.exists());
 
         let cfg = make_config(&checkpoint_dir);
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
 
-        // Directory now exists and is empty
         assert!(checkpoint_dir.exists());
         assert!(checkpoint_dir.is_dir());
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 0);
@@ -647,7 +482,6 @@ mod tests {
         let checkpoint_dir = temp_dir.path().join("checkpoints");
         std::fs::create_dir_all(&checkpoint_dir).unwrap();
 
-        // Create some files
         std::fs::write(checkpoint_dir.join("file1.txt"), "content1").unwrap();
         std::fs::write(checkpoint_dir.join("file2.txt"), "content2").unwrap();
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 2);
@@ -655,7 +489,6 @@ mod tests {
         let cfg = make_config(&checkpoint_dir);
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
 
-        // Directory still exists but is now empty
         assert!(checkpoint_dir.exists());
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 0);
     }
@@ -666,15 +499,12 @@ mod tests {
         let checkpoint_dir = temp_dir.path().join("checkpoints");
         std::fs::create_dir_all(&checkpoint_dir).unwrap();
 
-        // Create nested structure like real checkpoint dirs
         let topic_dir = checkpoint_dir.join("topic-name");
         let partition_dir = topic_dir.join("0");
         let attempt_dir = partition_dir.join("20260115_061456");
         std::fs::create_dir_all(&attempt_dir).unwrap();
         std::fs::write(attempt_dir.join("checkpoint.sst"), "sst data").unwrap();
         std::fs::write(attempt_dir.join("MANIFEST"), "manifest").unwrap();
-
-        // Also a file at top level
         std::fs::write(checkpoint_dir.join("lockfile"), "").unwrap();
 
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 2);
@@ -682,7 +512,6 @@ mod tests {
         let cfg = make_config(&checkpoint_dir);
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
 
-        // Directory still exists but all contents cleared
         assert!(checkpoint_dir.exists());
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 0);
         assert!(!topic_dir.exists());
@@ -691,10 +520,8 @@ mod tests {
     #[test]
     fn test_reset_checkpoint_directory_preserves_base_directory() {
         let temp_dir = TempDir::new().unwrap();
-        // Use the temp_dir itself as the checkpoint dir (simulates mount point)
         let checkpoint_dir = temp_dir.path().to_path_buf();
 
-        // Create some content
         let subdir = checkpoint_dir.join("subdir");
         std::fs::create_dir_all(&subdir).unwrap();
         std::fs::write(subdir.join("file.txt"), "content").unwrap();
@@ -703,7 +530,6 @@ mod tests {
         let cfg = make_config(&checkpoint_dir);
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
 
-        // Base directory preserved, contents cleared
         assert!(checkpoint_dir.exists());
         assert_eq!(std::fs::read_dir(&checkpoint_dir).unwrap().count(), 0);
     }
@@ -716,7 +542,6 @@ mod tests {
 
         let cfg = make_config(&checkpoint_dir);
 
-        // Call multiple times on empty directory
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
         KafkaDeduplicatorService::reset_checkpoint_directory(&cfg).unwrap();
 

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use futures::stream::{self, StreamExt};
+use lifecycle::Handle;
 use std::collections::HashSet;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -808,17 +809,20 @@ impl StoreManager {
         total_size > cleanup_threshold
     }
 
-    /// Start a periodic cleanup task that runs in the background
-    /// Returns a handle that can be used to stop the task
+    /// Start a periodic cleanup task that runs in the background.
+    /// Uses the lifecycle handle for shutdown coordination.
+    /// Returns a handle that can be used to stop the task.
     pub fn start_periodic_cleanup(
         self: Arc<Self>,
         cleanup_interval: Duration,
         orphan_min_staleness: Duration,
+        lifecycle_handle: Handle,
     ) -> CleanupTaskHandle {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let manager = self;
 
         let handle = tokio::spawn(async move {
+            let _guard = lifecycle_handle.process_scope();
             let mut interval = tokio::time::interval(cleanup_interval);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -829,6 +833,10 @@ impl StoreManager {
 
             loop {
                 tokio::select! {
+                    _ = lifecycle_handle.shutdown_recv() => {
+                        info!("Cleanup task received lifecycle shutdown signal");
+                        break;
+                    }
                     _ = interval.tick() => {
                         info!("Cleanup task tick - running periodic cleanup check");
 
@@ -1321,8 +1329,20 @@ mod tests {
 
     use super::*;
     use common_types::RawEvent;
+    use lifecycle::{ComponentOptions, Manager};
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    fn create_test_lifecycle_handle() -> Handle {
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut manager = Manager::builder("test-store-cleanup")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .with_test_shutdown(rx)
+            .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+            .build();
+        manager.register("cleanup-task", ComponentOptions::new())
+    }
 
     #[tokio::test]
     async fn test_global_capacity_management() {
@@ -1391,6 +1411,7 @@ mod tests {
         let cleanup_handle = manager.clone().start_periodic_cleanup(
             Duration::from_millis(100), // Very short interval for testing
             Duration::from_secs(0),     // No staleness for testing
+            create_test_lifecycle_handle(),
         );
 
         // Create a store and add data
@@ -1439,6 +1460,7 @@ mod tests {
         let cleanup_handle = manager.clone().start_periodic_cleanup(
             Duration::from_secs(60), // Long interval
             Duration::from_secs(0),  // No staleness for testing
+            create_test_lifecycle_handle(),
         );
 
         // Give it time to start

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -19,6 +19,7 @@ use kafka_deduplicator::test_utils::create_test_tracker;
 use common_types::CapturedEvent;
 
 use anyhow::Result;
+use lifecycle::{ComponentOptions, Manager};
 use rdkafka::{
     admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     config::ClientConfig,
@@ -59,6 +60,15 @@ fn create_batch_kafka_consumer(
 
     // Create shutdown channel - return sender so test can control shutdown
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mut manager = Manager::builder("test-batch-consumer")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let shutdown_handle = manager.register("consumer", ComponentOptions::new());
+    // Start monitor so the test_shutdown task runs; when test sends on shutdown_tx, token is cancelled
+    let _monitor_guard = manager.monitor_background();
 
     let (chan_tx, chan_rx) = unbounded_channel();
 
@@ -90,7 +100,7 @@ fn create_batch_kafka_consumer(
         Arc::new(TestRebalanceHandler::default()),
         processor,
         offset_tracker,
-        shutdown_rx,
+        shutdown_handle,
         topic,
         batch_size,
         batch_timeout,
@@ -502,6 +512,14 @@ async fn test_offset_commits_with_routing_processor() -> Result<()> {
         .set("heartbeat.interval.ms", "2000");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mut manager = Manager::builder("test-batch-consumer-offsets")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let shutdown_handle = manager.register("consumer", ComponentOptions::new());
+    let _monitor_guard = manager.monitor_background();
 
     // Create the processor that counts messages
     let processor = Arc::new(CountingProcessor::new());
@@ -535,7 +553,7 @@ async fn test_offset_commits_with_routing_processor() -> Result<()> {
         rebalance_handler,
         routing_processor,
         offset_tracker.clone(),
-        shutdown_rx,
+        shutdown_handle,
         &test_topic,
         50, // batch size
         Duration::from_millis(100),
@@ -658,6 +676,15 @@ async fn test_seek_partitions_rewinds_consumer() -> Result<()> {
         .set("heartbeat.interval.ms", "2000");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mut manager = Manager::builder("test-batch-consumer-seek")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let shutdown_handle = manager.register("consumer", ComponentOptions::new());
+    let _monitor_guard = manager.monitor_background();
+
     let (chan_tx, mut batch_rx) = unbounded_channel();
 
     struct TestProcessor {
@@ -685,7 +712,7 @@ async fn test_seek_partitions_rewinds_consumer() -> Result<()> {
         handler.clone(),
         processor,
         offset_tracker,
-        shutdown_rx,
+        shutdown_handle,
         &test_topic,
         10,
         Duration::from_millis(100),
@@ -797,6 +824,14 @@ async fn test_seek_partitions_command_handled() -> Result<()> {
         .set("heartbeat.interval.ms", "2000");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mut manager = Manager::builder("test-batch-consumer-seek-cmd")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let shutdown_handle = manager.register("consumer", ComponentOptions::new());
+    let _monitor_guard = manager.monitor_background();
 
     struct NoopProcessor;
     #[async_trait]
@@ -815,7 +850,7 @@ async fn test_seek_partitions_command_handled() -> Result<()> {
         handler.clone(),
         processor,
         offset_tracker,
-        shutdown_rx,
+        shutdown_handle,
         &test_topic,
         10,
         Duration::from_millis(100),

--- a/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/deduplication_integration_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use common_types::{CapturedEvent, RawEvent};
-use health::HealthRegistry;
 use kafka_deduplicator::{config::Config, service::KafkaDeduplicatorService};
+use lifecycle::Manager;
 use rdkafka::{
     admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     config::ClientConfig,
@@ -282,9 +282,15 @@ async fn test_basic_deduplication() -> Result<()> {
 
     // Create the service using the same abstraction as production
     println!("Creating Kafka Deduplicator service...");
-    let liveness = HealthRegistry::new("test_liveness");
-    let mut service = KafkaDeduplicatorService::new(config, liveness).await?;
-    service.initialize().await?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let mut manager = Manager::builder("test-dedup")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let mut service = KafkaDeduplicatorService::new(config, &mut manager).await?;
+    service.initialize(&mut manager).await?;
     println!("Service initialized");
 
     // Produce test events with explicit different timestamps to ensure distinct deduplication keys
@@ -316,19 +322,19 @@ async fn test_basic_deduplication() -> Result<()> {
     .await?;
     println!("Produced second batch");
 
-    // Run the service with a controlled shutdown
-    let shutdown_signal = async {
-        println!("Waiting 10 seconds for processing...");
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        println!("Initiating shutdown...");
-    };
+    // Run the service with lifecycle and controlled shutdown
+    let monitor_guard = manager.monitor_background();
+    service.spawn_consumer_task()?;
 
-    // Run service with custom shutdown signal
-    let service_handle =
-        tokio::spawn(async move { service.run_with_shutdown(shutdown_signal).await });
+    let monitor_handle = tokio::spawn(async move { monitor_guard.wait().await });
 
-    // Wait for service to complete
-    let _ = tokio::time::timeout(Duration::from_secs(15), service_handle).await;
+    println!("Waiting 10 seconds for processing...");
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    println!("Initiating shutdown...");
+    shutdown_tx.send(()).ok();
+
+    // Wait for monitor to complete
+    let _ = tokio::time::timeout(Duration::from_secs(15), monitor_handle).await;
     println!("Service stopped");
 
     // Consume from output topic to verify deduplication
@@ -521,25 +527,32 @@ async fn test_deduplication_with_different_events() -> Result<()> {
     let config = Config::init_with_defaults()?;
 
     // Create and initialize the service
-    let liveness = HealthRegistry::new("test_liveness");
-    let mut service = KafkaDeduplicatorService::new(config, liveness).await?;
-    service.initialize().await?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let mut manager = Manager::builder("test-dedup-different")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let mut service = KafkaDeduplicatorService::new(config, &mut manager).await?;
+    service.initialize(&mut manager).await?;
 
     // Produce events with same distinct_id but different event names
     produce_duplicate_events(&input_topic, "user_123", "event_a", 3).await?;
     produce_duplicate_events(&input_topic, "user_123", "event_b", 2).await?;
     produce_duplicate_events(&input_topic, "user_123", "event_c", 1).await?;
 
-    // Run the service with a controlled shutdown
-    let shutdown_signal = async {
-        tokio::time::sleep(Duration::from_secs(5)).await;
-    };
+    // Run the service with lifecycle and controlled shutdown
+    let monitor_guard = manager.monitor_background();
+    service.spawn_consumer_task()?;
 
-    let service_handle =
-        tokio::spawn(async move { service.run_with_shutdown(shutdown_signal).await });
+    let monitor_handle = tokio::spawn(async move { monitor_guard.wait().await });
 
-    // Wait for service to complete
-    let _ = tokio::time::timeout(Duration::from_secs(10), service_handle).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    shutdown_tx.send(()).ok();
+
+    // Wait for monitor to complete
+    let _ = tokio::time::timeout(Duration::from_secs(10), monitor_handle).await;
 
     // Verify output
     let output_messages = consume_output_messages(

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -351,13 +351,21 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
         .set("heartbeat.interval.ms", "2000");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let mut manager = lifecycle::Manager::builder("test-rebalance-e2e")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_test_shutdown(shutdown_rx)
+        .with_global_shutdown_timeout(std::time::Duration::from_secs(30))
+        .build();
+    let shutdown_handle = manager.register("consumer", lifecycle::ComponentOptions::new());
+    let _monitor_guard = manager.monitor_background();
 
     let consumer = BatchConsumer::<CapturedEvent>::new(
         &config,
         rebalance_handler,
         routing_processor,
         offset_tracker.clone(),
-        shutdown_rx,
+        shutdown_handle,
         &test_topic,
         50,
         Duration::from_millis(100),


### PR DESCRIPTION
## Problem
`kafka-deduplicator` could use more robust lifecycle management for the app and it's long-running async components.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add trait to `common/limiters` to ease the transition between `common/health` and `common/lifecycle` for dependent libraries like `common/kafka`
* Integrate `common/lifecycle` into `kafka-deduplicator`
* Related test suite and documentation updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will smoke test in PoC env when PR is landed
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
