### PR TITLE
feat(customer-journeys): Show paths from funnel steps in flow

### DIFF
--- a/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowEdge.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowEdge.tsx
@@ -64,7 +64,7 @@ export function JourneyFlowEdge({
             <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
             <EdgeLabelRenderer>
                 <div
-                    className="flex items-center gap-1 rounded bg-bg-light border border-border px-2 py-0.5 text-xs shadow-sm pointer-events-auto nopan"
+                    className="flex items-center gap-1 rounded bg-bg-light border border-border text-xs shadow-sm pointer-events-auto nopan px-2 py-0.5"
                     style={{
                         position: 'absolute',
                         transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowGraph.tsx
@@ -6,7 +6,6 @@ import {
     Controls,
     EdgeTypes,
     MiniMap,
-    Node,
     NodeTypes,
     ReactFlow,
     ReactFlowInstance,
@@ -21,17 +20,21 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { isInsightVizNode } from '~/queries/utils'
 
 import { JourneyFlowEdge, ProfileFlowEdge } from './FunnelFlowEdge'
-import { funnelFlowGraphLogic, FunnelFlowNodeData } from './funnelFlowGraphLogic'
+import { AnyFlowNode, funnelFlowGraphLogic } from './funnelFlowGraphLogic'
 import { JourneyFlowNode, ProfileFlowNode } from './FunnelFlowNode'
+import { PathFlowEdge } from './PathFlowEdge'
+import { PathFlowNode } from './PathFlowNode'
 
 const NODE_TYPES = {
     journey: JourneyFlowNode,
     profile: ProfileFlowNode,
+    pathNode: PathFlowNode,
 } as NodeTypes
 
 const EDGE_TYPES = {
     journey: JourneyFlowEdge,
     profile: ProfileFlowEdge,
+    pathFlow: PathFlowEdge,
 } as EdgeTypes
 
 const PROFILE_GRAPH_HEIGHT = 140
@@ -47,7 +50,7 @@ function FunnelFlowGraphContent(): JSX.Element {
     const { laidOutNodes, edges, fitViewOptions } = useValues(funnelFlowGraphLogic({ ...insightProps, isProfileMode }))
 
     const onInit = useCallback(
-        (instance: ReactFlowInstance<Node<FunnelFlowNodeData>>) => {
+        (instance: ReactFlowInstance<AnyFlowNode>) => {
             instance.fitView(fitViewOptions)
         },
         [fitViewOptions]
@@ -62,6 +65,7 @@ function FunnelFlowGraphContent(): JSX.Element {
             className="relative w-full"
             style={{ height: isProfileMode ? PROFILE_GRAPH_HEIGHT : 'var(--insight-viz-min-height)' }}
         >
+            {!isProfileMode && <style>{'.react-flow__edgelabel-renderer { z-index: 5; }'}</style>}
             <ReactFlow
                 nodes={laidOutNodes}
                 edges={edges}

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowNode.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowNode.tsx
@@ -14,7 +14,6 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
 
 import { funnelPersonsModalLogic } from '../funnelPersonsModalLogic'
-import { FunnelStepMore } from '../FunnelStepMore'
 import {
     formatConvertedCount,
     formatConvertedPercentage,
@@ -24,6 +23,7 @@ import {
 } from '../funnelUtils'
 import { ValueInspectorButton } from '../ValueInspectorButton'
 import { FunnelFlowNodeData, NODE_HEIGHT, NODE_WIDTH, PROFILE_NODE_WIDTH } from './funnelFlowGraphLogic'
+import { FunnelStepMoreFlow } from './FunnelStepMoreFlow'
 
 function OptionalChip(): JSX.Element {
     return (
@@ -113,7 +113,9 @@ export const JourneyFlowNode = React.memo(function JourneyFlowNode({
                             </div>
                             {isOptional && <OptionalChip />}
                         </div>
-                        <FunnelStepMore stepIndex={stepIndex} />
+                        <div className="shrink-0 self-start">
+                            <FunnelStepMoreFlow stepIndex={stepIndex} />
+                        </div>
                     </div>
                     {isFirstStep ? (
                         <LemonDivider />

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelStepMoreFlow.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/FunnelStepMoreFlow.tsx
@@ -1,0 +1,85 @@
+import { useActions, useValues } from 'kea'
+
+import { IconCollapse } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { FunnelPathType } from '~/types'
+
+import { funnelDataLogic } from '../funnelDataLogic'
+import { funnelPathsExpansionLogic } from './funnelPathsExpansionLogic'
+
+type FunnelStepMoreFlowProps = {
+    stepIndex: number
+}
+
+export function FunnelStepMoreFlow({ stepIndex }: FunnelStepMoreFlowProps): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource } = useValues(funnelDataLogic(insightProps))
+    const { expandedPath, pathsLoading } = useValues(funnelPathsExpansionLogic(insightProps))
+    const { expandPath, collapsePath } = useActions(funnelPathsExpansionLogic(insightProps))
+
+    const stepNumber = stepIndex + 1
+
+    if (querySource?.aggregation_group_type_index != undefined) {
+        return null
+    }
+
+    const isActiveOnThisStep = expandedPath !== null && expandedPath.stepIndex === stepIndex
+
+    const isActiveExpansion = (pathType: FunnelPathType, dropOff: boolean): boolean =>
+        isActiveOnThisStep && expandedPath!.pathType === pathType && expandedPath!.dropOff === dropOff
+
+    const handleClick = (pathType: FunnelPathType, dropOff: boolean): void => {
+        if (isActiveExpansion(pathType, dropOff)) {
+            collapsePath()
+        } else {
+            expandPath({ stepIndex, pathType, dropOff })
+        }
+    }
+
+    if (isActiveOnThisStep) {
+        return pathsLoading ? (
+            <Spinner textColored className="text-lg" />
+        ) : (
+            <LemonButton size="xsmall" icon={<IconCollapse />} onClick={() => collapsePath()} />
+        )
+    }
+
+    return (
+        <More
+            placement="bottom-start"
+            noPadding
+            overlay={
+                <>
+                    {stepNumber > 1 && (
+                        <LemonButton fullWidth onClick={() => handleClick(FunnelPathType.before, false)}>
+                            Show paths leading to step
+                        </LemonButton>
+                    )}
+                    {stepNumber > 1 && (
+                        <LemonButton fullWidth onClick={() => handleClick(FunnelPathType.between, false)}>
+                            Show paths between previous step and this step
+                        </LemonButton>
+                    )}
+                    <LemonButton fullWidth onClick={() => handleClick(FunnelPathType.after, false)}>
+                        Show paths after step
+                    </LemonButton>
+                    {stepNumber > 1 && (
+                        <LemonButton fullWidth onClick={() => handleClick(FunnelPathType.after, true)}>
+                            Show paths after dropoff
+                        </LemonButton>
+                    )}
+                    {stepNumber > 1 && (
+                        <LemonButton fullWidth onClick={() => handleClick(FunnelPathType.before, true)}>
+                            Show paths before dropoff
+                        </LemonButton>
+                    )}
+                </>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/PathFlowEdge.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/PathFlowEdge.tsx
@@ -1,0 +1,54 @@
+import { BaseEdge, Edge, EdgeLabelRenderer, EdgeProps, getBezierPath } from '@xyflow/react'
+
+import { PathFlowEdgeData } from './pathFlowUtils'
+
+const MIN_STROKE_WIDTH = 1
+const MAX_STROKE_WIDTH = 12
+
+export function PathFlowEdge({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    data,
+}: EdgeProps<Edge<PathFlowEdgeData>>): JSX.Element {
+    const { value, maxValue, isDropOff } = data!
+    const strokeWidth =
+        maxValue > 0 ? MIN_STROKE_WIDTH + (value / maxValue) * (MAX_STROKE_WIDTH - MIN_STROKE_WIDTH) : MIN_STROKE_WIDTH
+
+    const [edgePath, labelX, labelY] = getBezierPath({
+        sourceX,
+        sourceY,
+        targetX,
+        targetY,
+        sourcePosition,
+        targetPosition,
+    })
+
+    return (
+        <>
+            <BaseEdge
+                path={edgePath}
+                style={{
+                    strokeWidth,
+                    stroke: isDropOff ? 'var(--danger)' : 'var(--border-bold)',
+                    opacity: 0.6,
+                }}
+            />
+            <EdgeLabelRenderer>
+                <div
+                    className="rounded bg-bg-light border border-border px-1 py-0.5 text-xxs text-muted pointer-events-auto nopan"
+                    style={{
+                        position: 'absolute',
+                        transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+                    }}
+                >
+                    {isDropOff && <span className="text-danger mr-0.5">Dropoff</span>}
+                    {value}
+                </div>
+            </EdgeLabelRenderer>
+        </>
+    )
+}

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/PathFlowNode.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/PathFlowNode.tsx
@@ -1,0 +1,32 @@
+import { Handle, Position } from '@xyflow/react'
+import React from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { PathFlowNodeData, PATH_NODE_HEIGHT, PATH_NODE_WIDTH } from './pathFlowUtils'
+
+export const PathFlowNode = React.memo(function PathFlowNode({
+    data,
+    id,
+}: {
+    data: PathFlowNodeData
+    id: string
+}): JSX.Element {
+    return (
+        <div
+            className="flex items-center rounded border border-border bg-bg-light px-2 text-xs"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ width: PATH_NODE_WIDTH, height: PATH_NODE_HEIGHT }}
+        >
+            <Handle type="target" position={Position.Left} id={`${id}-target`} className="opacity-0" />
+            <Handle type="source" position={Position.Right} id={`${id}-source`} className="opacity-0" />
+
+            <Tooltip title={data.eventName}>
+                <span className="truncate flex-1">{data.displayName}</span>
+            </Tooltip>
+            <span className="ml-1 shrink-0 rounded bg-fill-highlight-100 px-1 text-muted text-xxs font-medium">
+                {data.count}
+            </span>
+        </div>
+    )
+})

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/funnelFlowGraphLogic.ts
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/funnelFlowGraphLogic.ts
@@ -10,6 +10,15 @@ import { FunnelStepWithConversionMetrics } from '~/types'
 
 import { funnelDataLogic } from '../funnelDataLogic'
 import type { funnelFlowGraphLogicType } from './funnelFlowGraphLogicType'
+import { funnelPathsExpansionLogic } from './funnelPathsExpansionLogic'
+import {
+    bridgeConfigForExpansion,
+    buildPathFlowElements,
+    PathFlowEdgeData,
+    PATH_NODE_HEIGHT,
+    PATH_NODE_WIDTH,
+    PathFlowNodeData,
+} from './pathFlowUtils'
 
 export const NODE_HEIGHT = 160
 export const NODE_WIDTH = 300
@@ -47,18 +56,21 @@ export interface FunnelFlowNodeData extends Record<string, unknown> {
 export interface FunnelFlowEdgeData extends Record<string, unknown> {
     step: FunnelStepWithConversionMetrics
     stepIndex: number
+    edgeIndex: number
 }
+
+export type AnyFlowNode = Node<FunnelFlowNodeData> | Node<PathFlowNodeData>
 
 const elk = new ELK()
 
 const DEFAULT_LOGIC_KEY = 'default_funnel_flow_graph'
 
 async function layoutNodes(
-    nodes: Node<FunnelFlowNodeData>[],
+    nodes: AnyFlowNode[],
     edges: Edge[],
     elkOptionsOverride?: Record<string, string>,
     elkNodeSize?: { width: number; height: number }
-): Promise<Node<FunnelFlowNodeData>[]> {
+): Promise<AnyFlowNode[]> {
     if (nodes.length === 0) {
         return []
     }
@@ -66,18 +78,21 @@ async function layoutNodes(
     const graph: ElkNode = {
         id: 'root',
         layoutOptions: { ...ELK_OPTIONS, ...elkOptionsOverride },
-        children: nodes.map((node) => ({
-            id: node.id,
-            width: elkNodeSize?.width ?? NODE_WIDTH,
-            height: elkNodeSize?.height ?? NODE_HEIGHT,
-            ports: [
-                { id: `${node.id}-target`, properties: { side: 'WEST' } },
-                { id: `${node.id}-source`, properties: { side: 'EAST' } },
-            ],
-            properties: {
-                'org.eclipse.elk.portConstraints': 'FIXED_ORDER',
-            },
-        })),
+        children: nodes.map((node) => {
+            const isPathNode = node.type === 'pathNode'
+            return {
+                id: node.id,
+                width: isPathNode ? PATH_NODE_WIDTH : (elkNodeSize?.width ?? NODE_WIDTH),
+                height: isPathNode ? PATH_NODE_HEIGHT : (elkNodeSize?.height ?? NODE_HEIGHT),
+                ports: [
+                    { id: `${node.id}-target`, properties: { side: 'WEST' } },
+                    { id: `${node.id}-source`, properties: { side: 'EAST' } },
+                ],
+                properties: {
+                    'org.eclipse.elk.portConstraints': 'FIXED_ORDER',
+                },
+            }
+        }),
         edges: edges.map((edge) => ({
             id: edge.id,
             sources: [edge.sourceHandle || edge.source],
@@ -108,16 +123,21 @@ export const funnelFlowGraphLogic = kea<funnelFlowGraphLogicType>([
     key(keyForInsightLogicProps(DEFAULT_LOGIC_KEY)),
 
     connect((props: InsightLogicProps) => ({
-        values: [funnelDataLogic(props), ['visibleStepsWithConversionMetrics', 'stepNames', 'isStepOptional']],
+        values: [
+            funnelDataLogic(props),
+            ['visibleStepsWithConversionMetrics', 'stepNames', 'isStepOptional'],
+            funnelPathsExpansionLogic(props),
+            ['expandedPath', 'expandedPathResults'],
+        ],
     })),
 
     actions({
-        setLaidOutNodes: (laidOutNodes: Node<FunnelFlowNodeData>[]) => ({ laidOutNodes }),
+        setLaidOutNodes: (laidOutNodes: AnyFlowNode[]) => ({ laidOutNodes }),
     }),
 
     reducers({
         laidOutNodes: [
-            [] as Node<FunnelFlowNodeData>[],
+            [] as AnyFlowNode[],
             {
                 setLaidOutNodes: (_, { laidOutNodes }) => laidOutNodes,
             },
@@ -142,7 +162,7 @@ export const funnelFlowGraphLogic = kea<funnelFlowGraphLogicType>([
             (isProfileMode) => (isProfileMode ? PROFILE_FIT_VIEW_OPTIONS : FIT_VIEW_OPTIONS),
         ],
 
-        nodes: [
+        funnelNodes: [
             (s) => [
                 s.visibleStepsWithConversionMetrics,
                 s.stepNames,
@@ -175,9 +195,9 @@ export const funnelFlowGraphLogic = kea<funnelFlowGraphLogicType>([
                 })
             },
         ],
-        edges: [
-            (s) => [s.nodes, s.nodeType],
-            (nodes, nodeType): Edge[] =>
+        funnelEdges: [
+            (s) => [s.funnelNodes, s.nodeType],
+            (nodes, nodeType): Edge<FunnelFlowEdgeData>[] =>
                 nodes.slice(0, -1).map((node, index) => {
                     const targetNode = nodes[index + 1]
                     const touchesOptionalStep = targetNode.data.isOptional
@@ -206,9 +226,65 @@ export const funnelFlowGraphLogic = kea<funnelFlowGraphLogicType>([
                         data: {
                             step: targetNode.data.step,
                             stepIndex: targetNode.data.stepIndex,
+                            edgeIndex: index,
                         },
                     }
                 }),
+        ],
+        expandedPathElements: [
+            (s) => [s.funnelNodes, s.expandedPath, s.expandedPathResults],
+            (
+                funnelNodes,
+                expandedPath,
+                expandedPathResults
+            ): {
+                nodes: Node<PathFlowNodeData>[]
+                edges: Edge<PathFlowEdgeData>[]
+                hiddenEdgeId: string | null
+            } | null => {
+                if (!expandedPath || !expandedPathResults) {
+                    return null
+                }
+                const bridgeConfig = bridgeConfigForExpansion(expandedPath)
+
+                const funnelStepByEventName = new Map<string, string>()
+                for (const node of funnelNodes) {
+                    const eventName = node.data.step.name
+                    if (!funnelStepByEventName.has(eventName)) {
+                        funnelStepByEventName.set(eventName, node.id)
+                    }
+                }
+
+                const { nodes, edges } = buildPathFlowElements(
+                    expandedPathResults,
+                    bridgeConfig.sourceStepId,
+                    bridgeConfig.targetStepId,
+                    bridgeConfig.isDropOff || undefined,
+                    funnelStepByEventName
+                )
+                return { nodes, edges, hiddenEdgeId: bridgeConfig.hiddenEdgeId }
+            },
+        ],
+        nodes: [
+            (s) => [s.funnelNodes, s.expandedPathElements],
+            (funnelNodes, expandedPathElements): AnyFlowNode[] => {
+                if (!expandedPathElements) {
+                    return funnelNodes
+                }
+                return [...funnelNodes, ...expandedPathElements.nodes]
+            },
+        ],
+        edges: [
+            (s) => [s.funnelEdges, s.expandedPathElements],
+            (funnelEdges, expandedPathElements): Edge[] => {
+                if (!expandedPathElements) {
+                    return funnelEdges
+                }
+                const visibleFunnelEdges = expandedPathElements.hiddenEdgeId
+                    ? funnelEdges.filter((e) => e.id !== expandedPathElements.hiddenEdgeId)
+                    : funnelEdges
+                return [...visibleFunnelEdges, ...expandedPathElements.edges]
+            },
         ],
     }),
 

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/funnelPathsExpansionLogic.ts
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/funnelPathsExpansionLogic.ts
@@ -1,0 +1,100 @@
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
+
+import { performQuery } from '~/queries/query'
+import { PathsLink, PathsQuery } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
+
+import { funnelDataLogic } from '../funnelDataLogic'
+import type { funnelPathsExpansionLogicType } from './funnelPathsExpansionLogicType'
+import { buildPathsQuery, PathExpansion, pathExpansionCacheKey } from './pathFlowUtils'
+
+const DEFAULT_LOGIC_KEY = 'default_funnel_paths_expansion'
+
+export const funnelPathsExpansionLogic = kea<funnelPathsExpansionLogicType>([
+    path((key) => ['scenes', 'funnels', 'FunnelFlowGraph', 'funnelPathsExpansionLogic', key]),
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_LOGIC_KEY)),
+
+    connect((props: InsightLogicProps) => ({
+        values: [funnelDataLogic(props), ['querySource']],
+    })),
+
+    actions({
+        expandPath: (expansion: PathExpansion) => ({ expansion }),
+        collapsePath: true,
+        setPathsResults: (cacheKey: string, results: PathsLink[]) => ({ cacheKey, results }),
+    }),
+
+    reducers({
+        expandedPath: [
+            null as PathExpansion | null,
+            {
+                expandPath: (_, { expansion }) => expansion,
+                collapsePath: () => null,
+            },
+        ],
+        pathsResultsCache: [
+            {} as Record<string, PathsLink[]>,
+            {
+                setPathsResults: (state, { cacheKey, results }) => ({ ...state, [cacheKey]: results }),
+            },
+        ],
+        pathsLoading: [
+            false,
+            {
+                expandPath: () => true,
+                setPathsResults: () => false,
+                collapsePath: () => false,
+            },
+        ],
+    }),
+
+    selectors({
+        expandedPathCacheKey: [
+            (s) => [s.expandedPath],
+            (expandedPath): string | null => (expandedPath ? pathExpansionCacheKey(expandedPath) : null),
+        ],
+        expandedPathResults: [
+            (s) => [s.expandedPathCacheKey, s.pathsResultsCache],
+            (cacheKey, pathsResultsCache): PathsLink[] | null =>
+                cacheKey ? (pathsResultsCache[cacheKey] ?? null) : null,
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        expandPath: async ({ expansion }, breakpoint) => {
+            if (values.expandedPathCacheKey && values.expandedPathResults) {
+                actions.setPathsResults(values.expandedPathCacheKey, values.expandedPathResults)
+                return
+            }
+
+            const { querySource } = values
+            if (!querySource || querySource.aggregation_group_type_index != undefined) {
+                actions.collapsePath()
+                lemonToast.info('Cannot expand paths for group aggregation')
+                return
+            }
+
+            const query = buildPathsQuery(expansion, querySource)
+            try {
+                const response = await performQuery<PathsQuery>(query, undefined, 'blocking')
+                breakpoint()
+                const results = (response?.results ?? []) as PathsLink[]
+                if (results.length === 0) {
+                    actions.collapsePath()
+                    lemonToast.info('Path expansion returned no results')
+                } else {
+                    actions.setPathsResults(values.expandedPathCacheKey!, results)
+                }
+            } catch {
+                breakpoint()
+                lemonToast.error('An error occurres when expanding paths')
+                actions.collapsePath()
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/pathFlowUtils.test.ts
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/pathFlowUtils.test.ts
@@ -1,0 +1,431 @@
+import { FunnelsQuery, NodeKind, PathsLink } from '~/queries/schema/schema-general'
+import { FunnelPathType } from '~/types'
+
+import {
+    bridgeConfigForExpansion,
+    buildPathFlowElements,
+    buildPathsQuery,
+    PathExpansion,
+    pathExpansionCacheKey,
+    PATH_NODE_HEIGHT,
+    PATH_NODE_WIDTH,
+} from './pathFlowUtils'
+
+const SAMPLE_LINKS: PathsLink[] = [
+    { source: '1_/home', target: '2_/pricing', value: 50, average_conversion_time: 30000 },
+    { source: '1_/home', target: '2_/docs', value: 30, average_conversion_time: 25000 },
+    { source: '2_/pricing', target: '3_/signup', value: 20, average_conversion_time: 45000 },
+    { source: '2_/docs', target: '3_/signup', value: 10, average_conversion_time: 60000 },
+]
+
+describe('buildPathFlowElements', () => {
+    it('returns empty elements for empty links', () => {
+        const result = buildPathFlowElements([], 'step-0', 'step-1')
+        expect(result.nodes).toEqual([])
+        expect(result.edges).toEqual([])
+    })
+
+    it('creates path nodes from links with correct dimensions', () => {
+        const { nodes } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        expect(nodes).toHaveLength(4)
+        for (const node of nodes) {
+            expect(node.type).toBe('pathNode')
+            expect(node.width).toBe(PATH_NODE_WIDTH)
+            expect(node.height).toBe(PATH_NODE_HEIGHT)
+            expect(node.draggable).toBe(false)
+            expect(node.connectable).toBe(false)
+        }
+    })
+
+    it('strips step prefix from event names', () => {
+        const { nodes } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const eventNames = nodes.map((n) => n.data.eventName).sort()
+        expect(eventNames).toEqual(['/docs', '/home', '/pricing', '/signup'])
+    })
+
+    it('assigns node IDs with path- prefix', () => {
+        const { nodes } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const nodeIds = nodes.map((n) => n.id).sort()
+        expect(nodeIds).toEqual(['path-1_/home', 'path-2_/docs', 'path-2_/pricing', 'path-3_/signup'])
+    })
+
+    it('creates edges between path nodes', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const pathEdges = edges.filter((e) => e.id.startsWith('path-edge-'))
+        expect(pathEdges).toHaveLength(4)
+    })
+
+    it('creates bridge edges from source funnel step to first-layer path nodes', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+        expect(bridgesFrom).toHaveLength(1)
+        expect(bridgesFrom[0].source).toBe('step-0')
+        expect(bridgesFrom[0].target).toBe('path-1_/home')
+    })
+
+    it('creates bridge edges from last-layer path nodes to target funnel step', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const bridgesTo = edges.filter((e) => e.id.startsWith('bridge-to-'))
+        expect(bridgesTo).toHaveLength(1)
+        expect(bridgesTo[0].source).toBe('path-3_/signup')
+        expect(bridgesTo[0].target).toBe('step-1')
+    })
+
+    it('sets maxValue on edge data for stroke width scaling', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        for (const edge of edges) {
+            expect(edge.data?.maxValue).toBe(50)
+        }
+    })
+
+    it('tracks count as max value across all links referencing the node', () => {
+        const { nodes } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const homeNode = nodes.find((n) => n.id === 'path-1_/home')
+        expect(homeNode?.data.count).toBe(50)
+
+        const signupNode = nodes.find((n) => n.id === 'path-3_/signup')
+        expect(signupNode?.data.count).toBe(20)
+    })
+
+    it('truncates long URL display names', () => {
+        const longUrlLinks: PathsLink[] = [
+            {
+                source: '1_https://example.com/very/long/path/to/some/page',
+                target: '2_https://example.com/another/very/long/path/page',
+                value: 10,
+                average_conversion_time: 5000,
+            },
+        ]
+        const { nodes } = buildPathFlowElements(longUrlLinks, 'step-0', 'step-1')
+
+        for (const node of nodes) {
+            expect(node.data.displayName.length).toBeLessThanOrEqual(28)
+        }
+    })
+
+    it('handles custom event names without URLs', () => {
+        const customEventLinks: PathsLink[] = [
+            { source: '1_$pageview', target: '2_button_clicked', value: 25, average_conversion_time: 1000 },
+        ]
+        const { nodes } = buildPathFlowElements(customEventLinks, 'step-0', 'step-1')
+
+        expect(nodes[0].data.eventName).toBe('$pageview')
+        expect(nodes[1].data.eventName).toBe('button_clicked')
+    })
+
+    it('skips source bridge edges when sourceStepId is null', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, null, 'step-1')
+
+        const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+        expect(bridgesFrom).toHaveLength(0)
+
+        const bridgesTo = edges.filter((e) => e.id.startsWith('bridge-to-'))
+        expect(bridgesTo).toHaveLength(1)
+    })
+
+    it('skips target bridge edges when targetStepId is null', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', null)
+
+        const bridgesTo = edges.filter((e) => e.id.startsWith('bridge-to-'))
+        expect(bridgesTo).toHaveLength(0)
+
+        const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+        expect(bridgesFrom).toHaveLength(1)
+    })
+
+    it('propagates isDropOff to source bridge edge data', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-1', null, true)
+
+        const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+        expect(bridgesFrom).toHaveLength(1)
+        expect(bridgesFrom[0].data?.isDropOff).toBe(true)
+    })
+
+    it('does not set isDropOff on source bridge edges by default', () => {
+        const { edges } = buildPathFlowElements(SAMPLE_LINKS, 'step-0', 'step-1')
+
+        const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+        expect(bridgesFrom[0].data?.isDropOff).toBeUndefined()
+    })
+})
+
+describe('bridgeConfigForExpansion', () => {
+    it.each([
+        {
+            name: 'between at step 1',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.between, dropOff: false },
+            expected: { sourceStepId: 'step-0', targetStepId: 'step-1', isDropOff: false, hiddenEdgeId: 'edge-0' },
+        },
+        {
+            name: 'between at step 2',
+            expansion: { stepIndex: 2, pathType: FunnelPathType.between, dropOff: false },
+            expected: { sourceStepId: 'step-1', targetStepId: 'step-2', isDropOff: false, hiddenEdgeId: 'edge-1' },
+        },
+        {
+            name: 'before step 1',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.before, dropOff: false },
+            expected: { sourceStepId: null, targetStepId: 'step-1', isDropOff: false, hiddenEdgeId: null },
+        },
+        {
+            name: 'before step 2',
+            expansion: { stepIndex: 2, pathType: FunnelPathType.before, dropOff: false },
+            expected: { sourceStepId: null, targetStepId: 'step-2', isDropOff: false, hiddenEdgeId: null },
+        },
+        {
+            name: 'after step 0 (first step)',
+            expansion: { stepIndex: 0, pathType: FunnelPathType.after, dropOff: false },
+            expected: { sourceStepId: 'step-0', targetStepId: null, isDropOff: false, hiddenEdgeId: null },
+        },
+        {
+            name: 'after step 2 (last step)',
+            expansion: { stepIndex: 2, pathType: FunnelPathType.after, dropOff: false },
+            expected: { sourceStepId: 'step-2', targetStepId: null, isDropOff: false, hiddenEdgeId: null },
+        },
+        {
+            name: 'after dropoff at step 1',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.after, dropOff: true },
+            expected: { sourceStepId: 'step-1', targetStepId: null, isDropOff: true, hiddenEdgeId: null },
+        },
+        {
+            name: 'before dropoff at step 1',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.before, dropOff: true },
+            expected: { sourceStepId: null, targetStepId: 'step-1', isDropOff: true, hiddenEdgeId: null },
+        },
+    ])('$name', ({ expansion, expected }) => {
+        expect(bridgeConfigForExpansion(expansion)).toEqual(expected)
+    })
+})
+
+describe('pathExpansionCacheKey', () => {
+    it('produces unique keys for different expansions', () => {
+        const expansions: PathExpansion[] = [
+            { stepIndex: 1, pathType: FunnelPathType.before, dropOff: false },
+            { stepIndex: 1, pathType: FunnelPathType.between, dropOff: false },
+            { stepIndex: 1, pathType: FunnelPathType.after, dropOff: false },
+            { stepIndex: 1, pathType: FunnelPathType.after, dropOff: true },
+            { stepIndex: 1, pathType: FunnelPathType.before, dropOff: true },
+            { stepIndex: 2, pathType: FunnelPathType.before, dropOff: false },
+        ]
+        const keys = expansions.map(pathExpansionCacheKey)
+        expect(new Set(keys).size).toBe(keys.length)
+    })
+})
+
+describe('buildPathFlowElements with funnel step dedup', () => {
+    const DEDUP_LINKS: PathsLink[] = [
+        { source: '1_Signed up', target: '2_/files', value: 40, average_conversion_time: 10000 },
+        { source: '2_/files', target: '3_Interacted with file', value: 25, average_conversion_time: 20000 },
+    ]
+
+    const funnelSteps = new Map([
+        ['Signed up', 'step-0'],
+        ['Interacted with file', 'step-1'],
+    ])
+
+    it.each([
+        {
+            name: 'after step: first-layer node matching source step is removed',
+            links: [
+                { source: '1_Signed up', target: '2_/pricing', value: 50, average_conversion_time: 10000 },
+                { source: '2_/pricing', target: '3_/checkout', value: 20, average_conversion_time: 5000 },
+            ] as PathsLink[],
+            sourceStepId: 'step-0',
+            targetStepId: null,
+            stepMap: funnelSteps,
+            expectedNodeIds: ['path-2_/pricing', 'path-3_/checkout'],
+            expectedBridgeFromCount: 0,
+            expectedBridgeToCount: 0,
+            expectedEdgePairs: [
+                ['step-0', 'path-2_/pricing'],
+                ['path-2_/pricing', 'path-3_/checkout'],
+            ],
+        },
+        {
+            name: 'between: boundary nodes matching source and target are both removed',
+            links: DEDUP_LINKS,
+            sourceStepId: 'step-0',
+            targetStepId: 'step-1',
+            stepMap: funnelSteps,
+            expectedNodeIds: ['path-2_/files'],
+            expectedBridgeFromCount: 0,
+            expectedBridgeToCount: 0,
+            expectedEdgePairs: [
+                ['step-0', 'path-2_/files'],
+                ['path-2_/files', 'step-1'],
+            ],
+        },
+        {
+            name: 'before step: intermediate node matching a funnel step is routed through it',
+            links: [
+                { source: '1_/home', target: '2_Signed up', value: 30, average_conversion_time: 10000 },
+                { source: '2_Signed up', target: '3_/files', value: 20, average_conversion_time: 5000 },
+                { source: '3_/files', target: '4_Interacted with file', value: 15, average_conversion_time: 3000 },
+            ] as PathsLink[],
+            sourceStepId: null,
+            targetStepId: 'step-1',
+            stepMap: funnelSteps,
+            expectedNodeIds: ['path-1_/home', 'path-3_/files'],
+            expectedBridgeFromCount: 0,
+            expectedBridgeToCount: 0,
+            expectedEdgePairs: [
+                ['path-1_/home', 'step-0'],
+                ['step-0', 'path-3_/files'],
+                ['path-3_/files', 'step-1'],
+            ],
+        },
+        {
+            name: 'no dedup when map is undefined',
+            links: DEDUP_LINKS,
+            sourceStepId: 'step-0',
+            targetStepId: 'step-1',
+            stepMap: undefined,
+            expectedNodeIds: ['path-1_Signed up', 'path-2_/files', 'path-3_Interacted with file'],
+            expectedBridgeFromCount: 1,
+            expectedBridgeToCount: 1,
+            expectedEdgePairs: [
+                ['step-0', 'path-1_Signed up'],
+                ['path-1_Signed up', 'path-2_/files'],
+                ['path-2_/files', 'path-3_Interacted with file'],
+                ['path-3_Interacted with file', 'step-1'],
+            ],
+        },
+        {
+            name: 'no dedup when map is empty',
+            links: DEDUP_LINKS,
+            sourceStepId: 'step-0',
+            targetStepId: 'step-1',
+            stepMap: new Map<string, string>(),
+            expectedNodeIds: ['path-1_Signed up', 'path-2_/files', 'path-3_Interacted with file'],
+            expectedBridgeFromCount: 1,
+            expectedBridgeToCount: 1,
+            expectedEdgePairs: [
+                ['step-0', 'path-1_Signed up'],
+                ['path-1_Signed up', 'path-2_/files'],
+                ['path-2_/files', 'path-3_Interacted with file'],
+                ['path-3_Interacted with file', 'step-1'],
+            ],
+        },
+        {
+            name: 'bridge kept when first-layer node maps to a different funnel step',
+            links: [
+                { source: '1_Interacted with file', target: '2_/other', value: 10, average_conversion_time: 5000 },
+            ] as PathsLink[],
+            sourceStepId: 'step-0',
+            targetStepId: null,
+            stepMap: funnelSteps,
+            expectedNodeIds: ['path-2_/other'],
+            expectedBridgeFromCount: 1,
+            expectedBridgeToCount: 0,
+            expectedEdgePairs: [
+                ['step-0', 'step-1'],
+                ['step-1', 'path-2_/other'],
+            ],
+        },
+    ])(
+        '$name',
+        ({
+            links,
+            sourceStepId,
+            targetStepId,
+            stepMap,
+            expectedNodeIds,
+            expectedBridgeFromCount,
+            expectedBridgeToCount,
+            expectedEdgePairs,
+        }) => {
+            const { nodes, edges } = buildPathFlowElements(links, sourceStepId, targetStepId, undefined, stepMap)
+
+            expect(nodes.map((n) => n.id).sort()).toEqual(expectedNodeIds.sort())
+
+            const bridgesFrom = edges.filter((e) => e.id.startsWith('bridge-from-'))
+            expect(bridgesFrom).toHaveLength(expectedBridgeFromCount)
+
+            const bridgesTo = edges.filter((e) => e.id.startsWith('bridge-to-'))
+            expect(bridgesTo).toHaveLength(expectedBridgeToCount)
+
+            const edgePairs = edges.map((e) => [e.source, e.target])
+            expect(edgePairs).toEqual(expectedEdgePairs)
+        }
+    )
+
+    it('drops self-loop edges when source and target resolve to the same funnel step', () => {
+        const selfLoopLinks: PathsLink[] = [
+            { source: '1_Signed up', target: '2_Signed up', value: 10, average_conversion_time: 1000 },
+            { source: '2_Signed up', target: '3_/other', value: 5, average_conversion_time: 2000 },
+        ]
+        const { nodes, edges } = buildPathFlowElements(selfLoopLinks, 'step-0', null, undefined, funnelSteps)
+
+        expect(nodes.map((n) => n.id)).toEqual(['path-3_/other'])
+
+        const selfLoops = edges.filter((e) => e.source === e.target)
+        expect(selfLoops).toHaveLength(0)
+
+        expect(edges.map((e) => [e.source, e.target])).toEqual([['step-0', 'path-3_/other']])
+    })
+
+    it('rewrites handle IDs to match the replacement funnel step node', () => {
+        const links: PathsLink[] = [
+            { source: '1_Signed up', target: '2_/other', value: 10, average_conversion_time: 5000 },
+        ]
+        const { edges } = buildPathFlowElements(links, 'step-0', null, undefined, funnelSteps)
+
+        const pathEdge = edges.find((e) => e.id.startsWith('path-edge-'))!
+        expect(pathEdge.sourceHandle).toBe('step-0-source')
+        expect(pathEdge.targetHandle).toBe('path-2_/other-target')
+    })
+})
+
+describe('buildPathsQuery', () => {
+    const querySource = {
+        kind: NodeKind.FunnelsQuery,
+        series: [],
+        dateRange: { date_from: '-7d' },
+    } as FunnelsQuery
+
+    it.each([
+        {
+            name: 'between at step 1 (funnelStep = 2)',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.between, dropOff: false },
+            expectedStep: 2,
+            expectedPathType: FunnelPathType.between,
+        },
+        {
+            name: 'before step 2 (funnelStep = 3)',
+            expansion: { stepIndex: 2, pathType: FunnelPathType.before, dropOff: false },
+            expectedStep: 3,
+            expectedPathType: FunnelPathType.before,
+        },
+        {
+            name: 'after step 0 (funnelStep = 1)',
+            expansion: { stepIndex: 0, pathType: FunnelPathType.after, dropOff: false },
+            expectedStep: 1,
+            expectedPathType: FunnelPathType.after,
+        },
+        {
+            name: 'after dropoff at step 1 (funnelStep = -2)',
+            expansion: { stepIndex: 1, pathType: FunnelPathType.after, dropOff: true },
+            expectedStep: -2,
+            expectedPathType: FunnelPathType.after,
+        },
+        {
+            name: 'before dropoff at step 2 (funnelStep = -3)',
+            expansion: { stepIndex: 2, pathType: FunnelPathType.before, dropOff: true },
+            expectedStep: -3,
+            expectedPathType: FunnelPathType.before,
+        },
+    ])('$name', ({ expansion, expectedStep, expectedPathType }) => {
+        const query = buildPathsQuery(expansion, querySource)
+
+        expect(query.funnelPathsFilter?.funnelStep).toBe(expectedStep)
+        expect(query.funnelPathsFilter?.funnelPathType).toBe(expectedPathType)
+        expect(query.dateRange?.date_from).toBe('-7d')
+    })
+})

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/pathFlowUtils.ts
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/pathFlowUtils.ts
@@ -1,0 +1,235 @@
+import { Edge, Node } from '@xyflow/react'
+
+import { FunnelsQuery, NodeKind, PathsLink, PathsQuery } from '~/queries/schema/schema-general'
+import { FunnelPathType, PathType } from '~/types'
+
+export const PATH_NODE_WIDTH = 180
+export const PATH_NODE_HEIGHT = 40
+
+export interface PathFlowNodeData extends Record<string, unknown> {
+    eventName: string
+    displayName: string
+    count: number
+}
+
+export interface PathFlowEdgeData extends Record<string, unknown> {
+    value: number
+    maxValue: number
+    isDropOff?: boolean
+}
+
+export interface PathExpansion {
+    stepIndex: number
+    pathType: FunnelPathType
+    dropOff: boolean
+}
+
+export interface BridgeConfig {
+    sourceStepId: string | null
+    targetStepId: string | null
+    isDropOff: boolean
+    hiddenEdgeId: string | null
+}
+
+export function pathExpansionCacheKey(expansion: PathExpansion): string {
+    return `${expansion.stepIndex}-${expansion.pathType}-${expansion.dropOff}`
+}
+
+export function bridgeConfigForExpansion(expansion: PathExpansion): BridgeConfig {
+    const { stepIndex, pathType, dropOff } = expansion
+
+    if (pathType === FunnelPathType.between) {
+        return {
+            sourceStepId: `step-${stepIndex - 1}`,
+            targetStepId: `step-${stepIndex}`,
+            isDropOff: false,
+            hiddenEdgeId: `edge-${stepIndex - 1}`,
+        }
+    }
+
+    if (pathType === FunnelPathType.before) {
+        return {
+            sourceStepId: null,
+            targetStepId: `step-${stepIndex}`,
+            isDropOff: dropOff,
+            hiddenEdgeId: null,
+        }
+    }
+
+    // after (with or without dropOff)
+    return {
+        sourceStepId: `step-${stepIndex}`,
+        targetStepId: null,
+        isDropOff: dropOff,
+        hiddenEdgeId: null,
+    }
+}
+
+function stripStepPrefix(name: string): string {
+    return name.replace(/^[0-9]+_/, '')
+}
+
+function extractLayerIndex(name: string): number {
+    const match = name.match(/^([0-9]+)_/)
+    return match ? parseInt(match[1], 10) : 0
+}
+
+function formatDisplayName(rawName: string): string {
+    const name = stripStepPrefix(rawName)
+    try {
+        const url = new URL(name)
+        const display = url.pathname + url.search
+        return display.length > 28 ? display.substring(0, 20) + '...' + display.slice(-7) : display
+    } catch {
+        return name.length > 28 ? name.substring(0, 20) + '...' + name.slice(-7) : name
+    }
+}
+
+interface PathFlowGraphElements {
+    nodes: Node<PathFlowNodeData>[]
+    edges: Edge<PathFlowEdgeData>[]
+}
+
+export function buildPathFlowElements(
+    pathsLinks: PathsLink[],
+    sourceStepId: string | null,
+    targetStepId: string | null,
+    isDropOff?: boolean,
+    funnelStepByEventName?: Map<string, string>
+): PathFlowGraphElements {
+    if (pathsLinks.length === 0) {
+        return { nodes: [], edges: [] }
+    }
+
+    const nodeMap = new Map<string, { eventName: string; displayName: string; count: number; layer: number }>()
+    const maxValue = Math.max(...pathsLinks.map((l) => l.value))
+
+    for (const link of pathsLinks) {
+        for (const name of [link.source, link.target]) {
+            if (!nodeMap.has(name)) {
+                nodeMap.set(name, {
+                    eventName: stripStepPrefix(name),
+                    displayName: formatDisplayName(name),
+                    count: 0,
+                    layer: extractLayerIndex(name),
+                })
+            }
+        }
+        const sourceNode = nodeMap.get(link.source)!
+        sourceNode.count = Math.max(sourceNode.count, link.value)
+        const targetNode = nodeMap.get(link.target)!
+        targetNode.count = Math.max(targetNode.count, link.value)
+    }
+
+    const nodeReplacement = new Map<string, string>()
+    if (funnelStepByEventName) {
+        for (const [rawName, data] of nodeMap) {
+            const funnelStepId = funnelStepByEventName.get(data.eventName)
+            if (funnelStepId) {
+                nodeReplacement.set(rawName, funnelStepId)
+            }
+        }
+    }
+
+    function resolveNodeId(rawName: string): string {
+        return nodeReplacement.get(rawName) ?? `path-${rawName}`
+    }
+
+    const nodes: Node<PathFlowNodeData>[] = []
+
+    for (const [rawName, data] of nodeMap) {
+        if (nodeReplacement.has(rawName)) {
+            continue
+        }
+        nodes.push({
+            id: `path-${rawName}`,
+            type: 'pathNode',
+            data: {
+                eventName: data.eventName,
+                displayName: data.displayName,
+                count: data.count,
+            },
+            position: { x: 0, y: 0 },
+            width: PATH_NODE_WIDTH,
+            height: PATH_NODE_HEIGHT,
+            draggable: false,
+            connectable: false,
+        })
+    }
+
+    const edges: Edge<PathFlowEdgeData>[] = []
+    for (let i = 0; i < pathsLinks.length; i++) {
+        const link = pathsLinks[i]
+        const resolvedSource = resolveNodeId(link.source)
+        const resolvedTarget = resolveNodeId(link.target)
+        if (resolvedSource === resolvedTarget) {
+            continue
+        }
+        edges.push({
+            id: `path-edge-${i}-${link.source}-${link.target}`,
+            source: resolvedSource,
+            target: resolvedTarget,
+            type: 'pathFlow',
+            sourceHandle: `${resolvedSource}-source`,
+            targetHandle: `${resolvedTarget}-target`,
+            data: { value: link.value, maxValue },
+        })
+    }
+
+    const minLayer = Math.min(...Array.from(nodeMap.values()).map((n) => n.layer))
+    const maxLayer = Math.max(...Array.from(nodeMap.values()).map((n) => n.layer))
+
+    const bridgeFromSource: Edge<PathFlowEdgeData>[] = []
+    const bridgeToTarget: Edge<PathFlowEdgeData>[] = []
+
+    for (const [rawName, data] of nodeMap) {
+        const resolvedId = resolveNodeId(rawName)
+        if (sourceStepId && data.layer === minLayer && resolvedId !== sourceStepId) {
+            bridgeFromSource.push({
+                id: `bridge-from-${sourceStepId}-${resolvedId}`,
+                source: sourceStepId,
+                target: resolvedId,
+                type: 'pathFlow',
+                sourceHandle: `${sourceStepId}-source`,
+                targetHandle: `${resolvedId}-target`,
+                data: { value: data.count, maxValue, isDropOff },
+            })
+        }
+        if (targetStepId && data.layer === maxLayer && resolvedId !== targetStepId) {
+            bridgeToTarget.push({
+                id: `bridge-to-${targetStepId}-${resolvedId}`,
+                source: resolvedId,
+                target: targetStepId,
+                type: 'pathFlow',
+                sourceHandle: `${resolvedId}-source`,
+                targetHandle: `${targetStepId}-target`,
+                data: { value: data.count, maxValue },
+            })
+        }
+    }
+
+    return {
+        nodes,
+        edges: [...bridgeFromSource, ...edges, ...bridgeToTarget],
+    }
+}
+
+export function buildPathsQuery(expansion: PathExpansion, querySource: FunnelsQuery): PathsQuery {
+    const stepNumber = expansion.stepIndex + 1
+    const funnelStep = expansion.dropOff ? stepNumber * -1 : stepNumber
+    return {
+        kind: NodeKind.PathsQuery,
+        funnelPathsFilter: {
+            funnelPathType: expansion.pathType,
+            funnelStep,
+            funnelSource: querySource,
+        },
+        pathsFilter: {
+            includeEventTypes: [PathType.PageView, PathType.CustomEvent],
+            edgeLimit: 15,
+        },
+        dateRange: {
+            date_from: querySource.dateRange?.date_from,
+        },
+    }
+}


### PR DESCRIPTION
## Problem

Funnel flow graphs need the ability to show detailed path analysis between funnel steps to help users understand user journeys and identify optimization opportunities. Currently, the funnel flow graph only shows the basic funnel steps without the ability to explore what happens between steps or after dropoffs.

Part of https://github.com/PostHog/posthog/issues/47326
## Changes

- **Added path expansion functionality**: Users can now click on funnel steps to expand and view detailed paths between steps, before steps, after steps, and after dropoffs

![image.png](https://app.graphite.com/user-attachments/assets/784e2fed-9f78-48e7-af32-0a667bf2ac4e.png)

Paths in-between steps
![image.png](https://app.graphite.com/user-attachments/assets/70a6c867-ec3d-4360-886e-c17f7530fda5.png)

Paths after dropoff
![image.png](https://app.graphite.com/user-attachments/assets/bc304252-84b7-4903-ba9f-74e521da4356.png)

- **New path visualization components**: 
  - `PathFlowNode` component for displaying individual path events with counts
  - `PathFlowEdge` component for showing path connections with variable stroke widths based on traffic volume
  - `FunnelStepMoreFlow` component providing expansion options menu
- **Smart path deduplication**: Path nodes that match existing funnel steps are automatically merged to avoid redundant visualization
- **Dynamic query execution**: Path data is fetched on-demand when users expand sections, with proper caching and error handling
- **Enhanced layout system**: Updated the graph layout algorithm to handle mixed node types (funnel steps and path nodes) with appropriate sizing
- **Visual improvements**: Added proper z-index handling for edge labels and updated styling for better readability

## How did you test this code?

Unit tests and manual tests

- Comprehensive unit tests for `pathFlowUtils` covering path element building, bridge configuration, query construction, and funnel step deduplication
- Tests verify proper handling of edge cases like empty results, self-loops, and various expansion scenarios

## Publish to changelog?
No, still behind feature flag