### PR TITLE
feat(lifecycle): prep for integration into kafka-deduplicator

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2094,6 +2094,7 @@ name = "common-kafka"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "common-liveness",
  "envconfig",
  "health",
  "rdkafka",
@@ -2105,6 +2106,10 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "common-liveness"
+version = "0.1.0"
 
 [[package]]
 name = "common-metrics"
@@ -3742,6 +3747,7 @@ name = "health"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "common-liveness",
  "time",
  "tokio",
  "tracing",
@@ -4937,6 +4943,7 @@ name = "lifecycle"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "common-liveness",
  "metrics",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "common/dns",
     "common/health",
     "common/kafka",
+    "common/liveness",
     "common/lifecycle",
     "common/limiters",
     "common/metrics",

--- a/rust/common/health/Cargo.toml
+++ b/rust/common/health/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+common-liveness = { path = "../liveness" }
 axum = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -201,6 +201,16 @@ impl HealthHandle {
     }
 }
 
+impl common_liveness::SyncLivenessReporter for HealthHandle {
+    fn report_healthy(&self) {
+        self.report_healthy_blocking();
+    }
+
+    fn report_unhealthy(&self) {
+        self.report_status_blocking(ComponentStatus::Unhealthy);
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum HealthStrategy {
     /// All components must be healthy for the registry to be healthy

--- a/rust/common/kafka/Cargo.toml
+++ b/rust/common/kafka/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+common-liveness = { path = "../liveness" }
 envconfig = { workspace = true }
 health = { path = "../health" }
 rdkafka = { workspace = true }

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -1,6 +1,7 @@
-use crate::config::KafkaConfig;
+use std::sync::Arc;
 
-use health::HealthHandle;
+use crate::config::KafkaConfig;
+use common_liveness::SyncLivenessReporter;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::{ClientConfig, ClientContext};
@@ -10,28 +11,39 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 
 pub struct KafkaContext {
-    liveness: HealthHandle,
+    liveness: Arc<dyn SyncLivenessReporter>,
 }
 
-impl From<HealthHandle> for KafkaContext {
-    fn from(value: HealthHandle) -> Self {
-        KafkaContext { liveness: value }
+impl KafkaContext {
+    pub fn new(liveness: impl SyncLivenessReporter + Clone + 'static) -> Self {
+        Self {
+            liveness: Arc::new(liveness),
+        }
+    }
+}
+
+impl From<health::HealthHandle> for KafkaContext {
+    fn from(value: health::HealthHandle) -> Self {
+        Self::new(value)
     }
 }
 
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, _: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
-        self.liveness.report_healthy_blocking();
+        self.liveness.report_healthy();
 
         // TODO: Take stats recording pieces that we want from `capture-rs`.
     }
 }
 
-pub async fn create_kafka_producer(
+pub async fn create_kafka_producer<L>(
     config: &KafkaConfig,
-    liveness: HealthHandle,
-) -> Result<FutureProducer<KafkaContext>, KafkaError> {
+    liveness: L,
+) -> Result<FutureProducer<KafkaContext>, KafkaError>
+where
+    L: SyncLivenessReporter + Clone + 'static,
+{
     let mut client_config = ClientConfig::new();
     client_config
         .set("bootstrap.servers", &config.kafka_hosts)
@@ -61,7 +73,8 @@ pub async fn create_kafka_producer(
     };
 
     debug!("rdkafka configuration: {:?}", client_config);
-    let api: FutureProducer<KafkaContext> = client_config.create_with_context(liveness.into())?;
+    let api: FutureProducer<KafkaContext> =
+        client_config.create_with_context(KafkaContext::new(liveness))?;
 
     // "Ping" the Kafka brokers by requesting metadata
     match api

--- a/rust/common/lifecycle/Cargo.toml
+++ b/rust/common/lifecycle/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+common-liveness = { path = "../liveness" }
 axum = { workspace = true }
 metrics = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -257,7 +257,7 @@ The crate emits metrics via the `metrics` facade (no recorder installed by this 
 | `lifecycle_shutdown_completed_total`            | Counter   | `service_name`, `clean`                               | Once when monitor returns successfully         |
 | `lifecycle_component_healthy`                   | Gauge     | `service_name`, `component`                           | Continuously during normal operation           |
 
-Label values: `trigger_reason` = `signal`, `prestop`, `test`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
+Label values: `trigger_reason` = `signal`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
 
 `lifecycle_shutdown_completed_total` is **not** emitted on global timeout or if the process is killed; that asymmetry with `lifecycle_shutdown_initiated_total` is how incomplete shutdowns (e.g. SIGKILL) are detected.
 

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -106,6 +106,7 @@ All options except `name` have sensible defaults.
 | `.with_prestop_check(bool)`               | Poll for pre-stop shutdown file (K8s pre-stop hook pattern).                                                                                                                                                   | `true`          |
 | `.with_prestop_path(path)`                | Override the pre-stop file path.                                                                                                                                                                               | `/tmp/shutdown` |
 | `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`            |
+| `.with_test_shutdown(receiver)`           | Inject a test shutdown trigger. When the oneshot receiver resolves (e.g. test sends on the paired sender), the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)` in tests. (see test `test_shutdown_trigger_initiates_shutdown`) | `None`          |
 | `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —               |
 
 ### register() / ComponentOptions
@@ -256,7 +257,7 @@ The crate emits metrics via the `metrics` facade (no recorder installed by this 
 | `lifecycle_shutdown_completed_total`            | Counter   | `service_name`, `clean`                               | Once when monitor returns successfully         |
 | `lifecycle_component_healthy`                   | Gauge     | `service_name`, `component`                           | Continuously during normal operation           |
 
-Label values: `trigger_reason` = `signal`, `prestop`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
+Label values: `trigger_reason` = `signal`, `prestop`, `test`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
 
 `lifecycle_shutdown_completed_total` is **not** emitted on global timeout or if the process is killed; that asymmetry with `lifecycle_shutdown_initiated_total` is how incomplete shutdowns (e.g. SIGKILL) are detected.
 
@@ -291,6 +292,24 @@ by `component`, `result`.
 - Incomplete shutdown count > 0 over 1h:
 `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h]) > 0`
 - Component unhealthy for > 2 consecutive scrapes: e.g. alert when `lifecycle_component_healthy{service_name="$service_name"}` is 0 for a given component for 2 scrape intervals.
+
+## Testing
+
+For deterministic shutdown in tests, use `with_trap_signals(false)`, `with_prestop_check(false)`, and `with_test_shutdown`:
+
+```rust
+let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+let mut manager = Manager::builder("test-service")
+    .with_trap_signals(false)
+    .with_prestop_check(false)
+    .with_test_shutdown(shutdown_rx)
+    .build();
+
+// ... register components, spawn monitor_background, spawn component tasks ...
+
+shutdown_tx.send(()).ok(); // test triggers shutdown
+guard.wait().await?;
+```
 
 ## SIGKILL detection
 

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -106,7 +106,7 @@ All options except `name` have sensible defaults.
 | `.with_prestop_check(bool)`               | Poll for pre-stop shutdown file (K8s pre-stop hook pattern).                                                                                                                                                   | `true`          |
 | `.with_prestop_path(path)`                | Override the pre-stop file path.                                                                                                                                                                               | `/tmp/shutdown` |
 | `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`            |
-| `.with_shutdown_token(token)`             | Use an external `CancellationToken`; caller triggers shutdown via `token.cancel()`. Use in tests for deterministic shutdown.                                                                                   | `None`          |
+| `.with_shutdown_token(token)`             | Caller supplies an external `CancellationToken`. Use in tests to trigger deterministic, app-global shutdown (simulate `SIGTERM` from k8s etc.)                                                                                   | `None`          |
 | `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —               |
 
 ### register() / ComponentOptions

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -16,6 +16,7 @@ Summary of how the library works and can be intergrated into your Rust services.
 - Register each app component on `Manager` and configure:
   - Optional active health reporting (usually not needed)
   - Optional graceful shutdown timeout (overrides global)
+  - If handle is for metrics server (etc.) set `builder.is_observability(true)`
   - Returns a `HealthHandle`
 - Pass or clone the health handle to the component prior to blocking in `main`:
   - If component is a function, clone handle into it's scope
@@ -23,7 +24,7 @@ Summary of how the library works and can be intergrated into your Rust services.
   - If the component runs for the full app lifecycle:
     - Create a drop guard at the top of the processing loop
     - Example: `let _completed = handle.process_scope();`
-    - Call `handle.work_completed();` prior to a clean exit
+    - Optional: call `handle.work_completed();` prior to a clean exit
     - Return an error or panic to signal completion and app shutdown
   - If using active health reporting:
     - Call `handle.report_healthy();` regularly
@@ -116,7 +117,8 @@ All options except `name` have sensible defaults.
 | Method                              | Effect                                                                                                                                                                                                                                 | Default                                                            |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | `ComponentOptions::new()`           | Base options with defaults for all fields.                                                                                                                                                                                             | —                                                                  |
-| `.with_graceful_shutdown(duration)` | Max time for this component to clean up after shutdown begins. Exceeded = marked timed out. (see test `component_timeout_then_late_drop_preserves_timeout`)                                                                            | `None` — waits indefinitely (bounded by `global_shutdown_timeout`) |
+| `.is_observability(bool)`           | Mark as an observability handle (e.g. metrics server). Shut down *after* all standard components finish. Cannot combine with `with_liveness_deadline`. (see test `observability_handle_shuts_down_after_standard_handles`)              | `false`                                                            |
+| `.with_graceful_shutdown(duration)` | Max time for this component to clean up after shutdown begins. Exceeded = marked timed out. (see test `component_timeout_then_late_drop_preserves_timeout`)                                                                            | `None` — waits indefinitely (bounded by `global_shutdown_timeout`). Observability handles default to `1s` if unset. |
 | `.with_liveness_deadline(duration)` | Component must call `report_healthy()` within this interval or the health monitor considers it stalled. After `stall_threshold` consecutive stalled checks, the manager triggers global shutdown. (see test `stall_triggers_shutdown`) | `None` — no health monitoring                                      |
 | `.with_stall_threshold(n)`          | Number of consecutive stalled health checks before the manager triggers global shutdown. Set higher for tolerance of transient hiccups. Only meaningful with `with_liveness_deadline`. (see test `stall_threshold_allows_recovery`)    | `1` — immediate shutdown on first stall                            |
 
@@ -131,9 +133,12 @@ Components in **Starting** state (never called `report_healthy()`) are skipped b
 ### Axum route setup
 
 ```rust
+let metrics_handle = manager.register(
+    "metrics",
+    ComponentOptions::new().is_observability(true),
+);
 let readiness = manager.readiness_handler();
 let liveness = manager.liveness_handler();
-let shutdown = manager.shutdown_signal();
 
 let app = Router::new()
     .route("/_readiness", get({
@@ -149,8 +154,9 @@ let guard = manager.monitor_background();
 
 let listener = TcpListener::bind("0.0.0.0:8080").await?;
 axum::serve(listener, app)
-    .with_graceful_shutdown(shutdown)
+    .with_graceful_shutdown(metrics_handle.shutdown_signal())
     .await?;
+metrics_handle.work_completed();
 
 guard.wait().await?;
 ```
@@ -229,7 +235,8 @@ After `signal_failure()`, just return — the manager records the failure immedi
 
 | Method                   | Use when                                                                                                                                                                                              |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shutdown_recv()`        | In `tokio::select!` to react to shutdown.                                                                                                                                                             |
+| `shutdown_recv()`        | In `tokio::select!` to react to shutdown. Returns a borrowed future — zero allocation per call. (see test `component_a_clean_shutdown`)                                                               |
+| `shutdown_signal()`      | Owned `'static` future for passing to `axum::serve(...).with_graceful_shutdown(handle.shutdown_signal())`. Clones the internal token once. (see test `handle_shutdown_signal_method`)                  |
 | `is_shutting_down()`     | Sync check (e.g. in a hot loop) to bail out.                                                                                                                                                          |
 | `signal_failure(reason)` | Fatal error; triggers global shutdown. Just return after calling it.                                                                                                                                  |
 | `request_shutdown()`     | Request clean shutdown (non-fatal). Then return (drop is enough).                                                                                                                                     |
@@ -244,6 +251,72 @@ After `signal_failure()`, just return — the manager records the failure immedi
 2. **Register order** — Register all components before calling `monitor()` or `monitor_background()`. The manager is consumed by those calls.
 3. **Health monitoring** — Activated by `with_liveness_deadline` on any component. You must call `report_healthy()` more frequently than `liveness_deadline`, or the health monitor triggers global shutdown after `stall_threshold` consecutive stalled checks. Components that haven't called `report_healthy()` yet (Starting state) are skipped. Use `with_health_poll_interval` on the builder to tune poll frequency (default 5s).
 4. **Struct-held handles** — If your struct owns the handle and `process()` is the run method, use `process_scope()`. Otherwise the manager is only notified when the struct is dropped, not when `process()` returns.
+
+## Observability handles
+
+Observability handles (`is_observability(true)`) implement **two-phase shutdown**: they stay alive while standard components drain, so metrics/health endpoints remain available throughout graceful shutdown.
+
+```text
+Phase 1: Normal operation — all components running
+Phase 2: Standard drain — standard shutdown_token cancelled, standard components drain
+Phase 3: Observability drain — observability shutdown_token cancelled, obs components drain (default 1s timeout)
+```
+
+### When to use
+
+Use `is_observability(true)` for components that serve infrastructure endpoints (metrics, health, pprof) and should outlive the app's business logic during shutdown. The canonical example is a metrics HTTP server.
+
+### Behavior
+
+- **Separate `CancellationToken`**: Observability handles receive a different token than standard handles. `handle.shutdown_recv()` and `handle.shutdown_signal()` resolve at the right time for each tier automatically.
+- **No health monitoring**: Observability handles cannot use `with_liveness_deadline` (panics at registration). They're lightweight infrastructure; active heartbeating would add complexity for no benefit.
+- **No metrics during Phase 3**: The manager only emits `tracing` logs for observability component outcomes. Since the metrics server itself may be draining, metric emission would be unreliable.
+- **Default 1s timeout**: Observability handles without explicit `with_graceful_shutdown` get a 1-second timeout. Override with `.with_graceful_shutdown(duration)` if your metrics server needs longer.
+- **Failures during normal operation**: An observability handle calling `signal_failure()` during Phase 1 triggers global shutdown for *all* components, same as a standard handle. (see test `observability_failure_during_normal_operation_triggers_shutdown`)
+
+### Example: metrics server as observability handle
+
+```rust
+let mut manager = Manager::builder("my-service").build();
+
+let consumer_handle = manager.register("consumer", ComponentOptions::new()
+    .with_graceful_shutdown(Duration::from_secs(10))
+    .with_liveness_deadline(Duration::from_secs(30)));
+
+let metrics_handle = manager.register("metrics", ComponentOptions::new()
+    .is_observability(true));
+
+let readiness = manager.readiness_handler();
+let liveness = manager.liveness_handler();
+let guard = manager.monitor_background();
+
+// Consumer task — uses standard shutdown token
+tokio::spawn(async move {
+    let _scope = consumer_handle.process_scope();
+    loop {
+        tokio::select! {
+            _ = consumer_handle.shutdown_recv() => return,
+            msg = recv_message() => {
+                process(msg).await;
+                consumer_handle.report_healthy();
+            }
+        }
+    }
+});
+
+// Metrics server — uses observability shutdown token, stays alive during consumer drain
+let app = Router::new()
+    .route("/_readiness", get(move || async move { readiness.check().await }))
+    .route("/_liveness", get(move || async move { liveness.check().into_response() }));
+
+let listener = TcpListener::bind("0.0.0.0:9090").await?;
+axum::serve(listener, app)
+    .with_graceful_shutdown(metrics_handle.shutdown_signal())
+    .await?;
+metrics_handle.work_completed();
+
+guard.wait().await?;
+```
 
 ## Metrics
 

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -106,7 +106,7 @@ All options except `name` have sensible defaults.
 | `.with_prestop_check(bool)`               | Poll for pre-stop shutdown file (K8s pre-stop hook pattern).                                                                                                                                                   | `true`          |
 | `.with_prestop_path(path)`                | Override the pre-stop file path.                                                                                                                                                                               | `/tmp/shutdown` |
 | `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`            |
-| `.with_test_shutdown(receiver)`           | Inject a test shutdown trigger. When the oneshot receiver resolves (e.g. test sends on the paired sender), the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)` in tests. (see test `test_shutdown_trigger_initiates_shutdown`) | `None`          |
+| `.with_shutdown_token(token)`             | Use an external `CancellationToken`; caller triggers shutdown via `token.cancel()`. Use in tests for deterministic shutdown.                                                                                   | `None`          |
 | `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —               |
 
 ### register() / ComponentOptions
@@ -295,19 +295,21 @@ by `component`, `result`.
 
 ## Testing
 
-For deterministic shutdown in tests, use `with_trap_signals(false)`, `with_prestop_check(false)`, and `with_test_shutdown`:
+For deterministic shutdown in tests, use `with_shutdown_token` on the builder. The test holds the token and calls `token.cancel()` to trigger shutdown:
 
 ```rust
-let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+use tokio_util::sync::CancellationToken;
+
+let shutdown_token = CancellationToken::new();
 let mut manager = Manager::builder("test-service")
     .with_trap_signals(false)
     .with_prestop_check(false)
-    .with_test_shutdown(shutdown_rx)
+    .with_shutdown_token(shutdown_token.clone())
     .build();
 
 // ... register components, spawn monitor_background, spawn component tasks ...
 
-shutdown_tx.send(()).ok(); // test triggers shutdown
+shutdown_token.cancel(); // test triggers shutdown
 guard.wait().await?;
 ```
 

--- a/rust/common/lifecycle/src/handle.rs
+++ b/rust/common/lifecycle/src/handle.rs
@@ -210,3 +210,13 @@ impl Drop for HandleInner {
         }
     }
 }
+
+impl common_liveness::SyncLivenessReporter for Handle {
+    fn report_healthy(&self) {
+        Handle::report_healthy(self);
+    }
+
+    fn report_unhealthy(&self) {
+        Handle::report_unhealthy(self);
+    }
+}

--- a/rust/common/lifecycle/src/handle.rs
+++ b/rust/common/lifecycle/src/handle.rs
@@ -55,14 +55,24 @@ pub(crate) struct HandleInner {
 }
 
 impl Handle {
-    /// Future that resolves when global shutdown begins (any trigger: signal, pre-stop,
-    /// [`signal_failure`](Handle::signal_failure), or [`request_shutdown`](Handle::request_shutdown)).
+    /// Future that resolves when shutdown begins for this handle's tier.
+    /// Standard handles: resolves when global shutdown begins.
+    /// Observability handles: resolves after all standard components finish.
     /// Use in `tokio::select!` to break out of work loops.
     pub fn shutdown_recv(&self) -> tokio_util::sync::WaitForCancellationFuture<'_> {
         self.inner.shutdown_token.cancelled()
     }
 
-    /// Returns true if shutdown has been initiated.
+    /// Owned future that resolves when shutdown begins for this handle's tier.
+    /// Same semantics as [`shutdown_recv`](Handle::shutdown_recv) but returns a
+    /// `'static` future suitable for passing to
+    /// `axum::serve(...).with_graceful_shutdown(handle.shutdown_signal())`.
+    pub fn shutdown_signal(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
+        let token = self.inner.shutdown_token.clone();
+        async move { token.cancelled().await }
+    }
+
+    /// Returns true if shutdown has been initiated for this handle's tier.
     pub fn is_shutting_down(&self) -> bool {
         self.inner.shutdown_token.is_cancelled()
     }

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -8,6 +8,7 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_PRESTOP_PATH: &str = "/tmp/shutdown";
+const DEFAULT_OBSERVABILITY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -86,8 +87,10 @@ impl ManagerBuilder {
             prestop_path: self.prestop_path,
             health_poll_interval: self.health_poll_interval,
             shutdown_token: self.external_shutdown_token.unwrap_or_default(),
+            observability_shutdown_token: CancellationToken::new(),
             event_tx_slot: Arc::new(OnceLock::new()),
             components: HashMap::new(),
+            observability_components: HashMap::new(),
             liveness_components: Vec::new(),
         }
     }
@@ -99,6 +102,7 @@ pub struct ComponentOptions {
     graceful_shutdown: Option<Duration>,
     liveness_deadline: Option<Duration>,
     stall_threshold: u32,
+    pub(crate) is_observability: bool,
     config_errors: Vec<String>,
 }
 
@@ -109,8 +113,20 @@ impl ComponentOptions {
             graceful_shutdown: None,
             liveness_deadline: None,
             stall_threshold: 1,
+            is_observability: false,
             config_errors: Vec::new(),
         }
+    }
+
+    /// Mark this component as an observability handle (e.g. metrics server).
+    /// Observability handles are shut down *after* all standard components finish,
+    /// ensuring metrics flow during the entire graceful shutdown process.
+    /// Observability handles do not participate in active health monitoring;
+    /// combining `is_observability(true)` with `with_liveness_deadline` will panic.
+    /// (see test `observability_handle_shuts_down_after_standard_handles`)
+    pub fn is_observability(mut self, enabled: bool) -> Self {
+        self.is_observability = enabled;
+        self
     }
 
     /// Max time this component gets for cleanup after shutdown begins. If exceeded,
@@ -187,8 +203,10 @@ pub struct Manager {
     prestop_path: PathBuf,
     health_poll_interval: Duration,
     shutdown_token: CancellationToken,
+    observability_shutdown_token: CancellationToken,
     event_tx_slot: Arc<OnceLock<mpsc::Sender<ComponentEvent>>>,
     components: HashMap<String, ComponentState>,
+    observability_components: HashMap<String, ComponentState>,
     liveness_components: Vec<LivenessComponentRef>,
 }
 
@@ -220,13 +238,19 @@ impl Manager {
             options.config_errors.join("; ")
         );
         assert!(
-            !self.components.contains_key(tag),
+            !self.components.contains_key(tag) && !self.observability_components.contains_key(tag),
             "component '{}' registered more than once",
+            tag
+        );
+        assert!(
+            !(options.is_observability && options.liveness_deadline.is_some()),
+            "component '{}': observability handles cannot use liveness_deadline",
             tag
         );
 
         let healthy_until_ms = Arc::new(AtomicI64::new(HEALTH_STARTING));
         let tag_owned = tag.to_string();
+        let is_obs = options.is_observability;
 
         if let Some(deadline) = options.liveness_deadline {
             let labels = [
@@ -252,12 +276,18 @@ impl Manager {
         } else {
             debug!(
                 component = %tag_owned,
+                observability = is_obs,
                 graceful_shutdown_secs = options.graceful_shutdown.map(|d| d.as_secs_f64()),
                 "Lifecycle: component registered"
             );
         }
 
-        self.components.insert(
+        let target_map = if is_obs {
+            &mut self.observability_components
+        } else {
+            &mut self.components
+        };
+        target_map.insert(
             tag_owned.clone(),
             ComponentState {
                 graceful_shutdown: options.graceful_shutdown,
@@ -265,9 +295,15 @@ impl Manager {
             },
         );
 
+        let shutdown_token = if is_obs {
+            self.observability_shutdown_token.clone()
+        } else {
+            self.shutdown_token.clone()
+        };
+
         let inner = Arc::new(HandleInner {
             tag: tag_owned,
-            shutdown_token: self.shutdown_token.clone(),
+            shutdown_token,
             event_tx: self.event_tx_slot.clone(),
             healthy_until_ms,
             liveness_deadline: options.liveness_deadline,
@@ -292,20 +328,11 @@ impl Manager {
         LivenessHandler::new()
     }
 
-    /// Future that resolves when shutdown begins. Pass to
-    /// `axum::serve(...).with_graceful_shutdown(manager.shutdown_signal())`
-    /// so the HTTP server stops accepting connections on shutdown.
-    pub fn shutdown_signal(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
-        let token = self.shutdown_token.clone();
-        async move {
-            token.cancelled().await;
-        }
-    }
-
     fn spawn_monitor_thread(self) -> oneshot::Receiver<Result<(), LifecycleError>> {
         let (tx, rx) = oneshot::channel();
 
-        let channel_size = self.components.len() * 2 + 2;
+        let total_components = self.components.len() + self.observability_components.len();
+        let channel_size = total_components * 2 + 2;
         let (event_tx, event_rx) = mpsc::channel(channel_size);
         self.event_tx_slot
             .set(event_tx)
@@ -337,6 +364,17 @@ impl Manager {
         MonitorGuard {
             rx: self.spawn_monitor_thread(),
         }
+    }
+
+    /// Look up which component map a tag belongs to and return a mutable reference.
+    fn get_component_mut(&mut self, tag: &str) -> Option<&mut ComponentState> {
+        self.components
+            .get_mut(tag)
+            .or_else(|| self.observability_components.get_mut(tag))
+    }
+
+    fn is_observability_tag(&self, tag: &str) -> bool {
+        self.observability_components.contains_key(tag)
     }
 
     async fn run_monitor_loop(
@@ -446,6 +484,8 @@ impl Manager {
 
         let mut first_failure: Option<LifecycleError> = None;
 
+        // --- Phase 1: Normal operation ---
+        // Events from both standard and observability components trigger shutdown.
         loop {
             tokio::select! {
                 biased;
@@ -457,7 +497,7 @@ impl Manager {
                             warn!(trigger_component = %tag, trigger_reason = "failure",
                                 "Lifecycle: shutdown initiated: {reason:#}");
                             shutdown_token.cancel();
-                            if let Some(s) = self.components.get_mut(&tag) {
+                            if let Some(s) = self.get_component_mut(&tag) {
                                 s.phase = ShutdownPhase::Died;
                             }
                             first_failure = first_failure.or(Some(LifecycleError::ComponentFailure { tag, reason }));
@@ -468,7 +508,7 @@ impl Manager {
                             warn!(trigger_component = %tag, trigger_reason = "died",
                                 "Lifecycle: shutdown initiated, component died unexpectedly");
                             shutdown_token.cancel();
-                            if let Some(s) = self.components.get_mut(&tag) {
+                            if let Some(s) = self.get_component_mut(&tag) {
                                 s.phase = ShutdownPhase::Died;
                             }
                             first_failure = first_failure.or(Some(LifecycleError::ComponentDied { tag }));
@@ -482,10 +522,10 @@ impl Manager {
                             break;
                         }
                         ComponentEvent::WorkCompleted { tag } => {
-                            if let Some(s) = self.components.get_mut(&tag) {
+                            if let Some(s) = self.get_component_mut(&tag) {
                                 s.phase = ShutdownPhase::Completed;
                             }
-                            if self.all_components_finished() {
+                            if self.all_finished() {
                                 return self.finalize(Instant::now(), first_failure);
                             }
                         }
@@ -499,161 +539,321 @@ impl Manager {
             }
         }
 
+        // --- Phase 2: Standard component drain ---
+        let shutdown_clock = Instant::now();
+        let global_deadline = shutdown_clock + global_timeout;
+
         for s in self.components.values_mut() {
             if s.phase == ShutdownPhase::Running {
                 s.phase = ShutdownPhase::ShuttingDown;
             }
         }
 
-        if self.all_components_finished() {
-            return self.finalize(Instant::now(), first_failure);
-        }
-
-        let shutdown_clock = Instant::now();
-        let global_deadline = shutdown_clock + global_timeout;
-        let mut component_deadlines: Vec<(String, Instant)> = self
-            .components
-            .iter()
-            .filter_map(|(tag, s)| {
-                s.graceful_shutdown
-                    .map(|d| (tag.clone(), shutdown_clock + d))
-            })
-            .collect();
-        component_deadlines.sort_by(|a, b| a.1.cmp(&b.1));
-
-        loop {
-            let now = Instant::now();
-            if now >= global_deadline {
-                let remaining: Vec<String> = self
-                    .components
-                    .iter()
-                    .filter(|(_, s)| {
-                        s.phase != ShutdownPhase::Completed
-                            && s.phase != ShutdownPhase::TimedOut
-                            && s.phase != ShutdownPhase::Died
-                    })
-                    .map(|(t, _)| t.clone())
-                    .collect();
-                for tag in &remaining {
-                    metrics::emit_component_shutdown_result(&name, tag, "timeout");
-                }
-                warn!(
-                    total_duration_secs = global_timeout.as_secs_f64(),
-                    remaining = ?remaining,
-                    "Lifecycle: global shutdown timeout reached"
-                );
-                return Err(LifecycleError::ShutdownTimeout {
-                    elapsed: global_timeout,
-                    remaining,
-                });
-            }
-
-            let next_component_timeout = component_deadlines
+        if !self.all_standard_finished() {
+            let mut component_deadlines: Vec<(String, Instant)> = self
+                .components
                 .iter()
-                .find(|(tag, _)| {
-                    self.components
-                        .get(tag)
-                        .map(|s| s.phase == ShutdownPhase::ShuttingDown)
-                        == Some(true)
+                .filter_map(|(tag, s)| {
+                    s.graceful_shutdown
+                        .map(|d| (tag.clone(), shutdown_clock + d))
                 })
-                .map(|(_, t)| *t);
+                .collect();
+            component_deadlines.sort_by(|a, b| a.1.cmp(&b.1));
 
-            let wait_duration = [
-                next_component_timeout.map(|t| t.saturating_duration_since(now)),
-                Some(global_deadline.saturating_duration_since(now)),
-            ]
-            .into_iter()
-            .flatten()
-            .min()
-            .unwrap_or(Duration::from_secs(1));
-
-            tokio::select! {
-                biased;
-
-                Some(event) = event_rx.recv() => {
-                    match event {
-                        ComponentEvent::WorkCompleted { tag } => {
-                            if let Some(s) = self.components.get_mut(&tag) {
-                                if s.phase == ShutdownPhase::ShuttingDown {
-                                    s.phase = ShutdownPhase::Completed;
-                                    let elapsed = shutdown_clock.elapsed();
-                                    metrics::emit_component_shutdown_duration(&name, &tag, "completed", elapsed.as_secs_f64());
-                                    metrics::emit_component_shutdown_result(&name, &tag, "completed");
-                                    info!(component = %tag,
-                                        duration_secs = elapsed.as_secs_f64(),
-                                        result = "completed",
-                                        "Lifecycle: component completed shutdown");
-                                } else {
-                                    debug!(component = %tag, phase = ?s.phase,
-                                        "Lifecycle: late WorkCompleted for already-finished component");
-                                }
-                            }
-                        }
-                        ComponentEvent::Died { tag } => {
-                            if let Some(s) = self.components.get_mut(&tag) {
-                                s.phase = ShutdownPhase::Died;
-                                let elapsed = shutdown_clock.elapsed();
-                                metrics::emit_component_shutdown_duration(&name, &tag, "died", elapsed.as_secs_f64());
-                                metrics::emit_component_shutdown_result(&name, &tag, "died");
-                                warn!(component = %tag,
-                                    duration_secs = elapsed.as_secs_f64(),
-                                    result = "died",
-                                    "Lifecycle: component died during shutdown");
-                            }
-                        }
-                        ComponentEvent::Failure { tag, reason } => {
-                            if let Some(s) = self.components.get_mut(&tag) {
-                                s.phase = ShutdownPhase::Died;
-                                let elapsed = shutdown_clock.elapsed();
-                                metrics::emit_component_shutdown_duration(&name, &tag, "died", elapsed.as_secs_f64());
-                                metrics::emit_component_shutdown_result(&name, &tag, "died");
-                                warn!(component = %tag,
-                                    duration_secs = elapsed.as_secs_f64(),
-                                    result = "died",
-                                    "Lifecycle: component failed during shutdown");
-                            }
-                            first_failure = first_failure.or(Some(LifecycleError::ComponentFailure { tag, reason }));
-                        }
-                        ComponentEvent::ShutdownRequested { .. } => {}
-                    }
-                    if self.all_components_finished() {
-                        return self.finalize(shutdown_clock, first_failure);
-                    }
+            loop {
+                let now = Instant::now();
+                if now >= global_deadline {
+                    return self.emit_global_timeout(&name, global_timeout);
                 }
-                _ = tokio::time::sleep(wait_duration) => {
-                    let now = Instant::now();
-                    for (tag, deadline) in &component_deadlines {
-                        if now >= *deadline {
-                            if let Some(s) = self.components.get_mut(tag) {
-                                if s.phase == ShutdownPhase::ShuttingDown {
-                                    s.phase = ShutdownPhase::TimedOut;
-                                    if let Some(d) = s.graceful_shutdown {
-                                        metrics::emit_component_shutdown_duration(&name, tag, "timeout", d.as_secs_f64());
+
+                let next_component_timeout = component_deadlines
+                    .iter()
+                    .find(|(tag, _)| {
+                        self.components
+                            .get(tag)
+                            .map(|s| s.phase == ShutdownPhase::ShuttingDown)
+                            == Some(true)
+                    })
+                    .map(|(_, t)| *t);
+
+                let wait_duration = [
+                    next_component_timeout.map(|t| t.saturating_duration_since(now)),
+                    Some(global_deadline.saturating_duration_since(now)),
+                ]
+                .into_iter()
+                .flatten()
+                .min()
+                .unwrap_or(Duration::from_secs(1));
+
+                tokio::select! {
+                    biased;
+
+                    Some(event) = event_rx.recv() => {
+                        match event {
+                            ComponentEvent::WorkCompleted { tag } => {
+                                if let Some(s) = self.get_component_mut(&tag) {
+                                    if s.phase == ShutdownPhase::ShuttingDown {
+                                        s.phase = ShutdownPhase::Completed;
+                                        if !self.is_observability_tag(&tag) {
+                                            let elapsed = shutdown_clock.elapsed();
+                                            metrics::emit_component_shutdown_duration(&name, &tag, "completed", elapsed.as_secs_f64());
+                                            metrics::emit_component_shutdown_result(&name, &tag, "completed");
+                                            info!(component = %tag,
+                                                duration_secs = elapsed.as_secs_f64(),
+                                                result = "completed",
+                                                "Lifecycle: component completed shutdown");
+                                        }
+                                    } else {
+                                        debug!(component = %tag, phase = ?s.phase,
+                                            "Lifecycle: late WorkCompleted for already-finished component");
                                     }
-                                    metrics::emit_component_shutdown_result(&name, tag, "timeout");
-                                    warn!(component = %tag,
-                                        duration_secs = s.graceful_shutdown.unwrap_or_default().as_secs_f64(),
-                                        result = "timeout",
-                                        "Lifecycle: component timed out during graceful shutdown");
+                                }
+                            }
+                            ComponentEvent::Died { tag } => {
+                                if let Some(s) = self.get_component_mut(&tag) {
+                                    s.phase = ShutdownPhase::Died;
+                                    if !self.is_observability_tag(&tag) {
+                                        let elapsed = shutdown_clock.elapsed();
+                                        metrics::emit_component_shutdown_duration(&name, &tag, "died", elapsed.as_secs_f64());
+                                        metrics::emit_component_shutdown_result(&name, &tag, "died");
+                                        warn!(component = %tag,
+                                            duration_secs = elapsed.as_secs_f64(),
+                                            result = "died",
+                                            "Lifecycle: component died during shutdown");
+                                    }
+                                }
+                            }
+                            ComponentEvent::Failure { tag, reason } => {
+                                if let Some(s) = self.get_component_mut(&tag) {
+                                    s.phase = ShutdownPhase::Died;
+                                    if !self.is_observability_tag(&tag) {
+                                        let elapsed = shutdown_clock.elapsed();
+                                        metrics::emit_component_shutdown_duration(&name, &tag, "died", elapsed.as_secs_f64());
+                                        metrics::emit_component_shutdown_result(&name, &tag, "died");
+                                        warn!(component = %tag,
+                                            duration_secs = elapsed.as_secs_f64(),
+                                            result = "died",
+                                            "Lifecycle: component failed during shutdown");
+                                    }
+                                }
+                                first_failure = first_failure.or(Some(LifecycleError::ComponentFailure { tag, reason }));
+                            }
+                            ComponentEvent::ShutdownRequested { .. } => {}
+                        }
+                        if self.all_standard_finished() {
+                            break;
+                        }
+                    }
+                    _ = tokio::time::sleep(wait_duration) => {
+                        let now = Instant::now();
+                        for (tag, deadline) in &component_deadlines {
+                            if now >= *deadline {
+                                if let Some(s) = self.components.get_mut(tag) {
+                                    if s.phase == ShutdownPhase::ShuttingDown {
+                                        s.phase = ShutdownPhase::TimedOut;
+                                        if let Some(d) = s.graceful_shutdown {
+                                            metrics::emit_component_shutdown_duration(&name, tag, "timeout", d.as_secs_f64());
+                                        }
+                                        metrics::emit_component_shutdown_result(&name, tag, "timeout");
+                                        warn!(component = %tag,
+                                            duration_secs = s.graceful_shutdown.unwrap_or_default().as_secs_f64(),
+                                            result = "timeout",
+                                            "Lifecycle: component timed out during graceful shutdown");
+                                    }
                                 }
                             }
                         }
-                    }
-                    if self.all_components_finished() {
-                        return self.finalize(shutdown_clock, first_failure);
+                        if self.all_standard_finished() {
+                            break;
+                        }
                     }
                 }
             }
         }
+
+        // --- Phase 3: Observability component drain ---
+        if self.observability_components.is_empty() {
+            return self.finalize_all(first_failure);
+        }
+
+        info!("Lifecycle: standard components finished, draining observability components");
+        self.observability_shutdown_token.cancel();
+
+        for s in self.observability_components.values_mut() {
+            if s.phase == ShutdownPhase::Running {
+                s.phase = ShutdownPhase::ShuttingDown;
+            }
+        }
+
+        if !self.all_observability_finished() {
+            let obs_clock = Instant::now();
+
+            let mut obs_deadlines: Vec<(String, Instant)> = self
+                .observability_components
+                .iter()
+                .map(|(tag, s)| {
+                    let timeout = s
+                        .graceful_shutdown
+                        .unwrap_or(DEFAULT_OBSERVABILITY_SHUTDOWN_TIMEOUT);
+                    (tag.clone(), obs_clock + timeout)
+                })
+                .collect();
+            obs_deadlines.sort_by(|a, b| a.1.cmp(&b.1));
+
+            loop {
+                let now = Instant::now();
+                if now >= global_deadline {
+                    return self.emit_global_timeout(&name, global_timeout);
+                }
+
+                let next_obs_timeout = obs_deadlines
+                    .iter()
+                    .find(|(tag, _)| {
+                        self.observability_components
+                            .get(tag)
+                            .map(|s| s.phase == ShutdownPhase::ShuttingDown)
+                            == Some(true)
+                    })
+                    .map(|(_, t)| *t);
+
+                let wait_duration = [
+                    next_obs_timeout.map(|t| t.saturating_duration_since(now)),
+                    Some(global_deadline.saturating_duration_since(now)),
+                ]
+                .into_iter()
+                .flatten()
+                .min()
+                .unwrap_or(Duration::from_secs(1));
+
+                tokio::select! {
+                    biased;
+
+                    Some(event) = event_rx.recv() => {
+                        match event {
+                            ComponentEvent::WorkCompleted { tag } => {
+                                if let Some(s) = self.observability_components.get_mut(&tag) {
+                                    if s.phase == ShutdownPhase::ShuttingDown {
+                                        s.phase = ShutdownPhase::Completed;
+                                        info!(component = %tag,
+                                            result = "completed",
+                                            "Lifecycle: observability component completed shutdown");
+                                    } else {
+                                        debug!(component = %tag, phase = ?s.phase,
+                                            "Lifecycle: late WorkCompleted for already-finished observability component");
+                                    }
+                                }
+                            }
+                            ComponentEvent::Died { tag } => {
+                                if let Some(s) = self.observability_components.get_mut(&tag) {
+                                    s.phase = ShutdownPhase::Died;
+                                    warn!(component = %tag,
+                                        result = "died",
+                                        "Lifecycle: observability component died during shutdown");
+                                }
+                            }
+                            ComponentEvent::Failure { tag, reason } => {
+                                if let Some(s) = self.observability_components.get_mut(&tag) {
+                                    s.phase = ShutdownPhase::Died;
+                                    warn!(component = %tag,
+                                        result = "died",
+                                        "Lifecycle: observability component failed during shutdown: {reason}");
+                                }
+                                first_failure = first_failure.or(Some(LifecycleError::ComponentFailure { tag, reason }));
+                            }
+                            ComponentEvent::ShutdownRequested { .. } => {}
+                        }
+                        if self.all_observability_finished() {
+                            break;
+                        }
+                    }
+                    _ = tokio::time::sleep(wait_duration) => {
+                        let now = Instant::now();
+                        for (tag, deadline) in &obs_deadlines {
+                            if now >= *deadline {
+                                if let Some(s) = self.observability_components.get_mut(tag) {
+                                    if s.phase == ShutdownPhase::ShuttingDown {
+                                        s.phase = ShutdownPhase::TimedOut;
+                                        warn!(component = %tag,
+                                            duration_secs = s.graceful_shutdown
+                                                .unwrap_or(DEFAULT_OBSERVABILITY_SHUTDOWN_TIMEOUT)
+                                                .as_secs_f64(),
+                                            result = "timeout",
+                                            "Lifecycle: observability component timed out during shutdown");
+                                    }
+                                }
+                            }
+                        }
+                        if self.all_observability_finished() {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.finalize_all(first_failure)
     }
 
-    fn all_components_finished(&self) -> bool {
+    fn all_standard_finished(&self) -> bool {
         self.components.values().all(|s| {
             matches!(
                 s.phase,
                 ShutdownPhase::Completed | ShutdownPhase::Died | ShutdownPhase::TimedOut
             )
         })
+    }
+
+    fn all_observability_finished(&self) -> bool {
+        self.observability_components.values().all(|s| {
+            matches!(
+                s.phase,
+                ShutdownPhase::Completed | ShutdownPhase::Died | ShutdownPhase::TimedOut
+            )
+        })
+    }
+
+    fn all_finished(&self) -> bool {
+        self.all_standard_finished() && self.all_observability_finished()
+    }
+
+    fn remaining_tags(&self) -> Vec<String> {
+        self.components
+            .iter()
+            .chain(self.observability_components.iter())
+            .filter(|(_, s)| {
+                !matches!(
+                    s.phase,
+                    ShutdownPhase::Completed | ShutdownPhase::TimedOut | ShutdownPhase::Died
+                )
+            })
+            .map(|(t, _)| t.clone())
+            .collect()
+    }
+
+    fn emit_global_timeout(
+        &self,
+        service_name: &str,
+        global_timeout: Duration,
+    ) -> Result<(), LifecycleError> {
+        let remaining = self.remaining_tags();
+        for tag in &remaining {
+            if !self.is_observability_tag(tag) {
+                metrics::emit_component_shutdown_result(service_name, tag, "timeout");
+            }
+        }
+        warn!(
+            total_duration_secs = global_timeout.as_secs_f64(),
+            remaining = ?remaining,
+            "Lifecycle: global shutdown timeout reached"
+        );
+        Err(LifecycleError::ShutdownTimeout {
+            elapsed: global_timeout,
+            remaining,
+        })
+    }
+
+    fn finalize_all(&self, first_failure: Option<LifecycleError>) -> Result<(), LifecycleError> {
+        self.finalize(Instant::now(), first_failure)
     }
 
     fn finalize(
@@ -665,6 +865,7 @@ impl Manager {
         let clean = self
             .components
             .values()
+            .chain(self.observability_components.values())
             .all(|s| s.phase == ShutdownPhase::Completed);
         metrics::emit_shutdown_completed(&self.name, clean);
         if clean {

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -30,7 +30,7 @@ pub struct ManagerBuilder {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
-    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
+    external_shutdown_token: Option<CancellationToken>,
 }
 
 impl ManagerBuilder {
@@ -69,13 +69,10 @@ impl ManagerBuilder {
         self
     }
 
-    /// Inject a test shutdown trigger. When the receiver resolves (e.g. test sends on the paired sender),
-    /// the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)`
-    /// in tests for deterministic, signal-free shutdown control.
-    ///
-    /// (see test `test_shutdown_trigger_initiates_shutdown`)
-    pub fn with_test_shutdown(mut self, receiver: oneshot::Receiver<()>) -> Self {
-        self.test_shutdown_receiver = Some(receiver);
+    /// Use an external shutdown token. The caller controls when shutdown begins by calling
+    /// `token.cancel()`. Use in tests for deterministic shutdown control.
+    pub fn with_shutdown_token(mut self, token: CancellationToken) -> Self {
+        self.external_shutdown_token = Some(token);
         self
     }
 
@@ -88,8 +85,7 @@ impl ManagerBuilder {
             enable_prestop_check: self.enable_prestop_check,
             prestop_path: self.prestop_path,
             health_poll_interval: self.health_poll_interval,
-            test_shutdown_receiver: self.test_shutdown_receiver,
-            shutdown_token: CancellationToken::new(),
+            shutdown_token: self.external_shutdown_token.unwrap_or_default(),
             event_tx_slot: Arc::new(OnceLock::new()),
             components: HashMap::new(),
             liveness_components: Vec::new(),
@@ -190,7 +186,6 @@ pub struct Manager {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
-    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
     shutdown_token: CancellationToken,
     event_tx_slot: Arc<OnceLock<mpsc::Sender<ComponentEvent>>>,
     components: HashMap<String, ComponentState>,
@@ -209,7 +204,7 @@ impl Manager {
             enable_prestop_check: true,
             prestop_path: PathBuf::from(DEFAULT_PRESTOP_PATH),
             health_poll_interval: Duration::from_secs(5),
-            test_shutdown_receiver: None,
+            external_shutdown_token: None,
         }
     }
 
@@ -387,20 +382,6 @@ impl Manager {
                         break;
                     }
                 }
-            });
-        }
-
-        if let Some(test_rx) = self.test_shutdown_receiver.take() {
-            let token = shutdown_token.clone();
-            let name_for_metrics = name.clone();
-            tokio::spawn(async move {
-                let _ = test_rx.await;
-                info!(
-                    trigger_reason = "test",
-                    "Lifecycle: shutdown initiated from test trigger"
-                );
-                metrics::emit_shutdown_initiated(&name_for_metrics, "test", "test");
-                token.cancel();
             });
         }
 

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -22,7 +22,7 @@ use crate::signals;
 
 /// Builder for [`Manager`]. Start with [`Manager::builder("name")`](Manager::builder),
 /// chain `.with_*()` calls, then call [`.build()`](ManagerBuilder::build).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ManagerBuilder {
     name: String,
     global_shutdown_timeout: Duration,
@@ -30,6 +30,7 @@ pub struct ManagerBuilder {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
+    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
 }
 
 impl ManagerBuilder {
@@ -68,6 +69,16 @@ impl ManagerBuilder {
         self
     }
 
+    /// Inject a test shutdown trigger. When the receiver resolves (e.g. test sends on the paired sender),
+    /// the manager triggers shutdown. Use with `with_trap_signals(false)` and `with_prestop_check(false)`
+    /// in tests for deterministic, signal-free shutdown control.
+    ///
+    /// (see test `test_shutdown_trigger_initiates_shutdown`)
+    pub fn with_test_shutdown(mut self, receiver: oneshot::Receiver<()>) -> Self {
+        self.test_shutdown_receiver = Some(receiver);
+        self
+    }
+
     /// Consume the builder and produce a [`Manager`].
     pub fn build(self) -> Manager {
         Manager {
@@ -77,6 +88,7 @@ impl ManagerBuilder {
             enable_prestop_check: self.enable_prestop_check,
             prestop_path: self.prestop_path,
             health_poll_interval: self.health_poll_interval,
+            test_shutdown_receiver: self.test_shutdown_receiver,
             shutdown_token: CancellationToken::new(),
             event_tx_slot: Arc::new(OnceLock::new()),
             components: HashMap::new(),
@@ -178,6 +190,7 @@ pub struct Manager {
     enable_prestop_check: bool,
     prestop_path: PathBuf,
     health_poll_interval: Duration,
+    test_shutdown_receiver: Option<oneshot::Receiver<()>>,
     shutdown_token: CancellationToken,
     event_tx_slot: Arc<OnceLock<mpsc::Sender<ComponentEvent>>>,
     components: HashMap<String, ComponentState>,
@@ -196,6 +209,7 @@ impl Manager {
             enable_prestop_check: true,
             prestop_path: PathBuf::from(DEFAULT_PRESTOP_PATH),
             health_poll_interval: Duration::from_secs(5),
+            test_shutdown_receiver: None,
         }
     }
 
@@ -373,6 +387,20 @@ impl Manager {
                         break;
                     }
                 }
+            });
+        }
+
+        if let Some(test_rx) = self.test_shutdown_receiver.take() {
+            let token = shutdown_token.clone();
+            let name_for_metrics = name.clone();
+            tokio::spawn(async move {
+                let _ = test_rx.await;
+                info!(
+                    trigger_reason = "test",
+                    "Lifecycle: shutdown initiated from test trigger"
+                );
+                metrics::emit_shutdown_initiated(&name_for_metrics, "test", "test");
+                token.cancel();
             });
         }
 

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use lifecycle::{ComponentOptions, LifecycleError, Manager};
+use tokio_util::sync::CancellationToken;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -841,16 +842,16 @@ async fn mixed_component_timeout_outcomes() {
     assert!(result.is_ok());
 }
 
-/// Test shutdown trigger initiates shutdown. Use with_trap_signals(false) and
-/// with_prestop_check(false) for deterministic, signal-free shutdown control.
+/// Test shutdown trigger initiates shutdown. Uses Manager::builder with with_shutdown_token
+/// so the test can trigger shutdown by calling token.cancel().
 #[tokio::test]
 async fn test_shutdown_trigger_initiates_shutdown() {
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let shutdown_token = CancellationToken::new();
     let mut manager = Manager::builder("test")
         .with_trap_signals(false)
         .with_prestop_check(false)
         .with_global_shutdown_timeout(Duration::from_secs(5))
-        .with_test_shutdown(shutdown_rx)
+        .with_shutdown_token(shutdown_token.clone())
         .build();
 
     let handle = manager.register("worker", ComponentOptions::new());
@@ -865,7 +866,7 @@ async fn test_shutdown_trigger_initiates_shutdown() {
     drop(handle);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
-    shutdown_tx.send(()).ok();
+    shutdown_token.cancel();
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -840,3 +840,35 @@ async fn mixed_component_timeout_outcomes() {
         .expect("timed out");
     assert!(result.is_ok());
 }
+
+/// Test shutdown trigger initiates shutdown. Use with_trap_signals(false) and
+/// with_prestop_check(false) for deterministic, signal-free shutdown control.
+#[tokio::test]
+async fn test_shutdown_trigger_initiates_shutdown() {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_test_shutdown(shutdown_rx)
+        .build();
+
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    let comp = ComponentA {
+        handle: handle.clone(),
+    };
+    tokio::spawn(async move {
+        comp.process().await;
+    });
+    drop(handle);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    shutdown_tx.send(()).ok();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -873,3 +873,316 @@ async fn test_shutdown_trigger_initiates_shutdown() {
         .expect("timed out");
     assert!(result.is_ok());
 }
+
+// ---------------------------------------------------------------------------
+// Section 7: Observability handle lifecycle
+//
+// Observability handles (is_observability=true) run on a separate shutdown
+// tier: they stay alive during the standard component drain (Phase 2) so
+// that metrics/health endpoints remain available, and are only cancelled
+// after all standard components finish (Phase 3). No metrics are emitted
+// for observability components during shutdown — only tracing logs.
+// ---------------------------------------------------------------------------
+
+fn obs_opts() -> ComponentOptions {
+    ComponentOptions::new().is_observability(true)
+}
+
+/// Observability handle's is_shutting_down() returns false while standard
+/// components drain; returns true only after they finish and the manager
+/// cancels the observability shutdown token.
+#[tokio::test]
+async fn observability_handle_runs_during_standard_shutdown() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let std_handle = manager.register("worker", ComponentOptions::new());
+    let obs_handle = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    let obs_clone = obs_handle.clone();
+    let obs_saw_shutdown = Arc::new(AtomicBool::new(false));
+    let obs_saw_shutdown_clone = obs_saw_shutdown.clone();
+
+    tokio::spawn(async move {
+        let _guard = std_handle.process_scope();
+        std_handle.shutdown_recv().await;
+        // Standard handle is shutting down; observability should NOT be yet
+        assert!(!obs_clone.is_shutting_down());
+        obs_saw_shutdown_clone.store(obs_clone.is_shutting_down(), Ordering::SeqCst);
+    });
+
+    tokio::spawn(async move {
+        let _guard = obs_handle.process_scope();
+        obs_handle.shutdown_recv().await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    shutdown_token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+    assert!(!obs_saw_shutdown.load(Ordering::SeqCst));
+}
+
+/// Register standard + observability handles, trigger shutdown, verify the
+/// observability handle sees its shutdown only after the standard handle
+/// completes. Observability shutdown is strictly ordered after standard drain.
+#[tokio::test]
+async fn observability_handle_shuts_down_after_standard_handles() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let std_handle = manager.register("worker", ComponentOptions::new());
+    let obs_handle = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    let std_exited = Arc::new(AtomicBool::new(false));
+    let std_exited_clone = std_exited.clone();
+    let std_exited_check = std_exited.clone();
+
+    tokio::spawn(async move {
+        let _guard = std_handle.process_scope();
+        std_handle.shutdown_recv().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        std_exited_clone.store(true, Ordering::SeqCst);
+    });
+
+    tokio::spawn(async move {
+        let _guard = obs_handle.process_scope();
+        obs_handle.shutdown_recv().await;
+        // By the time observability sees shutdown, standard must have exited
+        assert!(std_exited_check.load(Ordering::SeqCst));
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    shutdown_token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// Observability handle with no explicit graceful_shutdown gets the 1s default
+/// timeout. If it hangs past that, the manager marks it TimedOut and moves on.
+#[tokio::test]
+async fn observability_default_timeout_1s() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let obs_handle = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        obs_handle.shutdown_recv().await;
+        // Hang past the 1s default observability timeout
+        std::future::pending::<()>().await;
+    });
+
+    shutdown_token.cancel();
+
+    let start = std::time::Instant::now();
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    let elapsed = start.elapsed();
+
+    // Should resolve around 1s (the default obs timeout), not 5s (global)
+    assert!(result.is_ok());
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "took {elapsed:?}, expected ~1s default timeout"
+    );
+}
+
+/// Observability handle with explicit graceful_shutdown(2s) uses that instead
+/// of the 1s default.
+#[tokio::test]
+async fn observability_custom_timeout() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(10))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let obs_handle = manager.register(
+        "metrics",
+        ComponentOptions::new()
+            .is_observability(true)
+            .with_graceful_shutdown(Duration::from_millis(200)),
+    );
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        obs_handle.shutdown_recv().await;
+        // Hang past the 200ms custom timeout
+        std::future::pending::<()>().await;
+    });
+
+    shutdown_token.cancel();
+
+    let start = std::time::Instant::now();
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok());
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "took {elapsed:?}, expected ~200ms custom timeout"
+    );
+}
+
+/// Observability handle calling signal_failure() during normal operation
+/// triggers global shutdown for all components (standard and observability).
+#[tokio::test]
+async fn observability_failure_during_normal_operation_triggers_shutdown() {
+    let mut manager = test_manager();
+    let std_handle = manager.register("worker", ComponentOptions::new());
+    let obs_handle = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        let _guard = std_handle.process_scope();
+        std_handle.shutdown_recv().await;
+    });
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        obs_handle.signal_failure("metrics bind failed");
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentFailure { tag, reason })
+            if tag == "metrics" && reason == "metrics bind failed"
+    ));
+}
+
+/// Combining is_observability(true) with with_liveness_deadline panics at
+/// registration. Observability handles don't participate in health monitoring.
+#[tokio::test]
+#[should_panic(expected = "observability handles cannot use liveness_deadline")]
+async fn observability_with_liveness_panics() {
+    let mut manager = test_manager();
+    manager.register(
+        "bad",
+        ComponentOptions::new()
+            .is_observability(true)
+            .with_liveness_deadline(Duration::from_secs(5)),
+    );
+}
+
+/// Multi-component test with both standard and observability handles, all
+/// completing cleanly. Verifies the full two-phase shutdown flow end-to-end.
+#[tokio::test]
+async fn mixed_standard_and_observability_clean_shutdown() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let ha = manager.register("worker_a", ComponentOptions::new());
+    let hb = manager.register("worker_b", liveness_opts());
+    let obs = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    let comp_a = ComponentA { handle: ha.clone() };
+    let comp_b = ComponentB::new(hb.clone());
+
+    tokio::spawn(async move { comp_a.process().await });
+    tokio::spawn(async move { comp_b.process().await });
+    tokio::spawn(async move {
+        let _guard = obs.process_scope();
+        obs.shutdown_recv().await;
+    });
+
+    drop(ha);
+    drop(hb);
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    shutdown_token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// Handle::shutdown_signal() returns a working owned 'static future for both
+/// standard and observability handle types. This is the API used by
+/// axum::serve(...).with_graceful_shutdown(handle.shutdown_signal()).
+#[tokio::test]
+async fn handle_shutdown_signal_method() {
+    let shutdown_token = CancellationToken::new();
+    let mut manager = Manager::builder("test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .with_global_shutdown_timeout(Duration::from_secs(5))
+        .with_shutdown_token(shutdown_token.clone())
+        .build();
+
+    let std_handle = manager.register("worker", ComponentOptions::new());
+    let obs_handle = manager.register("metrics", obs_opts());
+    let guard = manager.monitor_background();
+
+    let std_signal = std_handle.shutdown_signal();
+    let obs_signal = obs_handle.shutdown_signal();
+
+    let std_signalled = Arc::new(AtomicBool::new(false));
+    let obs_signalled = Arc::new(AtomicBool::new(false));
+    let std_signalled_clone = std_signalled.clone();
+    let obs_signalled_clone = obs_signalled.clone();
+
+    tokio::spawn(async move {
+        std_signal.await;
+        std_signalled_clone.store(true, Ordering::SeqCst);
+        std_handle.work_completed();
+    });
+
+    tokio::spawn(async move {
+        obs_signal.await;
+        obs_signalled_clone.store(true, Ordering::SeqCst);
+        obs_handle.work_completed();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!std_signalled.load(Ordering::SeqCst));
+    assert!(!obs_signalled.load(Ordering::SeqCst));
+
+    shutdown_token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+    assert!(std_signalled.load(Ordering::SeqCst));
+    assert!(obs_signalled.load(Ordering::SeqCst));
+}

--- a/rust/common/liveness/Cargo.toml
+++ b/rust/common/liveness/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "common-liveness"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/rust/common/liveness/src/lib.rs
+++ b/rust/common/liveness/src/lib.rs
@@ -1,0 +1,7 @@
+//! Sync liveness reporting for components that must signal "I'm alive" from sync contexts
+//! (e.g. rdkafka stats callbacks). Both health::HealthHandle and lifecycle::Handle implement this.
+
+pub trait SyncLivenessReporter: Send + Sync {
+    fn report_healthy(&self);
+    fn report_unhealthy(&self);
+}

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -91,17 +91,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let metrics_handle = manager.register(
         "metrics_server",
-        ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(5)),
+        ComponentOptions::new().is_observability(true),
     );
 
     let readiness = manager.readiness_handler();
     let liveness = manager.liveness_handler();
-    let grpc_shutdown = manager.shutdown_signal();
-    let metrics_shutdown = manager.shutdown_signal();
 
     let monitor = manager.monitor_background();
 
-    // Metrics/health HTTP server
+    // Metrics/health HTTP server (observability handle — stays alive during standard drain)
     let metrics_port = config.metrics_port;
     tokio::spawn(async move {
         let _guard = metrics_handle.process_scope();
@@ -123,7 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Failed to bind metrics port");
         tracing::info!("Metrics server listening on {}", bind);
         axum::serve(listener, router)
-            .with_graceful_shutdown(metrics_shutdown)
+            .with_graceful_shutdown(metrics_handle.shutdown_signal())
             .await
             .expect("Metrics server error");
     });
@@ -139,7 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _guard = grpc_handle.process_scope();
         if let Err(e) = Server::builder()
             .add_service(PersonHogReplicaServer::new(service))
-            .serve_with_shutdown(grpc_addr, grpc_shutdown)
+            .serve_with_shutdown(grpc_addr, grpc_handle.shutdown_signal())
             .await
         {
             grpc_handle.signal_failure(format!("gRPC server error: {e}"));

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -59,16 +59,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "grpc-server",
         ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(15)),
     );
-    let metrics_handle = manager.register("metrics-server", ComponentOptions::new());
+    let metrics_handle = manager.register(
+        "metrics-server",
+        ComponentOptions::new().is_observability(true),
+    );
 
     let readiness = manager.readiness_handler();
     let liveness = manager.liveness_handler();
-    let grpc_shutdown = manager.shutdown_signal();
-    let metrics_shutdown = manager.shutdown_signal();
 
     let monitor_guard = manager.monitor_background();
 
-    // Metrics/health HTTP server
+    // Metrics/health HTTP server (observability handle — stays alive during standard drain)
     let metrics_port = config.metrics_port;
     tokio::spawn(async move {
         let _guard = metrics_handle.process_scope();
@@ -90,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Failed to bind metrics port");
         tracing::info!("Metrics server listening on {}", bind);
         axum::serve(listener, metrics_router)
-            .with_graceful_shutdown(metrics_shutdown)
+            .with_graceful_shutdown(metrics_handle.shutdown_signal())
             .await
             .expect("Metrics server error");
     });
@@ -115,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = Server::builder()
             .layer(GrpcMetricsLayer)
             .add_service(PersonHogServiceServer::new(service))
-            .serve_with_shutdown(grpc_addr, grpc_shutdown)
+            .serve_with_shutdown(grpc_addr, grpc_handle.shutdown_signal())
             .await
         {
             grpc_handle.signal_failure(format!("gRPC server error: {e}"));


### PR DESCRIPTION
## Problem
We need a temporary shim for the old health handle in `common/kafka` while transitioning projects onto `common/lifecycle`.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Shim trait for health handle transition
* Integrate shim into `common/kafka`
* Add a test utility to `lifecycle::Manager`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will smoke test this change on the next project `common/lifecycle` is integrated into that depends on `common/kafka` (deduplicator, batch-import-worker, capture, etc.)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
