### PR TITLE
feat: support batch-aware pipelines

### DIFF
--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -3,16 +3,14 @@ import { Message } from 'node-rdkafka'
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
-import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
-import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
 import { createExtractHeatmapDataStep } from '../event-processing/extract-heatmap-data-step'
+import { BatchStores } from '../event-processing/flush-batch-stores-step'
 import { createHogTransformEventStep } from '../event-processing/hog-transform-event-step'
 import { createNormalizeEventStep } from '../event-processing/normalize-event-step'
 import { createNormalizeProcessPersonFlagStep } from '../event-processing/normalize-process-person-flag-step'
@@ -37,46 +35,32 @@ export interface EventSubpipelineConfig {
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
-    personsStore: PersonsStore
-    groupStore: BatchWritingGroupStore
-    kafkaProducer: KafkaProducerWrapper
     groupId: string
     topHog: TopHogWrapper
 }
 
-export function createEventSubpipeline<TInput extends EventSubpipelineInput, TContext>(
+export function createEventSubpipeline<TInput extends EventSubpipelineInput & BatchStores, TContext>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: EventSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const {
-        options,
-        teamManager,
-        groupTypeManager,
-        hogTransformer,
-        personsStore,
-        groupStore,
-        kafkaProducer,
-        groupId,
-        topHog,
-    } = config
+    const { options, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
 
     return builder
         .pipe(createNormalizeProcessPersonFlagStep())
         .pipe(createHogTransformEventStep(hogTransformer))
         .pipe(createNormalizeEventStep())
-        .pipe(createProcessPersonlessStep(personsStore))
+        .pipe(createProcessPersonlessStep())
         .pipe(
-            topHog(createProcessPersonsStep(options, kafkaProducer, personsStore), [
+            topHog(createProcessPersonsStep(options), [
                 timer('process_persons_time', (input) => ({
                     team_id: String(input.team.id),
                     distinct_id: input.normalizedEvent.distinct_id,
                 })),
             ])
         )
-        .pipe(createPrepareEventStep(teamManager, groupTypeManager, groupStore, options))
+        .pipe(createPrepareEventStep(teamManager, groupTypeManager, options))
         .pipe(
             createExtractHeatmapDataStep({
-                kafkaProducer,
                 CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: options.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
             })
         )
@@ -84,7 +68,6 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
         .pipe(
             topHog(
                 createEmitEventStep({
-                    kafkaProducer,
                     clickhouseJsonEventsTopic: options.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
                     groupId,
                 }),

--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -3,6 +3,7 @@ import { Message } from 'node-rdkafka'
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
+import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
@@ -32,6 +33,7 @@ export interface EventSubpipelineConfig {
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
     }
+    kafkaProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
@@ -43,7 +45,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput & Ba
     builder: StartPipelineBuilder<TInput, TContext>,
     config: EventSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { options, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
+    const { options, kafkaProducer, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
 
     return builder
         .pipe(createNormalizeProcessPersonFlagStep())
@@ -61,6 +63,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput & Ba
         .pipe(createPrepareEventStep(teamManager, groupTypeManager, options))
         .pipe(
             createExtractHeatmapDataStep({
+                kafkaProducer,
                 CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: options.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
             })
         )
@@ -68,6 +71,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput & Ba
         .pipe(
             topHog(
                 createEmitEventStep({
+                    kafkaProducer,
                     clickhouseJsonEventsTopic: options.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
                     groupId,
                 }),

--- a/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
@@ -23,6 +24,7 @@ export interface HeatmapSubpipelineConfig {
     options: EventPipelineRunnerOptions & {
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
     }
+    kafkaProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
 }
@@ -31,7 +33,7 @@ export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput 
     builder: StartPipelineBuilder<TInput, TContext>,
     config: HeatmapSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { options, teamManager, groupTypeManager } = config
+    const { options, kafkaProducer, teamManager, groupTypeManager } = config
 
     return builder
         .pipe(createCheckHeatmapOptInStep())
@@ -40,6 +42,7 @@ export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput 
         .pipe(createPrepareEventStep(teamManager, groupTypeManager, options))
         .pipe(
             createExtractHeatmapDataStep({
+                kafkaProducer,
                 CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: options.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
             })
         )

--- a/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -1,14 +1,13 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
-import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { createCheckHeatmapOptInStep } from '../event-processing/check-heatmap-opt-in-step'
 import { createDisablePersonProcessingStep } from '../event-processing/disable-person-processing-step'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
 import { createExtractHeatmapDataStep } from '../event-processing/extract-heatmap-data-step'
+import { BatchStores } from '../event-processing/flush-batch-stores-step'
 import { createNormalizeEventStep } from '../event-processing/normalize-event-step'
 import { createPrepareEventStep } from '../event-processing/prepare-event-step'
 import { createSkipEmitEventStep } from '../event-processing/skip-emit-event-step'
@@ -26,24 +25,21 @@ export interface HeatmapSubpipelineConfig {
     }
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
-    groupStore: BatchWritingGroupStore
-    kafkaProducer: KafkaProducerWrapper
 }
 
-export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput, TContext>(
+export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput & BatchStores, TContext>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: HeatmapSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { options, teamManager, groupTypeManager, groupStore, kafkaProducer } = config
+    const { options, teamManager, groupTypeManager } = config
 
     return builder
         .pipe(createCheckHeatmapOptInStep())
         .pipe(createDisablePersonProcessingStep())
         .pipe(createNormalizeEventStep())
-        .pipe(createPrepareEventStep(teamManager, groupTypeManager, groupStore, options))
+        .pipe(createPrepareEventStep(teamManager, groupTypeManager, options))
         .pipe(
             createExtractHeatmapDataStep({
-                kafkaProducer,
                 CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: options.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
             })
         )

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -12,12 +12,15 @@ import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writ
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
-import { createFlushBatchStoresStep } from '../event-processing/flush-batch-stores-step'
+import {
+    BatchStores,
+    createFlushBatchStoresStep,
+    createSetBatchStoresStep,
+} from '../event-processing/flush-batch-stores-step'
 import { newBatchingPipeline } from '../pipelines/builders'
 import { TopHogRegistry, createTopHogWrapper } from '../pipelines/extensions/tophog'
 import { OkResultWithContext } from '../pipelines/filter-map-batch-pipeline'
 import { PipelineConfig } from '../pipelines/result-handling-pipeline'
-import { ok } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import {
     PerDistinctIdPipelineConfig,
@@ -70,7 +73,7 @@ export interface JoinedIngestionPipelineContext {
     message: Message
 }
 
-type PreprocessingOutput = PostTeamPreprocessingSubpipelineInput
+type PreprocessingOutput = PostTeamPreprocessingSubpipelineInput & BatchStores
 
 function addTeamToContext<T extends { team: Team }, C>(
     element: OkResultWithContext<T, C>
@@ -92,17 +95,8 @@ function getTokenAndDistinctId(input: PerDistinctIdPipelineInput): string {
 
 function mapToPerEventInput<C>(
     element: OkResultWithContext<PreprocessingOutput, C>
-): OkResultWithContext<PerDistinctIdPipelineInput, C> {
-    const input = element.result.value
-    return {
-        result: ok({
-            message: input.message,
-            event: input.event,
-            team: input.team,
-            headers: input.headers,
-        }),
-        context: element.context,
-    }
+): OkResultWithContext<PreprocessingOutput, C> {
+    return element
 }
 
 export function createJoinedIngestionPipeline<
@@ -154,7 +148,6 @@ export function createJoinedIngestionPipeline<
         preservePartitionLocality,
         overflowRedirectService,
         overflowLaneTTLRefreshService,
-        personsStore,
         personsPrefetchEnabled,
         hogTransformer,
         cdpHogWatcherSampleRate,
@@ -165,15 +158,12 @@ export function createJoinedIngestionPipeline<
         teamManager,
         groupTypeManager,
         hogTransformer,
-        personsStore,
-        groupStore,
-        kafkaProducer,
         groupId,
         topHog: topHogWrapper,
     }
 
-    return newBatchingPipeline<TInput, void, TContext>(
-        (beforeBatch) => beforeBatch.pipe(({ elements }) => Promise.resolve(ok({ elements, batchContext: {} }))),
+    return newBatchingPipeline<TInput, void, TContext, BatchStores>(
+        (beforeBatch) => beforeBatch.pipe(createSetBatchStoresStep({ personsStore, groupStore, kafkaProducer })),
         (batch) =>
             batch
                 .messageAware((b) =>
@@ -209,7 +199,9 @@ export function createJoinedIngestionPipeline<
                 )
                 .handleResults(pipelineConfig)
                 .handleSideEffects(promiseScheduler, { await: false }),
-        (afterBatch) => afterBatch.pipe(createFlushBatchStoresStep({ personsStore, groupStore, kafkaProducer })),
+        (afterBatch) => afterBatch.pipe(createFlushBatchStoresStep()),
+        // Batch stores (personsStore, groupStore) are singletons that don't support
+        // concurrent batches yet — they accumulate state across events and flush once.
         { concurrentBatches: 1 }
     )
 }

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -29,7 +29,6 @@ import {
 } from './per-distinct-id-pipeline'
 import {
     PostTeamPreprocessingSubpipelineConfig,
-    PostTeamPreprocessingSubpipelineInput,
     createPostTeamPreprocessingSubpipeline,
 } from './post-team-preprocessing-subpipeline'
 import { createPreTeamPreprocessingSubpipeline } from './pre-team-preprocessing-subpipeline'
@@ -73,8 +72,6 @@ export interface JoinedIngestionPipelineContext {
     message: Message
 }
 
-type PreprocessingOutput = PostTeamPreprocessingSubpipelineInput & BatchStores
-
 function addTeamToContext<T extends { team: Team }, C>(
     element: OkResultWithContext<T, C>
 ): OkResultWithContext<T, C & { team: Team }> {
@@ -91,12 +88,6 @@ function getTokenAndDistinctId(input: PerDistinctIdPipelineInput): string {
     const token = input.headers.token ?? ''
     const distinctId = input.event.distinct_id ?? ''
     return `${token}:${distinctId}`
-}
-
-function mapToPerEventInput<C>(
-    element: OkResultWithContext<PreprocessingOutput, C>
-): OkResultWithContext<PreprocessingOutput, C> {
-    return element
 }
 
 export function createJoinedIngestionPipeline<
@@ -183,16 +174,12 @@ export function createJoinedIngestionPipeline<
                                     createPostTeamPreprocessingSubpipeline(b, postTeamConfig)
                                         // Group by token:distinctId and process each group concurrently
                                         // Events within each group are processed sequentially
-                                        .filterMap(mapToPerEventInput, (b) =>
-                                            b
-                                                .groupBy(getTokenAndDistinctId)
-                                                .concurrently((eventsForDistinctId) =>
-                                                    eventsForDistinctId.sequentially((event) =>
-                                                        createPerDistinctIdPipeline(event, perEventConfig)
-                                                    )
-                                                )
+                                        .groupBy(getTokenAndDistinctId)
+                                        .concurrently((eventsForDistinctId) =>
+                                            eventsForDistinctId.sequentially((event) =>
+                                                createPerDistinctIdPipeline(event, perEventConfig)
+                                            )
                                         )
-                                        .gather()
                                 )
                                 .handleIngestionWarnings(kafkaProducer)
                         )

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -12,7 +12,7 @@ import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writ
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
-import { FlushBatchStoresStepConfig, flushBatchStores } from '../event-processing/flush-batch-stores-step'
+import { createFlushBatchStoresStep } from '../event-processing/flush-batch-stores-step'
 import { newBatchingPipeline } from '../pipelines/builders'
 import { TopHogRegistry, createTopHogWrapper } from '../pipelines/extensions/tophog'
 import { OkResultWithContext } from '../pipelines/filter-map-batch-pipeline'
@@ -172,10 +172,10 @@ export function createJoinedIngestionPipeline<
         topHog: topHogWrapper,
     }
 
-    return newBatchingPipeline<TInput, void, TContext, FlushBatchStoresStepConfig, TContext>(
-        (_batchContext, elements) => ({ elements }),
-        (builder) =>
-            builder
+    return newBatchingPipeline<TInput, void, TContext>(
+        (beforeBatch) => beforeBatch.pipe(({ elements }) => Promise.resolve(ok({ elements, batchContext: {} }))),
+        (batch) =>
+            batch
                 .messageAware((b) =>
                     b
                         .sequentially((b) =>
@@ -209,7 +209,7 @@ export function createJoinedIngestionPipeline<
                 )
                 .handleResults(pipelineConfig)
                 .handleSideEffects(promiseScheduler, { await: false }),
-        (batchContext, _elements, _batchId) => flushBatchStores(batchContext),
+        (afterBatch) => afterBatch.pipe(createFlushBatchStoresStep({ personsStore, groupStore, kafkaProducer })),
         { concurrentBatches: 1 }
     )
 }

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -12,8 +12,8 @@ import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writ
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
-import { createFlushBatchStoresStep } from '../event-processing/flush-batch-stores-step'
-import { BatchPipelineBuilder } from '../pipelines/builders/batch-pipeline-builders'
+import { FlushBatchStoresStepConfig, flushBatchStores } from '../event-processing/flush-batch-stores-step'
+import { newBatchingPipeline } from '../pipelines/builders'
 import { TopHogRegistry, createTopHogWrapper } from '../pipelines/extensions/tophog'
 import { OkResultWithContext } from '../pipelines/filter-map-batch-pipeline'
 import { PipelineConfig } from '../pipelines/result-handling-pipeline'
@@ -108,11 +108,7 @@ function mapToPerEventInput<C>(
 export function createJoinedIngestionPipeline<
     TInput extends JoinedIngestionPipelineInput,
     TContext extends JoinedIngestionPipelineContext,
->(
-    builder: BatchPipelineBuilder<TInput, TInput, TContext, TContext>,
-    config: JoinedIngestionPipelineConfig,
-    deps: JoinedIngestionPipelineDeps
-) {
+>(config: JoinedIngestionPipelineConfig, deps: JoinedIngestionPipelineDeps) {
     const {
         eventSchemaEnforcementEnabled,
         overflowEnabled,
@@ -176,46 +172,44 @@ export function createJoinedIngestionPipeline<
         topHog: topHogWrapper,
     }
 
-    return builder
-        .messageAware((b) =>
-            b
-                .sequentially((b) =>
-                    createPreTeamPreprocessingSubpipeline(b, {
-                        teamManager,
-                        eventIngestionRestrictionManager,
-                        overflowEnabled,
-                        overflowTopic,
-                        preservePartitionLocality,
-                    })
-                )
-                .filterMap(addTeamToContext, (b) =>
+    return newBatchingPipeline<TInput, void, TContext, FlushBatchStoresStepConfig, TContext>(
+        (_batchContext, elements) => ({ elements }),
+        (builder) =>
+            builder
+                .messageAware((b) =>
                     b
-                        .teamAware((b) =>
-                            createPostTeamPreprocessingSubpipeline(b, postTeamConfig)
-                                // Group by token:distinctId and process each group concurrently
-                                // Events within each group are processed sequentially
-                                .filterMap(mapToPerEventInput, (b) =>
-                                    b
-                                        .groupBy(getTokenAndDistinctId)
-                                        .concurrently((eventsForDistinctId) =>
-                                            eventsForDistinctId.sequentially((event) =>
-                                                createPerDistinctIdPipeline(event, perEventConfig)
-                                            )
-                                        )
-                                )
-                                .gather()
-                                // Flush person and group stores after all events processed
-                                .pipeBatch(
-                                    createFlushBatchStoresStep({
-                                        personsStore,
-                                        groupStore,
-                                        kafkaProducer,
-                                    })
-                                )
+                        .sequentially((b) =>
+                            createPreTeamPreprocessingSubpipeline(b, {
+                                teamManager,
+                                eventIngestionRestrictionManager,
+                                overflowEnabled,
+                                overflowTopic,
+                                preservePartitionLocality,
+                            })
                         )
-                        .handleIngestionWarnings(kafkaProducer)
+                        .filterMap(addTeamToContext, (b) =>
+                            b
+                                .teamAware((b) =>
+                                    createPostTeamPreprocessingSubpipeline(b, postTeamConfig)
+                                        // Group by token:distinctId and process each group concurrently
+                                        // Events within each group are processed sequentially
+                                        .filterMap(mapToPerEventInput, (b) =>
+                                            b
+                                                .groupBy(getTokenAndDistinctId)
+                                                .concurrently((eventsForDistinctId) =>
+                                                    eventsForDistinctId.sequentially((event) =>
+                                                        createPerDistinctIdPipeline(event, perEventConfig)
+                                                    )
+                                                )
+                                        )
+                                        .gather()
+                                )
+                                .handleIngestionWarnings(kafkaProducer)
+                        )
                 )
-        )
-        .handleResults(pipelineConfig)
-        .handleSideEffects(promiseScheduler, { await: false })
+                .handleResults(pipelineConfig)
+                .handleSideEffects(promiseScheduler, { await: false }),
+        (batchContext, _elements, _batchId) => flushBatchStores(batchContext),
+        { concurrentBatches: 1 }
+    )
 }

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -146,6 +146,7 @@ export function createJoinedIngestionPipeline<
 
     const perEventConfig: PerDistinctIdPipelineConfig = {
         options: perDistinctIdOptions,
+        kafkaProducer,
         teamManager,
         groupTypeManager,
         hogTransformer,

--- a/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -1,13 +1,11 @@
 import { Message } from 'node-rdkafka'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
-import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
-import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
+import { BatchStores } from '../event-processing/flush-batch-stores-step'
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 import { TopHogWrapper } from '../pipelines/extensions/tophog'
 import {
@@ -29,9 +27,6 @@ export interface PerDistinctIdPipelineConfig {
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
-    personsStore: PersonsStore
-    groupStore: BatchWritingGroupStore
-    kafkaProducer: KafkaProducerWrapper
     groupId: string
     topHog: TopHogWrapper
 }
@@ -54,21 +49,11 @@ function classifyEvent(input: PerDistinctIdPipelineInput): EventBranch {
     }
 }
 
-export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipelineInput, TContext>(
+export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipelineInput & BatchStores, TContext>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: PerDistinctIdPipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const {
-        options,
-        teamManager,
-        groupTypeManager,
-        hogTransformer,
-        personsStore,
-        groupStore,
-        kafkaProducer,
-        groupId,
-        topHog,
-    } = config
+    const { options, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
 
     return builder.retry(
         (e) =>
@@ -80,8 +65,6 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                             options,
                             teamManager,
                             groupTypeManager,
-                            groupStore,
-                            kafkaProducer,
                         })
                     )
                     .branch('event', (b) =>
@@ -90,9 +73,6 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                             teamManager,
                             groupTypeManager,
                             hogTransformer,
-                            personsStore,
-                            groupStore,
-                            kafkaProducer,
                             groupId,
                             topHog,
                         })

--- a/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -1,6 +1,7 @@
 import { Message } from 'node-rdkafka'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
+import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
@@ -24,6 +25,7 @@ export interface PerDistinctIdPipelineConfig {
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
     }
+    kafkaProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
@@ -53,7 +55,7 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
     builder: StartPipelineBuilder<TInput, TContext>,
     config: PerDistinctIdPipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { options, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
+    const { options, kafkaProducer, teamManager, groupTypeManager, hogTransformer, groupId, topHog } = config
 
     return builder.retry(
         (e) =>
@@ -63,6 +65,7 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                     .branch('heatmap', (b) =>
                         createHeatmapSubpipeline(b, {
                             options,
+                            kafkaProducer,
                             teamManager,
                             groupTypeManager,
                         })
@@ -70,6 +73,7 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                     .branch('event', (b) =>
                         createEventSubpipeline(b, {
                             options,
+                            kafkaProducer,
                             teamManager,
                             groupTypeManager,
                             hogTransformer,

--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -8,7 +8,6 @@ import { EventHeaders, Team } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
 import { EventSchemaEnforcementManager } from '../../utils/event-schema-enforcement-manager'
 import { prefetchPersonsStep } from '../../worker/ingestion/event-pipeline/prefetchPersonsStep'
-import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import {
     createApplyCookielessProcessingStep,
@@ -21,6 +20,7 @@ import {
     createValidateEventUuidStep,
 } from '../event-preprocessing'
 import { createDropOldEventsStep } from '../event-processing/drop-old-events-step'
+import { BatchStores } from '../event-processing/flush-batch-stores-step'
 import { createPrefetchHogFunctionsStep } from '../event-processing/prefetch-hog-functions-step'
 import { BatchPipelineBuilder } from '../pipelines/builders/batch-pipeline-builders'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
@@ -41,16 +41,15 @@ export interface PostTeamPreprocessingSubpipelineConfig {
     preservePartitionLocality: boolean
     overflowRedirectService?: OverflowRedirectService
     overflowLaneTTLRefreshService?: OverflowRedirectService
-    personsStore: PersonsStore
     personsPrefetchEnabled: boolean
     hogTransformer: HogTransformerService
     cdpHogWatcherSampleRate: number
 }
 
-export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPreprocessingSubpipelineInput, TContext>(
-    builder: BatchPipelineBuilder<TInput, TInput, TContext, TContext>,
-    config: PostTeamPreprocessingSubpipelineConfig
-) {
+export function createPostTeamPreprocessingSubpipeline<
+    TInput extends PostTeamPreprocessingSubpipelineInput & BatchStores,
+    TContext,
+>(builder: BatchPipelineBuilder<TInput, TInput, TContext, TContext>, config: PostTeamPreprocessingSubpipelineConfig) {
     const {
         eventIngestionRestrictionManager,
         eventSchemaEnforcementManager,
@@ -60,7 +59,6 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
         preservePartitionLocality,
         overflowRedirectService,
         overflowLaneTTLRefreshService,
-        personsStore,
         personsPrefetchEnabled,
         hogTransformer,
         cdpHogWatcherSampleRate,
@@ -92,9 +90,9 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             // Refresh TTLs for overflow lane events (keeps Redis flags alive)
             .pipeBatch(createOverflowLaneTTLRefreshStep(overflowLaneTTLRefreshService))
             // Prefetch must run after cookieless, as cookieless changes distinct IDs
-            .pipeBatch(prefetchPersonsStep(personsStore, personsPrefetchEnabled))
+            .pipeBatch(prefetchPersonsStep(personsPrefetchEnabled))
             // Batch insert personless distinct IDs after prefetch (uses prefetch cache)
-            .pipeBatch(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled))
+            .pipeBatch(processPersonlessDistinctIdsBatchStep(personsPrefetchEnabled))
             // Prefetch hog functions for all teams in the batch
             .pipeBatch(createPrefetchHogFunctionsStep(hogTransformer, cdpHogWatcherSampleRate))
     )

--- a/nodejs/src/ingestion/event-processing/create-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/create-event-step.ts
@@ -14,24 +14,17 @@ export interface CreateEventStepInput {
     message: Message
 }
 
-export interface CreateEventStepResult {
+export type CreateEventStepResult<TInput = CreateEventStepInput> = TInput & {
     eventToEmit: RawKafkaEvent
-    headers: EventHeaders
-    message: Message
 }
 
-export function createCreateEventStep<T extends CreateEventStepInput>(): ProcessingStep<T, CreateEventStepResult> {
-    return function createEventStep(input: T): Promise<PipelineResult<CreateEventStepResult>> {
-        const { person, preparedEvent, processPerson, historicalMigration, headers, message } = input
+export function createCreateEventStep<T extends CreateEventStepInput>(): ProcessingStep<T, CreateEventStepResult<T>> {
+    return function createEventStep(input: T): Promise<PipelineResult<CreateEventStepResult<T>>> {
+        const { person, preparedEvent, processPerson, historicalMigration, headers } = input
 
         const capturedAt = headers.now ?? null
         const rawEvent = createEvent(preparedEvent, person, processPerson, historicalMigration, capturedAt)
-        const result: CreateEventStepResult = {
-            eventToEmit: rawEvent,
-            headers,
-            message,
-        }
 
-        return Promise.resolve(ok(result, []))
+        return Promise.resolve(ok({ ...input, eventToEmit: rawEvent }, []))
     }
 }

--- a/nodejs/src/ingestion/event-processing/create-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/create-event-step.ts
@@ -14,17 +14,19 @@ export interface CreateEventStepInput {
     message: Message
 }
 
-export type CreateEventStepResult<TInput = CreateEventStepInput> = TInput & {
+export interface CreateEventStepResult {
     eventToEmit: RawKafkaEvent
+    headers: EventHeaders
+    message: Message
 }
 
-export function createCreateEventStep<T extends CreateEventStepInput>(): ProcessingStep<T, CreateEventStepResult<T>> {
-    return function createEventStep(input: T): Promise<PipelineResult<CreateEventStepResult<T>>> {
-        const { person, preparedEvent, processPerson, historicalMigration, headers } = input
+export function createCreateEventStep<T extends CreateEventStepInput>(): ProcessingStep<T, CreateEventStepResult> {
+    return function createEventStep(input: T): Promise<PipelineResult<CreateEventStepResult>> {
+        const { person, preparedEvent, processPerson, historicalMigration, headers, message } = input
 
         const capturedAt = headers.now ?? null
         const rawEvent = createEvent(preparedEvent, person, processPerson, historicalMigration, capturedAt)
 
-        return Promise.resolve(ok({ ...input, eventToEmit: rawEvent }, []))
+        return Promise.resolve(ok({ eventToEmit: rawEvent, headers, message }, []))
     }
 }

--- a/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
@@ -62,7 +62,6 @@ describe('emit-event-step', () => {
         } as any
 
         config = {
-            kafkaProducer: mockKafkaProducer,
             clickhouseJsonEventsTopic: 'clickhouse_events_json',
             groupId: 'test-group-id',
         }
@@ -90,7 +89,12 @@ describe('emit-event-step', () => {
     describe('createEmitEventStep', () => {
         it('should emit event successfully when eventToEmit is present', async () => {
             const step = createEmitEventStep(config)
-            const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             const result = await step(input)
 
@@ -116,7 +120,12 @@ describe('emit-event-step', () => {
             mockKafkaProducer.produce.mockRejectedValue(messageSizeTooLargeError)
 
             const step = createEmitEventStep(config)
-            const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             const result = await step(input)
 
@@ -142,7 +151,12 @@ describe('emit-event-step', () => {
             mockKafkaProducer.produce.mockRejectedValue(genericError)
 
             const step = createEmitEventStep(config)
-            const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             const result = await step(input)
 
@@ -158,7 +172,12 @@ describe('emit-event-step', () => {
 
         it('should serialize event correctly for Kafka', async () => {
             const step = createEmitEventStep(config)
-            const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             await step(input)
 
@@ -176,7 +195,12 @@ describe('emit-event-step', () => {
                 clickhouseJsonEventsTopic: 'custom_topic',
             }
             const step = createEmitEventStep(customConfig)
-            const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             await step(input)
 
@@ -194,7 +218,12 @@ describe('emit-event-step', () => {
                 ...mockRawEvent,
                 uuid: 'different-uuid',
             }
-            const input = { eventToEmit: eventWithDifferentUuid, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: eventWithDifferentUuid,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             await step(input)
 
@@ -211,6 +240,7 @@ describe('emit-event-step', () => {
                 eventToEmit: RawKafkaEvent
                 headers: EventHeaders
                 message: Message
+                kafkaProducer: KafkaProducerWrapper
                 customProperty: string
                 lastStep: string
             }
@@ -220,6 +250,7 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
                 customProperty: 'test',
                 lastStep: 'testStep',
             }
@@ -241,6 +272,7 @@ describe('emit-event-step', () => {
                 eventToEmit: RawKafkaEvent
                 headers: EventHeaders
                 message: Message
+                kafkaProducer: KafkaProducerWrapper
                 error?: string
             }
 
@@ -250,6 +282,7 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
             }
 
             const result = await step(input)
@@ -266,7 +299,12 @@ describe('emit-event-step', () => {
         describe('metrics tracking', () => {
             it('should increment eventProcessedAndIngestedCounter when event is successfully emitted', async () => {
                 const step = createEmitEventStep(config)
-                const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    headers: mockHeaders,
+                    message: mockMessage,
+                    kafkaProducer: mockKafkaProducer,
+                }
 
                 const result = await step(input)
 
@@ -285,7 +323,12 @@ describe('emit-event-step', () => {
                 mockKafkaProducer.produce.mockRejectedValue(kafkaError)
 
                 const step = createEmitEventStep(config)
-                const input = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    headers: mockHeaders,
+                    message: mockMessage,
+                    kafkaProducer: mockKafkaProducer,
+                }
 
                 const result = await step(input)
 
@@ -301,11 +344,17 @@ describe('emit-event-step', () => {
 
             it('should increment metric only once per successful emit', async () => {
                 const step = createEmitEventStep(config)
-                const input1 = { eventToEmit: mockRawEvent, headers: mockHeaders, message: mockMessage }
+                const input1 = {
+                    eventToEmit: mockRawEvent,
+                    headers: mockHeaders,
+                    message: mockMessage,
+                    kafkaProducer: mockKafkaProducer,
+                }
                 const input2 = {
                     eventToEmit: { ...mockRawEvent, uuid: 'different-uuid' },
                     headers: mockHeaders,
                     message: mockMessage,
+                    kafkaProducer: mockKafkaProducer,
                 }
 
                 // First emit
@@ -325,7 +374,12 @@ describe('emit-event-step', () => {
         it('should emit AI events with llma product track header', async () => {
             const aiEvent = { ...mockRawEvent, event: '$ai_generation' }
             const step = createEmitEventStep(config)
-            const input = { eventToEmit: aiEvent, headers: mockHeaders, message: mockMessage }
+            const input = {
+                eventToEmit: aiEvent,
+                headers: mockHeaders,
+                message: mockMessage,
+                kafkaProducer: mockKafkaProducer,
+            }
 
             await step(input)
 
@@ -400,6 +454,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: captureTime }),
                 message: createMessage(),
             }
@@ -419,6 +474,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders(),
                 message: createMessage(),
             }
@@ -433,6 +489,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ topic: undefined as unknown as string }),
             }
@@ -447,6 +504,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ partition: undefined as unknown as number }),
             }
@@ -462,6 +520,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(customConfig)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage(),
             }
@@ -479,6 +538,7 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
+                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ partition: 0 }),
             }
@@ -498,6 +558,7 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
+                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: captureTime }),
                     message: createMessage(),
                 }
@@ -517,6 +578,7 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(customConfig)
                 const input = {
                     eventToEmit: mockRawEvent,
+                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                     message: createMessage({ partition: 3 }),
                 }
@@ -534,6 +596,7 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
+                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders(),
                     message: createMessage(),
                 }
@@ -548,6 +611,7 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
+                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                     message: createMessage({ partition: undefined as unknown as number }),
                 }
@@ -562,6 +626,7 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
+                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 2500) }),
                     message: createMessage({ partition: 0 }),
                 }

--- a/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
@@ -62,6 +62,7 @@ describe('emit-event-step', () => {
         } as any
 
         config = {
+            kafkaProducer: mockKafkaProducer,
             clickhouseJsonEventsTopic: 'clickhouse_events_json',
             groupId: 'test-group-id',
         }
@@ -93,7 +94,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             const result = await step(input)
@@ -124,7 +124,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             const result = await step(input)
@@ -155,7 +154,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             const result = await step(input)
@@ -176,7 +174,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             await step(input)
@@ -199,7 +196,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             await step(input)
@@ -222,7 +218,6 @@ describe('emit-event-step', () => {
                 eventToEmit: eventWithDifferentUuid,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             await step(input)
@@ -240,7 +235,6 @@ describe('emit-event-step', () => {
                 eventToEmit: RawKafkaEvent
                 headers: EventHeaders
                 message: Message
-                kafkaProducer: KafkaProducerWrapper
                 customProperty: string
                 lastStep: string
             }
@@ -250,7 +244,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
                 customProperty: 'test',
                 lastStep: 'testStep',
             }
@@ -272,7 +265,6 @@ describe('emit-event-step', () => {
                 eventToEmit: RawKafkaEvent
                 headers: EventHeaders
                 message: Message
-                kafkaProducer: KafkaProducerWrapper
                 error?: string
             }
 
@@ -282,7 +274,6 @@ describe('emit-event-step', () => {
                 eventToEmit: mockRawEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             const result = await step(input)
@@ -303,7 +294,6 @@ describe('emit-event-step', () => {
                     eventToEmit: mockRawEvent,
                     headers: mockHeaders,
                     message: mockMessage,
-                    kafkaProducer: mockKafkaProducer,
                 }
 
                 const result = await step(input)
@@ -327,7 +317,6 @@ describe('emit-event-step', () => {
                     eventToEmit: mockRawEvent,
                     headers: mockHeaders,
                     message: mockMessage,
-                    kafkaProducer: mockKafkaProducer,
                 }
 
                 const result = await step(input)
@@ -348,13 +337,11 @@ describe('emit-event-step', () => {
                     eventToEmit: mockRawEvent,
                     headers: mockHeaders,
                     message: mockMessage,
-                    kafkaProducer: mockKafkaProducer,
                 }
                 const input2 = {
                     eventToEmit: { ...mockRawEvent, uuid: 'different-uuid' },
                     headers: mockHeaders,
                     message: mockMessage,
-                    kafkaProducer: mockKafkaProducer,
                 }
 
                 // First emit
@@ -378,7 +365,6 @@ describe('emit-event-step', () => {
                 eventToEmit: aiEvent,
                 headers: mockHeaders,
                 message: mockMessage,
-                kafkaProducer: mockKafkaProducer,
             }
 
             await step(input)
@@ -454,7 +440,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: captureTime }),
                 message: createMessage(),
             }
@@ -474,7 +459,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders(),
                 message: createMessage(),
             }
@@ -489,7 +473,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ topic: undefined as unknown as string }),
             }
@@ -504,7 +487,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ partition: undefined as unknown as number }),
             }
@@ -520,7 +502,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(customConfig)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage(),
             }
@@ -538,7 +519,6 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                kafkaProducer: mockKafkaProducer,
                 headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                 message: createMessage({ partition: 0 }),
             }
@@ -558,7 +538,6 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
-                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: captureTime }),
                     message: createMessage(),
                 }
@@ -578,7 +557,6 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(customConfig)
                 const input = {
                     eventToEmit: mockRawEvent,
-                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                     message: createMessage({ partition: 3 }),
                 }
@@ -596,7 +574,6 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
-                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders(),
                     message: createMessage(),
                 }
@@ -611,7 +588,6 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
-                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
                     message: createMessage({ partition: undefined as unknown as number }),
                 }
@@ -626,7 +602,6 @@ describe('emit-event-step', () => {
                 const step = createEmitEventStep(config)
                 const input = {
                     eventToEmit: mockRawEvent,
-                    kafkaProducer: mockKafkaProducer,
                     headers: createHeaders({ now: new Date(FAKE_NOW_MS - 2500) }),
                     message: createMessage({ partition: 0 }),
                 }

--- a/nodejs/src/ingestion/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.ts
@@ -10,6 +10,7 @@ import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EmitEventStepConfig {
+    kafkaProducer: KafkaProducerWrapper
     clickhouseJsonEventsTopic: string
     groupId: string
 }
@@ -18,15 +19,14 @@ export interface EmitEventStepInput {
     eventToEmit: RawKafkaEvent
     headers: EventHeaders
     message: Message
-    kafkaProducer: KafkaProducerWrapper
 }
 
 export function createEmitEventStep<T extends EmitEventStepInput>(
     config: EmitEventStepConfig
 ): ProcessingStep<T, void> {
     return function emitEventStep(input: T): Promise<PipelineResult<void>> {
-        const { eventToEmit, headers, message, kafkaProducer } = input
-        const { clickhouseJsonEventsTopic, groupId } = config
+        const { eventToEmit, headers, message } = input
+        const { clickhouseJsonEventsTopic, groupId, kafkaProducer } = config
 
         // Record ingestion lag metric if we have the required data
         if (headers?.now && message?.topic !== undefined && message?.partition !== undefined) {

--- a/nodejs/src/ingestion/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.ts
@@ -10,7 +10,6 @@ import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EmitEventStepConfig {
-    kafkaProducer: KafkaProducerWrapper
     clickhouseJsonEventsTopic: string
     groupId: string
 }
@@ -19,14 +18,15 @@ export interface EmitEventStepInput {
     eventToEmit: RawKafkaEvent
     headers: EventHeaders
     message: Message
+    kafkaProducer: KafkaProducerWrapper
 }
 
 export function createEmitEventStep<T extends EmitEventStepInput>(
     config: EmitEventStepConfig
 ): ProcessingStep<T, void> {
     return function emitEventStep(input: T): Promise<PipelineResult<void>> {
-        const { eventToEmit, headers, message } = input
-        const { kafkaProducer, clickhouseJsonEventsTopic, groupId } = config
+        const { eventToEmit, headers, message, kafkaProducer } = input
+        const { clickhouseJsonEventsTopic, groupId } = config
 
         // Record ingestion lag metric if we have the required data
         if (headers?.now && message?.topic !== undefined && message?.partition !== undefined) {

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
@@ -51,6 +51,7 @@ describe('createExtractHeatmapDataStep', () => {
         } as any
 
         step = createExtractHeatmapDataStep({
+            kafkaProducer: mockProducer,
             CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: 'clickhouse_heatmaps_test',
         })
     })
@@ -60,7 +61,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             delete event.properties.$heatmap_data
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -75,7 +76,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = null
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).not.toHaveBeenCalled()
@@ -85,7 +86,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = undefined
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).not.toHaveBeenCalled()
@@ -96,7 +97,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('extracts and queues heatmap data', async () => {
             const event = createTestEvent()
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -152,7 +153,7 @@ describe('createExtractHeatmapDataStep', () => {
                 'http://localhost:3000/about': [{ x: 300, y: 400, target_fixed: true, type: 'mousemove' }],
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -174,7 +175,7 @@ describe('createExtractHeatmapDataStep', () => {
                 $prev_pageview_max_scroll: 225,
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -211,7 +212,7 @@ describe('createExtractHeatmapDataStep', () => {
                 $prev_pageview_max_scroll: 500,
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -237,7 +238,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = {}
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -250,7 +251,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('drops event with invalid distinct_id', async () => {
             const event = createTestEvent({ distinctId: '' })
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -262,7 +263,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('drops event with illegal distinct_id', async () => {
             const event = createTestEvent({ distinctId: 'distinct_id' })
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -276,7 +277,7 @@ describe('createExtractHeatmapDataStep', () => {
             event.properties.$viewport_height = NaN
             event.properties.$viewport_width = 1071
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -289,7 +290,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             delete event.properties.$viewport_height
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -303,7 +304,7 @@ describe('createExtractHeatmapDataStep', () => {
                 '   ': [{ x: 100, y: 200, target_fixed: false, type: 'click' }],
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -326,7 +327,7 @@ describe('createExtractHeatmapDataStep', () => {
                 'http://localhost:3000/': 'not an array' as any,
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -356,7 +357,7 @@ describe('createExtractHeatmapDataStep', () => {
                 ],
             }
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -372,7 +373,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             const originalEvent = cloneObject(event)
 
-            await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            await step({ preparedEvent: event })
 
             expect(event).toEqual(originalEvent)
             expect(event.properties.$heatmap_data).toBeDefined()
@@ -408,7 +409,7 @@ describe('createExtractHeatmapDataStep', () => {
             }
             event.distinctId = null as any // This should cause an error
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             // The error should be caught and converted to a warning
             expect(result.type).toBe(PipelineResultType.DROP)
@@ -424,7 +425,7 @@ describe('createExtractHeatmapDataStep', () => {
             event.properties.$viewport_height = 1600
             event.properties.$viewport_width = 1280
 
-            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
+            const result = await step({ preparedEvent: event })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
@@ -51,7 +51,6 @@ describe('createExtractHeatmapDataStep', () => {
         } as any
 
         step = createExtractHeatmapDataStep({
-            kafkaProducer: mockProducer,
             CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: 'clickhouse_heatmaps_test',
         })
     })
@@ -61,7 +60,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             delete event.properties.$heatmap_data
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -76,7 +75,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = null
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).not.toHaveBeenCalled()
@@ -86,7 +85,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = undefined
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).not.toHaveBeenCalled()
@@ -97,7 +96,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('extracts and queues heatmap data', async () => {
             const event = createTestEvent()
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -153,7 +152,7 @@ describe('createExtractHeatmapDataStep', () => {
                 'http://localhost:3000/about': [{ x: 300, y: 400, target_fixed: true, type: 'mousemove' }],
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -175,7 +174,7 @@ describe('createExtractHeatmapDataStep', () => {
                 $prev_pageview_max_scroll: 225,
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -212,7 +211,7 @@ describe('createExtractHeatmapDataStep', () => {
                 $prev_pageview_max_scroll: 500,
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -238,7 +237,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             event.properties.$heatmap_data = {}
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -251,7 +250,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('drops event with invalid distinct_id', async () => {
             const event = createTestEvent({ distinctId: '' })
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -263,7 +262,7 @@ describe('createExtractHeatmapDataStep', () => {
         it('drops event with illegal distinct_id', async () => {
             const event = createTestEvent({ distinctId: 'distinct_id' })
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -277,7 +276,7 @@ describe('createExtractHeatmapDataStep', () => {
             event.properties.$viewport_height = NaN
             event.properties.$viewport_width = 1071
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -290,7 +289,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             delete event.properties.$viewport_height
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.DROP)
             if (result.type === PipelineResultType.DROP) {
@@ -304,7 +303,7 @@ describe('createExtractHeatmapDataStep', () => {
                 '   ': [{ x: 100, y: 200, target_fixed: false, type: 'click' }],
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -327,7 +326,7 @@ describe('createExtractHeatmapDataStep', () => {
                 'http://localhost:3000/': 'not an array' as any,
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
@@ -357,7 +356,7 @@ describe('createExtractHeatmapDataStep', () => {
                 ],
             }
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
@@ -373,7 +372,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             const originalEvent = cloneObject(event)
 
-            await step({ preparedEvent: event })
+            await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(event).toEqual(originalEvent)
             expect(event.properties.$heatmap_data).toBeDefined()
@@ -383,6 +382,7 @@ describe('createExtractHeatmapDataStep', () => {
             const event = createTestEvent()
             const input = {
                 preparedEvent: event,
+                kafkaProducer: mockProducer,
                 customField: 'test-value',
                 anotherField: 123,
             }
@@ -408,7 +408,7 @@ describe('createExtractHeatmapDataStep', () => {
             }
             event.distinctId = null as any // This should cause an error
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             // The error should be caught and converted to a warning
             expect(result.type).toBe(PipelineResultType.DROP)
@@ -424,7 +424,7 @@ describe('createExtractHeatmapDataStep', () => {
             event.properties.$viewport_height = 1600
             event.properties.$viewport_width = 1280
 
-            const result = await step({ preparedEvent: event })
+            const result = await step({ preparedEvent: event, kafkaProducer: mockProducer })
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -17,13 +17,15 @@ export type ExtractHeatmapDataStepResult<TInput> = TInput & {
     preparedEvent: PreIngestionEvent
 }
 
-export function createExtractHeatmapDataStep<
-    TInput extends ExtractHeatmapDataStepInput & { kafkaProducer: KafkaProducerWrapper },
->(config: { CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string }): ProcessingStep<TInput, ExtractHeatmapDataStepResult<TInput>> {
+export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataStepInput>(config: {
+    kafkaProducer: KafkaProducerWrapper
+    CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
+}): ProcessingStep<TInput, ExtractHeatmapDataStepResult<TInput>> {
     return async function extractHeatmapDataStep(
         input: TInput
     ): Promise<PipelineResult<ExtractHeatmapDataStepResult<TInput>>> {
-        const { preparedEvent, kafkaProducer } = input
+        const { preparedEvent } = input
+        const { kafkaProducer } = config
         const { eventUuid } = preparedEvent
         const acks: Promise<void>[] = []
         const warnings: PipelineWarning[] = []

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -1,6 +1,7 @@
 import { URL } from 'url'
 
-import { Hub, PreIngestionEvent, RawClickhouseHeatmapEvent, TimestampFormat } from '../../types'
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { PreIngestionEvent, RawClickhouseHeatmapEvent, TimestampFormat } from '../../types'
 import { logger } from '../../utils/logger'
 import { castTimestampOrNow } from '../../utils/utils'
 import { isDistinctIdIllegal } from '../../worker/ingestion/persons/person-merge-service'
@@ -16,13 +17,13 @@ export type ExtractHeatmapDataStepResult<TInput> = TInput & {
     preparedEvent: PreIngestionEvent
 }
 
-export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataStepInput>(
-    hub: Pick<Hub, 'CLICKHOUSE_HEATMAPS_KAFKA_TOPIC' | 'kafkaProducer'>
-): ProcessingStep<TInput, ExtractHeatmapDataStepResult<TInput>> {
+export function createExtractHeatmapDataStep<
+    TInput extends ExtractHeatmapDataStepInput & { kafkaProducer: KafkaProducerWrapper },
+>(config: { CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string }): ProcessingStep<TInput, ExtractHeatmapDataStepResult<TInput>> {
     return async function extractHeatmapDataStep(
         input: TInput
     ): Promise<PipelineResult<ExtractHeatmapDataStepResult<TInput>>> {
-        const { preparedEvent } = input
+        const { preparedEvent, kafkaProducer } = input
         const { eventUuid } = preparedEvent
         const acks: Promise<void>[] = []
         const warnings: PipelineWarning[] = []
@@ -39,8 +40,8 @@ export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataSt
 
             if (heatmapEvents.length > 0) {
                 acks.push(
-                    hub.kafkaProducer.queueMessages({
-                        topic: hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                    kafkaProducer.queueMessages({
+                        topic: config.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
                         messages: heatmapEvents.map((rawEvent) => ({
                             key: eventUuid,
                             value: JSON.stringify(rawEvent),

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
@@ -3,17 +3,27 @@ import { MessageSizeTooLarge } from '../../utils/db/error'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { FlushBatchStoresStepConfig, flushBatchStores } from './flush-batch-stores-step'
+import { AfterBatchInput, AfterBatchStep } from '../pipelines/batching-pipeline'
+import { isOkResult } from '../pipelines/results'
+import { createFlushBatchStoresStep } from './flush-batch-stores-step'
 
 jest.mock('../../worker/ingestion/utils', () => ({
     captureIngestionWarning: jest.fn(),
 }))
 
-describe('flushBatchStores', () => {
+describe('createFlushBatchStoresStep', () => {
     let mockPersonsStore: jest.Mocked<PersonsStore>
     let mockGroupStore: jest.Mocked<BatchWritingGroupStore>
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
-    let config: FlushBatchStoresStepConfig
+    let step: AfterBatchStep<void, any, Record<string, never>>
+
+    function makeInput(): AfterBatchInput<void, any, Record<string, never>> {
+        return {
+            elements: [],
+            batchContext: {},
+            batchId: 0,
+        }
+    }
 
     beforeEach(() => {
         mockPersonsStore = {
@@ -32,11 +42,11 @@ describe('flushBatchStores', () => {
             produce: jest.fn(),
         } as any
 
-        config = {
+        step = createFlushBatchStoresStep({
             personsStore: mockPersonsStore,
             groupStore: mockGroupStore,
             kafkaProducer: mockKafkaProducer,
-        }
+        })
 
         jest.clearAllMocks()
     })
@@ -45,7 +55,7 @@ describe('flushBatchStores', () => {
         mockPersonsStore.flush.mockResolvedValue([])
         mockGroupStore.flush.mockResolvedValue([])
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
         expect(mockPersonsStore.flush).toHaveBeenCalledTimes(1)
         expect(mockGroupStore.flush).toHaveBeenCalledTimes(1)
@@ -55,7 +65,7 @@ describe('flushBatchStores', () => {
         mockPersonsStore.flush.mockResolvedValue([])
         mockGroupStore.flush.mockResolvedValue([])
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
         expect(mockPersonsStore.reportBatch).toHaveBeenCalledTimes(1)
         expect(mockGroupStore.reportBatch).toHaveBeenCalledTimes(1)
@@ -65,13 +75,13 @@ describe('flushBatchStores', () => {
         mockPersonsStore.flush.mockResolvedValue([])
         mockGroupStore.flush.mockResolvedValue([])
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
         expect(mockPersonsStore.reset).toHaveBeenCalledTimes(1)
         expect(mockGroupStore.reset).toHaveBeenCalledTimes(1)
     })
 
-    it('should return undefined value and produce promises as side effects', async () => {
+    it('should return ok result with produce promises as side effects', async () => {
         const personMessages: FlushResult[] = [
             {
                 topicMessage: {
@@ -88,10 +98,12 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
-        expect(result.elements).toBeUndefined()
-        expect(result.sideEffects).toHaveLength(1)
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(1)
+        }
         expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
             topic: 'person_updates',
             key: Buffer.from('key1'),
@@ -120,10 +132,13 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
         expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(2)
-        expect(result.sideEffects).toHaveLength(2)
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(2)
+        }
     })
 
     it('should handle multiple flush results with multiple messages each', async () => {
@@ -151,20 +166,25 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
         expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(3)
-        expect(result.sideEffects).toHaveLength(3)
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(3)
+        }
     })
 
     it('should return empty side effects when no messages to produce', async () => {
         mockPersonsStore.flush.mockResolvedValue([])
         mockGroupStore.flush.mockResolvedValue([])
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
-        expect(result.elements).toBeUndefined()
-        expect(result.sideEffects).toHaveLength(0)
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(0)
+        }
     })
 
     it('should handle MessageSizeTooLarge errors gracefully', async () => {
@@ -184,16 +204,18 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockRejectedValue(new MessageSizeTooLarge('test', new Error('too large')))
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
-        // Side effect resolves (doesn't throw) because the error is caught
-        expect(result.sideEffects).toHaveLength(1)
-        await result.sideEffects![0]
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(1)
+            await result.sideEffects[0]
+        }
 
         expect(captureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
             eventUuid: 'uuid1',
             distinctId: 'user1',
-            step: 'flushBatchStores',
+            step: 'flushBatchStoresStep',
         })
     })
 
@@ -214,31 +236,34 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockRejectedValue(new Error('Kafka connection failed'))
 
-        const result = await flushBatchStores(config)
+        const result = await step(makeInput())
 
-        expect(result.sideEffects).toHaveLength(1)
-        await expect(result.sideEffects![0]).rejects.toThrow('Kafka connection failed')
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.sideEffects).toHaveLength(1)
+            await expect(result.sideEffects[0]).rejects.toThrow('Kafka connection failed')
+        }
     })
 
     it('should throw if person store flush fails', async () => {
         mockPersonsStore.flush.mockRejectedValue(new Error('Database connection failed'))
         mockGroupStore.flush.mockResolvedValue([])
 
-        await expect(flushBatchStores(config)).rejects.toThrow('Database connection failed')
+        await expect(step(makeInput())).rejects.toThrow('Database connection failed')
     })
 
     it('should throw if group store flush fails', async () => {
         mockPersonsStore.flush.mockResolvedValue([])
         mockGroupStore.flush.mockRejectedValue(new Error('Database connection failed'))
 
-        await expect(flushBatchStores(config)).rejects.toThrow('Database connection failed')
+        await expect(step(makeInput())).rejects.toThrow('Database connection failed')
     })
 
     it('should not reset or report if flush fails', async () => {
         mockPersonsStore.flush.mockRejectedValue(new Error('DB error'))
         mockGroupStore.flush.mockResolvedValue([])
 
-        await expect(flushBatchStores(config)).rejects.toThrow('DB error')
+        await expect(step(makeInput())).rejects.toThrow('DB error')
 
         expect(mockPersonsStore.reportBatch).not.toHaveBeenCalled()
         expect(mockGroupStore.reportBatch).not.toHaveBeenCalled()
@@ -261,7 +286,7 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
         expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
             topic: 'person_updates',
@@ -295,10 +320,8 @@ describe('flushBatchStores', () => {
             callOrder.push('group.reset')
         })
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
-        // Flushes happen in parallel, so order between them doesn't matter
-        // But reportBatch and reset must happen after flush
         expect(callOrder.slice(0, 2).sort()).toEqual(['group.flush', 'persons.flush'])
         expect(callOrder.slice(2)).toEqual(['persons.reportBatch', 'group.reportBatch', 'persons.reset', 'group.reset'])
     })
@@ -324,7 +347,7 @@ describe('flushBatchStores', () => {
         mockGroupStore.flush.mockResolvedValue([])
         mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        await flushBatchStores(config)
+        await step(makeInput())
 
         expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
             topic: 'person_updates',
@@ -332,5 +355,20 @@ describe('flushBatchStores', () => {
             value: Buffer.from('string-value'),
             headers: { header1: 'value1' },
         })
+    })
+
+    it('should pass through elements and batchContext in the result', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockResolvedValue([])
+
+        const input = makeInput()
+        input.elements = [{ result: 'test-element' }] as any
+        const result = await step(input)
+
+        expect(isOkResult(result)).toBe(true)
+        if (isOkResult(result)) {
+            expect(result.value.elements).toEqual([{ result: 'test-element' }])
+            expect(result.value.batchContext).toBe(input.batchContext)
+        }
     })
 })

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
@@ -3,17 +3,17 @@ import { MessageSizeTooLarge } from '../../utils/db/error'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { PipelineResultType } from '../pipelines/results'
-import { createFlushBatchStoresStep } from './flush-batch-stores-step'
+import { FlushBatchStoresStepConfig, flushBatchStores } from './flush-batch-stores-step'
 
 jest.mock('../../worker/ingestion/utils', () => ({
     captureIngestionWarning: jest.fn(),
 }))
 
-describe('flush-batch-stores-step', () => {
+describe('flushBatchStores', () => {
     let mockPersonsStore: jest.Mocked<PersonsStore>
     let mockGroupStore: jest.Mocked<BatchWritingGroupStore>
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
+    let config: FlushBatchStoresStepConfig
 
     beforeEach(() => {
         mockPersonsStore = {
@@ -32,457 +32,305 @@ describe('flush-batch-stores-step', () => {
             produce: jest.fn(),
         } as any
 
+        config = {
+            personsStore: mockPersonsStore,
+            groupStore: mockGroupStore,
+            kafkaProducer: mockKafkaProducer,
+        }
+
         jest.clearAllMocks()
     })
 
-    describe('createFlushBatchStoresStep', () => {
-        it('should flush both stores in parallel', async () => {
-            mockPersonsStore.flush.mockResolvedValue([])
-            mockGroupStore.flush.mockResolvedValue([])
+    it('should flush both stores in parallel', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockResolvedValue([])
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        await flushBatchStores(config)
 
-            const batch = [{ id: 1 }, { id: 2 }]
-            await step(batch)
+        expect(mockPersonsStore.flush).toHaveBeenCalledTimes(1)
+        expect(mockGroupStore.flush).toHaveBeenCalledTimes(1)
+    })
 
-            expect(mockPersonsStore.flush).toHaveBeenCalledTimes(1)
-            expect(mockGroupStore.flush).toHaveBeenCalledTimes(1)
-        })
+    it('should report batch metrics after flushing', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockResolvedValue([])
 
-        it('should report batch metrics after flushing', async () => {
-            mockPersonsStore.flush.mockResolvedValue([])
-            mockGroupStore.flush.mockResolvedValue([])
+        await flushBatchStores(config)
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        expect(mockPersonsStore.reportBatch).toHaveBeenCalledTimes(1)
+        expect(mockGroupStore.reportBatch).toHaveBeenCalledTimes(1)
+    })
 
-            await step([{ id: 1 }])
+    it('should reset both stores after flushing', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockResolvedValue([])
 
-            expect(mockPersonsStore.reportBatch).toHaveBeenCalledTimes(1)
-            expect(mockGroupStore.reportBatch).toHaveBeenCalledTimes(1)
-        })
+        await flushBatchStores(config)
 
-        it('should reset both stores after flushing', async () => {
-            mockPersonsStore.flush.mockResolvedValue([])
-            mockGroupStore.flush.mockResolvedValue([])
+        expect(mockPersonsStore.reset).toHaveBeenCalledTimes(1)
+        expect(mockGroupStore.reset).toHaveBeenCalledTimes(1)
+    })
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await step([{ id: 1 }])
-
-            expect(mockPersonsStore.reset).toHaveBeenCalledTimes(1)
-            expect(mockGroupStore.reset).toHaveBeenCalledTimes(1)
-        })
-
-        it('should create produce promises for person store messages', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [
-                            {
-                                key: 'key1',
-                                value: 'value1',
-                                headers: {},
-                            },
-                        ],
-                    },
-                    teamId: 1,
-                    distinctId: 'user1',
-                    uuid: 'uuid1',
+    it('should return undefined value and produce promises as side effects', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
                 },
-            ]
-
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            const results = await step([{ id: 1 }])
-
-            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-                topic: 'person_updates',
-                key: Buffer.from('key1'),
-                value: Buffer.from('value1'),
-                headers: {},
-            })
-
-            expect(results).toHaveLength(1)
-            expect(results[0].type).toBe(PipelineResultType.OK)
-            expect(results[0].sideEffects).toHaveLength(1)
-        })
-
-        it('should handle multiple messages per flush result', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [
-                            { key: 'key1', value: 'value1', headers: {} },
-                            { key: 'key2', value: 'value2', headers: {} },
-                        ],
-                    },
-                    teamId: 1,
-                    distinctId: 'user1',
-                    uuid: 'uuid1',
-                },
-            ]
-
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            const results = await step([{ id: 1 }])
-
-            expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(2)
-            expect(results[0].sideEffects).toHaveLength(2)
-        })
-
-        it('should return same number of results as batch size', async () => {
-            mockPersonsStore.flush.mockResolvedValue([])
-            mockGroupStore.flush.mockResolvedValue([])
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            const batch = [{ id: 1 }, { id: 2 }, { id: 3 }]
-            const results = await step(batch)
-
-            expect(results).toHaveLength(3)
-            results.forEach((result) => {
-                expect(result.type).toBe(PipelineResultType.OK)
-            })
-        })
-
-        it('should handle empty batch', async () => {
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            const results = await step([])
-
-            expect(results).toHaveLength(0)
-            expect(mockPersonsStore.flush).not.toHaveBeenCalled()
-            expect(mockGroupStore.flush).not.toHaveBeenCalled()
-        })
-
-        it('should handle MessageSizeTooLarge errors gracefully', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
-                    },
-                    teamId: 1,
-                    distinctId: 'user1',
-                    uuid: 'uuid1',
-                },
-            ]
-
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockRejectedValue(new MessageSizeTooLarge('test', new Error('too large')))
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            const results = await step([{ id: 1 }])
-
-            expect(captureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
-                eventUuid: 'uuid1',
+                teamId: 1,
                 distinctId: 'user1',
-                step: 'flushBatchStoresStep',
-            })
+                uuid: 'uuid1',
+            },
+        ]
 
-            expect(results).toHaveLength(1)
-            expect(results[0].type).toBe(PipelineResultType.OK)
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+        const result = await flushBatchStores(config)
+
+        expect(result.elements).toBeUndefined()
+        expect(result.sideEffects).toHaveLength(1)
+        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+            topic: 'person_updates',
+            key: Buffer.from('key1'),
+            value: Buffer.from('value1'),
+            headers: {},
         })
+    })
 
-        it('should propagate other Kafka produce errors', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
-                    },
-                    teamId: 1,
-                    distinctId: 'user1',
-                    uuid: 'uuid1',
+    it('should handle multiple messages per flush result', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [
+                        { key: 'key1', value: 'value1', headers: {} },
+                        { key: 'key2', value: 'value2', headers: {} },
+                    ],
                 },
-            ]
+                teamId: 1,
+                distinctId: 'user1',
+                uuid: 'uuid1',
+            },
+        ]
 
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-            const produceError = new Error('Kafka connection failed')
-            mockKafkaProducer.produce.mockRejectedValue(produceError)
+        const result = await flushBatchStores(config)
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(2)
+        expect(result.sideEffects).toHaveLength(2)
+    })
 
-            const results = await step([{ id: 1 }])
-
-            // Error should be in the side effect promise
-            expect(results[0].sideEffects).toHaveLength(1)
-            await expect(results[0].sideEffects[0]).rejects.toThrow('Kafka connection failed')
-        })
-
-        it('should throw if person store flush fails', async () => {
-            const flushError = new Error('Database connection failed')
-            mockPersonsStore.flush.mockRejectedValue(flushError)
-            mockGroupStore.flush.mockResolvedValue([])
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await expect(step([{ id: 1 }])).rejects.toThrow('Database connection failed')
-        })
-
-        it('should throw if group store flush fails', async () => {
-            const flushError = new Error('Database connection failed')
-            mockPersonsStore.flush.mockResolvedValue([])
-            mockGroupStore.flush.mockRejectedValue(flushError)
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await expect(step([{ id: 1 }])).rejects.toThrow('Database connection failed')
-        })
-
-        it('should handle null keys and values in messages', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [{ key: null, value: null, headers: {} }],
-                    },
-                    teamId: 1,
+    it('should handle multiple flush results with multiple messages each', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [
+                        { key: 'key1', value: 'value1', headers: {} },
+                        { key: 'key2', value: 'value2', headers: {} },
+                    ],
                 },
-            ]
-
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await step([{ id: 1 }])
-
-            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-                topic: 'person_updates',
-                key: null,
-                value: null,
-                headers: {},
-            })
-        })
-
-        it('should attach side effects only to first batch item to avoid duplication', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
-                    },
-                    teamId: 1,
+                teamId: 1,
+            },
+            {
+                topicMessage: {
+                    topic: 'person_distinct_ids',
+                    messages: [{ key: 'key3', value: 'value3', headers: {} }],
                 },
-            ]
+                teamId: 2,
+            },
+        ]
 
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        const result = await flushBatchStores(config)
 
-            const batch = [{ id: 1 }, { id: 2 }, { id: 3 }]
-            const results = await step(batch)
+        expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(3)
+        expect(result.sideEffects).toHaveLength(3)
+    })
 
-            // Only the first result should have side effects to avoid duplication
-            expect(results).toHaveLength(3)
-            expect(results[0].sideEffects).toHaveLength(1)
-            expect(results[1].sideEffects).toHaveLength(0)
-            expect(results[2].sideEffects).toHaveLength(0)
-        })
+    it('should return empty side effects when no messages to produce', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockResolvedValue([])
 
-        it('should call lifecycle methods in correct order', async () => {
-            const callOrder: string[] = []
+        const result = await flushBatchStores(config)
 
-            mockPersonsStore.flush.mockImplementation(() => {
-                callOrder.push('persons.flush')
-                return Promise.resolve([])
-            })
-            mockGroupStore.flush.mockImplementation(() => {
-                callOrder.push('group.flush')
-                return Promise.resolve([])
-            })
-            mockPersonsStore.reportBatch.mockImplementation(() => {
-                callOrder.push('persons.reportBatch')
-            })
-            mockGroupStore.reportBatch.mockImplementation(() => {
-                callOrder.push('group.reportBatch')
-            })
-            mockPersonsStore.reset.mockImplementation(() => {
-                callOrder.push('persons.reset')
-            })
-            mockGroupStore.reset.mockImplementation(() => {
-                callOrder.push('group.reset')
-            })
+        expect(result.elements).toBeUndefined()
+        expect(result.sideEffects).toHaveLength(0)
+    })
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await step([{ id: 1 }])
-
-            // Flushes happen in parallel, so order between them doesn't matter
-            // But reportBatch and reset must happen after flush
-            expect(callOrder.slice(0, 2).sort()).toEqual(['group.flush', 'persons.flush'])
-            expect(callOrder.slice(2)).toEqual([
-                'persons.reportBatch',
-                'group.reportBatch',
-                'persons.reset',
-                'group.reset',
-            ])
-        })
-
-        it('should produce messages with correct Buffer conversion', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [
-                            {
-                                key: 'string-key',
-                                value: 'string-value',
-                                headers: { header1: 'value1' },
-                            },
-                        ],
-                    },
-                    teamId: 1,
+    it('should handle MessageSizeTooLarge errors gracefully', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
                 },
-            ]
+                teamId: 1,
+                distinctId: 'user1',
+                uuid: 'uuid1',
+            },
+        ]
 
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockRejectedValue(new MessageSizeTooLarge('test', new Error('too large')))
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        const result = await flushBatchStores(config)
 
-            await step([{ id: 1 }])
+        // Side effect resolves (doesn't throw) because the error is caught
+        expect(result.sideEffects).toHaveLength(1)
+        await result.sideEffects![0]
 
-            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-                topic: 'person_updates',
-                key: Buffer.from('string-key'),
-                value: Buffer.from('string-value'),
-                headers: { header1: 'value1' },
-            })
+        expect(captureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
+            eventUuid: 'uuid1',
+            distinctId: 'user1',
+            step: 'flushBatchStores',
+        })
+    })
+
+    it('should propagate other Kafka produce errors', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
+                },
+                teamId: 1,
+                distinctId: 'user1',
+                uuid: 'uuid1',
+            },
+        ]
+
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockRejectedValue(new Error('Kafka connection failed'))
+
+        const result = await flushBatchStores(config)
+
+        expect(result.sideEffects).toHaveLength(1)
+        await expect(result.sideEffects![0]).rejects.toThrow('Kafka connection failed')
+    })
+
+    it('should throw if person store flush fails', async () => {
+        mockPersonsStore.flush.mockRejectedValue(new Error('Database connection failed'))
+        mockGroupStore.flush.mockResolvedValue([])
+
+        await expect(flushBatchStores(config)).rejects.toThrow('Database connection failed')
+    })
+
+    it('should throw if group store flush fails', async () => {
+        mockPersonsStore.flush.mockResolvedValue([])
+        mockGroupStore.flush.mockRejectedValue(new Error('Database connection failed'))
+
+        await expect(flushBatchStores(config)).rejects.toThrow('Database connection failed')
+    })
+
+    it('should not reset or report if flush fails', async () => {
+        mockPersonsStore.flush.mockRejectedValue(new Error('DB error'))
+        mockGroupStore.flush.mockResolvedValue([])
+
+        await expect(flushBatchStores(config)).rejects.toThrow('DB error')
+
+        expect(mockPersonsStore.reportBatch).not.toHaveBeenCalled()
+        expect(mockGroupStore.reportBatch).not.toHaveBeenCalled()
+        expect(mockPersonsStore.reset).not.toHaveBeenCalled()
+        expect(mockGroupStore.reset).not.toHaveBeenCalled()
+    })
+
+    it('should handle null keys and values in messages', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [{ key: null, value: null, headers: {} }],
+                },
+                teamId: 1,
+            },
+        ]
+
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+        await flushBatchStores(config)
+
+        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+            topic: 'person_updates',
+            key: null,
+            value: null,
+            headers: {},
+        })
+    })
+
+    it('should call lifecycle methods in correct order', async () => {
+        const callOrder: string[] = []
+
+        mockPersonsStore.flush.mockImplementation(() => {
+            callOrder.push('persons.flush')
+            return Promise.resolve([])
+        })
+        mockGroupStore.flush.mockImplementation(() => {
+            callOrder.push('group.flush')
+            return Promise.resolve([])
+        })
+        mockPersonsStore.reportBatch.mockImplementation(() => {
+            callOrder.push('persons.reportBatch')
+        })
+        mockGroupStore.reportBatch.mockImplementation(() => {
+            callOrder.push('group.reportBatch')
+        })
+        mockPersonsStore.reset.mockImplementation(() => {
+            callOrder.push('persons.reset')
+        })
+        mockGroupStore.reset.mockImplementation(() => {
+            callOrder.push('group.reset')
         })
 
-        it('should handle multiple flush results with multiple messages each', async () => {
-            const personMessages: FlushResult[] = [
-                {
-                    topicMessage: {
-                        topic: 'person_updates',
-                        messages: [
-                            { key: 'key1', value: 'value1', headers: {} },
-                            { key: 'key2', value: 'value2', headers: {} },
-                        ],
-                    },
-                    teamId: 1,
+        await flushBatchStores(config)
+
+        // Flushes happen in parallel, so order between them doesn't matter
+        // But reportBatch and reset must happen after flush
+        expect(callOrder.slice(0, 2).sort()).toEqual(['group.flush', 'persons.flush'])
+        expect(callOrder.slice(2)).toEqual(['persons.reportBatch', 'group.reportBatch', 'persons.reset', 'group.reset'])
+    })
+
+    it('should produce messages with correct Buffer conversion', async () => {
+        const personMessages: FlushResult[] = [
+            {
+                topicMessage: {
+                    topic: 'person_updates',
+                    messages: [
+                        {
+                            key: 'string-key',
+                            value: 'string-value',
+                            headers: { header1: 'value1' },
+                        },
+                    ],
                 },
-                {
-                    topicMessage: {
-                        topic: 'person_distinct_ids',
-                        messages: [{ key: 'key3', value: 'value3', headers: {} }],
-                    },
-                    teamId: 2,
-                },
-            ]
+                teamId: 1,
+            },
+        ]
 
-            mockPersonsStore.flush.mockResolvedValue(personMessages)
-            mockGroupStore.flush.mockResolvedValue([])
-            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+        mockPersonsStore.flush.mockResolvedValue(personMessages)
+        mockGroupStore.flush.mockResolvedValue([])
+        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
+        await flushBatchStores(config)
 
-            const results = await step([{ id: 1 }])
-
-            expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(3)
-            expect(results[0].sideEffects).toHaveLength(3)
-        })
-
-        it('should not reset or report if flush fails', async () => {
-            mockPersonsStore.flush.mockRejectedValue(new Error('DB error'))
-            mockGroupStore.flush.mockResolvedValue([])
-
-            const step = createFlushBatchStoresStep({
-                personsStore: mockPersonsStore,
-                groupStore: mockGroupStore,
-                kafkaProducer: mockKafkaProducer,
-            })
-
-            await expect(step([{ id: 1 }])).rejects.toThrow('DB error')
-
-            expect(mockPersonsStore.reportBatch).not.toHaveBeenCalled()
-            expect(mockGroupStore.reportBatch).not.toHaveBeenCalled()
-            expect(mockPersonsStore.reset).not.toHaveBeenCalled()
-            expect(mockGroupStore.reset).not.toHaveBeenCalled()
+        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+            topic: 'person_updates',
+            key: Buffer.from('string-key'),
+            value: Buffer.from('string-value'),
+            headers: { header1: 'value1' },
         })
     })
 })

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.test.ts
@@ -3,27 +3,19 @@ import { MessageSizeTooLarge } from '../../utils/db/error'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { AfterBatchInput, AfterBatchStep } from '../pipelines/batching-pipeline'
-import { isOkResult } from '../pipelines/results'
-import { createFlushBatchStoresStep } from './flush-batch-stores-step'
+import { AfterBatchInput } from '../pipelines/batching-pipeline'
+import { isOkResult, ok } from '../pipelines/results'
+import { BatchStores, createFlushBatchStoresStep, createSetBatchStoresStep } from './flush-batch-stores-step'
 
 jest.mock('../../worker/ingestion/utils', () => ({
     captureIngestionWarning: jest.fn(),
 }))
 
-describe('createFlushBatchStoresStep', () => {
+describe('flush-batch-stores-step', () => {
     let mockPersonsStore: jest.Mocked<PersonsStore>
     let mockGroupStore: jest.Mocked<BatchWritingGroupStore>
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
-    let step: AfterBatchStep<void, any, Record<string, never>>
-
-    function makeInput(): AfterBatchInput<void, any, Record<string, never>> {
-        return {
-            elements: [],
-            batchContext: {},
-            batchId: 0,
-        }
-    }
+    let storesConfig: BatchStores
 
     beforeEach(() => {
         mockPersonsStore = {
@@ -42,333 +34,382 @@ describe('createFlushBatchStoresStep', () => {
             produce: jest.fn(),
         } as any
 
-        step = createFlushBatchStoresStep({
+        storesConfig = {
             personsStore: mockPersonsStore,
             groupStore: mockGroupStore,
             kafkaProducer: mockKafkaProducer,
-        })
+        }
 
         jest.clearAllMocks()
     })
 
-    it('should flush both stores in parallel', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockResolvedValue([])
+    describe('createSetBatchStoresStep', () => {
+        it('should store config in batchContext and add stores to element values', async () => {
+            const elements = [
+                { result: ok({ value: 'el-1' }), context: { sideEffects: [], warnings: [] } },
+                { result: ok({ value: 'el-2' }), context: { sideEffects: [], warnings: [] } },
+            ]
+            const step = createSetBatchStoresStep<{ value: string }, any>(storesConfig)
+            const result = await step({ elements: elements as any, batchId: 0 })
 
-        await step(makeInput())
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.value.batchContext).toBe(storesConfig)
+                expect(result.value.elements).toHaveLength(2)
 
-        expect(mockPersonsStore.flush).toHaveBeenCalledTimes(1)
-        expect(mockGroupStore.flush).toHaveBeenCalledTimes(1)
+                const el0 = result.value.elements[0].result
+                const el1 = result.value.elements[1].result
+                expect(isOkResult(el0)).toBe(true)
+                expect(isOkResult(el1)).toBe(true)
+                if (isOkResult(el0) && isOkResult(el1)) {
+                    expect(el0.value.value).toBe('el-1')
+                    expect(el0.value.personsStore).toBe(mockPersonsStore)
+                    expect(el1.value.value).toBe('el-2')
+                    expect(el1.value.groupStore).toBe(mockGroupStore)
+                }
+            }
+        })
     })
 
-    it('should report batch metrics after flushing', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockResolvedValue([])
+    describe('createFlushBatchStoresStep', () => {
+        let step: ReturnType<typeof createFlushBatchStoresStep>
 
-        await step(makeInput())
+        function makeInput(): AfterBatchInput<void, any, BatchStores> {
+            return {
+                elements: [],
+                batchContext: storesConfig,
+                batchId: 0,
+            }
+        }
 
-        expect(mockPersonsStore.reportBatch).toHaveBeenCalledTimes(1)
-        expect(mockGroupStore.reportBatch).toHaveBeenCalledTimes(1)
-    })
+        beforeEach(() => {
+            step = createFlushBatchStoresStep()
+        })
 
-    it('should reset both stores after flushing', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockResolvedValue([])
+        it('should flush both stores in parallel', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockResolvedValue([])
 
-        await step(makeInput())
+            await step(makeInput())
 
-        expect(mockPersonsStore.reset).toHaveBeenCalledTimes(1)
-        expect(mockGroupStore.reset).toHaveBeenCalledTimes(1)
-    })
+            expect(mockPersonsStore.flush).toHaveBeenCalledTimes(1)
+            expect(mockGroupStore.flush).toHaveBeenCalledTimes(1)
+        })
 
-    it('should return ok result with produce promises as side effects', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
+        it('should report batch metrics after flushing', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockResolvedValue([])
+
+            await step(makeInput())
+
+            expect(mockPersonsStore.reportBatch).toHaveBeenCalledTimes(1)
+            expect(mockGroupStore.reportBatch).toHaveBeenCalledTimes(1)
+        })
+
+        it('should reset both stores after flushing', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockResolvedValue([])
+
+            await step(makeInput())
+
+            expect(mockPersonsStore.reset).toHaveBeenCalledTimes(1)
+            expect(mockGroupStore.reset).toHaveBeenCalledTimes(1)
+        })
+
+        it('should return ok result with produce promises as side effects', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
+                    },
+                    teamId: 1,
+                    distinctId: 'user1',
+                    uuid: 'uuid1',
                 },
-                teamId: 1,
+            ]
+
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+            const result = await step(makeInput())
+
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(1)
+            }
+            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+                topic: 'person_updates',
+                key: Buffer.from('key1'),
+                value: Buffer.from('value1'),
+                headers: {},
+            })
+        })
+
+        it('should handle multiple messages per flush result', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [
+                            { key: 'key1', value: 'value1', headers: {} },
+                            { key: 'key2', value: 'value2', headers: {} },
+                        ],
+                    },
+                    teamId: 1,
+                    distinctId: 'user1',
+                    uuid: 'uuid1',
+                },
+            ]
+
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+            const result = await step(makeInput())
+
+            expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(2)
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(2)
+            }
+        })
+
+        it('should handle multiple flush results with multiple messages each', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [
+                            { key: 'key1', value: 'value1', headers: {} },
+                            { key: 'key2', value: 'value2', headers: {} },
+                        ],
+                    },
+                    teamId: 1,
+                },
+                {
+                    topicMessage: {
+                        topic: 'person_distinct_ids',
+                        messages: [{ key: 'key3', value: 'value3', headers: {} }],
+                    },
+                    teamId: 2,
+                },
+            ]
+
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+            const result = await step(makeInput())
+
+            expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(3)
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(3)
+            }
+        })
+
+        it('should return empty side effects when no messages to produce', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockResolvedValue([])
+
+            const result = await step(makeInput())
+
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(0)
+            }
+        })
+
+        it('should handle MessageSizeTooLarge errors gracefully', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
+                    },
+                    teamId: 1,
+                    distinctId: 'user1',
+                    uuid: 'uuid1',
+                },
+            ]
+
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockRejectedValue(new MessageSizeTooLarge('test', new Error('too large')))
+
+            const result = await step(makeInput())
+
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(1)
+                await result.sideEffects[0]
+            }
+
+            expect(captureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
+                eventUuid: 'uuid1',
                 distinctId: 'user1',
-                uuid: 'uuid1',
-            },
-        ]
-
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-        const result = await step(makeInput())
-
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(1)
-        }
-        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-            topic: 'person_updates',
-            key: Buffer.from('key1'),
-            value: Buffer.from('value1'),
-            headers: {},
+                step: 'flushBatchStoresStep',
+            })
         })
-    })
 
-    it('should handle multiple messages per flush result', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [
-                        { key: 'key1', value: 'value1', headers: {} },
-                        { key: 'key2', value: 'value2', headers: {} },
-                    ],
+        it('should propagate other Kafka produce errors', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [{ key: 'key1', value: 'value1', headers: {} }],
+                    },
+                    teamId: 1,
+                    distinctId: 'user1',
+                    uuid: 'uuid1',
                 },
-                teamId: 1,
-                distinctId: 'user1',
-                uuid: 'uuid1',
-            },
-        ]
+            ]
 
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockRejectedValue(new Error('Kafka connection failed'))
 
-        const result = await step(makeInput())
+            const result = await step(makeInput())
 
-        expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(2)
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(2)
-        }
-    })
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toHaveLength(1)
+                await expect(result.sideEffects[0]).rejects.toThrow('Kafka connection failed')
+            }
+        })
 
-    it('should handle multiple flush results with multiple messages each', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [
-                        { key: 'key1', value: 'value1', headers: {} },
-                        { key: 'key2', value: 'value2', headers: {} },
-                    ],
+        it('should throw if person store flush fails', async () => {
+            mockPersonsStore.flush.mockRejectedValue(new Error('Database connection failed'))
+            mockGroupStore.flush.mockResolvedValue([])
+
+            await expect(step(makeInput())).rejects.toThrow('Database connection failed')
+        })
+
+        it('should throw if group store flush fails', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockRejectedValue(new Error('Database connection failed'))
+
+            await expect(step(makeInput())).rejects.toThrow('Database connection failed')
+        })
+
+        it('should not reset or report if flush fails', async () => {
+            mockPersonsStore.flush.mockRejectedValue(new Error('DB error'))
+            mockGroupStore.flush.mockResolvedValue([])
+
+            await expect(step(makeInput())).rejects.toThrow('DB error')
+
+            expect(mockPersonsStore.reportBatch).not.toHaveBeenCalled()
+            expect(mockGroupStore.reportBatch).not.toHaveBeenCalled()
+            expect(mockPersonsStore.reset).not.toHaveBeenCalled()
+            expect(mockGroupStore.reset).not.toHaveBeenCalled()
+        })
+
+        it('should handle null keys and values in messages', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [{ key: null, value: null, headers: {} }],
+                    },
+                    teamId: 1,
                 },
-                teamId: 1,
-            },
-            {
-                topicMessage: {
-                    topic: 'person_distinct_ids',
-                    messages: [{ key: 'key3', value: 'value3', headers: {} }],
+            ]
+
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+
+            await step(makeInput())
+
+            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+                topic: 'person_updates',
+                key: null,
+                value: null,
+                headers: {},
+            })
+        })
+
+        it('should call lifecycle methods in correct order', async () => {
+            const callOrder: string[] = []
+
+            mockPersonsStore.flush.mockImplementation(() => {
+                callOrder.push('persons.flush')
+                return Promise.resolve([])
+            })
+            mockGroupStore.flush.mockImplementation(() => {
+                callOrder.push('group.flush')
+                return Promise.resolve([])
+            })
+            mockPersonsStore.reportBatch.mockImplementation(() => {
+                callOrder.push('persons.reportBatch')
+            })
+            mockGroupStore.reportBatch.mockImplementation(() => {
+                callOrder.push('group.reportBatch')
+            })
+            mockPersonsStore.reset.mockImplementation(() => {
+                callOrder.push('persons.reset')
+            })
+            mockGroupStore.reset.mockImplementation(() => {
+                callOrder.push('group.reset')
+            })
+
+            await step(makeInput())
+
+            expect(callOrder.slice(0, 2).sort()).toEqual(['group.flush', 'persons.flush'])
+            expect(callOrder.slice(2)).toEqual([
+                'persons.reportBatch',
+                'group.reportBatch',
+                'persons.reset',
+                'group.reset',
+            ])
+        })
+
+        it('should produce messages with correct Buffer conversion', async () => {
+            const personMessages: FlushResult[] = [
+                {
+                    topicMessage: {
+                        topic: 'person_updates',
+                        messages: [
+                            {
+                                key: 'string-key',
+                                value: 'string-value',
+                                headers: { header1: 'value1' },
+                            },
+                        ],
+                    },
+                    teamId: 1,
                 },
-                teamId: 2,
-            },
-        ]
+            ]
 
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
+            mockPersonsStore.flush.mockResolvedValue(personMessages)
+            mockGroupStore.flush.mockResolvedValue([])
+            mockKafkaProducer.produce.mockResolvedValue(undefined as any)
 
-        const result = await step(makeInput())
+            await step(makeInput())
 
-        expect(mockKafkaProducer.produce).toHaveBeenCalledTimes(3)
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(3)
-        }
-    })
-
-    it('should return empty side effects when no messages to produce', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockResolvedValue([])
-
-        const result = await step(makeInput())
-
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(0)
-        }
-    })
-
-    it('should handle MessageSizeTooLarge errors gracefully', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
-                },
-                teamId: 1,
-                distinctId: 'user1',
-                uuid: 'uuid1',
-            },
-        ]
-
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockRejectedValue(new MessageSizeTooLarge('test', new Error('too large')))
-
-        const result = await step(makeInput())
-
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(1)
-            await result.sideEffects[0]
-        }
-
-        expect(captureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
-            eventUuid: 'uuid1',
-            distinctId: 'user1',
-            step: 'flushBatchStoresStep',
-        })
-    })
-
-    it('should propagate other Kafka produce errors', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [{ key: 'key1', value: 'value1', headers: {} }],
-                },
-                teamId: 1,
-                distinctId: 'user1',
-                uuid: 'uuid1',
-            },
-        ]
-
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockRejectedValue(new Error('Kafka connection failed'))
-
-        const result = await step(makeInput())
-
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.sideEffects).toHaveLength(1)
-            await expect(result.sideEffects[0]).rejects.toThrow('Kafka connection failed')
-        }
-    })
-
-    it('should throw if person store flush fails', async () => {
-        mockPersonsStore.flush.mockRejectedValue(new Error('Database connection failed'))
-        mockGroupStore.flush.mockResolvedValue([])
-
-        await expect(step(makeInput())).rejects.toThrow('Database connection failed')
-    })
-
-    it('should throw if group store flush fails', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockRejectedValue(new Error('Database connection failed'))
-
-        await expect(step(makeInput())).rejects.toThrow('Database connection failed')
-    })
-
-    it('should not reset or report if flush fails', async () => {
-        mockPersonsStore.flush.mockRejectedValue(new Error('DB error'))
-        mockGroupStore.flush.mockResolvedValue([])
-
-        await expect(step(makeInput())).rejects.toThrow('DB error')
-
-        expect(mockPersonsStore.reportBatch).not.toHaveBeenCalled()
-        expect(mockGroupStore.reportBatch).not.toHaveBeenCalled()
-        expect(mockPersonsStore.reset).not.toHaveBeenCalled()
-        expect(mockGroupStore.reset).not.toHaveBeenCalled()
-    })
-
-    it('should handle null keys and values in messages', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [{ key: null, value: null, headers: {} }],
-                },
-                teamId: 1,
-            },
-        ]
-
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-        await step(makeInput())
-
-        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-            topic: 'person_updates',
-            key: null,
-            value: null,
-            headers: {},
-        })
-    })
-
-    it('should call lifecycle methods in correct order', async () => {
-        const callOrder: string[] = []
-
-        mockPersonsStore.flush.mockImplementation(() => {
-            callOrder.push('persons.flush')
-            return Promise.resolve([])
-        })
-        mockGroupStore.flush.mockImplementation(() => {
-            callOrder.push('group.flush')
-            return Promise.resolve([])
-        })
-        mockPersonsStore.reportBatch.mockImplementation(() => {
-            callOrder.push('persons.reportBatch')
-        })
-        mockGroupStore.reportBatch.mockImplementation(() => {
-            callOrder.push('group.reportBatch')
-        })
-        mockPersonsStore.reset.mockImplementation(() => {
-            callOrder.push('persons.reset')
-        })
-        mockGroupStore.reset.mockImplementation(() => {
-            callOrder.push('group.reset')
+            expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
+                topic: 'person_updates',
+                key: Buffer.from('string-key'),
+                value: Buffer.from('string-value'),
+                headers: { header1: 'value1' },
+            })
         })
 
-        await step(makeInput())
+        it('should pass through elements and batchContext in the result', async () => {
+            mockPersonsStore.flush.mockResolvedValue([])
+            mockGroupStore.flush.mockResolvedValue([])
 
-        expect(callOrder.slice(0, 2).sort()).toEqual(['group.flush', 'persons.flush'])
-        expect(callOrder.slice(2)).toEqual(['persons.reportBatch', 'group.reportBatch', 'persons.reset', 'group.reset'])
-    })
+            const input = makeInput()
+            input.elements = [{ result: 'test-element' }] as any
+            const result = await step(input)
 
-    it('should produce messages with correct Buffer conversion', async () => {
-        const personMessages: FlushResult[] = [
-            {
-                topicMessage: {
-                    topic: 'person_updates',
-                    messages: [
-                        {
-                            key: 'string-key',
-                            value: 'string-value',
-                            headers: { header1: 'value1' },
-                        },
-                    ],
-                },
-                teamId: 1,
-            },
-        ]
-
-        mockPersonsStore.flush.mockResolvedValue(personMessages)
-        mockGroupStore.flush.mockResolvedValue([])
-        mockKafkaProducer.produce.mockResolvedValue(undefined as any)
-
-        await step(makeInput())
-
-        expect(mockKafkaProducer.produce).toHaveBeenCalledWith({
-            topic: 'person_updates',
-            key: Buffer.from('string-key'),
-            value: Buffer.from('string-value'),
-            headers: { header1: 'value1' },
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.value.elements).toEqual([{ result: 'test-element' }])
+                expect(result.value.batchContext).toBe(input.batchContext)
+            }
         })
-    })
-
-    it('should pass through elements and batchContext in the result', async () => {
-        mockPersonsStore.flush.mockResolvedValue([])
-        mockGroupStore.flush.mockResolvedValue([])
-
-        const input = makeInput()
-        input.elements = [{ result: 'test-element' }] as any
-        const result = await step(input)
-
-        expect(isOkResult(result)).toBe(true)
-        if (isOkResult(result)) {
-            expect(result.value.elements).toEqual([{ result: 'test-element' }])
-            expect(result.value.batchContext).toBe(input.batchContext)
-        }
     })
 })

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
@@ -4,8 +4,7 @@ import { logger } from '../../utils/logger'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { BatchProcessingStep } from '../pipelines/base-batch-pipeline'
-import { PipelineResult, ok } from '../pipelines/results'
+import { BatchResult } from '../pipelines/batching-pipeline'
 
 export interface FlushBatchStoresStepConfig {
     personsStore: PersonsStore
@@ -14,13 +13,12 @@ export interface FlushBatchStoresStepConfig {
 }
 
 /**
- * Batch processing step that flushes person and group stores and returns
- * Kafka produce promises as side effects.
+ * Flushes person and group stores and returns Kafka produce promises as side effects.
  *
- * This step should be added at the end of the pipeline after all events
- * have been processed but before handleResults/handleSideEffects.
+ * Used as the afterBatch hook in the joined ingestion pipeline, called once
+ * per batch after all events have been processed.
  *
- * The step:
+ * The function:
  * 1. Flushes both person and group stores (blocking DB operations)
  * 2. Creates Kafka produce promises for all store updates
  * 3. Returns those promises as side effects (non-blocking)
@@ -33,51 +31,31 @@ export interface FlushBatchStoresStepConfig {
  * @param config.personsStore - The person store (singleton per consumer)
  * @param config.groupStore - The group store (singleton per consumer)
  * @param config.kafkaProducer - Kafka producer for sending store updates
- *
- * @returns A batch processing step that flushes both stores
  */
-export function createFlushBatchStoresStep<T>(config: FlushBatchStoresStepConfig): BatchProcessingStep<T, void> {
+export async function flushBatchStores(config: FlushBatchStoresStepConfig): Promise<BatchResult<void>> {
     const { personsStore, groupStore, kafkaProducer } = config
 
-    return async function flushBatchStoresStep(batch: T[]): Promise<PipelineResult<void>[]> {
-        if (batch.length === 0) {
-            return []
-        }
+    try {
+        // Flush both stores in parallel (DB operations, still blocking)
+        const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
 
-        try {
-            // Flush both stores in parallel (DB operations, still blocking)
-            const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
+        // Create Kafka produce promises for all person/group store updates
+        const producePromises = createProducePromises(personsStoreMessages, kafkaProducer)
 
-            logger.info('🔄', 'flushBatchStoresStep: Flushed stores', {
-                batchSize: batch.length,
-                personStoreMessageCount: personsStoreMessages.length,
-            })
+        // Report metrics for this batch
+        personsStore.reportBatch()
+        groupStore.reportBatch()
 
-            // Create Kafka produce promises for all person/group store updates
-            const producePromises = createProducePromises(personsStoreMessages, kafkaProducer)
+        // Reset stores for next batch
+        personsStore.reset()
+        groupStore.reset()
 
-            // Report metrics for this batch
-            personsStore.reportBatch()
-            groupStore.reportBatch()
-
-            // Reset stores for next batch
-            personsStore.reset()
-            groupStore.reset()
-
-            // Return same number of results as input (cardinality requirement)
-            // Attach all side effects to the first result only to avoid duplication
-            // The pipeline framework will accumulate them into the first item's context
-            // We return undefined because this is a terminal step (BatchProcessingStep<T, void>)
-            return batch.map((_, index) => ok(undefined, index === 0 ? producePromises : []))
-        } catch (error) {
-            // If flush fails, the error will bubble up and fail the entire batch
-            // This maintains the existing behavior where flush errors are fatal
-            logger.error('❌', 'flushBatchStoresStep: Failed to flush stores', {
-                error,
-                batchSize: batch.length,
-            })
-            throw error
-        }
+        return { elements: undefined, sideEffects: producePromises }
+    } catch (error) {
+        // If flush fails, the error will bubble up and fail the entire batch
+        // This maintains the existing behavior where flush errors are fatal
+        logger.error('❌', 'flushBatchStores: Failed to flush stores', { error })
+        throw error
     }
 }
 
@@ -105,7 +83,7 @@ function createProducePromises(
                 .catch((error) => {
                     // Handle message size errors gracefully by capturing a warning
                     if (error instanceof MessageSizeTooLarge) {
-                        logger.warn('🪣', 'flushBatchStoresStep: Message size too large', {
+                        logger.warn('🪣', 'flushBatchStores: Message size too large', {
                             topic: record.topicMessage.topic,
                             teamId: record.teamId,
                             distinctId: record.distinctId,
@@ -114,11 +92,11 @@ function createProducePromises(
                         return captureIngestionWarning(kafkaProducer, record.teamId, 'message_size_too_large', {
                             eventUuid: record.uuid,
                             distinctId: record.distinctId,
-                            step: 'flushBatchStoresStep',
+                            step: 'flushBatchStores',
                         })
                     } else {
                         // Other errors should fail the side effect
-                        logger.error('❌', 'flushBatchStoresStep: Failed to produce message', {
+                        logger.error('❌', 'flushBatchStores: Failed to produce message', {
                             error,
                             topic: record.topicMessage.topic,
                             teamId: record.teamId,

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
@@ -4,7 +4,8 @@ import { logger } from '../../utils/logger'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { BatchResult } from '../pipelines/batching-pipeline'
+import { AfterBatchStep } from '../pipelines/batching-pipeline'
+import { ok } from '../pipelines/results'
 
 export interface FlushBatchStoresStepConfig {
     personsStore: PersonsStore
@@ -32,30 +33,28 @@ export interface FlushBatchStoresStepConfig {
  * @param config.groupStore - The group store (singleton per consumer)
  * @param config.kafkaProducer - Kafka producer for sending store updates
  */
-export async function flushBatchStores(config: FlushBatchStoresStepConfig): Promise<BatchResult<void>> {
+export function createFlushBatchStoresStep<TOutput, COutput, CBatch>(
+    config: FlushBatchStoresStepConfig
+): AfterBatchStep<TOutput, COutput, CBatch> {
     const { personsStore, groupStore, kafkaProducer } = config
 
-    try {
-        // Flush both stores in parallel (DB operations, still blocking)
-        const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
+    return async (input) => {
+        try {
+            const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
 
-        // Create Kafka produce promises for all person/group store updates
-        const producePromises = createProducePromises(personsStoreMessages, kafkaProducer)
+            const producePromises = createProducePromises(personsStoreMessages, kafkaProducer)
 
-        // Report metrics for this batch
-        personsStore.reportBatch()
-        groupStore.reportBatch()
+            personsStore.reportBatch()
+            groupStore.reportBatch()
 
-        // Reset stores for next batch
-        personsStore.reset()
-        groupStore.reset()
+            personsStore.reset()
+            groupStore.reset()
 
-        return { elements: undefined, sideEffects: producePromises }
-    } catch (error) {
-        // If flush fails, the error will bubble up and fail the entire batch
-        // This maintains the existing behavior where flush errors are fatal
-        logger.error('❌', 'flushBatchStores: Failed to flush stores', { error })
-        throw error
+            return ok({ elements: input.elements, batchContext: input.batchContext }, producePromises)
+        } catch (error) {
+            logger.error('❌', 'flushBatchStoresStep: Failed to flush stores', { error })
+            throw error
+        }
     }
 }
 
@@ -81,9 +80,8 @@ function createProducePromises(
                     headers: message.headers,
                 })
                 .catch((error) => {
-                    // Handle message size errors gracefully by capturing a warning
                     if (error instanceof MessageSizeTooLarge) {
-                        logger.warn('🪣', 'flushBatchStores: Message size too large', {
+                        logger.warn('🪣', 'flushBatchStoresStep: Message size too large', {
                             topic: record.topicMessage.topic,
                             teamId: record.teamId,
                             distinctId: record.distinctId,
@@ -92,11 +90,10 @@ function createProducePromises(
                         return captureIngestionWarning(kafkaProducer, record.teamId, 'message_size_too_large', {
                             eventUuid: record.uuid,
                             distinctId: record.distinctId,
-                            step: 'flushBatchStores',
+                            step: 'flushBatchStoresStep',
                         })
                     } else {
-                        // Other errors should fail the side effect
-                        logger.error('❌', 'flushBatchStores: Failed to produce message', {
+                        logger.error('❌', 'flushBatchStoresStep: Failed to produce message', {
                             error,
                             topic: record.topicMessage.topic,
                             teamId: record.teamId,

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
@@ -4,20 +4,41 @@ import { logger } from '../../utils/logger'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { FlushResult, PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { AfterBatchStep } from '../pipelines/batching-pipeline'
-import { ok } from '../pipelines/results'
+import { AfterBatchStep, BeforeBatchStep } from '../pipelines/batching-pipeline'
+import { isOkResult, ok } from '../pipelines/results'
 
-export interface FlushBatchStoresStepConfig {
+export interface BatchStores {
     personsStore: PersonsStore
     groupStore: BatchWritingGroupStore
     kafkaProducer: KafkaProducerWrapper
 }
 
 /**
+ * Sets the batch stores in the batch context and adds them to each element's value.
+ *
+ * Used as the beforeBatch hook in the joined ingestion pipeline to make the
+ * stores available to:
+ * - Sub-pipeline steps via element values (runtime access)
+ * - The afterBatch flush step via the batch context
+ */
+export function createSetBatchStoresStep<TInput, CInput>(
+    config: BatchStores
+): BeforeBatchStep<TInput, CInput, BatchStores> {
+    return (input) => {
+        const elements = input.elements.map((el) => ({
+            ...el,
+            result: isOkResult(el.result) ? ok({ ...el.result.value, ...config }) : el.result,
+        }))
+        return Promise.resolve(ok({ elements, batchContext: config }))
+    }
+}
+
+/**
  * Flushes person and group stores and returns Kafka produce promises as side effects.
  *
  * Used as the afterBatch hook in the joined ingestion pipeline, called once
- * per batch after all events have been processed.
+ * per batch after all events have been processed. Reads the stores from the
+ * batch context set by createSetBatchStoresStep.
  *
  * The function:
  * 1. Flushes both person and group stores (blocking DB operations)
@@ -27,18 +48,11 @@ export interface FlushBatchStoresStepConfig {
  * This allows the pipeline to handle Kafka produces the same way it handles
  * event emission - as side effects that can be scheduled and awaited separately
  * from the consumer commit.
- *
- * @param config - Configuration containing the stores and Kafka producer
- * @param config.personsStore - The person store (singleton per consumer)
- * @param config.groupStore - The group store (singleton per consumer)
- * @param config.kafkaProducer - Kafka producer for sending store updates
  */
-export function createFlushBatchStoresStep<TOutput, COutput, CBatch>(
-    config: FlushBatchStoresStepConfig
-): AfterBatchStep<TOutput, COutput, CBatch> {
-    const { personsStore, groupStore, kafkaProducer } = config
-
+export function createFlushBatchStoresStep<TOutput, COutput>(): AfterBatchStep<TOutput, COutput, BatchStores> {
     return async (input) => {
+        const { personsStore, groupStore, kafkaProducer } = input.batchContext
+
         try {
             const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
 

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
@@ -54,13 +54,17 @@ export function createFlushBatchStoresStep<TOutput, COutput>(): AfterBatchStep<T
         const { personsStore, groupStore, kafkaProducer } = input.batchContext
 
         try {
+            // Flush both stores in parallel (DB operations, still blocking)
             const [_groupResults, personsStoreMessages] = await Promise.all([groupStore.flush(), personsStore.flush()])
 
+            // Create Kafka produce promises for all person/group store updates
             const producePromises = createProducePromises(personsStoreMessages, kafkaProducer)
 
+            // Report metrics for this batch
             personsStore.reportBatch()
             groupStore.reportBatch()
 
+            // Reset stores for next batch
             personsStore.reset()
             groupStore.reset()
 
@@ -94,6 +98,7 @@ function createProducePromises(
                     headers: message.headers,
                 })
                 .catch((error) => {
+                    // Handle message size errors gracefully by capturing a warning
                     if (error instanceof MessageSizeTooLarge) {
                         logger.warn('🪣', 'flushBatchStoresStep: Message size too large', {
                             topic: record.topicMessage.topic,
@@ -107,6 +112,7 @@ function createProducePromises(
                             step: 'flushBatchStoresStep',
                         })
                     } else {
+                        // Other errors should fail the side effect
                         logger.error('❌', 'flushBatchStoresStep: Failed to produce message', {
                             error,
                             topic: record.topicMessage.topic,

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
@@ -41,6 +41,7 @@ type TestInput = {
     person: Person
     headers: EventHeaders
     message: Message
+    groupStore: BatchWritingGroupStore
 }
 
 describe('createPrepareEventStep', () => {
@@ -81,6 +82,7 @@ describe('createPrepareEventStep', () => {
         person: mockPerson,
         headers: mockHeaders,
         message: mockMessage,
+        groupStore: mockGroupStore,
         ...overrides,
     })
 
@@ -91,7 +93,7 @@ describe('createPrepareEventStep', () => {
         const preparedEvent = createTestPreIngestionEvent()
         mockProcessEvent.mockResolvedValue(preparedEvent)
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         const input = createInput({ processPerson })
@@ -123,7 +125,7 @@ describe('createPrepareEventStep', () => {
         mockProcessEvent.mockResolvedValue(createTestPreIngestionEvent())
         const headers = createTestEventHeaders({ historical_migration })
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         const result = await step(createInput({ headers }))
@@ -137,7 +139,7 @@ describe('createPrepareEventStep', () => {
     it('should strip normalizedEvent from the output', async () => {
         mockProcessEvent.mockResolvedValue(createTestPreIngestionEvent())
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         const result = await step(createInput())
@@ -154,7 +156,7 @@ describe('createPrepareEventStep', () => {
         jest.mocked(processAiEvent).mockReturnValue(transformedEvent)
         mockProcessEvent.mockResolvedValue(createTestPreIngestionEvent())
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         await step(createInput({ normalizedEvent: aiEvent }))
@@ -178,7 +180,7 @@ describe('createPrepareEventStep', () => {
         })
         mockProcessEvent.mockResolvedValue(createTestPreIngestionEvent())
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         const result = await step(createInput({ normalizedEvent: aiEvent }))
@@ -202,7 +204,7 @@ describe('createPrepareEventStep', () => {
         })
         mockProcessEvent.mockResolvedValue(createTestPreIngestionEvent())
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
         const result = await step(createInput())
@@ -215,7 +217,7 @@ describe('createPrepareEventStep', () => {
         const error = new Error('Processing failed')
         mockProcessEvent.mockRejectedValue(error)
 
-        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, mockGroupStore, {
+        const step = createPrepareEventStep<TestInput>(mockTeamManager, mockGroupTypeManager, {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         })
 

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.ts
@@ -27,10 +27,9 @@ export type PrepareEventStepResult<TInput> = Omit<TInput, 'normalizedEvent'> & {
     historicalMigration: boolean
 }
 
-export function createPrepareEventStep<TInput extends PrepareEventStepInput>(
+export function createPrepareEventStep<TInput extends PrepareEventStepInput & { groupStore: BatchWritingGroupStore }>(
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,
-    groupStore: BatchWritingGroupStore,
     options: Pick<EventPipelineRunnerOptions, 'SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP'>
 ): ProcessingStep<TInput, PrepareEventStepResult<TInput>> {
     const eventsProcessor = new EventsProcessor(
@@ -65,7 +64,7 @@ export function createPrepareEventStep<TInput extends PrepareEventStepInput>(
             parseEventTimestamp(event, invalidTimestampCallback),
             event.uuid,
             input.processPerson,
-            groupStore
+            input.groupStore
         )
         const historicalMigration = input.headers.historical_migration ?? false
 

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { PipelineResultType, isOkResult } from '~/ingestion/pipelines/results'
 import { PluginEvent, Properties } from '~/plugin-scaffold'
 import { BatchWritingPersonsStore } from '~/worker/ingestion/persons/batch-writing-person-store'
+import { PersonsStore } from '~/worker/ingestion/persons/persons-store'
 import { PostgresPersonRepository } from '~/worker/ingestion/persons/repositories/postgres-person-repository'
 
 import { createOrganization, createTeam, getTeam, resetTestDatabase } from '../../../tests/helpers/sql'
@@ -80,17 +81,18 @@ describe('createProcessPersonlessStep', () => {
         await closeHub(hub)
     })
 
-    const createInput = (overrides: Partial<ProcessPersonlessInput> = {}): ProcessPersonlessInput => ({
+    const createInput = (overrides: Partial<ProcessPersonlessInput> = {}) => ({
         normalizedEvent: pluginEvent,
         team,
         timestamp,
         processPerson: false,
         forceDisablePersonProcessing: false,
+        personsStore: personsStore as PersonsStore,
         ...overrides,
     })
 
     it('passes through when processPerson is true', async () => {
-        const step = createProcessPersonlessStep(personsStore)
+        const step = createProcessPersonlessStep()
         const input = createInput({ processPerson: true })
 
         const result = await step(input)
@@ -103,7 +105,7 @@ describe('createProcessPersonlessStep', () => {
 
     describe('basic personless functionality', () => {
         it('returns fake person when no existing person found', async () => {
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -124,7 +126,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -139,7 +141,7 @@ describe('createProcessPersonlessStep', () => {
         it('checks batch result for personless distinct ID when no person exists', async () => {
             const getPersonlessBatchResultSpy = jest.spyOn(personsStore, 'getPersonlessBatchResult')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             await step(createInput())
 
             expect(getPersonlessBatchResultSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
@@ -148,7 +150,7 @@ describe('createProcessPersonlessStep', () => {
         it('returns fake person when batch result indicates no merge', async () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(false)
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -168,7 +170,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -187,7 +189,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -208,7 +210,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -242,7 +244,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(true)
             const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -255,7 +257,7 @@ describe('createProcessPersonlessStep', () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
             const getPersonlessBatchResultSpy = jest.spyOn(personsStore, 'getPersonlessBatchResult')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput({ forceDisablePersonProcessing: true }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -273,7 +275,7 @@ describe('createProcessPersonlessStep', () => {
         it('performs normal processing when false', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             await step(createInput())
 
             expect(fetchForCheckingSpy).toHaveBeenCalled()
@@ -281,7 +283,7 @@ describe('createProcessPersonlessStep', () => {
 
         it('works with different distinct IDs', async () => {
             const distinctIds = ['user-1', 'user-2', 'user-3']
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
 
             for (const distinctId of distinctIds) {
                 const result = await step(

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -29,12 +29,13 @@ export type ProcessPersonlessOutput = {
  * 3. Calculates force_upgrade flag
  * 4. Returns person (real or fake) with potential force_upgrade flag
  */
-export function createProcessPersonlessStep<TInput extends ProcessPersonlessInput>(
-    personsStore: PersonsStore
-): ProcessingStep<TInput, TInput & ProcessPersonlessOutput> {
+export function createProcessPersonlessStep<
+    TInput extends ProcessPersonlessInput & { personsStore: PersonsStore },
+>(): ProcessingStep<TInput, TInput & ProcessPersonlessOutput> {
     return async function processPersonlessStep(
         input: TInput
     ): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
+        const { personsStore } = input
         if (input.processPerson) {
             return ok(input)
         }

--- a/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { PipelineResultType, isDlqResult, isOkResult, isRedirectResult } from '~/ingestion/pipelines/results'
 import { PluginEvent } from '~/plugin-scaffold'
 import { BatchWritingPersonsStore } from '~/worker/ingestion/persons/batch-writing-person-store'
+import { PersonsStore } from '~/worker/ingestion/persons/persons-store'
 import { PostgresPersonRepository } from '~/worker/ingestion/persons/repositories/postgres-person-repository'
 
 import {
@@ -70,10 +71,12 @@ describe('createProcessPersonsStep', () => {
         await closeHub(hub)
     })
 
-    const createInput = (overrides: Partial<ProcessPersonsInput> = {}): ProcessPersonsInput => ({
+    const createInput = (overrides: Partial<ProcessPersonsInput> = {}) => ({
         normalizedEvent: pluginEvent,
         team,
         timestamp,
+        kafkaProducer: hub.kafkaProducer,
+        personsStore: personsStore as PersonsStore,
         ...overrides,
     })
 
@@ -99,7 +102,7 @@ describe('createProcessPersonsStep', () => {
     }
 
     it('creates person with $set properties', async () => {
-        const step = createProcessPersonsStep(options, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(options)
         const result = await step(createInput())
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -135,7 +138,7 @@ describe('createProcessPersonsStep', () => {
         const processPerson = true
         const [normalizedEvent, normalizedTimestamp] = await normalizeEventStep(event, processPerson)
 
-        const step = createProcessPersonsStep(options, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(options)
         const result = await step(createInput({ normalizedEvent, timestamp: normalizedTimestamp }))
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -182,7 +185,7 @@ describe('createProcessPersonsStep', () => {
             created_at: DateTime.fromISO('1970-01-01T00:00:05.000Z'),
         }
 
-        const step = createProcessPersonsStep(options, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(options)
         const result = await step(createInput({ personlessPerson }))
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -204,7 +207,7 @@ describe('createProcessPersonsStep', () => {
             force_upgrade: true,
         }
 
-        const step = createProcessPersonsStep(options, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(options)
         const result = await step(createInput({ personlessPerson }))
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -219,7 +222,7 @@ describe('createProcessPersonsStep', () => {
     })
 
     it('preserves additional input fields in the output', async () => {
-        const step = createProcessPersonsStep(options, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(options)
         const input = { ...createInput(), extraField: 'preserved' }
 
         const result = await step(input)
@@ -250,7 +253,7 @@ describe('createProcessPersonsStep', () => {
             PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 2,
         }
 
-        const step = createProcessPersonsStep(limitOptions, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(limitOptions)
         const result = await step(
             createInput({
                 normalizedEvent: identifyEvent,
@@ -284,7 +287,7 @@ describe('createProcessPersonsStep', () => {
             PERSON_MERGE_ASYNC_TOPIC: 'async-merge-topic',
         }
 
-        const step = createProcessPersonsStep(asyncOptions, hub.kafkaProducer, personsStore)
+        const step = createProcessPersonsStep(asyncOptions)
         const result = await step(
             createInput({
                 normalizedEvent: identifyEvent,

--- a/nodejs/src/ingestion/event-processing/process-persons-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-persons-step.ts
@@ -25,11 +25,9 @@ export type ProcessPersonsOutput = {
     person: Person
 }
 
-export function createProcessPersonsStep<TInput extends ProcessPersonsInput>(
-    options: EventPipelineRunnerOptions,
-    kafkaProducer: KafkaProducerWrapper,
-    personsStore: PersonsStore
-): ProcessingStep<TInput, TInput & ProcessPersonsOutput> {
+export function createProcessPersonsStep<
+    TInput extends ProcessPersonsInput & { kafkaProducer: KafkaProducerWrapper; personsStore: PersonsStore },
+>(options: EventPipelineRunnerOptions): ProcessingStep<TInput, TInput & ProcessPersonsOutput> {
     const mergeMode = determineMergeMode(
         options.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
         options.PERSON_MERGE_ASYNC_ENABLED,
@@ -38,7 +36,7 @@ export function createProcessPersonsStep<TInput extends ProcessPersonsInput>(
     )
 
     return async function processPersonsStep(input: TInput): Promise<PipelineResult<TInput & ProcessPersonsOutput>> {
-        const { normalizedEvent, team, timestamp, personlessPerson } = input
+        const { normalizedEvent, team, timestamp, personlessPerson, kafkaProducer, personsStore } = input
 
         if (personlessPerson && !personlessPerson.force_upgrade) {
             return ok({ ...input, person: personlessPerson })

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -36,8 +36,6 @@ import {
     createJoinedIngestionPipeline,
 } from './analytics'
 import { CookielessManager } from './cookieless/cookieless-manager'
-import { BatchPipeline } from './pipelines/batch-pipeline.interface'
-import { newBatchPipelineBuilder } from './pipelines/builders'
 import { createContext } from './pipelines/helpers'
 import { ok } from './pipelines/results'
 import { TopHog } from './tophog'
@@ -92,11 +90,8 @@ export class IngestionConsumer {
     public readonly promiseScheduler = new PromiseScheduler()
     private topHog?: TopHog
 
-    private joinedPipeline!: BatchPipeline<
-        JoinedIngestionPipelineInput,
-        void,
-        JoinedIngestionPipelineContext,
-        JoinedIngestionPipelineContext
+    private joinedPipeline!: ReturnType<
+        typeof createJoinedIngestionPipeline<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>
     >
 
     constructor(
@@ -251,11 +246,7 @@ export class IngestionConsumer {
             groupTypeManager: this.deps.groupTypeManager,
             topHog: this.topHog!,
         }
-        this.joinedPipeline = createJoinedIngestionPipeline(
-            newBatchPipelineBuilder<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>(),
-            joinedPipelineConfig,
-            joinedPipelineDeps
-        ).build()
+        this.joinedPipeline = createJoinedIngestionPipeline(joinedPipelineConfig, joinedPipelineDeps)
 
         await this.kafkaConsumer.connect(async (messages) => {
             return await instrumentFn(
@@ -350,14 +341,22 @@ export class IngestionConsumer {
     private async runIngestionPipeline(messages: Message[]): Promise<void> {
         const batch = messages.map((message) => createContext(ok({ message }), { message }))
 
-        const feedResult = this.joinedPipeline.feed(batch)
+        const feedResult = this.joinedPipeline.feed(batch, {
+            personsStore: this.personsStore,
+            groupStore: this.groupStore,
+            kafkaProducer: this.kafkaProducer!,
+        })
         if (!feedResult.ok) {
             throw new Error(`Pipeline rejected batch: ${feedResult.reason}`)
         }
 
-        // Drain the pipeline
-        while ((await this.joinedPipeline.next()) !== null) {
-            // Continue until all results are processed
+        // Drain the pipeline, scheduling batch-level side effects
+        let result = await this.joinedPipeline.next()
+        while (result !== null) {
+            for (const sideEffect of result.sideEffects ?? []) {
+                void this.promiseScheduler.schedule(sideEffect)
+            }
+            result = await this.joinedPipeline.next()
         }
     }
 

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -350,7 +350,10 @@ export class IngestionConsumer {
     private async runIngestionPipeline(messages: Message[]): Promise<void> {
         const batch = messages.map((message) => createContext(ok({ message }), { message }))
 
-        this.joinedPipeline.feed(batch)
+        const feedResult = this.joinedPipeline.feed(batch)
+        if (!feedResult.ok) {
+            throw new Error(`Pipeline rejected batch: ${feedResult.reason}`)
+        }
 
         // Drain the pipeline
         while ((await this.joinedPipeline.next()) !== null) {

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -341,11 +341,7 @@ export class IngestionConsumer {
     private async runIngestionPipeline(messages: Message[]): Promise<void> {
         const batch = messages.map((message) => createContext(ok({ message }), { message }))
 
-        const feedResult = this.joinedPipeline.feed(batch, {
-            personsStore: this.personsStore,
-            groupStore: this.groupStore,
-            kafkaProducer: this.kafkaProducer!,
-        })
+        const feedResult = await this.joinedPipeline.feed(batch)
         if (!feedResult.ok) {
             throw new Error(`Pipeline rejected batch: ${feedResult.reason}`)
         }

--- a/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
@@ -1,5 +1,5 @@
 import { instrumentFn } from '../../common/tracing/tracing-utils'
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { PipelineResult, PipelineResultOk, isOkResult } from './results'
 
@@ -26,8 +26,8 @@ export class BaseBatchPipeline<TInput, TIntermediate, TOutput, CInput, COutput =
         this.stepName = this.currentStep.name || 'anonymousBatchStep'
     }
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/batch-pipeline-unwrapper.ts
+++ b/nodejs/src/ingestion/pipelines/batch-pipeline-unwrapper.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../utils/logger'
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { isOkResult } from './results'
 
 /**
@@ -9,8 +9,8 @@ import { isOkResult } from './results'
 export class BatchPipelineUnwrapper<TInput, TOutput, C> {
     constructor(private batchPipeline: BatchPipeline<TInput, TOutput, C>) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, C>): void {
-        this.batchPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, C>): FeedResult {
+        return this.batchPipeline.feed(elements)
     }
 
     async next(): Promise<TOutput[] | null> {

--- a/nodejs/src/ingestion/pipelines/batch-pipeline.interface.ts
+++ b/nodejs/src/ingestion/pipelines/batch-pipeline.interface.ts
@@ -5,10 +5,12 @@ import { PipelineResultWithContext } from './pipeline.interface'
  */
 export type BatchPipelineResultWithContext<T, C> = PipelineResultWithContext<T, C>[]
 
+export type FeedResult = { ok: true } | { ok: false; reason: string }
+
 /**
  * Interface for batch processing pipelines
  */
 export interface BatchPipeline<TInput, TOutput, CInput, COutput = CInput> {
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult
     next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null>
 }

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { Message } from 'node-rdkafka'
 
 import { BatchPipelineResultWithContext } from './batch-pipeline.interface'
-import { BatchResult, BatchingPipeline } from './batching-pipeline'
+import { BatchingPipeline } from './batching-pipeline'
 import { newBatchingPipeline } from './builders/helpers'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { ok } from './results'
@@ -31,41 +31,31 @@ function makeBatch(offsets: number[]): BatchPipelineResultWithContext<any, MsgCt
     }))
 }
 
-function noopBeforeBatch(
-    _batchContext: Record<string, never>,
-    elements: BatchPipelineResultWithContext<any, MsgCtx>,
-    _batchId: number
-): BatchResult<BatchPipelineResultWithContext<any, MsgCtx>> {
-    return { elements: elements as any }
-}
-
-function noopAfterBatch(): Promise<BatchResult<void>> {
-    return Promise.resolve({ elements: undefined })
-}
-
 describe('BatchingPipeline', () => {
-    let beforeBatch: jest.Mock
-    let afterBatch: jest.Mock
+    let beforeBatchStep: jest.Mock
+    let afterBatchStep: jest.Mock
 
     beforeEach(() => {
-        beforeBatch = jest.fn(noopBeforeBatch)
-        afterBatch = jest.fn(noopAfterBatch)
+        beforeBatchStep = jest.fn(({ elements }) => Promise.resolve(ok({ elements, batchContext: {} })))
+        afterBatchStep = jest.fn((input) =>
+            Promise.resolve(ok({ elements: input.elements, batchContext: input.batchContext }))
+        )
     })
 
     function createCollector(options?: { concurrentBatches?: number }) {
-        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, MsgCtx>(
-            beforeBatch,
+        return newBatchingPipeline<any, any, MsgCtx>(
+            (builder) => builder.pipe(beforeBatchStep),
             (builder) => builder,
-            afterBatch,
+            (builder) => builder.pipe(afterBatchStep),
             { concurrentBatches: Infinity, ...options }
         )
     }
 
     function createStreamingCollector() {
-        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, MsgCtx>(
-            beforeBatch,
+        return newBatchingPipeline<any, any, MsgCtx>(
+            (builder) => builder.pipe(beforeBatchStep),
             (builder) => builder.concurrently((b) => b.pipe((value) => Promise.resolve(ok(value)))),
-            afterBatch,
+            (builder) => builder.pipe(afterBatchStep),
             { concurrentBatches: Infinity }
         )
     }
@@ -87,27 +77,27 @@ describe('BatchingPipeline', () => {
     it('returns null when sub-pipeline is empty', async () => {
         const collector = createCollector()
         expect(await collector.next()).toBeNull()
-        expect(beforeBatch).not.toHaveBeenCalled()
-        expect(afterBatch).not.toHaveBeenCalled()
+        expect(beforeBatchStep).not.toHaveBeenCalled()
+        expect(afterBatchStep).not.toHaveBeenCalled()
     })
 
-    it('assigns sequential batch IDs to beforeBatch', () => {
+    it('assigns sequential batch IDs to beforeBatch', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]), {})
-        collector.feed(makeBatch([3]), {})
+        await collector.feed(makeBatch([1, 2]))
+        await collector.feed(makeBatch([3]))
 
-        expect(beforeBatch).toHaveBeenCalledTimes(2)
-        expect(beforeBatch.mock.calls[0][2]).toBe(0)
-        expect(beforeBatch.mock.calls[0][1]).toHaveLength(2)
-        expect(beforeBatch.mock.calls[1][2]).toBe(1)
-        expect(beforeBatch.mock.calls[1][1]).toHaveLength(1)
+        expect(beforeBatchStep).toHaveBeenCalledTimes(2)
+        expect(beforeBatchStep.mock.calls[0][0].batchId).toBe(0)
+        expect(beforeBatchStep.mock.calls[0][0].elements).toHaveLength(2)
+        expect(beforeBatchStep.mock.calls[1][0].batchId).toBe(1)
+        expect(beforeBatchStep.mock.calls[1][0].elements).toHaveLength(1)
     })
 
     it('tags each element with a monotonic messageId in context', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([10, 20, 30]), {})
+        await collector.feed(makeBatch([10, 20, 30]))
         const { allResults } = await drainAll(collector)
 
         expect(allResults).toHaveLength(3)
@@ -119,8 +109,8 @@ describe('BatchingPipeline', () => {
     it('continues messageId sequence across batches', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]), {})
-        collector.feed(makeBatch([3]), {})
+        await collector.feed(makeBatch([1, 2]))
+        await collector.feed(makeBatch([3]))
         const { allResults } = await drainAll(collector)
 
         expect(allResults).toHaveLength(3)
@@ -132,11 +122,11 @@ describe('BatchingPipeline', () => {
     it('returns ordered batch results when a batch completes', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2, 3]), {})
+        await collector.feed(makeBatch([1, 2, 3]))
         const { allResults } = await drainAll(collector)
 
-        expect(afterBatch).toHaveBeenCalledTimes(1)
-        expect(afterBatch.mock.calls[0][2]).toBe(0)
+        expect(afterBatchStep).toHaveBeenCalledTimes(1)
+        expect(afterBatchStep.mock.calls[0][0].batchId).toBe(0)
         expect(allResults).toHaveLength(3)
         expect(allResults[0].context.messageId).toBe(0)
         expect(allResults[1].context.messageId).toBe(1)
@@ -146,52 +136,52 @@ describe('BatchingPipeline', () => {
     it('tracks two batches independently', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]), {})
-        collector.feed(makeBatch([3]), {})
+        await collector.feed(makeBatch([1, 2]))
+        await collector.feed(makeBatch([3]))
         const { allResults } = await drainAll(collector)
 
-        expect(afterBatch).toHaveBeenCalledTimes(2)
+        expect(afterBatchStep).toHaveBeenCalledTimes(2)
         expect(allResults).toHaveLength(3)
     })
 
     it('handles single-message batches', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([42]), {})
+        await collector.feed(makeBatch([42]))
         const { allResults } = await drainAll(collector)
 
-        expect(beforeBatch).toHaveBeenCalledTimes(1)
-        expect(afterBatch).toHaveBeenCalledTimes(1)
+        expect(beforeBatchStep).toHaveBeenCalledTimes(1)
+        expect(afterBatchStep).toHaveBeenCalledTimes(1)
         expect(allResults).toHaveLength(1)
     })
 
     it('supports feed-drain-feed-drain cycle', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1]), {})
+        await collector.feed(makeBatch([1]))
         const { allResults: results1 } = await drainAll(collector)
-        expect(afterBatch).toHaveBeenCalledTimes(1)
+        expect(afterBatchStep).toHaveBeenCalledTimes(1)
         expect(results1).toHaveLength(1)
 
-        collector.feed(makeBatch([2]), {})
+        await collector.feed(makeBatch([2]))
         const { allResults: results2 } = await drainAll(collector)
-        expect(afterBatch).toHaveBeenCalledTimes(2)
-        expect(afterBatch.mock.calls[1][2]).toBe(1)
+        expect(afterBatchStep).toHaveBeenCalledTimes(2)
+        expect(afterBatchStep.mock.calls[1][0].batchId).toBe(1)
         expect(results2).toHaveLength(1)
     })
 
     it('awaits async afterBatch before returning from next()', async () => {
         const order: string[] = []
 
-        afterBatch.mockImplementation(async () => {
+        afterBatchStep.mockImplementation(async (input: any) => {
             order.push('callback-start')
             await new Promise((r) => setTimeout(r, 10))
             order.push('callback-end')
-            return { elements: undefined }
+            return ok({ elements: input.elements, batchContext: input.batchContext })
         })
 
         const collector = createCollector()
-        collector.feed(makeBatch([1]), {})
+        await collector.feed(makeBatch([1]))
 
         order.push('next-called')
         await collector.next()
@@ -204,31 +194,28 @@ describe('BatchingPipeline', () => {
         it('blocks until a batch completes', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1, 2, 3]), {})
+            await collector.feed(makeBatch([1, 2, 3]))
 
-            // next() loops internally until a batch completes
             const result = await collector.next()
             expect(result).not.toBeNull()
             expect(result!.elements).toHaveLength(3)
-            expect(afterBatch).toHaveBeenCalledTimes(1)
+            expect(afterBatchStep).toHaveBeenCalledTimes(1)
         })
 
         it('fires afterBatch for first batch even when second is still in flight', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1]), {})
-            collector.feed(makeBatch([2, 3]), {})
+            await collector.feed(makeBatch([1]))
+            await collector.feed(makeBatch([2, 3]))
 
-            // batch 0 has 1 element, next() loops until it completes
             const result0 = await collector.next()
-            expect(afterBatch).toHaveBeenCalledTimes(1)
-            expect(afterBatch.mock.calls[0][2]).toBe(0)
+            expect(afterBatchStep).toHaveBeenCalledTimes(1)
+            expect(afterBatchStep.mock.calls[0][0].batchId).toBe(0)
             expect(result0!.elements).toHaveLength(1)
 
-            // batch 1 has 2 elements, next() loops until it completes
             const result1 = await collector.next()
-            expect(afterBatch).toHaveBeenCalledTimes(2)
-            expect(afterBatch.mock.calls[1][2]).toBe(1)
+            expect(afterBatchStep).toHaveBeenCalledTimes(2)
+            expect(afterBatchStep.mock.calls[1][0].batchId).toBe(1)
             expect(result1!.elements).toHaveLength(2)
             expect(result1!.elements[0].context.messageId).toBe(1)
             expect(result1!.elements[1].context.messageId).toBe(2)
@@ -237,37 +224,45 @@ describe('BatchingPipeline', () => {
         it('returns results from multiple batches completing on the same next() call', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1]), {})
-            collector.feed(makeBatch([2]), {})
+            await collector.feed(makeBatch([1]))
+            await collector.feed(makeBatch([2]))
 
-            // Both batches are single-element. First next() may complete one or both.
             const result0 = await collector.next()
             expect(result0!.elements).toHaveLength(1)
 
             const result1 = await collector.next()
             expect(result1!.elements).toHaveLength(1)
 
-            expect(afterBatch).toHaveBeenCalledTimes(2)
+            expect(afterBatchStep).toHaveBeenCalledTimes(2)
         })
     })
 
     it('beforeBatch can add extra context to elements', async () => {
-        const collector = newBatchingPipeline<any, any, MsgCtx, string, MsgCtx>(
-            (_batchContext, elements, batchId) => ({
-                elements: elements.map((el) => ({
-                    ...el,
-                    context: {
-                        ...el.context,
-                        batchStore: `store-for-batch-${batchId}`,
-                    },
-                })),
-            }),
+        const collector = newBatchingPipeline<any, any, MsgCtx, string>(
+            (builder) =>
+                builder.pipe(({ elements, batchId }) =>
+                    Promise.resolve(
+                        ok({
+                            elements: elements.map((el: any) => ({
+                                ...el,
+                                context: {
+                                    ...el.context,
+                                    batchStore: `store-for-batch-${batchId}`,
+                                },
+                            })),
+                            batchContext: `store-for-batch-${batchId}`,
+                        })
+                    )
+                ),
             (builder) => builder,
-            () => Promise.resolve({ elements: undefined }),
+            (builder) =>
+                builder.pipe((input) =>
+                    Promise.resolve(ok({ elements: input.elements, batchContext: input.batchContext }))
+                ),
             { concurrentBatches: Infinity }
         )
 
-        collector.feed(makeBatch([1, 2]), `store-for-batch-0`)
+        await collector.feed(makeBatch([1, 2]))
         const { allResults } = await drainAll(collector)
 
         expect(allResults).toHaveLength(2)
@@ -277,26 +272,32 @@ describe('BatchingPipeline', () => {
         expect(allResults[1].context.messageId).toBe(1)
     })
 
-    it('passes batchContext from feed() to beforeBatch and afterBatch', async () => {
+    it('passes batchContext from beforeBatch to afterBatch', async () => {
         type Stores = { personsStore: string; groupStore: string }
 
         const capturedBefore: Stores[] = []
         const capturedAfter: Stores[] = []
-        const collector = newBatchingPipeline<any, any, MsgCtx, Stores, MsgCtx>(
-            (batchContext, elements) => {
-                capturedBefore.push(batchContext)
-                return { elements: elements as any }
-            },
+        const collector = newBatchingPipeline<any, any, MsgCtx, Stores>(
+            (builder) =>
+                builder.pipe(({ elements, batchId }) => {
+                    const batchContext: Stores =
+                        batchId === 0
+                            ? { personsStore: 'persons-0', groupStore: 'groups-0' }
+                            : { personsStore: 'persons-1', groupStore: 'groups-1' }
+                    capturedBefore.push(batchContext)
+                    return Promise.resolve(ok({ elements: elements as any, batchContext }))
+                }),
             (builder) => builder,
-            (batchContext) => {
-                capturedAfter.push(batchContext)
-                return Promise.resolve({ elements: undefined })
-            },
+            (builder) =>
+                builder.pipe((input) => {
+                    capturedAfter.push(input.batchContext)
+                    return Promise.resolve(ok({ elements: input.elements, batchContext: input.batchContext }))
+                }),
             { concurrentBatches: Infinity }
         )
 
-        collector.feed(makeBatch([1]), { personsStore: 'persons-0', groupStore: 'groups-0' })
-        collector.feed(makeBatch([2]), { personsStore: 'persons-1', groupStore: 'groups-1' })
+        await collector.feed(makeBatch([1]))
+        await collector.feed(makeBatch([2]))
         await drainAll(collector)
 
         expect(capturedBefore).toEqual([
@@ -310,32 +311,26 @@ describe('BatchingPipeline', () => {
     })
 
     describe('side effects', () => {
-        it('collects before hook side effects in next() result', async () => {
+        it('collects before pipeline side effects in next() result', async () => {
             const sideEffect = Promise.resolve('before-effect')
-            beforeBatch.mockImplementation((_batchCtx: any, elements: any) => ({
-                elements,
-                sideEffects: [sideEffect],
-            }))
+            beforeBatchStep.mockImplementation(({ elements }: any) => ok({ elements, batchContext: {} }, [sideEffect]))
 
             const collector = createCollector()
-            collector.feed(makeBatch([1]), {})
+            await collector.feed(makeBatch([1]))
 
             const result = await collector.next()
             expect(result).not.toBeNull()
             expect(result!.sideEffects).toContain(sideEffect)
         })
 
-        it('collects after hook side effects in next() result', async () => {
+        it('collects after pipeline side effects in next() result', async () => {
             const sideEffect = Promise.resolve('after-effect')
-            afterBatch.mockImplementation(() =>
-                Promise.resolve({
-                    elements: undefined,
-                    sideEffects: [sideEffect],
-                })
+            afterBatchStep.mockImplementation((input: any) =>
+                ok({ elements: input.elements, batchContext: input.batchContext }, [sideEffect])
             )
 
             const collector = createCollector()
-            collector.feed(makeBatch([1]), {})
+            await collector.feed(makeBatch([1]))
 
             const result = await collector.next()
             expect(result).not.toBeNull()
@@ -346,19 +341,15 @@ describe('BatchingPipeline', () => {
             const beforeEffect = Promise.resolve('before')
             const afterEffect = Promise.resolve('after')
 
-            beforeBatch.mockImplementation((_batchCtx: any, elements: any) => ({
-                elements,
-                sideEffects: [beforeEffect],
-            }))
-            afterBatch.mockImplementation(() =>
-                Promise.resolve({
-                    elements: undefined,
-                    sideEffects: [afterEffect],
-                })
+            beforeBatchStep.mockImplementation(({ elements }: any) =>
+                ok({ elements, batchContext: {} }, [beforeEffect])
+            )
+            afterBatchStep.mockImplementation((input: any) =>
+                ok({ elements: input.elements, batchContext: input.batchContext }, [afterEffect])
             )
 
             const collector = createCollector()
-            collector.feed(makeBatch([1]), {})
+            await collector.feed(makeBatch([1]))
 
             const result = await collector.next()
             expect(result).not.toBeNull()
@@ -367,34 +358,34 @@ describe('BatchingPipeline', () => {
     })
 
     describe('concurrentBatches', () => {
-        it('feed() rejects with reason when at limit (default concurrentBatches: 1)', () => {
+        it('feed() rejects with reason when at limit (default concurrentBatches: 1)', async () => {
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(collector.feed(makeBatch([1]), {})).toEqual({ ok: true })
-            expect(collector.feed(makeBatch([2]), {})).toMatchObject({ ok: false, reason: expect.any(String) })
+            expect(await collector.feed(makeBatch([1]))).toEqual({ ok: true })
+            expect(await collector.feed(makeBatch([2]))).toMatchObject({ ok: false, reason: expect.any(String) })
         })
 
         it('draining a batch frees a slot', async () => {
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(collector.feed(makeBatch([1]), {}).ok).toBe(true)
-            expect(collector.feed(makeBatch([2]), {}).ok).toBe(false)
+            expect((await collector.feed(makeBatch([1]))).ok).toBe(true)
+            expect((await collector.feed(makeBatch([2]))).ok).toBe(false)
 
             await drainAll(collector)
 
-            expect(collector.feed(makeBatch([3]), {}).ok).toBe(true)
+            expect((await collector.feed(makeBatch([3]))).ok).toBe(true)
         })
 
         it('feed() accepts when under limit and rejects when at limit', async () => {
             const collector = createCollector({ concurrentBatches: 2 })
 
-            expect(collector.feed(makeBatch([1]), {}).ok).toBe(true)
-            expect(collector.feed(makeBatch([2]), {}).ok).toBe(true)
-            expect(collector.feed(makeBatch([3]), {}).ok).toBe(false)
+            expect((await collector.feed(makeBatch([1]))).ok).toBe(true)
+            expect((await collector.feed(makeBatch([2]))).ok).toBe(true)
+            expect((await collector.feed(makeBatch([3]))).ok).toBe(false)
 
             await drainAll(collector)
 
-            expect(collector.feed(makeBatch([4]), {}).ok).toBe(true)
+            expect((await collector.feed(makeBatch([4]))).ok).toBe(true)
         })
     })
 })

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { Message } from 'node-rdkafka'
 
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
-import { BatchingContext, batch } from './batching-pipeline'
+import { BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchResult, BatchingContext, BatchingPipeline } from './batching-pipeline'
 import { newBatchingPipeline } from './builders/helpers'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { ok } from './results'
@@ -33,13 +33,25 @@ function makeBatch(offsets: number[]): BatchPipelineResultWithContext<any, MsgCt
     }))
 }
 
+function noopBeforeBatch(
+    _batchContext: Record<string, never>,
+    elements: BatchPipelineResultWithContext<any, MsgCtx>,
+    _batchId: number
+): BatchResult<BatchPipelineResultWithContext<any, MsgCtx & BatchingContext>> {
+    return { value: elements as any, sideEffects: [] }
+}
+
+function noopAfterBatch(): BatchResult<void> {
+    return { value: undefined, sideEffects: [] }
+}
+
 describe('BatchingPipeline', () => {
     let beforeBatch: jest.Mock
     let afterBatch: jest.Mock
 
     beforeEach(() => {
-        beforeBatch = jest.fn((elements, _batchId) => batch(elements, {}))
-        afterBatch = jest.fn()
+        beforeBatch = jest.fn(noopBeforeBatch)
+        afterBatch = jest.fn(noopAfterBatch)
     })
 
     function createCollector(options?: { concurrentBatches?: number }) {
@@ -60,14 +72,18 @@ describe('BatchingPipeline', () => {
         )
     }
 
-    async function drainAll<C>(pipeline: BatchPipeline<any, any, any, C>) {
-        const allResults: PipelineResultWithContext<any, C>[] = []
+    async function drainAll(
+        pipeline: BatchingPipeline<any, any, any, any, any, any>
+    ): Promise<{ allResults: PipelineResultWithContext<any, any>[]; allSideEffects: Promise<unknown>[] }> {
+        const allResults: PipelineResultWithContext<any, any>[] = []
+        const allSideEffects: Promise<unknown>[] = []
         let r = await pipeline.next()
         while (r !== null) {
-            allResults.push(...r)
+            allResults.push(...r.value)
+            allSideEffects.push(...r.sideEffects)
             r = await pipeline.next()
         }
-        return allResults
+        return { allResults, allSideEffects }
     }
 
     it('returns null when sub-pipeline is empty', async () => {
@@ -80,87 +96,87 @@ describe('BatchingPipeline', () => {
     it('assigns sequential batch IDs to beforeBatch', () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]))
-        collector.feed(makeBatch([3]))
+        collector.feed(makeBatch([1, 2]), {})
+        collector.feed(makeBatch([3]), {})
 
         expect(beforeBatch).toHaveBeenCalledTimes(2)
-        expect(beforeBatch.mock.calls[0][1]).toBe(0)
-        expect(beforeBatch.mock.calls[0][0]).toHaveLength(2)
-        expect(beforeBatch.mock.calls[1][1]).toBe(1)
-        expect(beforeBatch.mock.calls[1][0]).toHaveLength(1)
+        expect(beforeBatch.mock.calls[0][2]).toBe(0)
+        expect(beforeBatch.mock.calls[0][1]).toHaveLength(2)
+        expect(beforeBatch.mock.calls[1][2]).toBe(1)
+        expect(beforeBatch.mock.calls[1][1]).toHaveLength(1)
     })
 
     it('tags each element with a monotonic messageId in context', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([10, 20, 30]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([10, 20, 30]), {})
+        const { allResults } = await drainAll(collector)
 
-        expect(results).toHaveLength(3)
-        expect(results[0].context.messageId).toBe(0)
-        expect(results[1].context.messageId).toBe(1)
-        expect(results[2].context.messageId).toBe(2)
+        expect(allResults).toHaveLength(3)
+        expect(allResults[0].context.messageId).toBe(0)
+        expect(allResults[1].context.messageId).toBe(1)
+        expect(allResults[2].context.messageId).toBe(2)
     })
 
     it('continues messageId sequence across batches', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]))
-        collector.feed(makeBatch([3]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([1, 2]), {})
+        collector.feed(makeBatch([3]), {})
+        const { allResults } = await drainAll(collector)
 
-        expect(results).toHaveLength(3)
-        expect(results[0].context.messageId).toBe(0)
-        expect(results[1].context.messageId).toBe(1)
-        expect(results[2].context.messageId).toBe(2)
+        expect(allResults).toHaveLength(3)
+        expect(allResults[0].context.messageId).toBe(0)
+        expect(allResults[1].context.messageId).toBe(1)
+        expect(allResults[2].context.messageId).toBe(2)
     })
 
     it('returns ordered batch results when a batch completes', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2, 3]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([1, 2, 3]), {})
+        const { allResults } = await drainAll(collector)
 
         expect(afterBatch).toHaveBeenCalledTimes(1)
         expect(afterBatch.mock.calls[0][1]).toBe(0)
-        expect(results).toHaveLength(3)
-        expect(results[0].context.messageId).toBe(0)
-        expect(results[1].context.messageId).toBe(1)
-        expect(results[2].context.messageId).toBe(2)
+        expect(allResults).toHaveLength(3)
+        expect(allResults[0].context.messageId).toBe(0)
+        expect(allResults[1].context.messageId).toBe(1)
+        expect(allResults[2].context.messageId).toBe(2)
     })
 
     it('tracks two batches independently', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1, 2]))
-        collector.feed(makeBatch([3]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([1, 2]), {})
+        collector.feed(makeBatch([3]), {})
+        const { allResults } = await drainAll(collector)
 
         expect(afterBatch).toHaveBeenCalledTimes(2)
-        expect(results).toHaveLength(3)
+        expect(allResults).toHaveLength(3)
     })
 
     it('handles single-message batches', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([42]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([42]), {})
+        const { allResults } = await drainAll(collector)
 
         expect(beforeBatch).toHaveBeenCalledTimes(1)
         expect(afterBatch).toHaveBeenCalledTimes(1)
-        expect(results).toHaveLength(1)
+        expect(allResults).toHaveLength(1)
     })
 
     it('supports feed-drain-feed-drain cycle', async () => {
         const collector = createCollector()
 
-        collector.feed(makeBatch([1]))
-        const results1 = await drainAll(collector)
+        collector.feed(makeBatch([1]), {})
+        const { allResults: results1 } = await drainAll(collector)
         expect(afterBatch).toHaveBeenCalledTimes(1)
         expect(results1).toHaveLength(1)
 
-        collector.feed(makeBatch([2]))
-        const results2 = await drainAll(collector)
+        collector.feed(makeBatch([2]), {})
+        const { allResults: results2 } = await drainAll(collector)
         expect(afterBatch).toHaveBeenCalledTimes(2)
         expect(afterBatch.mock.calls[1][1]).toBe(1)
         expect(results2).toHaveLength(1)
@@ -173,10 +189,11 @@ describe('BatchingPipeline', () => {
             order.push('callback-start')
             await new Promise((r) => setTimeout(r, 10))
             order.push('callback-end')
+            return { value: undefined, sideEffects: [] }
         })
 
         const collector = createCollector()
-        collector.feed(makeBatch([1]))
+        collector.feed(makeBatch([1]), {})
 
         order.push('next-called')
         await collector.next()
@@ -186,145 +203,197 @@ describe('BatchingPipeline', () => {
     })
 
     describe('with streaming sub-pipeline', () => {
-        it('returns empty array when no batch completes on a next() call', async () => {
+        it('blocks until a batch completes', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1, 2, 3]))
+            collector.feed(makeBatch([1, 2, 3]), {})
 
-            // concurrently yields one result per next() call,
-            // so first two calls don't complete the batch
-            const first = await collector.next()
-            expect(first).toEqual([])
-
-            const second = await collector.next()
-            expect(second).toEqual([])
+            // next() loops internally until a batch completes
+            const result = await collector.next()
+            expect(result).not.toBeNull()
+            expect(result!.value).toHaveLength(3)
+            expect(afterBatch).toHaveBeenCalledTimes(1)
         })
 
         it('fires afterBatch for first batch even when second is still in flight', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1]))
-            collector.feed(makeBatch([2, 3]))
+            collector.feed(makeBatch([1]), {})
+            collector.feed(makeBatch([2, 3]), {})
 
-            // batch 0 has 1 element, completes on first next()
+            // batch 0 has 1 element, next() loops until it completes
             const result0 = await collector.next()
             expect(afterBatch).toHaveBeenCalledTimes(1)
             expect(afterBatch.mock.calls[0][1]).toBe(0)
-            expect(result0).toHaveLength(1)
+            expect(result0!.value).toHaveLength(1)
 
-            // batch 1 has 2 elements, still in flight
+            // batch 1 has 2 elements, next() loops until it completes
             const result1 = await collector.next()
-            expect(afterBatch).toHaveBeenCalledTimes(1)
-            expect(result1).toEqual([])
-
-            // batch 1 completes
-            const result2 = await collector.next()
             expect(afterBatch).toHaveBeenCalledTimes(2)
             expect(afterBatch.mock.calls[1][1]).toBe(1)
-            expect(result2).toHaveLength(2)
-            expect(result2![0].context.messageId).toBe(1)
-            expect(result2![1].context.messageId).toBe(2)
+            expect(result1!.value).toHaveLength(2)
+            expect(result1!.value[0].context.messageId).toBe(1)
+            expect(result1!.value[1].context.messageId).toBe(2)
         })
 
         it('returns results from multiple batches completing on the same next() call', async () => {
             const collector = createStreamingCollector()
 
-            collector.feed(makeBatch([1]))
-            collector.feed(makeBatch([2]))
+            collector.feed(makeBatch([1]), {})
+            collector.feed(makeBatch([2]), {})
 
-            // Both batches are single-element. concurrently queues both promises.
-            // First next() yields element from batch 0, completing batch 0.
+            // Both batches are single-element. First next() may complete one or both.
             const result0 = await collector.next()
-            expect(afterBatch).toHaveBeenCalledTimes(1)
-            expect(result0).toHaveLength(1)
+            expect(result0!.value).toHaveLength(1)
 
-            // Second next() yields element from batch 1, completing batch 1.
             const result1 = await collector.next()
+            expect(result1!.value).toHaveLength(1)
+
             expect(afterBatch).toHaveBeenCalledTimes(2)
-            expect(result1).toHaveLength(1)
         })
     })
 
     it('beforeBatch can add extra context to elements', async () => {
         const collector = newBatchingPipeline<any, any, MsgCtx, string, SubCtx>(
-            (elements, batchId) => ({
-                batchContext: `store-for-batch-${batchId}`,
-                elements: elements.map((el) => ({
+            (_batchContext, elements, batchId) => ({
+                value: elements.map((el) => ({
                     ...el,
                     context: {
                         ...el.context,
                         batchStore: `store-for-batch-${batchId}`,
                     },
                 })),
+                sideEffects: [],
             }),
             (builder) => builder,
-            () => {},
+            () => ({ value: undefined, sideEffects: [] }),
             { concurrentBatches: Infinity }
         )
 
-        collector.feed(makeBatch([1, 2]))
-        const results = await drainAll(collector)
+        collector.feed(makeBatch([1, 2]), `store-for-batch-0`)
+        const { allResults } = await drainAll(collector)
 
-        expect(results).toHaveLength(2)
-        expect(results[0].context).toHaveProperty('batchStore', 'store-for-batch-0')
-        expect(results[1].context).toHaveProperty('batchStore', 'store-for-batch-0')
-        expect(results[0].context.messageId).toBe(0)
-        expect(results[1].context.messageId).toBe(1)
+        expect(allResults).toHaveLength(2)
+        expect(allResults[0].context).toHaveProperty('batchStore', 'store-for-batch-0')
+        expect(allResults[1].context).toHaveProperty('batchStore', 'store-for-batch-0')
+        expect(allResults[0].context.messageId).toBe(0)
+        expect(allResults[1].context.messageId).toBe(1)
     })
 
-    it('passes batchContext from beforeBatch to afterBatch', async () => {
+    it('passes batchContext from feed() to beforeBatch and afterBatch', async () => {
         type Stores = { personsStore: string; groupStore: string }
 
-        const captured: Stores[] = []
+        const capturedBefore: Stores[] = []
+        const capturedAfter: Stores[] = []
         const collector = newBatchingPipeline<any, any, MsgCtx, Stores, SubCtx>(
-            (elements, batchId) =>
-                batch(elements, { personsStore: `persons-${batchId}`, groupStore: `groups-${batchId}` }),
+            (batchContext, elements, _batchId) => {
+                capturedBefore.push(batchContext)
+                return { value: elements as any, sideEffects: [] }
+            },
             (builder) => builder,
             (batchContext) => {
-                captured.push(batchContext)
+                capturedAfter.push(batchContext)
+                return { value: undefined, sideEffects: [] }
             },
             { concurrentBatches: Infinity }
         )
 
-        collector.feed(makeBatch([1]))
-        collector.feed(makeBatch([2]))
+        collector.feed(makeBatch([1]), { personsStore: 'persons-0', groupStore: 'groups-0' })
+        collector.feed(makeBatch([2]), { personsStore: 'persons-1', groupStore: 'groups-1' })
         await drainAll(collector)
 
-        expect(captured).toEqual([
+        expect(capturedBefore).toEqual([
             { personsStore: 'persons-0', groupStore: 'groups-0' },
             { personsStore: 'persons-1', groupStore: 'groups-1' },
         ])
+        expect(capturedAfter).toEqual([
+            { personsStore: 'persons-0', groupStore: 'groups-0' },
+            { personsStore: 'persons-1', groupStore: 'groups-1' },
+        ])
+    })
+
+    describe('side effects', () => {
+        it('collects before hook side effects in next() result', async () => {
+            const sideEffect = Promise.resolve('before-effect')
+            beforeBatch.mockImplementation((_batchCtx: any, elements: any, _batchId: number) => ({
+                value: elements,
+                sideEffects: [sideEffect],
+            }))
+
+            const collector = createCollector()
+            collector.feed(makeBatch([1]), {})
+
+            const result = await collector.next()
+            expect(result).not.toBeNull()
+            expect(result!.sideEffects).toContain(sideEffect)
+        })
+
+        it('collects after hook side effects in next() result', async () => {
+            const sideEffect = Promise.resolve('after-effect')
+            afterBatch.mockImplementation(() => ({
+                value: undefined,
+                sideEffects: [sideEffect],
+            }))
+
+            const collector = createCollector()
+            collector.feed(makeBatch([1]), {})
+
+            const result = await collector.next()
+            expect(result).not.toBeNull()
+            expect(result!.sideEffects).toContain(sideEffect)
+        })
+
+        it('concatenates before and after side effects', async () => {
+            const beforeEffect = Promise.resolve('before')
+            const afterEffect = Promise.resolve('after')
+
+            beforeBatch.mockImplementation((_batchCtx: any, elements: any, _batchId: number) => ({
+                value: elements,
+                sideEffects: [beforeEffect],
+            }))
+            afterBatch.mockImplementation(() => ({
+                value: undefined,
+                sideEffects: [afterEffect],
+            }))
+
+            const collector = createCollector()
+            collector.feed(makeBatch([1]), {})
+
+            const result = await collector.next()
+            expect(result).not.toBeNull()
+            expect(result!.sideEffects).toEqual([beforeEffect, afterEffect])
+        })
     })
 
     describe('concurrentBatches', () => {
         it('feed() rejects with reason when at limit (default concurrentBatches: 1)', () => {
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(collector.feed(makeBatch([1]))).toEqual({ ok: true })
-            expect(collector.feed(makeBatch([2]))).toMatchObject({ ok: false, reason: expect.any(String) })
+            expect(collector.feed(makeBatch([1]), {})).toEqual({ ok: true })
+            expect(collector.feed(makeBatch([2]), {})).toMatchObject({ ok: false, reason: expect.any(String) })
         })
 
         it('draining a batch frees a slot', async () => {
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(collector.feed(makeBatch([1])).ok).toBe(true)
-            expect(collector.feed(makeBatch([2])).ok).toBe(false)
+            expect(collector.feed(makeBatch([1]), {}).ok).toBe(true)
+            expect(collector.feed(makeBatch([2]), {}).ok).toBe(false)
 
             await drainAll(collector)
 
-            expect(collector.feed(makeBatch([3])).ok).toBe(true)
+            expect(collector.feed(makeBatch([3]), {}).ok).toBe(true)
         })
 
         it('feed() accepts when under limit and rejects when at limit', async () => {
             const collector = createCollector({ concurrentBatches: 2 })
 
-            expect(collector.feed(makeBatch([1])).ok).toBe(true)
-            expect(collector.feed(makeBatch([2])).ok).toBe(true)
-            expect(collector.feed(makeBatch([3])).ok).toBe(false)
+            expect(collector.feed(makeBatch([1]), {}).ok).toBe(true)
+            expect(collector.feed(makeBatch([2]), {}).ok).toBe(true)
+            expect(collector.feed(makeBatch([3]), {}).ok).toBe(false)
 
             await drainAll(collector)
 
-            expect(collector.feed(makeBatch([4])).ok).toBe(true)
+            expect(collector.feed(makeBatch([4]), {}).ok).toBe(true)
         })
     })
 })

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
@@ -42,11 +42,12 @@ describe('BatchingPipeline', () => {
         afterBatch = jest.fn()
     })
 
-    function createCollector() {
+    function createCollector(options?: { concurrentBatches?: number }) {
         return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
             beforeBatch,
             (builder) => builder,
-            afterBatch
+            afterBatch,
+            { concurrentBatches: Infinity, ...options }
         )
     }
 
@@ -54,7 +55,8 @@ describe('BatchingPipeline', () => {
         return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
             beforeBatch,
             (builder) => builder.concurrently((b) => b.pipe((value) => Promise.resolve(ok(value)))),
-            afterBatch
+            afterBatch,
+            { concurrentBatches: Infinity }
         )
     }
 
@@ -256,7 +258,8 @@ describe('BatchingPipeline', () => {
                 })),
             }),
             (builder) => builder,
-            () => {}
+            () => {},
+            { concurrentBatches: Infinity }
         )
 
         collector.feed(makeBatch([1, 2]))
@@ -279,7 +282,8 @@ describe('BatchingPipeline', () => {
             (builder) => builder,
             (batchContext) => {
                 captured.push(batchContext)
-            }
+            },
+            { concurrentBatches: Infinity }
         )
 
         collector.feed(makeBatch([1]))
@@ -290,5 +294,37 @@ describe('BatchingPipeline', () => {
             { personsStore: 'persons-0', groupStore: 'groups-0' },
             { personsStore: 'persons-1', groupStore: 'groups-1' },
         ])
+    })
+
+    describe('concurrentBatches', () => {
+        it('feed() rejects with reason when at limit (default concurrentBatches: 1)', () => {
+            const collector = createCollector({ concurrentBatches: 1 })
+
+            expect(collector.feed(makeBatch([1]))).toEqual({ ok: true })
+            expect(collector.feed(makeBatch([2]))).toMatchObject({ ok: false, reason: expect.any(String) })
+        })
+
+        it('draining a batch frees a slot', async () => {
+            const collector = createCollector({ concurrentBatches: 1 })
+
+            expect(collector.feed(makeBatch([1])).ok).toBe(true)
+            expect(collector.feed(makeBatch([2])).ok).toBe(false)
+
+            await drainAll(collector)
+
+            expect(collector.feed(makeBatch([3])).ok).toBe(true)
+        })
+
+        it('feed() accepts when under limit and rejects when at limit', async () => {
+            const collector = createCollector({ concurrentBatches: 2 })
+
+            expect(collector.feed(makeBatch([1])).ok).toBe(true)
+            expect(collector.feed(makeBatch([2])).ok).toBe(true)
+            expect(collector.feed(makeBatch([3])).ok).toBe(false)
+
+            await drainAll(collector)
+
+            expect(collector.feed(makeBatch([4])).ok).toBe(true)
+        })
     })
 })

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
@@ -1,0 +1,294 @@
+import { Message } from 'node-rdkafka'
+
+import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchingContext, batch } from './batching-pipeline'
+import { newBatchingPipeline } from './builders/helpers'
+import { PipelineResultWithContext } from './pipeline.interface'
+import { ok } from './results'
+
+type MsgCtx = { message: Message }
+type SubCtx = MsgCtx & BatchingContext
+
+function makeMessage(offset: number): Message {
+    return {
+        topic: 'test-topic',
+        partition: 0,
+        offset,
+        size: 0,
+        key: Buffer.from(`key${offset}`),
+        value: Buffer.from(`value${offset}`),
+        timestamp: Date.now(),
+    }
+}
+
+function makeBatch(offsets: number[]): BatchPipelineResultWithContext<any, MsgCtx> {
+    return offsets.map((offset) => ({
+        result: ok({ value: `msg-${offset}` }),
+        context: {
+            message: makeMessage(offset),
+            lastStep: undefined,
+            sideEffects: [],
+            warnings: [],
+        },
+    }))
+}
+
+describe('BatchingPipeline', () => {
+    let beforeBatch: jest.Mock
+    let afterBatch: jest.Mock
+
+    beforeEach(() => {
+        beforeBatch = jest.fn((elements, _batchId) => batch(elements, {}))
+        afterBatch = jest.fn()
+    })
+
+    function createCollector() {
+        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
+            beforeBatch,
+            (builder) => builder,
+            afterBatch
+        )
+    }
+
+    function createStreamingCollector() {
+        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
+            beforeBatch,
+            (builder) => builder.concurrently((b) => b.pipe((value) => Promise.resolve(ok(value)))),
+            afterBatch
+        )
+    }
+
+    async function drainAll<C>(pipeline: BatchPipeline<any, any, any, C>) {
+        const allResults: PipelineResultWithContext<any, C>[] = []
+        let r = await pipeline.next()
+        while (r !== null) {
+            allResults.push(...r)
+            r = await pipeline.next()
+        }
+        return allResults
+    }
+
+    it('returns null when sub-pipeline is empty', async () => {
+        const collector = createCollector()
+        expect(await collector.next()).toBeNull()
+        expect(beforeBatch).not.toHaveBeenCalled()
+        expect(afterBatch).not.toHaveBeenCalled()
+    })
+
+    it('assigns sequential batch IDs to beforeBatch', () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([1, 2]))
+        collector.feed(makeBatch([3]))
+
+        expect(beforeBatch).toHaveBeenCalledTimes(2)
+        expect(beforeBatch.mock.calls[0][1]).toBe(0)
+        expect(beforeBatch.mock.calls[0][0]).toHaveLength(2)
+        expect(beforeBatch.mock.calls[1][1]).toBe(1)
+        expect(beforeBatch.mock.calls[1][0]).toHaveLength(1)
+    })
+
+    it('tags each element with a monotonic messageId in context', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([10, 20, 30]))
+        const results = await drainAll(collector)
+
+        expect(results).toHaveLength(3)
+        expect(results[0].context.messageId).toBe(0)
+        expect(results[1].context.messageId).toBe(1)
+        expect(results[2].context.messageId).toBe(2)
+    })
+
+    it('continues messageId sequence across batches', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([1, 2]))
+        collector.feed(makeBatch([3]))
+        const results = await drainAll(collector)
+
+        expect(results).toHaveLength(3)
+        expect(results[0].context.messageId).toBe(0)
+        expect(results[1].context.messageId).toBe(1)
+        expect(results[2].context.messageId).toBe(2)
+    })
+
+    it('returns ordered batch results when a batch completes', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([1, 2, 3]))
+        const results = await drainAll(collector)
+
+        expect(afterBatch).toHaveBeenCalledTimes(1)
+        expect(afterBatch.mock.calls[0][1]).toBe(0)
+        expect(results).toHaveLength(3)
+        expect(results[0].context.messageId).toBe(0)
+        expect(results[1].context.messageId).toBe(1)
+        expect(results[2].context.messageId).toBe(2)
+    })
+
+    it('tracks two batches independently', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([1, 2]))
+        collector.feed(makeBatch([3]))
+        const results = await drainAll(collector)
+
+        expect(afterBatch).toHaveBeenCalledTimes(2)
+        expect(results).toHaveLength(3)
+    })
+
+    it('handles single-message batches', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([42]))
+        const results = await drainAll(collector)
+
+        expect(beforeBatch).toHaveBeenCalledTimes(1)
+        expect(afterBatch).toHaveBeenCalledTimes(1)
+        expect(results).toHaveLength(1)
+    })
+
+    it('supports feed-drain-feed-drain cycle', async () => {
+        const collector = createCollector()
+
+        collector.feed(makeBatch([1]))
+        const results1 = await drainAll(collector)
+        expect(afterBatch).toHaveBeenCalledTimes(1)
+        expect(results1).toHaveLength(1)
+
+        collector.feed(makeBatch([2]))
+        const results2 = await drainAll(collector)
+        expect(afterBatch).toHaveBeenCalledTimes(2)
+        expect(afterBatch.mock.calls[1][1]).toBe(1)
+        expect(results2).toHaveLength(1)
+    })
+
+    it('awaits async afterBatch before returning from next()', async () => {
+        const order: string[] = []
+
+        afterBatch.mockImplementation(async () => {
+            order.push('callback-start')
+            await new Promise((r) => setTimeout(r, 10))
+            order.push('callback-end')
+        })
+
+        const collector = createCollector()
+        collector.feed(makeBatch([1]))
+
+        order.push('next-called')
+        await collector.next()
+        order.push('next-resolved')
+
+        expect(order).toEqual(['next-called', 'callback-start', 'callback-end', 'next-resolved'])
+    })
+
+    describe('with streaming sub-pipeline', () => {
+        it('returns empty array when no batch completes on a next() call', async () => {
+            const collector = createStreamingCollector()
+
+            collector.feed(makeBatch([1, 2, 3]))
+
+            // concurrently yields one result per next() call,
+            // so first two calls don't complete the batch
+            const first = await collector.next()
+            expect(first).toEqual([])
+
+            const second = await collector.next()
+            expect(second).toEqual([])
+        })
+
+        it('fires afterBatch for first batch even when second is still in flight', async () => {
+            const collector = createStreamingCollector()
+
+            collector.feed(makeBatch([1]))
+            collector.feed(makeBatch([2, 3]))
+
+            // batch 0 has 1 element, completes on first next()
+            const result0 = await collector.next()
+            expect(afterBatch).toHaveBeenCalledTimes(1)
+            expect(afterBatch.mock.calls[0][1]).toBe(0)
+            expect(result0).toHaveLength(1)
+
+            // batch 1 has 2 elements, still in flight
+            const result1 = await collector.next()
+            expect(afterBatch).toHaveBeenCalledTimes(1)
+            expect(result1).toEqual([])
+
+            // batch 1 completes
+            const result2 = await collector.next()
+            expect(afterBatch).toHaveBeenCalledTimes(2)
+            expect(afterBatch.mock.calls[1][1]).toBe(1)
+            expect(result2).toHaveLength(2)
+            expect(result2![0].context.messageId).toBe(1)
+            expect(result2![1].context.messageId).toBe(2)
+        })
+
+        it('returns results from multiple batches completing on the same next() call', async () => {
+            const collector = createStreamingCollector()
+
+            collector.feed(makeBatch([1]))
+            collector.feed(makeBatch([2]))
+
+            // Both batches are single-element. concurrently queues both promises.
+            // First next() yields element from batch 0, completing batch 0.
+            const result0 = await collector.next()
+            expect(afterBatch).toHaveBeenCalledTimes(1)
+            expect(result0).toHaveLength(1)
+
+            // Second next() yields element from batch 1, completing batch 1.
+            const result1 = await collector.next()
+            expect(afterBatch).toHaveBeenCalledTimes(2)
+            expect(result1).toHaveLength(1)
+        })
+    })
+
+    it('beforeBatch can add extra context to elements', async () => {
+        const collector = newBatchingPipeline<any, any, MsgCtx, string, SubCtx>(
+            (elements, batchId) => ({
+                batchContext: `store-for-batch-${batchId}`,
+                elements: elements.map((el) => ({
+                    ...el,
+                    context: {
+                        ...el.context,
+                        batchStore: `store-for-batch-${batchId}`,
+                    },
+                })),
+            }),
+            (builder) => builder,
+            () => {}
+        )
+
+        collector.feed(makeBatch([1, 2]))
+        const results = await drainAll(collector)
+
+        expect(results).toHaveLength(2)
+        expect(results[0].context).toHaveProperty('batchStore', 'store-for-batch-0')
+        expect(results[1].context).toHaveProperty('batchStore', 'store-for-batch-0')
+        expect(results[0].context.messageId).toBe(0)
+        expect(results[1].context.messageId).toBe(1)
+    })
+
+    it('passes batchContext from beforeBatch to afterBatch', async () => {
+        type Stores = { personsStore: string; groupStore: string }
+
+        const captured: Stores[] = []
+        const collector = newBatchingPipeline<any, any, MsgCtx, Stores, SubCtx>(
+            (elements, batchId) =>
+                batch(elements, { personsStore: `persons-${batchId}`, groupStore: `groups-${batchId}` }),
+            (builder) => builder,
+            (batchContext) => {
+                captured.push(batchContext)
+            }
+        )
+
+        collector.feed(makeBatch([1]))
+        collector.feed(makeBatch([2]))
+        await drainAll(collector)
+
+        expect(captured).toEqual([
+            { personsStore: 'persons-0', groupStore: 'groups-0' },
+            { personsStore: 'persons-1', groupStore: 'groups-1' },
+        ])
+    })
+})

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.test.ts
@@ -1,14 +1,12 @@
 import { Message } from 'node-rdkafka'
 
 import { BatchPipelineResultWithContext } from './batch-pipeline.interface'
-import { BatchResult, BatchingContext, BatchingPipeline } from './batching-pipeline'
+import { BatchResult, BatchingPipeline } from './batching-pipeline'
 import { newBatchingPipeline } from './builders/helpers'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { ok } from './results'
 
 type MsgCtx = { message: Message }
-type SubCtx = MsgCtx & BatchingContext
-
 function makeMessage(offset: number): Message {
     return {
         topic: 'test-topic',
@@ -37,12 +35,12 @@ function noopBeforeBatch(
     _batchContext: Record<string, never>,
     elements: BatchPipelineResultWithContext<any, MsgCtx>,
     _batchId: number
-): BatchResult<BatchPipelineResultWithContext<any, MsgCtx & BatchingContext>> {
-    return { value: elements as any, sideEffects: [] }
+): BatchResult<BatchPipelineResultWithContext<any, MsgCtx>> {
+    return { elements: elements as any }
 }
 
-function noopAfterBatch(): BatchResult<void> {
-    return { value: undefined, sideEffects: [] }
+function noopAfterBatch(): Promise<BatchResult<void>> {
+    return Promise.resolve({ elements: undefined })
 }
 
 describe('BatchingPipeline', () => {
@@ -55,7 +53,7 @@ describe('BatchingPipeline', () => {
     })
 
     function createCollector(options?: { concurrentBatches?: number }) {
-        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
+        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, MsgCtx>(
             beforeBatch,
             (builder) => builder,
             afterBatch,
@@ -64,7 +62,7 @@ describe('BatchingPipeline', () => {
     }
 
     function createStreamingCollector() {
-        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, SubCtx>(
+        return newBatchingPipeline<any, any, MsgCtx, Record<string, never>, MsgCtx>(
             beforeBatch,
             (builder) => builder.concurrently((b) => b.pipe((value) => Promise.resolve(ok(value)))),
             afterBatch,
@@ -79,8 +77,8 @@ describe('BatchingPipeline', () => {
         const allSideEffects: Promise<unknown>[] = []
         let r = await pipeline.next()
         while (r !== null) {
-            allResults.push(...r.value)
-            allSideEffects.push(...r.sideEffects)
+            allResults.push(...r.elements)
+            allSideEffects.push(...(r.sideEffects ?? []))
             r = await pipeline.next()
         }
         return { allResults, allSideEffects }
@@ -138,7 +136,7 @@ describe('BatchingPipeline', () => {
         const { allResults } = await drainAll(collector)
 
         expect(afterBatch).toHaveBeenCalledTimes(1)
-        expect(afterBatch.mock.calls[0][1]).toBe(0)
+        expect(afterBatch.mock.calls[0][2]).toBe(0)
         expect(allResults).toHaveLength(3)
         expect(allResults[0].context.messageId).toBe(0)
         expect(allResults[1].context.messageId).toBe(1)
@@ -178,7 +176,7 @@ describe('BatchingPipeline', () => {
         collector.feed(makeBatch([2]), {})
         const { allResults: results2 } = await drainAll(collector)
         expect(afterBatch).toHaveBeenCalledTimes(2)
-        expect(afterBatch.mock.calls[1][1]).toBe(1)
+        expect(afterBatch.mock.calls[1][2]).toBe(1)
         expect(results2).toHaveLength(1)
     })
 
@@ -189,7 +187,7 @@ describe('BatchingPipeline', () => {
             order.push('callback-start')
             await new Promise((r) => setTimeout(r, 10))
             order.push('callback-end')
-            return { value: undefined, sideEffects: [] }
+            return { elements: undefined }
         })
 
         const collector = createCollector()
@@ -211,7 +209,7 @@ describe('BatchingPipeline', () => {
             // next() loops internally until a batch completes
             const result = await collector.next()
             expect(result).not.toBeNull()
-            expect(result!.value).toHaveLength(3)
+            expect(result!.elements).toHaveLength(3)
             expect(afterBatch).toHaveBeenCalledTimes(1)
         })
 
@@ -224,16 +222,16 @@ describe('BatchingPipeline', () => {
             // batch 0 has 1 element, next() loops until it completes
             const result0 = await collector.next()
             expect(afterBatch).toHaveBeenCalledTimes(1)
-            expect(afterBatch.mock.calls[0][1]).toBe(0)
-            expect(result0!.value).toHaveLength(1)
+            expect(afterBatch.mock.calls[0][2]).toBe(0)
+            expect(result0!.elements).toHaveLength(1)
 
             // batch 1 has 2 elements, next() loops until it completes
             const result1 = await collector.next()
             expect(afterBatch).toHaveBeenCalledTimes(2)
-            expect(afterBatch.mock.calls[1][1]).toBe(1)
-            expect(result1!.value).toHaveLength(2)
-            expect(result1!.value[0].context.messageId).toBe(1)
-            expect(result1!.value[1].context.messageId).toBe(2)
+            expect(afterBatch.mock.calls[1][2]).toBe(1)
+            expect(result1!.elements).toHaveLength(2)
+            expect(result1!.elements[0].context.messageId).toBe(1)
+            expect(result1!.elements[1].context.messageId).toBe(2)
         })
 
         it('returns results from multiple batches completing on the same next() call', async () => {
@@ -244,29 +242,28 @@ describe('BatchingPipeline', () => {
 
             // Both batches are single-element. First next() may complete one or both.
             const result0 = await collector.next()
-            expect(result0!.value).toHaveLength(1)
+            expect(result0!.elements).toHaveLength(1)
 
             const result1 = await collector.next()
-            expect(result1!.value).toHaveLength(1)
+            expect(result1!.elements).toHaveLength(1)
 
             expect(afterBatch).toHaveBeenCalledTimes(2)
         })
     })
 
     it('beforeBatch can add extra context to elements', async () => {
-        const collector = newBatchingPipeline<any, any, MsgCtx, string, SubCtx>(
+        const collector = newBatchingPipeline<any, any, MsgCtx, string, MsgCtx>(
             (_batchContext, elements, batchId) => ({
-                value: elements.map((el) => ({
+                elements: elements.map((el) => ({
                     ...el,
                     context: {
                         ...el.context,
                         batchStore: `store-for-batch-${batchId}`,
                     },
                 })),
-                sideEffects: [],
             }),
             (builder) => builder,
-            () => ({ value: undefined, sideEffects: [] }),
+            () => Promise.resolve({ elements: undefined }),
             { concurrentBatches: Infinity }
         )
 
@@ -285,15 +282,15 @@ describe('BatchingPipeline', () => {
 
         const capturedBefore: Stores[] = []
         const capturedAfter: Stores[] = []
-        const collector = newBatchingPipeline<any, any, MsgCtx, Stores, SubCtx>(
-            (batchContext, elements, _batchId) => {
+        const collector = newBatchingPipeline<any, any, MsgCtx, Stores, MsgCtx>(
+            (batchContext, elements) => {
                 capturedBefore.push(batchContext)
-                return { value: elements as any, sideEffects: [] }
+                return { elements: elements as any }
             },
             (builder) => builder,
             (batchContext) => {
                 capturedAfter.push(batchContext)
-                return { value: undefined, sideEffects: [] }
+                return Promise.resolve({ elements: undefined })
             },
             { concurrentBatches: Infinity }
         )
@@ -315,8 +312,8 @@ describe('BatchingPipeline', () => {
     describe('side effects', () => {
         it('collects before hook side effects in next() result', async () => {
             const sideEffect = Promise.resolve('before-effect')
-            beforeBatch.mockImplementation((_batchCtx: any, elements: any, _batchId: number) => ({
-                value: elements,
+            beforeBatch.mockImplementation((_batchCtx: any, elements: any) => ({
+                elements,
                 sideEffects: [sideEffect],
             }))
 
@@ -330,10 +327,12 @@ describe('BatchingPipeline', () => {
 
         it('collects after hook side effects in next() result', async () => {
             const sideEffect = Promise.resolve('after-effect')
-            afterBatch.mockImplementation(() => ({
-                value: undefined,
-                sideEffects: [sideEffect],
-            }))
+            afterBatch.mockImplementation(() =>
+                Promise.resolve({
+                    elements: undefined,
+                    sideEffects: [sideEffect],
+                })
+            )
 
             const collector = createCollector()
             collector.feed(makeBatch([1]), {})
@@ -347,14 +346,16 @@ describe('BatchingPipeline', () => {
             const beforeEffect = Promise.resolve('before')
             const afterEffect = Promise.resolve('after')
 
-            beforeBatch.mockImplementation((_batchCtx: any, elements: any, _batchId: number) => ({
-                value: elements,
+            beforeBatch.mockImplementation((_batchCtx: any, elements: any) => ({
+                elements,
                 sideEffects: [beforeEffect],
             }))
-            afterBatch.mockImplementation(() => ({
-                value: undefined,
-                sideEffects: [afterEffect],
-            }))
+            afterBatch.mockImplementation(() =>
+                Promise.resolve({
+                    elements: undefined,
+                    sideEffects: [afterEffect],
+                })
+            )
 
             const collector = createCollector()
             collector.feed(makeBatch([1]), {})

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../utils/logger'
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { PipelineResultWithContext } from './pipeline.interface'
 
 export interface BatchingContext {
@@ -90,7 +90,7 @@ export class BatchingPipeline<
         }
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
         const batchId = this.nextBatchId++
         const messageIds: number[] = []
         const inflight = new Set<number>()
@@ -122,6 +122,7 @@ export class BatchingPipeline<
         })
 
         this.subPipeline.feed(mappedElements)
+        return { ok: true }
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, CSubOut> | null> {

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -18,6 +18,14 @@ export function batch<CBatch, TInput, C>(
     return { batchContext, elements }
 }
 
+export interface BatchingPipelineOptions {
+    concurrentBatches: number
+}
+
+const BATCHING_PIPELINE_DEFAULTS: BatchingPipelineOptions = {
+    concurrentBatches: 1,
+}
+
 interface TrackedBatch<TOutput, CBatch, CSubOut> {
     batchContext: CBatch
     messageIds: number[]
@@ -73,6 +81,8 @@ export class BatchingPipeline<
     private batches = new Map<number, TrackedBatch<TOutput, CBatch, CSubOut>>()
     private messageIdToBatchId = new Map<number, number>()
 
+    private options: BatchingPipelineOptions
+
     constructor(
         private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, CSubOut>,
         private hooks: {
@@ -87,11 +97,19 @@ export class BatchingPipeline<
             ) =>
                 | BatchPipelineResultWithContext<TOutput, CSubOut>
                 | Promise<BatchPipelineResultWithContext<TOutput, CSubOut>>
-        }
-    ) {}
+        },
+        options?: Partial<BatchingPipelineOptions>
+    ) {
+        this.options = { ...BATCHING_PIPELINE_DEFAULTS, ...options }
+    }
 
     feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        if (this.batches.size >= this.options.concurrentBatches) {
+            return { ok: false, reason: `at concurrent batch capacity (${this.options.concurrentBatches})` }
+        }
+
         const batchId = this.nextBatchId++
+
         const messageIds: number[] = []
         const inflight = new Set<number>()
 

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -1,0 +1,174 @@
+import { logger } from '../../utils/logger'
+import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { PipelineResultWithContext } from './pipeline.interface'
+
+export interface BatchingContext {
+    messageId: number
+}
+
+export interface BeforeBatchResult<CBatch, TInput, C> {
+    batchContext: CBatch
+    elements: BatchPipelineResultWithContext<TInput, C>
+}
+
+export function batch<CBatch, TInput, C>(
+    elements: BatchPipelineResultWithContext<TInput, C>,
+    batchContext: CBatch
+): BeforeBatchResult<CBatch, TInput, C> {
+    return { batchContext, elements }
+}
+
+interface TrackedBatch<TOutput, CBatch, CSubOut> {
+    batchContext: CBatch
+    messageIds: number[]
+    inflight: Set<number>
+    results: Map<number, PipelineResultWithContext<TOutput, CSubOut>>
+}
+
+/**
+ * Pipeline step that tracks which messages belong to which feed() call (batch).
+ * When all messages from a batch have exited the pipeline, fires afterBatch
+ * with the results in their original feed order within the batch.
+ *
+ * Each call to feed() is a distinct batch. The collector assigns a monotonic
+ * messageId to each element via the context. As results come out of next(),
+ * the collector matches them to their batch and fires hooks.
+ *
+ * Lifecycle:
+ * - feed() tags elements with messageId, then calls beforeBatch which returns
+ *   a batchContext (opaque data carried per-batch) and mapped elements
+ *   (e.g. add per-batch stores to context). The mapped elements are fed to the
+ *   sub-pipeline.
+ * - next() collects results. When all messages in a batch complete, calls
+ *   afterBatch with the batchContext and ordered results, then returns results.
+ *
+ * Ordering guarantees:
+ * - Messages within a completed batch are returned in their original feed() order
+ * - Batches themselves are returned in completion order, NOT submission order.
+ *   If batch 1 completes before batch 0, batch 1's results appear first in next().
+ * - next() returns [] when the sub-pipeline produced results but no batch completed yet,
+ *   and null when the sub-pipeline is fully drained.
+ *
+ * Type parameters:
+ * - TInput/TOutput: value types flowing through the pipeline
+ * - CInput: context type accepted by feed() (without messageId)
+ * - CBatch: opaque batch context returned by beforeBatch, passed to afterBatch
+ * - CSubIn: context type fed to the sub-pipeline after beforeBatch maps elements.
+ *   Must extend CInput & BatchingContext. beforeBatch maps from
+ *   CInput & BatchingContext → CSubIn (e.g. to add per-batch stores).
+ * - CSubOut: context type returned by the sub-pipeline.
+ *   Must extend BatchingContext (messageId flows through the sub-pipeline).
+ */
+export class BatchingPipeline<
+    TInput,
+    TOutput,
+    CInput,
+    CBatch,
+    CSubIn extends CInput & BatchingContext,
+    CSubOut extends BatchingContext,
+> implements BatchPipeline<TInput, TOutput, CInput, CSubOut>
+{
+    private nextBatchId = 0
+    private nextMessageId = 0
+    private batches = new Map<number, TrackedBatch<TOutput, CBatch, CSubOut>>()
+    private messageIdToBatchId = new Map<number, number>()
+
+    constructor(
+        private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, CSubOut>,
+        private hooks: {
+            beforeBatch: (
+                elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext>,
+                batchId: number
+            ) => { batchContext: CBatch; elements: BatchPipelineResultWithContext<TInput, CSubIn> }
+            afterBatch: (
+                batchContext: CBatch,
+                results: BatchPipelineResultWithContext<TOutput, CSubOut>,
+                batchId: number
+            ) =>
+                | BatchPipelineResultWithContext<TOutput, CSubOut>
+                | Promise<BatchPipelineResultWithContext<TOutput, CSubOut>>
+        }
+    ) {}
+
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
+        const batchId = this.nextBatchId++
+        const messageIds: number[] = []
+        const inflight = new Set<number>()
+
+        const taggedElements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext> = elements.map(
+            (element) => {
+                const messageId = this.nextMessageId++
+                messageIds.push(messageId)
+                inflight.add(messageId)
+                this.messageIdToBatchId.set(messageId, batchId)
+
+                return {
+                    result: element.result,
+                    context: {
+                        ...element.context,
+                        messageId,
+                    },
+                }
+            }
+        )
+
+        const { batchContext, elements: mappedElements } = this.hooks.beforeBatch(taggedElements, batchId)
+
+        this.batches.set(batchId, {
+            batchContext,
+            messageIds,
+            inflight,
+            results: new Map(),
+        })
+
+        this.subPipeline.feed(mappedElements)
+    }
+
+    async next(): Promise<BatchPipelineResultWithContext<TOutput, CSubOut> | null> {
+        const result = await this.subPipeline.next()
+        if (result === null) {
+            if (this.batches.size > 0) {
+                logger.error('🪣', 'batching_pipeline sub-pipeline returned null with in-flight batches', {
+                    inflightBatches: this.batches.size,
+                    inflightMessages: this.messageIdToBatchId.size,
+                })
+            }
+            return null
+        }
+
+        const completedBatchResults: PipelineResultWithContext<TOutput, CSubOut>[] = []
+
+        for (const resultWithContext of result) {
+            const messageId = resultWithContext.context.messageId
+            const batchId = this.messageIdToBatchId.get(messageId)
+            if (batchId === undefined) {
+                logger.error('🪣', 'batching_pipeline received result with unknown messageId', { messageId })
+                continue
+            }
+
+            const batch = this.batches.get(batchId)
+            if (!batch) {
+                logger.error('🪣', 'batching_pipeline has batchId mapping but batch is missing', {
+                    messageId,
+                    batchId,
+                })
+                continue
+            }
+
+            batch.inflight.delete(messageId)
+            batch.results.set(messageId, resultWithContext)
+
+            if (batch.inflight.size === 0) {
+                const orderedResults = batch.messageIds.map((id) => batch.results.get(id)!)
+                this.batches.delete(batchId)
+                for (const id of batch.messageIds) {
+                    this.messageIdToBatchId.delete(id)
+                }
+                const mappedResults = await this.hooks.afterBatch(batch.batchContext, orderedResults, batchId)
+                completedBatchResults.push(...mappedResults)
+            }
+        }
+
+        return completedBatchResults
+    }
+}

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -13,7 +13,7 @@ export interface BeforeBatchInput<TInput, CInput> {
 }
 
 export interface BeforeBatchOutput<TInput, CInput, CBatch> {
-    elements: BatchPipelineResultWithContext<TInput, CInput>
+    elements: BatchPipelineResultWithContext<TInput & CBatch, CInput>
     batchContext: CBatch
 }
 
@@ -105,7 +105,7 @@ export class BatchingPipeline<
     private options: BatchingPipelineOptions
 
     constructor(
-        private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, COutput>,
+        private subPipeline: BatchPipeline<TInput & CBatch, TOutput, CSubIn, COutput>,
         private beforePipeline: Pipeline<
             BeforeBatchInput<TInput, CInput>,
             BeforeBatchOutput<TInput, CInput, CBatch>,
@@ -154,7 +154,7 @@ export class BatchingPipeline<
                     messageId,
                 },
             }
-        }) as unknown as BatchPipelineResultWithContext<TInput, CSubIn>
+        }) as unknown as BatchPipelineResultWithContext<TInput & CBatch, CSubIn>
 
         this.batches.set(batchId, {
             batchContext,

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -1,9 +1,40 @@
 import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
-import { PipelineResultWithContext } from './pipeline.interface'
+import { createContext } from './helpers'
+import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
+import { PipelineResult, isOkResult, ok } from './results'
 
 export interface BatchingContext {
     messageId: number
 }
+
+export interface BeforeBatchInput<TInput, CInput> {
+    elements: BatchPipelineResultWithContext<TInput, CInput>
+    batchId: number
+}
+
+export interface BeforeBatchOutput<TInput, CInput, CBatch> {
+    elements: BatchPipelineResultWithContext<TInput, CInput>
+    batchContext: CBatch
+}
+
+export interface AfterBatchInput<TOutput, COutput, CBatch> {
+    elements: BatchPipelineResultWithContext<TOutput, COutput>
+    batchContext: CBatch
+    batchId: number
+}
+
+export interface AfterBatchOutput<TOutput, COutput, CBatch> {
+    elements: BatchPipelineResultWithContext<TOutput, COutput>
+    batchContext: CBatch
+}
+
+export type BeforeBatchStep<TInput, CInput, CBatch> = (
+    input: BeforeBatchInput<TInput, CInput>
+) => Promise<PipelineResult<BeforeBatchOutput<TInput, CInput, CBatch>>>
+
+export type AfterBatchStep<TOutput, COutput, CBatch> = (
+    input: AfterBatchInput<TOutput, COutput, CBatch>
+) => Promise<PipelineResult<AfterBatchOutput<TOutput, COutput, CBatch>>>
 
 export interface BatchResult<T> {
     elements: T
@@ -18,11 +49,11 @@ const BATCHING_PIPELINE_DEFAULTS: BatchingPipelineOptions = {
     concurrentBatches: 1,
 }
 
-interface TrackedBatch<TOutput, CBatch, CSubOut> {
+interface TrackedBatch<TOutput, CBatch, COutput> {
     batchContext: CBatch
     messageIds: number[]
     inflight: Set<number>
-    results: Map<number, PipelineResultWithContext<TOutput, CSubOut>>
+    results: Map<number, PipelineResultWithContext<TOutput, COutput>>
     beforeSideEffects: Promise<unknown>[]
 }
 
@@ -54,7 +85,7 @@ interface TrackedBatch<TOutput, CBatch, CSubOut> {
  * - CBatch: opaque batch context passed to hooks
  * - CSubIn: context type fed to the sub-pipeline after beforeBatch maps elements.
  *   Must extend CInput & BatchingContext.
- * - CSubOut: context type returned by the sub-pipeline.
+ * - COutput: context type returned by the sub-pipeline.
  *   Must extend BatchingContext (messageId flows through the sub-pipeline).
  */
 export class BatchingPipeline<
@@ -63,48 +94,54 @@ export class BatchingPipeline<
     CInput,
     CBatch,
     CSubIn extends CInput & BatchingContext,
-    CSubOut extends BatchingContext,
+    COutput extends BatchingContext,
 > {
     private nextBatchId = 0
     private nextMessageId = 0
-    private batches = new Map<number, TrackedBatch<TOutput, CBatch, CSubOut>>()
+    private batches = new Map<number, TrackedBatch<TOutput, CBatch, COutput>>()
     private messageIdToBatchId = new Map<number, number>()
-    private completedResults: BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>>[] = []
+    private completedResults: BatchResult<BatchPipelineResultWithContext<TOutput, COutput>>[] = []
 
     private options: BatchingPipelineOptions
 
     constructor(
-        private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, CSubOut>,
-        private hooks: {
-            beforeBatch: (
-                batchContext: CBatch,
-                elements: BatchPipelineResultWithContext<TInput, CInput>,
-                batchId: number
-            ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>
-            afterBatch: (
-                batchContext: CBatch,
-                elements: BatchPipelineResultWithContext<TOutput, CSubOut>,
-                batchId: number
-            ) => Promise<BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>>>
-        },
+        private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, COutput>,
+        private beforePipeline: Pipeline<
+            BeforeBatchInput<TInput, CInput>,
+            BeforeBatchOutput<TInput, CInput, CBatch>,
+            Record<string, never>
+        >,
+        private afterPipeline: Pipeline<
+            AfterBatchInput<TOutput, COutput, CBatch>,
+            AfterBatchOutput<TOutput, COutput, CBatch>,
+            Record<string, never>
+        >,
         options?: Partial<BatchingPipelineOptions>
     ) {
         this.options = { ...BATCHING_PIPELINE_DEFAULTS, ...options }
     }
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>, batchContext: CBatch): FeedResult {
+    async feed(elements: BatchPipelineResultWithContext<TInput, CInput>): Promise<FeedResult> {
         if (this.batches.size >= this.options.concurrentBatches) {
             return { ok: false, reason: `at concurrent batch capacity (${this.options.concurrentBatches})` }
         }
 
         const batchId = this.nextBatchId++
 
-        const beforeResult = this.hooks.beforeBatch(batchContext, elements, batchId)
+        const beforeInput: BeforeBatchInput<TInput, CInput> = { elements, batchId }
+        const beforeResult = await this.beforePipeline.process(createContext(ok(beforeInput)))
+
+        if (!isOkResult(beforeResult.result)) {
+            return { ok: false, reason: `beforeBatch hook returned non-ok result for batch ${batchId}` }
+        }
+
+        const { elements: mappedElements, batchContext } = beforeResult.result.value
+        const beforeSideEffects = beforeResult.context.sideEffects
 
         const messageIds: number[] = []
         const inflight = new Set<number>()
 
-        const taggedElements = beforeResult.elements.map((element) => {
+        const taggedElements = mappedElements.map((element) => {
             const messageId = this.nextMessageId++
             messageIds.push(messageId)
             inflight.add(messageId)
@@ -124,14 +161,14 @@ export class BatchingPipeline<
             messageIds,
             inflight,
             results: new Map(),
-            beforeSideEffects: beforeResult.sideEffects ?? [],
+            beforeSideEffects,
         })
 
         this.subPipeline.feed(taggedElements)
         return { ok: true }
     }
 
-    async next(): Promise<BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>> | null> {
+    async next(): Promise<BatchResult<BatchPipelineResultWithContext<TOutput, COutput>> | null> {
         if (this.completedResults.length > 0) {
             return this.completedResults.shift()!
         }
@@ -170,9 +207,21 @@ export class BatchingPipeline<
                     for (const id of batch.messageIds) {
                         this.messageIdToBatchId.delete(id)
                     }
-                    const afterResult = await this.hooks.afterBatch(batch.batchContext, orderedResults, batchId)
-                    const sideEffects = [...batch.beforeSideEffects, ...(afterResult.sideEffects ?? [])]
-                    this.completedResults.push({ elements: afterResult.elements, sideEffects })
+
+                    const afterInput: AfterBatchInput<TOutput, COutput, CBatch> = {
+                        elements: orderedResults,
+                        batchContext: batch.batchContext,
+                        batchId,
+                    }
+                    const afterResult = await this.afterPipeline.process(createContext(ok(afterInput)))
+
+                    if (!isOkResult(afterResult.result)) {
+                        throw new Error(`batching_pipeline afterBatch hook returned non-ok result for batch ${batchId}`)
+                    }
+
+                    const afterSideEffects = afterResult.context.sideEffects
+                    const sideEffects = [...batch.beforeSideEffects, ...afterSideEffects]
+                    this.completedResults.push({ elements: afterResult.result.value.elements, sideEffects })
                 }
             }
 

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -6,8 +6,8 @@ export interface BatchingContext {
 }
 
 export interface BatchResult<T> {
-    value: T
-    sideEffects: Promise<unknown>[]
+    elements: T
+    sideEffects?: Promise<unknown>[]
 }
 
 export interface BatchingPipelineOptions {
@@ -83,9 +83,9 @@ export class BatchingPipeline<
             ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>
             afterBatch: (
                 batchContext: CBatch,
-                results: BatchPipelineResultWithContext<TOutput, CSubOut>,
+                elements: BatchPipelineResultWithContext<TOutput, CSubOut>,
                 batchId: number
-            ) => BatchResult<void> | Promise<BatchResult<void>>
+            ) => Promise<BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>>>
         },
         options?: Partial<BatchingPipelineOptions>
     ) {
@@ -104,7 +104,7 @@ export class BatchingPipeline<
         const messageIds: number[] = []
         const inflight = new Set<number>()
 
-        const taggedElements = beforeResult.value.map((element) => {
+        const taggedElements = beforeResult.elements.map((element) => {
             const messageId = this.nextMessageId++
             messageIds.push(messageId)
             inflight.add(messageId)
@@ -124,7 +124,7 @@ export class BatchingPipeline<
             messageIds,
             inflight,
             results: new Map(),
-            beforeSideEffects: beforeResult.sideEffects,
+            beforeSideEffects: beforeResult.sideEffects ?? [],
         })
 
         this.subPipeline.feed(taggedElements)
@@ -171,8 +171,8 @@ export class BatchingPipeline<
                         this.messageIdToBatchId.delete(id)
                     }
                     const afterResult = await this.hooks.afterBatch(batch.batchContext, orderedResults, batchId)
-                    const sideEffects = [...batch.beforeSideEffects, ...afterResult.sideEffects]
-                    this.completedResults.push({ value: orderedResults, sideEffects })
+                    const sideEffects = [...batch.beforeSideEffects, ...(afterResult.sideEffects ?? [])]
+                    this.completedResults.push({ elements: afterResult.elements, sideEffects })
                 }
             }
 

--- a/nodejs/src/ingestion/pipelines/batching-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/batching-pipeline.ts
@@ -1,4 +1,3 @@
-import { logger } from '../../utils/logger'
 import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { PipelineResultWithContext } from './pipeline.interface'
 
@@ -6,16 +5,9 @@ export interface BatchingContext {
     messageId: number
 }
 
-export interface BeforeBatchResult<CBatch, TInput, C> {
-    batchContext: CBatch
-    elements: BatchPipelineResultWithContext<TInput, C>
-}
-
-export function batch<CBatch, TInput, C>(
-    elements: BatchPipelineResultWithContext<TInput, C>,
-    batchContext: CBatch
-): BeforeBatchResult<CBatch, TInput, C> {
-    return { batchContext, elements }
+export interface BatchResult<T> {
+    value: T
+    sideEffects: Promise<unknown>[]
 }
 
 export interface BatchingPipelineOptions {
@@ -31,6 +23,7 @@ interface TrackedBatch<TOutput, CBatch, CSubOut> {
     messageIds: number[]
     inflight: Set<number>
     results: Map<number, PipelineResultWithContext<TOutput, CSubOut>>
+    beforeSideEffects: Promise<unknown>[]
 }
 
 /**
@@ -43,27 +36,24 @@ interface TrackedBatch<TOutput, CBatch, CSubOut> {
  * the collector matches them to their batch and fires hooks.
  *
  * Lifecycle:
- * - feed() tags elements with messageId, then calls beforeBatch which returns
- *   a batchContext (opaque data carried per-batch) and mapped elements
- *   (e.g. add per-batch stores to context). The mapped elements are fed to the
- *   sub-pipeline.
+ * - feed() runs beforeBatch which returns mapped elements and side effects.
+ *   Elements are tagged with messageId, then fed to the sub-pipeline.
  * - next() collects results. When all messages in a batch complete, calls
- *   afterBatch with the batchContext and ordered results, then returns results.
+ *   afterBatch with the batchContext and ordered results, then returns a
+ *   BatchResult with concatenated side effects.
  *
  * Ordering guarantees:
  * - Messages within a completed batch are returned in their original feed() order
  * - Batches themselves are returned in completion order, NOT submission order.
- *   If batch 1 completes before batch 0, batch 1's results appear first in next().
- * - next() returns [] when the sub-pipeline produced results but no batch completed yet,
- *   and null when the sub-pipeline is fully drained.
+ * - next() loops internally until a batch completes or the sub-pipeline drains.
+ * - next() returns null when all batches are drained and no buffered results remain.
  *
  * Type parameters:
  * - TInput/TOutput: value types flowing through the pipeline
  * - CInput: context type accepted by feed() (without messageId)
- * - CBatch: opaque batch context returned by beforeBatch, passed to afterBatch
+ * - CBatch: opaque batch context passed to hooks
  * - CSubIn: context type fed to the sub-pipeline after beforeBatch maps elements.
- *   Must extend CInput & BatchingContext. beforeBatch maps from
- *   CInput & BatchingContext → CSubIn (e.g. to add per-batch stores).
+ *   Must extend CInput & BatchingContext.
  * - CSubOut: context type returned by the sub-pipeline.
  *   Must extend BatchingContext (messageId flows through the sub-pipeline).
  */
@@ -74,12 +64,12 @@ export class BatchingPipeline<
     CBatch,
     CSubIn extends CInput & BatchingContext,
     CSubOut extends BatchingContext,
-> implements BatchPipeline<TInput, TOutput, CInput, CSubOut>
-{
+> {
     private nextBatchId = 0
     private nextMessageId = 0
     private batches = new Map<number, TrackedBatch<TOutput, CBatch, CSubOut>>()
     private messageIdToBatchId = new Map<number, number>()
+    private completedResults: BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>>[] = []
 
     private options: BatchingPipelineOptions
 
@@ -87,107 +77,108 @@ export class BatchingPipeline<
         private subPipeline: BatchPipeline<TInput, TOutput, CSubIn, CSubOut>,
         private hooks: {
             beforeBatch: (
-                elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext>,
+                batchContext: CBatch,
+                elements: BatchPipelineResultWithContext<TInput, CInput>,
                 batchId: number
-            ) => { batchContext: CBatch; elements: BatchPipelineResultWithContext<TInput, CSubIn> }
+            ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>
             afterBatch: (
                 batchContext: CBatch,
                 results: BatchPipelineResultWithContext<TOutput, CSubOut>,
                 batchId: number
-            ) =>
-                | BatchPipelineResultWithContext<TOutput, CSubOut>
-                | Promise<BatchPipelineResultWithContext<TOutput, CSubOut>>
+            ) => BatchResult<void> | Promise<BatchResult<void>>
         },
         options?: Partial<BatchingPipelineOptions>
     ) {
         this.options = { ...BATCHING_PIPELINE_DEFAULTS, ...options }
     }
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>, batchContext: CBatch): FeedResult {
         if (this.batches.size >= this.options.concurrentBatches) {
             return { ok: false, reason: `at concurrent batch capacity (${this.options.concurrentBatches})` }
         }
 
         const batchId = this.nextBatchId++
 
+        const beforeResult = this.hooks.beforeBatch(batchContext, elements, batchId)
+
         const messageIds: number[] = []
         const inflight = new Set<number>()
 
-        const taggedElements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext> = elements.map(
-            (element) => {
-                const messageId = this.nextMessageId++
-                messageIds.push(messageId)
-                inflight.add(messageId)
-                this.messageIdToBatchId.set(messageId, batchId)
+        const taggedElements = beforeResult.value.map((element) => {
+            const messageId = this.nextMessageId++
+            messageIds.push(messageId)
+            inflight.add(messageId)
+            this.messageIdToBatchId.set(messageId, batchId)
 
-                return {
-                    result: element.result,
-                    context: {
-                        ...element.context,
-                        messageId,
-                    },
-                }
+            return {
+                result: element.result,
+                context: {
+                    ...element.context,
+                    messageId,
+                },
             }
-        )
-
-        const { batchContext, elements: mappedElements } = this.hooks.beforeBatch(taggedElements, batchId)
+        }) as unknown as BatchPipelineResultWithContext<TInput, CSubIn>
 
         this.batches.set(batchId, {
             batchContext,
             messageIds,
             inflight,
             results: new Map(),
+            beforeSideEffects: beforeResult.sideEffects,
         })
 
-        this.subPipeline.feed(mappedElements)
+        this.subPipeline.feed(taggedElements)
         return { ok: true }
     }
 
-    async next(): Promise<BatchPipelineResultWithContext<TOutput, CSubOut> | null> {
-        const result = await this.subPipeline.next()
-        if (result === null) {
-            if (this.batches.size > 0) {
-                logger.error('🪣', 'batching_pipeline sub-pipeline returned null with in-flight batches', {
-                    inflightBatches: this.batches.size,
-                    inflightMessages: this.messageIdToBatchId.size,
-                })
-            }
-            return null
+    async next(): Promise<BatchResult<BatchPipelineResultWithContext<TOutput, CSubOut>> | null> {
+        if (this.completedResults.length > 0) {
+            return this.completedResults.shift()!
         }
 
-        const completedBatchResults: PipelineResultWithContext<TOutput, CSubOut>[] = []
-
-        for (const resultWithContext of result) {
-            const messageId = resultWithContext.context.messageId
-            const batchId = this.messageIdToBatchId.get(messageId)
-            if (batchId === undefined) {
-                logger.error('🪣', 'batching_pipeline received result with unknown messageId', { messageId })
-                continue
-            }
-
-            const batch = this.batches.get(batchId)
-            if (!batch) {
-                logger.error('🪣', 'batching_pipeline has batchId mapping but batch is missing', {
-                    messageId,
-                    batchId,
-                })
-                continue
-            }
-
-            batch.inflight.delete(messageId)
-            batch.results.set(messageId, resultWithContext)
-
-            if (batch.inflight.size === 0) {
-                const orderedResults = batch.messageIds.map((id) => batch.results.get(id)!)
-                this.batches.delete(batchId)
-                for (const id of batch.messageIds) {
-                    this.messageIdToBatchId.delete(id)
+        while (true) {
+            const result = await this.subPipeline.next()
+            if (result === null) {
+                if (this.batches.size > 0) {
+                    throw new Error(
+                        `batching_pipeline sub-pipeline returned null with ${this.batches.size} in-flight batches and ${this.messageIdToBatchId.size} in-flight messages`
+                    )
                 }
-                const mappedResults = await this.hooks.afterBatch(batch.batchContext, orderedResults, batchId)
-                completedBatchResults.push(...mappedResults)
+                return null
+            }
+
+            for (const resultWithContext of result) {
+                const messageId = resultWithContext.context.messageId
+                const batchId = this.messageIdToBatchId.get(messageId)
+                if (batchId === undefined) {
+                    throw new Error(`batching_pipeline received result with unknown messageId ${messageId}`)
+                }
+
+                const batch = this.batches.get(batchId)
+                if (!batch) {
+                    throw new Error(
+                        `batching_pipeline has batchId mapping but batch ${batchId} is missing for messageId ${messageId}`
+                    )
+                }
+
+                batch.inflight.delete(messageId)
+                batch.results.set(messageId, resultWithContext)
+
+                if (batch.inflight.size === 0) {
+                    const orderedResults = batch.messageIds.map((id) => batch.results.get(id)!)
+                    this.batches.delete(batchId)
+                    for (const id of batch.messageIds) {
+                        this.messageIdToBatchId.delete(id)
+                    }
+                    const afterResult = await this.hooks.afterBatch(batch.batchContext, orderedResults, batchId)
+                    const sideEffects = [...batch.beforeSideEffects, ...afterResult.sideEffects]
+                    this.completedResults.push({ value: orderedResults, sideEffects })
+                }
+            }
+
+            if (this.completedResults.length > 0) {
+                return this.completedResults.shift()!
             }
         }
-
-        return completedBatchResults
     }
 }

--- a/nodejs/src/ingestion/pipelines/buffering-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/buffering-batch-pipeline.ts
@@ -1,10 +1,11 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 
 export class BufferingBatchPipeline<TInput, CInput> implements BatchPipeline<TInput, TInput, CInput, CInput> {
     private buffer: BatchPipelineResultWithContext<TInput, CInput> = []
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
         this.buffer.push(...elements)
+        return { ok: true }
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TInput, CInput> | null> {

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -28,8 +28,13 @@ export function newBatchingPipeline<TInput, TOutput, CInput, CBatch = Record<str
         Record<string, never>
     >,
     callback: (
-        builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
-    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, COutput & BatchingContext>,
+        builder: BatchPipelineBuilder<
+            TInput & CBatch,
+            TInput & CBatch,
+            CInput & BatchingContext,
+            CInput & BatchingContext
+        >
+    ) => BatchPipelineBuilder<TInput & CBatch, TOutput, CInput & BatchingContext, COutput & BatchingContext>,
     afterBatch: (
         builder: StartPipelineBuilder<
             AfterBatchInput<TOutput, COutput & BatchingContext, CBatch>,
@@ -42,7 +47,9 @@ export function newBatchingPipeline<TInput, TOutput, CInput, CBatch = Record<str
     >,
     options?: Partial<BatchingPipelineOptions>
 ): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, COutput & BatchingContext> {
-    const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
+    const startBuilder = new BatchPipelineBuilder(
+        new BufferingBatchPipeline<TInput & CBatch, CInput & BatchingContext>()
+    )
     const subPipeline = callback(startBuilder).build()
 
     const beforePipeline = beforeBatch(

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -12,7 +12,7 @@ export function newPipelineBuilder<T, C = Record<string, never>>(): StartPipelin
     return new StartPipelineBuilder<T, C>()
 }
 
-export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut extends BatchingContext>(
+export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut>(
     beforeBatch: (
         batchContext: CBatch,
         elements: BatchPipelineResultWithContext<TInput, CInput>,
@@ -20,18 +20,23 @@ export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut ext
     ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>,
     callback: (
         builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
-    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut>,
-    afterBatch: (batchContext: CBatch, batchId: number) => BatchResult<void> | Promise<BatchResult<void>>,
+    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut & BatchingContext>,
+    afterBatch: (
+        batchContext: CBatch,
+        elements: BatchPipelineResultWithContext<TOutput, CSubOut & BatchingContext>,
+        batchId: number
+    ) => Promise<BatchResult<void>>,
     options?: Partial<BatchingPipelineOptions>
-): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut> {
+): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut & BatchingContext> {
     const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
     const subPipeline = callback(startBuilder).build()
     return new BatchingPipeline(
         subPipeline,
         {
             beforeBatch,
-            afterBatch: async (batchContext, _results, batchId) => {
-                return await afterBatch(batchContext, batchId)
+            afterBatch: async (batchContext, elements, batchId) => {
+                const result = await afterBatch(batchContext, elements, batchId)
+                return { elements, sideEffects: result.sideEffects }
             },
         },
         options

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -1,5 +1,5 @@
 import { BatchPipelineResultWithContext } from '../batch-pipeline.interface'
-import { BatchingContext, BatchingPipeline } from '../batching-pipeline'
+import { BatchingContext, BatchingPipeline, BatchingPipelineOptions } from '../batching-pipeline'
 import { BufferingBatchPipeline } from '../buffering-batch-pipeline'
 import { BatchPipelineBuilder } from './batch-pipeline-builders'
 import { StartPipelineBuilder } from './pipeline-builders'
@@ -20,15 +20,20 @@ export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut ext
     callback: (
         builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
     ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut>,
-    afterBatch: (batchContext: CBatch, batchId: number) => void | Promise<void>
+    afterBatch: (batchContext: CBatch, batchId: number) => void | Promise<void>,
+    options?: Partial<BatchingPipelineOptions>
 ): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut> {
     const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
     const subPipeline = callback(startBuilder).build()
-    return new BatchingPipeline(subPipeline, {
-        beforeBatch,
-        afterBatch: async (batchContext, results, batchId) => {
-            await afterBatch(batchContext, batchId)
-            return results
+    return new BatchingPipeline(
+        subPipeline,
+        {
+            beforeBatch,
+            afterBatch: async (batchContext, results, batchId) => {
+                await afterBatch(batchContext, batchId)
+                return results
+            },
         },
-    })
+        options
+    )
 }

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -1,8 +1,15 @@
-import { BatchPipelineResultWithContext } from '../batch-pipeline.interface'
-import { BatchResult, BatchingContext, BatchingPipeline, BatchingPipelineOptions } from '../batching-pipeline'
+import {
+    AfterBatchInput,
+    AfterBatchOutput,
+    BatchingContext,
+    BatchingPipeline,
+    BatchingPipelineOptions,
+    BeforeBatchInput,
+    BeforeBatchOutput,
+} from '../batching-pipeline'
 import { BufferingBatchPipeline } from '../buffering-batch-pipeline'
 import { BatchPipelineBuilder } from './batch-pipeline-builders'
-import { StartPipelineBuilder } from './pipeline-builders'
+import { PipelineBuilder, StartPipelineBuilder } from './pipeline-builders'
 
 export function newBatchPipelineBuilder<T, C = Record<string, never>>(): BatchPipelineBuilder<T, T, C> {
     return new BatchPipelineBuilder(new BufferingBatchPipeline<T, C>())
@@ -12,33 +19,39 @@ export function newPipelineBuilder<T, C = Record<string, never>>(): StartPipelin
     return new StartPipelineBuilder<T, C>()
 }
 
-export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut>(
+export function newBatchingPipeline<TInput, TOutput, CInput, CBatch = Record<string, never>, COutput = CInput>(
     beforeBatch: (
-        batchContext: CBatch,
-        elements: BatchPipelineResultWithContext<TInput, CInput>,
-        batchId: number
-    ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>,
+        builder: StartPipelineBuilder<BeforeBatchInput<TInput, CInput>, Record<string, never>>
+    ) => PipelineBuilder<
+        BeforeBatchInput<TInput, CInput>,
+        BeforeBatchOutput<TInput, CInput, CBatch>,
+        Record<string, never>
+    >,
     callback: (
         builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
-    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut & BatchingContext>,
+    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, COutput & BatchingContext>,
     afterBatch: (
-        batchContext: CBatch,
-        elements: BatchPipelineResultWithContext<TOutput, CSubOut & BatchingContext>,
-        batchId: number
-    ) => Promise<BatchResult<void>>,
+        builder: StartPipelineBuilder<
+            AfterBatchInput<TOutput, COutput & BatchingContext, CBatch>,
+            Record<string, never>
+        >
+    ) => PipelineBuilder<
+        AfterBatchInput<TOutput, COutput & BatchingContext, CBatch>,
+        AfterBatchOutput<TOutput, COutput & BatchingContext, CBatch>,
+        Record<string, never>
+    >,
     options?: Partial<BatchingPipelineOptions>
-): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut & BatchingContext> {
+): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, COutput & BatchingContext> {
     const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
     const subPipeline = callback(startBuilder).build()
-    return new BatchingPipeline(
-        subPipeline,
-        {
-            beforeBatch,
-            afterBatch: async (batchContext, elements, batchId) => {
-                const result = await afterBatch(batchContext, elements, batchId)
-                return { elements, sideEffects: result.sideEffects }
-            },
-        },
-        options
-    )
+
+    const beforePipeline = beforeBatch(
+        new StartPipelineBuilder<BeforeBatchInput<TInput, CInput>, Record<string, never>>()
+    ).build()
+
+    const afterPipeline = afterBatch(
+        new StartPipelineBuilder<AfterBatchInput<TOutput, COutput & BatchingContext, CBatch>, Record<string, never>>()
+    ).build()
+
+    return new BatchingPipeline(subPipeline, beforePipeline, afterPipeline, options)
 }

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -1,5 +1,5 @@
 import { BatchPipelineResultWithContext } from '../batch-pipeline.interface'
-import { BatchingContext, BatchingPipeline, BatchingPipelineOptions } from '../batching-pipeline'
+import { BatchResult, BatchingContext, BatchingPipeline, BatchingPipelineOptions } from '../batching-pipeline'
 import { BufferingBatchPipeline } from '../buffering-batch-pipeline'
 import { BatchPipelineBuilder } from './batch-pipeline-builders'
 import { StartPipelineBuilder } from './pipeline-builders'
@@ -14,13 +14,14 @@ export function newPipelineBuilder<T, C = Record<string, never>>(): StartPipelin
 
 export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut extends BatchingContext>(
     beforeBatch: (
-        elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext>,
+        batchContext: CBatch,
+        elements: BatchPipelineResultWithContext<TInput, CInput>,
         batchId: number
-    ) => { batchContext: CBatch; elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext> },
+    ) => BatchResult<BatchPipelineResultWithContext<TInput, CInput>>,
     callback: (
         builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
     ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut>,
-    afterBatch: (batchContext: CBatch, batchId: number) => void | Promise<void>,
+    afterBatch: (batchContext: CBatch, batchId: number) => BatchResult<void> | Promise<BatchResult<void>>,
     options?: Partial<BatchingPipelineOptions>
 ): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut> {
     const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
@@ -29,9 +30,8 @@ export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut ext
         subPipeline,
         {
             beforeBatch,
-            afterBatch: async (batchContext, results, batchId) => {
-                await afterBatch(batchContext, batchId)
-                return results
+            afterBatch: async (batchContext, _results, batchId) => {
+                return await afterBatch(batchContext, batchId)
             },
         },
         options

--- a/nodejs/src/ingestion/pipelines/builders/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/builders/helpers.ts
@@ -1,3 +1,5 @@
+import { BatchPipelineResultWithContext } from '../batch-pipeline.interface'
+import { BatchingContext, BatchingPipeline } from '../batching-pipeline'
 import { BufferingBatchPipeline } from '../buffering-batch-pipeline'
 import { BatchPipelineBuilder } from './batch-pipeline-builders'
 import { StartPipelineBuilder } from './pipeline-builders'
@@ -8,4 +10,25 @@ export function newBatchPipelineBuilder<T, C = Record<string, never>>(): BatchPi
 
 export function newPipelineBuilder<T, C = Record<string, never>>(): StartPipelineBuilder<T, C> {
     return new StartPipelineBuilder<T, C>()
+}
+
+export function newBatchingPipeline<TInput, TOutput, CInput, CBatch, CSubOut extends BatchingContext>(
+    beforeBatch: (
+        elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext>,
+        batchId: number
+    ) => { batchContext: CBatch; elements: BatchPipelineResultWithContext<TInput, CInput & BatchingContext> },
+    callback: (
+        builder: BatchPipelineBuilder<TInput, TInput, CInput & BatchingContext, CInput & BatchingContext>
+    ) => BatchPipelineBuilder<TInput, TOutput, CInput & BatchingContext, CSubOut>,
+    afterBatch: (batchContext: CBatch, batchId: number) => void | Promise<void>
+): BatchingPipeline<TInput, TOutput, CInput, CBatch, CInput & BatchingContext, CSubOut> {
+    const startBuilder = new BatchPipelineBuilder(new BufferingBatchPipeline<TInput, CInput & BatchingContext>())
+    const subPipeline = callback(startBuilder).build()
+    return new BatchingPipeline(subPipeline, {
+        beforeBatch,
+        afterBatch: async (batchContext, results, batchId) => {
+            await afterBatch(batchContext, batchId)
+            return results
+        },
+    })
 }

--- a/nodejs/src/ingestion/pipelines/builders/index.ts
+++ b/nodejs/src/ingestion/pipelines/builders/index.ts
@@ -6,4 +6,4 @@ export {
     TeamAwareBatchPipelineBuilder,
 } from './batch-pipeline-builders'
 export { BranchingPipelineBuilder, PipelineBuilder, StartPipelineBuilder } from './pipeline-builders'
-export { newBatchPipelineBuilder, newPipelineBuilder } from './helpers'
+export { newBatchPipelineBuilder, newBatchingPipeline, newPipelineBuilder } from './helpers'

--- a/nodejs/src/ingestion/pipelines/concurrent-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/concurrent-batch-pipeline.ts
@@ -1,4 +1,4 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { Pipeline, PipelineContext, PipelineResultWithContext } from './pipeline.interface'
 import { isOkResult } from './results'
 
@@ -17,8 +17,8 @@ export class ConcurrentBatchProcessingPipeline<
         private previousPipeline: BatchPipeline<TInput, TIntermediate, CInput, COutput>
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/concurrently-grouping-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/concurrently-grouping-batch-pipeline.ts
@@ -1,4 +1,4 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
 import { isOkResult } from './results'
 
@@ -33,8 +33,8 @@ export class ConcurrentlyGroupingBatchPipeline<TInput, TIntermediate, TOutput, T
         private previousPipeline: BatchPipeline<TInput, TIntermediate, CInput, COutput>
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/filter-map-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/filter-map-batch-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { Message } from 'node-rdkafka'
 
 import { createTestMessage } from '../../../tests/helpers/kafka-message'
-import { BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { FilterMapBatchPipeline, FilterMapMappingFunction } from './filter-map-batch-pipeline'
 import { createContext, createNewBatchPipeline } from './helpers'
 import { dlq, drop, ok, redirect } from './results'
@@ -280,11 +280,12 @@ describe('FilterMapBatchPipeline', () => {
             const subBatches: BatchPipelineResultWithContext<string, { message: Message }>[] = []
             let subIndex = 0
             const subPipeline = {
-                feed(elements: BatchPipelineResultWithContext<string, { message: Message }>) {
+                feed(elements: BatchPipelineResultWithContext<string, { message: Message }>): FeedResult {
                     subPipelineFeed(elements)
                     for (const el of elements) {
                         subBatches.push([el])
                     }
+                    return { ok: true }
                 },
                 next() {
                     if (subIndex >= subBatches.length) {

--- a/nodejs/src/ingestion/pipelines/filter-map-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/filter-map-batch-pipeline.ts
@@ -1,4 +1,4 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { PipelineContext, PipelineResultWithContext } from './pipeline.interface'
 import { PipelineResultOk, isOkResult } from './results'
 
@@ -38,8 +38,8 @@ export class FilterMapBatchPipeline<
         private subPipeline: BatchPipeline<TMapped, TOutput, CMapped, COutput>
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput | CIntermediate> | null> {

--- a/nodejs/src/ingestion/pipelines/gathering-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/gathering-batch-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { Message } from 'node-rdkafka'
 
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { GatheringBatchPipeline } from './gathering-batch-pipeline'
 import { createContext, createNewBatchPipeline } from './helpers'
 import { dlq, drop, ok, redirect } from './results'
@@ -14,8 +14,9 @@ class MockBatchProcessingPipeline<T, C> implements BatchPipeline<T, T, C> {
         this.results = results
     }
 
-    feed(elements: BatchPipelineResultWithContext<T, C>): void {
+    feed(elements: BatchPipelineResultWithContext<T, C>): FeedResult {
         this.results.push(elements)
+        return { ok: true }
     }
 
     async next(): Promise<BatchPipelineResultWithContext<T, C> | null> {

--- a/nodejs/src/ingestion/pipelines/gathering-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/gathering-batch-pipeline.ts
@@ -1,12 +1,12 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 
 export class GatheringBatchPipeline<TInput, TOutput, CInput, COutput = CInput>
     implements BatchPipeline<TInput, TOutput, CInput, COutput>
 {
     constructor(private subPipeline: BatchPipeline<TInput, TOutput, CInput, COutput>) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.subPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.subPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.ts
@@ -1,6 +1,6 @@
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { TeamIdContext } from './builders/batch-pipeline-builders'
 
 export class IngestionWarningHandlingBatchPipeline<
@@ -15,8 +15,8 @@ export class IngestionWarningHandlingBatchPipeline<
         private previousPipeline: BatchPipeline<TInput, TOutput, CInput, COutput>
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/result-handling-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/result-handling-pipeline.ts
@@ -4,7 +4,7 @@ import { KafkaProducerWrapper } from '../../kafka/producer'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { pipelineLastStepCounter } from '../../worker/ingestion/event-pipeline/metrics'
 import { logDroppedMessage, redirectMessageToTopic, sendMessageToDLQ } from '../../worker/ingestion/pipeline-helpers'
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { PipelineResult, isDlqResult, isDropResult, isOkResult, isRedirectResult } from './results'
 
 export type PipelineConfig = {
@@ -29,8 +29,8 @@ export class ResultHandlingPipeline<
         private config: PipelineConfig
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.pipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.pipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/sequential-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sequential-batch-pipeline.ts
@@ -1,4 +1,4 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
 import { isOkResult } from './results'
 
@@ -10,8 +10,8 @@ export class SequentialBatchPipeline<TInput, TIntermediate, TOutput, CInput, COu
         private previousPipeline: BatchPipeline<TInput, TIntermediate, CInput, COutput>
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.previousPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.previousPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/pipelines/side-effect-handling-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/side-effect-handling-pipeline.ts
@@ -1,4 +1,4 @@
-import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { BatchPipeline, BatchPipelineResultWithContext, FeedResult } from './batch-pipeline.interface'
 import { sideEffectResultCounter } from './metrics'
 
 export interface PromiseSchedulerInterface {
@@ -21,8 +21,8 @@ export class SideEffectHandlingPipeline<TInput, TOutput, CInput, COutput = CInpu
         private config: SideEffectHandlingConfig = { await: false }
     ) {}
 
-    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): void {
-        this.subPipeline.feed(elements)
+    feed(elements: BatchPipelineResultWithContext<TInput, CInput>): FeedResult {
+        return this.subPipeline.feed(elements)
     }
 
     async next(): Promise<BatchPipelineResultWithContext<TOutput, COutput> | null> {

--- a/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
+++ b/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
@@ -176,7 +176,10 @@ export async function runSessionReplayPipeline(
     }
 
     const batch = createBatch(messages.map((message) => ({ message })))
-    pipeline.feed(batch)
+    const feedResult = pipeline.feed(batch)
+    if (!feedResult.ok) {
+        throw new Error(`Pipeline rejected batch: ${feedResult.reason}`)
+    }
 
     const allResults: SessionReplayPipelineOutput[] = []
     let results = await pipeline.next()

--- a/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
@@ -8,12 +8,21 @@ type PrefetchPersonsStepInput = { event: PipelineEvent; team: Team; personsStore
 export function prefetchPersonsStep<T extends PrefetchPersonsStepInput>(enabled: boolean) {
     return function prefetchPersonsStep(events: T[]): Promise<PipelineResult<T>[]> {
         if (enabled && events.length > 0) {
-            const { personsStore } = events[0]
+            // Group by store instance — events in the same batch may reference different stores
+            const storeParams = new Map<PersonsStore, { teamId: number; distinctId: string }[]>()
+            for (const e of events) {
+                let params = storeParams.get(e.personsStore)
+                if (!params) {
+                    params = []
+                    storeParams.set(e.personsStore, params)
+                }
+                params.push({ teamId: e.team.id, distinctId: e.event.distinct_id })
+            }
             // Fire prefetch without awaiting. fetchForChecking/fetchForUpdate will wait
             // on the pending promises if they need data that's still being fetched
-            void personsStore.prefetchPersons(
-                events.map((x) => ({ teamId: x.team.id, distinctId: x.event.distinct_id }))
-            )
+            for (const [store, params] of storeParams) {
+                void store.prefetchPersons(params)
+            }
         }
         return Promise.resolve(events.map((event) => ok(event)))
     }

--- a/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
@@ -3,11 +3,12 @@ import { PipelineEvent, Team } from '~/types'
 
 import { PersonsStore } from '../persons/persons-store'
 
-type PrefetchPersonsStepInput = { event: PipelineEvent; team: Team }
+type PrefetchPersonsStepInput = { event: PipelineEvent; team: Team; personsStore: PersonsStore }
 
-export function prefetchPersonsStep<T extends PrefetchPersonsStepInput>(personsStore: PersonsStore, enabled: boolean) {
+export function prefetchPersonsStep<T extends PrefetchPersonsStepInput>(enabled: boolean) {
     return function prefetchPersonsStep(events: T[]): Promise<PipelineResult<T>[]> {
-        if (enabled) {
+        if (enabled && events.length > 0) {
+            const { personsStore } = events[0]
             // Fire prefetch without awaiting. fetchForChecking/fetchForUpdate will wait
             // on the pending promises if they need data that's still being fetched
             void personsStore.prefetchPersons(

--- a/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -7,7 +7,7 @@ import { PipelineEvent, Team } from '~/types'
 import { ONE_HOUR } from '../../../config/constants'
 import { PersonsStore } from '../persons/persons-store'
 
-type ProcessPersonlessDistinctIdsBatchStepInput = { event: PipelineEvent; team: Team }
+type ProcessPersonlessDistinctIdsBatchStepInput = { event: PipelineEvent; team: Team; personsStore: PersonsStore }
 
 export const personlessDistinctIdCacheOperationsCounter = new Counter({
     name: 'personless_distinct_id_cache_operations_total',
@@ -32,11 +32,11 @@ const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
  * and consumed by processPersonlessStep to determine force_upgrade.
  */
 export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonlessDistinctIdsBatchStepInput>(
-    personsStore: PersonsStore,
     enabled: boolean
 ) {
     return async function processPersonlessDistinctIdsBatchStep(events: T[]): Promise<PipelineResult<T>[]> {
-        if (enabled) {
+        if (enabled && events.length > 0) {
+            const { personsStore } = events[0]
             // Deduplicate personless events within the batch first, then check cache
             const seenInBatch = new Set<string>()
             let cacheHits = 0

--- a/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -36,11 +36,11 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
 ) {
     return async function processPersonlessDistinctIdsBatchStep(events: T[]): Promise<PipelineResult<T>[]> {
         if (enabled && events.length > 0) {
-            const { personsStore } = events[0]
-            // Deduplicate personless events within the batch first, then check cache
+            // Group personless entries by store instance — events in the same batch
+            // may reference different stores
             const seenInBatch = new Set<string>()
             let cacheHits = 0
-            const personlessEntries: { teamId: number; distinctId: string }[] = []
+            const storeEntries = new Map<PersonsStore, { teamId: number; distinctId: string }[]>()
 
             for (const e of events) {
                 if (e.event.properties?.$process_person_profile !== false) {
@@ -48,7 +48,6 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
                 }
                 const cacheKey = `${e.team.id}|${e.event.distinct_id}`
 
-                // Skip if already seen in this batch
                 if (seenInBatch.has(cacheKey)) {
                     continue
                 }
@@ -57,7 +56,12 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
                 if (PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(cacheKey)) {
                     cacheHits++
                 } else {
-                    personlessEntries.push({
+                    let entries = storeEntries.get(e.personsStore)
+                    if (!entries) {
+                        entries = []
+                        storeEntries.set(e.personsStore, entries)
+                    }
+                    entries.push({
                         teamId: e.team.id,
                         distinctId: e.event.distinct_id,
                     })
@@ -68,14 +72,20 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
                 personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit' }, cacheHits)
             }
 
-            if (personlessEntries.length > 0) {
-                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' }, personlessEntries.length)
+            const promises: Promise<void>[] = []
+            for (const [store, entries] of storeEntries) {
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' }, entries.length)
+                promises.push(store.processPersonlessDistinctIdsBatch(entries))
+            }
 
-                await personsStore.processPersonlessDistinctIdsBatch(personlessEntries)
+            if (promises.length > 0) {
+                await Promise.all(promises)
 
                 // Update LRU cache for all entries we just inserted
-                for (const entry of personlessEntries) {
-                    PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(`${entry.teamId}|${entry.distinctId}`, true)
+                for (const entries of storeEntries.values()) {
+                    for (const entry of entries) {
+                        PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(`${entry.teamId}|${entry.distinctId}`, true)
+                    }
                 }
             }
         }

--- a/nodejs/tests/main/process-event.test.ts
+++ b/nodejs/tests/main/process-event.test.ts
@@ -145,10 +145,11 @@ describe('processEvent', () => {
 
             if (isOkResult(createResult)) {
                 const emitEventStep = createEmitEventStep({
+                    kafkaProducer: hub.kafkaProducer,
                     clickhouseJsonEventsTopic: hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
                     groupId: 'test-group-id',
                 })
-                const emitResult = await emitEventStep({ ...createResult.value, kafkaProducer: hub.kafkaProducer })
+                const emitResult = await emitEventStep(createResult.value)
 
                 if (isOkResult(emitResult) && emitResult.sideEffects.length > 0) {
                     await Promise.allSettled(emitResult.sideEffects)

--- a/nodejs/tests/main/process-event.test.ts
+++ b/nodejs/tests/main/process-event.test.ts
@@ -145,11 +145,10 @@ describe('processEvent', () => {
 
             if (isOkResult(createResult)) {
                 const emitEventStep = createEmitEventStep({
-                    kafkaProducer: hub.kafkaProducer,
                     clickhouseJsonEventsTopic: hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
                     groupId: 'test-group-id',
                 })
-                const emitResult = await emitEventStep(createResult.value)
+                const emitResult = await emitEventStep({ ...createResult.value, kafkaProducer: hub.kafkaProducer })
 
                 if (isOkResult(emitResult) && emitResult.sideEffects.length > 0) {
                     await Promise.allSettled(emitResult.sideEffects)

--- a/nodejs/tests/worker/ingestion/event-pipeline/prefetchPersonsStep.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/prefetchPersonsStep.test.ts
@@ -1,0 +1,110 @@
+import { PipelineResultType } from '~/ingestion/pipelines/results'
+import { Team } from '~/types'
+
+import { prefetchPersonsStep } from '../../../../src/worker/ingestion/event-pipeline/prefetchPersonsStep'
+import { PersonsStore } from '../../../../src/worker/ingestion/persons/persons-store'
+import { createTestPluginEvent } from '../../../helpers/plugin-event'
+import { createTestTeam } from '../../../helpers/team'
+
+describe('prefetchPersonsStep', () => {
+    let mockPersonsStore: jest.Mocked<PersonsStore>
+    let team: Team
+
+    function createMockPersonsStore(): jest.Mocked<PersonsStore> {
+        return {
+            prefetchPersons: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<PersonsStore>
+    }
+
+    beforeEach(() => {
+        team = createTestTeam()
+        mockPersonsStore = createMockPersonsStore()
+    })
+
+    const createInput = (distinctId: string, overrides: { personsStore?: PersonsStore; team?: Team } = {}) => ({
+        event: createTestPluginEvent({
+            distinct_id: distinctId,
+            team_id: (overrides.team ?? team).id,
+        }),
+        team: overrides.team ?? team,
+        personsStore: (overrides.personsStore ?? mockPersonsStore) as PersonsStore,
+    })
+
+    describe('when enabled', () => {
+        it('should prefetch persons for all events', async () => {
+            const step = prefetchPersonsStep(true)
+            const events = [createInput('user-1'), createInput('user-2'), createInput('user-3')]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+            expect(mockPersonsStore.prefetchPersons).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+                { teamId: team.id, distinctId: 'user-2' },
+                { teamId: team.id, distinctId: 'user-3' },
+            ])
+        })
+
+        it('should not call prefetch for empty batch', async () => {
+            const step = prefetchPersonsStep(true)
+
+            const results = await step([])
+
+            expect(results).toHaveLength(0)
+            expect(mockPersonsStore.prefetchPersons).not.toHaveBeenCalled()
+        })
+
+        it('should group prefetch calls by store instance', async () => {
+            const storeA = createMockPersonsStore()
+            const storeB = createMockPersonsStore()
+            const step = prefetchPersonsStep(true)
+
+            const events = [
+                createInput('user-1', { personsStore: storeA }),
+                createInput('user-2', { personsStore: storeB }),
+                createInput('user-3', { personsStore: storeA }),
+                createInput('user-4', { personsStore: storeB }),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(4)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+
+            expect(storeA.prefetchPersons).toHaveBeenCalledTimes(1)
+            expect(storeA.prefetchPersons).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+                { teamId: team.id, distinctId: 'user-3' },
+            ])
+
+            expect(storeB.prefetchPersons).toHaveBeenCalledTimes(1)
+            expect(storeB.prefetchPersons).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-2' },
+                { teamId: team.id, distinctId: 'user-4' },
+            ])
+        })
+
+        it('should call prefetch once when all events share the same store', async () => {
+            const step = prefetchPersonsStep(true)
+            const events = [createInput('user-1'), createInput('user-2')]
+
+            await step(events)
+
+            expect(mockPersonsStore.prefetchPersons).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('when disabled', () => {
+        it('should not prefetch and return all events as OK', async () => {
+            const step = prefetchPersonsStep(false)
+            const events = [createInput('user-1'), createInput('user-2')]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+            expect(mockPersonsStore.prefetchPersons).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
@@ -1,5 +1,4 @@
 import { PipelineResultType } from '~/ingestion/pipelines/results'
-import { PluginEvent } from '~/plugin-scaffold'
 import { Team } from '~/types'
 
 import { PersonsStore } from '../../../../src/worker/ingestion/persons/persons-store'
@@ -27,10 +26,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         } as unknown as jest.Mocked<PersonsStore>
     })
 
-    const createInput = (
-        distinctId: string,
-        processPerson: boolean | undefined = undefined
-    ): { event: PluginEvent; team: Team } => ({
+    const createInput = (distinctId: string, processPerson: boolean | undefined = undefined) => ({
         event: createTestPluginEvent({
             distinct_id: distinctId,
             team_id: team.id,
@@ -38,11 +34,12 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             uuid: `uuid-${distinctId}`,
         }),
         team,
+        personsStore: mockPersonsStore as PersonsStore,
     })
 
     describe('when enabled', () => {
         it('should process personless events and call batch insert', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
             const events = [createInput('user-1', false), createInput('user-2', false), createInput('user-3', false)]
 
             const results = await step(events)
@@ -57,7 +54,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         })
 
         it('should skip non-personless events', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
             const events = [
                 createInput('user-1', true), // processPerson=true
                 createInput('user-2', false), // processPerson=false (personless)
@@ -73,7 +70,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         })
 
         it('should not call batch insert when no personless events', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
             const events = [createInput('user-1', true), createInput('user-2')]
 
             const results = await step(events)
@@ -85,7 +82,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         it('should return all events as OK even if batch insert fails', async () => {
             mockPersonsStore.processPersonlessDistinctIdsBatch.mockRejectedValue(new Error('DB error'))
 
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
             const events = [createInput('user-1', false)]
 
             // The step should throw since we don't handle errors gracefully
@@ -95,7 +92,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
 
     describe('when disabled', () => {
         it('should not process any events', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, false)
+            const step = processPersonlessDistinctIdsBatchStep(false)
             const events = [createInput('user-1', false), createInput('user-2', false)]
 
             const results = await step(events)
@@ -108,7 +105,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
 
     describe('LRU cache behavior', () => {
         it('should deduplicate entries within same batch before hitting cache', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
             const events = [
                 createInput('user-1', false),
                 createInput('user-1', false), // Duplicate - deduped before cache/insert
@@ -125,7 +122,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         })
 
         it('should use cache to skip already-inserted distinct IDs across batches', async () => {
-            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const step = processPersonlessDistinctIdsBatchStep(true)
 
             // First batch
             await step([createInput('user-1', false)])

--- a/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
@@ -10,6 +10,13 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
     let team: Team
     let processPersonlessDistinctIdsBatchStep: typeof import('../../../../src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep').processPersonlessDistinctIdsBatchStep
 
+    function createMockPersonsStore(): jest.Mocked<PersonsStore> {
+        return {
+            processPersonlessDistinctIdsBatch: jest.fn().mockResolvedValue(undefined),
+            getPersonlessBatchResult: jest.fn().mockReturnValue(undefined),
+        } as unknown as jest.Mocked<PersonsStore>
+    }
+
     beforeEach(async () => {
         // Reset modules to get a fresh LRU cache for each test
         jest.resetModules()
@@ -19,14 +26,14 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         processPersonlessDistinctIdsBatchStep = module.processPersonlessDistinctIdsBatchStep
 
         team = createTestTeam()
-
-        mockPersonsStore = {
-            processPersonlessDistinctIdsBatch: jest.fn().mockResolvedValue(undefined),
-            getPersonlessBatchResult: jest.fn().mockReturnValue(undefined),
-        } as unknown as jest.Mocked<PersonsStore>
+        mockPersonsStore = createMockPersonsStore()
     })
 
-    const createInput = (distinctId: string, processPerson: boolean | undefined = undefined) => ({
+    const createInput = (
+        distinctId: string,
+        processPerson: boolean | undefined = undefined,
+        overrides: { personsStore?: PersonsStore } = {}
+    ) => ({
         event: createTestPluginEvent({
             distinct_id: distinctId,
             team_id: team.id,
@@ -34,7 +41,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             uuid: `uuid-${distinctId}`,
         }),
         team,
-        personsStore: mockPersonsStore as PersonsStore,
+        personsStore: (overrides.personsStore ?? mockPersonsStore) as PersonsStore,
     })
 
     describe('when enabled', () => {
@@ -100,6 +107,80 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             expect(results).toHaveLength(2)
             expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
             expect(mockPersonsStore.processPersonlessDistinctIdsBatch).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('multiple store instances', () => {
+        it('should group batch inserts by store instance', async () => {
+            const storeA = createMockPersonsStore()
+            const storeB = createMockPersonsStore()
+            const step = processPersonlessDistinctIdsBatchStep(true)
+
+            const events = [
+                createInput('user-1', false, { personsStore: storeA }),
+                createInput('user-2', false, { personsStore: storeB }),
+                createInput('user-3', false, { personsStore: storeA }),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+
+            expect(storeA.processPersonlessDistinctIdsBatch).toHaveBeenCalledTimes(1)
+            expect(storeA.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+                { teamId: team.id, distinctId: 'user-3' },
+            ])
+
+            expect(storeB.processPersonlessDistinctIdsBatch).toHaveBeenCalledTimes(1)
+            expect(storeB.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-2' },
+            ])
+        })
+
+        it('should propagate errors from any store', async () => {
+            const storeA = createMockPersonsStore()
+            const storeB = createMockPersonsStore()
+            storeB.processPersonlessDistinctIdsBatch.mockRejectedValue(new Error('store B failed'))
+            const step = processPersonlessDistinctIdsBatchStep(true)
+
+            const events = [
+                createInput('user-1', false, { personsStore: storeA }),
+                createInput('user-2', false, { personsStore: storeB }),
+            ]
+
+            await expect(step(events)).rejects.toThrow('store B failed')
+        })
+
+        it('should not update cache when any store flush fails', async () => {
+            const storeA = createMockPersonsStore()
+            const storeB = createMockPersonsStore()
+            storeB.processPersonlessDistinctIdsBatch.mockRejectedValue(new Error('store B failed'))
+            const step = processPersonlessDistinctIdsBatchStep(true)
+
+            await expect(
+                step([
+                    createInput('user-1', false, { personsStore: storeA }),
+                    createInput('user-2', false, { personsStore: storeB }),
+                ])
+            ).rejects.toThrow()
+
+            // On retry, both entries should be sent again (not cached)
+            storeA.processPersonlessDistinctIdsBatch.mockClear()
+            storeB.processPersonlessDistinctIdsBatch.mockResolvedValue(undefined)
+
+            await step([
+                createInput('user-1', false, { personsStore: storeA }),
+                createInput('user-2', false, { personsStore: storeB }),
+            ])
+
+            expect(storeA.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+            ])
+            expect(storeB.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-2' },
+            ])
         })
     })
 


### PR DESCRIPTION
## Problem

Pipelines don't allow fully batch-aware processing and callbacks before and after the batch.

We would also like to be able to run a pipeline with multiple batches concurrently and rely on the pipeline construction to guarantee concurrency and ordering. This will be useful if we expose the ingestion pipeline as an API.

## Changes

- Adds a batching pipeline, which allows before and after batch hooks
- Adds result to the feed method for backpressure
- Refactors the steps to create, use and flush batch stores, even if there were multiple concurrent stores
- Updates the joined pipeline to make sure we only process one batch at a time due to limitations in the batch stores

## How did you test this code?

- Added tests for everything
- Existing regression tests