### PR TITLE
feat: Add ingested timestamp to Azure blob batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -9,7 +9,12 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.batch_exports.service import AzureBlobBatchExportInputs, BatchExportInsertInputs, BatchExportModel
+from posthog.batch_exports.service import (
+    AzureBlobBatchExportInputs,
+    BatchExportField,
+    BatchExportInsertInputs,
+    BatchExportModel,
+)
 from posthog.models.integration import AzureBlobIntegration, Integration
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -101,7 +106,11 @@ async def _get_azure_blob_integration(integration_id: int, team_id: int) -> Azur
     return AzureBlobIntegration(integration)
 
 
-azure_blob_default_fields = events_model_default_fields
+def azure_blob_default_fields() -> list[BatchExportField]:
+    """Azure blob default fields include ingested timestamp."""
+    default_fields = events_model_default_fields()
+    default_fields.append({"expression": "NOW64()", "alias": "azure_blob_ingested_timestamp"})
+    return default_fields
 
 
 class AzureBlobConsumer(Consumer):

--- a/products/batch_exports/backend/tests/temporal/destinations/azure_blob/__init__.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/azure_blob/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+# ensure asserts in the utils module are rewritten by pytest
+# see: https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("products.batch_exports.backend.tests.temporal.destinations.azure_blob.utils")

--- a/products/batch_exports/backend/tests/temporal/destinations/azure_blob/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/azure_blob/utils.py
@@ -64,11 +64,13 @@ def parse_jsonl(data: bytes) -> list[dict]:
     return [json.loads(line) for line in data.decode().strip().split("\n") if line]
 
 
-def normalize_record(record: dict, json_columns: tuple[str, ...]) -> dict:
+def normalize_record(record: dict, json_columns: tuple[str, ...], skip_columns: set[str] | None = None) -> dict:
     """Format datetimes as ISO strings and parse JSON columns."""
     normalized = {}
     for key, value in record.items():
-        if isinstance(value, dt.datetime):
+        if skip_columns and key in skip_columns:
+            continue
+        elif isinstance(value, dt.datetime):
             normalized[key] = value.isoformat()
         elif key in json_columns and value is not None:
             normalized[key] = json.loads(value)
@@ -158,8 +160,16 @@ async def assert_clickhouse_records_in_azure_blob(
         compression=compression,
         json_columns=json_columns,
     )
-
     model_name, fields, filters, extra_query_parameters = extract_model_configuration(batch_export_model)
+
+    if model_name == "events":
+        assert all("azure_blob_ingested_timestamp" in record for record in exported_records), (
+            "Export didn't include ingested timestamp when expected"
+        )
+
+        exported_records = [
+            {k: v for k, v in record.items() if k != "azure_blob_ingested_timestamp"} for record in exported_records
+        ]
 
     expected_records = []
     queue = RecordBatchQueue()
@@ -187,7 +197,9 @@ async def assert_clickhouse_records_in_azure_blob(
         if record_batch is None:
             break
         for record in record_batch.to_pylist():
-            expected_records.append(normalize_record(record, json_columns))
+            expected_records.append(
+                normalize_record(record, json_columns, skip_columns={"azure_blob_ingested_timestamp"})
+            )
 
     assert len(exported_records) > 0, "No records were exported to Azure Blob"
     assert len(expected_records) > 0, "No expected records were produced from Producer"


### PR DESCRIPTION
## Problem

Adds ingestion timestamp to Azure blob exports. I think this should be default moving forward for all new destinations. It's particularly easy for Azure blob as it being a file(blob)-based destination, there are no schema compatibility issues to worry about.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add the field to events model.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I've updated azure blob tests to check for the field. Not the actual value as that's coming from clickhouse.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

It's small, but yeah, we should say "When exporting events to Azure blob using batch exports, a new field will be included with the time of the export".

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
