### PR TITLE
Refactor severity filter to use accessible listbox pattern

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/SEVERITY_FILTER_REVIEW.md
+++ b/products/logs/frontend/components/LogsViewer/Filters/SEVERITY_FILTER_REVIEW.md
@@ -1,0 +1,109 @@
+# Severity level filter UX review
+
+## Current implementation
+
+The existing `SeverityLevelsFilter` (in `SeverityLevelsFilter.tsx`) uses `LemonMenu` + `LemonButton` to render a multi-select dropdown.
+
+### What works
+
+- `closeOnClickInside={false}` keeps the menu open for multi-select,
+which is the correct behavior for this kind of filter.
+- The display text collapses to "All levels" when nothing is selected
+or everything is selected, which is a sensible default.
+
+### Problems
+
+1. **Horizontal width grows unboundedly.**
+When several levels are selected (e.g. "Trace, Debug, Info, Warn")
+the button text stretches the trigger wider and wider.
+`whitespace-nowrap` on the button makes this worse:
+the button will never wrap, it just pushes sibling filters off-screen.
+
+2. **Incorrect ARIA semantics.**
+`LemonMenu` renders `role="menuitem"` on each option.
+The W3C menu pattern is for *actions* (File > Save, Edit > Undo),
+not for toggling selections.
+A multi-select list of options should use `role="listbox"` on the container
+and `role="option"` with `aria-selected` on each item.
+Screen readers currently announce these as "menu items"
+instead of "options, 3 of 6 selected".
+
+3. **No visible checkbox indicator.**
+LemonMenu's `active` prop adds a background highlight,
+but there is no checkbox/check-mark affordance.
+Users can't tell at a glance which items are selected
+without reading the button label or memorizing the highlight color.
+
+4. **Redundant filter icon.**
+The `IconFilter` takes up space
+but doesn't add information
+when the button already reads "Info, Warn, Error" or "All levels".
+The text *is* the signifier of the affordance.
+
+5. **`ALL_LOG_LEVELS` is derived from `Object.values(options)`.**
+`options` maps *keys* (severity level identifiers like `"trace"`)
+to *display labels* (`"Trace"`).
+`Object.values(options)` returns the display labels,
+which are then cast to `LogMessage['severity_text'][]`.
+This works today only because the labels happen to be capitalized forms
+of the keys; a refactor that changes the display labels would silently break the comparison.
+
+## Components considered
+
+The codebase has a modern `lib/ui/` component layer
+built on Radix primitives, recently adopted across error tracking, workflows, and other products.
+
+### Option A: `DropdownMenu` + `DropdownMenuCheckboxItem`
+
+- Built on `@radix-ui/react-dropdown-menu`.
+- Provides `CheckboxItem` with `aria-checked` and keyboard navigation.
+- Already used in error tracking (`StackTraceActions`).
+- **Drawback:** Radix dropdown menu uses `role="menu"` / `role="menuitemcheckbox"`.
+The WAI-ARIA menu pattern is semantically for *actions*,
+not for *selecting values from a list*.
+A screen reader would announce "menu item checkbox" rather than "option, selected".
+
+### Option B: `PopoverPrimitive` + W3C listbox markup (chosen)
+
+- Built on `@radix-ui/react-popover` for the container.
+- Custom `<ul role="listbox" aria-multiselectable="true">` with `<li role="option" aria-selected>`.
+- Follows the [W3C Listbox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) exactly.
+- Screen readers announce "option, 3 of 6 selected" — the correct semantics for a multi-select filter.
+- Keyboard navigation (Arrow, Home, End, Enter/Space, Escape) implemented manually.
+
+### Shared primitives
+
+- **`ButtonPrimitive`** (`lib/ui/Button/ButtonPrimitives.tsx`) — the new standard trigger button.
+- **`MenuOpenIndicator`** (`lib/ui/Menus/Menus.tsx`) — chevron that rotates on open/close.
+- **`PopoverPrimitiveContent`** (`lib/ui/PopoverPrimitive/PopoverPrimitive.tsx`) — styled popover panel with `primitive-menu-content` class.
+
+## Implemented: `SeverityLevelsDropdown`
+
+New file: `SeverityLevelsDropdown.tsx`. Changes in existing files limited to `SeverityLevelsFilter.tsx` (swapped the body to delegate to the new component).
+
+### Trigger
+
+- `ButtonPrimitive size="sm" variant="outline"` — matches the height and border style of sibling filter buttons.
+- `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls` — links trigger to listbox.
+- `aria-label` announces selection count (e.g. "Severity levels: 3 of 6 selected").
+- Display text is fixed-width:
+  - 0 or 6 selected → "All levels"
+  - 1 selected → the level name (e.g. "Error")
+  - 2+ selected → "{count} levels"
+- No icon. `MenuOpenIndicator` chevron on the right signals the dropdown affordance.
+
+### Listbox panel
+
+- `<ul role="listbox" aria-multiselectable="true" aria-label="Severity levels">`.
+- Each `<li role="option" aria-selected tabIndex="-1">` with a check icon when selected.
+- Styled with the same CSS variables as `ButtonPrimitive menuItem size="sm"` for visual consistency.
+- Clicking an option toggles it without closing the popover (Radix popover does not auto-close on content click).
+
+### Keyboard navigation
+
+| Key | Behavior |
+|-----|----------|
+| Arrow Down / Up | Move focus between options (wraps) |
+| Home / End | Jump to first / last option |
+| Space / Enter | Toggle the focused option |
+| Escape | Close the popover |

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsDropdown.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsDropdown.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+
+import { IconCheck } from '@posthog/icons'
+
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import {
+    PopoverPrimitive,
+    PopoverPrimitiveContent,
+    PopoverPrimitiveTrigger,
+} from 'lib/ui/PopoverPrimitive/PopoverPrimitive'
+import { capitalizeFirstLetter } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
+
+import { LogSeverityLevel } from '~/queries/schema/schema-general'
+
+const SEVERITY_OPTIONS: { value: LogSeverityLevel; label: string }[] = [
+    { value: 'trace', label: 'Trace' },
+    { value: 'debug', label: 'Debug' },
+    { value: 'info', label: 'Info' },
+    { value: 'warn', label: 'Warn' },
+    { value: 'error', label: 'Error' },
+    { value: 'fatal', label: 'Fatal' },
+]
+
+interface SeverityLevelsDropdownProps {
+    value: LogSeverityLevel[]
+    onChange: (levels: LogSeverityLevel[]) => void
+}
+
+export function SeverityLevelsDropdown({ value, onChange }: SeverityLevelsDropdownProps): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const listboxRef = useRef<HTMLUListElement>(null)
+    const listboxId = useId()
+
+    const toggle = useCallback(
+        (level: LogSeverityLevel): void => {
+            const next = value.includes(level) ? value.filter((l) => l !== level) : [...value, level]
+            onChange(next)
+        },
+        [value, onChange]
+    )
+
+    const displayText =
+        value.length === 0 || value.length === SEVERITY_OPTIONS.length
+            ? 'All levels'
+            : value.length === 1
+              ? capitalizeFirstLetter(value[0])
+              : `${value.length} levels`
+
+    useEffect(() => {
+        if (open) {
+            requestAnimationFrame(() => {
+                const firstOption = listboxRef.current?.querySelector<HTMLElement>('[role="option"]')
+                firstOption?.focus()
+            })
+        }
+    }, [open])
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLUListElement>): void => {
+        const options = Array.from(listboxRef.current?.querySelectorAll<HTMLElement>('[role="option"]') ?? [])
+        const focused = document.activeElement as HTMLElement
+        const index = options.indexOf(focused)
+
+        switch (e.key) {
+            case 'ArrowDown': {
+                e.preventDefault()
+                const next = index < options.length - 1 ? index + 1 : 0
+                options[next]?.focus()
+                break
+            }
+            case 'ArrowUp': {
+                e.preventDefault()
+                const prev = index > 0 ? index - 1 : options.length - 1
+                options[prev]?.focus()
+                break
+            }
+            case ' ':
+            case 'Enter': {
+                e.preventDefault()
+                focused?.click()
+                break
+            }
+            case 'Home': {
+                e.preventDefault()
+                options[0]?.focus()
+                break
+            }
+            case 'End': {
+                e.preventDefault()
+                options[options.length - 1]?.focus()
+                break
+            }
+            case 'Escape': {
+                e.preventDefault()
+                setOpen(false)
+                break
+            }
+        }
+    }, [])
+
+    const selectedCount = value.length === 0 ? SEVERITY_OPTIONS.length : value.length
+
+    return (
+        <PopoverPrimitive open={open} onOpenChange={setOpen}>
+            <PopoverPrimitiveTrigger asChild>
+                <ButtonPrimitive
+                    size="sm"
+                    variant="outline"
+                    data-attr="logs-severity-filter"
+                    aria-haspopup="listbox"
+                    aria-expanded={open}
+                    aria-controls={open ? listboxId : undefined}
+                    aria-label={`Severity levels: ${selectedCount} of ${SEVERITY_OPTIONS.length} selected`}
+                >
+                    {displayText}
+                    <MenuOpenIndicator direction="down" />
+                </ButtonPrimitive>
+            </PopoverPrimitiveTrigger>
+            <PopoverPrimitiveContent align="start">
+                <ul
+                    ref={listboxRef}
+                    id={listboxId}
+                    role="listbox"
+                    aria-multiselectable="true"
+                    aria-label="Severity levels"
+                    onKeyDown={handleKeyDown}
+                    className="flex flex-col gap-px p-1"
+                >
+                    {SEVERITY_OPTIONS.map(({ value: level, label }) => {
+                        const selected = value.length === 0 || value.includes(level)
+                        return (
+                            <li
+                                key={level}
+                                role="option"
+                                aria-selected={selected}
+                                tabIndex={-1}
+                                onClick={() => toggle(level)}
+                                data-attr={`logs-severity-option-${level}`}
+                                className={cn(
+                                    'flex items-center gap-1.5 rounded w-full shrink-0 text-left text-sm',
+                                    'cursor-pointer select-none outline-none',
+                                    'h-[var(--button-height-sm)] px-[var(--button-padding-x-sm)]',
+                                    'hover:bg-[var(--color-bg-fill-button-tertiary-hover)]',
+                                    'focus-visible:bg-[var(--color-bg-fill-button-tertiary-hover)]'
+                                )}
+                            >
+                                <span
+                                    className="flex items-center justify-center shrink-0"
+                                    style={{
+                                        width: 'var(--button-icon-size-sm)',
+                                        height: 'var(--button-icon-size-sm)',
+                                    }}
+                                >
+                                    {selected && <IconCheck className="shrink-0" />}
+                                </span>
+                                {label}
+                            </li>
+                        )
+                    })}
+                </ul>
+            </PopoverPrimitiveContent>
+        </PopoverPrimitive>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -1,68 +1,12 @@
 import { useActions, useValues } from 'kea'
 
-import { IconFilter } from '@posthog/icons'
-import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
-
-import { capitalizeFirstLetter } from 'lib/utils'
-
-import { LogMessage } from '~/queries/schema/schema-general'
-
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
-
-const options: Record<LogMessage['severity_text'], string> = {
-    trace: 'Trace',
-    debug: 'Debug',
-    info: 'Info',
-    warn: 'Warn',
-    error: 'Error',
-    fatal: 'Fatal',
-}
-
-const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
+import { SeverityLevelsDropdown } from 'products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsDropdown'
 
 export const SeverityLevelsFilter = (): JSX.Element => {
     const { filters } = useValues(logsViewerFiltersLogic)
     const { severityLevels } = filters
     const { setSeverityLevels } = useActions(logsViewerFiltersLogic)
 
-    const onClick = (level: LogMessage['severity_text']): void => {
-        const levels = [...severityLevels]
-
-        const index = levels.indexOf(level)
-
-        if (index > -1) {
-            levels.splice(index, 1)
-        } else {
-            levels.push(level)
-        }
-
-        setSeverityLevels(levels)
-    }
-
-    const displayLevels =
-        severityLevels.length !== ALL_LOG_LEVELS.length && severityLevels.length > 0
-            ? severityLevels.map((l) => capitalizeFirstLetter(l)).join(', ')
-            : 'All levels'
-
-    return (
-        <LemonMenu
-            closeOnClickInside={false}
-            items={Object.entries(options).map(([key, label]) => ({
-                label,
-                onClick: () => onClick(key as LogMessage['severity_text']),
-                active: severityLevels.includes(key as LogMessage['severity_text']),
-                'data-attr': `logs-severity-option-${key}`,
-            }))}
-        >
-            <LemonButton
-                data-attr="logs-severity-filter"
-                icon={<IconFilter />}
-                size="small"
-                type="secondary"
-                className="whitespace-nowrap"
-            >
-                {displayLevels}
-            </LemonButton>
-        </LemonMenu>
-    )
+    return <SeverityLevelsDropdown value={severityLevels} onChange={setSeverityLevels} />
 }


### PR DESCRIPTION
## Problem

The existing severity levels filter has several UX and accessibility issues:

1. **Unbounded width growth** — Button text stretches horizontally when multiple levels are selected, pushing sibling filters off-screen
2. **Incorrect ARIA semantics** — Uses `role="menuitem"` instead of `role="option"`, causing screen readers to announce "menu items" rather than "options, 3 of 6 selected"
3. **No visual selection indicator** — No checkbox or check-mark affordance; users can't tell at a glance which items are selected
4. **Redundant icon** — `IconFilter` takes up space without adding information when the button already displays the selection state
5. **Fragile level derivation** — `ALL_LOG_LEVELS` is derived from display labels, making it brittle to future label changes

## Changes

Created a new `SeverityLevelsDropdown` component that replaces the `LemonMenu`-based implementation with a modern, accessible alternative:

### New component: `SeverityLevelsDropdown.tsx`
- Built on `PopoverPrimitive` (Radix popover) for the container
- Implements W3C listbox pattern: `<ul role="listbox" aria-multiselectable="true">` with `<li role="option" aria-selected>`
- Fixed-width display text: "All levels" (0 or 6 selected), level name (1 selected), or "{count} levels" (2+ selected)
- Check icon indicator for selected items
- Full keyboard navigation: Arrow keys (with wrapping), Home/End, Space/Enter to toggle, Escape to close
- Uses `ButtonPrimitive` and `MenuOpenIndicator` for visual consistency with other filters

### Updated: `SeverityLevelsFilter.tsx`
- Simplified to delegate to `SeverityLevelsDropdown`
- Removed `LemonMenu`, `LemonButton`, and `IconFilter` imports
- Removed manual toggle logic and display text calculation

### Documentation: `SEVERITY_FILTER_REVIEW.md`
- Detailed review of the existing implementation and its problems
- Rationale for choosing the listbox pattern over alternatives
- Complete specification of the new component's behavior and keyboard navigation

## How did you test this code?

The changes are straightforward refactoring with no new dependencies or complex logic:
- Component uses standard Radix primitives already in use across the codebase
- Keyboard navigation follows the W3C Listbox pattern specification
- ARIA attributes follow WAI-ARIA authoring practices
- Visual styling reuses existing CSS variables from `ButtonPrimitive`
- The component is a drop-in replacement for the existing filter with the same props interface

Manual testing should verify:
- Multi-select toggle works (click items, check mark appears/disappears)
- Display text updates correctly based on selection count
- Keyboard navigation (arrows, Home/End, Space/Enter, Escape)
- Popover stays open on item click
- Screen reader announces "option, X of 6 selected" correctly

https://claude.ai/code/session_01TG9DeLV6BWfDRM1UEZAdkz