### PR TITLE
fix: Normalize UUID session IDs to lowercase for consistency

### DIFF
--- a/nodejs/src/ingestion/event-preprocessing/parse-headers.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/parse-headers.test.ts
@@ -273,6 +273,46 @@ describe('createParseHeadersStep', () => {
             )
         })
 
+        it('should lowercase UUID session_id from header', async () => {
+            const input = {
+                message: {
+                    headers: [{ session_id: Buffer.from('0192E72A-1DD2-7714-8000-8B3E4C123456') }],
+                } as Pick<Message, 'headers'>,
+            }
+            const result = await step(input)
+
+            expect(result).toEqual(
+                ok({
+                    ...input,
+                    headers: {
+                        session_id: '0192e72a-1dd2-7714-8000-8b3e4c123456',
+                        force_disable_person_processing: false,
+                        historical_migration: false,
+                    },
+                })
+            )
+        })
+
+        it('should not lowercase non-UUID session_id from header', async () => {
+            const input = {
+                message: {
+                    headers: [{ session_id: Buffer.from('Custom-Session-ID') }],
+                } as Pick<Message, 'headers'>,
+            }
+            const result = await step(input)
+
+            expect(result).toEqual(
+                ok({
+                    ...input,
+                    headers: {
+                        session_id: 'Custom-Session-ID',
+                        force_disable_person_processing: false,
+                        historical_migration: false,
+                    },
+                })
+            )
+        })
+
         it('should not include session_id when not present', async () => {
             const input = {
                 message: {

--- a/nodejs/src/ingestion/session_replay/parse-message-step.test.ts
+++ b/nodejs/src/ingestion/session_replay/parse-message-step.test.ts
@@ -530,4 +530,29 @@ describe('createParseMessageStep', () => {
         // The end timestamp is 8 days in the future
         expect(result.warnings[0].details.endDiffDays).toBeGreaterThanOrEqual(8)
     })
+
+    it.each([
+        ['uppercase UUID', '0192E72A-1DD2-7714-8000-8B3E4C123456', '0192e72a-1dd2-7714-8000-8b3e4c123456'],
+        ['lowercase UUID', '0192e72a-1dd2-7714-8000-8b3e4c123456', '0192e72a-1dd2-7714-8000-8b3e4c123456'],
+        ['mixed case UUID', '0192E72a-1Dd2-7714-8000-8b3E4c123456', '0192e72a-1dd2-7714-8000-8b3e4c123456'],
+        ['non-UUID session ID', 'custom-session-id', 'custom-session-id'],
+    ])('should handle %s session_id: %s -> %s', async (_desc, inputSessionId, expectedSessionId) => {
+        const step = createParseMessageStep()
+        const payload = createSnapshotPayload({
+            sessionId: inputSessionId,
+            snapshotItems: [
+                { type: 2, timestamp: Date.now() },
+                { type: 3, timestamp: Date.now() + 1000 },
+            ],
+            distinctId: 'user-123',
+        })
+        const input = createInput(0, 1, payload)
+
+        const result = await step(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.parsedMessage.session_id).toBe(expectedSessionId)
+        }
+    })
 })

--- a/nodejs/src/ingestion/session_replay/parse-message-step.ts
+++ b/nodejs/src/ingestion/session_replay/parse-message-step.ts
@@ -10,6 +10,7 @@ import {
     SnapshotEventSchema,
 } from '../../session-recording/kafka/types'
 import { parseJSON } from '../../utils/json-parse'
+import { UUID } from '../../utils/utils'
 import { dlq, drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -125,6 +126,12 @@ export function createParseMessageStep<T extends ParseMessageStepInput>(): Proce
             return dlq('received_non_snapshot_message')
         }
 
+        // If the session ID is a UUID, lowercase it for consistency.
+        // Some mobile apps send uppercase session IDs, which can cause issues on query paths
+        // where the session ID is parsed as a UUID and converted back to a string.
+        // See https://github.com/PostHog/posthog/issues/46111
+        const sessionId = UUID.validateString($session_id, false) ? $session_id.toLowerCase() : $session_id
+
         const result = getValidEvents($snapshot_items)
         if (!result) {
             return drop(
@@ -172,7 +179,7 @@ export function createParseMessageStep<T extends ParseMessageStepInput>(): Proce
             },
             headers: message.headers,
             distinct_id: messageResult.data.distinct_id,
-            session_id: $session_id,
+            session_id: sessionId,
             token: token ?? null,
             eventsByWindowId: {
                 [$window_id ?? '']: validEvents,

--- a/nodejs/src/ingestion/session_replay/parse-message-step.ts
+++ b/nodejs/src/ingestion/session_replay/parse-message-step.ts
@@ -10,7 +10,7 @@ import {
     SnapshotEventSchema,
 } from '../../session-recording/kafka/types'
 import { parseJSON } from '../../utils/json-parse'
-import { UUID } from '../../utils/utils'
+import { normalizeSessionId } from '../../utils/utils'
 import { dlq, drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -126,11 +126,7 @@ export function createParseMessageStep<T extends ParseMessageStepInput>(): Proce
             return dlq('received_non_snapshot_message')
         }
 
-        // If the session ID is a UUID, lowercase it for consistency.
-        // Some mobile apps send uppercase session IDs, which can cause issues on query paths
-        // where the session ID is parsed as a UUID and converted back to a string.
-        // See https://github.com/PostHog/posthog/issues/46111
-        const sessionId = UUID.validateString($session_id, false) ? $session_id.toLowerCase() : $session_id
+        const sessionId = normalizeSessionId($session_id)
 
         const result = getValidEvents($snapshot_items)
         if (!result) {

--- a/nodejs/src/kafka/consumer.ts
+++ b/nodejs/src/kafka/consumer.ts
@@ -26,6 +26,7 @@ import {
 import { sanitizeString } from '~/utils/db/utils'
 import { isTestEnv } from '~/utils/env-utils'
 import { parseJSON } from '~/utils/json-parse'
+import { normalizeSessionId } from '~/utils/utils'
 
 import { defaultConfig } from '../config/config'
 import { logger } from '../utils/logger'
@@ -883,7 +884,7 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
             } else if (key === 'distinct_id') {
                 result.distinct_id = sanitizeString(value)
             } else if (key === 'session_id') {
-                result.session_id = sanitizeString(value)
+                result.session_id = normalizeSessionId(sanitizeString(value))
             } else if (key === 'timestamp') {
                 result.timestamp = value
             } else if (key === 'event') {

--- a/nodejs/src/utils/event.ts
+++ b/nodejs/src/utils/event.ts
@@ -4,7 +4,7 @@ import { ClickHouseEvent, PipelineEvent, PostIngestionEvent, RawClickHouseEvent 
 import { personInitialAndUTMProperties, sanitizeString } from './db/utils'
 import { chainToElements } from './elements-chain'
 import { parseJSON } from './json-parse'
-import { UUID, clickHouseTimestampToDateTime } from './utils'
+import { clickHouseTimestampToDateTime, normalizeSessionId } from './utils'
 
 /** Parse an event row SELECTed from ClickHouse into a more malleable form. */
 export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHouseEvent {
@@ -128,13 +128,8 @@ export function sanitizeEvent<T extends PipelineEvent | PluginEvent>(event: T): 
         properties['$sent_at'] = event.sent_at
     }
 
-    // If the session ID is a UUID, we should lowercase it.
-    // This is because some mobile apps send an uppercase session ID, which can cause problems on some query paths
-    // where the session ID is parsed as a UUID and then converted back to a string.
-    // See https://github.com/PostHog/posthog/issues/46111
-    // Note: this is very defensive. In reality, session IDs should always be a UUIDv7 or undefined.
-    if (typeof properties['$session_id'] === 'string' && UUID.validateString(properties['$session_id'], false)) {
-        properties['$session_id'] = properties['$session_id'].toLowerCase()
+    if (typeof properties['$session_id'] === 'string') {
+        properties['$session_id'] = normalizeSessionId(properties['$session_id'])
     }
 
     event.properties = properties

--- a/nodejs/src/utils/utils.ts
+++ b/nodejs/src/utils/utils.ts
@@ -182,6 +182,14 @@ export class UUID {
     }
 }
 
+// Lowercase UUID session IDs for consistency. Some mobile apps send uppercase
+// session IDs, which causes issues on query paths where the session ID is parsed
+// as a UUID and converted back to a string.
+// See https://github.com/PostHog/posthog/issues/46111
+export function normalizeSessionId(sessionId: string): string {
+    return UUID.validateString(sessionId, false) ? sessionId.toLowerCase() : sessionId
+}
+
 /**
  * UUID (mostly) sortable by generation time.
  *


### PR DESCRIPTION
## Problem

Some mobile apps send uppercase session IDs, which can cause issues on query paths where the session ID is parsed as a UUID and converted back to a string. See #46111

We already made this change this for event ingestion, my worry is that this has broken some stuff.

Another fix we should introduce is joining events to replay by UUID rather than string, that will come in a later PR

## Changes

- Added logic to detect if a session ID is a valid UUID and normalize it to lowercase for consistency
- Session IDs that are not valid UUIDs (e.g., custom session IDs) are left unchanged
- Updated `parse-message-step.ts` to use the normalized session ID when building the parsed message
- Added comprehensive test cases covering uppercase, lowercase, mixed case UUIDs, and non-UUID session IDs

## How did you test this code?

Added parameterized unit tests (`it.each`) that verify:
- Uppercase UUIDs are converted to lowercase
- Lowercase UUIDs remain unchanged
- Mixed case UUIDs are normalized to lowercase
- Non-UUID session IDs are preserved as-is

All test cases validate that the parsed message contains the expected normalized session ID.

https://claude.ai/code/session_012s3eoawkAP8bmXPV8wTdFq