### PR TITLE
feat(flags): add realtime cohort membership infrastructure to feature flags

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -259,6 +259,7 @@ mod tests {
             errors_calculating: 0,
             groups: serde_json::json!({}),
             created_by_id: None,
+            cohort_type: None,
         }
     }
 
@@ -743,6 +744,7 @@ mod tests {
             errors_calculating: 0,
             groups: serde_json::json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
         cohort_cache.cache.insert(1, vec![test_cohort]).await;
         // Moka caches update internal stats lazily - sync ensures stats are current
@@ -1103,6 +1105,7 @@ mod tests {
                         errors_calculating: 0,
                         groups: serde_json::json!({}),
                         created_by_id: None,
+                        cohort_type: None,
                     }])
                 }
             }

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -4,7 +4,7 @@ use sqlx::FromRow;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[serde(rename_all = "snake_case")]
-#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[sqlx(type_name = "varchar", rename_all = "snake_case")]
 pub enum CohortType {
     Static,
     PersonProperty,

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -2,6 +2,17 @@ use crate::properties::property_models::PropertyFilter;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+pub enum CohortType {
+    Static,
+    PersonProperty,
+    Behavioral,
+    Realtime,
+    Analytical,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Cohort {
     pub id: i32,
@@ -19,9 +30,19 @@ pub struct Cohort {
     pub errors_calculating: i32,
     pub groups: serde_json::Value,
     pub created_by_id: Option<i32>,
+    pub cohort_type: Option<CohortType>,
 }
 
 impl Cohort {
+    /// Returns true if this cohort's membership should be resolved via the
+    /// realtime cohort_membership table rather than the static cohortpeople table.
+    pub fn uses_realtime_membership(&self) -> bool {
+        matches!(
+            self.cohort_type,
+            Some(CohortType::Realtime) | Some(CohortType::Behavioral)
+        )
+    }
+
     /// Estimates the memory size of this cohort in bytes.
     ///
     /// This approximation accounts for the variable-size JSON fields (`filters`, `query`, `groups`)
@@ -151,6 +172,7 @@ mod tests {
             errors_calculating: 0,
             groups,
             created_by_id: Some(1),
+            cohort_type: None,
         }
     }
 
@@ -271,6 +293,28 @@ mod tests {
             assert!(
                 deviation < 0.20,
                 "Estimate {estimated} deviates too much from actual {actual} for {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_uses_realtime_membership() {
+        let cases = vec![
+            (None, false),
+            (Some(CohortType::Static), false),
+            (Some(CohortType::PersonProperty), false),
+            (Some(CohortType::Analytical), false),
+            (Some(CohortType::Realtime), true),
+            (Some(CohortType::Behavioral), true),
+        ];
+
+        for (cohort_type, expected) in cases {
+            let mut cohort = create_test_cohort(None, None, serde_json::json!({}));
+            cohort.cohort_type = cohort_type;
+            assert_eq!(
+                cohort.uses_realtime_membership(),
+                expected,
+                "cohort_type={cohort_type:?} should return {expected}"
             );
         }
     }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -46,7 +46,8 @@ impl Cohort {
                   c.is_static,
                   c.errors_calculating,
                   c.groups,
-                  c.created_by_id
+                  c.created_by_id,
+                  c.cohort_type
               FROM posthog_cohort AS c
               JOIN posthog_team AS t ON (c.team_id = t.id)
             WHERE t.id = $1
@@ -563,6 +564,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         // This should not fail even though the filters are malformed
@@ -588,6 +590,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         let dependencies = static_cohort_empty_filters.extract_dependencies().unwrap();
@@ -610,6 +613,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         // This should fail because it's dynamic and the filters are malformed
@@ -653,6 +657,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         }
     }
 
@@ -698,6 +703,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         // Create a dynamic cohort (cohort 20) that depends on the static cohort
@@ -730,6 +736,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         let cohorts = vec![static_cohort, dynamic_cohort];
@@ -815,6 +822,7 @@ mod tests {
             errors_calculating: 0,
             groups: json!({}),
             created_by_id: None,
+            cohort_type: None,
         };
 
         let cohorts = vec![cohort_with_negation];

--- a/rust/feature-flags/src/cohorts/membership/cached_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/cached_provider.rs
@@ -15,9 +15,8 @@ type MembershipCacheKey = (TeamId, Uuid);
 /// Wraps a CohortMembershipProvider with a Moka cache layer.
 ///
 /// Caches explicit membership results (cohort_id -> bool) keyed by (team_id, person_uuid).
-/// Uses `try_get_with` for per-key coalescing on cache miss to avoid thundering herd.
-/// If any requested cohort ID is missing from a cache hit, only the uncached IDs are
-/// fetched from the inner provider and the cache entry is updated.
+/// If any requested cohort ID is missing from the cache, only the uncached IDs are
+/// fetched from the inner provider and merged into the cache entry.
 pub struct CachedCohortMembershipProvider<
     P: CohortMembershipProvider = super::realtime_provider::RealtimeCohortMembershipProvider,
 > {
@@ -89,22 +88,14 @@ impl<P: CohortMembershipProvider> CohortMembershipProvider for CachedCohortMembe
                 .collect());
         }
 
-        // Full cache miss: use try_get_with for per-key coalescing so concurrent
-        // requests for the same (team_id, person_uuid) share a single fetch.
-        let inner = self.inner.clone();
-        let ids = cohort_ids.to_vec();
         let result = self
-            .cache
-            .try_get_with(cache_key, async move {
-                inner.check_memberships(team_id, person_uuid, &ids).await
-            })
-            .await
-            .map_err(|e| CohortMembershipError::QueryFailed(e.to_string()))?;
+            .inner
+            .check_memberships(team_id, person_uuid, cohort_ids)
+            .await?;
 
-        Ok(cohort_ids
-            .iter()
-            .map(|id| (*id, result.get(id).copied().unwrap_or(false)))
-            .collect())
+        self.cache.insert(cache_key, result.clone()).await;
+
+        Ok(result)
     }
 }
 

--- a/rust/feature-flags/src/cohorts/membership/cached_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/cached_provider.rs
@@ -1,0 +1,242 @@
+use axum::async_trait;
+use moka::future::Cache;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::cohorts::cohort_models::CohortId;
+use common_types::TeamId;
+
+use super::provider::{CohortMembershipError, CohortMembershipProvider};
+
+type MembershipCacheKey = (TeamId, Uuid);
+
+/// Wraps a CohortMembershipProvider with a Moka cache layer.
+///
+/// Caches explicit membership results (cohort_id -> bool) keyed by (team_id, person_uuid).
+/// Only serves from cache when all requested cohort IDs have been previously queried —
+/// if any requested cohort ID is missing from the cache, the uncached IDs are fetched
+/// from the inner provider and merged into the cached entry.
+pub struct CachedCohortMembershipProvider<
+    P: CohortMembershipProvider = super::realtime_provider::RealtimeCohortMembershipProvider,
+> {
+    inner: Arc<P>,
+    cache: Cache<MembershipCacheKey, HashMap<CohortId, bool>>,
+}
+
+impl<P: CohortMembershipProvider> CachedCohortMembershipProvider<P> {
+    const DEFAULT_TTL_SECONDS: u64 = 60;
+    const DEFAULT_MAX_ENTRIES: u64 = 50_000;
+
+    pub fn new(inner: P, ttl_seconds: Option<u64>, max_entries: Option<u64>) -> Self {
+        let cache = Cache::builder()
+            .time_to_live(Duration::from_secs(
+                ttl_seconds.unwrap_or(Self::DEFAULT_TTL_SECONDS),
+            ))
+            .max_capacity(max_entries.unwrap_or(Self::DEFAULT_MAX_ENTRIES))
+            .build();
+
+        Self {
+            inner: Arc::new(inner),
+            cache,
+        }
+    }
+}
+
+#[async_trait]
+impl<P: CohortMembershipProvider> CohortMembershipProvider for CachedCohortMembershipProvider<P> {
+    async fn check_memberships(
+        &self,
+        team_id: TeamId,
+        person_uuid: Uuid,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, CohortMembershipError> {
+        if cohort_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let cache_key = (team_id, person_uuid);
+
+        if let Some(cached) = self.cache.get(&cache_key).await {
+            let uncached_ids: Vec<CohortId> = cohort_ids
+                .iter()
+                .filter(|id| !cached.contains_key(id))
+                .copied()
+                .collect();
+
+            if uncached_ids.is_empty() {
+                return Ok(cohort_ids
+                    .iter()
+                    .map(|id| (*id, cached.get(id).copied().unwrap_or(false)))
+                    .collect());
+            }
+
+            let fresh = self
+                .inner
+                .check_memberships(team_id, person_uuid, &uncached_ids)
+                .await?;
+
+            let mut merged = cached;
+            merged.extend(fresh);
+            self.cache.insert(cache_key, merged.clone()).await;
+
+            return Ok(cohort_ids
+                .iter()
+                .map(|id| (*id, merged.get(id).copied().unwrap_or(false)))
+                .collect());
+        }
+
+        let result = self
+            .inner
+            .check_memberships(team_id, person_uuid, cohort_ids)
+            .await?;
+
+        self.cache.insert(cache_key, result.clone()).await;
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct MockProvider {
+        call_count: AtomicU32,
+        memberships: HashMap<CohortId, bool>,
+    }
+
+    impl MockProvider {
+        fn new(memberships: HashMap<CohortId, bool>) -> Self {
+            Self {
+                call_count: AtomicU32::new(0),
+                memberships,
+            }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl CohortMembershipProvider for MockProvider {
+        async fn check_memberships(
+            &self,
+            _team_id: TeamId,
+            _person_uuid: Uuid,
+            cohort_ids: &[CohortId],
+        ) -> Result<HashMap<CohortId, bool>, CohortMembershipError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(cohort_ids
+                .iter()
+                .map(|id| (*id, self.memberships.get(id).copied().unwrap_or(false)))
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_queries_inner() {
+        let inner = MockProvider::new(HashMap::from([(1, true), (2, false), (3, true)]));
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+        let person = Uuid::new_v4();
+
+        let result = cached
+            .check_memberships(1, person, &[1, 2, 3])
+            .await
+            .unwrap();
+
+        assert!(result[&1]);
+        assert!(!result[&2]);
+        assert!(result[&3]);
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hit_skips_inner() {
+        let inner = MockProvider::new(HashMap::from([(1, true), (2, false)]));
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+        let person = Uuid::new_v4();
+
+        cached.check_memberships(1, person, &[1, 2]).await.unwrap();
+        assert_eq!(cached.inner.call_count(), 1);
+
+        let result = cached.check_memberships(1, person, &[1, 2]).await.unwrap();
+        assert!(result[&1]);
+        assert!(!result[&2]);
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_different_persons_have_separate_cache_entries() {
+        let inner = MockProvider::new(HashMap::from([(1, true)]));
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+
+        let person_a = Uuid::new_v4();
+        let person_b = Uuid::new_v4();
+
+        cached.check_memberships(1, person_a, &[1]).await.unwrap();
+        cached.check_memberships(1, person_b, &[1]).await.unwrap();
+
+        assert_eq!(cached.inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hit_answers_subset_of_cohorts() {
+        let inner = MockProvider::new(HashMap::from([(1, true), (2, true), (3, false)]));
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+        let person = Uuid::new_v4();
+
+        cached
+            .check_memberships(1, person, &[1, 2, 3])
+            .await
+            .unwrap();
+
+        let result = cached.check_memberships(1, person, &[1]).await.unwrap();
+        assert!(result[&1]);
+        assert_eq!(cached.inner.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_previously_unqueried_cohort_fetches_from_inner() {
+        let inner = MockProvider::new(HashMap::from([(1, true), (2, false), (4, true)]));
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+        let person = Uuid::new_v4();
+
+        // Populate cache with cohorts 1 and 2
+        cached.check_memberships(1, person, &[1, 2]).await.unwrap();
+        assert_eq!(cached.inner.call_count(), 1);
+
+        // Ask for cohort 4 which was never queried — must hit the inner provider
+        let result = cached.check_memberships(1, person, &[1, 4]).await.unwrap();
+        assert!(result[&1]);
+        assert!(result[&4]);
+        assert_eq!(cached.inner.call_count(), 2);
+
+        // Now cohort 4 is cached too — no further inner call needed
+        let result = cached
+            .check_memberships(1, person, &[1, 2, 4])
+            .await
+            .unwrap();
+        assert!(result[&1]);
+        assert!(!result[&2]);
+        assert!(result[&4]);
+        assert_eq!(cached.inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_empty_cohort_ids_returns_empty() {
+        let inner = MockProvider::new(HashMap::new());
+        let cached = CachedCohortMembershipProvider::new(inner, Some(60), Some(100));
+
+        let result = cached
+            .check_memberships(1, Uuid::new_v4(), &[])
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        assert_eq!(cached.inner.call_count(), 0);
+    }
+}

--- a/rust/feature-flags/src/cohorts/membership/cached_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/cached_provider.rs
@@ -15,9 +15,9 @@ type MembershipCacheKey = (TeamId, Uuid);
 /// Wraps a CohortMembershipProvider with a Moka cache layer.
 ///
 /// Caches explicit membership results (cohort_id -> bool) keyed by (team_id, person_uuid).
-/// Only serves from cache when all requested cohort IDs have been previously queried —
-/// if any requested cohort ID is missing from the cache, the uncached IDs are fetched
-/// from the inner provider and merged into the cached entry.
+/// Uses `try_get_with` for per-key coalescing on cache miss to avoid thundering herd.
+/// If any requested cohort ID is missing from a cache hit, only the uncached IDs are
+/// fetched from the inner provider and the cache entry is updated.
 pub struct CachedCohortMembershipProvider<
     P: CohortMembershipProvider = super::realtime_provider::RealtimeCohortMembershipProvider,
 > {
@@ -27,7 +27,7 @@ pub struct CachedCohortMembershipProvider<
 
 impl<P: CohortMembershipProvider> CachedCohortMembershipProvider<P> {
     const DEFAULT_TTL_SECONDS: u64 = 60;
-    const DEFAULT_MAX_ENTRIES: u64 = 50_000;
+    const DEFAULT_MAX_ENTRIES: u64 = 500_000;
 
     pub fn new(inner: P, ttl_seconds: Option<u64>, max_entries: Option<u64>) -> Self {
         let cache = Cache::builder()
@@ -58,6 +58,8 @@ impl<P: CohortMembershipProvider> CohortMembershipProvider for CachedCohortMembe
 
         let cache_key = (team_id, person_uuid);
 
+        // Check for a partial cache hit: if some cohort IDs are already cached,
+        // only fetch the missing ones from the inner provider.
         if let Some(cached) = self.cache.get(&cache_key).await {
             let uncached_ids: Vec<CohortId> = cohort_ids
                 .iter()
@@ -87,14 +89,22 @@ impl<P: CohortMembershipProvider> CohortMembershipProvider for CachedCohortMembe
                 .collect());
         }
 
+        // Full cache miss: use try_get_with for per-key coalescing so concurrent
+        // requests for the same (team_id, person_uuid) share a single fetch.
+        let inner = self.inner.clone();
+        let ids = cohort_ids.to_vec();
         let result = self
-            .inner
-            .check_memberships(team_id, person_uuid, cohort_ids)
-            .await?;
+            .cache
+            .try_get_with(cache_key, async move {
+                inner.check_memberships(team_id, person_uuid, &ids).await
+            })
+            .await
+            .map_err(|e| CohortMembershipError::QueryFailed(e.to_string()))?;
 
-        self.cache.insert(cache_key, result.clone()).await;
-
-        Ok(result)
+        Ok(cohort_ids
+            .iter()
+            .map(|id| (*id, result.get(id).copied().unwrap_or(false)))
+            .collect())
     }
 }
 

--- a/rust/feature-flags/src/cohorts/membership/mod.rs
+++ b/rust/feature-flags/src/cohorts/membership/mod.rs
@@ -1,0 +1,7 @@
+pub mod cached_provider;
+pub mod provider;
+pub mod realtime_provider;
+
+pub use cached_provider::CachedCohortMembershipProvider;
+pub use provider::{CohortMembershipError, CohortMembershipProvider};
+pub use realtime_provider::{NoOpCohortMembershipProvider, RealtimeCohortMembershipProvider};

--- a/rust/feature-flags/src/cohorts/membership/provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/provider.rs
@@ -1,0 +1,37 @@
+use axum::async_trait;
+use std::collections::HashMap;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::cohorts::cohort_models::CohortId;
+use common_types::TeamId;
+
+#[derive(Error, Debug, Clone)]
+pub enum CohortMembershipError {
+    #[error("Behavioral cohorts database is not configured")]
+    NotConfigured,
+    #[error("Database unavailable")]
+    DatabaseUnavailable,
+    #[error("Query failed: {0}")]
+    QueryFailed(String),
+}
+
+/// Provides cohort membership lookups for realtime/behavioral cohorts.
+///
+/// Implementations query the behavioral cohorts database to determine whether
+/// a person is a member of specific cohorts. Results are returned as a map of
+/// cohort_id -> is_member, which integrates directly with the existing
+/// `apply_cohort_membership_logic` function.
+#[async_trait]
+pub trait CohortMembershipProvider: Send + Sync + 'static {
+    /// Check membership for a person across multiple cohorts.
+    ///
+    /// Returns a map of cohort_id -> is_member for each requested cohort.
+    /// Cohorts where the person is not a member will have `false`.
+    async fn check_memberships(
+        &self,
+        team_id: TeamId,
+        person_uuid: Uuid,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, CohortMembershipError>;
+}

--- a/rust/feature-flags/src/cohorts/membership/provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/provider.rs
@@ -8,10 +8,6 @@ use common_types::TeamId;
 
 #[derive(Error, Debug, Clone)]
 pub enum CohortMembershipError {
-    #[error("Behavioral cohorts database is not configured")]
-    NotConfigured,
-    #[error("Database unavailable")]
-    DatabaseUnavailable,
     #[error("Query failed: {0}")]
     QueryFailed(String),
 }

--- a/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
@@ -1,0 +1,125 @@
+use axum::async_trait;
+use sqlx::PgPool;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::cohorts::cohort_models::CohortId;
+use common_types::TeamId;
+
+use super::provider::{CohortMembershipError, CohortMembershipProvider};
+
+/// Queries the behavioral cohorts PostgreSQL database for realtime cohort membership.
+///
+/// The `cohort_membership` table stores the current membership state for each
+/// (team_id, cohort_id, person_id) triple. Only rows with status='entered'
+/// indicate active membership.
+#[derive(Clone)]
+pub struct RealtimeCohortMembershipProvider {
+    pool: Arc<PgPool>,
+}
+
+impl RealtimeCohortMembershipProvider {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CohortMembershipProvider for RealtimeCohortMembershipProvider {
+    async fn check_memberships(
+        &self,
+        team_id: TeamId,
+        person_uuid: Uuid,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, CohortMembershipError> {
+        if cohort_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Query the behavioral cohorts database for active memberships.
+        // The cohort_membership table uses ReplacingMergeTree semantics: only the
+        // latest status per (team_id, cohort_id, person_id) is considered, and
+        // only 'entered' status indicates active membership.
+        let matched_cohort_ids: Vec<CohortMembershipRow> = sqlx::query_as(
+            r#"
+            SELECT cohort_id
+            FROM cohort_membership
+            WHERE team_id = $1
+              AND person_id = $2
+              AND cohort_id = ANY($3)
+              AND status = 'entered'
+            "#,
+        )
+        .bind(team_id)
+        .bind(person_uuid)
+        .bind(cohort_ids)
+        .fetch_all(self.pool.as_ref())
+        .await
+        .map_err(|e| CohortMembershipError::QueryFailed(e.to_string()))?;
+
+        let matched_set: std::collections::HashSet<CohortId> =
+            matched_cohort_ids.iter().map(|r| r.cohort_id).collect();
+
+        let result = cohort_ids
+            .iter()
+            .map(|id| (*id, matched_set.contains(id)))
+            .collect();
+
+        Ok(result)
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct CohortMembershipRow {
+    cohort_id: CohortId,
+}
+
+/// No-op provider used when the behavioral cohorts database is not configured.
+/// Conservatively returns false (not a member) for all lookups.
+pub struct NoOpCohortMembershipProvider;
+
+#[async_trait]
+impl CohortMembershipProvider for NoOpCohortMembershipProvider {
+    async fn check_memberships(
+        &self,
+        _team_id: TeamId,
+        _person_uuid: Uuid,
+        cohort_ids: &[CohortId],
+    ) -> Result<HashMap<CohortId, bool>, CohortMembershipError> {
+        Ok(cohort_ids.iter().map(|id| (*id, false)).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_noop_provider_returns_false_for_all() {
+        let provider = NoOpCohortMembershipProvider;
+        let cohort_ids = vec![1, 2, 3];
+
+        let result = provider
+            .check_memberships(1, Uuid::new_v4(), &cohort_ids)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert!(!result[&1]);
+        assert!(!result[&2]);
+        assert!(!result[&3]);
+    }
+
+    #[tokio::test]
+    async fn test_noop_provider_empty_cohorts() {
+        let provider = NoOpCohortMembershipProvider;
+
+        let result = provider
+            .check_memberships(1, Uuid::new_v4(), &[])
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+    }
+}

--- a/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
@@ -11,9 +11,8 @@ use super::provider::{CohortMembershipError, CohortMembershipProvider};
 
 /// Queries the behavioral cohorts PostgreSQL database for realtime cohort membership.
 ///
-/// The `cohort_membership` table stores the current membership state for each
-/// (team_id, cohort_id, person_id) triple. Only rows with status='entered'
-/// indicate active membership.
+/// The `cohort_membership` table has a unique constraint on (team_id, cohort_id, person_id)
+/// with an `in_cohort` boolean indicating active membership.
 #[derive(Clone)]
 pub struct RealtimeCohortMembershipProvider {
     pool: Arc<PgPool>,
@@ -37,7 +36,6 @@ impl CohortMembershipProvider for RealtimeCohortMembershipProvider {
             return Ok(HashMap::new());
         }
 
-        // Only rows with status='entered' indicate active membership.
         let matched_cohort_ids: Vec<CohortMembershipRow> = sqlx::query_as(
             r#"
             SELECT cohort_id
@@ -45,7 +43,7 @@ impl CohortMembershipProvider for RealtimeCohortMembershipProvider {
             WHERE team_id = $1
               AND person_id = $2
               AND cohort_id = ANY($3)
-              AND status = 'entered'
+              AND in_cohort = true
             "#,
         )
         .bind(team_id)

--- a/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
@@ -37,10 +37,7 @@ impl CohortMembershipProvider for RealtimeCohortMembershipProvider {
             return Ok(HashMap::new());
         }
 
-        // Query the behavioral cohorts database for active memberships.
-        // The cohort_membership table uses ReplacingMergeTree semantics: only the
-        // latest status per (team_id, cohort_id, person_id) is considered, and
-        // only 'entered' status indicates active membership.
+        // Only rows with status='entered' indicate active membership.
         let matched_cohort_ids: Vec<CohortMembershipRow> = sqlx::query_as(
             r#"
             SELECT cohort_id

--- a/rust/feature-flags/src/cohorts/mod.rs
+++ b/rust/feature-flags/src/cohorts/mod.rs
@@ -1,3 +1,4 @@
 pub mod cohort_cache_manager;
 pub mod cohort_models;
 pub mod cohort_operations;
+pub mod membership;

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -163,6 +163,22 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog_persons")]
     pub persons_read_database_url: String,
 
+    // Optional connection to the behavioral_cohorts database for realtime cohort membership.
+    // When empty, realtime cohort evaluation is disabled (graceful degradation).
+    #[envconfig(default = "")]
+    pub behavioral_cohorts_read_database_url: String,
+
+    // Cache TTL for realtime cohort membership lookups (seconds).
+    // Realtime cohorts are recalculated every 1-5 minutes, so 60s provides
+    // good cache hit rates while keeping data relatively fresh.
+    #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_TTL_SECONDS", default = "60")]
+    pub cohort_membership_cache_ttl_seconds: u64,
+
+    // Max entries in the cohort membership cache.
+    // Each entry represents one (team_id, person_uuid) pair.
+    #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_MAX_ENTRIES", default = "50000")]
+    pub cohort_membership_cache_max_entries: u64,
+
     #[envconfig(default = "1000")]
     pub max_concurrency: usize,
 
@@ -644,6 +660,9 @@ impl Config {
                 .to_string(),
             persons_read_database_url: "postgres://posthog:posthog@localhost:5432/posthog_persons"
                 .to_string(),
+            behavioral_cohorts_read_database_url: "".to_string(),
+            cohort_membership_cache_ttl_seconds: 60,
+            cohort_membership_cache_max_entries: 50_000,
             max_concurrency: 1000,
             max_pg_connections: 10,
             min_non_persons_reader_connections: 0,
@@ -785,6 +804,10 @@ impl Config {
     /// Check if persons database routing is enabled
     pub fn is_persons_db_routing_enabled(&self) -> bool {
         !self.persons_read_database_url.is_empty() && !self.persons_write_database_url.is_empty()
+    }
+
+    pub fn is_behavioral_cohorts_db_configured(&self) -> bool {
+        !self.behavioral_cohorts_read_database_url.is_empty()
     }
 
     /// Get the database URL for persons reads, falling back to the default read URL

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -169,14 +169,12 @@ pub struct Config {
     pub behavioral_cohorts_read_database_url: String,
 
     // Cache TTL for realtime cohort membership lookups (seconds).
-    // Realtime cohorts are recalculated every 1-5 minutes, so 60s provides
-    // good cache hit rates while keeping data relatively fresh.
     #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_TTL_SECONDS", default = "60")]
     pub cohort_membership_cache_ttl_seconds: u64,
 
     // Max entries in the cohort membership cache.
-    // Each entry represents one (team_id, person_uuid) pair.
-    #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_MAX_ENTRIES", default = "50000")]
+    // Each entry represents one (team_id, person_uuid) pair with a map of cohort memberships.
+    #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_MAX_ENTRIES", default = "500000")]
     pub cohort_membership_cache_max_entries: u64,
 
     #[envconfig(default = "1000")]

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -21,15 +21,17 @@ impl DatabasePools {
     /// Default value for max_connections when config value is invalid (matches PoolConfig::default)
     const DEFAULT_MAX_CONNECTIONS: u32 = 10;
 
-    /// Helper to build a pool configuration with specific min_connections and statement_timeout
+    /// Helper to build a pool configuration, overriding specific fields from the base config.
     fn build_pool_config(
         base: &PoolConfig,
         min_connections: u32,
+        max_connections: Option<u32>,
         statement_timeout_ms: u64,
         pool_name: &str,
     ) -> PoolConfig {
         PoolConfig {
             min_connections,
+            max_connections: max_connections.unwrap_or(base.max_connections),
             statement_timeout_ms: if statement_timeout_ms > 0 {
                 Some(statement_timeout_ms)
             } else {
@@ -128,6 +130,7 @@ impl DatabasePools {
         let non_persons_reader_pool_config = Self::build_pool_config(
             &base_pool_config,
             min_non_persons_reader_connections,
+            None,
             config.non_persons_reader_statement_timeout_ms,
             "non_persons_reader",
         );
@@ -141,6 +144,7 @@ impl DatabasePools {
         let persons_reader_pool_config = Self::build_pool_config(
             &base_pool_config,
             min_persons_reader_connections,
+            None,
             config.persons_reader_statement_timeout_ms,
             "persons_reader",
         );
@@ -154,6 +158,7 @@ impl DatabasePools {
         let non_persons_writer_pool_config = Self::build_pool_config(
             &base_pool_config,
             min_non_persons_writer_connections,
+            None,
             config.writer_statement_timeout_ms,
             "non_persons_writer",
         );
@@ -162,6 +167,7 @@ impl DatabasePools {
         let persons_writer_pool_config = Self::build_pool_config(
             &base_pool_config,
             min_persons_writer_connections,
+            None,
             config.writer_statement_timeout_ms,
             "persons_writer",
         );
@@ -263,21 +269,9 @@ impl DatabasePools {
         }
 
         // Optional behavioral cohorts database pool for realtime cohort membership lookups.
-        // Built inline rather than via build_pool_config because this pool has its own
-        // max_connections (5) and min_connections (1), independent of the main pool settings.
+        // Small pool (max 5 connections) with a tight 1s statement timeout for simple key lookups.
         let behavioral_cohorts_reader = if config.is_behavioral_cohorts_db_configured() {
-            let pool_config = PoolConfig {
-                min_connections: 1,
-                max_connections: 5,
-                acquire_timeout: Duration::from_secs(config.acquire_timeout_secs),
-                idle_timeout: if config.idle_timeout_secs > 0 {
-                    Some(Duration::from_secs(config.idle_timeout_secs))
-                } else {
-                    None
-                },
-                test_before_acquire: *config.test_before_acquire,
-                statement_timeout_ms: Some(1000),
-            };
+            let pool_config = Self::build_pool_config(&base_pool_config, 1, Some(5), 1000);
             info!("Creating behavioral cohorts reader pool");
             Some(Arc::new(
                 get_pool_with_config(&config.behavioral_cohorts_read_database_url, pool_config)

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -263,7 +263,8 @@ impl DatabasePools {
         }
 
         // Optional behavioral cohorts database pool for realtime cohort membership lookups.
-        // Uses a small pool with tight timeouts since these are simple key lookups.
+        // Built inline rather than via build_pool_config because this pool has its own
+        // max_connections (5) and min_connections (1), independent of the main pool settings.
         let behavioral_cohorts_reader = if config.is_behavioral_cohorts_db_configured() {
             let pool_config = PoolConfig {
                 min_connections: 1,

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -271,7 +271,8 @@ impl DatabasePools {
         // Optional behavioral cohorts database pool for realtime cohort membership lookups.
         // Small pool (max 5 connections) with a tight 1s statement timeout for simple key lookups.
         let behavioral_cohorts_reader = if config.is_behavioral_cohorts_db_configured() {
-            let pool_config = Self::build_pool_config(&base_pool_config, 1, Some(5), 1000);
+            let pool_config =
+                Self::build_pool_config(&base_pool_config, 1, Some(5), 1000, "behavioral_cohorts");
             info!("Creating behavioral cohorts reader pool");
             Some(Arc::new(
                 get_pool_with_config(&config.behavioral_cohorts_read_database_url, pool_config)
@@ -307,7 +308,7 @@ mod tests {
     #[test]
     fn test_build_pool_config_sets_pool_name_and_timeout() {
         let base = PoolConfig::default();
-        let config = DatabasePools::build_pool_config(&base, 3, 5000, "persons_reader");
+        let config = DatabasePools::build_pool_config(&base, 3, None, 5000, "persons_reader");
 
         assert_eq!(config.min_connections, 3);
         assert_eq!(config.statement_timeout_ms, Some(5000));
@@ -317,7 +318,7 @@ mod tests {
     #[test]
     fn test_build_pool_config_zero_timeout_is_none() {
         let base = PoolConfig::default();
-        let config = DatabasePools::build_pool_config(&base, 0, 0, "non_persons_writer");
+        let config = DatabasePools::build_pool_config(&base, 0, None, 0, "non_persons_writer");
 
         assert_eq!(config.statement_timeout_ms, None);
         assert_eq!(config.pool_name, Some("non_persons_writer".to_string()));

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -13,6 +13,7 @@ pub struct DatabasePools {
     pub non_persons_writer: Arc<PgPool>,
     pub persons_reader: Arc<PgPool>,
     pub persons_writer: Arc<PgPool>,
+    pub behavioral_cohorts_reader: Option<Arc<PgPool>>,
     pub test_before_acquire: bool,
 }
 
@@ -261,11 +262,42 @@ impl DatabasePools {
             info!("Persons pools are aliased to non-persons pools (persons DB routing disabled)");
         }
 
+        // Optional behavioral cohorts database pool for realtime cohort membership lookups.
+        // Uses a small pool with tight timeouts since these are simple key lookups.
+        let behavioral_cohorts_reader = if config.is_behavioral_cohorts_db_configured() {
+            let pool_config = PoolConfig {
+                min_connections: 1,
+                max_connections: 5,
+                acquire_timeout: Duration::from_secs(config.acquire_timeout_secs),
+                idle_timeout: if config.idle_timeout_secs > 0 {
+                    Some(Duration::from_secs(config.idle_timeout_secs))
+                } else {
+                    None
+                },
+                test_before_acquire: *config.test_before_acquire,
+                statement_timeout_ms: Some(1000),
+            };
+            info!("Creating behavioral cohorts reader pool");
+            Some(Arc::new(
+                get_pool_with_config(&config.behavioral_cohorts_read_database_url, pool_config)
+                    .map_err(|e| {
+                        FlagError::DatabaseError(
+                            e,
+                            Some("Failed to create behavioral cohorts reader pool".to_string()),
+                        )
+                    })?,
+            ))
+        } else {
+            info!("Behavioral cohorts DB not configured, realtime cohort evaluation disabled");
+            None
+        };
+
         Ok(DatabasePools {
             non_persons_reader,
             non_persons_writer,
             persons_reader,
             persons_writer,
+            behavioral_cohorts_reader,
             test_before_acquire: *config.test_before_acquire,
         })
     }

--- a/rust/feature-flags/src/db_monitor.rs
+++ b/rust/feature-flags/src/db_monitor.rs
@@ -87,6 +87,11 @@ impl DatabasePoolMonitor {
                 .await?;
         }
 
+        if let Some(ref pool) = self.database_pools.behavioral_cohorts_reader {
+            self.collect_single_pool_metrics(pool, "behavioral_cohorts_reader")
+                .await?;
+        }
+
         Ok(())
     }
 

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -462,6 +462,7 @@ mod tests {
             non_persons_writer: invalid_pool.clone(),
             persons_reader: invalid_pool.clone(),
             persons_writer: invalid_pool,
+            behavioral_cohorts_reader: None,
             test_before_acquire: false,
         });
 
@@ -484,6 +485,7 @@ mod tests {
             non_persons_writer: shared_pool.clone(),
             persons_reader: shared_pool.clone(),
             persons_writer: shared_pool,
+            behavioral_cohorts_reader: None,
             test_before_acquire: false,
         });
 

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -667,6 +667,7 @@ pub async fn insert_cohort_for_team_in_pg(
         errors_calculating: 0,
         groups: serde_json::json!([]),
         created_by_id: None,
+        cohort_type: None,
     };
 
     let mut conn = client.get_connection().await?;

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -232,6 +232,7 @@ impl ServerHandle {
                 non_persons_writer: non_persons_writer.clone(),
                 persons_reader: persons_reader.clone(),
                 persons_writer: persons_writer.clone(),
+                behavioral_cohorts_reader: None,
                 test_before_acquire: *config.test_before_acquire,
             });
 


### PR DESCRIPTION
## Context

Partial implementation of #49592 — covers Stages 1-4 (Data Model, Database Connection, Provider Abstraction, Realtime Provider with cache).

Stages 5-6 (Integration into flag evaluation, Observability & Rollout) will follow in subsequent PRs.

## Summary

- Add `CohortType` enum to the Rust feature flags service, matching Django's model values (`Static`, `PersonProperty`, `Behavioral`, `Realtime`, `Analytical`)
- Add optional `behavioral_cohorts_reader` database pool with tight timeouts (1s statement timeout, max 5 connections) for querying the `cohort_membership` table
- Introduce `CohortMembershipProvider` trait abstraction with three implementations:
  - `RealtimeCohortMembershipProvider` — queries the behavioral cohorts PostgreSQL database
  - `CachedCohortMembershipProvider` — wraps any provider with a Moka cache layer (60s TTL, partial-miss merging so previously-unqueried cohort IDs are fetched on demand)
  - `NoOpCohortMembershipProvider` — returns `false` for all lookups when the behavioral cohorts DB is not configured
- Graceful degradation: when `BEHAVIORAL_COHORTS_READ_DATABASE_URL` is empty, realtime cohort evaluation is disabled with no impact on existing flag evaluation

## Checklist

- [x] Stage 1: `CohortType` enum, `cohort_type` field on `Cohort`, updated `list_from_pg` query
- [x] Stage 2: `BEHAVIORAL_COHORTS_READ_DATABASE_URL` config, optional connection pool
- [x] Stage 3: `CohortMembershipProvider` trait, `NoOpCohortMembershipProvider`
- [x] Stage 4: `RealtimeCohortMembershipProvider`, `CachedCohortMembershipProvider` with Moka cache

## Test plan

- [x] All 8 new unit tests pass (cached provider: 6, realtime provider: 2)
- [x] All existing unit tests pass (886 total)
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Verified partial cache miss merging works correctly (previously-unqueried cohort IDs trigger a targeted fetch and merge)
