### PR TITLE
fix: Fix nuke command not adding back the hogli symlink

### DIFF
--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -619,9 +619,11 @@ utilities:
             - name: node_modules
               cmd: rm -rf **/node_modules
             - name: python venvs
-              cmd: rm -rf .venv .flox/cache/venv && uv sync --active
+              cmd: rm -rf .venv .flox/cache/venv
             - name: rust builds
               cmd: cd rust && cargo clean && find . -name 'index.node' -type f -delete
+            - name: flox on activate
+              cmd: ./.flox/env/on-activate.sh
             - dev:reset
         description: Wipe everything and rebuild (node_modules, Python, Rust, then dev:reset)
         prompt: true


### PR DESCRIPTION
## Problem
Flox is added to the path as a symlink that is created by the script `.flox/env/on-activate.sh`. This never gets run by the `nuke` command

## Changes

Run the `.flox/env/on-activate.sh` script in the nuke command

## How did you test this code?

I nuked my own dev env

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
