### PR TITLE
fix: cache group types in Redis to insulate from persons DB failures

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -30,7 +30,11 @@ from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group import Group
 from posthog.models.group.util import create_group, raw_create_group_ch
-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
+from posthog.models.group_type_mapping import (
+    GROUP_TYPE_MAPPING_SERIALIZER_FIELDS,
+    GroupTypeMapping,
+    invalidate_group_types_cache,
+)
 from posthog.models.user import User
 
 from products.event_definitions.backend.models.property_definition import PropertyType
@@ -111,6 +115,7 @@ class GroupsTypesViewSet(
             serializer.is_valid(raise_exception=True)
             serializer.save()
 
+        invalidate_group_types_cache(self.team.project_id)
         return self.list(request, *args, **kwargs)
 
     @action(methods=["PUT"], detail=False)
@@ -131,7 +136,12 @@ class GroupsTypesViewSet(
         dashboard = create_group_type_mapping_detail_dashboard(group_type_mapping, request.user)
         group_type_mapping.detail_dashboard_id = dashboard.id
         group_type_mapping.save()
+        invalidate_group_types_cache(self.team.project_id)
         return response.Response(self.get_serializer(group_type_mapping).data)
+
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        invalidate_group_types_cache(self.team.project_id)
 
     @action(methods=["PUT"], detail=False)
     def set_default_columns(self, request: request.Request, **kw):
@@ -144,6 +154,7 @@ class GroupsTypesViewSet(
 
         group_type_mapping.default_columns = request.data["default_columns"]
         group_type_mapping.save()
+        invalidate_group_types_cache(self.team.project_id)
         return response.Response(self.get_serializer(group_type_mapping).data)
 
 

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -7,6 +7,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, s
 from unittest import mock
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.db import IntegrityError
 
 from orjson import orjson
@@ -20,6 +21,7 @@ from posthog.helpers.dashboard_templates import create_group_type_mapping_detail
 from posthog.models import GroupTypeMapping, GroupUsageMetric, Person, PropertyDefinition
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group.util import create_group
+from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
 from posthog.models.organization import Organization
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.team.team import Team
@@ -1517,6 +1519,62 @@ class GroupsTypesViewSetTestCase(APIBaseTest):
         self.assertEqual(data["group_type"], "organization")
         self.assertEqual(data["group_type_index"], 0)
         self.assertIsNotNone(data["detail_dashboard"])
+
+    def _seed_cache(self):
+        """Populate the group types cache so we can verify invalidation."""
+        cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}"
+        cache.set(cache_key, [{"stale": True}], 300)
+        return cache_key
+
+    def test_update_metadata_invalidates_cache(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project=self.project, group_type="organization", group_type_index=0
+        )
+        cache_key = self._seed_cache()
+
+        response = self.client.patch(
+            self.url + "/update_metadata",
+            [{"group_type_index": 0, "name_singular": "org"}],
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_destroy_invalidates_cache(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project=self.project, group_type="organization", group_type_index=0
+        )
+        cache_key = self._seed_cache()
+
+        response = self.client.delete(self.url + "/0")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_create_detail_dashboard_invalidates_cache(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project=self.project, group_type="organization", group_type_index=0
+        )
+        cache_key = self._seed_cache()
+
+        response = self.client.put(self.url + "/create_detail_dashboard", {"group_type_index": 0})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_set_default_columns_invalidates_cache(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project=self.project, group_type="organization", group_type_index=0
+        )
+        cache_key = self._seed_cache()
+
+        response = self.client.put(
+            self.url + "/set_default_columns",
+            {"group_type_index": 0, "default_columns": ["name", "email"]},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(cache.get(cache_key))
 
 
 class GroupUsageMetricViewSetTestCase(APIBaseTest):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -49,7 +49,7 @@ from posthog.models import Dashboard, DashboardTile, Insight, Text
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.alert import AlertConfiguration
 from posthog.models.dashboard_templates import DashboardTemplate
-from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.group_type_mapping import GroupTypeMapping, invalidate_group_types_cache
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.tagged_item import TaggedItem
@@ -463,6 +463,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             if group_type_mapping:
                 group_type_mapping.detail_dashboard_id = None
                 group_type_mapping.save()
+                invalidate_group_types_cache(instance.team.project_id)
 
         request_filters = initial_data.get("filters")
         if request_filters:

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -38,7 +38,7 @@ from posthog.models.activity_logging.activity_log import (
     log_activity,
 )
 from posthog.models.activity_logging.activity_page import activity_page_response
-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
+from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.product_intent.product_intent import (
     ProductIntent,
@@ -264,12 +264,10 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
         return self.user_permissions.team(team).effective_membership_level
 
     def get_has_group_types(self, project: Project) -> bool:
-        return GroupTypeMapping.objects.filter(project_id=project.id).exists()
+        return len(self.get_group_types(project)) > 0
 
     def get_group_types(self, project: Project) -> list[dict[str, Any]]:
-        return list(
-            GroupTypeMapping.objects.filter(project_id=project.id).values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
-        )
+        return get_group_types_for_project(project.id)
 
     def get_live_events_token(self, project: Project) -> Optional[str]:
         team = project.teams.get(pk=project.pk)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -38,7 +38,7 @@ from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.data_color_theme import DataColorTheme
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
 from posthog.models.feature_flag import TeamDefaultEvaluationTag
-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
+from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.organization import OrganizationMembership
 from posthog.models.product_intent.product_intent import ProductIntentSerializer, calculate_product_activation
 from posthog.models.project import Project
@@ -395,14 +395,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         return self.user_permissions.team(team).effective_membership_level
 
     def get_has_group_types(self, team: Team) -> bool:
-        return GroupTypeMapping.objects.filter(project_id=team.project_id).exists()
+        return len(self.get_group_types(team)) > 0
 
     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
-        return list(
-            GroupTypeMapping.objects.filter(project_id=team.project_id)
-            .order_by("group_type_index")
-            .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
-        )
+        return get_group_types_for_project(team.project_id)
 
     def get_live_events_token(self, team: Team) -> str | None:
         return encode_jwt(

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest, snapshot
 from unittest import mock
 from unittest.mock import ANY, MagicMock, patch
 
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils.timezone import now
 
@@ -22,6 +23,7 @@ from posthog.models import Dashboard, DashboardTile, Filter, Insight, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.dashboard_tile import Text
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog
+from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.organization import Organization
 from posthog.models.project import Project
@@ -628,9 +630,13 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         group_type.detail_dashboard_id = dashboard.id
         group_type.save()
 
+        cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}"
+        cache.set(cache_key, [{"stale": True}], 300)
+
         self.dashboard_api.soft_delete(dashboard.id, "dashboards", {"delete_insights": True})
         group_type.refresh_from_db()
         self.assertIsNone(group_type.detail_dashboard_id)
+        self.assertIsNone(cache.get(cache_key))
 
     def test_dashboard_items(self):
         dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import OperationalError
 from django.http import HttpResponse
 from django.test import override_settings
 from django.utils import timezone
@@ -22,6 +23,7 @@ from posthog.api.test.batch_exports.conftest import start_test_worker
 from posthog.constants import AvailableFeature
 from posthog.models import ActivityLog
 from posthog.models.dashboard import Dashboard
+from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import Organization, OrganizationMembership
@@ -119,6 +121,9 @@ def team_api_test_factory():
                 project=self.project, team=other_team, group_type="place", group_type_index=1
             )
 
+            # Clear the cache so the next request fetches from DB
+            cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
+
             response = self.client.get("/api/environments/@current/")
             response_data = response.json()
 
@@ -156,6 +161,50 @@ def team_api_test_factory():
                     },
                 ],
             )
+
+        def test_group_types_graceful_degradation_on_db_failure(self):
+            """When the persons DB is unreachable, the endpoint still returns 200
+            with empty group types rather than a 500."""
+            with patch("posthog.models.group_type_mapping.GroupTypeMapping.objects") as mock_objects:
+                mock_objects.filter.return_value.order_by.return_value.values.side_effect = OperationalError(
+                    "could not connect to server"
+                )
+                cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
+
+                response = self.client.get("/api/environments/@current/")
+                response_data = response.json()
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
+                self.assertEqual(response_data["has_group_types"], False)
+                self.assertEqual(response_data["group_types"], [])
+
+        def test_group_types_cache_survives_db_failure(self):
+            """After a successful load populates the cache, a subsequent DB failure
+            still returns the cached data."""
+            other_team = Team.objects.create(organization=self.organization, project=self.project)
+            create_group_type_mapping_without_created_at(
+                project=self.project, team=other_team, group_type="company", group_type_index=0
+            )
+
+            # First request populates the cache
+            cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
+            response = self.client.get("/api/environments/@current/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["has_group_types"], True)
+            self.assertEqual(len(response.json()["group_types"]), 1)
+
+            # Second request with DB failure still returns cached data
+            with patch("posthog.models.group_type_mapping.GroupTypeMapping.objects") as mock_objects:
+                mock_objects.filter.return_value.order_by.return_value.values.side_effect = OperationalError(
+                    "could not connect to server"
+                )
+
+                response = self.client.get("/api/environments/@current/")
+                response_data = response.json()
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
+                self.assertEqual(response_data["has_group_types"], True)
+                self.assertEqual(response_data["group_types"][0]["group_type"], "company")
 
         def test_cant_retrieve_team_from_another_org(self):
             org = Organization.objects.create(name="New Org")

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -1,8 +1,20 @@
+from typing import Any
+
 from django.contrib.postgres.fields import ArrayField
-from django.db import models
+from django.core.cache import cache
+from django.db import DatabaseError, models
 from django.utils import timezone
 
+import structlog
+
 from posthog.models.utils import RootTeamMixin
+from posthog.utils import get_safe_cache
+
+logger = structlog.get_logger(__name__)
+
+GROUP_TYPES_CACHE_TTL = 60 * 5  # 5 minutes
+GROUP_TYPES_NEGATIVE_CACHE_TTL = 30  # seconds — short so we detect DB recovery quickly
+GROUP_TYPES_CACHE_KEY_PREFIX = "group_types_for_project_"
 
 # Defined here for reuse between OS and EE
 GROUP_TYPE_MAPPING_SERIALIZER_FIELDS = [
@@ -74,3 +86,42 @@ class GroupTypeMapping(RootTeamMixin, models.Model):
         if self._state.adding and self.created_at is None:
             self.created_at = timezone.now()
         super().save(*args, **kwargs)
+
+
+def invalidate_group_types_cache(project_id: int) -> None:
+    try:
+        cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{project_id}")
+    except Exception:
+        logger.debug("group_types_cache_invalidation_failure", project_id=project_id)
+
+
+def get_group_types_for_project(project_id: int) -> list[dict[str, Any]]:
+    """Fetch group types from cache, falling back to DB, then to empty list.
+
+    Group types live in the persons DB. If that DB is unreachable, we return
+    cached data (if available) or an empty list rather than failing the request.
+    """
+    cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{project_id}"
+
+    cached = get_safe_cache(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        result = list(
+            GroupTypeMapping.objects.filter(project_id=project_id)
+            .order_by("group_type_index")
+            .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
+        )
+        try:
+            cache.set(cache_key, result, GROUP_TYPES_CACHE_TTL)
+        except Exception:
+            pass
+        return result
+    except DatabaseError:
+        logger.warning("persons_db_group_types_failure", project_id=project_id, exc_info=True)
+        try:
+            cache.set(cache_key, [], GROUP_TYPES_NEGATIVE_CACHE_TTL)
+        except Exception:
+            pass
+        return []


### PR DESCRIPTION
## Problem

When the persons DB read replica is unreachable, every page load blocks because `/api/environments/@current/` queries `GroupTypeMapping` (routed to `persons_db_reader` via `PersonDBRouter`). Each connection attempt blocks for ~60s (OS TCP timeout, but there's [a PR to change that to 5s](https://github.com/PostHog/posthog/pull/49596)), exhausting all gunicorn workers and making the entire app unresponsive.

Group types are slow-changing metadata (only created when a new `$groupidentify` event type is first seen, or renamed via UI). They shouldn't require a DB query on every page load.

## Changes

- **`posthog/models/group_type_mapping.py`** — Add `get_group_types_for_project()` that reads group types through Django's cache framework (Redis-backed, 5-minute TTL). On DB failure, returns cached data if available, or negative-caches an empty list with a short TTL (30s) so subsequent requests fail fast instead of each one blocking on a DB connection attempt. Uses `get_safe_cache` so a Redis blip doesn't turn reads into 500s. Also adds `invalidate_group_types_cache()` for use by write paths. Cache keys and lookups are explicitly scoped to `project_id` to match the DB indexes and model constraints.
- **`posthog/api/team.py`** — `TeamSerializer.get_group_types` and `get_has_group_types` now use the cached accessor (passing `team.project_id`) instead of direct DB queries.
- **`posthog/api/project.py`** — Same change for `ProjectBackwardCompatSerializer`.
- **`ee/clickhouse/views/groups.py`** — All write paths in `GroupsTypesViewSet` (`update_metadata`, `create_detail_dashboard`, `set_default_columns`, `perform_destroy`) now invalidate the cache so UI changes are reflected immediately.
- **`posthog/api/dashboards/dashboard.py`** — Invalidates the cache when a dashboard deletion unlinks a group type mapping's `detail_dashboard`.
- **`posthog/api/test/test_team.py`** — Two new tests: graceful degradation on DB failure, and cache surviving a subsequent DB failure.
- **`ee/clickhouse/views/test/test_clickhouse_groups.py`** — Four new tests verifying cache invalidation after each write path.

### What this does NOT change

- No `connect_timeout` changes (separate PR)
- No changes to HogQL's GroupTypeMapping usage (different error handling needs)
- No changes to flag matching (already has its own try/except in `FlagsMatcherCache`)
- No cache invalidation from the Node.js ingestion path (out of scope — it doesn't go through Django)

## How did you test this code?

- Added `test_group_types_graceful_degradation_on_db_failure` — mocks `GroupTypeMapping.objects` to raise `OperationalError`, verifies endpoint returns 200 with `has_group_types=False` and `group_types=[]`
- Added `test_group_types_cache_survives_db_failure` — verifies cached data is returned after a successful load even when a subsequent DB query fails
- Added `test_update_metadata_invalidates_cache`, `test_destroy_invalidates_cache`, `test_create_detail_dashboard_invalidates_cache`, `test_set_default_columns_invalidates_cache` — each seeds the cache, performs a write via the API, and asserts the cache entry is gone
- Existing `test_retrieve_team_has_group_types` continues to pass
- Full `test_team.py`, `test_project.py`, and `test_clickhouse_groups.py` suites pass

## Open question

- [ ] Should we invalidate the cache entry from the Node ingestion service that creates new group type mappings? Or is waiting 5 minutes acceptable?

## Publish to changelog?

No