### PR TITLE
fix(live): de-deduplicate on uuid when receiving a new batch

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsLogic.tsx
@@ -37,11 +37,17 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
             [] as LiveEvent[],
             {
                 addEvents: (state, { events }) => {
-                    const newState = [...events, ...state]
-                    if (newState.length > 100) {
-                        return newState.slice(0, 100)
+                    const seen = new Set(state.map((e) => e.uuid).filter(Boolean))
+                    const dedupedIncoming: LiveEvent[] = []
+
+                    for (const event of events) {
+                        if (!seen.has(event.uuid)) {
+                            dedupedIncoming.push(event)
+                            seen.add(event.uuid)
+                        }
                     }
-                    return newState
+
+                    return [...dedupedIncoming, ...state].slice(0, 100)
                 },
                 clearEvents: () => [],
             },


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1772019944418429

Repro:
1. Go to https://us.posthog.com/project/2/activity/live
2. Wait 1-2 minutes
3. You'll see that the view turned somewhat stale and the same events are always on top

Likely cause of this is events with the same uuid coming in (see testing).

## Changes

De-duplicates events when adding them to the list.

## How did you test this code?

Didn't repro locally, instead used scripts in prod to narrow down the issue:

```js
(() => {
  const root = document.querySelector('[data-attr="live-events-table"]')
  if (!root) return console.warn('live-events-table not found')

  let lastKey = null
  let stagnantSeconds = 0
  let keyChanges = 0

  window.__liveUiInterval = setInterval(() => {
    const row = root.querySelector('tbody tr[data-row-key]')
    const key = row?.getAttribute('data-row-key') || '<none>'
    if (key === lastKey) stagnantSeconds++
    else {
      lastKey = key
      keyChanges++
      stagnantSeconds = 0
    }
    console.log({ key, keyChanges, stagnantSeconds })
  }, 1000)
})()
```


```js
(() => {
  const tbody = document.querySelector('[data-attr="live-events-table"] tbody')
  if (!tbody) return console.warn('tbody not found')

  const keys = [...tbody.querySelectorAll(':scope > tr[data-row-key]')].map((r) => r.getAttribute('data-row-key') || '')
  const uniq = new Set(keys)
  const dups = [...uniq].filter((k) => k && keys.filter((x) => x === k).length > 1)
  console.log({ rows: keys.length, unique: uniq.size, duplicateCount: dups.length, duplicates: dups.slice(0, 10) })
})()
```

They show:
- The list gets stagnant on the exact same key that appears in the duplicate list.
- There are duplicate row keys in the table.