### PR TITLE
feat(llma): add PostHog AI LLM analytics mode with Hog eval tool

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,7 +2,7 @@
 # Dockerfile.node - nodejs Only
 #
 # This Dockerfile builds only the nodejs (Node.js app) without Django, frontend, or other PostHog components.
-# Use this for running standalone nodejs instances.
+# Use this for running standalone Node.js plugin server instances.
 #
 
 #

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -307,7 +307,7 @@ class AssistantContextManager(AssistantContextMixin):
             hog_reference = f"\n{HOG_EVALUATION_REFERENCE}" if has_hog_eval else ""
 
             evaluations_context = (
-                f"<evaluations_context>The user is editing the following LLM evaluation:\n"
+                f"<evaluations_context>The user is editing the following LLM evaluation(s):\n"
                 f"{chr(10).join(eval_details)}"
                 f"{hog_reference}\n"
                 f"</evaluations_context>"

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -43,6 +43,7 @@ from .prompts import (
     CONTEXT_MODE_PROMPT,
     CONTEXT_MODE_SWITCH_PROMPT,
     CONTEXTUAL_TOOLS_REMINDER_PROMPT,
+    HOG_EVALUATION_REFERENCE,
     ROOT_DASHBOARD_CONTEXT_PROMPT,
     ROOT_DASHBOARDS_CONTEXT_PROMPT,
     ROOT_INSIGHT_CONTEXT_PROMPT,
@@ -288,6 +289,30 @@ class AssistantContextManager(AssistantContextMixin):
                     .to_string()
                 )
 
+        # Format evaluations context
+        evaluations_context = ""
+        if ui_context.evaluations:
+            eval_details = []
+            for evaluation in ui_context.evaluations:
+                name = evaluation.name or f"Evaluation {evaluation.id}"
+                lines = [f"- Name: {name}"]
+                if evaluation.description:
+                    lines.append(f"  Description: {evaluation.description}")
+                lines.append(f"  Type: {evaluation.evaluation_type}")
+                if evaluation.hog_source:
+                    lines.append(f"  Current Hog source:\n```hog\n{evaluation.hog_source}\n```")
+                eval_details.append("\n".join(lines))
+
+            has_hog_eval = any(e.evaluation_type == "hog" for e in ui_context.evaluations)
+            hog_reference = f"\n{HOG_EVALUATION_REFERENCE}" if has_hog_eval else ""
+
+            evaluations_context = (
+                f"<evaluations_context>The user is editing the following LLM evaluation:\n"
+                f"{chr(10).join(eval_details)}"
+                f"{hog_reference}\n"
+                f"</evaluations_context>"
+            )
+
         if (
             dashboard_context
             or insights_context
@@ -295,6 +320,7 @@ class AssistantContextManager(AssistantContextMixin):
             or events_context
             or actions_context
             or error_tracking_context
+            or evaluations_context
         ):
             return self._render_user_context_template(
                 dashboard_context,
@@ -303,6 +329,7 @@ class AssistantContextManager(AssistantContextMixin):
                 actions_context,
                 error_tracking_context,
                 notebooks_context,
+                evaluations_context,
             )
         return None
 
@@ -403,6 +430,7 @@ class AssistantContextManager(AssistantContextMixin):
         actions_context: str,
         error_tracking_context: str = "",
         notebooks_context: str = "",
+        evaluations_context: str = "",
     ) -> str:
         """Render the user context template with the provided context strings."""
         template = PromptTemplate.from_template(ROOT_UI_CONTEXT_PROMPT, template_format="mustache")
@@ -413,6 +441,7 @@ class AssistantContextManager(AssistantContextMixin):
             ui_context_events=events_context,
             ui_context_actions=actions_context,
             ui_context_error_tracking=error_tracking_context,
+            ui_context_evaluations=evaluations_context,
         ).to_string()
 
     async def _get_context_messages(self, state: BaseStateWithMessages) -> list[ContextMessage]:

--- a/ee/hogai/context/prompts.py
+++ b/ee/hogai/context/prompts.py
@@ -6,6 +6,7 @@ ROOT_UI_CONTEXT_PROMPT = """
 {{{ui_context_events}}}
 {{{ui_context_actions}}}
 {{{ui_context_error_tracking}}}
+{{{ui_context_evaluations}}}
 </attached_context>
 <system_reminder>
 The user can provide additional context in the <attached_context> tag.
@@ -42,6 +43,99 @@ Contextual tools that are available to you on this page are:
 {tools}
 IMPORTANT: this context may or may not be relevant to your tasks. You should not respond to this context unless it is highly relevant to your task.
 </system_reminder>
+""".strip()
+
+HOG_EVALUATION_REFERENCE = """
+Hog language reference for writing evaluations:
+
+Available globals:
+- `input`: LLM prompt/messages as a string (may be JSON — use `jsonParse(input)` to parse)
+- `output`: LLM response as a string (may be JSON — use `jsonParse(output)` to parse)
+- `properties`: all event properties (e.g. `properties.$ai_model`, `properties.$ai_total_cost_usd`, `properties.$ai_latency`, `properties.$ai_total_tokens`)
+- `event`: object with `uuid`, `event`, `distinct_id` fields
+
+Return type: boolean — `true` (pass) or `false` (fail)
+When "Allow N/A responses" is enabled on the evaluation, `return null` means "not applicable" (the evaluation criteria doesn't apply to this event).
+Use `print('...')` to add reasoning visible in evaluation results.
+
+When generating Hog code, use comments liberally (`//`) to explain what each section does and why.
+Many users are learning Hog for the first time, so the generated code should be educational and easy to follow.
+
+Syntax essentials:
+- Strings use SINGLE quotes: `'hello'` (not double quotes)
+- Assignment: `let x := 1` (use `:=`, not `=`)
+- No ternary operator — use `if/else` blocks
+- Comments: `//`, `--`, or `/* ... */`
+- Define functions: `fun myFunc(a, b) { return a + b }`
+- Lambdas: `let f := (x) -> x + 1`
+- For loops: `for (let i, item in array) { ... }`
+- Arrays/tuples are 1-indexed: `let a := [1,2,3]; print(a[1])` prints 1
+- Objects use single-quoted keys: `let o := {'key': 'value'}`
+- `null` is the null/missing value (used for N/A returns when enabled)
+
+CRITICAL — null handling (properties can be null!):
+- `ifNull(value, default)`: returns default if value is null
+- `coalesce(a, b, c)`: returns first non-null value
+- ALWAYS use `ifNull()` when accessing properties before comparing: `if (ifNull(properties.$ai_latency, 0) > 10)` — without this, comparing null > number throws a runtime error
+
+Standard library — strings:
+- `length(s)`, `empty(s)`, `notEmpty(s)` — length and emptiness checks (NOT `len()`)
+- `lower(s)`, `upper(s)`, `trim(s)`, `reverse(s)`
+- `concat(a, b, ...)` — concatenate strings
+- `substring(s, start, length)` — extract substring (1-indexed)
+- `replaceOne(s, needle, replacement)`, `replaceAll(s, needle, replacement)`
+- `splitByString(sep, s)` — split into array
+- `startsWith(s, prefix)`, `endsWith(s, suffix)`
+- `like`, `ilike`, `not like`, `not ilike` — SQL-style pattern matching (% and _)
+- `=~` (regex match), `!~` (regex not match), `=~*` / `!~*` (case-insensitive)
+- `match(s, pattern)` — regex match function
+
+Standard library — arrays:
+- `length(arr)`, `empty(arr)`
+- `arrayPushBack(arr, item)`, `arrayPushFront(arr, item)`
+- `arrayPopBack(arr)`, `arrayPopFront(arr)`
+- `has(arr, item)` — check if array contains item
+- `arraySort(arr)`, `arrayReverse(arr)`
+- `arrayMap(fn, arr)`, `arrayFilter(fn, arr)` — functional operations
+- `arrayCount(fn, arr)` — count matching elements
+
+Standard library — type & conversion:
+- `toString(x)`, `toInt(x)`, `toFloat(x)`
+- `typeof(x)` — returns 'string', 'integer', 'float', 'boolean', 'array', 'object', 'null'
+- `jsonParse(s)` — parse JSON string to object/array
+- `jsonStringify(x)` — serialize to JSON string
+
+Standard library — other:
+- `ifNull(value, default)`, `coalesce(a, b, ...)`
+- `now()`, `toUnixTimestamp(dt)`, `fromUnixTimestamp(n)`
+- `generateUUIDv4()`
+
+Example patterns for evaluations:
+- Output not empty: `return length(output) > 0`
+- Min length check: `return length(output) >= 100`
+- Keyword matching: loop over keywords array, use `output ilike concat('%', kw, '%')`
+- Cost/latency guard: `ifNull(properties.$ai_total_cost_usd, 0) > threshold`
+- Refusal detection: check for phrases like 'I cannot', 'I\\'m unable' via `ilike`
+- Error detection: split output by newlines, check each line for error patterns
+- Regex safety: use `output =~ 'pattern'` to detect emails, URLs, phone numbers
+- Parse messages: `let msgs := jsonParse(input); for (let i, msg in msgs) { ... }`
+- Conversation length: parse input messages array, check `length(messages) <= max`
+- Input relevance: extract key terms from input, check they appear in output
+
+Example — cost guard with null safety:
+```hog
+let cost := ifNull(properties.$ai_total_cost_usd, 0)
+let latency := ifNull(properties.$ai_latency, 0)
+if (cost > 0.05) {
+    print(concat('Cost $', toString(cost), ' exceeds budget'))
+    return false
+}
+if (latency > 10) {
+    print(concat('Latency ', toString(latency), 's too high'))
+    return false
+}
+return true
+```
 """.strip()
 
 CONTEXT_INITIAL_MODE_PROMPT = "Your initial mode is"

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -14,6 +14,7 @@ from posthog.schema import (
     ContextMessage,
     DashboardFilter,
     EntityType,
+    EvaluationType,
     EventsNode,
     FunnelsQuery,
     HogQLQuery,
@@ -24,6 +25,7 @@ from posthog.schema import (
     MaxBillingContextSubscriptionLevel,
     MaxBillingContextTrial,
     MaxDashboardContext,
+    MaxEvaluationContext,
     MaxEventContext,
     MaxInsightContext,
     MaxUIContext,
@@ -764,3 +766,87 @@ class TestAssistantContextManager(BaseTest):
         self.assertIn("sql", result.content)
         assert isinstance(result.meta, ModeContext)
         self.assertEqual(result.meta.mode, AgentMode.SQL)
+
+    @parameterized.expand(
+        [
+            [
+                "hog evaluation with source",
+                MaxEvaluationContext(
+                    id="eval-1",
+                    name="Check output",
+                    description="Validates output quality",
+                    evaluation_type=EvaluationType.HOG,
+                    hog_source="return length(output) > 0",
+                ),
+                [
+                    "<evaluations_context>",
+                    "Check output",
+                    "Validates output quality",
+                    "Type: hog",
+                    "return length(output) > 0",
+                    "Hog language reference for writing evaluations",
+                ],
+            ],
+            [
+                "llm judge evaluation without source",
+                MaxEvaluationContext(
+                    id="eval-2",
+                    name="LLM Judge Eval",
+                    evaluation_type=EvaluationType.LLM_JUDGE,
+                ),
+                [
+                    "<evaluations_context>",
+                    "LLM Judge Eval",
+                    "Type: llm_judge",
+                ],
+            ],
+            [
+                "evaluation with no name falls back",
+                MaxEvaluationContext(
+                    id="eval-3",
+                    evaluation_type=EvaluationType.HOG,
+                ),
+                ["<evaluations_context>", "Evaluation eval-3", "Type: hog"],
+            ],
+            [
+                "hog reference includes STL and example patterns",
+                MaxEvaluationContext(
+                    id="eval-4",
+                    name="STL test",
+                    evaluation_type=EvaluationType.HOG,
+                ),
+                [
+                    "Standard library — strings:",
+                    "Standard library — arrays:",
+                    "Standard library — type & conversion:",
+                    "arrayPushBack",
+                    "jsonParse",
+                    "splitByString",
+                    "Example patterns for evaluations:",
+                    "Refusal detection",
+                    "Cost/latency guard",
+                ],
+            ],
+        ]
+    )
+    async def test_format_ui_context_with_evaluation(self, _name, evaluation, expected_substrings):
+        ui_context = MaxUIContext(evaluations=[evaluation])
+        result = await self.context_manager._format_ui_context(ui_context)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        for substring in expected_substrings:
+            self.assertIn(substring, result)
+
+    async def test_format_ui_context_evaluation_no_hog_source(self):
+        evaluation = MaxEvaluationContext(
+            id="eval-4",
+            name="No source eval",
+            evaluation_type=EvaluationType.HOG,
+        )
+        ui_context = MaxUIContext(evaluations=[evaluation])
+        result = await self.context_manager._format_ui_context(ui_context)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertNotIn("Current Hog source:", result)

--- a/ee/hogai/core/agent_modes/presets/llm_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/llm_analytics.py
@@ -43,7 +43,34 @@ The assistant used the todo list because:
 3. Breaking this into steps ensures the assistant gets all necessary data before explaining
 """.strip()
 
-LLM_ANALYTICS_MODE_DESCRIPTION = "Specialized mode for analyzing LLM traces. Search and read LLM traces to understand model usage, costs, latency, and errors."
+POSITIVE_EXAMPLE_WRITE_AND_TEST_EVAL = """
+User: Write a Hog eval that checks if the output is longer than 10 characters
+Assistant: I'll write a Hog evaluation and test it against your recent events.
+*Uses run_hog_eval_test with source: 'let result := length(output) > 10; print(concat("Output length: ", toString(length(output)))); return result;'*
+""".strip()
+
+POSITIVE_EXAMPLE_WRITE_AND_TEST_EVAL_REASONING = """
+The assistant used run_hog_eval_test because:
+1. The user wants to create a Hog evaluation that checks output length
+2. The tool compiles and runs the code against real events to verify it works
+3. The results show whether the evaluation logic is correct
+""".strip()
+
+POSITIVE_EXAMPLE_FIX_EVAL_ERRORS = """
+User: The eval is failing with a null error on some events
+Assistant: I'll fix the null handling and test again.
+*Uses run_hog_eval_test with updated source that adds null checks*
+After seeing the results, the assistant explains what was fixed.
+""".strip()
+
+POSITIVE_EXAMPLE_FIX_EVAL_ERRORS_REASONING = """
+The assistant used run_hog_eval_test because:
+1. The user reported errors in the evaluation code
+2. Testing with the tool reveals which events cause null errors
+3. The assistant can iterate on the fix by running the tool again
+""".strip()
+
+LLM_ANALYTICS_MODE_DESCRIPTION = "Specialized mode for LLM analytics. Search and analyze LLM traces for usage, costs, latency, and errors. Write and test Hog evaluation code against real events."
 
 
 class LLMAnalyticsAgentToolkit(AgentToolkit):
@@ -56,12 +83,21 @@ class LLMAnalyticsAgentToolkit(AgentToolkit):
             example=POSITIVE_EXAMPLE_INVESTIGATE_EXPENSIVE,
             reasoning=POSITIVE_EXAMPLE_INVESTIGATE_EXPENSIVE_REASONING,
         ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_WRITE_AND_TEST_EVAL,
+            reasoning=POSITIVE_EXAMPLE_WRITE_AND_TEST_EVAL_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_FIX_EVAL_ERRORS,
+            reasoning=POSITIVE_EXAMPLE_FIX_EVAL_ERRORS_REASONING,
+        ),
     ]
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        tools: list[type[MaxTool]] = [SearchLLMTracesTool]
-        return tools
+        from products.llm_analytics.backend.tools.run_hog_eval_test import RunHogEvalTestTool
+
+        return [SearchLLMTracesTool, RunHogEvalTestTool]
 
 
 llm_analytics_agent = AgentModeDefinition(

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2909,7 +2909,6 @@
                 "upsert_alert",
                 "finalize_plan",
                 "call_mcp_server",
-                "recommend_products",
                 "search_llm_traces",
                 "run_hog_eval_test"
             ],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2909,7 +2909,9 @@
                 "upsert_alert",
                 "finalize_plan",
                 "call_mcp_server",
-                "search_llm_traces"
+                "recommend_products",
+                "search_llm_traces",
+                "run_hog_eval_test"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -493,6 +493,7 @@ export type AssistantTool =
     | 'finalize_plan'
     | 'call_mcp_server'
     | 'search_llm_traces'
+    | 'run_hog_eval_test'
 
 export enum AgentMode {
     ProductAnalytics = 'product_analytics',

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1012,6 +1012,19 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Searching LLM traces...'
         },
     },
+    run_hog_eval_test: {
+        name: 'Test evaluation',
+        description: 'Test evaluation code against sample events',
+        product: Scene.LLMAnalyticsEvaluation,
+        icon: iconForType('llm_evaluations'),
+        modes: [AgentMode.LLMAnalytics],
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Tested evaluation code'
+            }
+            return 'Testing evaluation code...'
+        },
+    },
 }
 
 export const MODE_DEFINITIONS: Record<
@@ -1071,7 +1084,7 @@ export const MODE_DEFINITIONS: Record<
     },
     [AgentMode.LLMAnalytics]: {
         name: 'LLM analytics',
-        description: 'Analyzes LLM traces.',
+        description: 'Analyzes LLM traces and writes evaluation code for LLM analytics.',
         icon: iconForType('llm_analytics'),
         scenes: new Set([
             Scene.LLMAnalytics,

--- a/frontend/src/scenes/max/maxContextConverters.test.ts
+++ b/frontend/src/scenes/max/maxContextConverters.test.ts
@@ -30,6 +30,78 @@ describe('maxContextConverters', () => {
                 },
             },
             {
+                name: 'converts evaluation with all fields',
+                input: {
+                    evaluation: {
+                        id: 'eval-123',
+                        name: 'Check output quality',
+                        description: 'Validates LLM output',
+                        evaluation_type: 'hog' as const,
+                        hog_source: 'return length(output) > 0',
+                    },
+                },
+                expected: {
+                    evaluations: [
+                        {
+                            id: 'eval-123',
+                            name: 'Check output quality',
+                            description: 'Validates LLM output',
+                            evaluation_type: 'hog',
+                            hog_source: 'return length(output) > 0',
+                            type: MaxContextType.EVALUATION,
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'converts evaluation with minimal fields',
+                input: {
+                    evaluation: {
+                        id: 'eval-456',
+                        evaluation_type: 'llm_judge' as const,
+                    },
+                },
+                expected: {
+                    evaluations: [
+                        {
+                            id: 'eval-456',
+                            name: undefined,
+                            description: undefined,
+                            evaluation_type: 'llm_judge',
+                            hog_source: undefined,
+                            type: MaxContextType.EVALUATION,
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'converts both error tracking issue and evaluation',
+                input: {
+                    errorTrackingIssue: { id: 'issue-1', name: 'Error' },
+                    evaluation: {
+                        id: 'eval-1',
+                        name: 'Test eval',
+                        evaluation_type: 'hog' as const,
+                        hog_source: 'return true',
+                    },
+                },
+                expected: {
+                    error_tracking_issues: [
+                        { id: 'issue-1', name: 'Error', type: MaxContextType.ERROR_TRACKING_ISSUE },
+                    ],
+                    evaluations: [
+                        {
+                            id: 'eval-1',
+                            name: 'Test eval',
+                            description: undefined,
+                            evaluation_type: 'hog',
+                            hog_source: 'return true',
+                            type: MaxContextType.EVALUATION,
+                        },
+                    ],
+                },
+            },
+            {
                 name: 'returns empty object for empty context',
                 input: {},
                 expected: {},

--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 
-import { IconBug, IconDashboard, IconGraph, IconNotebook } from '@posthog/icons'
+import { IconBug, IconCheckbox, IconDashboard, IconGraph, IconNotebook } from '@posthog/icons'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { objectsEqual } from 'lib/utils'
@@ -32,6 +32,7 @@ import {
     MaxContextType,
     MaxDashboardContext,
     MaxErrorTrackingIssueContext,
+    MaxEvaluationContext,
     MaxEventContext,
     MaxInsightContext,
     MaxNotebookContext,
@@ -41,6 +42,7 @@ import {
     actionToMaxContextPayload,
     dashboardToMaxContext,
     errorTrackingIssueToMaxContextPayload,
+    evaluationToMaxContextPayload,
     eventToMaxContextPayload,
     insightToMaxContext,
     notebookToMaxContextPayload,
@@ -85,12 +87,20 @@ export const maxContextLogic = kea<maxContextLogicType>([
         addOrUpdateContextAction: (data: ActionType) => ({ data }),
         addOrUpdateContextErrorTrackingIssue: (data: { id: string; name?: string | null }) => ({ data }),
         addOrUpdateContextNotebook: (data: { short_id: string; title?: string | null }) => ({ data }),
+        addOrUpdateContextEvaluation: (data: {
+            id: string
+            name?: string | null
+            description?: string | null
+            evaluation_type: 'hog' | 'llm_judge'
+            hog_source?: string | null
+        }) => ({ data }),
         removeContextInsight: (id: string | number) => ({ id }),
         removeContextDashboard: (id: string | number) => ({ id }),
         removeContextEvent: (id: string | number) => ({ id }),
         removeContextAction: (id: string | number) => ({ id }),
         removeContextErrorTrackingIssue: (id: string) => ({ id }),
         removeContextNotebook: (id: string) => ({ id }),
+        removeContextEvaluation: (id: string) => ({ id }),
         loadAndProcessDashboard: (data: DashboardItemInfo) => ({ data }),
         loadAndProcessInsight: (
             data: InsightItemInfo,
@@ -182,6 +192,28 @@ export const maxContextLogic = kea<maxContextLogicType>([
                     { data }: { data: { short_id: string; title?: string | null } }
                 ) => addOrUpdateEntity(state, notebookToMaxContextPayload(data)),
                 removeContextNotebook: (state: MaxNotebookContext[], { id }: { id: string }) => removeEntity(state, id),
+                resetContext: () => [],
+            },
+        ],
+        contextEvaluations: [
+            [] as MaxEvaluationContext[],
+            {
+                addOrUpdateContextEvaluation: (
+                    state: MaxEvaluationContext[],
+                    {
+                        data,
+                    }: {
+                        data: {
+                            id: string
+                            name?: string | null
+                            description?: string | null
+                            evaluation_type: 'hog' | 'llm_judge'
+                            hog_source?: string | null
+                        }
+                    }
+                ) => addOrUpdateEntity(state, evaluationToMaxContextPayload(data)),
+                removeContextEvaluation: (state: MaxEvaluationContext[], { id }: { id: string }) =>
+                    removeEntity(state, id),
                 resetContext: () => [],
             },
         ],
@@ -500,6 +532,8 @@ export const maxContextLogic = kea<maxContextLogicType>([
                                 return errorTrackingIssueToMaxContextPayload(item.data)
                             case MaxContextType.NOTEBOOK:
                                 return notebookToMaxContextPayload(item.data)
+                            case MaxContextType.EVALUATION:
+                                return evaluationToMaxContextPayload(item.data)
                             default:
                                 return null
                         }
@@ -554,6 +588,14 @@ export const maxContextLogic = kea<maxContextLogicType>([
                             type: MaxContextType.NOTEBOOK,
                             icon: IconNotebook,
                         })
+                    } else if (item.type == MaxContextType.EVALUATION) {
+                        options.push({
+                            id: item.id,
+                            name: item.name || `Evaluation ${item.id}`,
+                            value: item.id,
+                            type: MaxContextType.EVALUATION,
+                            icon: IconCheckbox,
+                        })
                     }
                 })
 
@@ -595,6 +637,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 s.contextActions,
                 s.contextErrorTrackingIssues,
                 s.contextNotebooks,
+                s.contextEvaluations,
                 s.sceneContext,
             ],
             (
@@ -605,6 +648,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 contextActions: MaxActionContext[],
                 contextErrorTrackingIssues: MaxErrorTrackingIssueContext[],
                 contextNotebooks: MaxNotebookContext[],
+                contextEvaluations: MaxEvaluationContext[],
                 sceneContext: MaxContextItem[]
             ): MaxUIContext | null => {
                 const context: MaxUIContext = {}
@@ -700,6 +744,17 @@ export const maxContextLogic = kea<maxContextLogicType>([
                     context.notebooks = Array.from(uniqueNotebooks.values())
                 }
 
+                // Add evaluations (combine manual selections + auto-added from scene context)
+                const sceneEvaluations = sceneContext.filter(
+                    (item): item is MaxEvaluationContext => item.type === MaxContextType.EVALUATION
+                )
+                const allEvaluations = [...contextEvaluations, ...sceneEvaluations]
+                if (allEvaluations.length > 0) {
+                    const uniqueEvaluations = new Map<string, MaxEvaluationContext>()
+                    allEvaluations.forEach((evaluation) => uniqueEvaluations.set(evaluation.id, evaluation))
+                    context.evaluations = Array.from(uniqueEvaluations.values())
+                }
+
                 return hasData ? context : null
             },
         ],
@@ -711,6 +766,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 s.contextActions,
                 s.contextErrorTrackingIssues,
                 s.contextNotebooks,
+                s.contextEvaluations,
                 s.sceneContext,
             ],
             (
@@ -720,6 +776,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 contextActions: MaxActionContext[],
                 contextErrorTrackingIssues: MaxErrorTrackingIssueContext[],
                 contextNotebooks: MaxNotebookContext[],
+                contextEvaluations: MaxEvaluationContext[],
                 sceneContext: MaxContextItem[]
             ): boolean => {
                 return [
@@ -729,6 +786,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                     contextActions,
                     contextErrorTrackingIssues,
                     contextNotebooks,
+                    contextEvaluations,
                     sceneContext,
                 ].some((arr) => arr.length > 0)
             },

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -540,6 +540,7 @@ class AssistantTool(StrEnum):
     FINALIZE_PLAN = "finalize_plan"
     CALL_MCP_SERVER = "call_mcp_server"
     SEARCH_LLM_TRACES = "search_llm_traces"
+    RUN_HOG_EVAL_TEST = "run_hog_eval_test"
 
 
 class AssistantToolCall(BaseModel):

--- a/products/llm_analytics/backend/tools/run_hog_eval_test.py
+++ b/products/llm_analytics/backend/tools/run_hog_eval_test.py
@@ -1,0 +1,173 @@
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from posthog.schema import AssistantTool
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.tool import MaxTool
+
+TOOL_DESCRIPTION = """Test Hog evaluation code against sample events from the last 7 days.
+
+Returns compilation errors if the code is invalid, or pass/fail/error results for each sample event.
+
+The Hog code receives these globals:
+- `input` (string): the LLM input (prompt/messages)
+- `output` (string): the LLM output (completion/response)
+- `properties` (object): all event properties
+- `event` (object): event metadata with `uuid`, `event`, `distinct_id`
+
+The code must return a boolean: `true` for pass, `false` for fail.
+Use `print()` statements to output reasoning.
+"""
+
+
+class RunHogEvalTestArgs(BaseModel):
+    source: str = Field(description="Hog evaluation source code to compile and test")
+    sample_count: int = Field(
+        default=3,
+        ge=1,
+        le=5,
+        description="Number of recent events to test against (1-5)",
+    )
+
+
+class RunHogEvalTestTool(MaxTool):
+    name: str = AssistantTool.RUN_HOG_EVAL_TEST.value
+    description: str = TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = RunHogEvalTestArgs
+
+    def get_required_resource_access(self):
+        return [("llm_analytics", "viewer")]
+
+    async def _arun_impl(self, source: str, sample_count: int = 3) -> tuple[str, Any]:
+        from posthog.cdp.validation import compile_hog
+        from posthog.temporal.llm_analytics.message_utils import extract_text_from_messages
+        from posthog.temporal.llm_analytics.run_evaluation import run_hog_eval
+
+        try:
+            bytecode = compile_hog(source, "destination")
+        except Exception as e:
+            return (f"Compilation error: {e}", None)
+
+        team = self._team
+
+        query = ast.SelectQuery(
+            select=[
+                ast.Field(chain=["uuid"]),
+                ast.Field(chain=["event"]),
+                ast.Field(chain=["properties"]),
+                ast.Field(chain=["distinct_id"]),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(
+                exprs=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.In,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value=["$ai_generation", "$ai_metric"]),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Gt,
+                        left=ast.Field(chain=["timestamp"]),
+                        right=ast.ArithmeticOperation(
+                            op=ast.ArithmeticOperationOp.Sub,
+                            left=ast.Call(name="now", args=[]),
+                            right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=7)]),
+                        ),
+                    ),
+                ]
+            ),
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
+            limit=ast.Constant(value=sample_count),
+        )
+
+        response = await database_sync_to_async(execute_hogql_query)(query=query, team=team, limit_context=None)
+
+        if not response.results:
+            return (
+                "No recent AI events found in the last 7 days. Ingest some $ai_generation or $ai_metric events first.",
+                None,
+            )
+
+        # Parse all events first to collect property keys and build event data
+        parsed_events: list[dict[str, Any]] = []
+        all_property_keys: set[str] = set()
+        for row in response.results:
+            properties = row[2]
+            if isinstance(properties, str):
+                properties = json.loads(properties)
+            all_property_keys.update(properties.keys())
+            parsed_events.append(
+                {
+                    "uuid": str(row[0]),
+                    "event": row[1],
+                    "properties": properties,
+                    "distinct_id": row[3] or "",
+                }
+            )
+
+        # Build a data summary so the LLM understands the event shape
+        ai_keys = sorted(k for k in all_property_keys if k.startswith("$ai_"))
+        other_keys = sorted(k for k in all_property_keys if not k.startswith("$ai_"))
+        lines: list[str] = [
+            f"Sampled {len(parsed_events)} event(s). Available properties on these events:",
+            f"  AI properties: {', '.join(ai_keys) if ai_keys else '(none)'}",
+            f"  Other properties: {', '.join(other_keys[:20])}" + (" ..." if len(other_keys) > 20 else ""),
+        ]
+
+        # Show a sample of key AI property values from the first event for context
+        first_props = parsed_events[0]["properties"]
+        if first_props.get("$ai_model"):
+            lines.append(f"  Sample $ai_model: {first_props['$ai_model']}")
+        if first_props.get("$ai_provider"):
+            lines.append(f"  Sample $ai_provider: {first_props['$ai_provider']}")
+        lines.append("")
+
+        # Run eval against each event
+        for event_data in parsed_events:
+            properties = event_data["properties"]
+            event_type = event_data["event"]
+
+            result = run_hog_eval(bytecode, event_data, allows_na=True)
+
+            if event_type == "$ai_generation":
+                input_raw = properties.get("$ai_input") or properties.get("$ai_input_state", "")
+                output_raw = (
+                    properties.get("$ai_output_choices")
+                    or properties.get("$ai_output")
+                    or properties.get("$ai_output_state", "")
+                )
+            else:
+                input_raw = properties.get("$ai_input_state", "")
+                output_raw = properties.get("$ai_output_state", "")
+
+            input_preview = extract_text_from_messages(input_raw)[:200]
+            output_preview = extract_text_from_messages(output_raw)[:200]
+
+            verdict = result["verdict"]
+            if result["error"]:
+                verdict_str = "ERROR"
+            elif verdict is True:
+                verdict_str = "PASS"
+            elif verdict is False:
+                verdict_str = "FAIL"
+            else:
+                verdict_str = "N/A"
+
+            lines.append(f"Event {event_data['uuid']} ({event_type}):")
+            lines.append(f"  Input:  {input_preview}")
+            lines.append(f"  Output: {output_preview}")
+            lines.append(f"  Result: {verdict_str}")
+            if result["reasoning"]:
+                lines.append(f"  Reasoning: {result['reasoning']}")
+            if result["error"]:
+                lines.append(f"  Error: {result['error']}")
+            lines.append("")
+
+        return ("\n".join(lines), None)

--- a/products/llm_analytics/backend/tools/test_run_hog_eval_test.py
+++ b/products/llm_analytics/backend/tools/test_run_hog_eval_test.py
@@ -1,0 +1,158 @@
+import json
+import uuid
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from parameterized import parameterized
+
+from products.llm_analytics.backend.tools.run_hog_eval_test import RunHogEvalTestTool
+
+
+def _make_event(
+    ai_input=None,
+    ai_output_choices=None,
+    event_type="$ai_generation",
+):
+    if ai_input is None:
+        ai_input = [{"role": "user", "content": "Hello"}]
+    if ai_output_choices is None:
+        ai_output_choices = [{"message": {"role": "assistant", "content": "Hi there!"}}]
+    return [
+        str(uuid.uuid4()),
+        event_type,
+        json.dumps(
+            {
+                "$ai_input": ai_input,
+                "$ai_output_choices": ai_output_choices,
+                "$ai_model": "gpt-4",
+            }
+        ),
+        "test-user",
+    ]
+
+
+def _run_tool(tool, **kwargs):
+    return async_to_sync(tool._arun_impl)(**kwargs)
+
+
+class TestRunHogEvalTestTool(BaseTest):
+    def _make_tool(self):
+        return RunHogEvalTestTool(team=self.team, user=self.user)
+
+    @parameterized.expand(
+        [
+            ("valid_return_true", "return true;", True),
+            ("valid_return_false", "return false;", False),
+            ("with_print", "print('checking'); return true;", True),
+            ("length_check", "return length(output) > 0;", True),
+        ]
+    )
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_compilation_and_execution(self, _name, source, expected_verdict, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = [_make_event()]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source=source, sample_count=1)
+
+        assert artifact is None
+        if expected_verdict:
+            assert "PASS" in result
+        else:
+            assert "FAIL" in result
+
+    def test_compilation_error(self):
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="this is not valid hog {{{{", sample_count=1)
+
+        assert "Compilation error" in result
+        assert artifact is None
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_no_events_found(self, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = []
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return true;", sample_count=3)
+
+        assert "No recent AI events" in result
+        assert artifact is None
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_runtime_error_handling(self, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = [_make_event()]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return properties.nonexistent.nested;", sample_count=1)
+
+        assert artifact is None
+        assert "Event" in result
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_result_formatting_includes_previews(self, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = [
+            _make_event(
+                ai_input=[{"role": "user", "content": "What is PostHog?"}],
+                ai_output_choices=[{"message": {"role": "assistant", "content": "PostHog is analytics."}}],
+            )
+        ]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return true;", sample_count=1)
+
+        assert "Input:" in result
+        assert "Output:" in result
+        assert "Result: PASS" in result
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_null_return_shows_na(self, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = [_make_event()]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return null;", sample_count=1)
+
+        assert artifact is None
+        assert "N/A" in result
+        assert "ERROR" not in result
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_runtime_error_shows_error_not_na(self, mock_query):
+        mock_response = MagicMock()
+        mock_response.results = [_make_event()]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return 42;", sample_count=1)
+
+        assert artifact is None
+        assert "Result: ERROR" in result
+        assert "Result: N/A" not in result
+
+    @patch("products.llm_analytics.backend.tools.run_hog_eval_test.execute_hogql_query")
+    def test_ai_metric_event_type(self, mock_query):
+        mock_response = MagicMock()
+        event_row = [
+            str(uuid.uuid4()),
+            "$ai_metric",
+            json.dumps({"$ai_input_state": "some input", "$ai_output_state": "some output"}),
+            "test-user",
+        ]
+        mock_response.results = [event_row]
+        mock_query.return_value = mock_response
+
+        tool = self._make_tool()
+        result, artifact = _run_tool(tool, source="return true;", sample_count=1)
+
+        assert "PASS" in result
+        assert "$ai_metric" in result

--- a/products/llm_analytics/frontend/evaluations/templates.ts
+++ b/products/llm_analytics/frontend/evaluations/templates.ts
@@ -53,8 +53,8 @@ export const defaultEvaluationTemplates: readonly EvaluationTemplate[] = [
 let max_cost := 0.05
 let max_latency := 10
 
-let cost := properties.$ai_total_cost_usd
-let latency := properties.$ai_latency
+let cost := ifNull(properties.$ai_total_cost_usd, 0)
+let latency := ifNull(properties.$ai_latency, 0)
 
 if (cost > max_cost) {
     print(concat('Cost $', toString(cost), ' exceeds budget $', toString(max_cost)))


### PR DESCRIPTION
## Problem

Users writing Hog evaluations have no in-product help for writing correct Hog code. There is also no PostHog AI mode that provides LLM-analytics-specific tools (searching traces, running eval tests) to assist with the evaluation authoring workflow.

Stacked on #49587.

## Changes

Adds a `LLMAnalytics` agent mode for PostHog AI. The mode auto-activates when navigating to any LLM analytics scene — no feature flag gate.

**Agent mode + tools**
- `AgentMode.LLMAnalytics` in `schema-assistant-messages.ts` and `posthog/schema.py`
- `ee/hogai/core/agent_modes/presets/llm_analytics.py`: mode preset registering `SearchLLMTracesTool` and `RunHogEvalTestTool`
- `RunHogEvalTestTool` (`products/llm_analytics/backend/tools/run_hog_eval_test.py`): compiles Hog source, queries recent `$ai_generation` / `$ai_metric` events, runs `run_hog_eval()` per event, returns verdict/reasoning/error — same helper as the Temporal activity

**Context injection**
- `MaxEvaluationContext` type and `MaxContextType.EVALUATION` enum value
- `evaluationToMaxContextPayload` and `MaxOpenContext.evaluation` in `utils.ts`
- `maxContextLogic.ts` updated with evaluation reducers, actions, and selectors
- Backend `context.py` renders `<evaluations_context>` block with evaluation state (name, type, Hog source) and conditionally injects the Hog language reference (only for `hog` type evals, not `llm_judge`)
- `prompts.py` adds `{{{ui_context_evaluations}}}` template variable and `HOG_EVALUATION_REFERENCE`

**Frontend**
- `max-constants.tsx`: mode definition with `run_hog_eval_test` tool entry, scenes set (all LLMA scenes)
- Mode auto-activates when navigating to any LLM analytics scene
- "Generate with AI" button in `EvaluationCodeEditor` (from parent PR #49587) opens Max side panel with evaluation context pre-loaded
- `templates.ts`: null-safe `ifNull()` guards on cost/latency Hog template

## How did you test this code?

Unit/integration tests included:

- `products/llm_analytics/backend/tools/test_run_hog_eval_test.py` — parameterized compilation success/error, no events, runtime error, result formatting, null returns, `$ai_metric` events
- `ee/hogai/context/test/test_context.py` — parameterized backend context rendering for evaluation state (hog with source, llm_judge without source, fallback names, STL reference)
- `frontend/src/scenes/max/maxContextConverters.test.ts` — evaluation context conversion (all fields, minimal fields, combined contexts)

## Publish to changelog?

No — this is part of an unreleased beta feature.