### PR TITLE
fix(frontend): lazy-load MonacoDiffEditor in ActivityLog

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -3,10 +3,10 @@ import './ActivityLog.scss'
 import useSize from '@react-hook/size'
 import clsx from 'clsx'
 import { useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { lazy, Suspense, useRef, useState } from 'react'
 
 import { IconCollapse, IconExpand } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonTabs } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonTabs, Spinner } from '@posthog/lemon-ui'
 
 import { ActivityLogLogicProps, activityLogLogic } from 'lib/components/ActivityLog/activityLogLogic'
 import { ActivityChange, HumanizedActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
@@ -24,8 +24,9 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, AvailableFeature } from '~/types'
 
 import { AccessDenied } from '../AccessDenied'
-import MonacoDiffEditor from '../MonacoDiffEditor'
 import { PayGateMini } from '../PayGateMini/PayGateMini'
+
+const MonacoDiffEditor = lazy(() => import('../MonacoDiffEditor'))
 import { ProductIntroduction } from '../ProductIntroduction/ProductIntroduction'
 
 export type ActivityLogProps = ActivityLogLogicProps & {
@@ -107,23 +108,25 @@ const JsonDiffViewer = ({ field, before, after }: JsonDiffViewerProps): JSX.Elem
     return (
         <div ref={containerRef} className="flex flex-col space-y-2 w-full">
             {field ? <h2>{field}</h2> : null}
-            <MonacoDiffEditor
-                original={JSON.stringify(before, null, 2)}
-                modified={JSON.stringify(after, null, 2)}
-                language="json"
-                width={width}
-                options={{
-                    renderOverviewRuler: false,
-                    scrollBeyondLastLine: false,
-                    hideUnchangedRegions: {
-                        enabled: true,
-                        contextLineCount: 3,
-                        minimumLineCount: 3,
-                        revealLineCount: 20,
-                    },
-                    diffAlgorithm: 'advanced',
-                }}
-            />
+            <Suspense fallback={<Spinner className="text-2xl mx-auto my-4" />}>
+                <MonacoDiffEditor
+                    original={JSON.stringify(before, null, 2)}
+                    modified={JSON.stringify(after, null, 2)}
+                    language="json"
+                    width={width}
+                    options={{
+                        renderOverviewRuler: false,
+                        scrollBeyondLastLine: false,
+                        hideUnchangedRegions: {
+                            enabled: true,
+                            contextLineCount: 3,
+                            minimumLineCount: 3,
+                            revealLineCount: 20,
+                        },
+                        diffAlgorithm: 'advanced',
+                    }}
+                />
+            </Suspense>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The MonacoDiffEditor component in the ActivityLog is loaded synchronously, which can impact initial page load performance since Monaco Editor is a large dependency that may not be immediately needed.

## Changes

- Converted MonacoDiffEditor import to lazy loading using React's `lazy()` function
- Wrapped MonacoDiffEditor usage in `Suspense` component to handle the loading state
- Added necessary React imports (`lazy`, `Suspense`) to support the lazy loading implementation

## How did you test this code?

![CleanShot 2026-02-28 at 19.16.43.gif](https://app.graphite.com/user-attachments/assets/0f95a719-0fc4-48ca-a4e0-e9f030db112a.gif)



👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No