### PR TITLE
fix(persons): fix editProperty mutation, error handling + tests

### DIFF
--- a/frontend/src/scenes/persons/person-utils.test.ts
+++ b/frontend/src/scenes/persons/person-utils.test.ts
@@ -3,7 +3,52 @@ import { urls } from 'scenes/urls'
 
 import { PersonType } from '~/types'
 
-import { asDisplay, asLink, getPersonColorIndex } from './person-utils'
+import { asDisplay, asLink, coercePropertyValue, getPersonColorIndex } from './person-utils'
+
+describe('coercePropertyValue', () => {
+    it.each<{ input: Parameters<typeof coercePropertyValue>[0]; expected: ReturnType<typeof coercePropertyValue> }>([
+        // numeric strings
+        { input: '42', expected: 42 },
+        { input: '3.14', expected: 3.14 },
+        { input: '-1', expected: -1 },
+        { input: '0', expected: 0 },
+        { input: '1e5', expected: 100000 },
+
+        // empty string passes through unchanged
+        { input: '', expected: '' },
+
+        // Infinity passes through as string (JSON.stringify(Infinity) === "null")
+        { input: 'Infinity', expected: 'Infinity' },
+        { input: '-Infinity', expected: '-Infinity' },
+
+        // boolean strings (case-insensitive)
+        { input: 'true', expected: true },
+        { input: 'TRUE', expected: true },
+        { input: 'True', expected: true },
+        { input: 'false', expected: false },
+        { input: 'FALSE', expected: false },
+
+        // null string
+        { input: 'null', expected: null },
+        { input: 'NULL', expected: null },
+
+        // NaN stays as string
+        { input: 'NaN', expected: 'NaN' },
+
+        // regular strings pass through
+        { input: 'hello', expected: 'hello' },
+        { input: 'user@example.com', expected: 'user@example.com' },
+        { input: ' true', expected: ' true' },
+
+        // non-string types pass through
+        { input: true, expected: true },
+        { input: false, expected: false },
+        { input: null, expected: null },
+        { input: 123, expected: 123 },
+    ])('coerces $input to $expected', ({ input, expected }) => {
+        expect(coercePropertyValue(input)).toBe(expected)
+    })
+})
 
 describe('the person header', () => {
     describe('linking to a person', () => {

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -107,6 +107,27 @@ export function asDisplay(
     return display ? midEllipsis(display, maxLength || 40) : 'Anonymous'
 }
 
+// Property editor inputs are always strings — coerce to native types before persisting
+export function coercePropertyValue(value: string | number | boolean | null): string | number | boolean | null {
+    if (value === null || value === '') {
+        return value
+    }
+
+    let result: string | number | boolean | null = value
+
+    const attemptedParsedNumber = Number(value)
+    if (Number.isFinite(attemptedParsedNumber) && typeof value !== 'boolean') {
+        result = attemptedParsedNumber
+    }
+
+    const lowercaseValue = typeof result === 'string' && result.toLowerCase()
+    if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
+        result = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
+    }
+
+    return result
+}
+
 export const asLink = (person?: PersonPropType | null): string | undefined =>
     person?.distinct_id
         ? urls.personByDistinctId(person.distinct_id)

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -120,9 +120,11 @@ export function coercePropertyValue(value: string | number | boolean | null): st
         result = attemptedParsedNumber
     }
 
-    const lowercaseValue = typeof result === 'string' && result.toLowerCase()
-    if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
-        result = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
+    if (typeof result === 'string') {
+        const lowercaseValue = result.toLowerCase()
+        if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
+            result = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
+        }
     }
 
     return result

--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -6,38 +6,41 @@ import { expectLogic } from 'kea-test-utils'
 import api from 'lib/api'
 
 import { useMocks } from '~/mocks/jest'
+import { MockSignature } from '~/mocks/utils'
 import { initKeaTests } from '~/test/init'
-import { PropertyFilterType, PropertyOperator } from '~/types'
+import { PersonsTabType, PersonType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { personsLogic } from './personsLogic'
 
 describe('personsLogic', () => {
     let logic: ReturnType<typeof personsLogic.build>
 
+    const mockPersonsApiHandler: MockSignature = (req) => {
+        if (['+', 'abc', 'xyz'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
+            return [200, { results: ['person from api'] }]
+        }
+        if (['test@test.com'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
+            return [
+                200,
+                {
+                    results: [
+                        {
+                            id: 1,
+                            name: 'test@test.com',
+                            distinct_ids: ['test@test.com'],
+                            uuid: 'abc-123',
+                        },
+                    ],
+                },
+            ]
+        }
+        return [200, { result: ['result from api'] }]
+    }
+
     beforeEach(() => {
         useMocks({
             get: {
-                '/api/environments/:team_id/persons/': (req) => {
-                    if (['+', 'abc', 'xyz'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
-                        return [200, { results: ['person from api'] }]
-                    }
-                    if (['test@test.com'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
-                        return [
-                            200,
-                            {
-                                results: [
-                                    {
-                                        id: 1,
-                                        name: 'test@test.com',
-                                        distinct_ids: ['test@test.com'],
-                                        uuid: 'abc-123',
-                                    },
-                                ],
-                            },
-                        ]
-                    }
-                    return [200, { result: ['result from api'] }]
-                },
+                '/api/environments/:team_id/persons/': mockPersonsApiHandler,
             },
         })
         initKeaTests()
@@ -143,6 +146,310 @@ describe('personsLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.loadCohorts()
             }).toMatchValues({ cohorts: null })
+        })
+    })
+
+    describe('editProperty', () => {
+        const person: PersonType = {
+            id: 'person-1',
+            uuid: 'uuid-1',
+            distinct_ids: ['did-1'],
+            properties: { existing: 'value' },
+            is_identified: true,
+            created_at: '2024-01-01',
+        }
+
+        beforeEach(() => {
+            logic.actions.setPerson(person)
+        })
+
+        it('updates existing property immutably', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/update_property/': [200, {}] },
+            })
+
+            const originalProperties = logic.values.person!.properties
+
+            await expectLogic(logic, () => {
+                logic.actions.editProperty('existing', 'new-value')
+            }).toFinishAllListeners()
+
+            expect(logic.values.person!.properties).toEqual({ existing: 'new-value' })
+            // The original properties object must not have been mutated
+            expect(originalProperties).toEqual({ existing: 'value' })
+        })
+
+        it('adds new property at the top', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/update_property/': [200, {}] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.editProperty('newKey', 'newVal')
+            }).toFinishAllListeners()
+
+            const keys = Object.keys(logic.values.person!.properties)
+            expect(keys[0]).toBe('newKey')
+            expect(logic.values.person!.properties).toEqual({ newKey: 'newVal', existing: 'value' })
+        })
+
+        it('rolls back on API failure', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/update_property/': () => [500, {}] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.editProperty('existing', 'will-fail')
+            }).toFinishAllListeners()
+
+            expect(logic.values.person!.properties).toEqual({ existing: 'value' })
+        })
+
+        it('coerces values via coercePropertyValue', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/update_property/': [200, {}] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.editProperty('existing', '42')
+            }).toFinishAllListeners()
+
+            expect(logic.values.person!.properties.existing).toBe(42)
+        })
+    })
+
+    describe('deleteProperty', () => {
+        const person: PersonType = {
+            id: 'person-1',
+            uuid: 'uuid-1',
+            distinct_ids: ['did-1'],
+            properties: { keep: 'yes', remove: 'me' },
+            is_identified: true,
+            created_at: '2024-01-01',
+        }
+
+        beforeEach(() => {
+            logic.actions.setPerson(person)
+        })
+
+        it('removes the property from person', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/delete_property/': [200, {}] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.deleteProperty('remove')
+            }).toFinishAllListeners()
+
+            expect(logic.values.person!.properties).toEqual({ keep: 'yes' })
+        })
+
+        it('rolls back on API failure', async () => {
+            useMocks({
+                get: { '/api/environments/:team_id/persons/': mockPersonsApiHandler },
+                post: { '/api/environments/:team_id/persons/:id/delete_property/': () => [500, {}] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.deleteProperty('remove')
+            }).toFinishAllListeners()
+
+            expect(logic.values.person!.properties).toEqual({ keep: 'yes', remove: 'me' })
+        })
+    })
+
+    describe('listFilters reducer', () => {
+        it('removes empty properties array', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setListFilters({ properties: [] })
+            }).toMatchValues({
+                listFilters: {},
+            })
+        })
+
+        it('filters out invalid property filters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setListFilters({
+                    properties: [
+                        { key: 'email', operator: PropertyOperator.IsSet, type: PropertyFilterType.Person },
+                        {} as any,
+                    ],
+                })
+            }).toMatchValues({
+                listFilters: {
+                    properties: [{ key: 'email', operator: PropertyOperator.IsSet, type: PropertyFilterType.Person }],
+                },
+            })
+        })
+
+        it('merges with existing filters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setListFilters({ search: 'alice' })
+            }).toMatchValues({
+                listFilters: { search: 'alice' },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setListFilters({
+                    properties: [{ key: 'name', operator: PropertyOperator.IsSet, type: PropertyFilterType.Person }],
+                })
+            }).toMatchValues({
+                listFilters: {
+                    search: 'alice',
+                    properties: [{ key: 'name', operator: PropertyOperator.IsSet, type: PropertyFilterType.Person }],
+                },
+            })
+        })
+    })
+
+    describe('setPerson / setPersons reducers', () => {
+        const personA: PersonType = {
+            id: '1',
+            uuid: 'uuid-1',
+            distinct_ids: ['a'],
+            properties: { name: 'Alice' },
+            is_identified: true,
+            created_at: '2024-01-01',
+        }
+        const personB: PersonType = {
+            id: '2',
+            uuid: 'uuid-2',
+            distinct_ids: ['b'],
+            properties: { name: 'Bob' },
+            is_identified: true,
+            created_at: '2024-01-02',
+        }
+
+        it('setPerson updates matching person in the list', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setPersons([personA, personB])
+            }).toMatchValues({
+                persons: expect.objectContaining({
+                    results: expect.arrayContaining([
+                        expect.objectContaining({ id: '1' }),
+                        expect.objectContaining({ id: '2' }),
+                    ]),
+                }),
+            })
+
+            const updatedA = { ...personA, properties: { name: 'Alice Updated' } }
+            await expectLogic(logic, () => {
+                logic.actions.setPerson(updatedA)
+            }).toMatchValues({
+                persons: expect.objectContaining({
+                    results: expect.arrayContaining([
+                        expect.objectContaining({ properties: { name: 'Alice Updated' } }),
+                        expect.objectContaining({ id: '2' }),
+                    ]),
+                }),
+            })
+        })
+
+        it('setPersons prepends to the results list', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setPersons([personA])
+            }).toMatchValues({
+                persons: expect.objectContaining({
+                    results: [expect.objectContaining({ id: '1' })],
+                }),
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setPersons([personB])
+            }).toMatchValues({
+                persons: expect.objectContaining({
+                    results: [expect.objectContaining({ id: '2' }), expect.objectContaining({ id: '1' })],
+                }),
+            })
+        })
+    })
+
+    describe('primaryDistinctId selector', () => {
+        it.each([
+            {
+                name: 'prefers non-UUID distinct IDs',
+                distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'alice@example.com'],
+                expected: 'alice@example.com',
+            },
+            {
+                name: 'returns first non-UUID when multiple exist',
+                distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'user123', 'alice@example.com'],
+                expected: 'user123',
+            },
+            {
+                name: 'falls back to first distinct ID when all look like UUIDs',
+                distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'],
+                expected: '550e8400-e29b-41d4-a716-446655440000',
+            },
+            {
+                name: 'returns null when person has no distinct IDs',
+                distinctIds: [],
+                expected: null,
+            },
+            {
+                name: 'handles hyphenated non-UUID strings',
+                distinctIds: ['my-custom-id-with-hyphens', '550e8400-e29b-41d4-a716-446655440000'],
+                expected: 'my-custom-id-with-hyphens',
+            },
+        ])('$name', async ({ distinctIds, expected }) => {
+            const person: PersonType = {
+                id: '1',
+                uuid: 'uuid-1',
+                distinct_ids: distinctIds,
+                properties: {},
+                is_identified: true,
+                created_at: '2024-01-01',
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setPerson(person)
+            }).toMatchValues({
+                primaryDistinctId: expected,
+            })
+        })
+
+        it('returns null when person is null', async () => {
+            await expectLogic(logic).toMatchValues({
+                primaryDistinctId: null,
+            })
+        })
+    })
+
+    describe('tab navigation', () => {
+        it('navigateToTab updates activeTab', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.navigateToTab(PersonsTabType.EVENTS)
+            }).toMatchValues({
+                activeTab: PersonsTabType.EVENTS,
+            })
+        })
+
+        it('setActiveTab updates activeTab', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab(PersonsTabType.COHORTS)
+            }).toMatchValues({
+                activeTab: PersonsTabType.COHORTS,
+            })
+        })
+
+        it('currentTab falls back to defaultTab when activeTab is null', async () => {
+            await expectLogic(logic).toMatchValues({
+                activeTab: null,
+                currentTab: logic.values.defaultTab,
+            })
+        })
+
+        it('currentTab uses activeTab when set', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab(PersonsTabType.EVENTS)
+            }).toMatchValues({
+                currentTab: PersonsTabType.EVENTS,
+            })
         })
     })
 })

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -31,7 +31,7 @@ import {
     PersonsTabType,
 } from '~/types'
 
-import { asDisplay, getHogqlQueryStringForPersonId } from './person-utils'
+import { asDisplay, coercePropertyValue, getHogqlQueryStringForPersonId } from './person-utils'
 import type { personsLogicType } from './personsLogicType'
 
 export interface PersonsLogicProps {
@@ -408,62 +408,52 @@ export const personsLogic = kea<personsLogicType>([
             const person = values.person
 
             if (person && person.id) {
-                let parsedValue = newValue
+                const parsedValue = coercePropertyValue(newValue ?? null)
 
-                // Instrumentation stuff
-                let action: 'added' | 'updated'
                 const oldPropertyType = person.properties[key] === null ? 'null' : typeof person.properties[key]
-                let newPropertyType: string = typeof newValue
+                const newPropertyType: string = parsedValue === null ? 'null' : typeof parsedValue
+                const action: 'added' | 'updated' = Object.keys(person.properties).includes(key) ? 'updated' : 'added'
 
-                // If the property is a number, store it as a number
-                // Guard against empty string: Number("") === 0, which is a false positive
-                const attemptedParsedNumber = Number(newValue)
-                if (!Number.isNaN(attemptedParsedNumber) && typeof newValue !== 'boolean' && newValue !== '') {
-                    parsedValue = attemptedParsedNumber
-                    newPropertyType = 'number'
+                const updatedProperties =
+                    action === 'added'
+                        ? { [key]: parsedValue, ...person.properties }
+                        : { ...person.properties, [key]: parsedValue }
+
+                actions.setPerson({ ...person, properties: updatedProperties })
+
+                try {
+                    await api.persons.updateProperty(person.id, key, parsedValue)
+                    lemonToast.success(`Person property ${action}`)
+
+                    eventUsageLogic.actions.reportPersonPropertyUpdated(
+                        action,
+                        Object.keys(updatedProperties).length,
+                        oldPropertyType,
+                        newPropertyType
+                    )
+                } catch {
+                    actions.setPerson({ ...person })
+                    lemonToast.error(`Failed to update person property`)
                 }
-
-                const lowercaseValue = typeof parsedValue === 'string' && parsedValue.toLowerCase()
-                if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
-                    parsedValue = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
-                    newPropertyType = parsedValue !== null ? 'boolean' : 'null'
-                }
-
-                if (!Object.keys(person.properties).includes(key)) {
-                    person.properties = { [key]: parsedValue, ...person.properties } // To add property at the top (if new)
-                    action = 'added'
-                } else {
-                    person.properties[key] = parsedValue
-                    action = 'updated'
-                }
-
-                actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
-                // :KLUDGE: Person properties are updated asynchronously in the plugin server - the response won't reflect
-                //      the _updated_ properties yet.
-                await api.persons.updateProperty(person.id, key, parsedValue)
-                lemonToast.success(`Person property ${action}`)
-
-                eventUsageLogic.actions.reportPersonPropertyUpdated(
-                    action,
-                    Object.keys(person.properties).length,
-                    oldPropertyType,
-                    newPropertyType
-                )
             }
         },
         deleteProperty: async ({ key }) => {
             const person = values.person
 
             if (person && person.id) {
-                const updatedProperties = { ...person.properties }
-                delete updatedProperties[key]
+                const { [key]: _, ...updatedProperties } = person.properties
 
-                actions.setPerson({ ...person, properties: updatedProperties }) // To update the UI immediately
-                // await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
-                await api.persons.deleteProperty(person.id, key)
-                lemonToast.success(`Person property deleted`)
+                actions.setPerson({ ...person, properties: updatedProperties })
 
-                eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
+                try {
+                    await api.persons.deleteProperty(person.id, key)
+                    lemonToast.success(`Person property deleted`)
+
+                    eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
+                } catch {
+                    actions.setPerson({ ...person })
+                    lemonToast.error(`Failed to delete person property`)
+                }
             }
         },
         navigateToCohort: ({ cohort }) => {

--- a/frontend/src/scenes/persons/personsSceneLogic.test.ts
+++ b/frontend/src/scenes/persons/personsSceneLogic.test.ts
@@ -1,0 +1,120 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene } from 'scenes/sceneTypes'
+
+import { useMocks } from '~/mocks/jest'
+import { MockSignature } from '~/mocks/utils'
+import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { PEOPLE_LIST_DEFAULT_QUERY, personsSceneLogic } from './personsSceneLogic'
+
+const blankScene = (): any => ({ scene: { component: () => null, logic: null } })
+const scenes: any = { [Scene.Persons]: blankScene }
+
+describe('personsSceneLogic', () => {
+    let logic: ReturnType<typeof personsSceneLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/persons/reset_person_distinct_id/': [200, {}],
+            },
+        })
+        initKeaTests()
+        sceneLogic({ scenes }).mount()
+        sceneLogic.actions.setTabs([
+            { id: '1', title: '...', pathname: '/', search: '', hash: '', active: true, iconType: 'blank' },
+        ])
+        logic = personsSceneLogic({ tabId: '1' })
+        logic.mount()
+    })
+
+    describe('query reducer', () => {
+        it('starts with default query', () => {
+            expectLogic(logic).toMatchValues({
+                query: PEOPLE_LIST_DEFAULT_QUERY,
+            })
+        })
+
+        it('setQuery preserves defaultColumns even when custom query omits them', () => {
+            const customQuery: DataTableNode = {
+                kind: NodeKind.DataTableNode,
+                source: {
+                    kind: NodeKind.ActorsQuery,
+                    select: ['person', 'person.created_at'],
+                },
+                full: true,
+            }
+
+            logic.actions.setQuery(customQuery)
+
+            expectLogic(logic).toMatchValues({
+                query: expect.objectContaining({
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.ActorsQuery,
+                        select: ['person', 'person.created_at'],
+                    },
+                    full: true,
+                    defaultColumns: PEOPLE_LIST_DEFAULT_QUERY.defaultColumns,
+                }),
+            })
+        })
+
+        it('setQuery replaces previous query state', () => {
+            const query1 = {
+                ...PEOPLE_LIST_DEFAULT_QUERY,
+                source: { ...PEOPLE_LIST_DEFAULT_QUERY.source, select: ['person'] },
+            }
+            const query2 = {
+                ...PEOPLE_LIST_DEFAULT_QUERY,
+                source: { ...PEOPLE_LIST_DEFAULT_QUERY.source, select: ['person', 'person.created_at'] },
+            }
+
+            logic.actions.setQuery(query1)
+            logic.actions.setQuery(query2)
+
+            expectLogic(logic).toMatchValues({
+                query: expect.objectContaining({
+                    source: expect.objectContaining({
+                        select: ['person', 'person.created_at'],
+                    }),
+                }),
+            })
+        })
+    })
+
+    describe('boolean reducers', () => {
+        it.each([
+            { action: 'setShowDisplayNameNudge', field: 'showDisplayNameNudge' },
+            { action: 'setIsBannerLoading', field: 'isBannerLoading' },
+        ])('$field starts false and toggles via $action', ({ action, field }) => {
+            expectLogic(logic).toMatchValues({ [field]: false })
+
+            logic.actions[action](true)
+            expectLogic(logic).toMatchValues({ [field]: true })
+
+            logic.actions[action](false)
+            expectLogic(logic).toMatchValues({ [field]: false })
+        })
+    })
+
+    describe('resetDeletedDistinctId listener', () => {
+        it('calls the API to reset a distinct ID', async () => {
+            const spy: MockSignature = jest.fn(() => [200, {}])
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/persons/reset_person_distinct_id/': spy,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.resetDeletedDistinctId('some-distinct-id')
+            }).toFinishAllListeners()
+
+            expect(spy).toHaveBeenCalledTimes(1)
+        })
+    })
+})


### PR DESCRIPTION
## Problem
Fixing a few issues I came across in persons code, when looking at some previous bugs and missing test coverage.
Specifically:
 - `editProperty` mutated `person.properties` in place, breaking Kea's immutability contract and causing stale UI state. 
 - API failures in both `editProperty` and `deleteProperty` were unhandled, leaving the UI in an inconsistent state with no user feedback.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
  - Add try/catch with optimistic rollback on API failure for `editProperty` and `deleteProperty`
  - Extract `coercePropertyValue` and test it
  - Fix mutation bug by building `updatedProperties` immutably via object spread
  - Add kea logic tests for `personsLogic` and `personsSceneLogic`


## How did you test this code?
the tests!

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
