### PR TITLE
chore(sandbox): whitelist modal.host domains

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -685,8 +685,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
             return True
 
-        if parsed.scheme == "https" and parsed.hostname and (
-            parsed.hostname.endswith(".modal.run") or parsed.hostname.endswith(".modal.host")
+        if (
+            parsed.scheme == "https"
+            and parsed.hostname
+            and (parsed.hostname.endswith(".modal.run") or parsed.hostname.endswith(".modal.host"))
         ):
             return True
 

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -673,6 +673,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         - http://localhost:{port} (Docker sandboxes)
         - http://127.0.0.1:{port} (Docker sandboxes)
         - https://*.modal.run (Modal sandboxes)
+        - https://*.modal.host (Modal connect token sandboxes)
         """
         from urllib.parse import urlparse
 
@@ -684,7 +685,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
             return True
 
-        if parsed.scheme == "https" and parsed.hostname and parsed.hostname.endswith(".modal.run"):
+        if parsed.scheme == "https" and parsed.hostname and (
+            parsed.hostname.endswith(".modal.run") or parsed.hostname.endswith(".modal.host")
+        ):
             return True
 
         return False

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1726,8 +1726,10 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         [
             ("docker_localhost", "http://localhost:47821"),
             ("docker_127", "http://127.0.0.1:47821"),
-            ("modal", "https://sb-abc123.modal.run"),
-            ("modal_subdomain", "https://test-sandbox-xyz.modal.run"),
+            ("modal_run", "https://sb-abc123.modal.run"),
+            ("modal_run_subdomain", "https://test-sandbox-xyz.modal.run"),
+            ("modal_host", "https://sb-abc123.w.modal.host"),
+            ("modal_host_connect_token", "https://a-ta-01kjnh54bc9wwbh7ydrk4yqq1d-b778iwq0t2a33tyjqdu6eyfjn.w.modal.host"),
         ]
     )
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1729,7 +1729,10 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
             ("modal_run", "https://sb-abc123.modal.run"),
             ("modal_run_subdomain", "https://test-sandbox-xyz.modal.run"),
             ("modal_host", "https://sb-abc123.w.modal.host"),
-            ("modal_host_connect_token", "https://a-ta-01kjnh54bc9wwbh7ydrk4yqq1d-b778iwq0t2a33tyjqdu6eyfjn.w.modal.host"),
+            (
+                "modal_host_connect_token",
+                "https://a-ta-01kjnh54bc9wwbh7ydrk4yqq1d-b778iwq0t2a33tyjqdu6eyfjn.w.modal.host",
+            ),
         ]
     )
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)


### PR DESCRIPTION
We were only whitelisting modal.run domains and not .host ones.