### PR TITLE
chore: added spinner to queued messages

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -7,7 +7,7 @@ import posthog from 'posthog-js'
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconArrowRight, IconCheck, IconPencil, IconStopFilled, IconTrash, IconX } from '@posthog/icons'
-import { LemonButton, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, LemonTextArea, Spinner } from '@posthog/lemon-ui'
 
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 import { userLogic } from 'scenes/userLogic'
@@ -158,6 +158,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         threadMessageCount,
         queueingEnabled,
         queuedMessages,
+        queueSubmitting,
     } = useValues(maxThreadLogic)
     const { askMax, stopGeneration, completeThreadGeneration, setSupportOverrideEnabled, updateQueuedMessage } =
         useActions(maxThreadLogic)
@@ -223,9 +224,12 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             Research mode is a free beta feature with lower daily limits
                         </div>
                     )}
-                    {queueingEnabled && queuedMessages.length > 0 && (
+                    {queueingEnabled && (queuedMessages.length > 0 || queueSubmitting) && (
                         <div className="px-3 py-2">
-                            <div className="text-xs text-muted mb-1.5">Up next</div>
+                            <div className="text-xs text-muted mb-1.5 flex items-center gap-1.5">
+                                Up next
+                                {queueSubmitting && <Spinner size="small" />}
+                            </div>
                             <div className="space-y-1.5">
                                 {displayQueuedMessages.map((message) => (
                                     <QueuedMessageItem

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -54,7 +54,6 @@ import {
     SubagentUpdateEvent,
     TaskExecutionStatus,
 } from '~/queries/schema/schema-assistant-messages'
-import { SidePanelTab } from '~/types'
 import {
     Conversation,
     ConversationDetail,
@@ -62,6 +61,7 @@ import {
     ConversationStatus,
     ConversationType,
     PendingApproval,
+    SidePanelTab,
 } from '~/types'
 
 import { MODE_DEFINITIONS, ToolRegistration } from './max-constants'
@@ -335,6 +335,14 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             {
                 loadQueueDataSuccess: (_, { queueData }) => queueData.limit,
                 setQueueLimit: (_, { limit }) => limit,
+            },
+        ],
+
+        queueSubmitting: [
+            false,
+            {
+                enqueueQueuedMessage: () => true,
+                setQueuedMessages: () => false,
             },
         ],
 
@@ -765,6 +773,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                actions.setQueuedMessages(values.queuedMessages)
                 if (error instanceof ApiError && error.status === 409) {
                     lemonToast.error('You can only queue two messages at a time.')
                     return


### PR DESCRIPTION
## Problem

If the queue API took too long to respond, the user was left without a signal that their queued message was received.

## Changes

Added a loading indicator to inform the user that their message was received and is being processed.

The ideal change would be to optimistically add the message and remove it after it's received, but that opens a can of worms that I decided to avoid for now.

## How did you test this code?

Tested in local env

## Publish to changelog?

No