### PR TITLE
fix(sql-editor): Don't show duplicate sidepanel + AI buttons

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -76,30 +76,32 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId, mode }: QueryWindowPr
                             data-attr="sql-editor-vim-toggle"
                         />
                     )}
-                    <SceneTitlePanelButton
-                        buttonClassName="size-[26px]"
-                        maxToolProps={{
-                            identifier: 'execute_sql',
-                            context: {
-                                current_query: queryInput,
-                            },
-                            contextDescription: {
-                                text: 'Current query',
-                                icon: iconForType('sql_editor'),
-                            },
-                            callback: (toolOutput: string) => {
-                                setSuggestedQueryInput(toolOutput, 'max_ai')
-                            },
-                            suggestions: [],
-                            onMaxOpen: () => {
-                                reportAIQueryPromptOpen()
-                            },
-                            introOverride: {
-                                headline: 'What data do you want to analyze?',
-                                description: 'Let me help you quickly write SQL, and tweak it.',
-                            },
-                        }}
-                    />
+                    {mode === SQLEditorMode.Embedded && (
+                        <SceneTitlePanelButton
+                            buttonClassName="size-[26px]"
+                            maxToolProps={{
+                                identifier: 'execute_sql',
+                                context: {
+                                    current_query: queryInput,
+                                },
+                                contextDescription: {
+                                    text: 'Current query',
+                                    icon: iconForType('sql_editor'),
+                                },
+                                callback: (toolOutput: string) => {
+                                    setSuggestedQueryInput(toolOutput, 'max_ai')
+                                },
+                                suggestions: [],
+                                onMaxOpen: () => {
+                                    reportAIQueryPromptOpen()
+                                },
+                                introOverride: {
+                                    headline: 'What data do you want to analyze?',
+                                    description: 'Let me help you quickly write SQL, and tweak it.',
+                                },
+                            }}
+                        />
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
## Problem
These buttons show twice in the SQL editor
<img width="328" height="193" alt="Screenshot 2026-03-02 at 09 57 52" src="https://github.com/user-attachments/assets/ce8bf7c6-981d-4500-8a8f-59fbd59f3671" />

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Show the buttons in `QueryWindow` only when in Embedded mode. So only see once here:
<img width="1512" height="853" alt="Screenshot 2026-03-02 at 09 55 19" src="https://github.com/user-attachments/assets/10a1a46b-cae9-4e23-bb65-08857840d2be" />

## How did you test this code?
manually 👀 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
