### PR TITLE
chore(replay): drop session_recording_encryption column from database

### DIFF
--- a/posthog/migrations/1025_drop_team_session_recording_encryption_column.py
+++ b/posthog/migrations/1025_drop_team_session_recording_encryption_column.py
@@ -11,8 +11,8 @@ class Migration(migrations.Migration):
             state_operations=[],
             database_operations=[
                 migrations.RunSQL(
-                    sql='ALTER TABLE "posthog_team" DROP COLUMN IF EXISTS "session_recording_encryption"',
-                    reverse_sql='ALTER TABLE "posthog_team" ADD COLUMN "session_recording_encryption" boolean NULL DEFAULT false',
+                    sql="ALTER TABLE posthog_team DROP COLUMN IF EXISTS session_recording_encryption",
+                    reverse_sql="ALTER TABLE posthog_team ADD COLUMN session_recording_encryption boolean NULL DEFAULT false",
                 ),
             ],
         ),

--- a/posthog/migrations/1025_drop_team_session_recording_encryption_column.py
+++ b/posthog/migrations/1025_drop_team_session_recording_encryption_column.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1024_remove_team_session_recording_encryption"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    sql='ALTER TABLE "posthog_team" DROP COLUMN IF EXISTS "session_recording_encryption"',
+                    reverse_sql='ALTER TABLE "posthog_team" ADD COLUMN "session_recording_encryption" boolean NULL DEFAULT false',
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1024_remove_team_session_recording_encryption
+1025_drop_team_session_recording_encryption_column


### PR DESCRIPTION
## Summary

- Phase 2 of the `session_recording_encryption` column removal
- Phase 1 (#49419) removed the field from Django's model state using `SeparateDatabaseAndState`
- This migration drops the actual column from Postgres now that all pods run code that no longer references it

## Test plan

- [x] `python manage.py makemigrations --check` confirms no pending migrations
- [x] Uses `DROP COLUMN IF EXISTS` for safety
- [x] Includes reverse SQL for rollback