### PR TITLE
feat(insights): show insight actions in disabled state for unsaved insights

### DIFF
--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
@@ -20,14 +20,11 @@ export function SceneAddToNotebookDropdownMenu({
     dataAttrKey,
     disabledReasons,
 }: SceneNotebookDropdownMenuProps): JSX.Element {
+    const isDisabled = disabledReasons ? Object.values(disabledReasons).some(Boolean) : false
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <ButtonPrimitive
-                    menuItem
-                    data-attr={`${dataAttrKey}-add-to-dropdown-menu`}
-                    disabledReasons={disabledReasons}
-                >
+            <DropdownMenuTrigger asChild disabled={isDisabled}>
+                <ButtonPrimitive menuItem data-attr={`${dataAttrKey}-add-to-dropdown-menu`}>
                     <IconPlusSmall />
                     Add to notebook
                     <MenuOpenIndicator className="ml-auto" />

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { IconDownload } from '@posthog/icons'
 
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonPrimitive, DisabledReasonsObject } from 'lib/ui/Button/ButtonPrimitives'
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -17,6 +17,7 @@ import { exportsLogic } from '../../ExportButton/exportsLogic'
 import { SubscriptionBaseProps } from '../../Subscriptions/utils'
 
 interface SceneExportDropdownMenuProps extends SubscriptionBaseProps {
+    disabledReasons?: DisabledReasonsObject
     dropdownMenuItems: {
         label?: string
         dataAttr: string
@@ -27,7 +28,10 @@ interface SceneExportDropdownMenuProps extends SubscriptionBaseProps {
     }[]
 }
 
-export function SceneExportDropdownMenu({ dropdownMenuItems }: SceneExportDropdownMenuProps): JSX.Element | null {
+export function SceneExportDropdownMenu({
+    dropdownMenuItems,
+    disabledReasons,
+}: SceneExportDropdownMenuProps): JSX.Element | null {
     const { actions } = exportsLogic
 
     const onExportClick = async (triggerExportProps: TriggerExportProps): Promise<void> => {
@@ -37,7 +41,7 @@ export function SceneExportDropdownMenu({ dropdownMenuItems }: SceneExportDropdo
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <ButtonPrimitive menuItem>
+                <ButtonPrimitive menuItem disabledReasons={disabledReasons}>
                     <IconDownload />
                     Export
                     <MenuOpenIndicator className="ml-auto" />

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
@@ -38,9 +38,11 @@ export function SceneExportDropdownMenu({
         actions.startExport(triggerExportProps)
     }
 
+    const isDisabled = disabledReasons ? Object.values(disabledReasons).some(Boolean) : false
+
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+            <DropdownMenuTrigger asChild disabled={isDisabled}>
                 <ButtonPrimitive menuItem disabledReasons={disabledReasons}>
                     <IconDownload />
                     Export

--- a/frontend/src/lib/components/Scenes/SceneAlertsButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneAlertsButton.tsx
@@ -4,7 +4,7 @@ import { router } from 'kea-router'
 import { IconWarning } from '@posthog/icons'
 
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonPrimitive, DisabledReasonsObject } from 'lib/ui/Button/ButtonPrimitives'
 import { urls } from 'scenes/urls'
 
 import { InsightLogicProps, InsightShortId } from '~/types'
@@ -16,9 +16,11 @@ interface SceneAlertsButtonProps extends SceneDataAttrKeyProps {
     insightId: number
     insightShortId: InsightShortId
     insightLogicProps: InsightLogicProps
+    disabledReasons?: DisabledReasonsObject
 }
 
 export function SceneAlertsButton({
+    disabledReasons,
     dataAttrKey,
     insightId,
     insightShortId,
@@ -34,6 +36,7 @@ export function SceneAlertsButton({
             menuItem
             onClick={() => push(urls.insightAlerts(insightShortId))}
             data-attr={`${dataAttrKey}-alerts-dropdown-menu-item`}
+            disabledReasons={disabledReasons}
         >
             <IconWithCount count={alerts?.length} showZero={false}>
                 <IconWarning />

--- a/frontend/src/lib/components/Scenes/SceneFavorite.tsx
+++ b/frontend/src/lib/components/Scenes/SceneFavorite.tsx
@@ -1,15 +1,16 @@
 import { IconStar, IconStarFilled } from '@posthog/icons'
 
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonPrimitive, DisabledReasonsObject } from 'lib/ui/Button/ButtonPrimitives'
 
 import { SceneDataAttrKeyProps } from './utils'
 
 interface SceneFavoriteProps extends SceneDataAttrKeyProps {
     onClick: () => void
     isFavorited: boolean
+    disabledReasons?: DisabledReasonsObject
 }
 
-export function SceneFavorite({ dataAttrKey, onClick, isFavorited }: SceneFavoriteProps): JSX.Element {
+export function SceneFavorite({ dataAttrKey, onClick, isFavorited, disabledReasons }: SceneFavoriteProps): JSX.Element {
     return (
         <ButtonPrimitive
             menuItem
@@ -17,6 +18,7 @@ export function SceneFavorite({ dataAttrKey, onClick, isFavorited }: SceneFavori
             data-attr={`${dataAttrKey}-favorite-button`}
             tooltip={isFavorited ? 'Unfavorite' : 'Favorite'}
             active={isFavorited}
+            disabledReasons={disabledReasons}
         >
             {isFavorited ? <IconStarFilled className="text-warning" /> : <IconStar />}
             Favorite

--- a/frontend/src/lib/components/Scenes/SceneMetalyticsSummaryButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneMetalyticsSummaryButton.tsx
@@ -12,7 +12,10 @@ import { FlaggedFeature } from '../FlaggedFeature'
 import { metalyticsLogic } from '../Metalytics/metalyticsLogic'
 import { SceneDataAttrKeyProps } from './utils'
 
-export function SceneMetalyticsSummaryButton({ dataAttrKey }: SceneDataAttrKeyProps): JSX.Element | null {
+export function SceneMetalyticsSummaryButton({
+    dataAttrKey,
+    disabledReasons,
+}: SceneDataAttrKeyProps): JSX.Element | null {
     const { instanceId, viewCount, viewCountLoading } = useValues(metalyticsLogic)
     const safeViewCount = viewCount?.views ?? 0
     const safeUniqueUsers = viewCount?.users ?? 0
@@ -29,6 +32,7 @@ export function SceneMetalyticsSummaryButton({ dataAttrKey }: SceneDataAttrKeyPr
                 tooltip={`${safeUniqueUsers} PostHog members have viewed this a total of ${safeViewCount} times. Click to see more.`}
                 menuItem
                 disabled={viewCountLoading}
+                disabledReasons={disabledReasons}
                 data-attr={`${dataAttrKey}-metalytics-summary-button`}
             >
                 {viewCountLoading ? <Spinner textColored /> : <IconPulse />}

--- a/frontend/src/lib/components/Scenes/SceneShareButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneShareButton.tsx
@@ -1,16 +1,17 @@
 import { IconShare } from '@posthog/icons'
 
-import { ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonPrimitive, ButtonPrimitiveProps, DisabledReasonsObject } from 'lib/ui/Button/ButtonPrimitives'
 
 import { SceneDataAttrKeyProps } from './utils'
 
 type SceneShareButtonProps = SceneDataAttrKeyProps & {
     buttonProps?: Omit<ButtonPrimitiveProps, 'children' | 'data-attr'>
+    disabledReasons?: DisabledReasonsObject
 }
 
-export function SceneShareButton({ buttonProps, dataAttrKey }: SceneShareButtonProps): JSX.Element {
+export function SceneShareButton({ buttonProps, dataAttrKey, disabledReasons }: SceneShareButtonProps): JSX.Element {
     return (
-        <ButtonPrimitive {...buttonProps} data-attr={`${dataAttrKey}-share-button`}>
+        <ButtonPrimitive {...buttonProps} data-attr={`${dataAttrKey}-share-button`} disabledReasons={disabledReasons}>
             <IconShare />
             Share or embed
         </ButtonPrimitive>

--- a/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
@@ -15,7 +15,12 @@ interface SceneSubscribeButtonProps extends SubscriptionBaseProps, SceneDataAttr
     dashboardId?: number
 }
 
-export function SceneSubscribeButton({ dataAttrKey, insight, dashboardId }: SceneSubscribeButtonProps): JSX.Element {
+export function SceneSubscribeButton({
+    dataAttrKey,
+    insight,
+    dashboardId,
+    disabledReasons,
+}: SceneSubscribeButtonProps): JSX.Element {
     const { push } = useActions(router)
 
     return (
@@ -23,6 +28,7 @@ export function SceneSubscribeButton({ dataAttrKey, insight, dashboardId }: Scen
             menuItem
             onClick={() => push(urlForSubscriptions({ insightShortId: insight?.short_id, dashboardId }))}
             data-attr={`${dataAttrKey}-subscribe-dropdown-menu-item`}
+            disabledReasons={disabledReasons}
         >
             <IconBell />
             Subscribe

--- a/frontend/src/lib/components/Scenes/utils.tsx
+++ b/frontend/src/lib/components/Scenes/utils.tsx
@@ -1,6 +1,6 @@
 import { IconCheck, IconLoading, IconX } from '@posthog/icons'
 
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { ButtonPrimitive, DisabledReasonsObject } from 'lib/ui/Button/ButtonPrimitives'
 import { SelectPrimitiveItemProps } from 'lib/ui/SelectPrimitive/SelectPrimitive'
 
 export type SceneCanEditProps = {
@@ -13,6 +13,7 @@ export type SceneLoadingProps = {
 
 export type SceneDataAttrKeyProps = {
     dataAttrKey: string
+    disabledReasons?: DisabledReasonsObject
 }
 
 export type SceneNameProps = {

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCode2, IconPencil, IconPeople, IconShare } from '@posthog/icons'
+import { IconCode2, IconPencil, IconPeople } from '@posthog/icons'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { SceneAddToDashboardButton } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToDashboardButton'
@@ -19,7 +19,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 
 import { ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
@@ -29,7 +28,7 @@ import { ExporterFormat, InsightLogicProps, InsightShortId, QueryBasedInsightMod
 import { endpointLogic } from 'products/endpoints/frontend/endpointLogic'
 
 import { insightModalsLogic } from '../insightModalsLogic'
-import { openSaveAsCohortDialog, openShareTemplateDialog } from './insightSidePanelDialogs'
+import { openSaveAsCohortDialog } from './insightSidePanelDialogs'
 
 const RESOURCE_TYPE = 'insight'
 
@@ -44,11 +43,9 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
     const { createStaticCohort } = useActions(exportsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { openCreateFromInsightModal } = useActions(endpointLogic({ tabId: insightProps.tabId || '' }))
-    const { preflight } = useValues(preflightLogic)
     const { push } = useActions(router)
     const { openAddToDashboardModal, openTerraformModal } = useActions(insightModalsLogic(insightLogicProps))
 
-    const siteUrl = preflight?.site_url || window.location.origin
     const isSavedInsight = hasDashboardItemId && !!insight?.id && !!insight?.short_id
     const canExport = exportContext != null && insight.short_id != null
     const canEditInSqlEditor =
@@ -122,11 +119,6 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                         : undefined
                 }
             />
-
-            <ButtonPrimitive onClick={() => openShareTemplateDialog(query, siteUrl)} menuItem>
-                <IconShare />
-                Share as template
-            </ButtonPrimitive>
 
             {canExport ? (
                 <SceneExportDropdownMenu

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -67,44 +67,66 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                 dataAttrKey={RESOURCE_TYPE}
                 onClick={() => setInsightMetadata({ favorited: !insight.favorited })}
                 isFavorited={insight.favorited ?? false}
+                disabledReasons={
+                    !isSavedInsight ? { 'You must save the insight first before favoriting it': true } : undefined
+                }
             />
 
-            {insight.short_id && (
-                <SceneAddToNotebookDropdownMenu shortId={insight.short_id} dataAttrKey={RESOURCE_TYPE} />
-            )}
+            <SceneAddToNotebookDropdownMenu
+                shortId={insight.short_id}
+                dataAttrKey={RESOURCE_TYPE}
+                disabledReasons={
+                    !isSavedInsight
+                        ? { 'You must save the insight first before adding it to a notebook': true }
+                        : undefined
+                }
+            />
 
             <SceneAddToDashboardButton
                 dashboard={isSavedInsight ? { onClick: openAddToDashboardModal } : undefined}
                 dataAttrKey={RESOURCE_TYPE}
+                disabledReasons={
+                    !isSavedInsight
+                        ? { 'You must save the insight first before adding it to a dashboard': true }
+                        : undefined
+                }
             />
 
-            {isSavedInsight && <SceneSubscribeButton insight={insight} dataAttrKey={RESOURCE_TYPE} />}
+            <SceneSubscribeButton
+                insight={insight}
+                dataAttrKey={RESOURCE_TYPE}
+                disabledReasons={
+                    !isSavedInsight ? { 'You must save the insight first before subscribing to it': true } : undefined
+                }
+            />
 
-            {isSavedInsight && (
-                <SceneAlertsButton
-                    insightId={insight.id!}
-                    insightShortId={insight.short_id as InsightShortId}
-                    insightLogicProps={insightLogicProps}
-                    dataAttrKey={RESOURCE_TYPE}
-                />
-            )}
+            <SceneAlertsButton
+                insightId={insight.id!}
+                insightShortId={insight.short_id as InsightShortId}
+                insightLogicProps={insightLogicProps}
+                dataAttrKey={RESOURCE_TYPE}
+                disabledReasons={
+                    !isSavedInsight ? { 'You must save the insight first before adding alerts to it': true } : undefined
+                }
+            />
 
-            {isSavedInsight && (
-                <SceneShareButton
-                    buttonProps={{
-                        menuItem: true,
-                        onClick: () => push(urls.insightSharing(insight.short_id!)),
-                    }}
-                    dataAttrKey={RESOURCE_TYPE}
-                />
-            )}
+            <SceneShareButton
+                buttonProps={{
+                    menuItem: true,
+                    onClick: () => push(urls.insightSharing(insight.short_id!)),
+                }}
+                dataAttrKey={RESOURCE_TYPE}
+                disabledReasons={
+                    !isSavedInsight
+                        ? { 'You must save the insight first before sharing it as a template': true }
+                        : undefined
+                }
+            />
 
-            {!insight.short_id && (
-                <ButtonPrimitive onClick={() => openShareTemplateDialog(query, siteUrl)} menuItem>
-                    <IconShare />
-                    Share as template...
-                </ButtonPrimitive>
-            )}
+            <ButtonPrimitive onClick={() => openShareTemplateDialog(query, siteUrl)} menuItem>
+                <IconShare />
+                Share as template
+            </ButtonPrimitive>
 
             {canExport ? (
                 <SceneExportDropdownMenu
@@ -134,8 +156,16 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                 Manage with Terraform
             </ButtonPrimitive>
 
-            {isSavedInsight && featureFlags[FEATURE_FLAGS.ENDPOINTS] ? (
-                <ButtonPrimitive onClick={openCreateFromInsightModal} menuItem>
+            {featureFlags[FEATURE_FLAGS.ENDPOINTS] ? (
+                <ButtonPrimitive
+                    onClick={openCreateFromInsightModal}
+                    menuItem
+                    disabledReasons={
+                        !isSavedInsight
+                            ? { 'You must save the insight first before creating an endpoint from it': true }
+                            : undefined
+                    }
+                >
                     <IconCode2 />
                     Create endpoint
                 </ButtonPrimitive>

--- a/frontend/src/scenes/insights/SidePanel/insightSidePanelDialogs.tsx
+++ b/frontend/src/scenes/insights/SidePanel/insightSidePanelDialogs.tsx
@@ -1,49 +1,10 @@
-import { IconInfo } from '@posthog/icons'
-
-import {
-    TEMPLATE_LINK_HEADING,
-    TEMPLATE_LINK_PII_WARNING,
-    TEMPLATE_LINK_TOOLTIP,
-} from 'lib/components/Sharing/templateLinkMessages'
-import { TemplateLinkSection } from 'lib/components/Sharing/TemplateLinkSection'
-import { TitleWithIcon } from 'lib/components/TitleWithIcon'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { getInsightDefinitionUrl } from 'lib/utils/insightLinks'
 
-import { AnyDataNode, Node, NodeKind } from '~/queries/schema/schema-general'
+import { AnyDataNode, NodeKind } from '~/queries/schema/schema-general'
 
 const RESOURCE_TYPE = 'insight'
-
-export function openShareTemplateDialog(query: Node | null, siteUrl: string): void {
-    const templateLink = getInsightDefinitionUrl({ query }, siteUrl)
-    LemonDialog.open({
-        title: (
-            <span className="flex items-center gap-2">
-                <TitleWithIcon
-                    icon={
-                        <Tooltip title={TEMPLATE_LINK_TOOLTIP}>
-                            <IconInfo />
-                        </Tooltip>
-                    }
-                >
-                    <b>{TEMPLATE_LINK_HEADING}</b>
-                </TitleWithIcon>
-            </span>
-        ),
-        content: (
-            <TemplateLinkSection
-                templateLink={templateLink}
-                heading={undefined}
-                piiWarning={TEMPLATE_LINK_PII_WARNING}
-            />
-        ),
-        width: 600,
-        primaryButton: { children: 'Close', type: 'secondary' },
-    })
-}
 
 export function openSaveAsCohortDialog(
     createStaticCohort: (name: string, query: AnyDataNode) => void,


### PR DESCRIPTION
## Problem

When looking at insight actions, certain actions are only visible when the insight has been saved.

This can be confusing for a user if they expect to see actions such as alerts, or exporting, and its not visible at all in the temporary insight state. It only becomes visible once the insight is saved.

## Changes

Makes all the actions available but in a disabled state if the short id was missing.


Before:
<img width="1520" height="498" alt="image" src="https://github.com/user-attachments/assets/dff1ee1b-0a67-4c11-9352-40cf08d21bf7" />

After:
<img width="1246" height="701" alt="image" src="https://github.com/user-attachments/assets/22b8a845-8b05-475a-8d5d-3e5ca5aa5d0e" />
<img width="571" height="491" alt="image" src="https://github.com/user-attachments/assets/81650497-fed3-4690-a103-0cbdcbe6627f" />
<img width="562" height="276" alt="image" src="https://github.com/user-attachments/assets/ff7df96d-36e6-455e-8eb4-a9f67dfa47d4" />
<img width="423" height="193" alt="image" src="https://github.com/user-attachments/assets/7ce2524e-4d9a-4883-8434-646a4476658f" />


## How did you test this code?

Locally.
