### PR TITLE
fix(llma): refresh lists when returning from detail views

### DIFF
--- a/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetLogic.ts
+++ b/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetLogic.ts
@@ -203,8 +203,6 @@ export const llmAnalyticsDatasetLogic = kea<llmAnalyticsDatasetLogicType>([
                             description: formValues.description,
                             metadata: coerceJsonToObject(formValues.metadata),
                         })
-                        llmAnalyticsDatasetsLogic.findMounted()?.actions.loadDatasets(false)
-
                         lemonToast.success('Dataset created successfully')
                         router.actions.replace(urls.llmAnalyticsDataset(savedDataset.id))
 
@@ -219,6 +217,7 @@ export const llmAnalyticsDatasetLogic = kea<llmAnalyticsDatasetLogicType>([
                         })
                         lemonToast.success('Dataset updated successfully')
                     }
+                    llmAnalyticsDatasetsLogic.findMounted()?.actions.loadDatasets(false)
                     actions.setDataset(savedDataset)
                     actions.editDataset(false)
                     actions.setDatasetFormValues(getDatasetFormDefaults(savedDataset))

--- a/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetsLogic.ts
+++ b/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetsLogic.ts
@@ -195,10 +195,12 @@ export const llmAnalyticsDatasetsLogic = kea<llmAnalyticsDatasetsLogicType>([
     }),
 
     tabAwareUrlToAction(({ actions, values }) => ({
-        [urls.llmAnalyticsDatasets()]: (_, searchParams) => {
+        [urls.llmAnalyticsDatasets()]: (_, searchParams, __, { method }) => {
             const newFilters = cleanFilters(searchParams)
             if (!objectsEqual(values.filters, newFilters)) {
                 actions.setFilters(newFilters, false)
+            } else if (method !== 'REPLACE') {
+                actions.loadDatasets(false)
             }
         },
     })),

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -402,7 +402,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 if (props.evaluationId === 'new') {
                     const response = await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
                     actions.saveEvaluationSuccess(response)
-                    llmEvaluationsLogic.findMounted()?.actions.loadEvaluations()
                 } else {
                     const response = await api.update(
                         `/api/environments/${teamId}/evaluations/${props.evaluationId}/`,
@@ -410,6 +409,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     )
                     actions.saveEvaluationSuccess(response)
                 }
+                llmEvaluationsLogic.findMounted()?.actions.loadEvaluations()
                 router.actions.push(urls.llmAnalyticsEvaluations(), router.values.searchParams)
             } catch (error) {
                 console.error('Failed to save evaluation:', error)

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -18,7 +18,6 @@ import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
-import { llmEvaluationsLogic } from './llmEvaluationsLogic'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
     EvaluationConditionSet,
@@ -409,7 +408,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     )
                     actions.saveEvaluationSuccess(response)
                 }
-                llmEvaluationsLogic.findMounted()?.actions.loadEvaluations()
                 router.actions.push(urls.llmAnalyticsEvaluations(), router.values.searchParams)
             } catch (error) {
                 console.error('Failed to save evaluation:', error)

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
@@ -260,7 +260,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
     }),
 
     tabAwareUrlToAction(({ actions, values }) => ({
-        [urls.llmAnalyticsEvaluations()]: (_, searchParams) => {
+        [urls.llmAnalyticsEvaluations()]: (_, searchParams, __, { method }) => {
             const showOfflineEvals = !!values.featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_OFFLINE_EVALS]
 
             if (!showOfflineEvals && (searchParams.tab === 'offline' || searchParams.tab === 'offline-evals')) {
@@ -278,6 +278,10 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
 
             if (dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo) {
                 actions.setDates(dateFrom, dateTo)
+            }
+
+            if (method !== 'REPLACE') {
+                actions.loadEvaluations()
             }
         },
         [urls.llmAnalyticsOfflineEvaluations()]: (_, searchParams) => {

--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -132,7 +132,6 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                             name: formValues.name,
                             prompt: formValues.prompt,
                         })
-                        llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
                         lemonToast.success('Prompt created successfully')
                         router.actions.replace(urls.llmAnalyticsPrompt(savedPrompt.name))
 
@@ -154,6 +153,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                         router.actions.replace(urls.llmAnalyticsPrompt(props.promptName))
                     }
 
+                    llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
                     actions.setPrompt(savedPrompt)
                     actions.setPromptFormValues(getPromptFormDefaults(savedPrompt))
                 } catch (error: unknown) {

--- a/products/llm_analytics/frontend/prompts/llmPromptsLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptsLogic.ts
@@ -176,10 +176,12 @@ export const llmPromptsLogic = kea<llmPromptsLogicType>([
     }),
 
     tabAwareUrlToAction(({ actions, values }) => ({
-        [urls.llmAnalyticsPrompts()]: (_, searchParams) => {
+        [urls.llmAnalyticsPrompts()]: (_, searchParams, __, { method }) => {
             const newFilters = cleanFilters(searchParams)
             if (!objectsEqual(values.filters, newFilters)) {
                 actions.setFilters(newFilters, false)
+            } else if (method !== 'REPLACE') {
+                actions.loadPrompts(false)
             }
         },
     })),


### PR DESCRIPTION
## Problem

When saving existing or creating new LLM analytics evaluations, prompts, or datasets, returning to the list view could show stale data.
This happened because list data was not consistently reloaded on navigation back from detail scenes.

## Changes

- Reload prompts and datasets lists on non-`REPLACE` navigation back to their list scenes, even when filters are unchanged.
- Reload evaluations list on non-`REPLACE` navigation back to the evaluations scene.
- Ensure detail save flows trigger list reloads for both create and update paths:
  - prompts
  - datasets
  - evaluations

## How did you test this code?

Manual testing by the author:

- Verified that creating/editing LLM analytics prompts, datasets, and evaluations updates list views correctly when returning from detail scenes.

Agent-run automated tests:

- `pnpm --filter=@posthog/frontend jest products/llm_analytics/frontend/datasets/llmAnalyticsDatasetsLogic.test.ts products/llm_analytics/frontend/datasets/llmAnalyticsDatasetLogic.test.ts products/llm_analytics/frontend/prompts/llmPromptLogic.test.ts products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts`
- `pnpm --filter=@posthog/frontend jest products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts`

## Publish to changelog?

no

