### PR TITLE
feat(insights-ai): ai analysis action buttons

### DIFF
--- a/frontend/src/scenes/insights/InsightAIAnalysis.tsx
+++ b/frontend/src/scenes/insights/InsightAIAnalysis.tsx
@@ -9,7 +9,9 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { InsightQueryNode } from '~/queries/schema/schema-general'
+import { SidePanelTab } from '~/types'
 
 import { insightAIAnalysisLogic } from './insightAIAnalysisLogic'
 import { insightLogic } from './insightLogic'
@@ -26,9 +28,10 @@ export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Elemen
     const { analysis, isAnalyzing, hasClickedAnalyze, analysisFeedbackGiven, analysisError } = useValues(
         insightAIAnalysisLogic({ insightId: insight.id, query })
     )
-    const { startAnalysis, resetAnalysis, reportAnalysisFeedback } = useActions(
+    const { resetAnalysis, reportAnalysisFeedback } = useActions(
         insightAIAnalysisLogic({ insightId: insight.id, query })
     )
+    const { openSidePanel } = useActions(sidePanelStateLogic)
 
     useEffect(() => {
         // Reset analysis when insight changes
@@ -57,17 +60,16 @@ export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Elemen
                             {analysisError}
                         </LemonBanner>
                     )}
-                    <AIConsentPopoverWrapper onApprove={startAnalysis}>
+                    <AIConsentPopoverWrapper onApprove={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}>
                         <LemonButton
                             type="primary"
-                            onClick={startAnalysis}
+                            onClick={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}
                             sideIcon={null}
-                            loading={isAnalyzing}
                             disabledReason={
                                 insightDataLoading ? 'Please wait for the insight to finish loading' : undefined
                             }
                         >
-                            Analyze with AI
+                            Explain this insight
                         </LemonButton>
                     </AIConsentPopoverWrapper>
                 </>

--- a/frontend/src/scenes/insights/InsightAIAnalysis.tsx
+++ b/frontend/src/scenes/insights/InsightAIAnalysis.tsx
@@ -25,8 +25,15 @@ export interface InsightAIAnalysisProps {
 export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Element | null {
     const { insight, insightProps } = useValues(insightLogic)
     const { insightDataLoading } = useValues(insightVizDataLogic(insightProps))
-    const { analysis, isAnalyzing, hasClickedAnalyze, hasClickedSuggestions, analysisFeedbackGiven, analysisError } =
-        useValues(insightAIAnalysisLogic({ insightId: insight.id, query }))
+    const {
+        analysis,
+        isAnalyzing,
+        hasClickedAnalyze,
+        hasClickedSuggestions,
+        analysisFeedbackGiven,
+        analysisError,
+        suggestionsLoading,
+    } = useValues(insightAIAnalysisLogic({ insightId: insight.id, query }))
     const { resetAnalysis, reportAnalysisFeedback, loadSuggestions, setHasClickedSuggestions } = useActions(
         insightAIAnalysisLogic({ insightId: insight.id, query })
     )
@@ -77,21 +84,21 @@ export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Elemen
                         </AIConsentPopoverWrapper>
                         <AIConsentPopoverWrapper
                             onApprove={() => {
-                                setHasClickedSuggestions(true)
+                                setHasClickedSuggestions()
                                 loadSuggestions({})
                             }}
                         >
                             <LemonButton
                                 type="secondary"
                                 onClick={() => {
-                                    setHasClickedSuggestions(true)
+                                    setHasClickedSuggestions()
                                     loadSuggestions({})
                                 }}
                                 sideIcon={null}
                                 data-attr="insight-ai-suggestions-button"
                                 disabledReason={
-                                    hasClickedSuggestions
-                                        ? 'Suggestions already loading'
+                                    suggestionsLoading
+                                        ? 'Generating suggestions...'
                                         : insightDataLoading
                                           ? 'Please wait for the insight to finish loading'
                                           : undefined

--- a/frontend/src/scenes/insights/InsightAIAnalysis.tsx
+++ b/frontend/src/scenes/insights/InsightAIAnalysis.tsx
@@ -25,10 +25,9 @@ export interface InsightAIAnalysisProps {
 export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Element | null {
     const { insight, insightProps } = useValues(insightLogic)
     const { insightDataLoading } = useValues(insightVizDataLogic(insightProps))
-    const { analysis, isAnalyzing, hasClickedAnalyze, analysisFeedbackGiven, analysisError } = useValues(
-        insightAIAnalysisLogic({ insightId: insight.id, query })
-    )
-    const { resetAnalysis, reportAnalysisFeedback } = useActions(
+    const { analysis, isAnalyzing, hasClickedAnalyze, hasClickedSuggestions, analysisFeedbackGiven, analysisError } =
+        useValues(insightAIAnalysisLogic({ insightId: insight.id, query }))
+    const { resetAnalysis, reportAnalysisFeedback, loadSuggestions, setHasClickedSuggestions } = useActions(
         insightAIAnalysisLogic({ insightId: insight.id, query })
     )
     const { openSidePanel } = useActions(sidePanelStateLogic)
@@ -60,18 +59,49 @@ export function InsightAIAnalysis({ query }: InsightAIAnalysisProps): JSX.Elemen
                             {analysisError}
                         </LemonBanner>
                     )}
-                    <AIConsentPopoverWrapper onApprove={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}>
-                        <LemonButton
-                            type="primary"
-                            onClick={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}
-                            sideIcon={null}
-                            disabledReason={
-                                insightDataLoading ? 'Please wait for the insight to finish loading' : undefined
-                            }
+                    <div className="flex gap-2 flex-wrap">
+                        <AIConsentPopoverWrapper
+                            onApprove={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}
                         >
-                            Explain this insight
-                        </LemonButton>
-                    </AIConsentPopoverWrapper>
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => openSidePanel(SidePanelTab.Max, '!Explain this insight')}
+                                sideIcon={null}
+                                data-attr="insight-ai-explain-button"
+                                disabledReason={
+                                    insightDataLoading ? 'Please wait for the insight to finish loading' : undefined
+                                }
+                            >
+                                Explain this insight
+                            </LemonButton>
+                        </AIConsentPopoverWrapper>
+                        <AIConsentPopoverWrapper
+                            onApprove={() => {
+                                setHasClickedSuggestions(true)
+                                loadSuggestions({})
+                            }}
+                        >
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => {
+                                    setHasClickedSuggestions(true)
+                                    loadSuggestions({})
+                                }}
+                                sideIcon={null}
+                                data-attr="insight-ai-suggestions-button"
+                                disabledReason={
+                                    hasClickedSuggestions
+                                        ? 'Suggestions already loading'
+                                        : insightDataLoading
+                                          ? 'Please wait for the insight to finish loading'
+                                          : undefined
+                                }
+                            >
+                                Suggest insights to dive deeper
+                            </LemonButton>
+                        </AIConsentPopoverWrapper>
+                    </div>
+                    {hasClickedSuggestions && <InsightSuggestions insightId={insight.id} query={query} />}
                 </>
             ) : isAnalyzing ? (
                 <div className="flex items-center gap-2 text-muted">

--- a/frontend/src/scenes/insights/InsightSuggestions.tsx
+++ b/frontend/src/scenes/insights/InsightSuggestions.tsx
@@ -109,25 +109,20 @@ export function InsightSuggestions({ insightId, query }: InsightSuggestionsProps
     }
 
     if (suggestions.length === 0) {
-        return null
+        return <p className="text-muted mt-4">No suggestions this time. Try a different insight.</p>
     }
 
     return (
-        <div className="mt-4">
-            <h3 className="font-semibold text-base m-0 mb-2">Explore related insights</h3>
-            <p className="text-muted mb-4">Suggested follow-up insights to understand your data better</p>
-
-            <div className="space-y-2">
-                {suggestions.map((suggestion, index) => (
-                    <InsightSuggestionRow
-                        key={index}
-                        suggestion={suggestion}
-                        index={index}
-                        insightId={insightId}
-                        query={query}
-                    />
-                ))}
-            </div>
+        <div className="mt-4 space-y-2">
+            {suggestions.map((suggestion, index) => (
+                <InsightSuggestionRow
+                    key={index}
+                    suggestion={suggestion}
+                    index={index}
+                    insightId={insightId}
+                    query={query}
+                />
+            ))}
         </div>
     )
 }

--- a/frontend/src/scenes/insights/insightAIAnalysisLogic.ts
+++ b/frontend/src/scenes/insights/insightAIAnalysisLogic.ts
@@ -30,6 +30,7 @@ export const insightAIAnalysisLogic = kea<insightAIAnalysisLogicType>([
     actions({
         startAnalysis: true,
         setHasClickedAnalyze: (hasClicked: boolean) => ({ hasClicked }),
+        setHasClickedSuggestions: (hasClicked: boolean) => ({ hasClicked }),
         resetAnalysis: true,
         reportAnalysisFeedback: (isPositive: boolean) => ({ isPositive }),
         reportSuggestionFeedback: (suggestionIndex: number, suggestionTitle: string, isPositive: boolean) => ({
@@ -76,6 +77,13 @@ export const insightAIAnalysisLogic = kea<insightAIAnalysisLogicType>([
             false,
             {
                 setHasClickedAnalyze: (_, { hasClicked }) => hasClicked,
+                resetAnalysis: () => false,
+            },
+        ],
+        hasClickedSuggestions: [
+            false,
+            {
+                setHasClickedSuggestions: (_, { hasClicked }) => hasClicked,
                 resetAnalysis: () => false,
             },
         ],

--- a/frontend/src/scenes/insights/insightAIAnalysisLogic.ts
+++ b/frontend/src/scenes/insights/insightAIAnalysisLogic.ts
@@ -30,7 +30,7 @@ export const insightAIAnalysisLogic = kea<insightAIAnalysisLogicType>([
     actions({
         startAnalysis: true,
         setHasClickedAnalyze: (hasClicked: boolean) => ({ hasClicked }),
-        setHasClickedSuggestions: (hasClicked: boolean) => ({ hasClicked }),
+        setHasClickedSuggestions: true,
         resetAnalysis: true,
         reportAnalysisFeedback: (isPositive: boolean) => ({ isPositive }),
         reportSuggestionFeedback: (suggestionIndex: number, suggestionTitle: string, isPositive: boolean) => ({
@@ -83,7 +83,7 @@ export const insightAIAnalysisLogic = kea<insightAIAnalysisLogicType>([
         hasClickedSuggestions: [
             false,
             {
-                setHasClickedSuggestions: (_, { hasClicked }) => hasClicked,
+                setHasClickedSuggestions: () => true,
                 resetAnalysis: () => false,
             },
         ],
@@ -130,6 +130,14 @@ export const insightAIAnalysisLogic = kea<insightAIAnalysisLogicType>([
         startAnalysis: () => {
             actions.setHasClickedAnalyze(true)
             posthog.capture('insight ai analysis started', {
+                insight_id: props.insightId,
+                insight_type: props.query.kind,
+                team_id: values.currentTeamId,
+                organization_id: values.currentOrganization?.id,
+            })
+        },
+        setHasClickedSuggestions: () => {
+            posthog.capture('insight ai suggestions clicked', {
                 insight_id: props.insightId,
                 insight_type: props.query.kind,
                 team_id: values.currentTeamId,


### PR DESCRIPTION
## Problem
We want to separate out insight ai analysis actions to track usage across both and see what's more useful.

## Changes
<img width="1087" height="147" alt="image" src="https://github.com/user-attachments/assets/0550d5c2-8b2c-4a19-b6f8-a55752787cfd" />

Also 'Explain this insight' opens in the PostHog AI sidebar as we've now done the work to make PostHog AI have the current insight in context, so can answer/explain the insight in more detail.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
