### PR TITLE
refactor(persons): swap persons to personLogic in PersonPreview

### DIFF
--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -1,6 +1,5 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { combineUrl } from 'kea-router'
-import { useEffect } from 'react'
 
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
@@ -17,7 +16,7 @@ import { urls } from 'scenes/urls'
 import { ActivityTab, PropertyDefinitionType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { asDisplay } from './person-utils'
-import { personsLogic } from './personsLogic'
+import { personLogic } from './personLogic'
 
 export type PersonPreviewProps = {
     distinctId?: string
@@ -26,17 +25,8 @@ export type PersonPreviewProps = {
 }
 
 export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
-    const logicProps = { syncWithUrl: false, urlId: props.distinctId || props.personId }
-    const { loadPerson, loadPersonUUID } = useActions(personsLogic(logicProps))
-    const { person, personLoading } = useValues(personsLogic(logicProps))
-
-    useEffect(() => {
-        if (props.distinctId) {
-            loadPerson(props.distinctId)
-        } else if (props.personId) {
-            loadPersonUUID(props.personId)
-        }
-    }, [loadPerson, loadPersonUUID, props.distinctId, props.personId])
+    const logicProps = { id: props.personId, distinctId: props.distinctId }
+    const { person, personLoading } = useValues(personLogic(logicProps))
 
     if (!props.distinctId && !props.personId) {
         return null

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -25,12 +25,15 @@ export type PersonPreviewProps = {
 }
 
 export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
-    const logicProps = { id: props.personId, distinctId: props.distinctId }
-    const { person, personLoading } = useValues(personLogic(logicProps))
-
     if (!props.distinctId && !props.personId) {
         return null
     }
+    return <PersonPreviewInner {...props} />
+}
+
+function PersonPreviewInner(props: PersonPreviewProps): JSX.Element | null {
+    const logicProps = { id: props.personId, distinctId: props.distinctId }
+    const { person, personLoading } = useValues(personLogic(logicProps))
 
     if (personLoading) {
         return <Spinner />


### PR DESCRIPTION
 ## Problem                                                                                                                           
                                                                                                                                       
  `PersonPreview` was using `personsLogic` to load a single person. `personsLogic` is the full persons list logic, it brings along list state, cohort loaders, URL sync, and export config, none of which the preview needs. It also required a manual `useEffect` to trigger loading.                                                      
                                                                                                                                       
  ## Changes                                                            
  - Switch `PersonPreview` from `personsLogic` to `personLogic`, which is purpose-built for loading a single person
  - Remove the `useEffect` as `personLogic` uses kea `lazyLoaders`, so data loads automatically when the component mounts and reads the selector

  ## How did you test this code?
- All tests previously in the stack pass around persons
- Just looking at it, works the same. 

  ## Publish to changelog?

  No
