### PR TITLE
feat: configure httpx and aiohttp to use egress proxy

### DIFF
--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -4,13 +4,13 @@ from typing import Any
 
 from django.conf import settings
 
-import aiohttp
 import structlog
 from slack_sdk.errors import SlackApiError
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.subscription import Subscription
+from posthog.security.outbound_proxy import external_aiohttp_session
 
 from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE, _has_asset_failed
 
@@ -245,7 +245,7 @@ async def send_slack_message_with_integration_async(
     message_data = _prepare_slack_message(subscription, assets, total_asset_count, is_new_subscription)
     slack_integration = SlackIntegration(integration)
 
-    async with aiohttp.ClientSession() as slack_session:
+    async with external_aiohttp_session() as slack_session:
         async_client = slack_integration.async_client(session=slack_session)
 
         message_res = await _send_slack_message_with_retry(

--- a/ee/vercel/client.py
+++ b/ee/vercel/client.py
@@ -8,7 +8,7 @@ import structlog
 from requests import HTTPError, RequestException, Timeout
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from posthog.security.outbound_proxy import make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests_session
 
 logger = structlog.get_logger(__name__)
 
@@ -51,7 +51,7 @@ class VercelAPIClient:
         self.bearer_token = bearer_token
         self.timeout = timeout
         self.base_url = base_url
-        self.session = make_proxied_requests_session()
+        self.session = external_requests_session()
 
         # Not all endpoints (Such as SSO token exchange) require authorization
         if bearer_token and bearer_token.strip():

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -83,7 +83,7 @@ from posthog.models.organization import Organization
 from posthog.models.user import NOTIFICATION_DEFAULTS, ROLE_CHOICES, Notifications, ShortcutPosition
 from posthog.permissions import APIScopePermission, TimeSensitiveActionPermission, UserNoOrgMembershipDeletePermission
 from posthog.rate_limit import ToolbarOAuthRefreshThrottle, UserAuthenticationThrottle, UserEmailVerificationThrottle
-from posthog.security.outbound_proxy import external_requests, make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests, external_requests_session
 from posthog.tasks import user_identify
 from posthog.tasks.email import (
     send_email_change_emails,
@@ -1320,7 +1320,7 @@ def test_slack_webhook(request):
         return JsonResponse({"error": "no webhook URL"})
     message = {"text": "_Greetings_ from PostHog!"}
     try:
-        session = make_proxied_requests_session()
+        session = external_requests_session()
 
         if not settings.DEBUG:
             raise_if_user_provided_url_unsafe(webhook)

--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -17,7 +17,7 @@ from clickhouse_driver.errors import Error, ErrorCodes
 from posthog.clickhouse.cluster import ClickhouseCluster, ExponentialBackoff, RetryPolicy, get_cluster
 from posthog.kafka_client.client import _KafkaProducer
 from posthog.redis import get_client, redis
-from posthog.security.outbound_proxy import make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests_session
 from posthog.utils import initialize_self_capture_api_token
 
 
@@ -246,7 +246,7 @@ class ClayWebhookResource(dagster.ConfigurableResource):
 
     def send(self, data: list[dict]) -> requests.Response:
         """Send data to Clay webhook."""
-        with make_proxied_requests_session() as session:
+        with external_requests_session() as session:
             return self._send_with_retry(session, data)
 
     def _get_batch_size(self, batch: list[dict]) -> int:

--- a/posthog/management/commands/create_channel_definitions_file.py
+++ b/posthog/management/commands/create_channel_definitions_file.py
@@ -9,8 +9,9 @@ from typing import Optional
 
 from django.core.management.base import BaseCommand
 
-import aiohttp
 import structlog
+
+from posthog.security.outbound_proxy import external_aiohttp_session
 
 OUTPUT_FILE = "posthog/models/channel_type/channel_definitions.json"
 
@@ -511,7 +512,7 @@ async def parallel_lookup_up_apple_apps(url_entries):
                 pass
         return app_ids, entry
 
-    async with aiohttp.ClientSession(read_timeout=60, conn_timeout=60) as session:
+    async with external_aiohttp_session(read_timeout=60, conn_timeout=60) as session:
         return await asyncio.gather(*(f(url_entry, session) for url_entry in url_entries))
 
 
@@ -537,5 +538,5 @@ async def parallel_lookup_up_android_apps(url_entries):
                 app_ids.append(package_name)
         return app_ids, entry
 
-    async with aiohttp.ClientSession(read_timeout=60, conn_timeout=60) as session:
+    async with external_aiohttp_session(read_timeout=60, conn_timeout=60) as session:
         return await asyncio.gather(*(f(url_entry, session) for url_entry in url_entries))

--- a/posthog/security/outbound_proxy.py
+++ b/posthog/security/outbound_proxy.py
@@ -53,7 +53,7 @@ def get_proxy_url() -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def make_proxied_requests_session() -> requests.Session:
+def external_requests_session() -> requests.Session:
     session = requests.Session()
     cfg = get_proxy_config()
     if cfg:
@@ -61,7 +61,7 @@ def make_proxied_requests_session() -> requests.Session:
     return session
 
 
-external_requests: requests.Session = make_proxied_requests_session()
+external_requests: requests.Session = external_requests_session()
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/security/outbound_proxy.py
+++ b/posthog/security/outbound_proxy.py
@@ -11,6 +11,10 @@ user-controlled URL:
     from posthog.security.outbound_proxy import external_httpx
     external_httpx.get("https://api.example.com/data")
 
+    from posthog.security.outbound_proxy import external_httpx_client
+    with external_httpx_client() as client:
+        client.get("https://api.example.com/data")
+
     from posthog.security.outbound_proxy import external_aiohttp_session
     async with external_aiohttp_session() as session:
         async with session.get("https://api.example.com/data") as resp: ...
@@ -83,6 +87,24 @@ class _LazyExternalHttpx:
 
 
 external_httpx: Any = _LazyExternalHttpx()
+
+
+def external_httpx_client(**kwargs: Any) -> Any:
+    """Create a new ``httpx.Client`` that routes through the proxy.
+
+    Use this when you need a context-managed client with a distinct lifecycle
+    (e.g. connection pooling scoped to a task).  For simple one-off calls,
+    ``external_httpx.get(...)`` is sufficient.
+
+    Usage::
+
+        with external_httpx_client() as client:
+            resp = client.get("https://api.example.com/data")
+    """
+    import httpx
+
+    proxy_url = get_proxy_url()
+    return httpx.Client(proxy=proxy_url, **kwargs) if proxy_url else httpx.Client(**kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/security/test/test_outbound_proxy.py
+++ b/posthog/security/test/test_outbound_proxy.py
@@ -5,9 +5,9 @@ import requests_mock as rm
 from posthog.security.outbound_proxy import (
     external_aiohttp_session,
     external_requests,
+    external_requests_session,
     get_proxy_config,
     get_proxy_url,
-    make_proxied_requests_session,
 )
 
 
@@ -53,7 +53,7 @@ def test_get_proxy_url(enabled, url, expected, settings):
 def test_make_proxied_session(enabled, url, settings):
     settings.OUTBOUND_PROXY_ENABLED = enabled
     settings.OUTBOUND_PROXY_URL = url
-    session = make_proxied_requests_session()
+    session = external_requests_session()
     if enabled and url:
         assert session.proxies["http"] == url
         assert session.proxies["https"] == url

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -60,6 +60,9 @@ CSSSelector = Literal[".InsightCard", ".ExportedInsight", ".replayer-wrapper", "
 # NOTE: We purposefully DON'T re-use the driver. It would be slightly faster but would keep an in-memory browser
 # window permanently around which is unnecessary
 def get_driver() -> webdriver.Chrome:
+    # this instance of Chrome does *not* use the egress proxy.
+    # after multiple attempts, we were not able to get selenium to actually use the proxy.
+    # the risk is minimal though, since this always uses a URL hardoded to settings.SITE_URL
     options = Options()
     options.add_argument("--headless=new")  # Hint: Try removing this line when debugging
     options.add_argument("--force-device-scale-factor=2")  # Scale factor for higher res image
@@ -71,10 +74,6 @@ def get_driver() -> webdriver.Chrome:
     options.add_experimental_option(
         "excludeSwitches", ["enable-automation"]
     )  # Removes the "Chrome is being controlled by automated test software" bar
-
-    if settings.OUTBOUND_PROXY_ENABLED and settings.OUTBOUND_PROXY_URL:
-        options.add_argument(f"--proxy-server={settings.OUTBOUND_PROXY_URL}")
-        options.add_argument("--proxy-bypass-list=<-loopback>")
 
     # Create a unique prefix for the temporary directory
     pid = os.getpid()

--- a/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
@@ -3,7 +3,7 @@ from typing import Any
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.security.outbound_proxy import external_requests, make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests, external_requests_session
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.buildbetter.queries import QUERIES, VIEWER_QUERY
 from posthog.temporal.data_imports.sources.buildbetter.settings import BUILDBETTER_API_URL, BUILDBETTER_ENDPOINTS
@@ -30,7 +30,7 @@ def _make_paginated_request(
 
     graphql_query_name = endpoint_config.graphql_query_name or endpoint_name
 
-    sess = make_proxied_requests_session()
+    sess = external_requests_session()
     sess.headers.update(
         {
             "X-Buildbetter-API-Key": api_key,

--- a/posthog/temporal/data_imports/sources/linear/linear.py
+++ b/posthog/temporal/data_imports/sources/linear/linear.py
@@ -3,7 +3,7 @@ from typing import Any
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.security.outbound_proxy import external_requests, make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests, external_requests_session
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.linear.queries import QUERIES, VIEWER_QUERY
 from posthog.temporal.data_imports.sources.linear.settings import (
@@ -33,7 +33,7 @@ def _make_paginated_request(
 
     graphql_query_name = endpoint_config.graphql_query_name or endpoint_name
 
-    sess = make_proxied_requests_session()
+    sess = external_requests_session()
     sess.headers.update(
         {
             "Authorization": f"Bearer {access_token}",

--- a/posthog/temporal/data_imports/sources/pinterest_ads/utils.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/utils.py
@@ -5,7 +5,7 @@ import requests
 import structlog
 from dateutil import parser
 
-from posthog.security.outbound_proxy import make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests_session
 from posthog.temporal.data_imports.sources.pinterest_ads.settings import (
     ANALYTICS_COLUMNS,
     ANALYTICS_ENDPOINT_PATHS,
@@ -23,7 +23,7 @@ logger = structlog.get_logger(__name__)
 
 
 def build_session(access_token: str) -> requests.Session:
-    session = make_proxied_requests_session()
+    session = external_requests_session()
     session.headers.update(
         {
             "Authorization": f"Bearer {access_token}",

--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -6,7 +6,7 @@ import requests
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.security.outbound_proxy import external_requests, make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests, external_requests_session
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.shopify.constants import ID, resolve_schema_name
 from posthog.temporal.data_imports.sources.shopify.settings import ENDPOINT_CONFIGS
@@ -144,7 +144,7 @@ def shopify_source(
     schema_name = resolve_schema_name(graphql_object_name)
 
     def get_rows():
-        sess = make_proxied_requests_session()
+        sess = external_requests_session()
         sess.headers.update({"X-Shopify-Access-Token": shopify_access_token, "Content-Type": "application/json"})
         graphql_object = SHOPIFY_GRAPHQL_OBJECTS.get(schema_name)
         if not graphql_object:
@@ -205,7 +205,7 @@ def validate_credentials(shopify_store_id: str, shopify_client_id: str, shopify_
     """
     api_url = SHOPIFY_API_URL.format(shopify_store_id, SHOPIFY_API_VERSION)
     shopify_access_token = _get_shopify_access_token(shopify_store_id, shopify_client_id, shopify_client_secret)
-    sess = make_proxied_requests_session()
+    sess = external_requests_session()
     sess.headers.update(
         {
             "Content-Type": "application/json",

--- a/posthog/temporal/data_imports/sources/vitally/vitally.py
+++ b/posthog/temporal/data_imports/sources/vitally/vitally.py
@@ -9,7 +9,7 @@ from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from requests import JSONDecodeError
 from structlog.types import FilteringBoundLogger
 
-from posthog.security.outbound_proxy import external_requests, make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests, external_requests_session
 from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resources
 from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 
@@ -364,7 +364,7 @@ def get_messages(
 
     logger.debug("Requesting first page")
 
-    with make_proxied_requests_session() as session:
+    with external_requests_session() as session:
         while paginator.has_next_page:
             paginator.update_request(request)
             prepared_request = session.prepare_request(request)

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -13,7 +13,7 @@ import structlog
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from posthog.security.outbound_proxy import make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests_session
 
 from .config import Config
 
@@ -87,7 +87,7 @@ class PostHogClient:
 
     def _create_http_session(self) -> requests.Session:
         """Create an HTTP session with urllib3 retry logic for transient failures."""
-        session = make_proxied_requests_session()
+        session = external_requests_session()
         retry_strategy = Retry(
             total=self.HTTP_RETRY_TOTAL,
             backoff_factor=self.HTTP_RETRY_BACKOFF_FACTOR,

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -13,6 +13,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.service import BatchExportField, BatchExportInsertInputs, HttpBatchExportInputs
 from posthog.models import BatchExportRun
+from posthog.security.outbound_proxy import external_aiohttp_session
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
@@ -294,7 +295,7 @@ async def insert_into_http_activity(inputs: HttpInsertInputs) -> BatchExportResu
 
                 activity.heartbeat(last_uploaded_timestamp)
 
-            async with aiohttp.ClientSession() as session:
+            async with external_aiohttp_session() as session:
                 for record_batch in record_iterator:
                     for row in record_batch.select(columns).to_pylist():
                         # Format result row as PostHog event, write JSON to the batch file.

--- a/products/llm_analytics/backend/llm/providers/openrouter.py
+++ b/products/llm_analytics/backend/llm/providers/openrouter.py
@@ -10,6 +10,8 @@ from collections.abc import Generator
 import httpx
 import openai
 
+from posthog.security.outbound_proxy import external_httpx
+
 from products.llm_analytics.backend.llm.providers.openai import OpenAIAdapter, OpenAIConfig
 from products.llm_analytics.backend.llm.types import (
     AnalyticsContext,
@@ -61,7 +63,7 @@ class OpenRouterAdapter(OpenAIAdapter):
         from products.llm_analytics.backend.models.provider_keys import LLMProviderKey
 
         try:
-            response = httpx.get(
+            response = external_httpx.get(
                 "https://openrouter.ai/api/v1/auth/key",
                 headers={"Authorization": f"Bearer {api_key}"},
                 timeout=OpenAIConfig.TIMEOUT,

--- a/products/llm_analytics/backend/llm/providers/test/test_openrouter.py
+++ b/products/llm_analytics/backend/llm/providers/test/test_openrouter.py
@@ -20,7 +20,9 @@ class TestOpenRouterValidateKey:
         mock_response = MagicMock()
         mock_response.status_code = status_code
 
-        with patch("products.llm_analytics.backend.llm.providers.openrouter.httpx.get", return_value=mock_response):
+        with patch(
+            "products.llm_analytics.backend.llm.providers.openrouter.external_httpx.get", return_value=mock_response
+        ):
             state, message = OpenRouterAdapter.validate_key("sk-or-test-key")
 
         assert state == expected_state
@@ -28,7 +30,7 @@ class TestOpenRouterValidateKey:
 
     def test_validate_key_timeout_returns_error(self):
         with patch(
-            "products.llm_analytics.backend.llm.providers.openrouter.httpx.get",
+            "products.llm_analytics.backend.llm.providers.openrouter.external_httpx.get",
             side_effect=httpx.TimeoutException("timeout"),
         ):
             state, message = OpenRouterAdapter.validate_key("sk-or-test-key")
@@ -38,7 +40,7 @@ class TestOpenRouterValidateKey:
 
     def test_validate_key_connection_error_returns_error(self):
         with patch(
-            "products.llm_analytics.backend.llm.providers.openrouter.httpx.get",
+            "products.llm_analytics.backend.llm.providers.openrouter.external_httpx.get",
             side_effect=httpx.ConnectError("connection refused"),
         ):
             state, message = OpenRouterAdapter.validate_key("sk-or-test-key")

--- a/products/web_analytics/dags/cache_favicons.py
+++ b/products/web_analytics/dags/cache_favicons.py
@@ -9,6 +9,7 @@ from dagster_aws.s3 import S3Resource
 from posthog.clickhouse.client import sync_execute
 from posthog.dags.common import JobOwners
 from posthog.models.team import Team
+from posthog.security.outbound_proxy import external_httpx
 
 
 def get_last_cached_domains(context: dagster.AssetExecutionContext, asset_key: str) -> set[str]:
@@ -105,7 +106,7 @@ def _download_and_cache_favicons(
     all_cached_domains = previously_cached.copy()
     skipped_count = 0
 
-    with httpx.Client() as client:
+    with external_httpx.Client() as client:
         for domain in domains:
             if domain in previously_cached:
                 context.log.debug(f"Skipping download for '{domain}' - already cached.")

--- a/products/web_analytics/dags/cache_favicons.py
+++ b/products/web_analytics/dags/cache_favicons.py
@@ -9,7 +9,7 @@ from dagster_aws.s3 import S3Resource
 from posthog.clickhouse.client import sync_execute
 from posthog.dags.common import JobOwners
 from posthog.models.team import Team
-from posthog.security.outbound_proxy import external_httpx
+from posthog.security.outbound_proxy import external_httpx_client
 
 
 def get_last_cached_domains(context: dagster.AssetExecutionContext, asset_key: str) -> set[str]:
@@ -106,7 +106,7 @@ def _download_and_cache_favicons(
     all_cached_domains = previously_cached.copy()
     skipped_count = 0
 
-    with external_httpx.Client() as client:
+    with external_httpx_client() as client:
         for domain in domains:
             if domain in previously_cached:
                 context.log.debug(f"Skipping download for '{domain}' - already cached.")

--- a/products/workflows/backend/services/customerio_client.py
+++ b/products/workflows/backend/services/customerio_client.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 import requests
 
-from posthog.security.outbound_proxy import make_proxied_requests_session
+from posthog.security.outbound_proxy import external_requests_session
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class CustomerIOClient:
         self.api_key = app_api_key
         self.timeout = timeout
         self.BASE_URL = self.EU_BASE_URL if region.lower() == "eu" else self.US_BASE_URL
-        self.session = make_proxied_requests_session()
+        self.session = external_requests_session()
         # Don't store credentials in session headers - add them per request instead
         self.session.headers.update({"Accept": "application/json", "Content-Type": "application/json"})
 


### PR DESCRIPTION
`requests` is already configured to use the proxy. This only applies to dev.