### PR TITLE
chore: bump paramiko from 3.4.0 to 3.4.1

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -295,7 +295,7 @@ jobs:
         timeout-minutes: 60
         name: Setup DO Hobby Instance and test
         needs: [wait-for-docker-image, changes]
-        if: always() && ((needs.changes.outputs.should_run == 'true' && needs.wait-for-docker-image.result == 'success') || github.event_name == 'push')
+        if: always() && ((needs.changes.outputs.should_run == 'true' && needs.wait-for-docker-image.outputs.conclusion == 'success') || github.event_name == 'push')
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -254,7 +254,7 @@ jobs:
                           body: errorBody,
                       });
             - name: Fail if Docker build failed
-              if: steps.wait-for-image.outputs.conclusion != 'success'
+              if: steps.wait-for-image.outputs.conclusion != 'success' && steps.wait-for-image.outputs.conclusion != 'skipped'
               run: |
                   echo "Docker image build failed with conclusion: ${{ steps.wait-for-image.outputs.conclusion }}"
                   exit 1

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -253,11 +253,16 @@ jobs:
                           comment_id: parseInt(commentId),
                           body: errorBody,
                       });
-            - name: Fail if Docker build failed
-              if: steps.wait-for-image.outputs.conclusion != 'success' && steps.wait-for-image.outputs.conclusion != 'skipped'
+            - name: Check Docker image build result
               run: |
-                  echo "Docker image build failed with conclusion: ${{ steps.wait-for-image.outputs.conclusion }}"
-                  exit 1
+                  conclusion="${{ steps.wait-for-image.outputs.conclusion }}"
+                  if [ "$conclusion" = "skipped" ]; then
+                    echo "Docker image build skipped"
+                    exit 0
+                  elif [ "$conclusion" != "success" ]; then
+                    echo "Docker image build failed with conclusion: $conclusion"
+                    exit 1
+                  fi
             - name: Update comment - Docker image ready
               if: steps.check-preview.outputs.preview == 'true' && steps.wait-for-image.outputs.conclusion == 'success'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/posthog/api/test/test_toolbar_oauth_authorize.py
+++ b/posthog/api/test/test_toolbar_oauth_authorize.py
@@ -2,7 +2,13 @@ from urllib.parse import parse_qs, urlparse
 
 from posthog.test.base import APIBaseTest
 
+from django.conf import settings
+from django.test import override_settings
 
+from posthog.api.oauth.test_dcr import generate_rsa_key
+
+
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestToolbarOAuthAuthorize(APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/posthog/api/test/test_toolbar_oauth_endpoint_auth.py
+++ b/posthog/api/test/test_toolbar_oauth_endpoint_auth.py
@@ -13,10 +13,12 @@ from datetime import timedelta
 from posthog.test.base import APIBaseTest
 
 from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.api.oauth.test_dcr import generate_rsa_key
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 
 
@@ -43,6 +45,7 @@ def _make_token(user, app, token_str, scope="*", delta_hours=1):
     )
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestToolbarEndpointOAuthAuth(APIBaseTest):
     """
     Every toolbar-consumed endpoint should accept OAuth access tokens
@@ -195,6 +198,7 @@ class TestToolbarEndpointOAuthAuth(APIBaseTest):
         )
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestUploadedMediaOAuthAuth(APIBaseTest):
     """uploaded_media is tested separately — its only toolbar action is POST (upload)."""
 
@@ -248,6 +252,7 @@ class TestUploadedMediaOAuthAuth(APIBaseTest):
         assert response.status_code != 401
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestHedgehogConfigOAuthAuth(APIBaseTest):
     """hedgehog_config uses /api/users/@me/ path, not team-scoped, so tested separately."""
 
@@ -298,6 +303,7 @@ class TestHedgehogConfigOAuthAuth(APIBaseTest):
         assert response.status_code in (401, 403)
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestToolbarOAuthScopesConfig(APIBaseTest):
     """Verify TOOLBAR_OAUTH_SCOPES covers every toolbar endpoint scope."""
 

--- a/posthog/api/test/test_toolbar_oauth_primitives.py
+++ b/posthog/api/test/test_toolbar_oauth_primitives.py
@@ -13,6 +13,7 @@ from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
+from posthog.api.oauth.test_dcr import generate_rsa_key
 from posthog.api.oauth.toolbar_service import (
     CALLBACK_PATH,
     ToolbarOAuthError,
@@ -24,6 +25,7 @@ from posthog.auth import TemporaryTokenAuthentication
 from posthog.models import Organization, Team, User
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestToolbarOAuthPrimitives(APIBaseTest):
     def setUp(self):
         super().setUp()
@@ -694,6 +696,7 @@ class TestTokenEndpointStatusRemapping(APIBaseTest):
         assert cm.exception.status_code == expected_status
 
 
+@override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": generate_rsa_key()})
 class TestToolbarOAuthCallbackExchange(APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
     "openpyxl==3.1.2",
     "orjson==3.11.5",
     "pandas~=2.2.2",
-    "paramiko==3.4.0",
+    "paramiko==3.4.1",
     "phonenumberslite==8.13.6",
     "pillow==12.1.1",
     "posthoganalytics==7.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4559,16 +4559,16 @@ wheels = [
 
 [[package]]
 name = "paramiko"
-version = "3.4.0"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
     { name = "pynacl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/af/11996c4df4f9caff87997ad2d3fd8825078c277d6a928446d2b6cf249889/paramiko-3.4.0.tar.gz", hash = "sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3", size = 1277306, upload-time = "2023-12-18T19:35:32.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/6a/1d85cc9f5eaf49a769c7128039074bbb8127aba70756f05dfcf4326e72a1/paramiko-3.4.1.tar.gz", hash = "sha256:8b15302870af7f6652f2e038975c1d2973f06046cb5d7d65355668b3ecbece0c", size = 1703011, upload-time = "2024-08-11T18:56:25.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/50/8792484502c8141c20c996b802fefa8435a9c018a2bb440a06b172782118/paramiko-3.4.0-py3-none-any.whl", hash = "sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7", size = 225900, upload-time = "2023-12-18T19:35:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6e/4a52a8923d840107024b844d83502dfa6a1e5399ad31cf9d1a4ddbaaa7e5/paramiko-3.4.1-py3-none-any.whl", hash = "sha256:8e49fd2f82f84acf7ffd57c64311aa2b30e575370dc23bdb375b10262f7eac32", size = 226224, upload-time = "2024-08-11T18:56:23.528Z" },
 ]
 
 [[package]]
@@ -5159,7 +5159,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = "==1.33.1" },
     { name = "orjson", specifier = "==3.11.5" },
     { name = "pandas", specifier = "~=2.2.2" },
-    { name = "paramiko", specifier = "==3.4.0" },
+    { name = "paramiko", specifier = "==3.4.1" },
     { name = "phonenumberslite", specifier = "==8.13.6" },
     { name = "pillow", specifier = "==12.1.1" },
     { name = "playwright", specifier = "~=1.54.0" },


### PR DESCRIPTION
Local development containers spam the following `CryptographyDeprecationWarning`:

```
/python-runtime/lib/python3.12/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "cipher": algorithms.TripleDES,

/python-runtime/lib/python3.12/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "class": algorithms.TripleDES,
```


This is a known issue (https://github.com/paramiko/paramiko/issues/2419), fixed in https://github.com/paramiko/paramiko/pull/2421.

The [3.4.1 release](https://www.paramiko.org/changelog.html) (2024-08-11) includes the TripleDES deprecation fix. The remaining items in the changelog are minor bug fixes with no breaking changes.

I have tested the change locally through `pytest products/data_warehouse/backend/models/test/test_ssh_tunnel.py` which succeeds.