### PR TITLE
fix: check specific event ids

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/README.md
+++ b/posthog/temporal/ingestion_acceptance_test/README.md
@@ -74,7 +74,7 @@ class TestExample(AcceptanceTest):
 - `merge_dangerously(into_id, from_id)` - Merge two persons
 - `query_event_by_uuid(uuid)` - Poll for an event by UUID
 - `query_person_by_distinct_id(distinct_id)` - Poll for a person
-- `query_events_by_person_id(person_id, expected_count)` - Poll for events by person
+- `query_events_by_person_id(person_id, expected_event_uuids)` - Poll for events by person
 
 **Available assertion methods:**
 

--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -11,7 +11,7 @@ from posthog.temporal.ingestion_acceptance_test.client import PostHogClient
 from posthog.temporal.ingestion_acceptance_test.config import Config
 from posthog.temporal.ingestion_acceptance_test.results import TestSuiteResult
 from posthog.temporal.ingestion_acceptance_test.runner import run_tests
-from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification
+from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification, send_slack_timeout_notification
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import discover_tests
 
 logger = structlog.get_logger(__name__)
@@ -53,8 +53,15 @@ async def run_ingestion_acceptance_tests() -> dict:
 
     tests = discover_tests()
     client = PostHogClient(config, posthog_sdk)
-    with ThreadPoolExecutor() as executor:
-        result: TestSuiteResult = await asyncio.to_thread(run_tests, config, tests, client, executor)
+    try:
+        with ThreadPoolExecutor() as executor:
+            result: TestSuiteResult = await asyncio.wait_for(
+                asyncio.to_thread(run_tests, config, tests, client, executor),
+                timeout=config.activity_timeout_seconds,
+            )
+    except TimeoutError:
+        send_slack_timeout_notification(config)
+        raise
 
     logger.info(
         "Ingestion acceptance tests completed",

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -239,18 +239,18 @@ class PostHogClient:
             description=f"person with distinct_id '{distinct_id}'",
         )
 
-    def query_events_by_person_id(self, person_id: str, expected_count: int) -> list[CapturedEvent] | None:
-        """Query for events by person_id, polling until expected count is reached or timeout.
+    def query_events_by_person_id(self, person_id: str, expected_event_uuids: set[str]) -> list[CapturedEvent] | None:
+        """Query for events by person_id, polling until all expected UUIDs are found or timeout.
 
         Args:
             person_id: The person ID to search events for.
-            expected_count: The minimum number of events expected.
+            expected_event_uuids: Set of event UUIDs that must all be present.
 
         Returns:
-            List of events if expected_count is reached, None if timeout.
+            List of events if all expected UUIDs are found, None if timeout.
         """
         return self._poll_until_found(
-            fetch_fn=lambda: self._fetch_events_by_person_id(person_id, expected_count),
+            fetch_fn=lambda: self._fetch_events_by_person_id(person_id, expected_event_uuids),
             description=f"events for person '{person_id}'",
         )
 
@@ -395,8 +395,8 @@ class PostHogClient:
             created_at=row.get("created_at", ""),
         )
 
-    def _fetch_events_by_person_id(self, person_id: str, expected_count: int) -> list[CapturedEvent] | None:
-        """Fetch events by person_id. Returns None if fewer than expected_count events found.
+    def _fetch_events_by_person_id(self, person_id: str, expected_event_uuids: set[str]) -> list[CapturedEvent] | None:
+        """Fetch events by person_id. Returns None if not all expected UUIDs are found.
 
         Includes a timestamp filter to benefit from ClickHouse's table partitioning
         (PARTITION BY toYYYYMM(timestamp)) and ordering (ORDER BY includes toDate(timestamp)).
@@ -416,7 +416,8 @@ class PostHogClient:
                 "min_timestamp": self._test_start_date.isoformat(),
             },
         )
-        if len(rows) < expected_count:
+        found_uuids = {row.get("uuid", "") for row in rows}
+        if not expected_event_uuids.issubset(found_uuids):
             return None
 
         events = []

--- a/posthog/temporal/ingestion_acceptance_test/config.py
+++ b/posthog/temporal/ingestion_acceptance_test/config.py
@@ -21,6 +21,7 @@ class Config(BaseSettings):
     personal_api_key: str
     event_timeout_seconds: int = Field(default=600)
     poll_interval_seconds: float = Field(default=10.0)
+    activity_timeout_seconds: int = Field(default=600)
     slack_webhook_url: str | None = Field(default=None)
 
     @field_validator("api_host")
@@ -35,4 +36,5 @@ class Config(BaseSettings):
             "project_id": self.project_id,
             "event_timeout_seconds": str(self.event_timeout_seconds),
             "poll_interval_seconds": str(self.poll_interval_seconds),
+            "activity_timeout_seconds": str(self.activity_timeout_seconds),
         }

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -117,6 +117,56 @@ def _build_context_block(config: Config, result: TestSuiteResult) -> dict[str, A
     }
 
 
+def send_slack_timeout_notification(config: Config) -> bool:
+    """Send a timeout notification to Slack via incoming webhook.
+
+    Args:
+        config: Configuration containing the Slack webhook URL.
+
+    Returns:
+        True if notification was sent successfully or skipped, False on send failure.
+    """
+    if not config.slack_webhook_url:
+        logger.debug("Slack webhook URL not configured, skipping timeout notification")
+        return True
+
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":hourglass: *Ingestion Acceptance Tests Timed Out*",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f":globe_with_meridians: Env: {config.api_host} | "
+                        f":file_folder: Project: {config.project_id} | "
+                        f":stopwatch: Timeout: {config.activity_timeout_seconds}s"
+                    ),
+                },
+            ],
+        },
+    ]
+
+    try:
+        response = external_requests.post(
+            config.slack_webhook_url,
+            json={"blocks": blocks},
+            timeout=10,
+        )
+        response.raise_for_status()
+        logger.info("Slack timeout notification sent successfully")
+        return True
+    except requests.RequestException as e:
+        logger.warning("Failed to send Slack timeout notification", error=str(e))
+        return False
+
+
 def _build_failed_tests_blocks(result: TestSuiteResult) -> list[dict[str, Any]]:
     failed_tests = [r for r in result.results if r.status in ("failed", "error")]
     if not failed_tests:

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
@@ -41,4 +41,4 @@ class TestAlias(AcceptanceTest):
         # Query all events for this person - should have all 3 specific events
         expected_uuids = {first_event_uuid, second_event_uuid, alias_event_uuid}
         events = self.client.query_events_by_person_id(person.id, expected_event_uuids=expected_uuids)
-        assert events is not None, "Expected events not found for person after alias withing time budget"
+        assert events is not None, "Expected events not found for person after alias within time budget"

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
@@ -39,10 +39,6 @@ class TestAlias(AcceptanceTest):
         assert person is not None, "Alias not propagated within time budget"
 
         # Query all events for this person - should have all 3 specific events
-        events = self.client.query_events_by_person_id(person.id, expected_count=3)
-        assert events is not None, "Expected at least 3 events for person after alias"
-
-        event_uuids = {e.uuid for e in events}
-        assert first_event_uuid in event_uuids, "First event not found in person's events"
-        assert second_event_uuid in event_uuids, "Second event not found in person's events"
-        assert alias_event_uuid in event_uuids, "Alias event not found in person's events"
+        expected_uuids = {first_event_uuid, second_event_uuid, alias_event_uuid}
+        events = self.client.query_events_by_person_id(person.id, expected_event_uuids=expected_uuids)
+        assert events is not None, "Expected events not found for person after alias withing time budget"

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
@@ -65,4 +65,4 @@ class TestMergeDangerously(AcceptanceTest):
         # Query all events for the merged person - should have events from both A and B
         expected_uuids = {event_uuid_a, event_uuid_b, merge_event_uuid, post_merge_event_uuid}
         events = self.client.query_events_by_person_id(merged_person.id, expected_event_uuids=expected_uuids)
-        assert events is not None, "Expected events not found for merged person after merge withing time budget"
+        assert events is not None, "Expected events not found for merged person after merge within time budget"

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
@@ -35,14 +35,14 @@ class TestMergeDangerously(AcceptanceTest):
 
         # Verify both persons exist
         person_a = self.client.query_person_by_distinct_id(distinct_id_a)
-        assert person_a is not None, "Person A not found"
+        assert person_a is not None, "Person A not found within time budget"
         person_b = self.client.query_person_by_distinct_id(distinct_id_b)
-        assert person_b is not None, "Person B not found"
+        assert person_b is not None, "Person B not found within time budget"
 
         # Merge Person B into Person A
         merge_event_uuid = self.client.merge_dangerously(distinct_id_a, distinct_id_b)
         found_merge = self.client.query_event_by_uuid(merge_event_uuid)
-        assert found_merge is not None, "Merge event not found"
+        assert found_merge is not None, "Merge event not found within time budget"
 
         # Wait for merge to propagate - Person A should have updated timestamp
         # We need to set a new timestamp on Person A to detect when merge completes
@@ -51,11 +51,11 @@ class TestMergeDangerously(AcceptanceTest):
             "$test_post_merge", distinct_id_a, {"$set": {"$test_timestamp": post_merge_timestamp}}
         )
         found_post_merge = self.client.query_event_by_uuid(post_merge_event_uuid)
-        assert found_post_merge is not None, "Post-merge event not found"
+        assert found_post_merge is not None, "Post-merge event not found within time budget"
 
         # Query Person A with the post-merge timestamp to ensure merge has propagated
         merged_person = self.client.query_person_by_distinct_id(distinct_id_a, min_timestamp=post_merge_timestamp)
-        assert merged_person is not None, "Merged person not found"
+        assert merged_person is not None, "Person not updated after merge within time budget"
 
         # After merge, Person A should have Person B's extra_prop (properties merge)
         # Note: Person A's name takes precedence over Person B's name
@@ -63,11 +63,6 @@ class TestMergeDangerously(AcceptanceTest):
         assert merged_person.properties.get("extra_prop") == "from_b", "Person B's extra_prop should be merged"
 
         # Query all events for the merged person - should have events from both A and B
-        # Expected: event_a, event_b, merge_event, post_merge_event = 4 events
-        events = self.client.query_events_by_person_id(merged_person.id, expected_count=4)
-        assert events is not None, "Expected 4 events for merged person"
-
-        # Verify both original event UUIDs are present
-        event_uuids = {e.uuid for e in events}
-        assert event_uuid_a in event_uuids, "Person A's event not found after merge"
-        assert event_uuid_b in event_uuids, "Person B's event not found after merge"
+        expected_uuids = {event_uuid_a, event_uuid_b, merge_event_uuid, post_merge_event_uuid}
+        events = self.client.query_events_by_person_id(merged_person.id, expected_event_uuids=expected_uuids)
+        assert events is not None, "Expected events not found for merged person after merge withing time budget"

--- a/posthog/temporal/ingestion_acceptance_test/workflows.py
+++ b/posthog/temporal/ingestion_acceptance_test/workflows.py
@@ -33,7 +33,7 @@ class IngestionAcceptanceTestWorkflow(PostHogWorkflow):
         """
         result = await temporalio.workflow.execute_activity(
             run_ingestion_acceptance_tests,
-            start_to_close_timeout=timedelta(minutes=10),
+            start_to_close_timeout=timedelta(minutes=11),
             retry_policy=RetryPolicy(
                 maximum_attempts=1,
             ),

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
@@ -1,0 +1,89 @@
+import time
+import asyncio
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.ingestion_acceptance_test.config import Config
+
+
+def _make_config(**overrides) -> Config:
+    defaults = {
+        "api_host": "https://test.posthog.com",
+        "project_api_key": "phc_test_key",
+        "project_id": "12345",
+        "personal_api_key": "phx_personal_key",
+        "slack_webhook_url": "https://hooks.slack.com/services/T00/B00/XXX",
+        "activity_timeout_seconds": 1,
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+class TestRunIngestionAcceptanceTestsTimeout:
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.send_slack_timeout_notification")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.send_slack_notification")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.PostHogClient")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.posthoganalytics.Posthog")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.discover_tests", return_value=[])
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.Config")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.run_tests")
+    @pytest.mark.asyncio
+    async def test_sends_slack_timeout_notification_on_timeout(
+        self,
+        mock_run_tests: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_discover: MagicMock,
+        mock_posthog: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_send_slack: MagicMock,
+        mock_send_timeout: MagicMock,
+    ) -> None:
+        config = _make_config()
+        mock_config_cls.return_value = config
+
+        def slow_run_tests(*args, **kwargs):
+            time.sleep(5)
+
+        mock_run_tests.side_effect = slow_run_tests
+
+        from posthog.temporal.ingestion_acceptance_test.activities import run_ingestion_acceptance_tests
+
+        with pytest.raises(asyncio.TimeoutError):
+            await run_ingestion_acceptance_tests()
+
+        mock_send_timeout.assert_called_once_with(config)
+        mock_send_slack.assert_not_called()
+
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.send_slack_timeout_notification")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.send_slack_notification")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.PostHogClient")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.posthoganalytics.Posthog")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.discover_tests", return_value=[])
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.Config")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.run_tests")
+    @pytest.mark.asyncio
+    async def test_does_not_send_timeout_notification_when_tests_complete(
+        self,
+        mock_run_tests: MagicMock,
+        mock_config_cls: MagicMock,
+        mock_discover: MagicMock,
+        mock_posthog: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_send_slack: MagicMock,
+        mock_send_timeout: MagicMock,
+    ) -> None:
+        config = _make_config()
+        mock_config_cls.return_value = config
+
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"success": True}
+        mock_run_tests.return_value = mock_result
+
+        from posthog.temporal.ingestion_acceptance_test.activities import run_ingestion_acceptance_tests
+
+        result = await run_ingestion_acceptance_tests()
+
+        assert result == {"success": True}
+        mock_send_timeout.assert_not_called()
+        mock_send_slack.assert_called_once()

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
@@ -7,17 +7,16 @@ from unittest.mock import MagicMock, patch
 from posthog.temporal.ingestion_acceptance_test.config import Config
 
 
-def _make_config(**overrides) -> Config:
-    defaults = {
-        "api_host": "https://test.posthog.com",
-        "project_api_key": "phc_test_key",
-        "project_id": "12345",
-        "personal_api_key": "phx_personal_key",
-        "slack_webhook_url": "https://hooks.slack.com/services/T00/B00/XXX",
-        "activity_timeout_seconds": 1,
-    }
-    defaults.update(overrides)
-    return Config(**defaults)
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        api_host="https://test.posthog.com",
+        project_api_key="phc_test_key",
+        project_id="12345",
+        personal_api_key="phx_personal_key",
+        slack_webhook_url="https://hooks.slack.com/services/T00/B00/XXX",
+        activity_timeout_seconds=1,
+    )
 
 
 class TestRunIngestionAcceptanceTestsTimeout:
@@ -38,8 +37,8 @@ class TestRunIngestionAcceptanceTestsTimeout:
         mock_client_cls: MagicMock,
         mock_send_slack: MagicMock,
         mock_send_timeout: MagicMock,
+        config: Config,
     ) -> None:
-        config = _make_config()
         mock_config_cls.return_value = config
 
         def slow_run_tests(*args, **kwargs):
@@ -72,8 +71,8 @@ class TestRunIngestionAcceptanceTestsTimeout:
         mock_client_cls: MagicMock,
         mock_send_slack: MagicMock,
         mock_send_timeout: MagicMock,
+        config: Config,
     ) -> None:
-        config = _make_config()
         mock_config_cls.return_value = config
 
         mock_result = MagicMock()

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -362,7 +362,7 @@ class TestTimestampFiltering:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json.return_value = {"results": [], "columns": []}
 
-            client._fetch_events_by_person_id("test-person-id", expected_count=1)
+            client._fetch_events_by_person_id("test-person-id", expected_event_uuids={"some-uuid"})
 
             mock_post.assert_called_once()
             call_kwargs = mock_post.call_args[1]

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ingestion_acceptance_test.config import Config
 from posthog.temporal.ingestion_acceptance_test.results import TestResult, TestSuiteResult
-from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification
+from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification, send_slack_timeout_notification
 
 
 @pytest.fixture
@@ -181,4 +181,54 @@ class TestSendSlackNotification:
 
         send_slack_notification(config_no_webhook, failing_result)
 
+        mock_post.assert_not_called()
+
+
+class TestSendSlackTimeoutNotification:
+    @patch("posthog.temporal.ingestion_acceptance_test.slack.external_requests.post")
+    def test_posts_timeout_message_to_webhook(self, mock_post: MagicMock, config: Config) -> None:
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = send_slack_timeout_notification(config)
+
+        assert result is True
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        assert url == "https://hooks.slack.com/services/T00/B00/XXX"
+
+    @patch("posthog.temporal.ingestion_acceptance_test.slack.external_requests.post")
+    def test_payload_contains_timeout_header(self, mock_post: MagicMock, config: Config) -> None:
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        send_slack_timeout_notification(config)
+
+        payload = mock_post.call_args[1]["json"]
+        header_text = payload["blocks"][0]["text"]["text"]
+        assert "Timed Out" in header_text
+
+    @patch("posthog.temporal.ingestion_acceptance_test.slack.external_requests.post")
+    def test_payload_contains_environment_and_timeout_info(self, mock_post: MagicMock, config: Config) -> None:
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        send_slack_timeout_notification(config)
+
+        payload = mock_post.call_args[1]["json"]
+        context_text = payload["blocks"][1]["elements"][0]["text"]
+        assert "test.posthog.com" in context_text
+        assert "12345" in context_text
+        assert "600s" in context_text
+
+    @patch("posthog.temporal.ingestion_acceptance_test.slack.external_requests.post")
+    def test_does_nothing_when_no_webhook_url(self, mock_post: MagicMock) -> None:
+        config_no_webhook = Config(
+            api_host="https://test.posthog.com",
+            project_api_key="phc_test_key",
+            project_id="12345",
+            personal_api_key="phx_personal_key",
+            slack_webhook_url=None,
+        )
+
+        result = send_slack_timeout_notification(config_no_webhook)
+
+        assert result is True
         mock_post.assert_not_called()


### PR DESCRIPTION
## Problem

Some of the tests check if a number of expected events can be found and then checks each event individually. Because capturing might fail and retry, at times we might find the expected number of events but not the events that were expected.

## Changes

Rather than checking the individual events data after finding the expected number of events, we now check if the list of expected events are found, and only then check information for each individual event.

Additionally, an alert in case the test fails to complete within the expected time was added.

## How did you test this code?
Unit tests

## Publish to changelog?
