### PR TITLE
refactor(llma): extract model matching utils and provider key helpers

### DIFF
--- a/products/llm_analytics/frontend/playground/playgroundModelMatching.test.ts
+++ b/products/llm_analytics/frontend/playground/playgroundModelMatching.test.ts
@@ -1,0 +1,131 @@
+import type { LLMProviderKey } from '../settings/llmProviderKeysLogic'
+import {
+    isTraceLikeSelection,
+    matchClosestModel,
+    matchClosestModelOption,
+    type MatchModelOption,
+    resolveTraceModelSelection,
+} from './playgroundModelMatching'
+
+const model = (id: string, providerKeyId?: string): MatchModelOption => ({ id, providerKeyId })
+
+const providerKey = (id: string, provider: string, state: string = 'ok'): LLMProviderKey =>
+    ({ id, provider, state }) as LLMProviderKey
+
+describe('playgroundModelMatching', () => {
+    describe('isTraceLikeSelection', () => {
+        it.each([
+            { model: undefined, provider: undefined, expected: false },
+            { model: 'gpt-4', provider: undefined, expected: false },
+            { model: undefined, provider: 'openai', expected: true },
+            { model: 'gpt-4', provider: 'openai', expected: true },
+            { model: 'anthropic/claude-sonnet-4', provider: undefined, expected: true },
+            { model: 'openrouter/anthropic/claude-3-opus', provider: undefined, expected: true },
+            { model: '', provider: undefined, expected: false },
+            { model: '', provider: '', expected: false },
+            { model: 'gpt-4', provider: '', expected: false },
+        ])('($model, $provider) => $expected', ({ model, provider, expected }) => {
+            expect(isTraceLikeSelection(model, provider)).toBe(expected)
+        })
+    })
+
+    describe('matchClosestModel', () => {
+        const models = [
+            model('gpt-4.1'),
+            model('gpt-4.1-mini'),
+            model('gpt-5'),
+            model('gpt-5-mini'),
+            model('claude-3-opus'),
+        ]
+
+        it.each([
+            { target: 'gpt-5', expected: 'gpt-5' },
+            { target: 'gpt-5-mini', expected: 'gpt-5-mini' },
+            { target: 'claude-3-opus', expected: 'claude-3-opus' },
+            { target: 'GPT-5', expected: 'gpt-5' },
+            { target: 'gpt-5-2025-08-07', expected: 'gpt-5' },
+            { target: 'gpt-5-mini-turbo-2025', expected: 'gpt-5-mini' },
+            { target: 'llama-3-70b', expected: 'gpt-5-mini' },
+            { target: '', expected: 'gpt-5-mini' },
+        ])('$target => $expected', ({ target, expected }) => {
+            expect(matchClosestModel(target, models)).toBe(expected)
+        })
+
+        it('returns default when no models available', () => {
+            expect(matchClosestModel('gpt-5', [])).toBe('gpt-5-mini')
+        })
+    })
+
+    describe('matchClosestModelOption', () => {
+        it('prefers exact match', () => {
+            const models = [model('gpt-5'), model('gpt-5-mini')]
+            expect(matchClosestModelOption('gpt-5', models)?.id).toBe('gpt-5')
+        })
+
+        it('prefers case-insensitive exact match', () => {
+            const models = [model('GPT-5'), model('gpt-5-mini')]
+            expect(matchClosestModelOption('gpt-5', models)?.id).toBe('GPT-5')
+        })
+
+        it('matches by namespace variant stripping', () => {
+            const models = [model('claude-sonnet-4'), model('gpt-5')]
+            expect(matchClosestModelOption('anthropic/claude-sonnet-4', models)?.id).toBe('claude-sonnet-4')
+        })
+
+        it('picks preferred provider key among duplicates', () => {
+            const models = [model('gpt-5', 'key-b'), model('gpt-5', 'key-a')]
+            const keys = [providerKey('key-b', 'openai'), providerKey('key-a', 'openai')]
+            const result = matchClosestModelOption('gpt-5', models, keys)
+            expect(result?.providerKeyId).toBe('key-a')
+        })
+
+        it('returns null for empty model list', () => {
+            expect(matchClosestModelOption('gpt-5', [])).toBeNull()
+        })
+    })
+
+    describe('resolveTraceModelSelection', () => {
+        const trialModels = [model('gpt-5'), model('gpt-5-mini'), model('claude-sonnet-4')]
+
+        it('resolves exact match from available models', () => {
+            const result = resolveTraceModelSelection('claude-sonnet-4', 'anthropic', trialModels, [])
+            expect(result.resolvedModelId).toBe('claude-sonnet-4')
+        })
+
+        it('resolves gateway-style model by stripping namespace', () => {
+            const result = resolveTraceModelSelection('anthropic/claude-sonnet-4', 'anthropic', trialModels, [])
+            expect(result.resolvedModelId).toBe('claude-sonnet-4')
+        })
+
+        it('resolves snapshot model ID via prefix matching', () => {
+            const result = resolveTraceModelSelection('gpt-5-2025-08-07', 'openai', trialModels, [])
+            expect(result.resolvedModelId).toBe('gpt-5')
+        })
+
+        it('falls back to raw model ID when no match found', () => {
+            const result = resolveTraceModelSelection('llama-3-70b', 'meta', trialModels, [])
+            expect(result.resolvedModelId).toBe('llama-3-70b')
+        })
+
+        it('resolves provider key for BYOK models', () => {
+            const byokModels = [model('claude-sonnet-4', 'byok-key-1')]
+            const keys = [providerKey('byok-key-1', 'anthropic')]
+            const result = resolveTraceModelSelection('claude-sonnet-4', 'anthropic', byokModels, keys)
+            expect(result.resolvedModelId).toBe('claude-sonnet-4')
+            expect(result.providerKeyId).toBe('byok-key-1')
+        })
+
+        it('scopes matching to namespace prefix when model has slashes', () => {
+            const models = [model('claude-sonnet-4', 'key-a'), model('gpt-5', 'key-b')]
+            const result = resolveTraceModelSelection('anthropic/claude-sonnet-4-5-20250929', 'anthropic', models, [])
+            expect(result.resolvedModelId).toBe('claude-sonnet-4')
+        })
+
+        it('picks deterministic provider key from sorted order', () => {
+            const models = [model('claude-sonnet-4', 'key-z'), model('claude-sonnet-4', 'key-a')]
+            const keys = [providerKey('key-a', 'anthropic'), providerKey('key-z', 'anthropic')]
+            const result = resolveTraceModelSelection('claude-sonnet-4', 'anthropic', models, keys)
+            expect(result.providerKeyId).toBe('key-a')
+        })
+    })
+})

--- a/products/llm_analytics/frontend/playground/playgroundModelMatching.ts
+++ b/products/llm_analytics/frontend/playground/playgroundModelMatching.ts
@@ -1,0 +1,321 @@
+import type { PromptConfig } from '../llmAnalyticsPlaygroundLogic'
+import type { ModelOption } from '../modelPickerLogic'
+import {
+    firstUsableProviderKeyIdForProvider,
+    type LLMProviderKey,
+    normalizeLLMProvider,
+    sortedUsableProviderKeyIds,
+} from '../settings/llmProviderKeysLogic'
+
+export interface MatchModelOption {
+    id: string
+    providerKeyId?: string
+}
+
+interface MatchOptions {
+    scopeToNamespacePrefix: boolean
+    includeCanonicalFallback: boolean
+    includeDefaultFallback: boolean
+}
+
+const DEFAULT_MATCH_MODEL = 'gpt-5-mini'
+
+const TRACE_MATCH_OPTIONS: MatchOptions = {
+    scopeToNamespacePrefix: true,
+    includeCanonicalFallback: true,
+    includeDefaultFallback: false,
+}
+
+const DEFAULT_MATCH_OPTIONS: MatchOptions = {
+    scopeToNamespacePrefix: false,
+    includeCanonicalFallback: false,
+    includeDefaultFallback: true,
+}
+
+function normalizeModelId(modelId: string): string {
+    return modelId.trim().toLowerCase()
+}
+
+function canonicalizeModelId(modelId: string): string {
+    return normalizeModelId(modelId).replace(/[^a-z0-9]/g, '')
+}
+
+function comparableModelIdVariants(modelId: string): string[] {
+    const normalizedModelId = normalizeModelId(modelId)
+    const segments = normalizedModelId.split('/').filter(Boolean)
+    const variants: string[] = []
+
+    for (let index = 0; index < segments.length; index++) {
+        variants.push(segments.slice(index).join('/'))
+    }
+
+    if (variants.length === 0 && normalizedModelId.length > 0) {
+        variants.push(normalizedModelId)
+    }
+
+    return Array.from(new Set(variants))
+}
+
+function hasComparableModelVariantMatch(
+    leftModelId: string,
+    rightModelId: string,
+    matcher: (leftVariant: string, rightVariant: string) => boolean
+): boolean {
+    const leftVariants = comparableModelIdVariants(leftModelId)
+    const rightVariants = comparableModelIdVariants(rightModelId)
+    return leftVariants.some((leftVariant) => rightVariants.some((rightVariant) => matcher(leftVariant, rightVariant)))
+}
+
+function isSuffixEquivalentModelId(leftModelId: string, rightModelId: string): boolean {
+    return (
+        leftModelId === rightModelId ||
+        leftModelId.endsWith(`/${rightModelId}`) ||
+        rightModelId.endsWith(`/${leftModelId}`)
+    )
+}
+
+function pickPreferredModelOption(
+    candidates: MatchModelOption[],
+    providerKeys: LLMProviderKey[]
+): MatchModelOption | null {
+    if (candidates.length === 0) {
+        return null
+    }
+
+    const providerKeyOrder = sortedUsableProviderKeyIds(providerKeys)
+    if (providerKeyOrder.length === 0) {
+        return candidates[0]
+    }
+
+    const providerKeyRank = new Map(providerKeyOrder.map((keyId, index) => [keyId, index]))
+    return [...candidates].sort((a, b) => {
+        const aRank = a.providerKeyId
+            ? (providerKeyRank.get(a.providerKeyId) ?? Number.MAX_SAFE_INTEGER)
+            : Number.MAX_SAFE_INTEGER
+        const bRank = b.providerKeyId
+            ? (providerKeyRank.get(b.providerKeyId) ?? Number.MAX_SAFE_INTEGER)
+            : Number.MAX_SAFE_INTEGER
+        if (aRank !== bRank) {
+            return aRank - bRank
+        }
+        return a.id.localeCompare(b.id)
+    })[0]
+}
+
+function inferProviderFromModelId(modelId: string): string | null {
+    const normalizedModelId = normalizeModelId(modelId)
+    const candidateProvider = normalizedModelId.split('/')[0]
+    return normalizeLLMProvider(candidateProvider)
+}
+
+function resolveProviderKeyIdForTraceModel(
+    modelId: string,
+    provider: string | null,
+    availableModels: MatchModelOption[],
+    providerKeys: LLMProviderKey[]
+): string | null {
+    const exactMatches = availableModels.filter((model) => model.id === modelId)
+    if (exactMatches.length > 0) {
+        return pickPreferredModelOption(exactMatches, providerKeys)?.providerKeyId ?? null
+    }
+
+    const normalizedModelId = normalizeModelId(modelId)
+    const normalizedExactMatches = availableModels.filter((model) => normalizeModelId(model.id) === normalizedModelId)
+    if (normalizedExactMatches.length > 0) {
+        return pickPreferredModelOption(normalizedExactMatches, providerKeys)?.providerKeyId ?? null
+    }
+
+    return firstUsableProviderKeyIdForProvider(provider ?? inferProviderFromModelId(modelId) ?? undefined, providerKeys)
+}
+
+function getModelCandidates(
+    targetModel: string,
+    availableModels: MatchModelOption[],
+    scopeToNamespacePrefix: boolean
+): MatchModelOption[] {
+    if (!scopeToNamespacePrefix) {
+        return availableModels
+    }
+
+    const normalizedTarget = normalizeModelId(targetModel)
+    const targetPrefix = normalizedTarget.split('/')[0]
+    const scoped = availableModels.filter((model) => normalizeModelId(model.id).startsWith(`${targetPrefix}/`))
+    return scoped.length > 0 ? scoped : availableModels
+}
+
+function bestPrefixMatches(targetModel: string, candidates: MatchModelOption[]): MatchModelOption[] {
+    const prefixMatchesWithLength = candidates
+        .map((model) => {
+            const modelVariants = comparableModelIdVariants(model.id)
+            const targetVariants = comparableModelIdVariants(targetModel)
+            const bestPrefixLength = modelVariants.reduce((bestLength, modelVariant) => {
+                const matchingVariant = targetVariants.find((targetVariant) => targetVariant.startsWith(modelVariant))
+                return matchingVariant ? Math.max(bestLength, modelVariant.length) : bestLength
+            }, 0)
+            return { model, bestPrefixLength }
+        })
+        .filter((item) => item.bestPrefixLength > 0)
+
+    if (prefixMatchesWithLength.length === 0) {
+        return []
+    }
+
+    const longestPrefixLength = Math.max(...prefixMatchesWithLength.map((item) => item.bestPrefixLength))
+    return prefixMatchesWithLength
+        .filter((item) => item.bestPrefixLength === longestPrefixLength)
+        .map((item) => item.model)
+}
+
+function bestCanonicalPrefixMatches(targetModel: string, candidates: MatchModelOption[]): MatchModelOption[] {
+    const targetCanonical = canonicalizeModelId(targetModel)
+    const canonicalPrefixMatchesWithLength = candidates
+        .map((model) => {
+            const candidateCanonical = canonicalizeModelId(model.id)
+            if (!candidateCanonical) {
+                return { model, prefixLength: 0 }
+            }
+            const prefixLength = targetCanonical.startsWith(candidateCanonical) ? candidateCanonical.length : 0
+            return { model, prefixLength }
+        })
+        .filter((item) => item.prefixLength > 0)
+
+    if (canonicalPrefixMatchesWithLength.length === 0) {
+        return []
+    }
+
+    const longestCanonicalPrefixLength = Math.max(...canonicalPrefixMatchesWithLength.map((item) => item.prefixLength))
+    return canonicalPrefixMatchesWithLength
+        .filter((item) => item.prefixLength === longestCanonicalPrefixLength)
+        .map((item) => item.model)
+}
+
+function findMatchedModelOption(
+    targetModel: string,
+    availableModels: MatchModelOption[],
+    providerKeys: LLMProviderKey[],
+    options: MatchOptions
+): MatchModelOption | null {
+    if (availableModels.length === 0) {
+        return null
+    }
+
+    const candidates = getModelCandidates(targetModel, availableModels, options.scopeToNamespacePrefix)
+    const normalizedTarget = normalizeModelId(targetModel)
+
+    const exactIdMatches = candidates.filter((model) => model.id === targetModel)
+    if (exactIdMatches.length > 0) {
+        return pickPreferredModelOption(exactIdMatches, providerKeys)
+    }
+
+    const exactNormalizedIdMatches = candidates.filter((model) => normalizeModelId(model.id) === normalizedTarget)
+    if (exactNormalizedIdMatches.length > 0) {
+        return pickPreferredModelOption(exactNormalizedIdMatches, providerKeys)
+    }
+
+    const exactComparableMatches = candidates.filter((model) =>
+        hasComparableModelVariantMatch(
+            model.id,
+            targetModel,
+            (leftVariant, rightVariant) => leftVariant === rightVariant
+        )
+    )
+    if (exactComparableMatches.length > 0) {
+        return pickPreferredModelOption(exactComparableMatches, providerKeys)
+    }
+
+    const suffixEquivalentMatches = candidates.filter((model) =>
+        hasComparableModelVariantMatch(model.id, targetModel, isSuffixEquivalentModelId)
+    )
+    if (suffixEquivalentMatches.length > 0) {
+        return pickPreferredModelOption(suffixEquivalentMatches, providerKeys)
+    }
+
+    const prefixMatches = bestPrefixMatches(targetModel, candidates)
+    if (prefixMatches.length > 0) {
+        return pickPreferredModelOption(prefixMatches, providerKeys)
+    }
+
+    if (options.includeCanonicalFallback) {
+        const targetCanonical = canonicalizeModelId(targetModel)
+        const canonicalExactMatches = candidates.filter((model) => canonicalizeModelId(model.id) === targetCanonical)
+        if (canonicalExactMatches.length > 0) {
+            return pickPreferredModelOption(canonicalExactMatches, providerKeys)
+        }
+
+        const canonicalPrefixMatches = bestCanonicalPrefixMatches(targetModel, candidates)
+        if (canonicalPrefixMatches.length > 0) {
+            return pickPreferredModelOption(canonicalPrefixMatches, providerKeys)
+        }
+    }
+
+    if (options.includeDefaultFallback) {
+        const defaultModelMatches = candidates.filter((model) => model.id === DEFAULT_MATCH_MODEL)
+        if (defaultModelMatches.length > 0) {
+            return pickPreferredModelOption(defaultModelMatches, providerKeys)
+        }
+
+        return pickPreferredModelOption(candidates, providerKeys)
+    }
+
+    return null
+}
+
+export function isTraceLikeSelection(model: string | undefined, provider: string | undefined): boolean {
+    return Boolean(provider) || Boolean(model && model.includes('/'))
+}
+
+export function resolveTraceModelSelection(
+    modelId: string,
+    provider: string | null,
+    availableModels: MatchModelOption[],
+    providerKeys: LLMProviderKey[]
+): { resolvedModelId: string; providerKeyId?: string } {
+    const matchedModel = findMatchedModelOption(modelId, availableModels, providerKeys, TRACE_MATCH_OPTIONS)
+    if (matchedModel) {
+        return { resolvedModelId: matchedModel.id, providerKeyId: matchedModel.providerKeyId }
+    }
+
+    const providerKeyId =
+        resolveProviderKeyIdForTraceModel(modelId, provider, availableModels, providerKeys) ?? undefined
+    return { resolvedModelId: modelId, providerKeyId }
+}
+
+export function matchClosestModelOption(
+    targetModel: string,
+    availableModels: MatchModelOption[],
+    providerKeys: LLMProviderKey[] = []
+): MatchModelOption | null {
+    return findMatchedModelOption(targetModel, availableModels, providerKeys, DEFAULT_MATCH_OPTIONS)
+}
+
+export function matchClosestModel(targetModel: string, availableModels: MatchModelOption[]): string {
+    return matchClosestModelOption(targetModel, availableModels)?.id ?? DEFAULT_MATCH_MODEL
+}
+
+export function resolveProviderKeyForPrompt(
+    prompt: Pick<PromptConfig, 'model' | 'selectedProviderKeyId'>,
+    modelOptions: ModelOption[],
+    providerKeys: LLMProviderKey[]
+): LLMProviderKey | null {
+    if (prompt.selectedProviderKeyId) {
+        const exactMatch = providerKeys.find((k) => k.id === prompt.selectedProviderKeyId)
+        if (exactMatch) {
+            return exactMatch
+        }
+    }
+
+    const selectedModel = modelOptions.find((m) => m.id === prompt.model)
+    if (!selectedModel) {
+        return null
+    }
+
+    if (selectedModel.providerKeyId) {
+        const exactMatch = providerKeys.find((k) => k.id === selectedModel.providerKeyId)
+        if (exactMatch) {
+            return exactMatch
+        }
+    }
+
+    const provider = selectedModel.provider.toLowerCase()
+    return providerKeys.find((k) => k.provider === provider && k.state !== 'invalid') ?? null
+}

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -26,6 +26,20 @@ export function providerSortIndex(provider: string): number {
     return index === -1 ? PROVIDER_ORDER.length : index
 }
 
+/** Normalize provider aliases from traces/config into canonical LLMProvider keys. */
+export function normalizeLLMProvider(provider: string | undefined): LLMProvider | null {
+    if (!provider) {
+        return null
+    }
+
+    const normalized = provider.trim().toLowerCase()
+    if (normalized === 'google' || normalized === 'google-ai-studio') {
+        return 'gemini'
+    }
+
+    return normalized in LLM_PROVIDER_LABELS ? (normalized as LLMProvider) : null
+}
+
 export interface LLMProviderKey {
     id: string
     provider: LLMProvider
@@ -43,6 +57,43 @@ export interface LLMProviderKey {
         email: string
     } | null
     last_used_at: string | null
+}
+
+/** Canonical provider key ordering: provider order, then key name, then id. */
+export function sortProviderKeys(keys: LLMProviderKey[]): LLMProviderKey[] {
+    return [...keys].sort((a, b) => {
+        const providerDiff = providerSortIndex(a.provider) - providerSortIndex(b.provider)
+        if (providerDiff !== 0) {
+            return providerDiff
+        }
+
+        const nameDiff = (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base' })
+        if (nameDiff !== 0) {
+            return nameDiff
+        }
+
+        return a.id.localeCompare(b.id)
+    })
+}
+
+export function sortedUsableProviderKeyIds(keys: LLMProviderKey[]): string[] {
+    return sortProviderKeys(keys)
+        .filter((key) => key.state !== 'invalid')
+        .map((key) => key.id)
+}
+
+export function firstUsableProviderKeyIdForProvider(
+    provider: string | undefined,
+    keys: LLMProviderKey[]
+): string | null {
+    const normalizedProvider = normalizeLLMProvider(provider)
+    if (!normalizedProvider) {
+        return null
+    }
+
+    return (
+        sortProviderKeys(keys).find((key) => key.state !== 'invalid' && key.provider === normalizedProvider)?.id ?? null
+    )
 }
 
 export interface EvaluationConfig {


### PR DESCRIPTION
## Problem

The playground logic contains complex model-matching logic tightly coupled with kea state management. Extracting these as pure functions makes them testable in isolation and reusable.

## Changes

- Extracts pure model-matching functions into `playgroundModelMatching.ts`: `matchClosestModel`, `resolveTraceModelSelection`, `resolveProviderKeyForPrompt`, `isTraceLikeSelection`
- Adds provider key helper utilities to `llmProviderKeysLogic.ts`: `normalizeLLMProvider()`, `sortProviderKeys()`, `sortedUsableProviderKeyIds()`, `firstUsableProviderKeyIdForProvider()`
- All functions are pure with no kea dependencies

**Stack: 3/4** — pure utility extraction with tests

## How did you test this code?

- `playgroundModelMatching.test.ts` — 30 tests covering exact matching, suffix matching, prefix matching, canonical fallbacks, and provider key resolution

## Publish to changelog?

no