### PR TITLE
refactor(llma): consolidate model picker and simplify evaluations

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
@@ -18,7 +18,6 @@ import {
     LemonDropdown,
     LemonInput,
     LemonModal,
-    LemonSearchableSelect,
     LemonSelect,
     LemonSkeleton,
     LemonSwitch,
@@ -33,7 +32,6 @@ import { humanFriendlyDuration } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { SceneExport } from 'scenes/sceneTypes'
 
-import { ByokModelPicker } from './ByokModelPicker'
 import { JSONEditor } from './components/JSONEditor'
 import { MetadataHeader } from './ConversationDisplay/MetadataHeader'
 import {
@@ -43,6 +41,8 @@ import {
     PromptConfig,
     llmAnalyticsPlaygroundLogic,
 } from './llmAnalyticsPlaygroundLogic'
+import { getModelPickerFooterLink, ModelPicker as ModelPickerDropdown } from './ModelPicker'
+import { modelPickerLogic } from './modelPickerLogic'
 const INLINE_JSON_MAX_LINES = 20
 const INLINE_JSON_MAX_HEIGHT_CLASS = 'max-h-[420px] overflow-y-auto'
 const TOOLS_MODAL_EDITOR_HEIGHT = 460
@@ -296,15 +296,11 @@ function getModelOptionsErrorMessage(errorStatus: number | null): string | null 
 
 function ModelPicker({ promptId }: { promptId: string }): JSX.Element {
     const prompt = usePromptConfig(promptId)
-    const {
-        effectiveModelOptions,
-        hasByokKeys,
-        modelOptions,
-        modelOptionsLoading,
-        modelOptionsErrorStatus,
-        groupedModelOptions,
-    } = useValues(llmAnalyticsPlaygroundLogic)
+    const { effectiveModelOptions, hasByokKeys, modelOptions, modelOptionsLoading, modelOptionsErrorStatus } =
+        useValues(llmAnalyticsPlaygroundLogic)
     const { setModel, loadModelOptions } = useActions(llmAnalyticsPlaygroundLogic)
+    const { providerModelGroups, trialProviderModelGroups, byokModelsLoading, trialModelsLoading } =
+        useValues(modelPickerLogic)
 
     if (!prompt) {
         return <LemonSkeleton className="h-10" />
@@ -315,10 +311,13 @@ function ModelPicker({ promptId }: { promptId: string }): JSX.Element {
         const selectedModel = options.find((m) => m.id === prompt.model)
 
         return (
-            <ByokModelPicker
+            <ModelPickerDropdown
                 model={prompt.model}
                 selectedProviderKeyId={prompt.selectedProviderKeyId}
                 onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
+                groups={providerModelGroups}
+                loading={byokModelsLoading}
+                footerLink={getModelPickerFooterLink(true)}
                 selectedModelName={selectedModel?.name}
                 data-attr={`playground-model-selector-${promptId}`}
             />
@@ -330,25 +329,24 @@ function ModelPicker({ promptId }: { promptId: string }): JSX.Element {
 
     return (
         <>
-            {modelOptionsLoading && !options.length ? (
-                <LemonSkeleton className="h-10" />
+            {trialModelsLoading && !options.length ? (
+                <ModelPickerDropdown
+                    model={prompt.model}
+                    selectedProviderKeyId={null}
+                    onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
+                    groups={trialProviderModelGroups}
+                    loading={trialModelsLoading}
+                    footerLink={getModelPickerFooterLink(false)}
+                    data-attr={`playground-model-selector-${promptId}`}
+                />
             ) : (
-                <LemonSearchableSelect
-                    className="w-full"
-                    placeholder="Select model"
-                    value={prompt.model}
-                    onChange={(value) => value && setModel(value, undefined, promptId)}
-                    options={groupedModelOptions}
-                    searchPlaceholder="Search models..."
-                    searchKeys={['label', 'value', 'tooltip']}
-                    loading={modelOptionsLoading}
-                    disabledReason={
-                        modelOptionsLoading
-                            ? 'Loading models...'
-                            : options.length === 0
-                              ? 'No models available'
-                              : undefined
-                    }
+                <ModelPickerDropdown
+                    model={prompt.model}
+                    selectedProviderKeyId={null}
+                    onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
+                    groups={trialProviderModelGroups}
+                    loading={trialModelsLoading}
+                    footerLink={getModelPickerFooterLink(false)}
                     data-attr={`playground-model-selector-${promptId}`}
                 />
             )}

--- a/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
@@ -284,21 +284,10 @@ function PromptResultCard({ item }: { item?: ComparisonItem }): JSX.Element {
     )
 }
 
-function getModelOptionsErrorMessage(errorStatus: number | null): string | null {
-    if (errorStatus === null) {
-        return null
-    }
-    if (errorStatus === 429) {
-        return 'Too many requests. Please wait a moment and try again.'
-    }
-    return 'Failed to load models. Please refresh the page or try again later.'
-}
-
 function ModelPicker({ promptId }: { promptId: string }): JSX.Element {
     const prompt = usePromptConfig(promptId)
-    const { effectiveModelOptions, hasByokKeys, modelOptions, modelOptionsLoading, modelOptionsErrorStatus } =
-        useValues(llmAnalyticsPlaygroundLogic)
-    const { setModel, loadModelOptions } = useActions(llmAnalyticsPlaygroundLogic)
+    const { effectiveModelOptions, hasByokKeys } = useValues(llmAnalyticsPlaygroundLogic)
+    const { setModel } = useActions(llmAnalyticsPlaygroundLogic)
     const { providerModelGroups, trialProviderModelGroups, byokModelsLoading, trialModelsLoading } =
         useValues(modelPickerLogic)
 
@@ -306,63 +295,22 @@ function ModelPicker({ promptId }: { promptId: string }): JSX.Element {
         return <LemonSkeleton className="h-10" />
     }
 
-    if (hasByokKeys) {
-        const options = Array.isArray(effectiveModelOptions) ? effectiveModelOptions : []
-        const selectedModel = options.find((m) => m.id === prompt.model)
-
-        return (
-            <ModelPickerDropdown
-                model={prompt.model}
-                selectedProviderKeyId={prompt.selectedProviderKeyId}
-                onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
-                groups={providerModelGroups}
-                loading={byokModelsLoading}
-                footerLink={getModelPickerFooterLink(true)}
-                selectedModelName={selectedModel?.name}
-                data-attr={`playground-model-selector-${promptId}`}
-            />
-        )
-    }
-
-    const options = Array.isArray(modelOptions) ? modelOptions : []
-    const errorMessage = getModelOptionsErrorMessage(modelOptionsErrorStatus)
+    const options = Array.isArray(effectiveModelOptions) ? effectiveModelOptions : []
+    const selectedModel = options.find((m) => m.id === prompt.model)
+    const groups = hasByokKeys ? providerModelGroups : trialProviderModelGroups
+    const loading = hasByokKeys ? byokModelsLoading : trialModelsLoading
 
     return (
-        <>
-            {trialModelsLoading && !options.length ? (
-                <ModelPickerDropdown
-                    model={prompt.model}
-                    selectedProviderKeyId={null}
-                    onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
-                    groups={trialProviderModelGroups}
-                    loading={trialModelsLoading}
-                    footerLink={getModelPickerFooterLink(false)}
-                    data-attr={`playground-model-selector-${promptId}`}
-                />
-            ) : (
-                <ModelPickerDropdown
-                    model={prompt.model}
-                    selectedProviderKeyId={null}
-                    onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
-                    groups={trialProviderModelGroups}
-                    loading={trialModelsLoading}
-                    footerLink={getModelPickerFooterLink(false)}
-                    data-attr={`playground-model-selector-${promptId}`}
-                />
-            )}
-            {options.length === 0 && !modelOptionsLoading && (
-                <div className="mt-1">
-                    <p className="text-xs text-danger">{errorMessage || 'No models available.'}</p>
-                    <button
-                        type="button"
-                        className="text-xs text-link mt-1 underline"
-                        onClick={() => loadModelOptions()}
-                    >
-                        Retry
-                    </button>
-                </div>
-            )}
-        </>
+        <ModelPickerDropdown
+            model={prompt.model}
+            selectedProviderKeyId={prompt.selectedProviderKeyId}
+            onSelect={(modelId, providerKeyId) => setModel(modelId, providerKeyId, promptId)}
+            groups={groups}
+            loading={loading}
+            footerLink={getModelPickerFooterLink(hasByokKeys)}
+            selectedModelName={selectedModel?.name}
+            data-attr={`playground-model-selector-${promptId}`}
+        />
     )
 }
 

--- a/products/llm_analytics/frontend/ModelPicker.tsx
+++ b/products/llm_analytics/frontend/ModelPicker.tsx
@@ -9,7 +9,7 @@ import { urls } from '~/scenes/urls'
 
 import { LLMProviderIcon } from './LLMProviderIcon'
 import { type ModelOption, type ProviderModelGroup } from './modelPickerLogic'
-import { type LLMProvider } from './settings/llmProviderKeysLogic'
+import { type LLMProvider, toLLMProvider } from './settings/llmProviderKeysLogic'
 
 const PROVIDER_SETTINGS_URL = urls.settings('environment-llm-analytics', 'llm-analytics-byok')
 
@@ -21,7 +21,7 @@ export function getModelPickerFooterLink(hasByokKeys: boolean): { label: string;
 }
 
 export function parseTrialProviderKeyId(providerKeyId: string): LLMProvider | null {
-    return providerKeyId.startsWith('trial:') ? (providerKeyId.slice(6) as LLMProvider) || null : null
+    return providerKeyId.startsWith('trial:') ? toLLMProvider(providerKeyId.slice(6)) : null
 }
 
 export interface ModelPickerProps {

--- a/products/llm_analytics/frontend/ModelPicker.tsx
+++ b/products/llm_analytics/frontend/ModelPicker.tsx
@@ -1,53 +1,102 @@
-import { useActions, useMountedLogic, useValues } from 'kea'
+import { useMemo, useState } from 'react'
 
 import { IconChevronDown, IconChevronRight } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
 import { LemonMenu, LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
-import { urls } from 'scenes/urls'
 
-import { byokModelPickerLogic } from './byokModelPickerLogic'
-import { ModelOption } from './llmAnalyticsPlaygroundLogic'
+import { urls } from '~/scenes/urls'
+
 import { LLMProviderIcon } from './LLMProviderIcon'
+import { type ModelOption, type ProviderModelGroup } from './modelPickerLogic'
+import { type LLMProvider } from './settings/llmProviderKeysLogic'
 
-export interface ByokModelPickerProps {
+const PROVIDER_SETTINGS_URL = urls.settings('environment-llm-analytics', 'llm-analytics-byok')
+
+export function getModelPickerFooterLink(hasByokKeys: boolean): { label: string; to: string } {
+    return {
+        label: hasByokKeys ? 'Configure AI providers' : 'Add your own API keys',
+        to: PROVIDER_SETTINGS_URL,
+    }
+}
+
+export function parseTrialProviderKeyId(providerKeyId: string): LLMProvider | null {
+    return providerKeyId.startsWith('trial:') ? (providerKeyId.slice(6) as LLMProvider) || null : null
+}
+
+export interface ModelPickerProps {
     model: string
     selectedProviderKeyId: string | null
     onSelect: (modelId: string, providerKeyId: string) => void
+    groups: ProviderModelGroup[]
+    loading?: boolean
+    footerLink?: { label: string; to: string } | null
     placeholder?: string
     selectedModelName?: string
     'data-attr'?: string
 }
 
-export function ByokModelPicker({
+export function findSelectedProvider(
+    groups: ProviderModelGroup[],
+    model: string,
+    providerKeyId: string | null
+): LLMProvider | null {
+    // Try exact match on providerKeyId first
+    const exactMatch = groups.find((g) => g.providerKeyId === providerKeyId && g.models.some((m) => m.id === model))
+    if (exactMatch) {
+        return exactMatch.provider
+    }
+    // Fall back to matching by model id alone (e.g., trial mode where providerKeyId is null)
+    const modelMatch = groups.find((g) => g.models.some((m) => m.id === model))
+    return modelMatch?.provider ?? null
+}
+
+export function filterGroups(groups: ProviderModelGroup[], search: string): ProviderModelGroup[] {
+    if (!search) {
+        return groups
+    }
+    const lower = search.toLowerCase()
+    return groups
+        .map((group) => ({
+            ...group,
+            models: group.models.filter(
+                (m) => m.name.toLowerCase().includes(lower) || m.id.toLowerCase().includes(lower)
+            ),
+        }))
+        .filter((group) => group.models.length > 0)
+}
+
+export function ModelPicker({
     model,
     selectedProviderKeyId,
     onSelect,
+    groups,
+    loading = false,
+    footerLink,
     placeholder = 'Select model',
     selectedModelName,
     'data-attr': dataAttr,
-}: ByokModelPickerProps): JSX.Element {
-    useMountedLogic(byokModelPickerLogic)
-    const {
-        search,
-        filteredProviderModelGroups,
-        selectedProviderForModel,
-        byokModelsLoading,
-        providerKeysLoading,
-        isProviderExpanded,
-        hasExplicitExpandState,
-    } = useValues(byokModelPickerLogic)
-    const { setSearch, clearSearch, toggleProviderExpanded } = useActions(byokModelPickerLogic)
+}: ModelPickerProps): JSX.Element {
+    const [search, setSearch] = useState('')
+    const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({})
 
-    const selectedProvider = selectedProviderForModel(model, selectedProviderKeyId)
+    const filteredGroups = useMemo(() => filterGroups(groups, search), [groups, search])
+    const selectedProvider = useMemo(
+        () => findSelectedProvider(groups, model, selectedProviderKeyId),
+        [groups, model, selectedProviderKeyId]
+    )
+
+    const toggleProviderExpanded = (providerKeyId: string): void => {
+        setExpandedProviders((prev) => ({ ...prev, [providerKeyId]: !prev[providerKeyId] }))
+    }
 
     const handleVisibilityChange = (visible: boolean): void => {
         if (!visible) {
-            clearSearch()
+            setSearch('')
         }
     }
 
-    if (byokModelsLoading || providerKeysLoading) {
+    if (loading) {
         return <LemonSkeleton className="h-10" />
     }
 
@@ -69,7 +118,7 @@ export function ByokModelPicker({
                 </div>
             ),
         },
-        ...filteredProviderModelGroups.map((group): LemonMenuItems[number] => {
+        ...filteredGroups.map((group): LemonMenuItems[number] => {
             if (group.disabled) {
                 return {
                     icon: <LLMProviderIcon provider={group.provider} />,
@@ -78,13 +127,15 @@ export function ByokModelPicker({
                 }
             }
 
-            const isActiveGroup = group.providerKeyId === selectedProviderKeyId
+            const isActiveGroup =
+                group.providerKeyId === selectedProviderKeyId ||
+                (selectedProviderKeyId === null && group.models.some((m) => m.id === model))
 
             const buildModelItem = (m: ModelOption): LemonMenuItem => ({
                 icon: <LLMProviderIcon provider={group.provider} />,
                 label: m.name,
                 tooltip: m.description || undefined,
-                active: isActiveGroup && m.id === model,
+                active: m.id === model && isActiveGroup,
                 onClick: () => onSelect(m.id, group.providerKeyId),
             })
 
@@ -93,7 +144,6 @@ export function ByokModelPicker({
             const hasOther = other.length > 0
             const hasRecommended = recommended.length > 0
 
-            // When searching or no split needed, show all models flat
             if (isSearching || !hasOther || !hasRecommended) {
                 return {
                     icon: <LLMProviderIcon provider={group.provider} />,
@@ -106,9 +156,8 @@ export function ByokModelPicker({
             // Auto-expand when the selected model is in the collapsed section,
             // but only as a default — once the user explicitly toggles, respect their choice.
             const selectedIsHidden = isActiveGroup && other.some((m) => m.id === model)
-            const expanded = hasExplicitExpandState(group.providerKeyId)
-                ? isProviderExpanded(group.providerKeyId)
-                : selectedIsHidden
+            const hasExplicitState = group.providerKeyId in expandedProviders
+            const expanded = hasExplicitState ? !!expandedProviders[group.providerKeyId] : selectedIsHidden
 
             return {
                 icon: <LLMProviderIcon provider={group.provider} />,
@@ -137,15 +186,19 @@ export function ByokModelPicker({
                 ],
             }
         }),
-        {
-            label: () => (
-                <div className="px-2 py-1.5 border-t">
-                    <Link to={urls.settings('environment-llm-analytics', 'llm-analytics-byok')} className="text-xs">
-                        Configure AI providers
-                    </Link>
-                </div>
-            ),
-        },
+        ...(footerLink
+            ? [
+                  {
+                      label: () => (
+                          <div className="px-2 py-1.5 border-t">
+                              <Link to={footerLink.to} className="text-xs">
+                                  {footerLink.label}
+                              </Link>
+                          </div>
+                      ),
+                  },
+              ]
+            : []),
     ]
 
     return (

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -9,8 +9,6 @@ import {
     LemonButton,
     LemonDivider,
     LemonInput,
-    LemonSearchableSelect,
-    LemonSelect,
     LemonSkeleton,
     LemonSwitch,
     LemonTag,
@@ -30,15 +28,9 @@ import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBread
 import { urls } from '~/scenes/urls'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
-import { ByokModelPicker } from '../ByokModelPicker'
-import { byokModelPickerLogic } from '../byokModelPickerLogic'
-import { LLM_PROVIDER_SELECT_OPTIONS } from '../LLMProviderIcon'
-import { LLMProvider } from '../settings/llmProviderKeysLogic'
-import {
-    providerKeyStateIssueDescription,
-    providerKeyStateSuffix,
-    providerLabel,
-} from '../settings/providerKeyStateUtils'
+import { getModelPickerFooterLink, ModelPicker } from '../ModelPicker'
+import { modelPickerLogic } from '../modelPickerLogic'
+import { providerKeyStateIssueDescription, providerLabel } from '../settings/providerKeyStateUtils'
 import { EvaluationPromptEditor } from './components/EvaluationPromptEditor'
 import { EvaluationRunsTable } from './components/EvaluationRunsTable'
 import { EvaluationTriggers } from './components/EvaluationTriggers'
@@ -300,21 +292,25 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
 }
 
 function EvaluationModelPicker(): JSX.Element {
-    const { hasByokKeys, byokModels } = useValues(byokModelPickerLogic)
     const {
-        selectedProvider,
-        selectedKeyId,
-        selectedModel,
-        keysForSelectedProvider,
-        availableModels,
-        availableModelsLoading,
+        hasByokKeys,
+        byokModels,
+        trialModels,
+        providerModelGroups,
+        trialProviderModelGroups,
+        byokModelsLoading,
+        trialModelsLoading,
         providerKeysLoading,
-        selectedPickerProviderKeyId,
-    } = useValues(llmEvaluationLogic)
-    const { setSelectedProvider, setSelectedKeyId, setSelectedModel, selectModelFromPicker } =
-        useActions(llmEvaluationLogic)
+    } = useValues(modelPickerLogic)
+    const { selectedModel, selectedPickerProviderKeyId } = useValues(llmEvaluationLogic)
+    const { selectModelFromPicker } = useActions(llmEvaluationLogic)
 
-    const selectedModelName = byokModels.find((m) => m.id === selectedModel)?.name
+    const allModels = hasByokKeys ? byokModels : trialModels
+    const selectedModelName = allModels.find((m) => m.id === selectedModel)?.name
+    const groups = hasByokKeys ? providerModelGroups : trialProviderModelGroups
+    const loading = hasByokKeys ? byokModelsLoading || providerKeysLoading : trialModelsLoading
+
+    const footerLink = getModelPickerFooterLink(hasByokKeys)
 
     return (
         <div className="bg-bg-light border rounded p-6">
@@ -324,80 +320,18 @@ function EvaluationModelPicker(): JSX.Element {
             </p>
 
             <div className="space-y-4">
-                {hasByokKeys ? (
-                    <Field name="model" label="Model">
-                        <ByokModelPicker
-                            model={selectedModel}
-                            selectedProviderKeyId={selectedPickerProviderKeyId}
-                            onSelect={selectModelFromPicker}
-                            selectedModelName={selectedModelName}
-                            data-attr="evaluation-model-selector"
-                        />
-                    </Field>
-                ) : (
-                    <>
-                        <Field name="provider" label="Provider">
-                            <LemonSelect
-                                value={selectedProvider}
-                                onChange={(value) => setSelectedProvider(value as LLMProvider)}
-                                options={LLM_PROVIDER_SELECT_OPTIONS}
-                                fullWidth
-                            />
-                        </Field>
-
-                        <Field
-                            name="provider_key"
-                            label={
-                                <div className="flex items-center gap-1">
-                                    <span>API key</span>
-                                    <span className="text-muted">-</span>
-                                    <Link to={urls.settings('environment-llm-analytics', 'llm-analytics-byok')}>
-                                        Manage
-                                    </Link>
-                                </div>
-                            }
-                        >
-                            <LemonSelect
-                                value={selectedKeyId || 'posthog_default'}
-                                onChange={(value) => setSelectedKeyId(value === 'posthog_default' ? null : value)}
-                                options={[
-                                    ...(keysForSelectedProvider.length === 0
-                                        ? [{ value: 'posthog_default', label: 'PostHog default' }]
-                                        : []),
-                                    ...keysForSelectedProvider.map((key) => ({
-                                        value: key.id,
-                                        label: `${key.name}${providerKeyStateSuffix(key.state)}`,
-                                    })),
-                                ]}
-                                loading={providerKeysLoading}
-                                fullWidth
-                            />
-                        </Field>
-
-                        <Field name="model" label="Model">
-                            <>
-                                <LemonSearchableSelect
-                                    value={selectedModel || undefined}
-                                    onChange={(value) => setSelectedModel(value || '')}
-                                    options={availableModels.map((model) => ({
-                                        value: model.id,
-                                        label: model.id,
-                                        disabledReason:
-                                            !selectedKeyId && !model.posthog_available ? 'Requires API key' : undefined,
-                                    }))}
-                                    searchPlaceholder="Search models..."
-                                    loading={availableModelsLoading}
-                                    placeholder="Select a model"
-                                    fullWidth
-                                    disabledReason={!selectedKeyId ? 'Select a provider key first' : undefined}
-                                />
-                                {!selectedKeyId && (
-                                    <p className="text-xs text-muted mt-1">Add your own API key for model selection</p>
-                                )}
-                            </>
-                        </Field>
-                    </>
-                )}
+                <Field name="model" label="Model">
+                    <ModelPicker
+                        model={selectedModel}
+                        selectedProviderKeyId={selectedPickerProviderKeyId}
+                        onSelect={selectModelFromPicker}
+                        groups={groups}
+                        loading={loading}
+                        footerLink={footerLink}
+                        selectedModelName={selectedModelName}
+                        data-attr="evaluation-model-selector"
+                    />
+                </Field>
             </div>
         </div>
     )

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -268,28 +268,6 @@ describe('llmEvaluationLogic', () => {
             })
         })
 
-        describe('providerKeysByProvider', () => {
-            beforeEach(() => {
-                logic = llmEvaluationLogic({ evaluationId: 'new' })
-                logic.mount()
-            })
-
-            it('groups keys by provider', async () => {
-                await expectLogic(keysLogic).toDispatchActions(['loadProviderKeysSuccess'])
-
-                const byProvider = logic.values.providerKeysByProvider
-                expect(byProvider.openai).toHaveLength(1)
-                expect(byProvider.openai[0].id).toBe('key-1')
-                expect(byProvider.anthropic).toHaveLength(1)
-                expect(byProvider.anthropic[0].id).toBe('key-2')
-                expect(byProvider.gemini).toHaveLength(0)
-                expect(byProvider.openrouter).toHaveLength(1)
-                expect(byProvider.openrouter[0].id).toBe('key-3')
-                expect(byProvider.fireworks).toHaveLength(1)
-                expect(byProvider.fireworks[0].id).toBe('key-4')
-            })
-        })
-
         describe('evaluationProviderKeyIssue', () => {
             beforeEach(() => {
                 logic = llmEvaluationLogic({ evaluationId: 'eval-123' })
@@ -661,45 +639,55 @@ describe('llmEvaluationLogic', () => {
         })
     })
 
-    describe('provider selection', () => {
+    describe('selectModelFromPicker', () => {
         beforeEach(() => {
             logic = llmEvaluationLogic({ evaluationId: 'new' })
             logic.mount()
         })
 
-        it('setSelectedProvider dispatches loadAvailableModels', async () => {
+        it('sets model configuration from BYOK provider key', async () => {
             await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+            await expectLogic(keysLogic).toDispatchActions(['loadProviderKeysSuccess'])
 
-            logic.actions.setSelectedProvider('anthropic')
+            logic.actions.selectModelFromPicker('gpt-5', 'key-1')
 
             await expectLogic(logic).toMatchValues({
-                selectedProvider: 'anthropic',
+                selectedModel: 'gpt-5',
+                evaluation: expect.objectContaining({
+                    model_configuration: {
+                        provider: 'openai',
+                        model: 'gpt-5',
+                        provider_key_id: 'key-1',
+                    },
+                }),
             })
         })
 
-        it('setSelectedKeyId resets model selection', async () => {
+        it('sets model configuration from trial provider key', async () => {
             await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
 
-            logic.actions.setSelectedModel('gpt-5-mini')
-
-            await expectLogic(logic).toMatchValues({ selectedModel: 'gpt-5-mini' })
-
-            logic.actions.setSelectedKeyId('key-1')
-
-            await expectLogic(logic).toMatchValues({ selectedModel: '' })
-        })
-
-        it('setSelectedModel updates model configuration', async () => {
-            await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
-
-            logic.actions.setSelectedModel('gpt-5-mini')
+            logic.actions.selectModelFromPicker('gpt-5', 'trial:openai')
 
             await expectLogic(logic).toMatchValues({
-                selectedModel: 'gpt-5-mini',
+                selectedModel: 'gpt-5',
                 evaluation: expect.objectContaining({
-                    model_configuration: expect.objectContaining({
-                        model: 'gpt-5-mini',
-                    }),
+                    model_configuration: {
+                        provider: 'openai',
+                        model: 'gpt-5',
+                        provider_key_id: null,
+                    },
+                }),
+            })
+        })
+
+        it('ignores empty modelId', async () => {
+            await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+
+            logic.actions.selectModelFromPicker('', 'key-1')
+
+            await expectLogic(logic).toMatchValues({
+                evaluation: expect.objectContaining({
+                    model_configuration: null,
                 }),
             })
         })

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -12,7 +12,8 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { LLMProvider, LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
+import { parseTrialProviderKeyId } from '../ModelPicker'
+import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
@@ -27,11 +28,6 @@ import {
     EvaluationSummaryFilter,
     ModelConfiguration,
 } from './types'
-
-export interface AvailableModel {
-    id: string
-    posthog_available: boolean
-}
 
 export interface LLMEvaluationLogicProps {
     evaluationId: string
@@ -56,7 +52,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         ],
         actions: [
             llmProviderKeysLogic,
-            ['loadProviderKeys', 'loadProviderKeysSuccess'],
+            ['loadProviderKeys'],
             signalSourcesLogic,
             [
                 'loadSourceConfigs',
@@ -92,9 +88,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         refreshEvaluationRuns: true,
 
         // Model selection actions
-        setSelectedProvider: (provider: LLMProvider) => ({ provider }),
-        setSelectedKeyId: (keyId: string | null) => ({ keyId }),
-        setSelectedModel: (model: string) => ({ model }),
         selectModelFromPicker: (modelId: string, providerKeyId: string) => ({ modelId, providerKeyId }),
 
         // Evaluation summary actions
@@ -120,31 +113,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                         evaluationId: props.evaluationId,
                         forceRefresh: values.isForceRefresh,
                     })
-                },
-            },
-        ],
-        availableModels: [
-            [] as AvailableModel[],
-            {
-                loadAvailableModels: async ({
-                    provider,
-                    keyId,
-                }: {
-                    provider: LLMProvider
-                    keyId: string | null
-                }): Promise<AvailableModel[]> => {
-                    const teamId = teamLogic.values.currentTeamId
-                    if (!teamId) {
-                        return []
-                    }
-                    const params = new URLSearchParams({ provider })
-                    if (keyId) {
-                        params.append('key_id', keyId)
-                    }
-                    const response = await api.get(
-                        `/api/environments/${teamId}/llm_analytics/models/?${params.toString()}`
-                    )
-                    return response.models
                 },
             },
         ],
@@ -203,24 +171,9 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 saveEvaluationSuccess: (_, { evaluation }) => evaluation,
             },
         ],
-        selectedProvider: [
-            'openai' as LLMProvider,
-            {
-                setSelectedProvider: (_, { provider }) => provider,
-                loadEvaluationSuccess: (_, { evaluation }) => evaluation?.model_configuration?.provider || 'openai',
-            },
-        ],
-        selectedKeyId: [
-            null as string | null,
-            {
-                setSelectedKeyId: (_, { keyId }) => keyId,
-                loadEvaluationSuccess: (_, { evaluation }) => evaluation?.model_configuration?.provider_key_id || null,
-            },
-        ],
         selectedModel: [
             '' as string,
             {
-                setSelectedModel: (_, { model }) => model,
                 selectModelFromPicker: (_, { modelId }) => modelId,
                 loadEvaluationSuccess: (_, { evaluation }) => evaluation?.model_configuration?.model || '',
             },
@@ -354,48 +307,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             }
         },
 
-        loadEvaluationSuccess: ({ evaluation }) => {
-            // Load available models for the current provider/key combination
-            if (evaluation) {
-                const provider = evaluation.model_configuration?.provider || 'openai'
-                let keyId = evaluation.model_configuration?.provider_key_id || null
-
-                // Auto-select user's first key if none set (for new OR existing evals)
-                if (!keyId) {
-                    const keysForProvider = values.providerKeysByProvider[provider] || []
-                    if (keysForProvider.length > 0) {
-                        keyId = keysForProvider[0].id
-                        actions.setSelectedKeyId(keyId)
-                    }
-                }
-
-                actions.loadAvailableModels({ provider, keyId })
-            }
-        },
-
-        loadProviderKeysSuccess: () => {
-            const evaluation = values.evaluation
-
-            // For new evals without a key, auto-select first key
-            if (evaluation && !evaluation.id && !values.selectedKeyId) {
-                const keysForProvider = values.providerKeysByProvider[values.selectedProvider] || []
-                if (keysForProvider.length > 0) {
-                    const keyId = keysForProvider[0].id
-                    actions.setSelectedKeyId(keyId)
-                    actions.loadAvailableModels({ provider: values.selectedProvider, keyId })
-                }
-            }
-
-            // For existing evals, if selected key no longer exists, reload evaluation to get fresh data
-            if (evaluation && evaluation.id && values.selectedKeyId) {
-                const keysForProvider = values.providerKeysByProvider[values.selectedProvider] || []
-                const keyExists = keysForProvider.some((key) => key.id === values.selectedKeyId)
-                if (!keyExists) {
-                    actions.loadEvaluation()
-                }
-            }
-        },
-
         refreshEvaluationRuns: () => {
             actions.loadEvaluationRuns()
         },
@@ -505,63 +416,26 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             }
         },
 
-        setSelectedProvider: ({ provider }) => {
-            // When provider changes, auto-select user's first key if they have one, otherwise use PostHog default
-            const keysForProvider = values.providerKeysByProvider[provider] || []
-            const keyId = keysForProvider.length > 0 ? keysForProvider[0].id : null
-            actions.loadAvailableModels({ provider, keyId })
-            actions.setSelectedKeyId(keyId)
-            actions.setSelectedModel('')
-        },
-
-        setSelectedKeyId: ({ keyId }) => {
-            // When key changes, reload available models and reset model selection
-            const provider = values.selectedProvider
-            actions.loadAvailableModels({ provider, keyId })
-            actions.setSelectedModel('')
-        },
-
-        setSelectedModel: ({ model }) => {
-            // When model is selected, update the model configuration
-            if (model) {
-                const modelConfig: ModelConfiguration = {
-                    provider: values.selectedProvider,
-                    model,
-                    provider_key_id: values.selectedKeyId,
-                }
-                actions.setModelConfiguration(modelConfig)
-            } else {
-                actions.setModelConfiguration(null)
-            }
-        },
-
         selectModelFromPicker: ({ modelId, providerKeyId }) => {
+            if (!modelId) {
+                return
+            }
+            const trialProvider = parseTrialProviderKeyId(providerKeyId)
+            if (trialProvider) {
+                actions.setModelConfiguration({
+                    provider: trialProvider,
+                    model: modelId,
+                    provider_key_id: null,
+                })
+                return
+            }
             const key = values.providerKeys.find((k: LLMProviderKey) => k.id === providerKeyId)
-            if (key && modelId) {
+            if (key) {
                 actions.setModelConfiguration({
                     provider: key.provider,
                     model: modelId,
                     provider_key_id: providerKeyId,
                 })
-            }
-        },
-
-        loadAvailableModelsSuccess: ({ availableModels }) => {
-            // If the currently selected model is not in the available models, reset it
-            if (values.selectedModel && !availableModels.some((m: AvailableModel) => m.id === values.selectedModel)) {
-                actions.setSelectedModel('')
-            }
-            // Auto-select the first available model if none selected
-            if (!values.selectedModel && availableModels.length > 0) {
-                // When using PostHog key (no selectedKeyId), pick first PostHog-available model
-                if (!values.selectedKeyId) {
-                    const firstPostHogModel = availableModels.find((m: AvailableModel) => m.posthog_available)
-                    if (firstPostHogModel) {
-                        actions.setSelectedModel(firstPostHogModel.id)
-                    }
-                } else {
-                    actions.setSelectedModel(availableModels[0].id)
-                }
             }
         },
     })),
@@ -601,31 +475,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     evaluation.conditions.every((c) => c.rollout_percentage > 0 && c.rollout_percentage <= 100)
                 )
             },
-        ],
-
-        providerKeysByProvider: [
-            (s) => [s.providerKeys],
-            (providerKeys: LLMProviderKey[]) => {
-                const byProvider: Record<LLMProvider, LLMProviderKey[]> = {
-                    openai: [],
-                    anthropic: [],
-                    gemini: [],
-                    openrouter: [],
-                    fireworks: [],
-                }
-                for (const key of providerKeys) {
-                    if (key.provider in byProvider) {
-                        byProvider[key.provider as LLMProvider].push(key)
-                    }
-                }
-                return byProvider
-            },
-        ],
-
-        keysForSelectedProvider: [
-            (s) => [s.providerKeysByProvider, s.selectedProvider],
-            (providerKeysByProvider: Record<LLMProvider, LLMProviderKey[]>, selectedProvider: LLMProvider) =>
-                providerKeysByProvider[selectedProvider] || [],
         ],
 
         evaluationProviderKeyIssue: [

--- a/products/llm_analytics/frontend/llmAnalyticsPlaygroundLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsPlaygroundLogic.ts
@@ -10,27 +10,12 @@ import { isObject, uuid } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { byokModelPickerLogic } from './byokModelPickerLogic'
 import type { llmAnalyticsPlaygroundLogicType } from './llmAnalyticsPlaygroundLogicType'
-import { LLMProvider, LLMProviderKey, llmProviderKeysLogic, providerSortIndex } from './settings/llmProviderKeysLogic'
+import { type ModelOption, type ProviderModelGroup, modelPickerLogic } from './modelPickerLogic'
+import { LLMProviderKey, llmProviderKeysLogic, providerSortIndex } from './settings/llmProviderKeysLogic'
 import { normalizeRole } from './utils'
 
-export interface ModelOption {
-    id: string
-    name: string
-    provider: string
-    description: string
-    providerKeyId?: string
-    isRecommended?: boolean
-}
-
-export interface ProviderModelGroup {
-    provider: LLMProvider
-    providerKeyId: string
-    label: string
-    models: ModelOption[]
-    disabled?: boolean
-}
+export type { ModelOption, ProviderModelGroup }
 
 enum NormalizedMessageRole {
     User = 'user',
@@ -304,8 +289,8 @@ export const llmAnalyticsPlaygroundLogic = kea<llmAnalyticsPlaygroundLogicType>(
     path(['products', 'llm_analytics', 'frontend', 'llmAnalyticsPlaygroundLogic']),
 
     connect(() => ({
-        values: [byokModelPickerLogic, ['byokModels', 'hasByokKeys'], llmProviderKeysLogic, ['providerKeys']],
-        actions: [byokModelPickerLogic, ['loadByokModelsSuccess']],
+        values: [modelPickerLogic, ['byokModels', 'hasByokKeys'], llmProviderKeysLogic, ['providerKeys']],
+        actions: [modelPickerLogic, ['loadByokModelsSuccess']],
     })),
 
     actions({

--- a/products/llm_analytics/frontend/modelPickerLogic.test.ts
+++ b/products/llm_analytics/frontend/modelPickerLogic.test.ts
@@ -3,7 +3,13 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { byokModelPickerLogic } from './byokModelPickerLogic'
+import { filterGroups, findSelectedProvider, parseTrialProviderKeyId } from './ModelPicker'
+import {
+    buildTrialProviderModelGroups,
+    modelPickerLogic,
+    type ModelOption,
+    type ProviderModelGroup,
+} from './modelPickerLogic'
 
 // API responses use snake_case is_recommended
 const BYOK_OPENAI_MODELS = [
@@ -27,8 +33,8 @@ const BYOK_ANTHROPIC_MODELS = [
     { id: 'claude-sonnet-4', name: 'Claude Sonnet 4', provider: 'Anthropic', description: '', is_recommended: true },
 ]
 
-describe('byokModelPickerLogic', () => {
-    let logic: ReturnType<typeof byokModelPickerLogic.build>
+describe('modelPickerLogic', () => {
+    let logic: ReturnType<typeof modelPickerLogic.build>
 
     beforeEach(() => {
         initKeaTests()
@@ -57,7 +63,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -91,7 +97,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -117,7 +123,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -149,7 +155,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -184,7 +190,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -219,7 +225,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -241,7 +247,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -260,7 +266,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -294,7 +300,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -331,7 +337,7 @@ describe('byokModelPickerLogic', () => {
                 },
             })
 
-            logic = byokModelPickerLogic()
+            logic = modelPickerLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
 
@@ -342,171 +348,94 @@ describe('byokModelPickerLogic', () => {
             expect(labels).toEqual(['OpenAI (Production)', 'OpenAI (Staging)'])
         })
     })
+})
 
-    describe('selectedProviderForModel', () => {
-        it('should return the provider for a matching model and key', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': {
-                        results: [
-                            { id: 'key-1', provider: 'openai', name: 'Key', state: 'ok' },
-                            { id: 'key-2', provider: 'anthropic', name: 'Key', state: 'ok' },
-                        ],
-                    },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
-                    },
-                    '/api/llm_proxy/models/': (req: any) => {
-                        const keyId = req.url.searchParams.get('provider_key_id')
-                        if (keyId === 'key-1') {
-                            return [200, BYOK_OPENAI_MODELS]
-                        }
-                        if (keyId === 'key-2') {
-                            return [200, BYOK_ANTHROPIC_MODELS]
-                        }
-                        return [200, []]
-                    },
-                },
-            })
+const MODEL_A: ModelOption = { id: 'gpt-5', name: 'GPT-5', provider: 'OpenAI', description: '' }
+const MODEL_B: ModelOption = { id: 'claude-sonnet-4', name: 'Claude Sonnet 4', provider: 'Anthropic', description: '' }
+const MODEL_C: ModelOption = {
+    id: 'gpt-4.1',
+    name: 'GPT-4.1',
+    provider: 'OpenAI',
+    description: '',
+    isRecommended: true,
+}
 
-            logic = byokModelPickerLogic()
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
+const GROUPS: ProviderModelGroup[] = [
+    { provider: 'openai', providerKeyId: 'key-1', label: 'OpenAI', models: [MODEL_A, MODEL_C] },
+    { provider: 'anthropic', providerKeyId: 'key-2', label: 'Anthropic', models: [MODEL_B] },
+]
 
-            expect(logic.values.selectedProviderForModel('gpt-4.1', 'key-1')).toBe('openai')
-            expect(logic.values.selectedProviderForModel('claude-sonnet-4', 'key-2')).toBe('anthropic')
-            expect(logic.values.selectedProviderForModel('nonexistent', 'key-1')).toBeNull()
-            expect(logic.values.selectedProviderForModel('gpt-4.1', 'wrong-key')).toBeNull()
-        })
+describe('parseTrialProviderKeyId', () => {
+    it.each([
+        ['trial:openai', 'openai'],
+        ['trial:anthropic', 'anthropic'],
+        ['key-123', null],
+        ['', null],
+        ['trial:', null],
+    ])('parseTrialProviderKeyId(%s) => %s', (input, expected) => {
+        expect(parseTrialProviderKeyId(input)).toBe(expected)
+    })
+})
+
+describe('findSelectedProvider', () => {
+    it.each([
+        ['exact match by providerKeyId and model', 'gpt-5', 'key-1', 'openai'],
+        ['fallback to model-only match when providerKeyId is null', 'claude-sonnet-4', null, 'anthropic'],
+        ['returns null when model not found', 'unknown-model', 'key-1', null],
+        ['returns null for empty groups', 'gpt-5', 'key-1', null],
+    ] as const)('%s', (_, model, providerKeyId, expected) => {
+        const groups = expected === null && model === 'gpt-5' ? [] : GROUPS
+        expect(findSelectedProvider(groups as ProviderModelGroup[], model, providerKeyId)).toBe(expected)
+    })
+})
+
+describe('filterGroups', () => {
+    it('returns all groups when search is empty', () => {
+        expect(filterGroups(GROUPS, '')).toBe(GROUPS)
     })
 
-    describe('filteredProviderModelGroups', () => {
-        it('should filter models by search string matching name or id', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': {
-                        results: [{ id: 'key-1', provider: 'openai', name: 'Key', state: 'ok' }],
-                    },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
-                    },
-                    '/api/llm_proxy/models/': (req: any) => {
-                        if (req.url.searchParams.get('provider_key_id') === 'key-1') {
-                            return [200, BYOK_OPENAI_MODELS]
-                        }
-                        return [200, []]
-                    },
-                },
-            })
+    it('filters models by name (case-insensitive)', () => {
+        const result = filterGroups(GROUPS, 'claude')
+        expect(result).toHaveLength(1)
+        expect(result[0].provider).toBe('anthropic')
+    })
 
-            logic = byokModelPickerLogic()
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
+    it('filters models by id', () => {
+        const result = filterGroups(GROUPS, 'gpt-4.1')
+        expect(result).toHaveLength(1)
+        expect(result[0].models).toHaveLength(1)
+        expect(result[0].models[0].id).toBe('gpt-4.1')
+    })
 
-            logic.actions.setSearch('gpt-5')
+    it('removes groups with no matching models', () => {
+        expect(filterGroups(GROUPS, 'nonexistent')).toHaveLength(0)
+    })
+})
 
-            const filtered = logic.values.filteredProviderModelGroups
-            expect(filtered).toHaveLength(1)
-            expect(filtered[0].models).toHaveLength(1)
-            expect(filtered[0].models[0].id).toBe('gpt-5')
-        })
+describe('buildTrialProviderModelGroups', () => {
+    it('groups models by provider with trial: prefix keys', () => {
+        const models: ModelOption[] = [MODEL_A, MODEL_C, MODEL_B]
+        const groups = buildTrialProviderModelGroups(models)
 
-        it('should return all groups when search is empty', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': {
-                        results: [{ id: 'key-1', provider: 'openai', name: 'Key', state: 'ok' }],
-                    },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
-                    },
-                    '/api/llm_proxy/models/': (req: any) => {
-                        if (req.url.searchParams.get('provider_key_id') === 'key-1') {
-                            return [200, BYOK_OPENAI_MODELS]
-                        }
-                        return [200, []]
-                    },
-                },
-            })
+        expect(groups).toHaveLength(2)
+        expect(groups[0].provider).toBe('openai')
+        expect(groups[0].providerKeyId).toBe('trial:openai')
+        expect(groups[0].models).toHaveLength(2)
+        expect(groups[1].provider).toBe('anthropic')
+        expect(groups[1].providerKeyId).toBe('trial:anthropic')
+        expect(groups[1].models).toHaveLength(1)
+    })
 
-            logic = byokModelPickerLogic()
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
+    it('returns empty array for empty input', () => {
+        expect(buildTrialProviderModelGroups([])).toEqual([])
+    })
 
-            expect(logic.values.filteredProviderModelGroups).toEqual(logic.values.providerModelGroups)
-        })
-
-        it('should hide disabled groups during search', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': {
-                        results: [
-                            { id: 'key-1', provider: 'openai', name: 'OpenAI Key', state: 'ok' },
-                            { id: 'key-2', provider: 'anthropic', name: 'Anthropic Key', state: 'error' },
-                        ],
-                    },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
-                    },
-                    '/api/llm_proxy/models/': (req: any) => {
-                        if (req.url.searchParams.get('provider_key_id') === 'key-1') {
-                            return [200, BYOK_OPENAI_MODELS]
-                        }
-                        return [200, []]
-                    },
-                },
-            })
-
-            logic = byokModelPickerLogic()
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
-
-            // Without search, disabled group should be present
-            const allGroups = logic.values.filteredProviderModelGroups
-            expect(allGroups.some((g) => g.disabled)).toBe(true)
-
-            // With search, disabled group should be hidden
-            logic.actions.setSearch('gpt')
-            const filtered = logic.values.filteredProviderModelGroups
-            expect(filtered.every((g) => !g.disabled)).toBe(true)
-            expect(filtered).toHaveLength(1)
-            expect(filtered[0].provider).toBe('openai')
-        })
-
-        it('should exclude groups with no matching models', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': {
-                        results: [
-                            { id: 'key-1', provider: 'openai', name: 'OpenAI Key', state: 'ok' },
-                            { id: 'key-2', provider: 'anthropic', name: 'Anthropic Key', state: 'ok' },
-                        ],
-                    },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
-                    },
-                    '/api/llm_proxy/models/': (req: any) => {
-                        const keyId = req.url.searchParams.get('provider_key_id')
-                        if (keyId === 'key-1') {
-                            return [200, BYOK_OPENAI_MODELS]
-                        }
-                        if (keyId === 'key-2') {
-                            return [200, BYOK_ANTHROPIC_MODELS]
-                        }
-                        return [200, []]
-                    },
-                },
-            })
-
-            logic = byokModelPickerLogic()
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
-
-            logic.actions.setSearch('claude')
-
-            const filtered = logic.values.filteredProviderModelGroups
-            expect(filtered).toHaveLength(1)
-            expect(filtered[0].provider).toBe('anthropic')
-        })
+    it('sorts groups by provider order', () => {
+        const models: ModelOption[] = [
+            { ...MODEL_B, provider: 'Anthropic' },
+            { ...MODEL_A, provider: 'OpenAI' },
+        ]
+        const groups = buildTrialProviderModelGroups(models)
+        expect(groups.map((g) => g.provider)).toEqual(['openai', 'anthropic'])
     })
 })

--- a/products/llm_analytics/frontend/modelPickerLogic.ts
+++ b/products/llm_analytics/frontend/modelPickerLogic.ts
@@ -1,10 +1,9 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { afterMount, connect, kea, listeners, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
-import type { byokModelPickerLogicType } from './byokModelPickerLogicType'
-import { ModelOption, ProviderModelGroup } from './llmAnalyticsPlaygroundLogic'
+import type { modelPickerLogicType } from './modelPickerLogicType'
 import {
     LLMProvider,
     LLMProviderKey,
@@ -14,32 +13,49 @@ import {
 } from './settings/llmProviderKeysLogic'
 import { isUnhealthyProviderKeyState, providerKeyStateSuffix } from './settings/providerKeyStateUtils'
 
-export const byokModelPickerLogic = kea<byokModelPickerLogicType>([
-    path(['products', 'llm_analytics', 'frontend', 'byokModelPickerLogic']),
+export interface ModelOption {
+    id: string
+    name: string
+    provider: string
+    description: string
+    providerKeyId?: string
+    isRecommended?: boolean
+}
+
+export interface ProviderModelGroup {
+    provider: LLMProvider
+    providerKeyId: string
+    label: string
+    models: ModelOption[]
+    disabled?: boolean
+}
+
+export function buildTrialProviderModelGroups(models: ModelOption[]): ProviderModelGroup[] {
+    const byProvider: Record<string, ModelOption[]> = {}
+    for (const model of models) {
+        const provider = model.provider || 'Unknown'
+        if (!byProvider[provider]) {
+            byProvider[provider] = []
+        }
+        byProvider[provider].push(model)
+    }
+    return Object.entries(byProvider)
+        .sort(([a], [b]) => providerSortIndex(a) - providerSortIndex(b))
+        .map(([provider, providerModels]) => ({
+            provider: provider.toLowerCase() as LLMProvider,
+            providerKeyId: `trial:${provider.toLowerCase()}`,
+            label: LLM_PROVIDER_LABELS[provider.toLowerCase() as LLMProvider] ?? provider,
+            models: providerModels,
+        }))
+}
+
+export const modelPickerLogic = kea<modelPickerLogicType>([
+    path(['products', 'llm_analytics', 'frontend', 'modelPickerLogic']),
 
     connect(() => ({
         values: [llmProviderKeysLogic, ['providerKeys', 'providerKeysLoading']],
         actions: [llmProviderKeysLogic, ['loadProviderKeysSuccess']],
     })),
-
-    actions({
-        setSearch: (search: string) => ({ search }),
-        clearSearch: true,
-        toggleProviderExpanded: (providerKeyId: string) => ({ providerKeyId }),
-    }),
-
-    reducers({
-        search: ['' as string, { setSearch: (_, { search }) => search, clearSearch: () => '' }],
-        expandedProviders: [
-            {} as Record<string, boolean>,
-            {
-                toggleProviderExpanded: (state, { providerKeyId }) => ({
-                    ...state,
-                    [providerKeyId]: !state[providerKeyId],
-                }),
-            },
-        ],
-    }),
 
     loaders(({ values }) => ({
         byokModels: {
@@ -82,6 +98,21 @@ export const byokModelPickerLogic = kea<byokModelPickerLogicType>([
                 return Array.from(dedupedModels.values())
             },
         },
+        trialModels: {
+            __default: [] as ModelOption[],
+            loadTrialModels: async (): Promise<ModelOption[]> => {
+                const rawModels = (await api.get('/api/llm_proxy/models/')) as (Omit<ModelOption, 'isRecommended'> & {
+                    is_recommended?: boolean
+                })[]
+                return (rawModels ?? []).map((m) => ({
+                    id: m.id,
+                    name: m.name,
+                    provider: m.provider,
+                    description: m.description,
+                    isRecommended: m.is_recommended ?? false,
+                }))
+            },
+        },
     })),
 
     listeners(({ actions }) => ({
@@ -91,6 +122,7 @@ export const byokModelPickerLogic = kea<byokModelPickerLogicType>([
     })),
 
     afterMount(({ actions, values }) => {
+        actions.loadTrialModels()
         if (values.providerKeys.length > 0) {
             actions.loadByokModels()
         }
@@ -100,6 +132,11 @@ export const byokModelPickerLogic = kea<byokModelPickerLogicType>([
         hasByokKeys: [
             (s) => [s.providerKeys],
             (providerKeys: LLMProviderKey[]): boolean => providerKeys.some((k) => k.state === 'ok'),
+        ],
+        trialProviderModelGroups: [
+            (s) => [s.trialModels],
+            (trialModels: ModelOption[]): ProviderModelGroup[] =>
+                buildTrialProviderModelGroups(Array.isArray(trialModels) ? trialModels : []),
         ],
         providerModelGroups: [
             (s) => [s.byokModels, s.providerKeys],
@@ -159,45 +196,6 @@ export const byokModelPickerLogic = kea<byokModelPickerLogicType>([
                     return a.label.localeCompare(b.label)
                 })
             },
-        ],
-        selectedProviderForModel: [
-            (s) => [s.providerModelGroups],
-            (groups: ProviderModelGroup[]) =>
-                (model: string, providerKeyId: string | null): LLMProvider | null => {
-                    const group = groups.find(
-                        (g) => g.providerKeyId === providerKeyId && g.models.some((m) => m.id === model)
-                    )
-                    return group?.provider ?? null
-                },
-        ],
-        filteredProviderModelGroups: [
-            (s) => [s.providerModelGroups, s.search],
-            (groups: ProviderModelGroup[], search: string): ProviderModelGroup[] => {
-                if (!search) {
-                    return groups
-                }
-                const lower = search.toLowerCase()
-                return groups
-                    .map((group) => ({
-                        ...group,
-                        models: group.models.filter(
-                            (m) => m.name.toLowerCase().includes(lower) || m.id.toLowerCase().includes(lower)
-                        ),
-                    }))
-                    .filter((group) => group.models.length > 0)
-            },
-        ],
-        isProviderExpanded: [
-            (s) => [s.expandedProviders],
-            (expandedProviders: Record<string, boolean>) =>
-                (providerKeyId: string): boolean =>
-                    !!expandedProviders[providerKeyId],
-        ],
-        hasExplicitExpandState: [
-            (s) => [s.expandedProviders],
-            (expandedProviders: Record<string, boolean>) =>
-                (providerKeyId: string): boolean =>
-                    providerKeyId in expandedProviders,
         ],
     }),
 ])

--- a/products/llm_analytics/frontend/modelPickerLogic.ts
+++ b/products/llm_analytics/frontend/modelPickerLogic.ts
@@ -5,11 +5,12 @@ import api from 'lib/api'
 
 import type { modelPickerLogicType } from './modelPickerLogicType'
 import {
-    LLMProvider,
+    type LLMProvider,
     LLMProviderKey,
     LLM_PROVIDER_LABELS,
     llmProviderKeysLogic,
     providerSortIndex,
+    toLLMProvider,
 } from './settings/llmProviderKeysLogic'
 import { isUnhealthyProviderKeyState, providerKeyStateSuffix } from './settings/providerKeyStateUtils'
 
@@ -41,12 +42,20 @@ export function buildTrialProviderModelGroups(models: ModelOption[]): ProviderMo
     }
     return Object.entries(byProvider)
         .sort(([a], [b]) => providerSortIndex(a) - providerSortIndex(b))
-        .map(([provider, providerModels]) => ({
-            provider: provider.toLowerCase() as LLMProvider,
-            providerKeyId: `trial:${provider.toLowerCase()}`,
-            label: LLM_PROVIDER_LABELS[provider.toLowerCase() as LLMProvider] ?? provider,
-            models: providerModels,
-        }))
+        .flatMap(([provider, providerModels]) => {
+            const llmProvider = toLLMProvider(provider)
+            if (!llmProvider) {
+                return []
+            }
+            return [
+                {
+                    provider: llmProvider,
+                    providerKeyId: `trial:${llmProvider}`,
+                    label: LLM_PROVIDER_LABELS[llmProvider] ?? provider,
+                    models: providerModels,
+                },
+            ]
+        })
 }
 
 export const modelPickerLogic = kea<modelPickerLogicType>([

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -18,12 +18,28 @@ export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
     fireworks: 'Fireworks',
 }
 
+const LLM_PROVIDERS = new Set<string>(Object.keys(LLM_PROVIDER_LABELS))
+
+export function isLLMProvider(value: string): value is LLMProvider {
+    return LLM_PROVIDERS.has(value)
+}
+
+/** Normalize a raw provider string to an LLMProvider, or null if unrecognized. */
+export function toLLMProvider(raw: string): LLMProvider | null {
+    const normalized = raw.toLowerCase()
+    if (isLLMProvider(normalized)) {
+        return normalized
+    }
+    console.error(`[LLM Analytics] Unknown LLM provider: "${raw}"`)
+    return null
+}
+
 const PROVIDER_ORDER = Object.keys(LLM_PROVIDER_LABELS) as LLMProvider[]
 
 /** Sort index for a provider string. Unknown providers sort last. */
 export function providerSortIndex(provider: string): number {
-    const index = PROVIDER_ORDER.indexOf(provider.toLowerCase() as LLMProvider)
-    return index === -1 ? PROVIDER_ORDER.length : index
+    const normalized = toLLMProvider(provider)
+    return normalized ? PROVIDER_ORDER.indexOf(normalized) : PROVIDER_ORDER.length
 }
 
 export interface LLMProviderKey {


### PR DESCRIPTION
## Problem

The LLM analytics playground uses a monolithic `llmAnalyticsPlaygroundLogic` that's grown too large to maintain. The model picker is duplicated between the playground and evaluations. This is the first PR in a 3-part stack to clean this up.

## Changes

- Renames `ByokModelPicker` → `ModelPicker` and moves `ModelOption`/`ProviderModelGroup` types into a dedicated `modelPickerLogic`
- Adds trial model support to the model picker
- Simplifies evaluations to use the shared `ModelPicker` instead of the old three-step provider/key/model flow
- Adds backwards-compatible re-exports from `llmAnalyticsPlaygroundLogic` so existing playground code keeps compiling

**Stack: 1\/3** — model picker consolidation

## How did you test this code?

- `modelPickerLogic.test.ts` — 26 tests passing
- `llmEvaluationLogic.test.ts` — 43 tests passing

## Publish to changelog?

no