### PR TITLE
fix: reject replay requests with empty token

### DIFF
--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -19,6 +19,7 @@ use crate::{
     global_rate_limiter::GlobalRateLimitKey,
     payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
+    token::validate_token,
     v0_request::ProcessingContext,
 };
 
@@ -109,6 +110,7 @@ pub async fn handle_recording_payload(
     let token = events[0]
         .extract_token()
         .ok_or(CaptureError::NoTokenError)?;
+    validate_token(&token)?;
     Span::current().record("token", &token);
 
     counter!("capture_events_received_total").increment(events.len() as u64);


### PR DESCRIPTION
## Problem

We're passing on session replay messages with empty token value, which get shuffled to DLQ.

## Changes

Returns 401 from capture if the token is not correct.

## How did you test this code?

- Added a new integration test
- Regression tests 