### PR TITLE
feat: sort projects in weekly digest

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1489,7 +1489,7 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
         else list(all_memberships)
     )
 
-    date_suffix = timezone.now().strftime("%Y-%W-%d-%H")
+    date_suffix = timezone.now().strftime("%Y-%W")
     sent_count = 0
 
     for membership in memberships:
@@ -1518,6 +1518,8 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
 
         if not user_team_sections:
             continue
+
+        user_team_sections.sort(key=lambda d: d["exception_count"], reverse=True)
 
         campaign_key = f"error_tracking_weekly_digest_{org_id}_{user.uuid}_{date_suffix}"
         message = EmailMessage(

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -297,8 +297,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="send HogFunctions daily digest",
     )
 
+    # Send Error Tracking weekly digest at 8:30 AM UTC on Monday
     sender.add_periodic_task(
-        crontab(minute="0"),
+        crontab(hour="8", minute="30", day_of_week="mon"),
         send_error_tracking_weekly_digest.s(),
         name="send Error Tracking weekly digest",
     )


### PR DESCRIPTION
- sort projects within ET weekly digest by occurrence count,
- change cron back to once per week on Monday.