### PR TITLE
feat: wire spike detection config

### DIFF
--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -478,20 +478,14 @@ impl Client for RedisClient {
 
     async fn batch_set_nx_ex(
         &self,
-        items: Vec<(String, String)>,
-        ttl_seconds: usize,
+        items: Vec<(String, String, usize)>,
     ) -> Result<Vec<bool>, CustomRedisError> {
         if items.is_empty() {
             return Ok(vec![]);
         }
         let mut pipe = redis::pipe();
-        for (k, v) in &items {
-            pipe.cmd("SET")
-                .arg(k)
-                .arg(v)
-                .arg("NX")
-                .arg("EX")
-                .arg(ttl_seconds);
+        for (k, v, ttl) in &items {
+            pipe.cmd("SET").arg(k).arg(v).arg("NX").arg("EX").arg(ttl);
         }
         let mut conn = self.connection.clone();
         let results: Vec<Option<String>> = pipe.query_async(&mut conn).await?;

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -266,8 +266,7 @@ pub trait Client: Send + Sync {
     ) -> Result<(), CustomRedisError>;
     async fn batch_set_nx_ex(
         &self,
-        items: Vec<(String, String)>,
-        ttl_seconds: usize,
+        items: Vec<(String, String, usize)>, // (key, value, ttl_seconds)
     ) -> Result<Vec<bool>, CustomRedisError>;
     async fn batch_del(&self, keys: Vec<String>) -> Result<(), CustomRedisError>;
     /// Execute a batch of pipeline commands in a single round-trip.

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -501,10 +501,9 @@ impl Client for MockRedisClient {
 
     async fn batch_set_nx_ex(
         &self,
-        items: Vec<(String, String)>,
-        _ttl_seconds: usize,
+        items: Vec<(String, String, usize)>,
     ) -> Result<Vec<bool>, CustomRedisError> {
-        let keys: Vec<String> = items.iter().map(|(k, _)| k.clone()).collect();
+        let keys: Vec<String> = items.iter().map(|(k, _, _)| k.clone()).collect();
         self.lock_calls().push(MockRedisCall {
             op: "batch_set_nx_ex".to_string(),
             key: format!("items={}", items.len()),

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -468,10 +468,9 @@ impl Client for ReadWriteClient {
 
     async fn batch_set_nx_ex(
         &self,
-        items: Vec<(String, String)>,
-        ttl_seconds: usize,
+        items: Vec<(String, String, usize)>,
     ) -> Result<Vec<bool>, CustomRedisError> {
-        self.writer.batch_set_nx_ex(items, ttl_seconds).await
+        self.writer.batch_set_nx_ex(items).await
     }
 
     async fn batch_del(&self, keys: Vec<String>) -> Result<(), CustomRedisError> {

--- a/rust/cymbal/.sqlx/query-0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983.json
+++ b/rust/cymbal/.sqlx/query-0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT pp.id, pp.created_at, pp.team_id, pp.uuid, '{}'::jsonb as properties, pp.is_identified, pp.is_user_id, pp.version\n                FROM posthog_person pp\n                INNER JOIN posthog_persondistinctid\n                    ON pp.id = posthog_persondistinctid.person_id\n                WHERE\n                    posthog_persondistinctid.distinct_id = $1\n                    AND posthog_persondistinctid.team_id = $2\n                    AND pp.team_id = $2\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_identified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_user_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      null,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "0075dc262b54e2c4b0139e12a298169e4825500508e9a3a25971813a18fac983"
+}

--- a/rust/cymbal/.sqlx/query-0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50.json
+++ b/rust/cymbal/.sqlx/query-0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0a5daf41fe9185ee691c87aa6e009100999e6ec1c85bf2ab9bdacb933b4a7c50"
+}

--- a/rust/cymbal/.sqlx/query-4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f.json
+++ b/rust/cymbal/.sqlx/query-4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1 AND group_type = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4122d9f532c4eb09667b5d665f947708e778b99c6ec471f72079af5149ac878f"
+}

--- a/rust/cymbal/.sqlx/query-8994b430575bbed344b30c246de080a61a1e38069d6d29f2d483f74673f38694.json
+++ b/rust/cymbal/.sqlx/query-8994b430575bbed344b30c246de080a61a1e38069d6d29f2d483f74673f38694.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT multiplier, threshold, snooze_duration_minutes\n                FROM posthog_errortrackingspikedetectionconfig\n                WHERE team_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "multiplier",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "threshold",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "snooze_duration_minutes",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8994b430575bbed344b30c246de080a61a1e38069d6d29f2d483f74673f38694"
+}

--- a/rust/cymbal/.sqlx/query-9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520.json
+++ b/rust/cymbal/.sqlx/query-9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, group_type, group_type_index, team_id FROM posthog_grouptypemapping WHERE team_id = $1 AND group_type_index = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "group_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "group_type_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "team_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9797599a9be923f86da25f824e6992763239554455e0fc17ab6fc9c6797a1520"
+}

--- a/rust/cymbal/.sqlx/query-e46f992f9e11fa1c806213ac0c55ced00ee810de2e6bf755997500ef60f7353f.json
+++ b/rust/cymbal/.sqlx/query-e46f992f9e11fa1c806213ac0c55ced00ee810de2e6bf755997500ef60f7353f.json
@@ -1,0 +1,256 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    autocapture_opt_out,\n                    autocapture_exceptions_opt_in,\n                    autocapture_web_vitals_opt_in,\n                    capture_performance_opt_in,\n                    capture_console_log_opt_in,\n                    logs_settings as \"logs_settings: _\",\n                    session_recording_opt_in,\n                    inject_web_apps,\n                    surveys_opt_in,\n                    heatmaps_opt_in,\n                    capture_dead_clicks,\n                    flags_persistence_default,\n                    session_recording_sample_rate,\n                    session_recording_minimum_duration_milliseconds,\n                    autocapture_web_vitals_allowed_metrics as \"autocapture_web_vitals_allowed_metrics: _\",\n                    autocapture_exceptions_errors_to_ignore as \"autocapture_exceptions_errors_to_ignore: _\",\n                    session_recording_linked_flag as \"session_recording_linked_flag: _\",\n                    session_recording_network_payload_capture_config as \"session_recording_network_payload_capture_config: _\",\n                    session_recording_masking_config as \"session_recording_masking_config: _\",\n                    session_replay_config as \"session_replay_config: _\",\n                    survey_config as \"survey_config: _\",\n                    session_recording_url_trigger_config as \"session_recording_url_trigger_config: _\",\n                    session_recording_url_blocklist_config as \"session_recording_url_blocklist_config: _\",\n                    session_recording_event_trigger_config as \"session_recording_event_trigger_config: _\",\n                    session_recording_trigger_match_type_config,\n                    recording_domains,\n                    cookieless_server_hash_mode,\n                    timezone,\n                    conversations_enabled,\n                    conversations_settings as \"conversations_settings: _\"\n                FROM posthog_team\n                WHERE id = $1\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "api_token",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "anonymize_ips",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "person_processing_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "autocapture_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "autocapture_exceptions_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "autocapture_web_vitals_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "capture_performance_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "capture_console_log_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 15,
+        "name": "logs_settings: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "session_recording_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "inject_web_apps",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "surveys_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "heatmaps_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "capture_dead_clicks",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 21,
+        "name": "flags_persistence_default",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "session_recording_sample_rate",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 23,
+        "name": "session_recording_minimum_duration_milliseconds",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "autocapture_web_vitals_allowed_metrics: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 25,
+        "name": "autocapture_exceptions_errors_to_ignore: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 26,
+        "name": "session_recording_linked_flag: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 27,
+        "name": "session_recording_network_payload_capture_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 28,
+        "name": "session_recording_masking_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 29,
+        "name": "session_replay_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 30,
+        "name": "survey_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 31,
+        "name": "session_recording_url_trigger_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 32,
+        "name": "session_recording_url_blocklist_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 33,
+        "name": "session_recording_event_trigger_config: _",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 34,
+        "name": "session_recording_trigger_match_type_config",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 35,
+        "name": "recording_domains",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 36,
+        "name": "cookieless_server_hash_mode",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 37,
+        "name": "timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 38,
+        "name": "conversations_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 39,
+        "name": "conversations_settings: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "e46f992f9e11fa1c806213ac0c55ced00ee810de2e6bf755997500ef60f7353f"
+}

--- a/rust/cymbal/.sqlx/query-ed6ac21bc07d6b3bb5394c416fe0b0131c367bac05cca6c82348a42cf163c476.json
+++ b/rust/cymbal/.sqlx/query-ed6ac21bc07d6b3bb5394c416fe0b0131c367bac05cca6c82348a42cf163c476.json
@@ -1,0 +1,256 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    id,\n                    project_id,\n                    organization_id,\n                    uuid,\n                    api_token,\n                    name,\n                    created_at,\n                    updated_at,\n                    anonymize_ips,\n                    person_processing_opt_out,\n                    autocapture_opt_out,\n                    autocapture_exceptions_opt_in,\n                    autocapture_web_vitals_opt_in,\n                    capture_performance_opt_in,\n                    capture_console_log_opt_in,\n                    logs_settings as \"logs_settings: _\",\n                    session_recording_opt_in,\n                    inject_web_apps,\n                    surveys_opt_in,\n                    heatmaps_opt_in,\n                    capture_dead_clicks,\n                    flags_persistence_default,\n                    session_recording_sample_rate,\n                    session_recording_minimum_duration_milliseconds,\n                    autocapture_web_vitals_allowed_metrics as \"autocapture_web_vitals_allowed_metrics: _\",\n                    autocapture_exceptions_errors_to_ignore as \"autocapture_exceptions_errors_to_ignore: _\",\n                    session_recording_linked_flag as \"session_recording_linked_flag: _\",\n                    session_recording_network_payload_capture_config as \"session_recording_network_payload_capture_config: _\",\n                    session_recording_masking_config as \"session_recording_masking_config: _\",\n                    session_replay_config as \"session_replay_config: _\",\n                    survey_config as \"survey_config: _\",\n                    session_recording_url_trigger_config as \"session_recording_url_trigger_config: _\",\n                    session_recording_url_blocklist_config as \"session_recording_url_blocklist_config: _\",\n                    session_recording_event_trigger_config as \"session_recording_event_trigger_config: _\",\n                    session_recording_trigger_match_type_config,\n                    recording_domains,\n                    cookieless_server_hash_mode,\n                    timezone,\n                    conversations_enabled,\n                    conversations_settings as \"conversations_settings: _\"\n                FROM posthog_team\n                WHERE api_token = $1\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "api_token",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "anonymize_ips",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "person_processing_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "autocapture_opt_out",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "autocapture_exceptions_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "autocapture_web_vitals_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "capture_performance_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "capture_console_log_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 15,
+        "name": "logs_settings: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "session_recording_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "inject_web_apps",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "surveys_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "heatmaps_opt_in",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "capture_dead_clicks",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 21,
+        "name": "flags_persistence_default",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "session_recording_sample_rate",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 23,
+        "name": "session_recording_minimum_duration_milliseconds",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 24,
+        "name": "autocapture_web_vitals_allowed_metrics: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 25,
+        "name": "autocapture_exceptions_errors_to_ignore: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 26,
+        "name": "session_recording_linked_flag: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 27,
+        "name": "session_recording_network_payload_capture_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 28,
+        "name": "session_recording_masking_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 29,
+        "name": "session_replay_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 30,
+        "name": "survey_config: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 31,
+        "name": "session_recording_url_trigger_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 32,
+        "name": "session_recording_url_blocklist_config: _",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 33,
+        "name": "session_recording_event_trigger_config: _",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 34,
+        "name": "session_recording_trigger_match_type_config",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 35,
+        "name": "recording_domains",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 36,
+        "name": "cookieless_server_hash_mode",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 37,
+        "name": "timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 38,
+        "name": "conversations_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 39,
+        "name": "conversations_settings: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "ed6ac21bc07d6b3bb5394c416fe0b0131c367bac05cca6c82348a42cf163c476"
+}

--- a/rust/cymbal/.sqlx/query-f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8.json
+++ b/rust/cymbal/.sqlx/query-f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT pp.id, pp.created_at, pp.team_id, pp.uuid, pp.properties, pp.is_identified, pp.is_user_id, pp.version\n                FROM posthog_person pp\n                INNER JOIN posthog_persondistinctid\n                    ON pp.id = posthog_persondistinctid.person_id\n                WHERE\n                    posthog_persondistinctid.distinct_id = $1\n                    AND posthog_persondistinctid.team_id = $2\n                    AND pp.team_id = $2\n                LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_identified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_user_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "f73889687c0d58e9800b6df9c8faa1e85e7696dc5cabaa30e4490e558afa93b8"
+}

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -21,6 +21,7 @@ pub mod pipeline;
 pub mod posthog_utils;
 pub mod router;
 pub mod server;
+pub mod spike_config;
 pub mod stages;
 pub mod symbol_store;
 pub mod teams;

--- a/rust/cymbal/src/spike_config.rs
+++ b/rust/cymbal/src/spike_config.rs
@@ -1,0 +1,44 @@
+const DEFAULT_SPIKE_MULTIPLIER: f64 = 10.0;
+const DEFAULT_MIN_SPIKE_THRESHOLD: i64 = 500;
+const DEFAULT_SPIKE_ALERT_COOLDOWN_SECONDS: usize = 10 * 60;
+
+#[derive(Debug, Clone)]
+pub struct SpikeDetectionConfig {
+    pub multiplier: f64,
+    pub threshold: i64,
+    pub snooze_duration_seconds: usize,
+}
+
+impl Default for SpikeDetectionConfig {
+    fn default() -> Self {
+        Self {
+            multiplier: DEFAULT_SPIKE_MULTIPLIER,
+            threshold: DEFAULT_MIN_SPIKE_THRESHOLD,
+            snooze_duration_seconds: DEFAULT_SPIKE_ALERT_COOLDOWN_SECONDS,
+        }
+    }
+}
+
+impl SpikeDetectionConfig {
+    pub async fn load_for_team<'c, E>(conn: E, team_id: i32) -> Result<Option<Self>, sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let row = sqlx::query!(
+            r#"
+                SELECT multiplier, threshold, snooze_duration_minutes
+                FROM posthog_errortrackingspikedetectionconfig
+                WHERE team_id = $1
+            "#,
+            team_id
+        )
+        .fetch_optional(conn)
+        .await?;
+
+        Ok(row.map(|r| Self {
+            multiplier: r.multiplier as f64,
+            threshold: r.threshold as i64,
+            snooze_duration_seconds: (r.snooze_duration_minutes * 60) as usize,
+        }))
+    }
+}

--- a/rust/cymbal/src/stages/alerting/spike_alert.rs
+++ b/rust/cymbal/src/stages/alerting/spike_alert.rs
@@ -62,7 +62,7 @@ impl Stage for SpikeAlertStage {
             .map(|issue| (issue.id, issue))
             .collect::<HashMap<_, _>>();
 
-        do_spike_detection(self.context, issues_by_id, issues_count_by_id).await;
+        do_spike_detection(self.context, issues_by_id, issues_count_by_id).await?;
 
         Ok(batch)
     }

--- a/rust/cymbal/src/stages/alerting/spike_detection.rs
+++ b/rust/cymbal/src/stages/alerting/spike_detection.rs
@@ -9,22 +9,21 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::app_context::AppContext;
+use crate::error::UnhandledError;
 use crate::issue_resolution::Issue;
 use crate::metric_consts::{
     SPIKE_ACQUIRE_LOCKS_TIME, SPIKE_EMIT_EVENTS_TIME, SPIKE_GET_SPIKING_ISSUES_TIME,
     SPIKE_INCREMENT_ISSUE_BUCKETS_TIME, SPIKE_INCREMENT_TEAM_BUCKETS_TIME,
     SPIKE_ISSUES_BLOCKED_BY_COOLDOWN, SPIKE_ISSUES_CHECKED, SPIKE_ISSUES_SPIKING,
 };
+use crate::spike_config::SpikeDetectionConfig;
 
 const ISSUE_BUCKET_TTL_SECONDS: usize = 60 * 60;
 const ISSUE_BUCKET_INTERVAL_MINUTES: i64 = 5;
-const SPIKE_MULTIPLIER: f64 = 10.0;
 const NUM_BUCKETS: usize = 12;
-const SPIKE_ALERT_COOLDOWN_SECONDS: usize = 10 * 60;
 
 const ISSUE_SPIKING_EVENT: &str = "$error_tracking_issue_spiking";
 const MIN_HISTORICAL_BUCKETS_FOR_ISSUE_BASELINE: usize = 1;
-const MIN_SPIKE_THRESHOLD: i64 = 500;
 
 fn issue_bucket_key(issue_id: &Uuid, timestamp: &str) -> String {
     format!("issue-buckets:{issue_id}-{timestamp}")
@@ -171,9 +170,9 @@ pub async fn do_spike_detection(
     context: Arc<AppContext>,
     issues_by_id: HashMap<Uuid, Issue>,
     issue_counts: HashMap<Uuid, u32>,
-) {
+) -> Result<(), UnhandledError> {
     if issue_counts.is_empty() {
-        return;
+        return Ok(());
     }
 
     let allowed_team_ids = parse_enabled_team_ids(&context.config.spike_alert_enabled_team_ids);
@@ -186,13 +185,19 @@ pub async fn do_spike_detection(
     };
 
     if issues_by_id.is_empty() {
-        return;
+        return Ok(());
     }
 
     let issue_counts: HashMap<Uuid, u32> = issue_counts
         .into_iter()
         .filter(|(id, _)| issues_by_id.contains_key(id))
         .collect();
+
+    let team_ids = issues_by_id.values().map(|i| i.team_id);
+    let team_configs = context
+        .team_manager
+        .get_spike_detection_configs(&context.posthog_pool, team_ids)
+        .await;
 
     let issue_buckets_timer = common_metrics::timing_guard(SPIKE_INCREMENT_ISSUE_BUCKETS_TIME, &[]);
     try_increment_issue_buckets(&*context.issue_buckets_redis_client, &issue_counts).await;
@@ -210,17 +215,19 @@ pub async fn do_spike_detection(
     metrics::counter!(SPIKE_ISSUES_CHECKED).increment(issues_by_id.len() as u64);
 
     let get_spiking_timer = common_metrics::timing_guard(SPIKE_GET_SPIKING_ISSUES_TIME, &[]);
-    match get_spiking_issues(&*context.issue_buckets_redis_client, &issues_by_id).await {
-        Ok(spiking) => {
-            get_spiking_timer.fin();
-            metrics::counter!(SPIKE_ISSUES_SPIKING).increment(spiking.len() as u64);
-            emit_spiking_events(&context, spiking).await;
-        }
-        Err(err) => {
-            get_spiking_timer.fin();
-            warn!("Failed to detect spikes: {err}");
-        }
-    }
+    let spiking = get_spiking_issues(
+        &*context.issue_buckets_redis_client,
+        &issues_by_id,
+        &team_configs,
+    )
+    .await;
+    get_spiking_timer.fin();
+    let spiking = spiking?;
+
+    metrics::counter!(SPIKE_ISSUES_SPIKING).increment(spiking.len() as u64);
+    emit_spiking_events(&context, spiking, &team_configs).await;
+
+    Ok(())
 }
 
 fn parse_enabled_team_ids(config_value: &str) -> Option<Vec<i32>> {
@@ -235,28 +242,47 @@ fn parse_enabled_team_ids(config_value: &str) -> Option<Vec<i32>> {
     )
 }
 
-async fn emit_spiking_events(context: &AppContext, spiking: Vec<SpikingIssue>) {
+async fn acquire_cooldown_locks(
+    redis: &(dyn Client + Send + Sync),
+    items: &[(String, usize)],
+) -> Result<Vec<bool>, common_redis::CustomRedisError> {
+    let batch = items
+        .iter()
+        .map(|(key, ttl)| (key.clone(), "1".to_string(), *ttl))
+        .collect();
+    redis.batch_set_nx_ex(batch).await
+}
+
+async fn emit_spiking_events(
+    context: &AppContext,
+    spiking: Vec<SpikingIssue>,
+    team_configs: &HashMap<i32, SpikeDetectionConfig>,
+) {
     if spiking.is_empty() {
         return;
     }
 
     let locks_timer = common_metrics::timing_guard(SPIKE_ACQUIRE_LOCKS_TIME, &[]);
-    let cooldown_items: Vec<(String, String)> = spiking
-        .iter()
-        .map(|s| (cooldown_key(&s.issue.id), "1".to_string()))
-        .collect();
-    let lock_results = match context
-        .issue_buckets_redis_client
-        .batch_set_nx_ex(cooldown_items, SPIKE_ALERT_COOLDOWN_SECONDS)
-        .await
-    {
-        Ok(results) => results,
-        Err(e) => {
-            locks_timer.fin();
-            warn!("Failed to acquire spike cooldown locks: {e}");
-            return;
-        }
-    };
+    let (spiking, cooldown_items): (Vec<SpikingIssue>, Vec<(String, usize)>) = spiking
+        .into_iter()
+        .map(|s| {
+            let config = team_configs
+                .get(&s.issue.team_id)
+                .expect("team config always present - verified in get_spiking_issues");
+            let key = cooldown_key(&s.issue.id);
+            (s, (key, config.snooze_duration_seconds))
+        })
+        .unzip();
+
+    let lock_results =
+        match acquire_cooldown_locks(&*context.issue_buckets_redis_client, &cooldown_items).await {
+            Ok(results) => results,
+            Err(e) => {
+                locks_timer.fin();
+                warn!("Failed to acquire spike cooldown locks: {e}");
+                return;
+            }
+        };
 
     let blocked_count = lock_results.iter().filter(|&&acquired| !acquired).count();
     metrics::counter!(SPIKE_ISSUES_BLOCKED_BY_COOLDOWN).increment(blocked_count as u64);
@@ -379,17 +405,18 @@ fn compute_issue_baseline(historical_buckets: &[Option<i64>], team_baseline: f64
     }
 }
 
-fn is_spiking(current_value: i64, baseline: f64) -> bool {
-    if current_value < MIN_SPIKE_THRESHOLD {
+fn is_spiking(current_value: i64, baseline: f64, config: &SpikeDetectionConfig) -> bool {
+    if current_value < config.threshold {
         return false;
     }
-    current_value as f64 > baseline * SPIKE_MULTIPLIER
+    current_value as f64 > baseline * config.multiplier
 }
 
 async fn get_spiking_issues(
     redis: &(dyn Client + Send + Sync),
     issues_by_id: &HashMap<Uuid, Issue>,
-) -> Result<Vec<SpikingIssue>, common_redis::CustomRedisError> {
+    team_configs: &HashMap<i32, SpikeDetectionConfig>,
+) -> Result<Vec<SpikingIssue>, UnhandledError> {
     if issues_by_id.is_empty() {
         return Ok(vec![]);
     }
@@ -409,27 +436,31 @@ async fn get_spiking_issues(
 
     let team_baselines: HashMap<i32, f64> = compute_team_baselines(&team_buckets);
 
-    let spiking = issue_buckets
-        .iter()
-        .filter_map(|bucket| {
-            let issue = issues_by_id.get(&bucket.issue_id)?;
+    let mut spiking = Vec::new();
+    for bucket in &issue_buckets {
+        let Some(issue) = issues_by_id.get(&bucket.issue_id) else {
+            continue;
+        };
 
-            let current_value = bucket.values[0].unwrap_or(0);
-            let historical = &bucket.values[1..];
-            let team_baseline = *team_baselines.get(&issue.team_id).unwrap_or(&0.0);
-            let baseline = compute_issue_baseline(historical, team_baseline);
+        let current_value = bucket.values[0].unwrap_or(0);
+        let historical = &bucket.values[1..];
+        let team_baseline = *team_baselines.get(&issue.team_id).unwrap_or(&0.0);
+        let baseline = compute_issue_baseline(historical, team_baseline);
+        let config = team_configs.get(&issue.team_id).ok_or_else(|| {
+            UnhandledError::Other(format!(
+                "No spike detection config for team {}",
+                issue.team_id
+            ))
+        })?;
 
-            if is_spiking(current_value, baseline) {
-                Some(SpikingIssue {
-                    issue: issue.clone(),
-                    computed_baseline: baseline,
-                    current_bucket_value: current_value,
-                })
-            } else {
-                None
-            }
-        })
-        .collect();
+        if is_spiking(current_value, baseline, config) {
+            spiking.push(SpikingIssue {
+                issue: issue.clone(),
+                computed_baseline: baseline,
+                current_bucket_value: current_value,
+            });
+        }
+    }
 
     Ok(spiking)
 }
@@ -591,7 +622,8 @@ mod tests {
         }
 
         async fn get_spiking(&self) -> Vec<SpikingIssue> {
-            get_spiking_issues(&self.redis, &self.issues_by_id())
+            let configs = HashMap::from([(self.team_id, SpikeDetectionConfig::default())]);
+            get_spiking_issues(&self.redis, &self.issues_by_id(), &configs)
                 .await
                 .unwrap()
         }
@@ -1014,7 +1046,13 @@ mod tests {
             redis.scard_ret(&team_issue_set_key(team_2, ts), Ok(0));
         }
 
-        let result = get_spiking_issues(&redis, &issues_by_id).await.unwrap();
+        let configs = HashMap::from([
+            (team_1, SpikeDetectionConfig::default()),
+            (team_2, SpikeDetectionConfig::default()),
+        ]);
+        let result = get_spiking_issues(&redis, &issues_by_id, &configs)
+            .await
+            .unwrap();
 
         // Should have 3 spiking issues: A, B, E
         assert_eq!(result.len(), 3);

--- a/rust/cymbal/src/teams.rs
+++ b/rust/cymbal/src/teams.rs
@@ -12,7 +12,9 @@ use crate::{
     fingerprinting::grouping_rules::GroupingRule,
     metric_consts::ANCILLARY_CACHE,
     pipeline::IncomingEvent,
-    sanitize_string, WithIndices,
+    sanitize_string,
+    spike_config::SpikeDetectionConfig,
+    WithIndices,
 };
 
 #[derive(Clone)]
@@ -21,6 +23,7 @@ pub struct TeamManager {
     pub assignment_rules: Cache<TeamId, Vec<AssignmentRule>>,
     pub grouping_rules: Cache<TeamId, Vec<GroupingRule>>,
     pub group_type_indices: Cache<TeamId, Vec<GroupType>>,
+    pub spike_detection_configs: Cache<TeamId, Option<SpikeDetectionConfig>>,
 }
 
 impl TeamManager {
@@ -51,11 +54,16 @@ impl TeamManager {
             })
             .build();
 
+        let spike_detection_configs = CacheBuilder::new(config.max_team_cache_size)
+            .time_to_live(Duration::from_secs(config.team_cache_ttl_secs))
+            .build();
+
         Self {
             token_cache: cache,
             assignment_rules,
             grouping_rules,
             group_type_indices,
+            spike_detection_configs,
         }
     }
 
@@ -124,6 +132,59 @@ impl TeamManager {
         let rules = GroupingRule::load_for_team(e, team_id).await?;
         self.grouping_rules.insert(team_id, rules.clone());
         Ok(rules)
+    }
+
+    pub async fn get_spike_detection_config<'c, E>(
+        &self,
+        e: E,
+        team_id: TeamId,
+    ) -> Result<SpikeDetectionConfig, UnhandledError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        if let Some(cached) = self.spike_detection_configs.get(&team_id) {
+            metrics::counter!(ANCILLARY_CACHE, "type" => "spike_detection_config", "outcome" => "hit")
+                .increment(1);
+            return Ok(cached.unwrap_or_default());
+        }
+        metrics::counter!(ANCILLARY_CACHE, "type" => "spike_detection_config", "outcome" => "miss")
+            .increment(1);
+        let config = SpikeDetectionConfig::load_for_team(e, team_id).await?;
+        self.spike_detection_configs.insert(team_id, config.clone());
+        Ok(config.unwrap_or_default())
+    }
+
+    pub async fn get_spike_detection_configs(
+        &self,
+        pool: &sqlx::PgPool,
+        team_ids: impl IntoIterator<Item = i32>,
+    ) -> HashMap<TeamId, SpikeDetectionConfig> {
+        let unique_ids: std::collections::HashSet<i32> = team_ids.into_iter().collect();
+
+        let tasks: Vec<(i32, _)> = unique_ids
+            .into_iter()
+            .map(|team_id| {
+                let manager = self.clone();
+                let pool = pool.clone();
+                let task = tokio::spawn(async move {
+                    manager.get_spike_detection_config(&pool, team_id).await
+                });
+                (team_id, task)
+            })
+            .collect();
+
+        let mut result = HashMap::new();
+        for (team_id, task) in tasks {
+            let config = match task.await.expect("Task was not cancelled") {
+                Ok(config) => config,
+                Err(e) => {
+                    warn!("Failed to load spike detection config for team {team_id}, using defaults: {e}");
+                    SpikeDetectionConfig::default()
+                }
+            };
+            result.insert(team_id, config);
+        }
+        result
     }
 
     pub async fn get_group_types<'c, E>(


### PR DESCRIPTION
Wire spike detection config to cymbal.

Tested this locally. Looks good. Only strange thing is that this relies on 5m cache and there is no really way to invalidate that as it's not stored in Redis but rather in-memory. We could send some kind of signal to all cymbal pods to invalidate that cache but seems like an overkill for such feature