### PR TITLE
fix(frontend): lazy-load NotebookPanel in SidePanel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -1,14 +1,18 @@
 import './SidePanel.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef } from 'react'
+import { lazy, Suspense, useEffect, useRef } from 'react'
 
 import { IconBook, IconGear, IconInfo, IconLock, IconLogomark, IconNotebook } from '@posthog/icons'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { cn } from 'lib/utils/css-classes'
-import { NotebookPanel } from 'scenes/notebooks/NotebookPanel/NotebookPanel'
+
+const NotebookPanel = lazy(() =>
+    import('scenes/notebooks/NotebookPanel/NotebookPanel').then((m) => ({ default: m.NotebookPanel }))
+)
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import {
@@ -223,7 +227,9 @@ export function SidePanel({ className }: { className?: string }): JSX.Element | 
             {PanelContent && (
                 <SidePanelNavigation activeTab={activeTab as SidePanelTab} onTabChange={(tab) => openSidePanel(tab)}>
                     <ErrorBoundary>
-                        <PanelContent />
+                        <Suspense fallback={<Spinner className="text-4xl mx-auto mt-16" />}>
+                            <PanelContent />
+                        </Suspense>
                     </ErrorBoundary>
                 </SidePanelNavigation>
             )}


### PR DESCRIPTION
## Problem

The NotebookPanel component is being loaded synchronously, which can impact the initial bundle size and loading performance of the SidePanel component.

## Changes

- Converted NotebookPanel import to lazy loading using React's `lazy()` function
- Wrapped the PanelContent component with `Suspense` to handle the loading state during dynamic import
- Added necessary React imports (`lazy`, `Suspense`) to support the lazy loading implementation

## How did you test this code?

## ![CleanShot 2026-02-28 at 19.02.38.png](https://app.graphite.com/user-attachments/assets/91b2536e-5ec5-44dd-8f22-6efeb891211f.png)



## Publish to changelog?

No