### PR TITLE
fix(e2e): Funnel tests failing at certain times

### DIFF
--- a/playwright/e2e/product-analytics/insights/funnels.spec.ts
+++ b/playwright/e2e/product-analytics/insights/funnels.spec.ts
@@ -2,7 +2,7 @@ import { InsightShortId, InsightType } from '~/types'
 
 import { InsightPage } from '../../../page-models/insightPage'
 import { randomString } from '../../../utils'
-import { createEvent, daysAgo, hoursAgo } from '../../../utils/event-data'
+import { createEvent, daysAgo } from '../../../utils/event-data'
 import { PlaywrightSetupEvent } from '../../../utils/playwright-setup'
 import { PlaywrightWorkspaceSetupResult, expect, test } from '../../../utils/workspace-test-base'
 
@@ -31,11 +31,23 @@ function generateFunnelEvents(): PlaywrightSetupEvent[] {
     const chrome = { $browser: 'Chrome', $session_id: 'chrome-session' }
     const firefox = { $browser: 'Firefox', $session_id: 'firefox-session' }
 
+    // Midpoint between step 1 and step 2 — immune to time-of-day drift
+    const betweenStep1And2 = (() => {
+        const d = new Date()
+        d.setDate(d.getDate() - 5)
+        d.setHours(12, 0, 0, 0)
+        return d.toISOString()
+    })()
+
     return [
         ...createEvent({ event: STEP_1, user: chromeUsers, timestamp: daysAgo(5), properties: chrome }).repeat(10),
         ...createEvent({ event: STEP_1, user: firefoxUsers, timestamp: daysAgo(5), properties: firefox }).repeat(10),
-        ...createEvent({ event: EXCLUSION_EVENT, user: 'chrome-user-0', timestamp: hoursAgo(108), properties: chrome })
-            .events,
+        ...createEvent({
+            event: EXCLUSION_EVENT,
+            user: 'chrome-user-0',
+            timestamp: betweenStep1And2,
+            properties: chrome,
+        }).events,
         ...createEvent({ event: STEP_2, user: chromeUsers, timestamp: daysAgo(4), properties: chrome }).repeat(10),
         ...createEvent({ event: STEP_3, user: chromeUsers, timestamp: daysAgo(3), properties: chrome }).repeat(5),
     ]


### PR DESCRIPTION
## Problem

For the exclusion funnel test, wether the exclusion event ends up being between the other events dependded on the time of day, which caused this to fail now, and pass earlier 🫠 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Set time to midday on the day between the events.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
