### PR TITLE
fix: Properly handle SRV hostname resolution for Mongo source

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
 import certifi
+import dns.resolver
 from bson import ObjectId
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymongo import MongoClient
@@ -184,6 +185,17 @@ def _parse_connection_string(connection_string: str) -> dict[str, Any]:
         "connection_string": connection_string,
         "is_srv": parsed.scheme == "mongodb+srv",
     }
+
+
+def _resolve_srv_hosts(hostname: str) -> list[str]:
+    """Resolve MongoDB SRV DNS records to get actual server hostnames.
+
+    SRV hostnames (used by mongodb+srv://) don't have A/AAAA records,
+    so we need to resolve the SRV records first to get the real hosts
+    for SSRF validation.
+    """
+    answers = dns.resolver.resolve(f"_mongodb._tcp.{hostname}", "SRV")
+    return [str(rdata.target).rstrip(".") for rdata in answers]
 
 
 def _get_schema_from_query(collection: Collection) -> list[tuple[str, str]]:

--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import contextlib
 import collections
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
@@ -12,6 +12,7 @@ from bson import ObjectId
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymongo import MongoClient
 from pymongo.collection import Collection
+from pymongo.server_description import ServerDescription
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
@@ -99,14 +100,14 @@ def _build_query(
     return query
 
 
-def _make_safe_server_selector(team_id: int):
+def _make_safe_server_selector(team_id: int) -> Callable[[list[ServerDescription]], list[ServerDescription]]:
     """Create a PyMongo server_selector that rejects servers resolving to internal IPs.
 
     Runs on every topology update (including SRV re-resolution), preventing
     TOCTOU attacks where DNS records change after initial validation.
     """
 
-    def selector(server_descriptions):
+    def selector(server_descriptions: list[ServerDescription]) -> list[ServerDescription]:
         safe = []
         for server in server_descriptions:
             host = server.address[0]

--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -8,7 +8,6 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
 import certifi
-import dns.resolver
 from bson import ObjectId
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymongo import MongoClient
@@ -20,6 +19,7 @@ from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES
+from posthog.temporal.data_imports.sources.common.mixins import _is_host_safe
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
@@ -99,11 +99,34 @@ def _build_query(
     return query
 
 
+def _make_safe_server_selector(team_id: int):
+    """Create a PyMongo server_selector that rejects servers resolving to internal IPs.
+
+    Runs on every topology update (including SRV re-resolution), preventing
+    TOCTOU attacks where DNS records change after initial validation.
+    """
+
+    def selector(server_descriptions):
+        safe = []
+        for server in server_descriptions:
+            host = server.address[0]
+            is_safe, _ = _is_host_safe(host, team_id)
+            if is_safe:
+                safe.append(server)
+        return safe
+
+    return selector
+
+
 @contextlib.contextmanager
-def mongo_client(connection_string: str) -> Iterator[MongoClient]:
-    client: MongoClient = MongoClient(
-        connection_string, serverSelectionTimeoutMS=10000, tls=True, tlsCAFile=certifi.where()
-    )
+def mongo_client(connection_string: str, team_id: int) -> Iterator[MongoClient]:
+    kwargs: dict[str, Any] = {
+        "serverSelectionTimeoutMS": 10000,
+        "tls": True,
+        "tlsCAFile": certifi.where(),
+        "server_selector": _make_safe_server_selector(team_id),
+    }
+    client: MongoClient = MongoClient(connection_string, **kwargs)
     try:
         yield client
     finally:
@@ -187,17 +210,6 @@ def _parse_connection_string(connection_string: str) -> dict[str, Any]:
     }
 
 
-def _resolve_srv_hosts(hostname: str) -> list[str]:
-    """Resolve MongoDB SRV DNS records to get actual server hostnames.
-
-    SRV hostnames (used by mongodb+srv://) don't have A/AAAA records,
-    so we need to resolve the SRV records first to get the real hosts
-    for SSRF validation.
-    """
-    answers = dns.resolver.resolve(f"_mongodb._tcp.{hostname}", "SRV")
-    return [str(rdata.target).rstrip(".") for rdata in answers]
-
-
 def _get_schema_from_query(collection: Collection) -> list[tuple[str, str]]:
     """Infer schema from MongoDB collection using aggregation to get document keys and types."""
     try:
@@ -278,12 +290,12 @@ def _determine_field_type_from_bson_types(bson_types: list[str]) -> str:
     return "string"
 
 
-def get_schemas(config: MongoDBSourceConfig) -> dict[str, list[tuple[str, str]]]:
+def get_schemas(config: MongoDBSourceConfig, team_id: int) -> dict[str, list[tuple[str, str]]]:
     """Get all collections from MongoDB source database to sync."""
 
     connection_params = _parse_connection_string(config.connection_string)
 
-    with mongo_client(config.connection_string) as client:
+    with mongo_client(config.connection_string, team_id=team_id) as client:
         if not connection_params["database"]:
             raise ValueError("Database name is required in connection string")
 
@@ -306,9 +318,9 @@ def get_schemas(config: MongoDBSourceConfig) -> dict[str, list[tuple[str, str]]]
     return schema_list
 
 
-def get_collection_names(config: MongoDBSourceConfig) -> list[str]:
+def get_collection_names(config: MongoDBSourceConfig, team_id: int) -> list[str]:
     connection_params = _parse_connection_string(config.connection_string)
-    with mongo_client(config.connection_string) as client:
+    with mongo_client(config.connection_string, team_id=team_id) as client:
         if not connection_params["database"]:
             raise ValueError("Database name is required in connection string")
         db = client[connection_params["database"]]
@@ -335,6 +347,7 @@ def mongo_source(
     connection_string: str,
     collection_name: str,
     logger: FilteringBoundLogger,
+    team_id: int,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Optional[Any],
     incremental_field: Optional[str] = None,
@@ -346,7 +359,7 @@ def mongo_source(
         raise ValueError("Database name is required in connection string")
 
     # Create MongoDB client
-    with mongo_client(connection_string) as client:
+    with mongo_client(connection_string, team_id=team_id) as client:
         db = client[connection_params["database"]]
         collection = db[collection_name]
 
@@ -366,7 +379,7 @@ def mongo_source(
 
     def get_rows() -> Iterator[dict[str, Any]]:
         # New connection for data reading
-        with mongo_client(connection_string) as read_client:
+        with mongo_client(connection_string, team_id=team_id) as read_client:
             read_db = read_client[connection_params["database"]]
             read_collection = read_db[collection_name]
 

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -16,7 +16,6 @@ from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from posthog.temporal.data_imports.sources.mongodb.mongo import (
     _parse_connection_string,
-    _resolve_srv_hosts,
     filter_mongo_incremental_fields,
     get_collection_names,
     get_schemas as get_mongo_schemas,
@@ -37,10 +36,10 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return {"The DNS query name does not exist": None, "authentication failed": None, "SSL handshake failed": None}
 
     def get_schemas(self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        mongo_schemas = get_mongo_schemas(config)
+        mongo_schemas = get_mongo_schemas(config, team_id=team_id)
 
         connection_params = _parse_connection_string(config.connection_string)
-        with mongo_client(config.connection_string) as client:
+        with mongo_client(config.connection_string, team_id=team_id) as client:
             db = client[connection_params["database"]]
             filtered_results = [
                 (collection_name, filter_mongo_incremental_fields(columns, db[collection_name]))
@@ -78,24 +77,18 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         if not connection_params.get("database"):
             return False, "Database name is required in connection string"
 
-        if connection_params["is_srv"]:
-            try:
-                srv_hosts = _resolve_srv_hosts(connection_params["host"])
-            except Exception:
-                return False, "Host could not be resolved"
-            if not srv_hosts:
-                return False, "Host could not be resolved"
-            for srv_host in srv_hosts:
-                valid_host, host_errors = self.is_database_host_valid(srv_host, team_id)
-                if not valid_host:
-                    return False, host_errors
-        else:
+        if not connection_params["is_srv"]:
+            # For SRV connections the hostname is a DNS namespace (e.g.
+            # cluster0.mongodb.net), not a real host. Actual server addresses
+            # are resolved at connection time and validated by
+            # _make_safe_server_selector instead.
+            # This check allows an early failure for obviously invalid connection strings for non SRV connections.
             valid_host, host_errors = self.is_database_host_valid(connection_params["host"], team_id)
             if not valid_host:
                 return False, host_errors
 
         try:
-            collection_names = get_collection_names(config)
+            collection_names = get_collection_names(config, team_id=team_id)
             if len(collection_names) == 0:
                 return False, "No collections found in database"
         except OperationFailure as e:
@@ -116,6 +109,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             incremental_field=inputs.incremental_field,
             incremental_field_type=inputs.incremental_field_type,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value,
+            team_id=inputs.team_id,
         )
 
     @property

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -16,6 +16,7 @@ from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from posthog.temporal.data_imports.sources.mongodb.mongo import (
     _parse_connection_string,
+    _resolve_srv_hosts,
     filter_mongo_incremental_fields,
     get_collection_names,
     get_schemas as get_mongo_schemas,
@@ -77,9 +78,21 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         if not connection_params.get("database"):
             return False, "Database name is required in connection string"
 
-        valid_host, host_errors = self.is_database_host_valid(connection_params["host"], team_id)
-        if not valid_host:
-            return False, host_errors
+        if connection_params["is_srv"]:
+            try:
+                srv_hosts = _resolve_srv_hosts(connection_params["host"])
+            except Exception:
+                return False, "Host could not be resolved"
+            if not srv_hosts:
+                return False, "Host could not be resolved"
+            for srv_host in srv_hosts:
+                valid_host, host_errors = self.is_database_host_valid(srv_host, team_id)
+                if not valid_host:
+                    return False, host_errors
+        else:
+            valid_host, host_errors = self.is_database_host_valid(connection_params["host"], team_id)
+            if not valid_host:
+                return False, host_errors
 
         try:
             collection_names = get_collection_names(config)

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+from pymongo.server_description import ServerDescription
+
+from posthog.temporal.data_imports.sources.mongodb.mongo import _make_safe_server_selector
+
+
+class TestSafeServerSelector(SimpleTestCase):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_filters_out_servers_with_internal_ips(self):
+        selector = _make_safe_server_selector(team_id=999)
+        servers = [
+            ServerDescription(("10.0.0.1", 27017)),
+            ServerDescription(("8.8.8.8", 27017)),
+        ]
+
+        result = selector(servers)
+
+        assert len(result) == 1
+        assert result[0].address == ("8.8.8.8", 27017)
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_returns_empty_when_all_servers_internal(self):
+        selector = _make_safe_server_selector(team_id=999)
+        servers = [
+            ServerDescription(("10.0.0.1", 27017)),
+            ServerDescription(("192.168.1.1", 27017)),
+        ]
+
+        result = selector(servers)
+
+        assert result == []
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allows_all_public_servers(self):
+        selector = _make_safe_server_selector(team_id=999)
+        servers = [
+            ServerDescription(("8.8.8.8", 27017)),
+            ServerDescription(("1.1.1.1", 27017)),
+        ]
+
+        result = selector(servers)
+
+        assert len(result) == 2
+
+    @parameterized.expand(
+        [
+            ("loopback", "127.0.0.1"),
+            ("link_local_imds", "169.254.169.254"),
+            ("private_172", "172.16.0.1"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_blocks_various_internal_addresses(self, _name: str, host: str):
+        selector = _make_safe_server_selector(team_id=999)
+        servers = [ServerDescription((host, 27017))]
+
+        result = selector(servers)
+
+        assert result == []
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_whitelisted_team_allows_internal_ips(self):
+        selector = _make_safe_server_selector(team_id=2)
+        servers = [ServerDescription(("10.0.0.1", 27017))]
+
+        result = selector(servers)
+
+        assert len(result) == 1
+
+    @patch("posthog.temporal.data_imports.sources.common.mixins.is_cloud", return_value=False)
+    def test_self_hosted_allows_internal_ips(self, _mock_is_cloud):
+        selector = _make_safe_server_selector(team_id=999)
+        servers = [ServerDescription(("10.0.0.1", 27017))]
+
+        result = selector(servers)
+
+        assert len(result) == 1


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/49108 we added host validation for MongoDB SRV records, but we were checking the SRV namespace hostname, rather than the host the SRV record resolves to. The resolved host is what MongoDB connects to, and could point at internal IPs.

## Changes

Use the Mongo client's `server_selector` callback to check whether the host(s) the SRV record resolves to non-internal hosts.

https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient
https://pymongo.readthedocs.io/en/stable/api/pymongo/server_description.html#pymongo.server_description.ServerDescription

## How did you test this code?

Tested locally with a MongoDB connection string that uses SRV connection (i.e. `mongodb+srv://`), as well as added some unit tests to cover.