### PR TITLE
fix(insights): navigate to correct settings section for test account filter

### DIFF
--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -36,7 +36,12 @@ export function TestAccountFilterSwitch({ checked, onChange, ...props }: TestAcc
                         size="small"
                         noPadding
                         className="ml-1"
-                        onClick={() => openSettingsPanel({ settingId: 'internal-user-filtering' })}
+                        onClick={() =>
+                            openSettingsPanel({
+                                sectionId: 'project-product-analytics',
+                                settingId: 'internal-user-filtering',
+                            })
+                        }
                     />
                 </div>
             }


### PR DESCRIPTION
When clicking the gear icon on the "Filter out internal and test users" toggle, the settings panel now navigates directly to the internal user filtering section instead of showing the default project settings.

Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1772310459820239?thread_ts=1772310105.088219&cid=C0ACRAMJUAG

https://claude.ai/code/session_01SQgr5x9fMKmKiSBFqgyLCk

![CleanShot 2026-03-01 at 18 05 08](https://github.com/user-attachments/assets/0d9f594d-1424-45e1-948d-1dd9aa1d8e02)

