### PR TITLE
fix(frontend): replace wildcard Icons import with explicit lookup map

### DIFF
--- a/frontend/src/scenes/onboarding/billing/FreeTierLimits.tsx
+++ b/frontend/src/scenes/onboarding/billing/FreeTierLimits.tsx
@@ -1,9 +1,8 @@
 import { useValues } from 'kea'
 
-import * as Icons from '@posthog/icons'
-
 import { billingLogic } from 'scenes/billing/billingLogic'
 
+import { getProductIcon } from '../productSelection/ProductSelection'
 import { availableOnboardingProducts } from '../utils'
 
 type FreeTierLimit = {
@@ -23,11 +22,10 @@ const formatFreeTierLimit = (value: number): string => {
 }
 
 const FreeTierItem = ({ limit }: { limit: FreeTierLimit }): JSX.Element => {
-    const Icon = Icons[limit.icon as keyof typeof Icons]
     return (
         <div className="flex flex-col items-center w-36">
             <div className="flex gap-1 items-center">
-                <Icon className="w-6 h-6" color={limit.color} />
+                {getProductIcon(limit.icon, { iconColor: limit.color, className: 'w-6 h-6' })}
             </div>
             <strong className="text-[15px] text-center leading-none mt-2 mb-1">{limit.title}</strong>
             <div className="text-sm text-center text-success dark:text-green-400">

--- a/frontend/src/scenes/onboarding/productSelection/ProductSelection.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/ProductSelection.tsx
@@ -1,8 +1,37 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
-import * as Icons from '@posthog/icons'
-import { IconArrowRight, IconChevronDown, IconSparkles } from '@posthog/icons'
+import {
+    IconArrowRight,
+    IconBolt,
+    IconBuilding,
+    IconChevronDown,
+    IconClock,
+    IconCursor,
+    IconDatabase,
+    IconDecisionTree,
+    IconDownload,
+    IconGear,
+    IconGraph,
+    IconLlmAnalytics,
+    IconLogomark,
+    IconMessage,
+    IconNotification,
+    IconPassword,
+    IconPeople,
+    IconPieChart,
+    IconPlaylist,
+    IconRevert,
+    IconRewindPlay,
+    IconSampling,
+    IconSparkles,
+    IconStack,
+    IconTerminal,
+    IconTestTube,
+    IconToggle,
+    IconUnlock,
+    IconWarning,
+} from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonCard, LemonLabel, LemonSelect, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { Logomark } from 'lib/brand/Logomark'
@@ -15,7 +44,35 @@ import { UseCaseDefinition } from '../productRecommendations'
 import { availableOnboardingProducts } from '../utils'
 import { productSelectionLogic } from './productSelectionLogic'
 
-const isValidIconKey = (key: string): key is keyof typeof Icons => key in Icons
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string; color?: string }>> = {
+    IconBolt,
+    IconBuilding,
+    IconClock,
+    IconCursor,
+    IconDatabase,
+    IconDecisionTree,
+    IconDownload,
+    IconGear,
+    IconGraph,
+    IconLlmAnalytics,
+    IconLogomark,
+    IconMessage,
+    IconNotification,
+    IconPassword,
+    IconPeople,
+    IconPieChart,
+    IconPlaylist,
+    IconRevert,
+    IconRewindPlay,
+    IconSampling,
+    IconStack,
+    IconTerminal,
+    IconTestTube,
+    IconToggle,
+    IconUnlock,
+    IconWarning,
+}
+
 type AvailableOnboardingProductKey = keyof typeof availableOnboardingProducts
 
 const isAvailableOnboardingProductKey = (key: string | ProductKey): key is AvailableOnboardingProductKey =>
@@ -25,12 +82,12 @@ export function getProductIcon(
     iconKey?: string | null,
     { iconColor, className }: { iconColor?: string; className?: string } = {}
 ): JSX.Element {
-    if (iconKey && isValidIconKey(iconKey)) {
-        const IconComponent = Icons[iconKey]
+    const IconComponent = iconKey ? ICON_MAP[iconKey] : undefined
+    if (IconComponent) {
         return <IconComponent className={className} color={iconColor} />
     }
 
-    return <Icons.IconLogomark className={className} />
+    return <IconLogomark className={className} />
 }
 
 function BrowsingHistoryBanner(): JSX.Element | null {
@@ -170,7 +227,7 @@ function ChoosePathStep(): JSX.Element {
                 >
                     <div className="flex flex-col items-center text-center gap-3">
                         <div className="text-3xl">
-                            <Icons.IconCursor className="text-3xl" color="rgb(100, 116, 139)" />
+                            <IconCursor className="text-3xl" color="rgb(100, 116, 139)" />
                         </div>
                         <div>
                             <div className="font-semibold mb-1">I'll pick myself</div>


### PR DESCRIPTION
## Problem

The onboarding components were importing the entire `@posthog/icons` library, which could lead to larger bundle sizes and less explicit dependencies. The icon usage needed to be optimized for better tree-shaking and clearer imports.

only 6kb reduction in the end so :shrug:

## Changes

- Replaced wildcard import of `@posthog/icons` with explicit named imports in `ProductSelection.tsx`
- Created an `ICON_MAP` object to map icon names to their components for dynamic icon rendering
- Updated `getProductIcon` function to use the new icon mapping approach instead of dynamic property access
- Refactored `FreeTierLimits.tsx` to use the centralized `getProductIcon` function instead of direct icon imports
- Removed unused `Icons` import from `FreeTierLimits.tsx`

## How did you test this code?

![CleanShot 2026-02-28 at 20.16.55.png](https://app.graphite.com/user-attachments/assets/938403fe-d779-4bd4-a895-f5311cfea6fb.png)

we can still load pages that have these icons on them

## Publish to changelog?

No