### PR TITLE
chore: check the backups status for the last 30 days

### DIFF
--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -202,7 +202,7 @@ class Backup:
             f"""
             SELECT hostname(), argMax(status, event_time_microseconds), argMax(left(error, 400), event_time_microseconds), max(event_time_microseconds)
             FROM system.backup_log
-            WHERE (start_time >= (now() - toIntervalDay(7))) AND name LIKE '%{self.path}%' AND status NOT IN ('RESTORING', 'RESTORED', 'RESTORE_FAILED')
+            WHERE (event_date >= (now() - toIntervalDay(30))) AND name LIKE '%{self.path}%' AND status NOT IN ('RESTORING', 'RESTORED', 'RESTORE_FAILED')
             GROUP BY hostname()
             """
         )


### PR DESCRIPTION
## Problem

When we clean backups, we search the stored backups in S3 for the last 7 days, which may not be enough to find the latest full successful backup.

## Changes

Increase for the last 30 days, and also use the primary key.