### PR TITLE
fix: margin for error tracking

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -86,7 +86,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                     onNameChange={updateName}
                                     description={null}
                                     resourceType={{ type: 'error_tracking' }}
-                                    className="px-2 h-[50px] @2xl/main-content:relative top-[0px] mt-0 mx-0"
+                                    className="px-2 h-[50px] @2xl/main-content:relative top-[0px] mt-0 mx-0 mb-0"
                                     actions={
                                         <div className="flex items-center gap-1">
                                             <StatusIndicator status={issue.status} withTooltip />


### PR DESCRIPTION
## Problem

<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/da12752a-c271-4a3f-8f99-cf6fc27b370b" />

## Changes
Fix margin

## How did you test this code?
can't test :(

## Publish to changelog?
no
