### PR TITLE
fix(mcp-apps): add y-axis labels to bar and line charts

### DIFF
--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -81,14 +81,30 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     return (
         <div>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.5rem' }}>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    marginBottom: '0.5rem',
+                }}
+            >
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={chartMode} onChange={setChartMode} options={CHART_MODE_OPTIONS} />
             </div>
             {chartMode === 'bar' ? (
-                <BarChart series={series} labels={labels} maxValue={maxValue} />
+                <BarChart
+                    series={series}
+                    labels={labels}
+                    maxValue={maxValue}
+                    yAxisLabel={series.length === 1 ? series[0].label : undefined}
+                />
             ) : (
-                <LineChart series={series} labels={labels} maxValue={maxValue} />
+                <LineChart
+                    series={series}
+                    labels={labels}
+                    maxValue={maxValue}
+                    yAxisLabel={series.length === 1 ? series[0].label : undefined}
+                />
             )}
         </div>
     )

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -96,14 +96,14 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                     series={series}
                     labels={labels}
                     maxValue={maxValue}
-                    yAxisLabel={series.length === 1 ? series[0].label : undefined}
+                    yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
                 />
             ) : (
                 <LineChart
                     series={series}
                     labels={labels}
                     maxValue={maxValue}
-                    yAxisLabel={series.length === 1 ? series[0].label : undefined}
+                    yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
                 />
             )}
         </div>

--- a/services/mcp/src/ui-apps/components/charts/BarChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/BarChart.tsx
@@ -30,9 +30,10 @@ export interface BarChartProps {
     labels: string[]
     maxValue: number
     showLegend?: boolean
+    yAxisLabel?: string
 }
 
-export function BarChart({ series, labels, maxValue, showLegend = true }: BarChartProps): ReactElement {
+export function BarChart({ series, labels, maxValue, showLegend = true, yAxisLabel }: BarChartProps): ReactElement {
     const innerWidth = CHART_WIDTH - PADDING.left - PADDING.right
     const innerHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom
 
@@ -45,6 +46,19 @@ export function BarChart({ series, labels, maxValue, showLegend = true }: BarCha
     return (
         <div>
             <svg viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} style={{ width: '100%', height: '400px' }}>
+                {yAxisLabel && (
+                    <text
+                        x={12}
+                        y={PADDING.top + innerHeight / 2}
+                        textAnchor="middle"
+                        fontSize="11"
+                        fill="var(--color-text-secondary, #6b7280)"
+                        transform={`rotate(-90, 12, ${PADDING.top + innerHeight / 2})`}
+                    >
+                        {yAxisLabel}
+                    </text>
+                )}
+
                 {/* Y-axis labels */}
                 {[0, 0.5, 1].map((ratio) => {
                     const value = maxValue * ratio

--- a/services/mcp/src/ui-apps/components/charts/BarChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/BarChart.tsx
@@ -30,7 +30,7 @@ export interface BarChartProps {
     labels: string[]
     maxValue: number
     showLegend?: boolean
-    yAxisLabel?: string
+    yAxisLabel?: string | undefined
 }
 
 export function BarChart({ series, labels, maxValue, showLegend = true, yAxisLabel }: BarChartProps): ReactElement {

--- a/services/mcp/src/ui-apps/components/charts/LineChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/LineChart.tsx
@@ -30,7 +30,7 @@ export interface LineChartProps {
     labels: string[]
     maxValue: number
     showLegend?: boolean
-    yAxisLabel?: string
+    yAxisLabel?: string | undefined
 }
 
 export function LineChart({ series, labels, maxValue, showLegend = true, yAxisLabel }: LineChartProps): ReactElement {

--- a/services/mcp/src/ui-apps/components/charts/LineChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/LineChart.tsx
@@ -30,9 +30,10 @@ export interface LineChartProps {
     labels: string[]
     maxValue: number
     showLegend?: boolean
+    yAxisLabel?: string
 }
 
-export function LineChart({ series, labels, maxValue, showLegend = true }: LineChartProps): ReactElement {
+export function LineChart({ series, labels, maxValue, showLegend = true, yAxisLabel }: LineChartProps): ReactElement {
     const innerWidth = CHART_WIDTH - PADDING.left - PADDING.right
     const innerHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom
 
@@ -42,6 +43,19 @@ export function LineChart({ series, labels, maxValue, showLegend = true }: LineC
     return (
         <div>
             <svg viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} style={{ width: '100%', height: '400px' }}>
+                {yAxisLabel && (
+                    <text
+                        x={12}
+                        y={PADDING.top + innerHeight / 2}
+                        textAnchor="middle"
+                        fontSize="11"
+                        fill="var(--color-text-secondary, #6b7280)"
+                        transform={`rotate(-90, 12, ${PADDING.top + innerHeight / 2})`}
+                    >
+                        {yAxisLabel}
+                    </text>
+                )}
+
                 {/* Y-axis labels */}
                 {[0, 0.5, 1].map((ratio) => {
                     const value = maxValue * ratio


### PR DESCRIPTION
## Problem

Charts displaying a single data series lack a y-axis label, making it unclear what metric is being visualized. When multiple series are present, a label would be redundant due to the legend, but single-series charts benefit from explicit axis labeling for better clarity.

## Changes

- Added optional `yAxisLabel` prop to `BarChart` and `LineChart` components
- Updated `TrendsVisualizer` to pass the series label as the y-axis label when only a single series is present
- Rendered y-axis label as rotated text on the left side of both chart types, using secondary text color for visual hierarchy
- Improved code formatting in `TrendsVisualizer` for better readability

## How did you test this code?

Code review of the changes:
- Verified that `yAxisLabel` is only passed when `series.length === 1`, preventing redundant labels with multi-series charts
- Confirmed the SVG text element is conditionally rendered only when `yAxisLabel` is provided
- Checked that the rotation transform correctly positions the label vertically on the y-axis
- Ensured styling uses CSS variables for consistency with the design system

https://claude.ai/code/session_01LRz4JZ8fgEFqGgycooNPA8