### PR TITLE
feat(flags): add soft-delete manager to FeatureFlag

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -1044,7 +1044,7 @@ class EnterpriseExperimentsViewSet(
         except ValueError:
             return Response({"error": "Invalid limit or offset"}, status=400)
 
-        queryset = FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False)
+        queryset = FeatureFlag.objects.filter(team__project_id=self.project_id)
 
         # Filter for multivariate flags with at least 2 variants and first variant is "control"
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (static SQL, no user input)

--- a/ee/hogai/context/feature_flag/context.py
+++ b/ee/hogai/context/feature_flag/context.py
@@ -31,9 +31,9 @@ class FeatureFlagContext:
         """Fetch the feature flag from the database."""
         try:
             if self._flag_id is not None:
-                return await FeatureFlag.objects.aget(id=self._flag_id, team=self._team, deleted=False)
+                return await FeatureFlag.objects.aget(id=self._flag_id, team=self._team)
             elif self._flag_key is not None:
-                return await FeatureFlag.objects.aget(key=self._flag_key, team=self._team, deleted=False)
+                return await FeatureFlag.objects.aget(key=self._flag_key, team=self._team)
             return None
         except FeatureFlag.DoesNotExist:
             return None

--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -34,7 +34,9 @@ class ExperimentAdminForm(ModelForm):
             if "holdout" in self.fields:
                 self.fields["holdout"].queryset = ExperimentHoldout.objects.filter(team=self.instance.team)  # type: ignore
             if "feature_flag" in self.fields:
-                self.fields["feature_flag"].queryset = FeatureFlag.objects.filter(team=self.instance.team)  # type: ignore
+                self.fields["feature_flag"].queryset = FeatureFlag.objects_including_soft_deleted.filter(  # type: ignore[attr-defined]
+                    team=self.instance.team
+                )
 
 
 def has_legacy_metric(metrics):

--- a/posthog/admin/admins/feature_flag_admin.py
+++ b/posthog/admin/admins/feature_flag_admin.py
@@ -20,6 +20,9 @@ class FeatureFlagAdmin(admin.ModelAdmin):
     readonly_fields = ("usage_dashboard",)
     ordering = ("-created_at",)
 
+    def get_queryset(self, request):
+        return FeatureFlag.objects_including_soft_deleted.all()
+
     @admin.display(description="Team")
     def team_link(self, flag: FeatureFlag):
         return format_html(

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -804,7 +804,7 @@ class CohortSerializer(serializers.ModelSerializer):
         instance = cast(Cohort, self.instance)
         cohort_id = instance.pk
 
-        flags = FeatureFlag.objects.filter(team__project_id=self.context["project_id"], active=True, deleted=False)
+        flags = FeatureFlag.objects.filter(team__project_id=self.context["project_id"], active=True)
         cohort_used_in_flags = len([flag for flag in flags if cohort_id in flag.get_cohort_ids()]) > 0
 
         if not cohort_used_in_flags:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1132,7 +1132,7 @@ class FeatureFlagSerializer(
         encrypt_flag_payloads(validated_data)
 
         try:
-            FeatureFlag.objects.filter(
+            FeatureFlag.objects_including_soft_deleted.filter(
                 key=validated_data["key"],
                 team__project_id=self.context["project_id"],
                 deleted=True,
@@ -2866,7 +2866,7 @@ class FeatureFlagViewSet(
         page = request.validated_query_data["page"]
 
         item_id = kwargs["pk"]
-        if not FeatureFlag.objects.filter(id=item_id, team__project_id=self.project_id).exists():
+        if not FeatureFlag.objects_including_soft_deleted.filter(id=item_id, team__project_id=self.project_id).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -146,7 +146,7 @@ def find_dependent_flags(flag_to_check: FeatureFlag) -> list[FeatureFlag]:
     """Find all active flags that depend on the given flag via flag-type filter properties."""
     return list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=flag_to_check.team, deleted=False, active=True)
+        FeatureFlag.objects.filter(team=flag_to_check.team, active=True)
         .exclude(id=flag_to_check.id)
         .extra(
             where=[
@@ -186,7 +186,7 @@ def find_dependent_flags_batch(
 
     dependent_flags = list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=team, deleted=False, active=True)
+        FeatureFlag.objects.filter(team=team, active=True)
         .exclude(id__in=flag_ids)
         .extra(
             where=[
@@ -272,7 +272,7 @@ def check_flag_limits_for_team(
         return
 
     count_limit = settings.MAX_FEATURE_FLAGS_PER_TEAM
-    flag_count = FeatureFlag.objects.filter(team_id=team_id, deleted=False).count()
+    flag_count = FeatureFlag.objects.filter(team_id=team_id).count()
 
     if flag_count >= count_limit:
         raise serializers.ValidationError(
@@ -732,7 +732,7 @@ class FeatureFlagSerializer(
             exclude_kwargs = {"pk": cast(FeatureFlag, self.instance).pk}
 
         if (
-            FeatureFlag.objects.filter(key=value, team__project_id=self.context["project_id"], deleted=False)
+            FeatureFlag.objects.filter(key=value, team__project_id=self.context["project_id"])
             .exclude(**exclude_kwargs)
             .exists()
         ):
@@ -1015,7 +1015,7 @@ class FeatureFlagSerializer(
             )
 
         try:
-            flag = FeatureFlag.objects.get(id=flag_id, team__project_id=self.context["project_id"], deleted=False)
+            flag = FeatureFlag.objects.get(id=flag_id, team__project_id=self.context["project_id"])
 
             # Check if the referenced flag is active
             if not flag.active:
@@ -1962,7 +1962,7 @@ class FeatureFlagViewSet(
         ).values_list("internal_targeting_flag_id", flat=True)
 
         feature_flags = list(
-            FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False)
+            FeatureFlag.objects.filter(team__project_id=self.project_id)
             .exclude(Q(id__in=survey_flag_ids))
             .exclude(Q(id__in=product_tour_internal_targeting_flags))
             .order_by("-created_at")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1660,7 +1660,10 @@ class FeatureFlagViewSet(
     """
 
     scope_object = "feature_flag"
-    queryset = FeatureFlag.objects.all()
+    # Use the unfiltered manager so non-list actions (retrieve, update, etc.)
+    # can access soft-deleted flags. The list action applies its own
+    # deleted=False filter in safely_get_queryset.
+    queryset = FeatureFlag.objects_including_soft_deleted.all()
     serializer_class = FeatureFlagSerializer
     authentication_classes = [
         TemporaryTokenAuthentication,  # Allows endpoint to be called from the Toolbar

--- a/posthog/api/flag_value.py
+++ b/posthog/api/flag_value.py
@@ -60,7 +60,7 @@ class FlagValueViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             return response.Response({"error": "Invalid flag ID - must be a valid integer"}, status=400)
 
         try:
-            flag = FeatureFlag.objects.get(team=self.team, id=flag_id_int, deleted=False)
+            flag = FeatureFlag.objects.get(team=self.team, id=flag_id_int)
         except FeatureFlag.DoesNotExist:
             return response.Response({"error": "Feature flag not found"}, status=404)
 

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -462,7 +462,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -1198,7 +1199,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature-new'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -1927,7 +1929,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -2793,7 +2796,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature-new'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -2964,7 +2968,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -3717,7 +3722,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -4478,7 +4484,8 @@
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_user" T5 ON ("posthog_featureflag"."last_modified_by_id" = T5."id")
-  WHERE ("posthog_team"."project_id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_team"."project_id" = 99999
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -4484,8 +4484,7 @@
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_user" T5 ON ("posthog_featureflag"."last_modified_by_id" = T5."id")
-  WHERE (NOT ("posthog_featureflag"."deleted")
-         AND "posthog_team"."project_id" = 99999
+  WHERE ("posthog_team"."project_id" = 99999
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -3032,7 +3032,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 8767}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -211,7 +211,6 @@
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE (NOT ("posthog_featureflag"."deleted")
-         AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 1
@@ -229,8 +228,7 @@
                  WHERE U0."id" = 99999
                  LIMIT 1)
               OR ("posthog_team"."parent_team_id" IS NULL
-                  AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT "posthog_featureflag"."deleted")
+                  AND "posthog_featureflag"."team_id" = 99999)))
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.14

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -3032,7 +3032,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 8767}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -197,7 +197,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
@@ -209,7 +210,8 @@
   SELECT 1 AS "a"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 1
@@ -220,13 +222,14 @@
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
          AND NOT "posthog_featureflag"."deleted")
   '''
 # ---
@@ -1160,7 +1163,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'copied-flag-key'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -2401,7 +2405,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''
@@ -3310,7 +3315,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'key-1'
          AND "posthog_featureflag"."team_id" IN (1,
                                                  2,

--- a/posthog/management/commands/fix_invalid_flag_property_types.py
+++ b/posthog/management/commands/fix_invalid_flag_property_types.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         # Only fetch flags that have invalid property types (efficient DB-level filter)
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (INVALID_FLAGS_SQL is a static constant, admin-only command)
-        flags = FeatureFlag.objects.filter(deleted=False, active=True).extra(where=[f"EXISTS ({INVALID_FLAGS_SQL})"])
+        flags = FeatureFlag.objects.filter(active=True).extra(where=[f"EXISTS ({INVALID_FLAGS_SQL})"])
         if team_id:
             flags = flags.filter(team_id=team_id)
             self.stdout.write(f"Filtering to team_id={team_id}")

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -61,14 +61,20 @@ class Command(BaseCommand):
 
         first_user = cast(User, User.objects.first())
         for team in Team.objects.all():
-            existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
-            deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
+            existing_flags = set(
+                FeatureFlag.objects_including_soft_deleted.filter(team=team).values_list("key", flat=True)
+            )
+            deleted_flags = set(
+                FeatureFlag.objects_including_soft_deleted.filter(team=team, deleted=True).values_list("key", flat=True)
+            )
             for flag in flags.keys():
                 flag_type = flags[flag]
                 is_enabled = flag not in INACTIVE_FLAGS
 
                 if flag in deleted_flags:
-                    ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
+                    ff = FeatureFlag.objects_including_soft_deleted.filter(team=team, key=flag).first()
+                    if not ff:
+                        continue
                     ff.deleted = False
                     ff.active = is_enabled
                     ff.save()

--- a/posthog/management/commands/sync_feature_flags_from_api.py
+++ b/posthog/management/commands/sync_feature_flags_from_api.py
@@ -54,9 +54,13 @@ def sync_feature_flags_from_api(
         output_fn(f"\nProcessing project {project.id} - {project.name or ''}")
         output_fn("=" * 50)
 
-        existing_flags = FeatureFlag.objects.filter(team__project_id=project.id).values_list("key", flat=True)
-        deleted_flags = FeatureFlag.objects.filter(team__project_id=project.id, deleted=True).values_list(
-            "key", flat=True
+        existing_flags = set(
+            FeatureFlag.objects_including_soft_deleted.filter(team__project_id=project.id).values_list("key", flat=True)
+        )
+        deleted_flags = set(
+            FeatureFlag.objects_including_soft_deleted.filter(team__project_id=project.id, deleted=True).values_list(
+                "key", flat=True
+            )
         )
 
         enabled_flags = sum(1 for flag_data in data["flags"].values() if flag_data.get("enabled", False))
@@ -70,7 +74,7 @@ def sync_feature_flags_from_api(
         for flag_key, flag_data in data["flags"].items():
             is_enabled = flag_data.get("enabled", False)
             if flag_key in deleted_flags and is_enabled:
-                ff = FeatureFlag.objects.get(team__project_id=project.id, key=flag_key)
+                ff = FeatureFlag.objects_including_soft_deleted.get(team__project_id=project.id, key=flag_key)
                 ff.deleted = False
                 ff.active = True
                 ff.save()

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -254,7 +254,7 @@ class AutoProjectMiddleware:
                 feature_flag_id = path_parts[1]
                 if feature_flag_id.isnumeric():
                     # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
-                    return FeatureFlag.objects.filter(deleted=False, id=feature_flag_id)
+                    return FeatureFlag.objects.filter(id=feature_flag_id)
             elif path_parts[0] == "action":
                 action_id = path_parts[1]
                 if action_id.isnumeric():

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -23,7 +23,7 @@ from posthog.models.file_system.file_system_representation import FileSystemRepr
 from posthog.models.property import GroupTypeIndex
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.signals import mutable_receiver
-from posthog.models.utils import RootTeamMixin, UUIDModel
+from posthog.models.utils import RootTeamManager, RootTeamMixin, UUIDModel
 
 FIVE_DAYS = 60 * 60 * 24 * 5  # 5 days in seconds
 
@@ -32,6 +32,11 @@ logger = structlog.get_logger(__name__)
 if TYPE_CHECKING:
     from posthog.models.tag import Tag
     from posthog.models.team import Team
+
+
+class FeatureFlagManager(RootTeamManager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(deleted=True)
 
 
 class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.Model):
@@ -117,6 +122,9 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
         blank=True,
         help_text="Last time this feature flag was called (from $feature_flag_called events)",
     )
+
+    objects = FeatureFlagManager()  # type: ignore
+    objects_including_soft_deleted: models.Manager["FeatureFlag"] = RootTeamManager()
 
     class Meta:
         constraints = [models.UniqueConstraint(fields=["team", "key"], name="unique key for team")]

--- a/posthog/models/feature_flag/flag_status.py
+++ b/posthog/models/feature_flag/flag_status.py
@@ -45,7 +45,11 @@ class FeatureFlagStatusChecker:
             return FeatureFlagStatus.UNKNOWN, "Must provide feature flag or feature flag id"
 
         try:
-            flag = FeatureFlag.objects.get(pk=self.feature_flag_id) if self.feature_flag_id else self.feature_flag
+            flag = (
+                FeatureFlag.objects_including_soft_deleted.get(pk=self.feature_flag_id)
+                if self.feature_flag_id
+                else self.feature_flag
+            )
         except FeatureFlag.DoesNotExist:
             return FeatureFlagStatus.UNKNOWN, "Flag could not be found"
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -384,7 +384,7 @@ def _get_team_ids_with_flags() -> set[int]:
     {"flags": []}.
     """
     start_time = time.time()
-    result = set(FeatureFlag.objects.filter(active=True, deleted=False).values_list("team_id", flat=True).distinct())
+    result = set(FeatureFlag.objects.filter(active=True).values_list("team_id", flat=True).distinct())
     duration_ms = (time.time() - start_time) * 1000
 
     logger.info(
@@ -421,7 +421,7 @@ def _get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
 
     cutoff = timezone.now() - timedelta(minutes=grace_period_minutes)
     return set(
-        FeatureFlag.objects.filter(team_id__in=team_ids, updated_at__gte=cutoff, active=True, deleted=False)
+        FeatureFlag.objects.filter(team_id__in=team_ids, updated_at__gte=cutoff, active=True)
         .values_list("team_id", flat=True)
         .distinct()
     )

--- a/posthog/models/feature_flag/test/test_feature_flag_manager.py
+++ b/posthog/models/feature_flag/test/test_feature_flag_manager.py
@@ -1,0 +1,14 @@
+from posthog.test.base import BaseTest
+
+from posthog.models import FeatureFlag
+
+
+class TestFeatureFlagManager(BaseTest):
+    def test_default_manager_excludes_soft_deleted_flags(self):
+        FeatureFlag.objects.create(team=self.team, key="live", created_by=self.user)
+        FeatureFlag.objects_including_soft_deleted.create(
+            team=self.team, key="deleted", created_by=self.user, deleted=True
+        )
+
+        assert FeatureFlag.objects.filter(team=self.team).count() == 1
+        assert FeatureFlag.objects_including_soft_deleted.filter(team=self.team).count() == 2

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -143,7 +143,7 @@ class RemoteConfig(UUIDTModel):
         config = {
             "token": team.api_token,
             "supportedCompression": ["gzip", "gzip-js"],
-            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True, deleted=False).count() > 0,
+            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True).count() > 0,
             "captureDeadClicks": bool(team.capture_dead_clicks),
             "capturePerformance": (
                 {

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -217,7 +217,7 @@ def compute_feature_flag_metrics(self: PushGatewayTask) -> None:
         registry=self.metrics_registry,
     )
 
-    base_qs = FeatureFlag.objects.filter(deleted=False, active=True)
+    base_qs = FeatureFlag.objects.filter(active=True)
 
     # Top 5 by flag count (secondary sort by team_id for deterministic ordering on ties)
     top_by_count = list(

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -528,13 +528,14 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''
@@ -743,7 +744,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   FOR
   UPDATE
@@ -774,7 +776,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''
@@ -827,13 +830,14 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''
@@ -1431,7 +1435,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."key" = 'flag-1'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'flag-1')
   LIMIT 21
   '''
 # ---
@@ -1600,7 +1605,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   FOR
   UPDATE
@@ -1631,7 +1637,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -122,7 +122,7 @@ class CreateExperimentTool(MaxTool):
                 raise ValueError(f"An experiment with name '{name}' already exists")
 
             try:
-                feature_flag = FeatureFlag.objects.get(team=self._team, key=feature_flag_key, deleted=False)
+                feature_flag = FeatureFlag.objects.get(team=self._team, key=feature_flag_key)
             except FeatureFlag.DoesNotExist:
                 raise ValueError(f"Feature flag '{feature_flag_key}' does not exist")
 

--- a/products/feature_flags/backend/max_tools.py
+++ b/products/feature_flags/backend/max_tools.py
@@ -292,7 +292,7 @@ class CreateFeatureFlagTool(MaxTool):
 
                     @database_sync_to_async
                     def get_existing_flag():
-                        return FeatureFlag.objects.filter(team=self._team, key=flag_schema.key, deleted=False).first()
+                        return FeatureFlag.objects.filter(team=self._team, key=flag_schema.key).first()
 
                     existing = await get_existing_flag()
                     if existing:


### PR DESCRIPTION
## Summary

- Add `FeatureFlagManager` that auto-excludes `deleted=True` records, following the same pattern used by `Insight`, `Dashboard`, and `DashboardTemplate`
- Fix ~20 call sites that previously omitted `deleted=False` (potential bugs resolved for free)
- Switch call sites that intentionally access deleted flags to `objects_including_soft_deleted`

## Changes

**Model** (`posthog/models/feature_flag/feature_flag.py`):
- `FeatureFlagManager` extends `RootTeamManager`, excludes `deleted=True`
- `objects = FeatureFlagManager()` (default manager)
- `objects_including_soft_deleted = RootTeamManager()` (escape hatch)

**Call sites switched to `objects_including_soft_deleted`**:
- `flag_status.py` — loads deleted flags to return `DELETED` status
- `feature_flag_admin.py` — admin shows all records
- `experiment_admin.py` — flag dropdown includes deleted flags referenced by experiments
- `sync_feature_flags.py` / `sync_feature_flags_from_api.py` — queries and undeletes flags
- `feature_flag.py` (activity endpoint) — deleted flags still show history
- `feature_flag.py` (serializer create) — deletes soft-deleted flag before creating with same key

**Bugs fixed automatically** (previously missing `deleted=False`):
- `cohort.py`, `scheduled_change.py`, `survey.py`, `approvals/actions/feature_flags.py`, `flag_analytics.py`, `product_intent.py`, `early_access_features`, `product_tours`, `auto_rollback_feature_flag.py`, `organization_feature_flag.py`, `hedgebox/matrix.py`
- `usage_report.py` — previously counted deleted flags in totals; now correctly excludes them

No migration needed — Django managers are Python-only.

## Test plan

- [x] `pytest posthog/api/test/test_feature_flag.py` — 277 passed
- [x] `pytest posthog/api/test/test_organization_feature_flag.py` — 27 passed
- [x] `pytest posthog/models/feature_flag/` — 174 passed
- [x] Updated SQL snapshot tests reflecting new `NOT (posthog_featureflag.deleted)` clause
- [x] `ruff check` and `ruff format` pass