### PR TITLE
fix(ci): add snapshot handling to turborepo product test shards

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -384,8 +384,15 @@ jobs:
                   include-hidden-files: true
                   retention-days: 2
 
+            - name: Verify new snapshots for flakiness
+              if: ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              shell: bash
+              run: |
+                  .github/scripts/verify-new-snapshots.sh
+
             - name: Generate snapshot patch
               if: ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              shell: bash
               run: |
                   mkdir -p /tmp/patches
                   git add -N '*.ambr' || true

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -264,7 +264,7 @@ jobs:
     # Each job gets its own runner + Docker stack, so no shared DB conflicts
     # Small products (< 50 tests) are grouped into a single job to avoid setup overhead
     turbo-tests:
-        needs: [changes, turbo-discover]
+        needs: [changes, turbo-discover, detect-snapshot-mode]
         if: >-
             always() &&
             needs.turbo-discover.result == 'success' &&
@@ -371,6 +371,7 @@ jobs:
                   # On master, also collect timing data for pytest-split sharding.
                   PYTEST_ADDOPTS: >-
                       --reuse-db
+                      ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
 
@@ -382,6 +383,28 @@ jobs:
                   path: .test_durations
                   include-hidden-files: true
                   retention-days: 2
+
+            - name: Generate snapshot patch
+              if: ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              run: |
+                  mkdir -p /tmp/patches
+                  git add -N '*.ambr' || true
+                  if ! git diff --quiet '*.ambr' 2>/dev/null; then
+                    git diff --binary --full-index '*.ambr' > /tmp/patches/backend-Products-${{ strategy.job-index }}.patch
+                    echo "Generated patch with $(wc -l < /tmp/patches/backend-Products-${{ strategy.job-index }}.patch) lines"
+                  else
+                    echo "No snapshot changes to patch"
+                  fi
+
+            - name: Upload snapshot patch
+              if: ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: snapshot-patch-Products-${{ strategy.job-index }}
+                  path: /tmp/patches/
+                  if-no-files-found: ignore
+                  retention-days: 1
+
     check-idor-coverage:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true'
@@ -1428,7 +1451,7 @@ jobs:
     # Aggregate and commit snapshot changes from all matrix jobs
     handle-snapshots:
         name: Commit snapshot changes
-        needs: [changes, detect-snapshot-mode, django]
+        needs: [changes, detect-snapshot-mode, django, turbo-tests]
         # Only in UPDATE mode - CHECK mode verifies snapshots match exactly
         # Run even if some matrix jobs failed (to commit snapshots from passing jobs)
         if: ${{ always() && needs.detect-snapshot-mode.outputs.mode == 'update' && needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}


### PR DESCRIPTION
**Problem**
The turbo-tests job was missing all snapshot infrastructure that the Django matrix tests have. Products under `products/` have `.ambr` snapshot files but turborepo shards never passed `--snapshot-update`, never generated patches, and `handle-snapshots` didn't wait for them — so snapshot changes from product tests were silently ignored.

**Changes**
- turbo-tests now depends on `detect-snapshot-mode` and passes `--snapshot-update` via `PYTEST_ADDOPTS` in update mode
- Snapshot patch generation + artifact upload added after product test runs (same approach as Django shards)
- `handle-snapshots` now waits for `turbo-tests` too — the existing `snapshot-patch-*` download glob already covers the new `snapshot-patch-Products-*` artifacts