### PR TITLE
fix(hogql): variable errors if none match

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -121,6 +121,36 @@ def process_query_model(
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
+    if isinstance(query, HogQLAutocomplete):
+        return get_hogql_autocomplete(query=query, team=team, user=user)
+
+    if isinstance(query, HogQLMetadata):
+        metadata_query = HogQLMetadata.model_validate(query)
+        return get_hogql_metadata(query=metadata_query, team=team, user=user)
+
+    if isinstance(query, DatabaseSchemaQuery):
+        joins = DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True)
+        database = Database.create_for(team=team, modifiers=create_default_modifiers_for_team(team), user=user)
+        context = HogQLContext(team_id=team.pk, team=team, database=database, user=user)
+        return DatabaseSchemaQueryResponse(
+            tables=database.serialize(context, include_hidden_posthog_tables=True),
+            joins=[
+                DataWarehouseViewLink.model_validate(
+                    {
+                        "id": str(join.id),
+                        "source_table_name": join.source_table_name,
+                        "source_table_key": join.source_table_key,
+                        "joining_table_name": join.joining_table_name,
+                        "joining_table_key": join.joining_table_key,
+                        "field_name": join.field_name,
+                        "configuration": join.configuration,
+                        "created_at": join.created_at.isoformat(),
+                    }
+                )
+                for join in joins
+            ],
+        )
+
     try:
         query_runner = get_query_runner(query, team, limit_context=limit_context)
     except ValueError:  # This query doesn't run via query runner
@@ -157,34 +187,6 @@ def process_query_model(
                 )
             except Exception as e:
                 result = HogQueryResponse(results=f"ERROR: {str(e)}")
-        elif isinstance(query, HogQLAutocomplete):
-            result = get_hogql_autocomplete(query=query, team=team, user=user)
-        elif isinstance(query, HogQLMetadata):
-            metadata_query = HogQLMetadata.model_validate(query)
-            metadata_response = get_hogql_metadata(query=metadata_query, team=team, user=user)
-            result = metadata_response
-        elif isinstance(query, DatabaseSchemaQuery):
-            joins = DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True)
-            database = Database.create_for(team=team, modifiers=create_default_modifiers_for_team(team), user=user)
-            context = HogQLContext(team_id=team.pk, team=team, database=database, user=user)
-            result = DatabaseSchemaQueryResponse(
-                tables=database.serialize(context, include_hidden_posthog_tables=True),
-                joins=[
-                    DataWarehouseViewLink.model_validate(
-                        {
-                            "id": str(join.id),
-                            "source_table_name": join.source_table_name,
-                            "source_table_key": join.source_table_key,
-                            "joining_table_name": join.joining_table_name,
-                            "joining_table_key": join.joining_table_key,
-                            "field_name": join.field_name,
-                            "configuration": join.configuration,
-                            "created_at": join.created_at.isoformat(),
-                        }
-                    )
-                    for join in joins
-                ],
-            )
         else:
             raise ValidationError(f"Unsupported query kind: {query.__class__.__name__}")
     else:  # Query runner available - it will handle execution as well as caching

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -161,7 +161,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         result = process_query_model(self.team, query, user=self.user)
 
-        self.assertIn("suggestions", result.model_dump())
+        self.assertIn("suggestions", result.model_dump())  # type: ignore
         mock_get_query_runner.assert_not_called()
 
     @also_test_with_materialized_columns(["key"])

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -21,6 +21,8 @@ from posthog.schema import (
     CachedRetentionQueryResponse,
     EventPropertyFilter,
     EventsQuery,
+    HogLanguage,
+    HogQLAutocomplete,
     HogQLPropertyFilter,
     HogQLQuery,
     MeanRetentionCalculation,
@@ -31,7 +33,7 @@ from posthog.schema import (
 
 from posthog.hogql.constants import LimitContext
 
-from posthog.api.services.query import process_query_dict
+from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.utils import UUIDT
 
@@ -146,6 +148,21 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     "results": [[2, "sign out"], [1, "sign up"]],
                 },
             )
+
+    @patch("posthog.api.services.query.get_query_runner")
+    def test_hogql_autocomplete_bypasses_query_runner(self, mock_get_query_runner):
+        query = HogQLAutocomplete(
+            kind="HogQLAutocomplete",
+            query="select event from events",
+            language=HogLanguage.HOG_QL,
+            startPosition=6,
+            endPosition=6,
+        )
+
+        result = process_query_model(self.team, query, user=self.user)
+
+        self.assertIn("suggestions", result.model_dump())
+        mock_get_query_runner.assert_not_called()
 
     @also_test_with_materialized_columns(["key"])
     @snapshot_clickhouse_queries

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -71,7 +71,7 @@ def get_hogql_metadata(
                     hogql_ast = replace_filters(hogql_ast, query.filters, team)
                 if query.variables or finder.placeholder_fields or finder.placeholder_expressions:
                     hogql_ast = replace_variables(
-                        hogql_ast, list(query.variables.values()) if query.variables else {}, team
+                        hogql_ast, list(query.variables.values()) if query.variables else [], team
                     )
                     hogql_ast = cast(ast.SelectQuery, replace_placeholders(hogql_ast, query.globals))
 

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -69,9 +69,10 @@ def get_hogql_metadata(
                 finder = find_placeholders(hogql_ast)
                 if finder.has_filters:
                     hogql_ast = replace_filters(hogql_ast, query.filters, team)
-                if query.variables:
-                    hogql_ast = replace_variables(hogql_ast, list(query.variables.values()), team)
-                if finder.placeholder_fields or finder.placeholder_expressions:
+                if query.variables or finder.placeholder_fields or finder.placeholder_expressions:
+                    hogql_ast = replace_variables(
+                        hogql_ast, list(query.variables.values()) if query.variables else {}, team
+                    )
                     hogql_ast = cast(ast.SelectQuery, replace_placeholders(hogql_ast, query.globals))
 
             hogql_table_names = get_table_names(hogql_ast)

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -288,6 +288,13 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
         self.assertTrue(metadata.isValid)
         self.assertEqual(metadata.errors, [])
 
+    def test_metadata_variable_placeholder_without_variables(self):
+        metadata = self._select_with_variables("SELECT {variables.company_name}")
+
+        self.assertFalse(metadata.isValid)
+        self.assertEqual(len(metadata.errors), 1)
+        self.assertIn("company_name", metadata.errors[0].message)
+
     def test_metadata_property_type_notice_no_debug(self):
         try:
             from ee.clickhouse.materialized_columns.analyze import materialize

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -16,6 +16,7 @@ from posthog.schema import (
 from posthog.hogql.metadata import get_hogql_metadata
 
 from posthog.models import Cohort, PropertyDefinition
+from posthog.models.insight_variable import InsightVariable
 
 from products.data_warehouse.backend.models import ExternalDataSource, ExternalDataSourceType
 
@@ -40,6 +41,21 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
         return get_hogql_metadata(
             query=HogQLMetadata(
                 kind="HogQLMetadata", language=HogLanguage.HOG_QL, query=query, response=None, modifiers=modifiers
+            ),
+            team=self.team,
+        )
+
+    def _select_with_variables(
+        self, query: str, variables: Optional[dict[str, dict]] = None, globals: Optional[dict] = None
+    ) -> HogQLMetadataResponse:
+        return get_hogql_metadata(
+            query=HogQLMetadata(
+                kind="HogQLMetadata",
+                language=HogLanguage.HOG_QL,
+                query=query,
+                response=None,
+                variables=variables,
+                globals=globals,
             ),
             team=self.team,
         )
@@ -250,6 +266,27 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 ],
             },
         )
+
+    def test_metadata_replaces_variable_placeholders(self):
+        insight_variable = InsightVariable.objects.create(
+            team=self.team,
+            name="Company",
+            code_name="company_name",
+            type=InsightVariable.Type.STRING,
+        )
+        metadata = self._select_with_variables(
+            "SELECT {variables.company_name}",
+            variables={
+                "company_name": {
+                    "code_name": "company_name",
+                    "value": "Acme",
+                    "variableId": str(insight_variable.id),
+                }
+            },
+        )
+
+        self.assertTrue(metadata.isValid)
+        self.assertEqual(metadata.errors, [])
 
     def test_metadata_property_type_notice_no_debug(self):
         try:

--- a/products/data_warehouse/backend/models/table.py
+++ b/products/data_warehouse/backend/models/table.py
@@ -388,7 +388,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 hogql_type_str = clickhouse_type.partition("(")[0]
                 hogql_type = CLICKHOUSE_HOGQL_MAPPING[hogql_type_str]
             else:
-                hogql_type = STR_TO_HOGQL_MAPPING[type["hogql"]]
+                hogql_type = STR_TO_HOGQL_MAPPING.get(type["hogql"], STR_TO_HOGQL_MAPPING["UnknownDatabaseField"])
 
             fields[column] = hogql_type(name=column, nullable=is_nullable)
 

--- a/products/data_warehouse/backend/models/util.py
+++ b/products/data_warehouse/backend/models/util.py
@@ -171,6 +171,12 @@ STR_TO_HOGQL_MAPPING = {
     "StringDatabaseField": StringDatabaseField,
     "StringJSONDatabaseField": StringJSONDatabaseField,
     "UnknownDatabaseField": UnknownDatabaseField,
+    "boolean": BooleanDatabaseField,
+    "date": DateDatabaseField,
+    "datetime": DateTimeDatabaseField,
+    "integer": IntegerDatabaseField,
+    "float": FloatDatabaseField,
+    "string": StringDatabaseField,
 }
 
 


### PR DESCRIPTION
## Problem

Three things:

First, if you had a HogQL query with a bunch of placeholders, all variables, but none matched any real variable names you had defined, we threw a weird error:

<img width="499" height="55" alt="image" src="https://github.com/user-attachments/assets/f5104615-f87c-494c-ac69-9fbe9ae685a4" />

Second, "ValueError: Can't get a runner for an unknown query kind: HogQLAutocomplete" got sometimes thrown. 

Third, I was getting a bunch of errors from products/data_warehouse/backend/models/table.py about missing keys. 

## Changes

Fix all three errors.

Always run the variable replacement code which errors on unknown variables... even if no variables were sent with the query.

<img width="408" height="121" alt="Screenshot 2026-03-03 at 09 27 10" src="https://github.com/user-attachments/assets/a288d640-bf05-4e3f-8072-eea60573905a" />

Fix the "ValueError: Can't get a runner for an unknown query kind: HogQLAutocomplete" error by rearranging some code.

Also fix the missing key error. Postgres warehouse tables were throwing errors when the HogQL field type was set as "integer". Not sure how it got that way, but now we don't crash.

## How did you test this code?

Added tests and locally got rid of the red underline.

## Publish to changelog?

no