### PR TITLE
fix: Do not partition consumer table in BigQuery

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -1054,6 +1054,8 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                     bigquery_target_table.parents,
                     primary_key=bigquery_target_table.primary_key,
                     version_key=bigquery_target_table.version_key,
+                    # Do not partition the consumer table to avoid running into quota errors.
+                    time_partitioning=None,
                 )
 
                 if inputs.use_json_type:

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -283,7 +283,7 @@ class BigQueryTable(Table[BigQueryField]):
         primary_key: collections.abc.Iterable[str],
         version_key: collections.abc.Iterable[str],
     ) -> typing.Self:
-        return cls.from_arrow_schema_with_field_type(
+        self = cls.from_arrow_schema_with_field_type(
             schema,
             BigQueryField,
             table_id,
@@ -291,6 +291,13 @@ class BigQueryTable(Table[BigQueryField]):
             primary_key,
             version_key,
         )
+        if "timestamp" in self:
+            # TODO: Choosing which column and granularity to use as partitioning should be a configuration parameter.
+            # 'timestamp' is used for backwards compatibility.
+            self.time_partitioning = bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY, field="timestamp"
+            )
+        return self
 
     @property
     def project_id(self) -> str:
@@ -354,12 +361,8 @@ class BigQueryClient:
 
         bq_table = bigquery.Table(table.fully_qualified_name, schema=schema)
 
-        if isinstance(table, BigQueryTable) and "timestamp" in table:
-            # TODO: Maybe choosing which column to use as partitioning should be a configuration parameter.
-            # 'timestamp' is used for backwards compatibility.
-            bq_table.time_partitioning = bigquery.TimePartitioning(
-                type_=bigquery.TimePartitioningType.DAY, field="timestamp"
-            )
+        if isinstance(table, BigQueryTable) and table.time_partitioning is not None:
+            bq_table.time_partitioning = table.time_partitioning
 
         created_bq_table = await asyncio.to_thread(self.sync_client.create_table, bq_table, exists_ok=exists_ok)
 

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_activity.py
@@ -763,3 +763,57 @@ async def test_insert_into_bigquery_activity_from_stage_handles_datetime_to_int(
         sort_key="person_id",
         timestamp_columns=("created_at",),
     )
+
+
+async def test_insert_into_bigquery_activity_creates_tables_with_the_right_partitioning(
+    clickhouse_client,
+    activity_environment,
+    bigquery_client,
+    bigquery_config,
+    bigquery_dataset,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+):
+    """Test that the `insert_into_bigquery_activity_from_stage` correctly partitions.
+
+    We expect the final table to always be partitioned by day (partly for backwards
+    compatibility, this may change in the future), and the consumer table to not be
+    partitioned.
+    """
+    model = BatchExportModel(name="events", schema=None)
+    table_id = f"test_insert_activity_partitioning_{ateam.pk}"
+
+    with (
+        unittest.mock.patch(
+            "products.batch_exports.backend.temporal.destinations.bigquery_batch_export.BigQueryClient.delete_table",
+            return_value=None,
+        ) as mocked_delete,
+    ):
+        await _run_activity(
+            activity_environment,
+            bigquery_client=bigquery_client,
+            clickhouse_client=clickhouse_client,
+            team=ateam,
+            table_id=table_id,
+            dataset_id=bigquery_dataset.dataset_id,
+            data_interval_start=data_interval_start,
+            data_interval_end=data_interval_end,
+            batch_export_model=model,
+            bigquery_config=bigquery_config,
+            sort_key="event",
+        )
+
+    final_table = bigquery_client.get_table(f"{bigquery_dataset.dataset_id}.{table_id}")
+
+    data_interval_end_str = data_interval_end.strftime("%Y-%m-%d_%H-%M-%S")
+    stage_table_id = f"stage_{table_id}_{data_interval_end_str}_{ateam.pk}_1"
+    consumer_table = bigquery_client.get_table(f"{bigquery_dataset.dataset_id}.{stage_table_id}")
+
+    mocked_delete.assert_called_once()
+    assert final_table.time_partitioning is not None
+    assert final_table.time_partitioning == bigquery.table.TimePartitioning(
+        type_=bigquery.TimePartitioningType.DAY, field="timestamp"
+    )
+    assert consumer_table.time_partitioning is None

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -1,9 +1,20 @@
+import random
+import string
+
 import pytest
 from unittest.mock import MagicMock
 
+from google.cloud import bigquery
+
 from products.batch_exports.backend.temporal.destinations.bigquery_batch_export import (
     BigQueryClient,
+    BigQueryField,
+    BigQueryTable,
+    BigQueryType,
     StartQueryTimeoutError,
+)
+from products.batch_exports.backend.tests.temporal.destinations.bigquery.utils import (
+    SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS,
 )
 
 
@@ -56,3 +67,36 @@ async def test_execute_query_pending_timeout(states_sequence: list[str], should_
             poll_interval=0.01,
         )
         assert result == mock_result
+
+
+@SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fields,time_partitioning",
+    [
+        [(BigQueryField("id", BigQueryType("INT64", False), False),), None],
+        [
+            (
+                BigQueryField("id", BigQueryType("INT64", False), False),
+                BigQueryField("timestamp", BigQueryType("TIMESTAMP", False), False),
+            ),
+            bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY, field="timestamp"),
+        ],
+    ],
+)
+async def test_create_table(fields, time_partitioning, bigquery_client, bigquery_config, bigquery_dataset):
+    """Assert tables are created."""
+    table = BigQueryTable(
+        f"test_table_{''.join(random.choices(string.ascii_letters, k=10))}",
+        fields,
+        parents=(bigquery_client.project, bigquery_dataset.dataset_id),
+        time_partitioning=time_partitioning,
+    )
+    client = BigQueryClient(bigquery_client)
+    created = await client.create_table(table)
+
+    try:
+        assert created.time_partitioning == table.time_partitioning == time_partitioning
+        assert all(field.name in created for field in fields)
+    finally:
+        await client.delete_table(table)


### PR DESCRIPTION
## Problem

BigQuery enforces a quota for load jobs to partitioned tables. We partition the final destination table for our users, but we don't need to partition the consumer table. This should help avoid any quota issues.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Do not partition consumer table when merging into final table.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran bigquery tests. Added new unit tests to specifically check partition settings.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
