### PR TITLE
chore(modeling): drop old dag id text fields from DB

### DIFF
--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -93,7 +93,7 @@ def validate_migration_sql(sql) -> bool:
             )
             return True
 
-        if "DROP COLUMN" in operation_sql:
+        if "DROP COLUMN" in operation_sql and "-- drop-column-ignore" not in operation_sql:
             print(
                 f"\n\n\033[91mFound a DROP COLUMN command. This will lead to the app crashing while we roll out, and it will mean we can't roll back beyond this PR. Instead, please use the deprecate_field function: `from django_deprecate_fields import deprecate_field` and `your_field = deprecate_field(models.IntegerField(null=True, blank=True))`\nSource: `{operation_sql}`"
             )

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -233,8 +233,15 @@ def _extract_model_name_from_table(table_name: str, app_label: Optional[str] = N
         if parts[: len(app_parts)] == app_parts:
             model_parts = parts[len(app_parts) :]
         else:
-            # Fallback: assume single-word app
-            model_parts = parts[1:]
+            # Handle custom db_table with "posthog_" prefix and joined app label
+            # e.g., posthog_datamodelingnode (app=data_modeling) -> node
+            joined_prefix = "posthog_" + app_label.replace("_", "")
+            if table_name.startswith(joined_prefix):
+                remainder = table_name[len(joined_prefix) :]
+                model_parts = remainder.split("_") if remainder else []
+            else:
+                # Fallback: assume single-word app
+                model_parts = parts[1:]
     else:
         # Skip first part (assumed to be app label like 'posthog')
         model_parts = parts[1:]

--- a/products/data_modeling/backend/migrations/0019_drop_old_dag_text_columns.py
+++ b/products/data_modeling/backend/migrations/0019_drop_old_dag_text_columns.py
@@ -12,7 +12,8 @@ class Migration(migrations.Migration):
             database_operations=[
                 migrations.RunSQL(
                     "ALTER TABLE posthog_datamodelingnode DROP COLUMN IF EXISTS dag_id, DROP COLUMN IF EXISTS dag_id_text;"
-                    " ALTER TABLE posthog_datamodelingedge DROP COLUMN IF EXISTS dag_id, DROP COLUMN IF EXISTS dag_id_text;",
+                    " ALTER TABLE posthog_datamodelingedge DROP COLUMN IF EXISTS dag_id, DROP COLUMN IF EXISTS dag_id_text;"
+                    " -- drop-column-ignore: staged drop, fields removed from Django state in migration 0018",
                     migrations.RunSQL.noop,
                 ),
             ],

--- a/products/data_modeling/backend/migrations/0019_drop_old_dag_text_columns.py
+++ b/products/data_modeling/backend/migrations/0019_drop_old_dag_text_columns.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_modeling", "0018_switch_constraints_to_dag_fk"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    "ALTER TABLE posthog_datamodelingnode DROP COLUMN IF EXISTS dag_id, DROP COLUMN IF EXISTS dag_id_text;"
+                    " ALTER TABLE posthog_datamodelingedge DROP COLUMN IF EXISTS dag_id, DROP COLUMN IF EXISTS dag_id_text;",
+                    migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/data_modeling/backend/migrations/max_migration.txt
+++ b/products/data_modeling/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0018_switch_constraints_to_dag_fk
+0019_drop_old_dag_text_columns


### PR DESCRIPTION
## Problem

more migrations. drop the old dag id text fields from the db

## Changes

still must not break CI

## How did you test this code?

i didn't

## Publish to changelog?

no
