### PR TITLE
fix: save logs on flox activation error

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -23,6 +23,27 @@ _cleanup_tmpfiles() {
 }
 trap _cleanup_tmpfiles EXIT
 
+_strip_ansi() {
+  sed $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tr -d '\r'
+}
+
+_save_failure_log() {
+  local label="$1"
+  local tmpfile="$2"
+  local logdir="$FLOX_ENV_CACHE/activation-error-logs"
+  mkdir -p "$logdir"
+
+  local slug="${label// /-}"
+  local logfile="$logdir/${slug}-$(date +%Y%m%d-%H%M%S).log"
+  {
+    echo "── ${label} (failed) ──"
+    _strip_ansi < "$tmpfile"
+    echo ""
+  } > "$logfile"
+  echo -e "    ${C_DIM}$(tail -n 15 "$tmpfile" | _strip_ansi)${C_RESET}"
+  echo -e "    ${C_DIM}Full log: ${logfile}${C_RESET}"
+}
+
 # ── Step runner ─────────────────────────────────────────────────────
 # Runs a command with a spinner and live output preview.
 # Usage: run_step "Label" command [args...]
@@ -48,6 +69,7 @@ run_step() {
       echo -e "\r  ${C_GREEN}✓${C_RESET} ${label}"
     else
       echo -e "\r  ${C_RED}✗${C_RESET} ${label}  (failed)"
+      _save_failure_log "$label" "$tmpfile"
       return 1
     fi
     return 0
@@ -106,8 +128,8 @@ run_step() {
     if [[ "$had_output" == true ]]; then printf "\033[2K"; fi
   else
     printf "\r\033[2K  ${C_RED}✗${C_RESET} %-42s %3ds\n" "$label" "$elapsed"
-    # Show last few lines of output on failure
-    echo -e "    ${C_DIM}$(tail -n 3 "$tmpfile" 2>/dev/null)${C_RESET}"
+    # Save failure log and show last few lines of output on failure
+    _save_failure_log "$label" "$tmpfile"
     return $exit_code
   fi
 }

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -31,17 +31,23 @@ _save_failure_log() {
   local label="$1"
   local tmpfile="$2"
   local logdir="$FLOX_ENV_CACHE/activation-error-logs"
-  mkdir -p "$logdir"
-
   local slug="${label// /-}"
   local logfile="$logdir/${slug}-$(date +%Y%m%d-%H%M%S).log"
-  {
-    echo "── ${label} (failed) ──"
-    _strip_ansi < "$tmpfile"
-    echo ""
-  } > "$logfile"
-  echo -e "    ${C_DIM}$(tail -n 15 "$tmpfile" | _strip_ansi)${C_RESET}"
-  echo -e "    ${C_DIM}Full log: ${logfile}${C_RESET}"
+
+  local log_saved=0
+  # Best-effort: failures here must not abort the script under `set -euo pipefail`.
+  if mkdir -p "$logdir" 2>/dev/null; then
+    {
+      echo "── ${label} (failed) ──"
+      _strip_ansi < "$tmpfile"
+      echo ""
+    } 2>/dev/null > "$logfile" && log_saved=1 || true
+  fi
+
+  printf '    %b%s%b\n' "${C_DIM}" "$(tail -n 15 "$tmpfile" 2>/dev/null | _strip_ansi || true)" "${C_RESET}"
+  if [[ "$log_saved" -eq 1 ]]; then
+    printf '    %bFull log: %s%b\n' "${C_DIM}" "$logfile" "${C_RESET}"
+  fi
 }
 
 # ── Step runner ─────────────────────────────────────────────────────


### PR DESCRIPTION
While trying to set up PostHog for local development, I ran into an error during `flox activate` but the output wasn't very useful for debugging -

```
$ flox activate

PostHog dev ── master

  ✓ Python packages                              1s
  ✗ Node packages                                1s
    } Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm

Node.js v24.12.0
✘ ERROR: Running hook.on-activate failed
```

So I've created this PR that shows the last 15 lines of output on error and saves the full error log to disk (ANSI-stripped) for easier debugging -

```
$ flox activate

PostHog dev ── master

  ✓ Python packages                              0s
  ✗ Node packages                                1s
          at async installVersion (/.../corepack.cjs:22360:55)
      at async Engine.ensurePackageManager (/.../corepack.cjs:22873:32)
      at async Engine.executePackageManagerRequest (/.../corepack.cjs:22984:25)
      at async Object.runMain (/.../corepack.cjs:23684:7) {
    [cause]: Error: self-signed certificate in certificate chain
        at TLSSocket.onConnectSecure (node:_tls_wrap:1631:34)
        ...
      code: 'SELF_SIGNED_CERT_IN_CHAIN'
    }
  }
}

Node.js v24.12.0
    Full log: /home/parin/posthog/.flox/cache/activation-error-logs/Node-packages-20260227-154820.log
```