### PR TITLE
chore: add partitions to tophog emitted events

### DIFF
--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -94,6 +94,10 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
                         team_id: String(input.eventToEmit.team_id),
                         distinct_id: input.eventToEmit.distinct_id,
                     })),
+                    count('emitted_events_per_partition', (input) => ({
+                        team_id: String(input.eventToEmit.team_id),
+                        partition: String(input.message.partition),
+                    })),
                 ]
             )
         )

--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -93,6 +93,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
                     count('emitted_events_per_distinct_id', (input) => ({
                         team_id: String(input.eventToEmit.team_id),
                         distinct_id: input.eventToEmit.distinct_id,
+                        partition: String(input.message.partition),
                     })),
                     count('emitted_events_per_partition', (input) => ({
                         team_id: String(input.eventToEmit.team_id),


### PR DESCRIPTION
## Problem

We're lacking a bit of observability on top teams and distinct ids per partition.

## Changes

- Adds a new tophog metric for teams per partition
- Adds partition number to per distinct id events metric

## How did you test this code?

Will monitor on production