### PR TITLE
fix(replay): clamp playback position to recording duration

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -202,6 +202,28 @@ describe('sessionRecordingPlayerLogic', () => {
         })
     })
 
+    describe('currentPlayerTime clamping', () => {
+        // Mock recording: start=1682952380877, end=1682952392745, durationMs=11868
+        const START = 1682952380877
+        const DURATION = 11868
+
+        it.each([
+            { description: 'before start', timestamp: START - 1000, expected: 0 },
+            { description: 'at start', timestamp: START, expected: 0 },
+            { description: 'at midpoint', timestamp: START + 5000, expected: 5000 },
+            { description: 'at end', timestamp: START + DURATION, expected: DURATION },
+            { description: 'beyond end', timestamp: START + DURATION + 5000, expected: DURATION },
+        ])('clamps to [$expected] when $description', async ({ timestamp, expected }) => {
+            await expectLogic(logic).toDispatchActions([
+                sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '2' }).actionTypes.loadRecordingMetaSuccess,
+            ])
+
+            logic.actions.setCurrentTimestamp(timestamp)
+
+            expect(logic.values.currentPlayerTime).toBe(expected)
+        })
+    })
+
     describe('loading session core', () => {
         it('loads metadata and snapshots by default', async () => {
             silenceKeaLoadersErrors()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -912,7 +912,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 if (!currentTimestamp || !sessionPlayerData?.start) {
                     return 0
                 }
-                return Math.max(0, currentTimestamp - sessionPlayerData.start.valueOf())
+                const time = currentTimestamp - sessionPlayerData.start.valueOf()
+                return clamp(time, 0, sessionPlayerData.durationMs || Infinity)
             },
         ],
 


### PR DESCRIPTION
## Summary

- Fixes bug where the playback position display can show a time longer than the total recording duration (e.g. "2:15 / 2:10")
- The `currentPlayerTime` selector only floored at 0 but had no upper bound — when the animation loop manually advances the timestamp (rrweb stuck or in gap segments), it can push past the recording end
- Clamps `currentPlayerTime` to `[0, durationMs]` at the selector level, which is the single source of truth for both the time display and seekbar position

## Test plan

- [ ] Play a recording to the end and verify the time display never exceeds the total duration
- [ ] Scrub to the end of a recording and verify the position stays within bounds
- [ ] Play a recording with gap segments and verify time display stays correct
- [ ] Verify normal playback and seeking still work as expected