### PR TITLE
feat(llm-gateway): use per-request posthog client in llm gateway callback

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -56,22 +56,6 @@ class PostHogCallback(InstrumentedCallback):
         self._api_key = api_key
         self._host = host
 
-    def _capture_sync(self, **capture_kwargs: Any) -> None:
-        client = Posthog(
-            self._api_key,
-            host=self._host,
-            sync_mode=True,
-            enable_local_evaluation=False,
-        )
-        try:
-            client.capture(**capture_kwargs)
-        finally:
-            client.shutdown()
-
-    def _capture_fire_and_forget(self, **capture_kwargs: Any) -> None:
-        loop = asyncio.get_running_loop()
-        loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
-
     async def _on_success(
         self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
     ) -> None:
@@ -219,6 +203,29 @@ class PostHogCallback(InstrumentedCallback):
             groups=capture_kwargs.get("groups"),
         )
         self._capture_fire_and_forget(**capture_kwargs)
+
+    def _capture_fire_and_forget(self, **capture_kwargs: Any) -> None:
+        """
+        Initializes a separate client for the capture operation to avoid payload bloat.
+        Fires in background thread to avoid blocking the main thread.
+        """
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
+
+    def _capture_sync(self, **capture_kwargs: Any) -> None:
+        client = Posthog(
+            self._api_key,
+            host=self._host,
+            sync_mode=True,
+            enable_local_evaluation=False,
+        )
+        try:
+            client.capture(**capture_kwargs)
+        except Exception as e:
+            client.capture_exception(e, **capture_kwargs)
+            logger.exception("posthog_capture_failed", error=str(e))
+        finally:
+            client.shutdown()
 
     def _extract_metadata(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         litellm_params = kwargs.get("litellm_params", {}) or {}

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import json
 from functools import partial
 from typing import Any
 from uuid import uuid4
@@ -44,6 +45,30 @@ def _replace_binary_content(data: Any) -> Any:
             return {k: _replace_binary_content(v) for k, v in data.items()}
         case _:
             return data
+
+
+_MAX_CAPTURE_SIZE = 15 * 1024 * 1024
+_MIN_FIELD_SIZE_TO_TRUNCATE = 10 * 1024
+_TRUNCATION_MARKER = "[truncated: content too large for capture]"
+_TRUNCATABLE_FIELDS = ("$ai_output_choices", "$ai_input")
+
+
+def _truncate_for_capture(properties: dict[str, Any]) -> dict[str, Any]:
+    serialized = json.dumps(properties, default=str)
+    if len(serialized) <= _MAX_CAPTURE_SIZE:
+        return properties
+
+    result = dict(properties)
+    for field in _TRUNCATABLE_FIELDS:
+        if field not in result:
+            continue
+        field_size = len(json.dumps(result[field], default=str))
+        if field_size < _MIN_FIELD_SIZE_TO_TRUNCATE:
+            continue
+        result[field] = _TRUNCATION_MARKER
+        if len(json.dumps(result, default=str)) <= _MAX_CAPTURE_SIZE:
+            break
+    return result
 
 
 class PostHogCallback(InstrumentedCallback):
@@ -122,6 +147,8 @@ class PostHogCallback(InstrumentedCallback):
         time_to_first_token = get_time_to_first_token()
         if time_to_first_token is not None:
             properties["$ai_time_to_first_token"] = time_to_first_token
+
+        properties = _truncate_for_capture(properties)
 
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -1,10 +1,11 @@
 import ast
-import json
+import asyncio
+from functools import partial
 from typing import Any
 from uuid import uuid4
 
-import posthoganalytics
 import structlog
+from posthoganalytics import Posthog
 
 from llm_gateway.callbacks.base import InstrumentedCallback
 from llm_gateway.request_context import (
@@ -45,30 +46,6 @@ def _replace_binary_content(data: Any) -> Any:
             return data
 
 
-_MAX_CAPTURE_SIZE = 800 * 1024
-_MIN_FIELD_SIZE_TO_TRUNCATE = 10 * 1024
-_TRUNCATION_MARKER = "[truncated: content too large for capture]"
-_TRUNCATABLE_FIELDS = ("$ai_output_choices", "$ai_input")
-
-
-def _truncate_for_capture(properties: dict[str, Any]) -> dict[str, Any]:
-    serialized = json.dumps(properties, default=str)
-    if len(serialized) <= _MAX_CAPTURE_SIZE:
-        return properties
-
-    result = dict(properties)
-    for field in _TRUNCATABLE_FIELDS:
-        if field not in result:
-            continue
-        field_size = len(json.dumps(result[field], default=str))
-        if field_size < _MIN_FIELD_SIZE_TO_TRUNCATE:
-            continue
-        result[field] = _TRUNCATION_MARKER
-        if len(json.dumps(result, default=str)) <= _MAX_CAPTURE_SIZE:
-            break
-    return result
-
-
 class PostHogCallback(InstrumentedCallback):
     """Custom PostHog callback for LLM analytics."""
 
@@ -78,8 +55,22 @@ class PostHogCallback(InstrumentedCallback):
         super().__init__()
         self._api_key = api_key
         self._host = host
-        posthoganalytics.api_key = api_key
-        posthoganalytics.host = host
+
+    def _capture_sync(self, **capture_kwargs: Any) -> None:
+        client = Posthog(
+            self._api_key,
+            host=self._host,
+            sync_mode=True,
+            enable_local_evaluation=False,
+        )
+        try:
+            client.capture(**capture_kwargs)
+        finally:
+            client.shutdown()
+
+    def _capture_fire_and_forget(self, **capture_kwargs: Any) -> None:
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(None, partial(self._capture_sync, **capture_kwargs))
 
     async def _on_success(
         self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
@@ -148,8 +139,6 @@ class PostHogCallback(InstrumentedCallback):
         if time_to_first_token is not None:
             properties["$ai_time_to_first_token"] = time_to_first_token
 
-        properties = _truncate_for_capture(properties)
-
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,
             "event": "$ai_generation",
@@ -165,7 +154,7 @@ class PostHogCallback(InstrumentedCallback):
             properties=properties,
             groups=capture_kwargs.get("groups"),
         )
-        posthoganalytics.capture(**capture_kwargs)
+        self._capture_fire_and_forget(**capture_kwargs)
 
     async def _on_failure(
         self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
@@ -229,7 +218,7 @@ class PostHogCallback(InstrumentedCallback):
             properties=properties,
             groups=capture_kwargs.get("groups"),
         )
-        posthoganalytics.capture(**capture_kwargs)
+        self._capture_fire_and_forget(**capture_kwargs)
 
     def _extract_metadata(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         litellm_params = kwargs.get("litellm_params", {}) or {}

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -1,9 +1,10 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.callbacks.posthog import PostHogCallback, _replace_binary_content
+from llm_gateway.callbacks.posthog import PostHogCallback, _replace_binary_content, _truncate_for_capture
 
 
 def _run_sync(executor, fn, *args):
@@ -389,3 +390,135 @@ class TestReplaceBinaryContent:
     )
     def test_replace_binary_content(self, input_data, expected):
         assert _replace_binary_content(input_data) == expected
+
+
+_MAX_SIZE = 15 * 1024 * 1024
+_TRUNCATION_MARKER = "[truncated: content too large for capture]"
+
+
+class TestTruncateForCapture:
+    @pytest.mark.parametrize(
+        "description,properties",
+        [
+            (
+                "small event unchanged",
+                {
+                    "$ai_model": "claude-3-opus",
+                    "$ai_input": [{"role": "user", "content": "Hello"}],
+                    "$ai_output_choices": "Hi there!",
+                    "$ai_input_tokens": 10,
+                },
+            ),
+            (
+                "no content fields unchanged",
+                {
+                    "$ai_model": "gpt-4",
+                    "$ai_input_tokens": 100,
+                    "$ai_output_tokens": 200,
+                },
+            ),
+        ],
+    )
+    def test_small_events_not_truncated(self, description: str, properties: dict) -> None:
+        result = _truncate_for_capture(properties)
+        assert result == properties
+
+    def test_large_output_truncated(self) -> None:
+        large_output = "x" * (_MAX_SIZE + 1)
+        properties = {
+            "$ai_model": "claude-3-opus",
+            "$ai_input": [{"role": "user", "content": "short"}],
+            "$ai_output_choices": large_output,
+            "$ai_input_tokens": 10,
+            "$ai_output_tokens": 5000,
+        }
+
+        result = _truncate_for_capture(properties)
+
+        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
+        assert result["$ai_input"] == [{"role": "user", "content": "short"}]
+        assert result["$ai_input_tokens"] == 10
+        assert result["$ai_output_tokens"] == 5000
+        assert len(json.dumps(result)) < _MAX_SIZE
+
+    def test_both_fields_truncated_when_both_large(self) -> None:
+        large_content = "y" * _MAX_SIZE
+        properties = {
+            "$ai_model": "claude-3-opus",
+            "$ai_input": [{"role": "user", "content": large_content}],
+            "$ai_output_choices": large_content,
+            "$ai_input_tokens": 10,
+        }
+
+        result = _truncate_for_capture(properties)
+
+        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
+        assert result["$ai_input"] == _TRUNCATION_MARKER
+        assert result["$ai_input_tokens"] == 10
+        assert len(json.dumps(result)) < _MAX_SIZE
+
+    def test_does_not_mutate_original(self) -> None:
+        large_output = "z" * (_MAX_SIZE + 1)
+        original_input = [{"role": "user", "content": "hello"}]
+        properties = {
+            "$ai_input": original_input,
+            "$ai_output_choices": large_output,
+        }
+
+        result = _truncate_for_capture(properties)
+
+        assert result is not properties
+        assert properties["$ai_output_choices"] == large_output
+        assert properties["$ai_input"] is original_input
+
+    def test_small_fields_not_truncated_even_if_total_large(self) -> None:
+        properties = {
+            "$ai_input": "small input",
+            "$ai_output_choices": "x" * (_MAX_SIZE + 1),
+        }
+
+        result = _truncate_for_capture(properties)
+
+        assert result["$ai_input"] == "small input"
+        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
+
+    @pytest.mark.asyncio
+    async def test_on_success_truncates_oversized_content(self) -> None:
+        mock_client = MagicMock()
+        callback = PostHogCallback(api_key="test-key", host="https://test.posthog.com")
+        auth_user = AuthenticatedUser(user_id=123, team_id=456, auth_method="personal_api_key", distinct_id="user-123")
+        large_response = "R" * (16 * 1024 * 1024)
+        kwargs = {
+            "standard_logging_object": {
+                "model": "claude-3-opus",
+                "custom_llm_provider": "anthropic",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "prompt_tokens": 10,
+                "completion_tokens": 50000,
+                "response_time": 2.5,
+                "response_cost": 1.23,
+                "response": large_response,
+            },
+            "litellm_params": {},
+        }
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor.side_effect = _run_sync
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="wizard"),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+            patch("llm_gateway.callbacks.posthog.asyncio") as mock_asyncio,
+        ):
+            mock_asyncio.get_running_loop.return_value = mock_loop
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_output_choices"] == _TRUNCATION_MARKER
+            assert props["$ai_model"] == "claude-3-opus"
+            assert props["$ai_input_tokens"] == 10
+            assert props["$ai_output_tokens"] == 50000
+            assert props["$ai_total_cost_usd"] == 1.23
+            assert props["$ai_latency"] == 2.5
+            assert len(json.dumps(props)) < _MAX_SIZE

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -1,10 +1,14 @@
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.callbacks.posthog import PostHogCallback, _replace_binary_content, _truncate_for_capture
+from llm_gateway.callbacks.posthog import PostHogCallback, _replace_binary_content
+
+
+def _run_sync(executor, fn, *args):
+    """Execute the function synchronously, bypassing the thread pool for tests."""
+    fn(*args)
 
 
 class TestPostHogCallback:
@@ -34,10 +38,29 @@ class TestPostHogCallback:
             "response": "Hello! How can I help?",
         }
 
+    @pytest.fixture
+    def mock_posthog_client(self):
+        mock_client = MagicMock()
+        with patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client) as mock_cls:
+            yield mock_cls, mock_client
+
+    @pytest.fixture(autouse=True)
+    def mock_event_loop(self):
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor.side_effect = _run_sync
+        with patch("llm_gateway.callbacks.posthog.asyncio") as mock_asyncio:
+            mock_asyncio.get_running_loop.return_value = mock_loop
+            yield mock_loop
+
     @pytest.mark.asyncio
     async def test_on_success_captures_event(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, standard_logging_object: dict
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
     ) -> None:
+        mock_cls, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": standard_logging_object,
             "litellm_params": {},
@@ -46,12 +69,14 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="wizard"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            mock_posthog.capture.assert_called_once()
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            mock_cls.assert_called_once_with(
+                "test-key", host="https://test.posthog.com", sync_mode=True, enable_local_evaluation=False
+            )
+            mock_client.capture.assert_called_once()
+            call_kwargs = mock_client.capture.call_args.kwargs
 
             assert call_kwargs["distinct_id"] == "user-distinct-id-123"
             assert call_kwargs["event"] == "$ai_generation"
@@ -66,30 +91,38 @@ class TestPostHogCallback:
             assert props["$ai_total_cost_usd"] == 0.05
             assert props["team_id"] == 456
             assert props["ai_product"] == "wizard"
-            mock_posthog.flush.assert_not_called()
+            mock_client.shutdown.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_on_success_uses_uuid_when_no_auth_user(
-        self, callback: PostHogCallback, standard_logging_object: dict
+        self,
+        callback: PostHogCallback,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
 
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=None),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
             patch("llm_gateway.callbacks.posthog.uuid4", return_value=MagicMock(hex="test-uuid")),
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            call_kwargs = mock_client.capture.call_args.kwargs
             # distinct_id should be a UUID string since no auth user
             assert "groups" not in call_kwargs  # No team_id means no groups
 
     @pytest.mark.asyncio
     async def test_on_success_uses_end_user_id_for_distinct_id(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, standard_logging_object: dict
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": standard_logging_object,
             "litellm_params": {"metadata": {"user_id": "trace-id-123"}},
@@ -98,11 +131,10 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id="end-user-123")
 
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            call_kwargs = mock_client.capture.call_args.kwargs
             assert call_kwargs["distinct_id"] == "end-user-123"
 
             props = call_kwargs["properties"]
@@ -111,8 +143,9 @@ class TestPostHogCallback:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("method_name", ["_on_success", "_on_failure"])
     async def test_oauth_uses_auth_user_distinct_id_not_end_user_id(
-        self, callback: PostHogCallback, method_name: str
+        self, callback: PostHogCallback, method_name: str, mock_posthog_client: tuple
     ) -> None:
+        _, mock_client = mock_posthog_client
         oauth_user = AuthenticatedUser(
             user_id=123,
             team_id=456,
@@ -136,18 +169,18 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=oauth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="wizard"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             method = getattr(callback, method_name)
             await method(kwargs, None, 0.0, 1.0, end_user_id="123")
 
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            call_kwargs = mock_client.capture.call_args.kwargs
             assert call_kwargs["distinct_id"] == "real-posthog-distinct-id"
 
     @pytest.mark.asyncio
     async def test_on_failure_captures_error_event(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": {
                 "model": "claude-3-opus",
@@ -160,12 +193,11 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="twig"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            mock_posthog.capture.assert_called_once()
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            mock_client.capture.assert_called_once()
+            call_kwargs = mock_client.capture.call_args.kwargs
 
             assert call_kwargs["distinct_id"] == "user-distinct-id-123"
             assert call_kwargs["event"] == "$ai_generation"
@@ -175,12 +207,13 @@ class TestPostHogCallback:
             assert props["$ai_is_error"] is True
             assert props["$ai_error"] == "Rate limit exceeded"
             assert props["ai_product"] == "twig"
-            mock_posthog.flush.assert_not_called()
+            mock_client.shutdown.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_on_success_without_optional_fields(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": {
                 "model": "gpt-4",
@@ -192,11 +225,10 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            props = mock_posthog.capture.call_args.kwargs["properties"]
+            props = mock_client.capture.call_args.kwargs["properties"]
             assert props["$ai_input_tokens"] == 0
             assert props["$ai_output_tokens"] == 0
             assert "$ai_total_cost_usd" not in props
@@ -208,8 +240,14 @@ class TestPostHogCallback:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("product", ["wizard", "twig", "llm_gateway"])
     async def test_on_success_includes_ai_product(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, standard_logging_object: dict, product: str
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        product: str,
+        mock_posthog_client: tuple,
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": standard_logging_object,
             "litellm_params": {},
@@ -218,18 +256,18 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value=product),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            props = mock_posthog.capture.call_args.kwargs["properties"]
+            props = mock_client.capture.call_args.kwargs["properties"]
             assert props["ai_product"] == product
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("product", ["wizard", "twig", "llm_gateway"])
     async def test_on_failure_includes_ai_product(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, product: str
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, product: str, mock_posthog_client: tuple
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": {
                 "model": "claude-3-opus",
@@ -242,17 +280,21 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value=product),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            props = mock_posthog.capture.call_args.kwargs["properties"]
+            props = mock_client.capture.call_args.kwargs["properties"]
             assert props["ai_product"] == product
 
     @pytest.mark.asyncio
     async def test_on_success_uses_passed_end_user_id(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, standard_logging_object: dict
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": standard_logging_object,
             "litellm_params": {"metadata": {"user_id": "metadata-user-id"}},
@@ -261,11 +303,10 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="growth"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id="openai-end-user-456")
 
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            call_kwargs = mock_client.capture.call_args.kwargs
             assert call_kwargs["distinct_id"] == "openai-end-user-456"
             assert call_kwargs["groups"] == {"project": 456}
 
@@ -274,8 +315,9 @@ class TestPostHogCallback:
 
     @pytest.mark.asyncio
     async def test_on_failure_uses_passed_end_user_id(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
     ) -> None:
+        _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": {
                 "model": "gpt-4",
@@ -288,11 +330,10 @@ class TestPostHogCallback:
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="growth"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
         ):
             await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id="openai-end-user-789")
 
-            call_kwargs = mock_posthog.capture.call_args.kwargs
+            call_kwargs = mock_client.capture.call_args.kwargs
             assert call_kwargs["distinct_id"] == "openai-end-user-789"
             assert call_kwargs["properties"]["$ai_trace_id"] == "trace-id-from-metadata"
 
@@ -348,129 +389,3 @@ class TestReplaceBinaryContent:
     )
     def test_replace_binary_content(self, input_data, expected):
         assert _replace_binary_content(input_data) == expected
-
-
-_MAX_SIZE = 800 * 1024
-_TRUNCATION_MARKER = "[truncated: content too large for capture]"
-
-
-class TestTruncateForCapture:
-    @pytest.mark.parametrize(
-        "description,properties",
-        [
-            (
-                "small event unchanged",
-                {
-                    "$ai_model": "claude-3-opus",
-                    "$ai_input": [{"role": "user", "content": "Hello"}],
-                    "$ai_output_choices": "Hi there!",
-                    "$ai_input_tokens": 10,
-                },
-            ),
-            (
-                "no content fields unchanged",
-                {
-                    "$ai_model": "gpt-4",
-                    "$ai_input_tokens": 100,
-                    "$ai_output_tokens": 200,
-                },
-            ),
-        ],
-    )
-    def test_small_events_not_truncated(self, description: str, properties: dict) -> None:
-        result = _truncate_for_capture(properties)
-        assert result == properties
-
-    def test_large_output_truncated(self) -> None:
-        large_output = "x" * (_MAX_SIZE + 1)
-        properties = {
-            "$ai_model": "claude-3-opus",
-            "$ai_input": [{"role": "user", "content": "short"}],
-            "$ai_output_choices": large_output,
-            "$ai_input_tokens": 10,
-            "$ai_output_tokens": 5000,
-        }
-
-        result = _truncate_for_capture(properties)
-
-        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
-        assert result["$ai_input"] == [{"role": "user", "content": "short"}]
-        assert result["$ai_input_tokens"] == 10
-        assert result["$ai_output_tokens"] == 5000
-        assert len(json.dumps(result)) < _MAX_SIZE
-
-    def test_both_fields_truncated_when_both_large(self) -> None:
-        large_content = "y" * _MAX_SIZE
-        properties = {
-            "$ai_model": "claude-3-opus",
-            "$ai_input": [{"role": "user", "content": large_content}],
-            "$ai_output_choices": large_content,
-            "$ai_input_tokens": 10,
-        }
-
-        result = _truncate_for_capture(properties)
-
-        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
-        assert result["$ai_input"] == _TRUNCATION_MARKER
-        assert result["$ai_input_tokens"] == 10
-        assert len(json.dumps(result)) < _MAX_SIZE
-
-    def test_does_not_mutate_original(self) -> None:
-        large_output = "z" * (_MAX_SIZE + 1)
-        original_input = [{"role": "user", "content": "hello"}]
-        properties = {
-            "$ai_input": original_input,
-            "$ai_output_choices": large_output,
-        }
-
-        result = _truncate_for_capture(properties)
-
-        assert result is not properties
-        assert properties["$ai_output_choices"] == large_output
-        assert properties["$ai_input"] is original_input
-
-    def test_small_fields_not_truncated_even_if_total_large(self) -> None:
-        properties = {
-            "$ai_input": "small input",
-            "$ai_output_choices": "x" * (_MAX_SIZE + 1),
-        }
-
-        result = _truncate_for_capture(properties)
-
-        assert result["$ai_input"] == "small input"
-        assert result["$ai_output_choices"] == _TRUNCATION_MARKER
-
-    @pytest.mark.asyncio
-    async def test_on_success_truncates_oversized_content(self) -> None:
-        callback = PostHogCallback(api_key="test-key", host="https://test.posthog.com")
-        auth_user = AuthenticatedUser(user_id=123, team_id=456, auth_method="personal_api_key", distinct_id="user-123")
-        large_response = "R" * (900 * 1024)
-        kwargs = {
-            "standard_logging_object": {
-                "model": "claude-3-opus",
-                "custom_llm_provider": "anthropic",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "prompt_tokens": 10,
-                "completion_tokens": 50000,
-                "response_time": 2.5,
-                "response_cost": 1.23,
-                "response": large_response,
-            },
-            "litellm_params": {},
-        }
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="wizard"),
-            patch("llm_gateway.callbacks.posthog.posthoganalytics") as mock_posthog,
-        ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_posthog.capture.call_args.kwargs["properties"]
-            assert props["$ai_output_choices"] == _TRUNCATION_MARKER
-            assert props["$ai_model"] == "claude-3-opus"
-            assert props["$ai_input_tokens"] == 10
-            assert props["$ai_output_tokens"] == 50000
-            assert props["$ai_total_cost_usd"] == 1.23
-            assert props["$ai_latency"] == 2.5
-            assert len(json.dumps(props)) < _MAX_SIZE


### PR DESCRIPTION
## Problem

I noticed that we use a shared client across all requests in LLM Gateway, which leads to the blob size issue on the capture endpoint. PostHog AI wants to use LLM Gateway, but we need full logs.

## Changes

- Refactored the capture of LLM traces to be a background pooled process with a single client per request.

## How did you test this code?

Manual testing