### PR TITLE
Add postHogQuery async function for HogQL queries

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -27,6 +27,8 @@ import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import { capitalizeFirstLetter, objectsEqual, uuid } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
+import { HogQLQueryEditor } from '~/queries/nodes/HogQLQuery/HogQLQueryEditor'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { CyclotronJobInputSchemaType, CyclotronJobInputType, CyclotronJobInvocationGlobalsWithInputs } from '~/types'
 
 import { EmailTemplater } from '../../../scenes/hog-functions/email-templater/EmailTemplater'
@@ -473,6 +475,17 @@ function CyclotronJobInputRenderer({
                     value={input.value}
                     onChange={onValueChange}
                     sampleGlobalsWithInputs={sampleGlobalsWithInputs}
+                />
+            )
+        case 'hogql':
+            return (
+                <HogQLQueryEditor
+                    query={{ kind: NodeKind.HogQLQuery, query: input.value ?? '' }}
+                    onChange={(query) => onChange?.({ ...input, value: query })}
+                    embedded
+                    editorFooter={(hasErrors, error) =>
+                        hasErrors && error ? <div className="text-danger text-sm p-1">{error}</div> : <></>
+                    }
                 />
             )
         default:

--- a/nodejs/src/cdp/async-functions/index.ts
+++ b/nodejs/src/cdp/async-functions/index.ts
@@ -1,3 +1,4 @@
 import './conversations'
 import './fetch-handler'
+import './posthog-query'
 import './send-email'

--- a/nodejs/src/cdp/async-functions/posthog-query.test.ts
+++ b/nodejs/src/cdp/async-functions/posthog-query.test.ts
@@ -1,0 +1,151 @@
+import { DateTime } from 'luxon'
+
+import { getAsyncFunctionHandler } from '../async-function-registry'
+import { AsyncFunctionContext } from '../async-function-registry'
+import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, MinimalLogEntry } from '../types'
+import './posthog-query'
+
+describe('postHogQuery async function', () => {
+    const handler = getAsyncFunctionHandler('postHogQuery')!
+
+    function createMockContext(overrides: Partial<AsyncFunctionContext> = {}): AsyncFunctionContext {
+        return {
+            invocation: {
+                teamId: 1,
+            } as any,
+            globals: {} as any,
+            teamManager: {
+                getTeam: jest.fn().mockResolvedValue({ api_token: 'test-token-123' }),
+            } as any,
+            siteUrl: 'https://us.posthog.com',
+            ...overrides,
+        }
+    }
+
+    function createMockResult(): CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> {
+        return {
+            invocation: {
+                queueParameters: null,
+            } as any,
+            finished: false,
+            logs: [],
+            metrics: [],
+            capturedPostHogEvents: [],
+        }
+    }
+
+    it('should be registered', () => {
+        expect(handler).toBeDefined()
+    })
+
+    describe('execute', () => {
+        it('should set up fetch queue parameters for a valid query', async () => {
+            const context = createMockContext()
+            const result = createMockResult()
+
+            await handler.execute([{ query: 'SELECT event FROM events LIMIT 10' }], context, result)
+
+            expect(result.invocation.queueParameters).toEqual({
+                type: 'fetch',
+                url: 'https://us.posthog.com/api/environments/1/query/',
+                method: 'POST',
+                body: JSON.stringify({ query: { kind: 'HogQLQuery', query: 'SELECT event FROM events LIMIT 10' } }),
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer test-token-123',
+                },
+            })
+        })
+
+        it('should throw when query is missing', async () => {
+            const context = createMockContext()
+            const result = createMockResult()
+
+            await expect(handler.execute([{}], context, result)).rejects.toThrow(
+                "[HogFunction] - postHogQuery call missing 'query' property"
+            )
+        })
+
+        it('should throw when query is not a string', async () => {
+            const context = createMockContext()
+            const result = createMockResult()
+
+            await expect(handler.execute([{ query: 123 }], context, result)).rejects.toThrow(
+                "[HogFunction] - postHogQuery call missing 'query' property"
+            )
+        })
+
+        it('should throw when args are undefined', async () => {
+            const context = createMockContext()
+            const result = createMockResult()
+
+            await expect(handler.execute([undefined], context, result)).rejects.toThrow(
+                "[HogFunction] - postHogQuery call missing 'query' property"
+            )
+        })
+
+        it('should throw when team is not found', async () => {
+            const context = createMockContext({
+                teamManager: {
+                    getTeam: jest.fn().mockResolvedValue(null),
+                } as any,
+            })
+            const result = createMockResult()
+
+            await expect(handler.execute([{ query: 'SELECT 1' }], context, result)).rejects.toThrow('Team 1 not found')
+        })
+
+        it('should use the correct team ID in the URL', async () => {
+            const context = createMockContext({
+                invocation: { teamId: 42 } as any,
+            })
+            const result = createMockResult()
+
+            await handler.execute([{ query: 'SELECT 1' }], context, result)
+
+            expect((result.invocation.queueParameters as any).url).toBe(
+                'https://us.posthog.com/api/environments/42/query/'
+            )
+        })
+    })
+
+    describe('mock', () => {
+        it('should return mock query results', () => {
+            const logs: MinimalLogEntry[] = []
+            const result = handler.mock([{ query: 'SELECT event, count() FROM events GROUP BY event' }], logs)
+
+            expect(result).toEqual({
+                status: 200,
+                body: {
+                    columns: ['event', 'count'],
+                    results: [
+                        ['pageview', 1000],
+                        ['$autocapture', 500],
+                        ['$identify', 250],
+                    ],
+                    hasMore: false,
+                    hogql: 'SELECT event, count() FROM events GROUP BY event',
+                },
+            })
+        })
+
+        it('should add log entries', () => {
+            const logs: MinimalLogEntry[] = []
+            handler.mock([{ query: 'SELECT 1' }], logs)
+
+            expect(logs).toHaveLength(2)
+            expect(logs[0].level).toBe('info')
+            expect(logs[0].message).toBe("Async function 'postHogQuery' was mocked with arguments:")
+            expect(logs[1].level).toBe('info')
+            expect(logs[1].message).toContain('postHogQuery(')
+            expect(logs[1].message).toContain('SELECT 1')
+        })
+
+        it('should handle missing query in mock gracefully', () => {
+            const logs: MinimalLogEntry[] = []
+            const result = handler.mock([{}], logs)
+
+            expect(result.body.hogql).toBe('')
+        })
+    })
+})

--- a/nodejs/src/cdp/async-functions/posthog-query.ts
+++ b/nodejs/src/cdp/async-functions/posthog-query.ts
@@ -1,0 +1,59 @@
+import { DateTime } from 'luxon'
+
+import { CyclotronInvocationQueueParametersFetchSchema } from '~/schema/cyclotron'
+
+import { registerAsyncFunction } from '../async-function-registry'
+
+registerAsyncFunction('postHogQuery', {
+    execute: async (args, context, result) => {
+        const [opts] = args as [Record<string, any> | undefined]
+        const query = opts?.query
+
+        if (!query || typeof query !== 'string') {
+            throw new Error("[HogFunction] - postHogQuery call missing 'query' property")
+        }
+
+        const team = await context.teamManager.getTeam(context.invocation.teamId)
+        if (!team) {
+            throw new Error(`Team ${context.invocation.teamId} not found`)
+        }
+
+        result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
+            type: 'fetch',
+            url: `${context.siteUrl}/api/environments/${context.invocation.teamId}/query/`,
+            method: 'POST',
+            body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${team.api_token}`,
+            },
+        })
+    },
+
+    mock: (args, logs) => {
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `Async function 'postHogQuery' was mocked with arguments:`,
+        })
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `postHogQuery(${JSON.stringify(args[0], null, 2)})`,
+        })
+
+        return {
+            status: 200,
+            body: {
+                columns: ['event', 'count'],
+                results: [
+                    ['pageview', 1000],
+                    ['$autocapture', 500],
+                    ['$identify', 250],
+                ],
+                hasMore: false,
+                hogql: args[0]?.query ?? '',
+            },
+        }
+    },
+})

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.test.ts
@@ -1,0 +1,94 @@
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './posthog-query.template'
+
+describe('posthog query template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should invoke the async function with the query', async () => {
+        const response = await tester.invoke({
+            query: 'SELECT event, count() FROM events GROUP BY event',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"query":{"kind":"HogQLQuery","query":"SELECT event, count() FROM events GROUP BY event"}}",
+              "headers": {
+                "Authorization": "Bearer ",
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "http://localhost:8000/api/environments/1/query/",
+            }
+        `)
+    })
+
+    it('should return the response body on success', async () => {
+        const response = await tester.invoke({
+            query: 'SELECT event, count() FROM events GROUP BY event',
+        })
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 200,
+            body: {
+                columns: ['event', 'count'],
+                results: [
+                    ['pageview', 1000],
+                    ['$autocapture', 500],
+                ],
+                hasMore: false,
+            },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+        expect(fetchResponse.execResult).toMatchInlineSnapshot(`
+            {
+              "columns": [
+                "event",
+                "count",
+              ],
+              "hasMore": false,
+              "results": [
+                [
+                  "pageview",
+                  1000,
+                ],
+                [
+                  "$autocapture",
+                  500,
+                ],
+              ],
+            }
+        `)
+    })
+
+    it('should throw an error when query fails', async () => {
+        const response = await tester.invoke({
+            query: 'SELECT invalid FROM events',
+        })
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 400,
+            body: { error: 'Invalid query' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toMatchInlineSnapshot(`"Query failed with status: 400"`)
+    })
+
+    it('should throw an error when query is empty', async () => {
+        const response = await tester.invoke({
+            query: '',
+        })
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toMatchInlineSnapshot(`"Query is required"`)
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.ts
@@ -1,0 +1,38 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'hidden',
+    type: 'destination',
+    id: 'template-posthog-query',
+    name: 'PostHog query',
+    description: 'Run a HogQL query against PostHog data and store the result',
+    icon_url: '/static/posthog-icon.svg',
+    category: ['Custom', 'Analytics'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.query)) {
+  throw Error('Query is required')
+}
+
+let response := postHogQuery({'query': inputs.query})
+
+if (response.status != 200) {
+  throw Error(f'Query failed with status: {response.status}')
+}
+
+return response.body
+`,
+    inputs_schema: [
+        {
+            key: 'query',
+            type: 'hogql',
+            label: 'HogQL query',
+            secret: false,
+            required: true,
+            templating: false,
+            default: 'SELECT event, count() AS count FROM events GROUP BY event ORDER BY count DESC LIMIT 10',
+            description: 'The HogQL query to run against PostHog data.',
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -20,6 +20,7 @@ import { template as posthogGroupIdentifyTemplate } from './_destinations/postho
 import { template as posthogUpdatePersonPropertiesTemplate } from './_destinations/posthog_capture/posthog-update-person-properties.template'
 import { template as posthogGetTicketTemplate } from './_destinations/posthog_conversations/posthog-get-ticket.template'
 import { template as posthogUpdateTicketTemplate } from './_destinations/posthog_conversations/posthog-update-ticket.template'
+import { template as posthogQueryTemplate } from './_destinations/posthog_workflows/posthog-query.template'
 import { template as posthogSetHogflowVariableTemplate } from './_destinations/posthog_workflows/posthog-set-variable.template'
 import { template as redditAdsTemplate } from './_destinations/reddit_ads/reddit.template'
 import { template as snapchatAdsTemplate } from './_destinations/snapchat_ads/snapchat.template'
@@ -64,6 +65,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     posthogGroupIdentifyTemplate,
     posthogUpdatePersonPropertiesTemplate,
     posthogSetHogflowVariableTemplate,
+    posthogQueryTemplate,
     posthogGetTicketTemplate,
     posthogUpdateTicketTemplate,
     hubspotCompanyTemplate,

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -334,6 +334,7 @@ export type HogFunctionInputSchemaType = {
         | 'dictionary'
         | 'choice'
         | 'json'
+        | 'hogql'
         | 'integration'
         | 'integration_field'
         | 'email'

--- a/nodejs/src/schema/cyclotron.ts
+++ b/nodejs/src/schema/cyclotron.ts
@@ -16,6 +16,7 @@ export const CyclotronJobInputSchemaTypeSchema = z.object({
         'dictionary',
         'choice',
         'json',
+        'hogql',
         'integration',
         'integration_field',
         'email',

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/index.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/index.ts
@@ -1,1 +1,2 @@
 import './conversations'
+import './posthog-query'

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/posthog-query.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/posthog-query.ts
@@ -1,0 +1,14 @@
+import { registerActionNodeCategory } from 'products/workflows/frontend/Workflows/hogflows/registry/actions/actionNodeRegistry'
+
+registerActionNodeCategory({
+    label: 'Analytics',
+    nodes: [
+        {
+            type: 'function',
+            name: 'Run query',
+            description: 'Run a HogQL query against PostHog data and store the result.',
+            config: { template_id: 'template-posthog-query', inputs: {} },
+            output_variable: { key: 'query_result', result_path: null, spread: false },
+        },
+    ],
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -65,6 +65,7 @@ export const CyclotronJobInputSchemaTypeSchema = z.object({
         'dictionary',
         'choice',
         'json',
+        'hogql',
         'integration',
         'integration_field',
         'email',


### PR DESCRIPTION
## Problem

Users need a way to execute HogQL queries against PostHog data from within Hog Functions and workflows. This requires a new async function that can be called from Hog code to run queries and retrieve results.

## Changes

Added a new `postHogQuery` async function that enables executing HogQL queries:

- **Async Function Implementation** (`nodejs/src/cdp/async-functions/posthog-query.ts`):
  - Validates query input (required, must be string)
  - Fetches team API token from team manager
  - Sets up a fetch queue parameter to call PostHog's query API endpoint
  - Includes mock implementation for testing/preview

- **Hog Function Template** (`nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.ts`):
  - Provides a user-friendly wrapper around the async function
  - Validates query is not empty
  - Handles error responses from the API
  - Returns query results to the caller

- **Frontend Integration**:
  - Added `HogQLQueryEditor` component support in `CyclotronJobInputRenderer` for `hogql` input type
  - Allows users to write HogQL queries with syntax highlighting and validation

- **Workflow Registry**:
  - Registered the "Run query" action node in the Analytics category
  - Makes the function discoverable in the workflows UI

- **Type Definitions**:
  - Added `'hogql'` to `HogFunctionInputSchemaType` across schema definitions

## How did you test this code?

Added comprehensive test coverage:

- **Unit tests** (`nodejs/src/cdp/async-functions/posthog-query.test.ts`):
  - Validates async function registration
  - Tests successful query execution with correct fetch parameters
  - Tests error handling for missing/invalid queries
  - Tests team lookup and URL construction with different team IDs
  - Tests mock implementation with log output

- **Integration tests** (`nodejs/src/cdp/templates/_destinations/posthog_workflows/posthog-query.template.ts`):
  - Tests template invocation with valid queries
  - Tests successful response handling
  - Tests error handling for failed queries
  - Tests validation of required query input

All tests pass and cover the main execution paths and error cases.

## Publish to changelog?

Yes - this adds a new capability for users to query PostHog data from workflows.

https://claude.ai/code/session_01LFm1gkU1skxJ5qv8pUvizB