### PR TITLE
fix(llma): sort BYOK provider keys table

### DIFF
--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -29,6 +29,7 @@ import {
     LLMProviderKeyState,
     LLM_PROVIDER_LABELS,
     llmProviderKeysLogic,
+    sortProviderKeys,
 } from './llmProviderKeysLogic'
 import { TrialUsageMeterDisplay } from './TrialUsageMeter'
 
@@ -656,7 +657,7 @@ export function LLMProviderKeysSettings(): JSX.Element {
                         ) : (
                             <LemonTable
                                 columns={columns}
-                                dataSource={providerKeys}
+                                dataSource={sortProviderKeys(providerKeys)}
                                 loading={providerKeysLoading}
                                 rowKey="id"
                             />


### PR DESCRIPTION
## Problem

The BYOK provider keys table in LLM analytics settings displays keys in an unordered/arbitrary order, making it harder to find keys when multiple are configured.

## Changes

Apply the existing `sortProviderKeys` ordering to the table's data source. Keys are now sorted by provider (OpenAI, Anthropic, Gemini, OpenRouter, Fireworks), then name, then id.

No new logic was needed — the `sortProviderKeys` function was already defined and used elsewhere but wasn't applied to the settings table.

## How did you test this code?

Verified in the BYOK settings UI that keys now display in consistent provider/name order.

## Publish to changelog?

no