### PR TITLE
feat(llma): process raw OTel events in ingestion pipeline

### DIFF
--- a/nodejs/src/ingestion/ai/convert-raw-event.test.ts
+++ b/nodejs/src/ingestion/ai/convert-raw-event.test.ts
@@ -1,0 +1,76 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { convertRawEvent } from './convert-raw-event'
+
+const createEvent = (properties?: Record<string, unknown>): PluginEvent => ({
+    event: '$ai_generation',
+    distinct_id: 'user-123',
+    team_id: 1,
+    properties,
+    uuid: 'test-uuid',
+    timestamp: new Date().toISOString(),
+    ip: '127.0.0.1',
+    site_url: 'https://app.posthog.com',
+    now: new Date().toISOString(),
+})
+
+describe('convertRawEvent', () => {
+    it('maps OTel attributes to PostHog properties when source is otel', () => {
+        const event = createEvent({
+            $ai_ingestion_source: 'otel',
+            'gen_ai.request.model': 'gpt-4',
+            'gen_ai.provider.name': 'openai',
+        })
+
+        convertRawEvent(event)
+
+        expect(event.properties!.$ai_model).toBe('gpt-4')
+        expect(event.properties!.$ai_provider).toBe('openai')
+        expect(event.properties!['gen_ai.request.model']).toBeUndefined()
+        expect(event.properties!['gen_ai.provider.name']).toBeUndefined()
+    })
+
+    it.each([
+        ['undefined source', {}],
+        ['sdk source', { $ai_ingestion_source: 'sdk' }],
+        ['missing properties', undefined],
+    ])('is a no-op when %s', (_label, properties) => {
+        const event = createEvent(properties)
+        const before = event.properties ? { ...event.properties } : undefined
+        convertRawEvent(event)
+        expect(event.properties).toEqual(before)
+    })
+
+    describe('debug mode', () => {
+        it('sets $ai_debug flag and snapshots raw properties into $ai_debug_data', () => {
+            const event = createEvent({
+                $ai_ingestion_source: 'otel',
+                'posthog.ai.debug': 'true',
+                'gen_ai.request.model': 'gpt-4',
+                'gen_ai.provider.name': 'openai',
+            })
+
+            convertRawEvent(event)
+
+            expect(event.properties!.$ai_model).toBe('gpt-4')
+            expect(event.properties!['gen_ai.request.model']).toBeUndefined()
+
+            expect(event.properties!.$ai_debug).toBe(true)
+            expect(event.properties!.$ai_debug_data).toBeDefined()
+            expect(event.properties!.$ai_debug_data['gen_ai.request.model']).toBe('gpt-4')
+            expect(event.properties!.$ai_debug_data['gen_ai.provider.name']).toBe('openai')
+        })
+
+        it.each([
+            ['absent', { $ai_ingestion_source: 'otel', 'gen_ai.request.model': 'gpt-4' }],
+            ['empty string', { $ai_ingestion_source: 'otel', 'posthog.ai.debug': '', 'gen_ai.request.model': 'gpt-4' }],
+            ['zero', { $ai_ingestion_source: 'otel', 'posthog.ai.debug': 0, 'gen_ai.request.model': 'gpt-4' }],
+            ['false', { $ai_ingestion_source: 'otel', 'posthog.ai.debug': false, 'gen_ai.request.model': 'gpt-4' }],
+        ])('does not set debug properties when posthog.ai.debug is %s', (_label, properties) => {
+            const event = createEvent(properties)
+            convertRawEvent(event)
+            expect(event.properties!.$ai_debug).toBeUndefined()
+            expect(event.properties!.$ai_debug_data).toBeUndefined()
+        })
+    })
+})

--- a/nodejs/src/ingestion/ai/convert-raw-event.ts
+++ b/nodejs/src/ingestion/ai/convert-raw-event.ts
@@ -1,0 +1,17 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { convertOtelEvent } from './otel'
+
+export function convertRawEvent(event: PluginEvent): void {
+    if (event.properties?.$ai_ingestion_source === 'otel') {
+        const debug = !!event.properties['posthog.ai.debug']
+        const rawProperties = debug ? structuredClone(event.properties) : undefined
+
+        convertOtelEvent(event)
+
+        if (debug) {
+            event.properties.$ai_debug = true
+            event.properties.$ai_debug_data = rawProperties
+        }
+    }
+}

--- a/nodejs/src/ingestion/ai/index.ts
+++ b/nodejs/src/ingestion/ai/index.ts
@@ -1,7 +1,1 @@
-/**
- * AI event processing module.
- *
- * This module provides the main entry point for AI event enrichment at ingestion time.
- */
-
 export { AI_EVENT_TYPES, EventWithProperties, normalizeTraceProperties, processAiEvent } from './process-ai-event'

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -1,0 +1,181 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { mapOtelAttributes } from './attribute-mapping'
+
+const createEvent = (event: string, properties: Record<string, unknown>): PluginEvent => ({
+    event,
+    distinct_id: 'user-123',
+    team_id: 1,
+    properties,
+    uuid: 'test-uuid',
+    timestamp: new Date().toISOString(),
+    ip: '127.0.0.1',
+    site_url: 'https://app.posthog.com',
+    now: new Date().toISOString(),
+})
+
+describe('mapOtelAttributes', () => {
+    it.each([
+        ['gen_ai.input.messages', '$ai_input'],
+        ['gen_ai.output.messages', '$ai_output_choices'],
+        ['gen_ai.usage.input_tokens', '$ai_input_tokens'],
+        ['gen_ai.usage.output_tokens', '$ai_output_tokens'],
+        ['gen_ai.response.model', '$ai_model'],
+        ['gen_ai.provider.name', '$ai_provider'],
+        ['server.address', '$ai_base_url'],
+        ['telemetry.sdk.name', '$ai_lib'],
+        ['telemetry.sdk.version', '$ai_lib_version'],
+        ['$otel_span_name', '$ai_span_name'],
+    ])('renames %s to %s', (otelKey, phKey) => {
+        const event = createEvent('$ai_generation', { [otelKey]: 'test-value' })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe('test-value')
+        expect(event.properties![otelKey]).toBeUndefined()
+    })
+
+    it('JSON-parses string values for $ai_input and $ai_output_choices', () => {
+        const event = createEvent('$ai_generation', {
+            'gen_ai.input.messages': '[{"role": "user", "content": "Hello"}]',
+            'gen_ai.output.messages': '[{"role": "assistant", "content": "Hi"}]',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
+        expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hi' }])
+    })
+
+    it('keeps original string when JSON parsing fails', () => {
+        const event = createEvent('$ai_generation', {
+            'gen_ai.input.messages': 'not valid json',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_input).toBe('not valid json')
+    })
+
+    it('does not JSON-parse already-parsed objects', () => {
+        const parsed = [{ role: 'user', content: 'Hello' }]
+        const event = createEvent('$ai_generation', {
+            'gen_ai.input.messages': parsed,
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_input).toEqual(parsed)
+    })
+
+    it('preserves unknown attributes', () => {
+        const event = createEvent('$ai_generation', {
+            'custom.attribute': 'custom-value',
+            'gen_ai.response.model': 'gpt-4',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!['custom.attribute']).toBe('custom-value')
+        expect(event.properties!.$ai_model).toBe('gpt-4')
+    })
+
+    it.each([
+        ['gen_ai.system', '$ai_provider', 'openai'],
+        ['gen_ai.request.model', '$ai_model', 'gpt-4'],
+    ])('uses %s as fallback for %s', (otelKey, phKey, value) => {
+        const event = createEvent('$ai_generation', { [otelKey]: value })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe(value)
+        expect(event.properties![otelKey]).toBeUndefined()
+    })
+
+    it.each([
+        ['gen_ai.system', '$ai_provider', 'gen_ai.provider.name'],
+        ['gen_ai.request.model', '$ai_model', 'gen_ai.response.model'],
+    ])('does not override %s when primary mapping for %s exists', (fallbackKey, phKey, primaryKey) => {
+        const event = createEvent('$ai_generation', { [primaryKey]: 'primary', [fallbackKey]: 'fallback' })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe('primary')
+        expect(event.properties![fallbackKey]).toBeUndefined()
+    })
+
+    it('prefers gen_ai.response.model over gen_ai.request.model', () => {
+        const event = createEvent('$ai_generation', {
+            'gen_ai.request.model': 'gpt-4o-mini',
+            'gen_ai.response.model': 'gpt-4o-mini-2024-07-18',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_model).toBe('gpt-4o-mini-2024-07-18')
+        expect(event.properties!['gen_ai.request.model']).toBeUndefined()
+        expect(event.properties!['gen_ai.response.model']).toBeUndefined()
+    })
+
+    it.each(['telemetry.sdk.language', 'gen_ai.operation.name', 'posthog.ai.debug'])(
+        'strips %s from properties',
+        (key) => {
+            const event = createEvent('$ai_generation', { [key]: 'some-value' })
+            mapOtelAttributes(event)
+            expect(event.properties![key]).toBeUndefined()
+        }
+    )
+
+    it('computes $ai_latency from OTel timestamps', () => {
+        const event = createEvent('$ai_generation', {
+            $otel_start_time_unix_nano: '1704067200000000000',
+            $otel_end_time_unix_nano: '1704067201500000000',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!['$ai_latency']).toBe(1.5)
+        expect(event.properties!['$otel_start_time_unix_nano']).toBeUndefined()
+        expect(event.properties!['$otel_end_time_unix_nano']).toBeUndefined()
+    })
+
+    it('does not set $ai_latency when end <= start', () => {
+        const event = createEvent('$ai_generation', {
+            $otel_start_time_unix_nano: '1000000000000000000',
+            $otel_end_time_unix_nano: '0',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!['$ai_latency']).toBeUndefined()
+    })
+
+    it('does not crash on malformed nanosecond timestamps', () => {
+        const event = createEvent('$ai_generation', {
+            $otel_start_time_unix_nano: 'not-a-number',
+            $otel_end_time_unix_nano: 'also-bad',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!['$ai_latency']).toBeUndefined()
+        expect(event.properties!['$otel_start_time_unix_nano']).toBeUndefined()
+        expect(event.properties!['$otel_end_time_unix_nano']).toBeUndefined()
+    })
+
+    it('strips OTel timestamp properties even when latency cannot be computed', () => {
+        const event = createEvent('$ai_generation', {
+            $otel_start_time_unix_nano: '1000000000000000000',
+            $otel_end_time_unix_nano: '0',
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!['$otel_start_time_unix_nano']).toBeUndefined()
+        expect(event.properties!['$otel_end_time_unix_nano']).toBeUndefined()
+    })
+
+    it('promotes root $ai_span to $ai_trace', () => {
+        const event = createEvent('$ai_span', {
+            $otel_start_time_unix_nano: '0',
+            $otel_end_time_unix_nano: '0',
+        })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_trace')
+    })
+
+    it('does not promote $ai_span with parent to $ai_trace', () => {
+        const event = createEvent('$ai_span', {
+            $ai_parent_id: 'abc123',
+            $otel_start_time_unix_nano: '0',
+            $otel_end_time_unix_nano: '0',
+        })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_span')
+    })
+
+    it('does not promote $ai_generation to $ai_trace', () => {
+        const event = createEvent('$ai_generation', {
+            $otel_start_time_unix_nano: '0',
+            $otel_end_time_unix_nano: '0',
+        })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_generation')
+    })
+})

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -1,0 +1,93 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { parseJSON } from '../../../utils/json-parse'
+
+const ATTRIBUTE_MAP: Record<string, string> = {
+    'gen_ai.input.messages': '$ai_input',
+    'gen_ai.output.messages': '$ai_output_choices',
+    'gen_ai.usage.input_tokens': '$ai_input_tokens',
+    'gen_ai.usage.output_tokens': '$ai_output_tokens',
+    'gen_ai.response.model': '$ai_model',
+    'gen_ai.provider.name': '$ai_provider',
+    'server.address': '$ai_base_url',
+    'telemetry.sdk.name': '$ai_lib',
+    'telemetry.sdk.version': '$ai_lib_version',
+    $otel_span_name: '$ai_span_name',
+}
+
+const FALLBACK_ATTRIBUTE_MAP: Record<string, string> = {
+    'gen_ai.system': '$ai_provider',
+    'gen_ai.request.model': '$ai_model',
+}
+
+const STRIP_ATTRIBUTES = new Set([
+    'telemetry.sdk.language',
+    'gen_ai.operation.name',
+    'posthog.ai.debug',
+    'user.id',
+    'posthog.distinct_id',
+])
+
+const JSON_PARSE_PROPERTIES = new Set(['$ai_input', '$ai_output_choices'])
+
+export function mapOtelAttributes(event: PluginEvent): void {
+    if (!event.properties) {
+        return
+    }
+
+    for (const [otelKey, phKey] of Object.entries(ATTRIBUTE_MAP)) {
+        if (event.properties[otelKey] !== undefined) {
+            let value = event.properties[otelKey]
+            if (JSON_PARSE_PROPERTIES.has(phKey) && typeof value === 'string') {
+                try {
+                    value = parseJSON(value)
+                } catch {
+                    // Keep original string value if parsing fails
+                }
+            }
+            event.properties[phKey] = value
+            delete event.properties[otelKey]
+        }
+    }
+
+    for (const [otelKey, phKey] of Object.entries(FALLBACK_ATTRIBUTE_MAP)) {
+        if (event.properties[otelKey] !== undefined && event.properties[phKey] === undefined) {
+            event.properties[phKey] = event.properties[otelKey]
+        }
+        delete event.properties[otelKey]
+    }
+
+    computeLatency(event)
+    promoteRootSpanToTrace(event)
+
+    for (const key of STRIP_ATTRIBUTES) {
+        delete event.properties[key]
+    }
+}
+
+function computeLatency(event: PluginEvent): void {
+    const props = event.properties!
+    const startStr = props['$otel_start_time_unix_nano']
+    const endStr = props['$otel_end_time_unix_nano']
+
+    if (typeof startStr === 'string' && typeof endStr === 'string') {
+        try {
+            const start = BigInt(startStr)
+            const end = BigInt(endStr)
+            if (end > start) {
+                props['$ai_latency'] = Number(end - start) / 1_000_000_000
+            }
+        } catch {
+            // Ignore malformed nanosecond timestamps
+        }
+    }
+
+    delete props['$otel_start_time_unix_nano']
+    delete props['$otel_end_time_unix_nano']
+}
+
+function promoteRootSpanToTrace(event: PluginEvent): void {
+    if (event.event === '$ai_span' && !event.properties!['$ai_parent_id']) {
+        event.event = '$ai_trace'
+    }
+}

--- a/nodejs/src/ingestion/ai/otel/index.test.ts
+++ b/nodejs/src/ingestion/ai/otel/index.test.ts
@@ -124,6 +124,22 @@ describe('convertOtelEvent', () => {
             expect(event.properties!['$ai_output_state']).toEqual(structured)
         })
 
+        it.each([
+            ['number', '42'],
+            ['boolean', 'true'],
+            ['null', 'null'],
+        ])('keeps final_result as string when parsed value is a %s', (_label, value) => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify([
+                    { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                ]),
+                final_result: value,
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toBe(value)
+        })
+
         it('keeps final_result as plain string when not valid JSON', () => {
             const event = createEvent('$ai_span', {
                 'pydantic_ai.all_messages': JSON.stringify([
@@ -148,6 +164,24 @@ describe('convertOtelEvent', () => {
             convertOtelEvent(event)
 
             expect(event.properties!['$ai_output_state']).toBe('The answer is 42')
+        })
+
+        it('filters non-object items from pydantic_ai.all_messages', () => {
+            const messages = [
+                'not an object',
+                { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                42,
+                null,
+                [1, 2, 3],
+                { role: 'model-text-response', parts: [{ type: 'text', content: 'Hi!' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_input_state']).toEqual(messages[1])
+            expect(event.properties!['$ai_output_state']).toEqual(messages[5])
         })
 
         it('uses agent_name as fallback for $ai_span_name', () => {

--- a/nodejs/src/ingestion/ai/otel/index.test.ts
+++ b/nodejs/src/ingestion/ai/otel/index.test.ts
@@ -1,0 +1,386 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { mapOtelAttributes } from './attribute-mapping'
+import { convertOtelEvent } from './index'
+
+jest.mock('./attribute-mapping', () => ({
+    mapOtelAttributes: jest.fn(),
+}))
+
+const mockedMapOtelAttributes = jest.mocked(mapOtelAttributes)
+
+const createEvent = (event: string, properties: Record<string, unknown>): PluginEvent => ({
+    event,
+    distinct_id: 'user-123',
+    team_id: 1,
+    properties,
+    uuid: 'test-uuid',
+    timestamp: new Date().toISOString(),
+    ip: '127.0.0.1',
+    site_url: 'https://app.posthog.com',
+    now: new Date().toISOString(),
+})
+
+describe('convertOtelEvent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('library detection', () => {
+        it.each([
+            ['no library markers', {}],
+            ['only gen_ai.system', { 'gen_ai.system': 'openai' }],
+            ['only gen_ai.provider.name', { 'gen_ai.provider.name': 'anthropic' }],
+        ])('runs general mapping directly when %s', (_label, properties) => {
+            const event = createEvent('$ai_generation', properties)
+            convertOtelEvent(event)
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+        })
+
+        it.each([
+            ['pydantic_ai.all_messages', { 'pydantic_ai.all_messages': '[]' }],
+            ['logfire.msg', { 'logfire.msg': 'running 1 tool' }],
+            ['logfire.json_schema', { 'logfire.json_schema': '{}' }],
+            ['model_request_parameters', { model_request_parameters: '{}' }],
+        ])('detects pydantic-ai library from %s attribute', (_label, properties) => {
+            const event = createEvent('$ai_span', properties)
+            convertOtelEvent(event)
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+        })
+
+        it('detects pydantic-ai even when gen_ai.system is set to a different provider', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system': 'openai',
+                'logfire.json_schema': '{}',
+            })
+            convertOtelEvent(event)
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+        })
+    })
+
+    describe('pydantic-ai middleware on $ai_trace (root span)', () => {
+        beforeEach(() => {
+            // mapOtelAttributes promotes $ai_span → $ai_trace for root spans
+            mockedMapOtelAttributes.mockImplementation((e) => {
+                if (e.event === '$ai_span' && !e.properties?.['$ai_parent_id']) {
+                    e.event = '$ai_trace'
+                }
+            })
+        })
+
+        it('extracts input from pydantic_ai.all_messages and output from final_result', () => {
+            const messages = [
+                { role: 'system', parts: [{ type: 'text', content: 'You are helpful' }] },
+                { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+                final_result: 'The answer is 42',
+                'gen_ai.agent.name': 'my-agent',
+                'logfire.msg': 'agent run',
+                'logfire.json_schema': '{}',
+            })
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_trace')
+            expect(event.properties!['$ai_input_state']).toEqual(messages[1])
+            expect(event.properties!['$ai_output_state']).toBe('The answer is 42')
+            expect(event.properties!['$ai_span_name']).toBe('my-agent')
+            expect(event.properties!['pydantic_ai.all_messages']).toBeUndefined()
+            expect(event.properties!['final_result']).toBeUndefined()
+            expect(event.properties!['gen_ai.agent.name']).toBeUndefined()
+            expect(event.properties!['logfire.msg']).toBeUndefined()
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+        })
+
+        it('falls back to last non-user/system message for output when final_result is absent', () => {
+            const messages = [
+                { role: 'system', parts: [{ type: 'text', content: 'You are helpful' }] },
+                { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                { role: 'model-text-response', parts: [{ type: 'text', content: 'Hi there!' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+                'gen_ai.agent.name': 'my-agent',
+            })
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_trace')
+            expect(event.properties!['$ai_input_state']).toEqual(messages[1])
+            expect(event.properties!['$ai_output_state']).toEqual(messages[2])
+        })
+
+        it('parses final_result JSON string into object for $ai_output_state', () => {
+            const structured = { name: 'Montreal', country: 'Canada', population: 1700000 }
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify([
+                    { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                ]),
+                final_result: JSON.stringify(structured),
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toEqual(structured)
+        })
+
+        it('keeps final_result as plain string when not valid JSON', () => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify([
+                    { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                ]),
+                final_result: 'The answer is 42',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toBe('The answer is 42')
+        })
+
+        it('prefers final_result over message fallback for output', () => {
+            const messages = [
+                { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                { role: 'model-text-response', parts: [{ type: 'text', content: 'Hi there!' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+                final_result: 'The answer is 42',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toBe('The answer is 42')
+        })
+
+        it('uses agent_name as fallback for $ai_span_name', () => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': '[]',
+                agent_name: 'fallback-agent',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_span_name']).toBe('fallback-agent')
+            expect(event.properties!['agent_name']).toBeUndefined()
+        })
+
+        it('uses logfire.msg as $ai_span_name when no agent name and no $otel_span_name', () => {
+            const event = createEvent('$ai_span', {
+                'logfire.msg': 'agent run',
+                'pydantic_ai.all_messages': '[]',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_span_name']).toBe('agent run')
+        })
+
+        it('does not set $ai_span_name when no sources available', () => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': '[]',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_span_name']).toBeUndefined()
+        })
+
+        it('maps model_name to $ai_model and strips it', () => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': '[]',
+                model_name: 'openai:gpt-4o',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_model']).toBe('openai:gpt-4o')
+            expect(event.properties!['model_name']).toBeUndefined()
+        })
+
+        it('does not overwrite $ai_model when already set', () => {
+            const event = createEvent('$ai_span', {
+                'pydantic_ai.all_messages': '[]',
+                $ai_model: 'existing-model',
+                model_name: 'openai:gpt-4o',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_model']).toBe('existing-model')
+            expect(event.properties!['model_name']).toBeUndefined()
+        })
+    })
+
+    describe('pydantic-ai middleware on nested agent-run $ai_span', () => {
+        it('extracts input/output and agent name from nested agent-run span', () => {
+            const messages = [
+                { role: 'user', parts: [{ type: 'text', content: 'Tell me about Python' }] },
+                { role: 'model-text-response', parts: [{ type: 'text', content: 'Python was created in 1991.' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-trace-1',
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+                final_result: 'Python was created in 1991.',
+                'gen_ai.agent.name': 'research_agent',
+                agent_name: 'research_agent',
+                model_name: 'gpt-4o-mini',
+                'logfire.msg': 'agent run',
+                'logfire.json_schema': '{}',
+            })
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_span')
+            expect(event.properties!['$ai_input_state']).toEqual(messages[0])
+            expect(event.properties!['$ai_output_state']).toBe('Python was created in 1991.')
+            expect(event.properties!['$ai_span_name']).toBe('research_agent')
+            expect(event.properties!['$ai_model']).toBe('gpt-4o-mini')
+            expect(event.properties!['pydantic_ai.all_messages']).toBeUndefined()
+            expect(event.properties!['final_result']).toBeUndefined()
+            expect(event.properties!['agent_name']).toBeUndefined()
+            expect(event.properties!['gen_ai.agent.name']).toBeUndefined()
+            expect(event.properties!['logfire.msg']).toBeUndefined()
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+            expect(event.properties!['model_name']).toBeUndefined()
+        })
+
+        it('falls back to last assistant message when nested span has no final_result', () => {
+            const messages = [
+                { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+                { role: 'model-text-response', parts: [{ type: 'text', content: 'Hi there!' }] },
+            ]
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-trace-1',
+                'pydantic_ai.all_messages': JSON.stringify(messages),
+                'gen_ai.agent.name': 'sub_agent',
+            })
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_span')
+            expect(event.properties!['$ai_output_state']).toEqual(messages[1])
+        })
+    })
+
+    describe('pydantic-ai middleware on $ai_span with tool data', () => {
+        it('maps tool_arguments and tool_response to state properties', () => {
+            const toolArgs = { latitude: 45.5, longitude: -73.5 }
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'running tool: get_weather',
+                tool_arguments: JSON.stringify(toolArgs),
+                tool_response: 'Sunny, 25°C',
+                'gen_ai.tool.name': 'get_weather',
+                'gen_ai.tool.call.id': 'call-123',
+                'logfire.json_schema': '{}',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_input_state']).toEqual(toolArgs)
+            expect(event.properties!['$ai_output_state']).toBe('Sunny, 25°C')
+            expect(event.properties!['$ai_span_name']).toBe('get_weather')
+            expect(event.properties!['tool_arguments']).toBeUndefined()
+            expect(event.properties!['tool_response']).toBeUndefined()
+            expect(event.properties!['gen_ai.tool.name']).toBeUndefined()
+            expect(event.properties!['gen_ai.tool.call.id']).toBeUndefined()
+            expect(event.properties!['logfire.msg']).toBeUndefined()
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+        })
+
+        it('parses tool_response JSON string into object for $ai_output_state', () => {
+            const toolResponse = { temperature: 25, unit: 'celsius', condition: 'sunny' }
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'running tool: get_weather',
+                tool_response: JSON.stringify(toolResponse),
+                'gen_ai.tool.name': 'get_weather',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toEqual(toolResponse)
+        })
+
+        it('keeps tool_response as plain string when not valid JSON', () => {
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'running tool: get_weather',
+                tool_response: 'Sunny, 25°C',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_output_state']).toBe('Sunny, 25°C')
+        })
+
+        it('keeps tool_arguments as string when JSON parsing fails', () => {
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'tool run',
+                tool_arguments: 'not json',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_input_state']).toBe('not json')
+        })
+
+        it('passes through already-parsed tool_arguments', () => {
+            const toolArgs = { key: 'value' }
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'tool run',
+                tool_arguments: toolArgs,
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_input_state']).toEqual(toolArgs)
+        })
+    })
+
+    describe('pydantic-ai middleware on plain $ai_span', () => {
+        it('strips logfire keys and uses logfire.msg as $ai_span_name fallback', () => {
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'logfire.msg': 'running 1 tool',
+                'logfire.json_schema': '{}',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('running 1 tool')
+            expect(event.properties!['logfire.msg']).toBeUndefined()
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+        })
+    })
+
+    describe('pydantic-ai middleware on $ai_generation', () => {
+        it('strips logfire and model_request_parameters from generation events with openai provider', () => {
+            const event = createEvent('$ai_generation', {
+                'gen_ai.system': 'openai',
+                'logfire.json_schema': '{"type": "object"}',
+                'operation.cost': '0.001',
+                model_request_parameters: '{"temperature": 0.7}',
+            })
+            convertOtelEvent(event)
+
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+            expect(event.properties!['logfire.json_schema']).toBeUndefined()
+            expect(event.properties!['operation.cost']).toBeUndefined()
+            expect(event.properties!['model_request_parameters']).toBeUndefined()
+        })
+    })
+
+    describe('pydantic-ai middleware strips redundant usage detail attributes', () => {
+        it.each(['$ai_generation', '$ai_trace'])('strips gen_ai.usage.details.* from %s events', (eventType) => {
+            const event = createEvent(eventType, {
+                'logfire.msg': 'test',
+                'gen_ai.usage.details.input_tokens': 100,
+                'gen_ai.usage.details.output_tokens': 50,
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['gen_ai.usage.details.input_tokens']).toBeUndefined()
+            expect(event.properties!['gen_ai.usage.details.output_tokens']).toBeUndefined()
+        })
+    })
+
+    describe('pydantic-ai middleware sets $ai_lib', () => {
+        it.each(['$ai_generation', '$ai_span', '$ai_trace'])(
+            'sets $ai_lib to opentelemetry/pydantic-ai on %s events',
+            (eventType) => {
+                const event = createEvent(eventType, { 'logfire.msg': 'test' })
+                convertOtelEvent(event)
+                expect(event.properties!['$ai_lib']).toBe('opentelemetry/pydantic-ai')
+            }
+        )
+
+        it('overwrites $ai_lib from generic OTel mapping', () => {
+            const event = createEvent('$ai_generation', {
+                'logfire.msg': 'test',
+                $ai_lib: 'opentelemetry',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_lib']).toBe('opentelemetry/pydantic-ai')
+        })
+    })
+})

--- a/nodejs/src/ingestion/ai/otel/index.ts
+++ b/nodejs/src/ingestion/ai/otel/index.ts
@@ -1,0 +1,154 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { parseJSON } from '../../../utils/json-parse'
+import { mapOtelAttributes } from './attribute-mapping'
+
+type OtelLibraryMiddleware = (event: PluginEvent, next: () => void) => void
+
+const LOGFIRE_STRIP_KEYS = [
+    'logfire.json_schema',
+    'logfire.msg',
+    'operation.cost',
+    'model_request_parameters',
+    'model_name',
+    'gen_ai.usage.details.input_tokens',
+    'gen_ai.usage.details.output_tokens',
+]
+
+function pydanticAiMiddleware(event: PluginEvent, next: () => void): void {
+    if (!event.properties) {
+        return next()
+    }
+    const props = event.properties
+
+    next()
+
+    // logfire.msg as fallback when $otel_span_name was empty
+    if (props['$ai_span_name'] === undefined && props['logfire.msg'] !== undefined) {
+        props['$ai_span_name'] = props['logfire.msg']
+    }
+
+    const isAgentRun = event.event === '$ai_trace' || props['pydantic_ai.all_messages'] !== undefined
+    if (isAgentRun) {
+        let messages: Record<string, unknown>[] | undefined
+        const allMessages = props['pydantic_ai.all_messages']
+        if (typeof allMessages === 'string') {
+            try {
+                const parsed = parseJSON(allMessages)
+                if (Array.isArray(parsed)) {
+                    messages = parsed
+                }
+            } catch {
+                // Keep as-is if parsing fails
+            }
+        }
+
+        if (messages) {
+            const userMessage = messages.find((m) => m.role === 'user')
+            if (userMessage) {
+                props['$ai_input_state'] = userMessage
+            }
+        }
+
+        if (props['final_result'] !== undefined) {
+            let finalResult = props['final_result']
+            if (typeof finalResult === 'string') {
+                try {
+                    finalResult = parseJSON(finalResult)
+                } catch {
+                    // Keep original string
+                }
+            }
+            props['$ai_output_state'] = finalResult
+        } else if (messages) {
+            const lastAssistant = messages.findLast((m) => m.role !== 'user' && m.role !== 'system')
+            if (lastAssistant) {
+                props['$ai_output_state'] = lastAssistant
+            }
+        }
+
+        const agentName = props['gen_ai.agent.name'] ?? props['agent_name']
+        if (agentName !== undefined) {
+            props['$ai_span_name'] = agentName
+        }
+
+        if (props['$ai_model'] === undefined && props['model_name'] !== undefined) {
+            props['$ai_model'] = props['model_name']
+        }
+
+        delete props['pydantic_ai.all_messages']
+        delete props['final_result']
+        delete props['agent_name']
+        delete props['gen_ai.agent.name']
+    }
+
+    if (event.event === '$ai_span') {
+        if (props['tool_arguments'] !== undefined) {
+            let toolArgs = props['tool_arguments']
+            if (typeof toolArgs === 'string') {
+                try {
+                    toolArgs = parseJSON(toolArgs)
+                } catch {
+                    // Keep original string
+                }
+            }
+            props['$ai_input_state'] = toolArgs
+        }
+
+        if (props['tool_response'] !== undefined) {
+            let toolResponse = props['tool_response']
+            if (typeof toolResponse === 'string') {
+                try {
+                    toolResponse = parseJSON(toolResponse)
+                } catch {
+                    // Keep original string
+                }
+            }
+            props['$ai_output_state'] = toolResponse
+        }
+
+        if (props['gen_ai.tool.name'] !== undefined) {
+            props['$ai_span_name'] = props['gen_ai.tool.name']
+        }
+
+        delete props['tool_arguments']
+        delete props['tool_response']
+        delete props['gen_ai.tool.name']
+        delete props['gen_ai.tool.call.id']
+    }
+
+    props['$ai_lib'] = 'opentelemetry/pydantic-ai'
+
+    for (const key of LOGFIRE_STRIP_KEYS) {
+        delete props[key]
+    }
+}
+
+const LIBRARY_MIDDLEWARE: Record<string, OtelLibraryMiddleware> = {
+    'pydantic-ai': pydanticAiMiddleware,
+}
+
+const PYDANTIC_MARKER_KEYS = [
+    'pydantic_ai.all_messages',
+    'logfire.msg',
+    'logfire.json_schema',
+    'model_request_parameters',
+]
+
+function detectLibrary(event: PluginEvent): string | undefined {
+    if (PYDANTIC_MARKER_KEYS.some((key) => event.properties?.[key] !== undefined)) {
+        return 'pydantic-ai'
+    }
+    return undefined
+}
+
+export function convertOtelEvent(event: PluginEvent): void {
+    const library = detectLibrary(event)
+    const middleware = library ? LIBRARY_MIDDLEWARE[library] : undefined
+
+    if (middleware) {
+        middleware(event, () => mapOtelAttributes(event))
+    } else {
+        mapOtelAttributes(event)
+    }
+}

--- a/nodejs/src/ingestion/ai/otel/index.ts
+++ b/nodejs/src/ingestion/ai/otel/index.ts
@@ -36,7 +36,10 @@ function pydanticAiMiddleware(event: PluginEvent, next: () => void): void {
             try {
                 const parsed = parseJSON(allMessages)
                 if (Array.isArray(parsed)) {
-                    messages = parsed
+                    messages = parsed.filter(
+                        (item): item is Record<string, unknown> =>
+                            typeof item === 'object' && item !== null && !Array.isArray(item)
+                    )
                 }
             } catch {
                 // Keep as-is if parsing fails
@@ -54,7 +57,10 @@ function pydanticAiMiddleware(event: PluginEvent, next: () => void): void {
             let finalResult = props['final_result']
             if (typeof finalResult === 'string') {
                 try {
-                    finalResult = parseJSON(finalResult)
+                    const parsed = parseJSON(finalResult)
+                    if (typeof parsed === 'object' && parsed !== null) {
+                        finalResult = parsed
+                    }
                 } catch {
                     // Keep original string
                 }

--- a/nodejs/src/ingestion/ai/process-ai-event.ts
+++ b/nodejs/src/ingestion/ai/process-ai-event.ts
@@ -10,6 +10,7 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { logger } from '../../utils/logger'
+import { convertRawEvent } from './convert-raw-event'
 import { EventWithProperties, extractCoreModelParams, processCost } from './costs'
 import { processAiErrorNormalization } from './errors'
 import { processAiToolCallExtraction } from './tools'
@@ -41,6 +42,9 @@ export const AI_EVENT_TYPES = new Set([
  * 5. Extract tool calls (generation events only)
  */
 export const processAiEvent = (event: PluginEvent): PluginEvent | EventWithProperties => {
+    // Map OTel attribute names to PostHog property names before any other processing.
+    convertRawEvent(event)
+
     // If the event doesn't carry properties, there's nothing to do.
     if (!isEventWithProperties(event)) {
         return event


### PR DESCRIPTION
## Problem

Handles the ingestion part of our LLMA OTel MVP (split from #48625). When a raw OTel event arrives from the capture endpoint, the plugin server needs to map OTel span attributes to known PostHog AI event properties.

## Changes

- Adds `nodejs/src/ingestion/ai/otel/` module with attribute mapping and span-to-event conversion
- Adds conversion logic in `convert-raw-event.ts` to detect and route OTel events
- Comprehensive test coverage for attribute mapping and event conversion

## How did you test this code?

Unit tests covering attribute mapping, span conversion, and raw event routing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No, still in testing / MVP stage.