### PR TITLE
fix(devex): Passthrough env vars when running start/start-vite via turbo

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -8,5 +8,8 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
+# Auto-accept corepack download prompts (hangs in non-interactive contexts)
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start-vite

--- a/bin/start-frontend-vite
+++ b/bin/start-frontend-vite
@@ -8,5 +8,8 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
+# Auto-accept corepack download prompts (hangs in non-interactive contexts)
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start-vite

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,14 @@
             "inputs": ["src", "Cargo.toml", "!**/*.pyc"],
             "outputs": ["dist", "index.node", ".turbo"],
             "env": ["RUST_VERSION", "SHARD_INDEX", "SHARD_COUNT"],
-            "passThroughEnv": ["RUSTUP_HOME", "CARGO_HOME", "DATABASE_URL", "REDIS_URL", "NODE_OPTIONS"]
+            "passThroughEnv": [
+                "RUSTUP_HOME",
+                "CARGO_HOME",
+                "DATABASE_URL",
+                "REDIS_URL",
+                "NODE_OPTIONS",
+                "SSL_CERT_FILE"
+            ]
         },
         "test": {
             "dependsOn": ["^build"],
@@ -44,13 +51,13 @@
             "dependsOn": ["^build"],
             "persistent": true,
             "cache": false,
-            "passThroughEnv": ["SKIP_TYPEGEN"]
+            "passThroughEnv": ["SKIP_TYPEGEN", "COREPACK_ENABLE_DOWNLOAD_PROMPT", "SSL_CERT_FILE"]
         },
         "start-vite": {
             "dependsOn": ["^build"],
             "persistent": true,
             "cache": false,
-            "passThroughEnv": ["SKIP_TYPEGEN"]
+            "passThroughEnv": ["SKIP_TYPEGEN", "COREPACK_ENABLE_DOWNLOAD_PROMPT", "SSL_CERT_FILE"]
         },
         "dev": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The no-interaction first-time setup with `hogli` fails when trying to run the frontend since it requires the user to accept corepack installing `pnpm` globally.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* Set `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to auto-accept installing `pnpm`
* Pass through `COREPACK_ENABLE_DOWNLOAD_PROMPT` and `SSL_CERT_FILE`  in turbo (avoids strict mode)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Ran `corepack cache clean` to remove the cached/downloaded version of `pnpm` and tried both `hogli start` and `bin/turbo run start-vite --filter=@posthog/frontend` until they both worked (ie downloaded `pnpm`).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no