### PR TITLE
perf: use deque for FIFO queues across batch exports, signals, CDP, and lineage

### DIFF
--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import deque
 from typing import Any, Optional
 
 from rest_framework import serializers
@@ -422,11 +423,11 @@ def topological_sort(nodes: list[str], edges: dict[str, list[str]]) -> list[str]
                 in_degree[node] = in_degree[node] + 1
 
     # Find all nodes with in_degree 0
-    queue = [n for n, d in in_degree.items() if d == 0]
+    queue = deque(n for n, d in in_degree.items() if d == 0)
     sorted_list = []
 
     while queue:
-        current = queue.pop(0)
+        current = queue.popleft()
         sorted_list.append(current)
         # Decrease in-degree of dependent nodes
         for node, deps in edges.items():

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -7,6 +7,7 @@ import datetime as dt
 import operator
 import dataclasses
 import collections.abc
+from collections import deque
 
 from django.conf import settings
 
@@ -142,13 +143,11 @@ def generate_query_ranges(
         return
 
     epoch = dt.datetime.fromtimestamp(0, tz=dt.UTC)
-    list_done_ranges: list[tuple[dt.datetime, dt.datetime]] = list(done_ranges)
-
-    list_done_ranges.sort(key=operator.itemgetter(0))
+    list_done_ranges: deque[tuple[dt.datetime, dt.datetime]] = deque(sorted(done_ranges, key=operator.itemgetter(0)))
 
     while True:
         try:
-            next_range: tuple[dt.datetime | None, dt.datetime] = list_done_ranges.pop(0)
+            next_range: tuple[dt.datetime | None, dt.datetime] = list_done_ranges.popleft()
         except IndexError:
             if remaining_range[0] != remaining_range[1]:
                 # If they were equal it would mean we have finished.

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -1,11 +1,11 @@
-from collections import deque
-import math
-import uuid
-import typing
 import asyncio
-import datetime as dt
-import operator
 import collections.abc
+import datetime as dt
+import math
+import operator
+import typing
+import uuid
+from collections import deque
 
 from django.conf import settings
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -1,3 +1,4 @@
+from collections import deque
 import math
 import uuid
 import typing
@@ -599,13 +600,11 @@ def generate_query_ranges(
         return
 
     epoch = dt.datetime.fromtimestamp(0, tz=dt.UTC)
-    list_done_ranges: list[tuple[dt.datetime, dt.datetime]] = list(done_ranges)
-
-    list_done_ranges.sort(key=operator.itemgetter(0))
+    list_done_ranges: deque[tuple[dt.datetime, dt.datetime]] = deque(sorted(done_ranges, key=operator.itemgetter(0)))
 
     while True:
         try:
-            next_range: tuple[dt.datetime | None, dt.datetime] = list_done_ranges.pop(0)
+            next_range: tuple[dt.datetime | None, dt.datetime] = list_done_ranges.popleft()
         except IndexError:
             if remaining_range[0] != remaining_range[1]:
                 # If they were equal it would mean we have finished.

--- a/products/data_warehouse/backend/api/lineage.py
+++ b/products/data_warehouse/backend/api/lineage.py
@@ -85,10 +85,10 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
 
     # Recursively fetch all dependencies with a bfs
     # Fetch everything by names, ids and names are the same right now
-    to_process = [(root_query.name, root_query.external_tables)]
+    to_process = deque([(root_query.name, root_query.external_tables)])
 
     while to_process:
-        current_id, external_tables = to_process.pop(0)
+        current_id, external_tables = to_process.popleft()
 
         # Batch lookup all external tables at this level
         unseen_external_tables = [et for et in external_tables if et not in seen_nodes]

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -2,6 +2,7 @@ import os
 import json
 import uuid
 import asyncio
+from collections import deque
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from typing import Literal, Optional
@@ -858,7 +859,7 @@ class TeamSignalGroupingWorkflow:
     """
 
     def __init__(self) -> None:
-        self._signal_buffer: list[EmitSignalInputs] = []
+        self._signal_buffer: deque[EmitSignalInputs] = deque()
         self._signals_processed: int = 0
         meter = workflow.metric_meter()
         self._signals_received_counter = meter.create_counter(
@@ -892,7 +893,7 @@ class TeamSignalGroupingWorkflow:
 
         while True:
             await workflow.wait_condition(lambda: len(self._signal_buffer) > 0)
-            signal = self._signal_buffer.pop(0)
+            signal = self._signal_buffer.popleft()
             self._buffer_size_gauge.set(len(self._signal_buffer))
 
             try:


### PR DESCRIPTION
## Problem

Five files use `.pop(0)` for FIFO queue processing (BFS traversals, topological sorts, event buffers). Each `.pop(0)` on a Python list is **O(n)** because it shifts all remaining elements.

## Solution

Switch to `collections.deque` with `.popleft()` for **O(1)** front removal.

## Changes

| File | Pattern |
|------|---------|
| `products/batch_exports/backend/temporal/spmc.py` | Done-ranges drain loop |
| `products/batch_exports/backend/temporal/batch_exports.py` | Done-ranges drain loop |
| `products/data_warehouse/backend/api/lineage.py` | BFS traversal (already imported deque) |
| `posthog/cdp/validation.py` | Topological sort BFS |
| `products/signals/backend/temporal/grouping.py` | Signal buffer drain |

All `.append()`, `.extend()`, and `len()` calls work identically on deque.