### PR TITLE
fix: exclude soft-deleted feature flags from usage report counts

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -257,6 +257,15 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesM
                 active=True,
             )
 
+            FeatureFlag.objects.create(
+                team=self.org_1_team_1,
+                name="Soft-deleted",
+                key="deleted-flag",
+                created_by=self.user,
+                active=True,
+                deleted=True,
+            )
+
             ErrorTrackingIssue.objects.create(team=self.org_1_team_1)
 
             uuids = [uuid4() for _ in range(0, 10)]

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1876,10 +1876,13 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             .order_by("team_id")
         ),
         "teams_with_ff_count": list(
-            FeatureFlag.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            FeatureFlag.objects.filter(deleted=False).values("team_id").annotate(total=Count("id")).order_by("team_id")
         ),
         "teams_with_ff_active_count": list(
-            FeatureFlag.objects.filter(active=True).values("team_id").annotate(total=Count("id")).order_by("team_id")
+            FeatureFlag.objects.filter(active=True, deleted=False)
+            .values("team_id")
+            .annotate(total=Count("id"))
+            .order_by("team_id")
         ),
         "teams_with_issues_created_total": list(
             ErrorTrackingIssue.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")


### PR DESCRIPTION
## Problem

The usage report counts soft-deleted feature flags in both `ff_count` and `ff_active_count`. This inflates the reported numbers since flags that users have deleted are still being counted.

## Changes

- Added `deleted=False` filter to both `teams_with_ff_count` and `teams_with_ff_active_count` queries in `_get_all_usage_data`, consistent with how other entities (HogFunctions, DataWarehouse tables, batch exports) already exclude deleted records.
- Added a soft-deleted feature flag to the test data to verify it is excluded from counts.

## How did you test this code?

- Added a soft-deleted feature flag (`active=True, deleted=True`) to existing test setup. The existing expected counts (`ff_count: 2`, `ff_active_count: 1`) now also validate that the deleted flag is excluded.
- Ran `pytest posthog/tasks/test/test_usage_report.py::TestUsageReport` — passes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No