### PR TITLE
fix(frontend): remove LemonTextAreaMarkdown from LemonTextArea barrel

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
@@ -4,7 +4,7 @@ import { Field, Form } from 'kea-forms'
 import { textCardModalLogic } from 'lib/components/Cards/TextCard/textCardModalLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
-import { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea'
+import { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown'
 
 import { DashboardType, QueryBasedInsightModel } from '~/types'
 

--- a/frontend/src/lib/lemon-ui/LemonTextArea/index.ts
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/index.ts
@@ -1,3 +1,2 @@
 export type { LemonTextAreaProps } from './LemonTextArea'
 export { LemonTextArea } from './LemonTextArea'
-export { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown'

--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -8,11 +8,11 @@ import {
     LemonModalProps,
     LemonSelect,
     LemonSelectOptions,
-    LemonTextAreaMarkdown,
     Link,
 } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown'
 import { shortTimeZone } from 'lib/utils'
 import { urls } from 'scenes/urls'
 

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -3,11 +3,12 @@ import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconCheck, IconPencil, IconX } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTag, LemonTextAreaMarkdown } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown'
 import { LemonWidget } from 'lib/lemon-ui/LemonWidget/LemonWidget'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'


### PR DESCRIPTION
poking about with vercel's new react skills

## Problem

The `LemonTextAreaMarkdown` component was being exported from the main `LemonTextArea` index file and imported inconsistently across the codebase, creating confusion about the proper import path and module organization.

## Changes

- Removed `LemonTextAreaMarkdown` export from the main `LemonTextArea` index file
- Updated all imports of `LemonTextAreaMarkdown` to use the direct path `lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown`
- Standardized import patterns across `TextCardModal.tsx`, `AnnotationModal.tsx`, and `UserInterview.tsx`

## How did you test this code?

Verified that all import statements are correctly updated and the component can be imported from its direct path.

can still use text cards

## ![CleanShot 2026-02-28 at 20.47.00.png](https://app.graphite.com/user-attachments/assets/3260902a-8510-436f-a54f-e95a814e57d2.png)



## Publish to changelog?

No