### PR TITLE
chore(flox): add Xcode license acceptance check during activation

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -160,7 +160,7 @@ if [[ "$(uname -s)" == "Darwin" ]] && command -v xcodebuild >/dev/null 2>&1 \
       fi
       echo
     elif [[ ! -t 0 ]]; then
-      warn_step "Xcode license not accepted  ${C_DIM}(run 'sudo xcodebuild -license')${C_RESET}"
+      echo -e "  ${C_YELLOW}⚠${C_RESET} Xcode license not accepted  ${C_DIM}(run 'sudo xcodebuild -license')${C_RESET}"
     fi
   fi
 fi

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -137,27 +137,31 @@ if [[ -t 0 ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE
 fi
 
 # ── Xcode license check (macOS only) ─────────────────────────────────
-if [[ "$(uname -s)" == "Darwin" ]] && command -v xcodebuild >/dev/null 2>&1; then
+# Only check when full Xcode.app is installed (not just Command Line Tools),
+# since xcodebuild -license check returns non-zero for CLT-only setups too.
+if [[ "$(uname -s)" == "Darwin" ]] && command -v xcodebuild >/dev/null 2>&1 \
+   && [[ "$(xcode-select -p 2>/dev/null)" == /Applications/Xcode*.app/* ]]; then
   if ! xcodebuild -license check >/dev/null 2>&1; then
-    echo -e "${C_YELLOW}⚠${C_RESET}  Xcode license not accepted. Native builds may fail."
-    if [[ -t 0 ]]; then
+    if [[ -t 0 ]] && [[ ! -f "$FLOX_ENV_CACHE/.hush-xcode-license" ]]; then
+      warn_step "Xcode license not accepted. Native builds may fail."
       read -p "$(echo -e "   Accept Xcode license now? (Y/n) ")" -n 1 -r
       echo
       if [[ $REPLY =~ ^[Yy]$ || -z $REPLY ]]; then
         echo -e "   ${C_DIM}Running: sudo xcodebuild -license accept${C_RESET}"
         if sudo xcodebuild -license accept; then
-          echo -e "   ${C_GREEN}✓${C_RESET} Xcode license accepted"
+          done_step "Xcode license accepted"
         else
           echo -e "   ${C_RED}✗${C_RESET} Failed to accept Xcode license"
           echo -e "   ${C_DIM}Run 'sudo xcodebuild -license' manually to resolve.${C_RESET}"
         fi
       else
+        touch "$FLOX_ENV_CACHE/.hush-xcode-license"
         echo -e "   ${C_DIM}Skipped. Run 'sudo xcodebuild -license' if builds fail.${C_RESET}"
       fi
-    else
-      echo -e "   ${C_DIM}Run 'sudo xcodebuild -license' to accept.${C_RESET}"
+      echo
+    elif [[ ! -t 0 ]]; then
+      warn_step "Xcode license not accepted  ${C_DIM}(run 'sudo xcodebuild -license')${C_RESET}"
     fi
-    echo
   fi
 fi
 

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -136,6 +136,31 @@ if [[ -t 0 ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE
   echo
 fi
 
+# ── Xcode license check (macOS only) ─────────────────────────────────
+if [[ "$(uname -s)" == "Darwin" ]] && command -v xcodebuild >/dev/null 2>&1; then
+  if ! xcodebuild -license check >/dev/null 2>&1; then
+    echo -e "${C_YELLOW}⚠${C_RESET}  Xcode license not accepted. Native builds may fail."
+    if [[ -t 0 ]]; then
+      read -p "$(echo -e "   Accept Xcode license now? (Y/n) ")" -n 1 -r
+      echo
+      if [[ $REPLY =~ ^[Yy]$ || -z $REPLY ]]; then
+        echo -e "   ${C_DIM}Running: sudo xcodebuild -license accept${C_RESET}"
+        if sudo xcodebuild -license accept; then
+          echo -e "   ${C_GREEN}✓${C_RESET} Xcode license accepted"
+        else
+          echo -e "   ${C_RED}✗${C_RESET} Failed to accept Xcode license"
+          echo -e "   ${C_DIM}Run 'sudo xcodebuild -license' manually to resolve.${C_RESET}"
+        fi
+      else
+        echo -e "   ${C_DIM}Skipped. Run 'sudo xcodebuild -license' if builds fail.${C_RESET}"
+      fi
+    else
+      echo -e "   ${C_DIM}Run 'sudo xcodebuild -license' to accept.${C_RESET}"
+    fi
+    echo
+  fi
+fi
+
 # ── Header ──────────────────────────────────────────────────────────
 _branch=$(git -C "$FLOX_ENV_PROJECT" branch --show-current 2>/dev/null || echo "???")
 echo -e "\n${C_CYAN}PostHog dev${C_RESET} ${C_DIM}── ${_branch}${C_RESET}\n"


### PR DESCRIPTION
Check if Xcode license is accepted on macOS during flox activate. If not accepted, prompt the user to accept it to prevent native build failures (e.g., node-rdkafka compilation).

https://claude.ai/code/session_016tHzB5snWbpz3rL9Wkrwqe

## Problem

Some of our build steps require the Xcode terms to have been accepted. Sometimes, if they haven't, this can lead to subtle weird problems, like e.g. a node module failing to install but not including anything about Xcode in the error message.

## Changes
Check the license situation during flox activate. If it's already been accepted then do nothing, if it hasn't been accepted then run the command to accept.

## How did you test this code?

I tried the no-op path where it's already been accepted.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
