### PR TITLE
fix: let database assign IDs in feature-flags tests

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -188,7 +188,6 @@ mod tests {
             setup_redis_client, TestContext,
         },
     };
-    use rand::Rng;
 
     #[tokio::test]
     async fn test_fetch_flags_from_redis() {
@@ -302,11 +301,8 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        let random_id_1 = rand::thread_rng().gen_range(1_000_000..i32::MAX);
-        let random_id_2 = rand::thread_rng().gen_range(1_000_000..i32::MAX);
-
         let flag1 = FeatureFlagRow {
-            id: random_id_1,
+            id: 0,
             team_id: team.id,
             name: Some("Test Flag".to_string()),
             key: "test_flag".to_string(),
@@ -321,7 +317,7 @@ mod tests {
         };
 
         let flag2 = FeatureFlagRow {
-            id: random_id_2,
+            id: 0,
             team_id: team.id,
             name: Some("Test Flag 2".to_string()),
             key: "test_flag_2".to_string(),
@@ -414,14 +410,12 @@ mod tests {
             .expect("Failed to get connection");
 
         // Insert a regular feature flag via raw SQL (is_remote_configuration = false)
-        let regular_flag_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, false, false, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, false, false, '2024-06-17')"#,
         )
-        .bind(regular_flag_id)
         .bind(team.id)
         .bind("Regular Flag")
         .bind("regular_flag")
@@ -431,14 +425,12 @@ mod tests {
         .expect("Failed to insert regular flag");
 
         // Insert an unencrypted remote config flag via raw SQL
-        let unencrypted_remote_config_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, true, false, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, true, false, '2024-06-17')"#,
         )
-        .bind(unencrypted_remote_config_id)
         .bind(team.id)
         .bind("Unencrypted Remote Config Flag")
         .bind("unencrypted_remote_config_flag")
@@ -448,14 +440,12 @@ mod tests {
         .expect("Failed to insert unencrypted remote config flag");
 
         // Insert an encrypted remote config flag via raw SQL
-        let encrypted_remote_config_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, true, true, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, true, true, '2024-06-17')"#,
         )
-        .bind(encrypted_remote_config_id)
         .bind(team.id)
         .bind("Encrypted Remote Config Flag")
         .bind("encrypted_remote_config_flag")
@@ -497,14 +487,12 @@ mod tests {
             .expect("Failed to get connection");
 
         // Insert flag with is_remote_configuration = NULL, has_encrypted_payloads = false
-        let null_remote_config_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, false, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, NULL, false, '2024-06-17')"#,
         )
-        .bind(null_remote_config_id)
         .bind(team.id)
         .bind("Null Remote Config Flag")
         .bind("null_remote_config")
@@ -514,14 +502,12 @@ mod tests {
         .expect("Failed to insert null remote config flag");
 
         // Insert flag with is_remote_configuration = true, has_encrypted_payloads = NULL
-        let null_encrypted_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, true, NULL, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, true, NULL, '2024-06-17')"#,
         )
-        .bind(null_encrypted_id)
         .bind(team.id)
         .bind("Null Encrypted Flag")
         .bind("null_encrypted")
@@ -531,14 +517,12 @@ mod tests {
         .expect("Failed to insert null encrypted flag");
 
         // Insert legacy flag with both fields NULL
-        let legacy_flag_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, NULL, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, NULL, NULL, '2024-06-17')"#,
         )
-        .bind(legacy_flag_id)
         .bind(team.id)
         .bind("Legacy Flag")
         .bind("legacy_flag")
@@ -549,14 +533,12 @@ mod tests {
 
         // Insert flag with is_remote_configuration = NULL, has_encrypted_payloads = true
         // This should still be included because is_remote_configuration is not TRUE
-        let null_remote_encrypted_true_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
         sqlx::query(
             r#"INSERT INTO posthog_featureflag
-            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+            (team_id, name, key, filters, deleted, active, ensure_experience_continuity,
              is_remote_configuration, has_encrypted_payloads, created_at)
-            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, true, '2024-06-17')"#,
+            VALUES ($1, $2, $3, $4, false, true, false, NULL, true, '2024-06-17')"#,
         )
-        .bind(null_remote_encrypted_true_id)
         .bind(team.id)
         .bind("Null Remote Encrypted True Flag")
         .bind("null_remote_encrypted_true")

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -459,7 +459,13 @@ pub async fn insert_new_team_in_pg(
     // Create team model
     let id = match team_id {
         Some(value) => value,
-        None => rand::thread_rng().gen_range(1_000_000..i32::MAX),
+        None => {
+            let mut non_persons_conn = non_persons_client.get_connection().await?;
+            let row: (i32,) = sqlx::query_as("SELECT nextval('posthog_team_id_seq')::int")
+                .fetch_one(&mut *non_persons_conn)
+                .await?;
+            row.0
+        }
     };
     let token = random_string("phc_", 12);
     let team = Team {
@@ -507,15 +513,10 @@ pub async fn insert_flag_for_team_in_pg(
     team_id: i32,
     flag: Option<FeatureFlagRow>,
 ) -> Result<FeatureFlagRow, Error> {
-    let id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
-
-    let payload_flag = match flag {
-        Some(mut value) => {
-            value.id = id;
-            value
-        }
+    let mut payload_flag = match flag {
+        Some(value) => value,
         None => FeatureFlagRow {
-            id,
+            id: 0, // Placeholder, will be updated after insertion
             key: "flag1".to_string(),
             name: Some("flag1 description".to_string()),
             active: true,
@@ -544,13 +545,14 @@ pub async fn insert_flag_for_team_in_pg(
     };
 
     let mut conn = client.get_connection().await?;
-    let res = sqlx::query(
+    let row: (i32,) = sqlx::query_as(
         r#"INSERT INTO posthog_featureflag
-        (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity, evaluation_runtime, created_at) VALUES
-        ($1, $2, $3, $4, $5, $6, $7, $8, $9, '2024-06-17')"#
-    ).bind(payload_flag.id).bind(team_id).bind(&payload_flag.name).bind(&payload_flag.key).bind(&payload_flag.filters).bind(payload_flag.deleted).bind(payload_flag.active).bind(payload_flag.ensure_experience_continuity).bind(&payload_flag.evaluation_runtime).execute(&mut *conn).await?;
+        (team_id, name, key, filters, deleted, active, ensure_experience_continuity, evaluation_runtime, created_at) VALUES
+        ($1, $2, $3, $4, $5, $6, $7, $8, '2024-06-17')
+        RETURNING id"#
+    ).bind(team_id).bind(&payload_flag.name).bind(&payload_flag.key).bind(&payload_flag.filters).bind(payload_flag.deleted).bind(payload_flag.active).bind(payload_flag.ensure_experience_continuity).bind(&payload_flag.evaluation_runtime).fetch_one(&mut *conn).await?;
 
-    assert_eq!(res.rows_affected(), 1);
+    payload_flag.id = row.0;
 
     Ok(payload_flag)
 }
@@ -1251,8 +1253,12 @@ impl TestContext {
 
         const ORG_ID: &str = "019026a4be8000005bf3171d00629163";
 
-        // Create team model
-        let id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
+        // Create team model with a sequence-assigned ID
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        let row: (i32,) = sqlx::query_as("SELECT nextval('posthog_team_id_seq')::int")
+            .fetch_one(&mut *conn)
+            .await?;
+        let id = row.0;
         let team = Team {
             id,
             name: "Test Team".to_string(),

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -5,6 +5,7 @@ use base64::{engine::general_purpose, Engine as _};
 use feature_flags::api::types::{FlagsResponse, LegacyFlagsResponse};
 use limiters::redis::ServiceName;
 use rand::Rng;
+
 use reqwest::StatusCode;
 use rstest::rstest;
 use serde_json::{json, Value};
@@ -1003,9 +1004,8 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "example_id".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let team_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(Some(team_id)).await.unwrap();
+    let team = context.insert_new_team(None).await.unwrap();
 
     // need this for the test to work, since we look up the dinstinct_id <-> person_id in from the DB at the beginning
     // of the flag evaluation process
@@ -2765,9 +2765,8 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
     let config = DEFAULT_TEST_CONFIG.clone();
     let distinct_id = "user_with_numeric_group".to_string();
     let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let team_id = rand::thread_rng().gen_range(1_000_000..i32::MAX);
     let context = TestContext::new(None).await;
-    let team = context.insert_new_team(Some(team_id)).await.unwrap();
+    let team = context.insert_new_team(None).await.unwrap();
 
     context
         .insert_person(team.id, distinct_id.clone(), None)


### PR DESCRIPTION
## Problem

Feature-flags Rust tests generate random integers as primary keys for teams and flags, which occasionally collide against a shared Postgres database, causing flaky test failures. PR #49539 widened the random range as a band-aid; this PR addresses the root cause.

## Changes

- **`insert_new_team_in_pg()` / `create_team_with_secret_token()`**: When no team ID is provided, use `SELECT nextval('posthog_team_id_seq')` to get a sequence-assigned ID instead of `rand::gen_range`. This guarantees uniqueness across concurrent test runs.
- **`insert_flag_for_team_in_pg()`**: Remove random ID generation, drop `id` from the INSERT column list, and add `RETURNING id` — matching the existing `insert_cohort_for_team_in_pg()` pattern.
- **Inline test SQL in `feature_flag_list.rs`**: Same treatment — remove `id` from INSERTs, let the database auto-assign.
- **`test_flags.rs`**: Two tests that manually generated team IDs now use `insert_new_team(None)`.
- Net result: -12 lines, zero `gen_range` calls remaining for team/flag IDs.

Follow-up to #49539.

## How did you test this code?

`cargo test -p feature-flags --all-targets` — 870 passed, 7 pre-existing GeoIP failures (missing local DB file, unrelated).

## Publish to changelog?

No