### PR TITLE
chore: add heatmaps codeowners-soft to web analytics

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -114,6 +114,18 @@ frontend/src/toolbar/web-vitals/** @PostHog/team-web-analytics
 rust/common/cookieless/** @PostHog/team-web-analytics
 nodejs/src/ingestion/cookieless/** @PostHog/team-web-analytics
 
+# Heatmaps - owned by @PostHog/team-web-analytics
+frontend/src/scenes/heatmaps/** @PostHog/team-web-analytics
+frontend/src/lib/components/heatmaps/** @PostHog/team-web-analytics
+frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts @PostHog/team-web-analytics
+posthog/heatmaps/** @PostHog/team-web-analytics
+posthog/models/heatmap_saved.py @PostHog/team-web-analytics
+posthog/hogql/database/schema/heatmaps.py @PostHog/team-web-analytics
+posthog/tasks/heatmap_screenshot.py @PostHog/team-web-analytics
+nodejs/src/ingestion/analytics/heatmap-subpipeline.ts @PostHog/team-web-analytics
+nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts @PostHog/team-web-analytics
+nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts @PostHog/team-web-analytics
+
 # Analytics Platform - owned by @PostHog/team-analytics-platform
 posthog/dags/locations/analytics*platform.py @PostHog/team-analytics-platform
 ee/tasks/subscriptions/** @PostHog/team-analytics-platform


### PR DESCRIPTION
## Problem

The heatmaps feature is owned by @PostHog/team-web-analytics, but the relevant code paths were not defined in the CODEOWNERS configuration. This means code reviews for heatmap-related changes were not being automatically routed to the appropriate team.

## Changes

Added comprehensive codeowner entries for all heatmap-related code across the repository:
- Frontend heatmap scenes and components
- Backend heatmap models and database schema
- Heatmap screenshot task processing
- Node.js ingestion pipeline steps for heatmap data extraction

All paths are now assigned to @PostHog/team-web-analytics for proper code review routing.

## How did you test this code?

N/A - This is a configuration change to CODEOWNERS-soft. The syntax and paths follow the existing pattern in the file and will be validated by GitHub's CODEOWNERS parser.

## Publish to changelog?

No

https://claude.ai/code/session_011TDFtkLN57Bet2N1aK5VJ9