### PR TITLE
fix(code): shallow clone repos in cloud runs

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -499,7 +499,7 @@ class DockerSandbox:
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            f"git clone {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            f"git clone --depth 1 --single-branch {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id}")

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -383,7 +383,7 @@ class ModalSandbox:
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            f"git clone {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            f"git clone --depth 1 --single-branch {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id}")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloning large repositories into sandboxes was taking a significant amount of time (e.g., 1m 30s for `posthog/posthog`), impacting the speed and efficiency of sandbox operations.

## Changes

Modified the `clone_repository` method in `products/tasks/backend/services/docker_sandbox.py` and `products/tasks/backend/services/modal_sandbox.py` to perform a shallow clone using `git clone --depth 1 --single-branch`.

This change drastically reduces clone times:
*   **Full clone**: ~1m 30s
*   **Shallow clone (`--depth 1 --single-branch`)**: ~4.7s (for `posthog/posthog`)

Other options like `--filter=blob:none` were tested and found to be slower, while `--no-tags` provided marginal gains and was removed as requested.

## How did you test this code?

*   **Manual Timing Tests**: Performed timing benchmarks by cloning `posthog/posthog` with various `git clone` options to verify performance improvements.
*   **Automated Tests**:
    *   Ran specific unit tests for `docker_sandbox.py` and `modal_sandbox.py` (all 12 tests passed).
    *   Ran broader test suites for both files (all 57 tests passed).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Yes

---
<p><a href="https://cursor.com/agents/bc-f58310c8-f66d-4fe1-885b-be2ba78d1f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f58310c8-f66d-4fe1-885b-be2ba78d1f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->