### PR TITLE
feat(sql-editor): limit tree traversal depth

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -112,7 +112,7 @@ type TableLookupEntry = {
 
 type TableLookup = Record<string, TableLookupEntry>
 
-const MAX_FIELD_TRAVERSAL_DEPTH = 25
+const MAX_FIELD_TRAVERSAL_DEPTH = 10
 
 type FieldTraversalOptions = {
     expandedLazyNodeIds?: Set<string>


### PR DESCRIPTION
## Problem

Users are reporting stuck SQL editors.

## Changes

Limit lazy table expansion to a depth of 10. The previous 25 was too ambitious.

## How did you test this code?

Clicked locally, nothing changed.

## Publish to changelog?

no