### PR TITLE
feat(flags): dispatch celery task from rust

### DIFF
--- a/docs/internal/feature-flags/celery-task-dispatch-from-rust.md
+++ b/docs/internal/feature-flags/celery-task-dispatch-from-rust.md
@@ -1,0 +1,97 @@
+# Dispatching Celery tasks from Rust
+
+The `common-redis` crate provides a `celery` module that lets any Rust service dispatch tasks to Django's Celery workers without needing a Python process or the Celery client library.
+
+## How it works
+
+Celery uses Redis as its message broker. Tasks are JSON messages sitting in a Redis list (the `celery` key by default). Workers consume them with `BRPOP`.
+
+The Rust function builds a message that conforms to the [Celery v2 message protocol](https://docs.celeryq.dev/en/stable/internals/protocol.html) and `LPUSH`es it to the queue. From the worker's perspective, it's indistinguishable from a task sent by Python.
+
+```text
+Rust service
+  │
+  │  LPUSH "celery" <json envelope>
+  ▼
+Redis (broker)
+  │
+  │  BRPOP "celery"
+  ▼
+Celery worker (Django)
+  │
+  │  Deserializes envelope, resolves task name, calls function
+  ▼
+@shared_task handler
+```
+
+## Usage
+
+```rust
+use common_redis::celery::send_celery_task;
+
+send_celery_task(
+    &redis_client,
+    "posthog.tasks.my_module.my_task",
+    &serde_json::json!([1, "hello"]),
+    &serde_json::json!({"team_id": 42}),
+).await?;
+```
+
+The task name must be the fully qualified Python path to a `@shared_task` function that Celery's `autodiscover_tasks()` has registered. On the Django side, the task is a normal shared task:
+
+```python
+from celery import shared_task
+
+@shared_task(ignore_result=True)
+def my_task(x, greeting, team_id=None):
+    ...
+```
+
+## Message format
+
+The envelope pushed to Redis looks like:
+
+```json
+{
+  "body": "<base64-encoded JSON: [args, kwargs, embed]>",
+  "content-encoding": "utf-8",
+  "content-type": "application/json",
+  "headers": {
+    "lang": "py",
+    "task": "posthog.tasks.my_module.my_task",
+    "id": "<uuid>",
+    "root_id": "<uuid>",
+    "parent_id": null,
+    "retries": 0,
+    "timelimit": [null, null],
+    "origin": "posthog-rust",
+    "ignore_result": true
+  },
+  "properties": {
+    "correlation_id": "<uuid>",
+    "delivery_mode": 2,
+    "delivery_info": { "exchange": "", "routing_key": "celery" },
+    "priority": 0,
+    "body_encoding": "base64",
+    "delivery_tag": "<uuid>"
+  }
+}
+```
+
+The `body`, once base64-decoded, is a JSON array: `[args, kwargs, embed]`. The `embed` object (`callbacks`, `errbacks`, `chain`, `chord`) is always null for standalone tasks.
+
+## Code location
+
+- Module: `rust/common/redis/src/celery.rs`
+- `build_celery_message()` builds the JSON envelope (pure function, no I/O)
+- `send_celery_task()` builds + pushes to Redis via the `Client` trait
+
+## Testing
+
+Tests validate the serialization contract without needing Redis:
+
+```bash
+cd rust && cargo test -p common-redis -- celery
+```
+
+Since the message format is the contract between Rust and Python, the tests verify the JSON structure matches what Celery expects. Celery's own deserialization is well-tested library code and doesn't need additional coverage on our side.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2135,12 +2135,15 @@ name = "common-redis"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "redis",
  "serde-pickle",
+ "serde_json",
  "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "zstd",
 ]
 

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -13,6 +13,9 @@ serde-pickle = { version = "1.1.1" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 zstd = "0.13"
+base64 = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/rust/common/redis/src/celery.rs
+++ b/rust/common/redis/src/celery.rs
@@ -34,8 +34,8 @@ fn build_celery_message_with_id(
         kwargs,
         {"callbacks": null, "errbacks": null, "chain": null, "chord": null}
     ]);
-    let body_b64 = base64::engine::general_purpose::STANDARD
-        .encode(body_json.to_string().as_bytes());
+    let body_b64 =
+        base64::engine::general_purpose::STANDARD.encode(body_json.to_string().as_bytes());
 
     let message = serde_json::json!({
         "body": body_b64,
@@ -181,7 +181,10 @@ mod tests {
         let p2: serde_json::Value = serde_json::from_str(&msg2).unwrap();
 
         assert_ne!(p1["headers"]["id"], p2["headers"]["id"]);
-        assert_ne!(p1["properties"]["delivery_tag"], p2["properties"]["delivery_tag"]);
+        assert_ne!(
+            p1["properties"]["delivery_tag"],
+            p2["properties"]["delivery_tag"]
+        );
     }
 
     #[test]
@@ -204,4 +207,5 @@ mod tests {
             assert_eq!(calls[0].key, "celery");
         });
     }
+
 }

--- a/rust/common/redis/src/celery.rs
+++ b/rust/common/redis/src/celery.rs
@@ -1,0 +1,207 @@
+use base64::Engine;
+use uuid::Uuid;
+
+use crate::{Client, CustomRedisError};
+
+const DEFAULT_QUEUE: &str = "celery";
+
+/// Build a Celery v2 protocol message envelope as a JSON string.
+///
+/// This produces the exact format that Kombu (Celery's transport layer) expects
+/// when consuming from a Redis list: a JSON object with base64-encoded body,
+/// headers carrying task metadata, and properties for routing.
+pub fn build_celery_message(
+    task_name: &str,
+    args: &serde_json::Value,
+    kwargs: &serde_json::Value,
+) -> String {
+    let task_id = Uuid::new_v4().to_string();
+    let delivery_tag = Uuid::new_v4().to_string();
+
+    build_celery_message_with_id(task_name, args, kwargs, &task_id, &delivery_tag)
+}
+
+/// Same as `build_celery_message` but with explicit IDs for deterministic testing.
+fn build_celery_message_with_id(
+    task_name: &str,
+    args: &serde_json::Value,
+    kwargs: &serde_json::Value,
+    task_id: &str,
+    delivery_tag: &str,
+) -> String {
+    let body_json = serde_json::json!([
+        args,
+        kwargs,
+        {"callbacks": null, "errbacks": null, "chain": null, "chord": null}
+    ]);
+    let body_b64 = base64::engine::general_purpose::STANDARD
+        .encode(body_json.to_string().as_bytes());
+
+    let message = serde_json::json!({
+        "body": body_b64,
+        "content-encoding": "utf-8",
+        "content-type": "application/json",
+        "headers": {
+            "lang": "py",
+            "task": task_name,
+            "id": task_id,
+            "shadow": null,
+            "eta": null,
+            "expires": null,
+            "group": null,
+            "retries": 0,
+            "timelimit": [null, null],
+            "root_id": task_id,
+            "parent_id": null,
+            "origin": "posthog-rust",
+            "ignore_result": true,
+        },
+        "properties": {
+            "correlation_id": task_id,
+            "reply_to": "",
+            "delivery_mode": 2,
+            "delivery_info": {"exchange": "", "routing_key": DEFAULT_QUEUE},
+            "priority": 0,
+            "body_encoding": "base64",
+            "delivery_tag": delivery_tag,
+        }
+    });
+
+    message.to_string()
+}
+
+/// Push a Celery task message onto the broker queue via LPUSH.
+///
+/// The Celery worker consumes from the tail (BRPOP), so LPUSH gives FIFO ordering.
+pub async fn send_celery_task(
+    client: &dyn Client,
+    task_name: &str,
+    args: &serde_json::Value,
+    kwargs: &serde_json::Value,
+) -> Result<(), CustomRedisError> {
+    let message = build_celery_message(task_name, args, kwargs);
+    client.lpush(DEFAULT_QUEUE.to_string(), message).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decode_body(message: &serde_json::Value) -> serde_json::Value {
+        let body_b64 = message["body"].as_str().unwrap();
+        let body_bytes = base64::engine::general_purpose::STANDARD
+            .decode(body_b64)
+            .unwrap();
+        serde_json::from_slice(&body_bytes).unwrap()
+    }
+
+    #[test]
+    fn test_body_encodes_args_kwargs_and_embed() {
+        let msg = build_celery_message_with_id(
+            "myapp.tasks.add",
+            &serde_json::json!([1, 2]),
+            &serde_json::json!({"team_id": 42}),
+            "test-id",
+            "test-tag",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let body = decode_body(&parsed);
+
+        assert_eq!(body[0], serde_json::json!([1, 2]));
+        assert_eq!(body[1], serde_json::json!({"team_id": 42}));
+        assert_eq!(
+            body[2],
+            serde_json::json!({"callbacks": null, "errbacks": null, "chain": null, "chord": null})
+        );
+    }
+
+    #[test]
+    fn test_headers_carry_task_metadata() {
+        let msg = build_celery_message_with_id(
+            "posthog.tasks.calculate.run",
+            &serde_json::json!([]),
+            &serde_json::json!({}),
+            "abc-123",
+            "tag-456",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let headers = &parsed["headers"];
+
+        assert_eq!(headers["task"], "posthog.tasks.calculate.run");
+        assert_eq!(headers["id"], "abc-123");
+        assert_eq!(headers["root_id"], "abc-123");
+        assert_eq!(headers["parent_id"], serde_json::Value::Null);
+        assert_eq!(headers["lang"], "py");
+        assert_eq!(headers["retries"], 0);
+        assert_eq!(headers["ignore_result"], true);
+    }
+
+    #[test]
+    fn test_properties_route_to_celery_queue() {
+        let msg = build_celery_message_with_id(
+            "myapp.tasks.add",
+            &serde_json::json!([]),
+            &serde_json::json!({}),
+            "abc-123",
+            "tag-456",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let props = &parsed["properties"];
+
+        assert_eq!(props["correlation_id"], "abc-123");
+        assert_eq!(props["delivery_tag"], "tag-456");
+        assert_eq!(props["delivery_mode"], 2);
+        assert_eq!(props["body_encoding"], "base64");
+        assert_eq!(props["priority"], 0);
+        assert_eq!(props["delivery_info"]["routing_key"], "celery");
+        assert_eq!(props["delivery_info"]["exchange"], "");
+    }
+
+    #[test]
+    fn test_envelope_content_type_fields() {
+        let msg = build_celery_message_with_id(
+            "t",
+            &serde_json::json!([]),
+            &serde_json::json!({}),
+            "id",
+            "tag",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+
+        assert_eq!(parsed["content-type"], "application/json");
+        assert_eq!(parsed["content-encoding"], "utf-8");
+    }
+
+    #[test]
+    fn test_build_celery_message_generates_unique_ids() {
+        let msg1 = build_celery_message("t", &serde_json::json!([]), &serde_json::json!({}));
+        let msg2 = build_celery_message("t", &serde_json::json!([]), &serde_json::json!({}));
+
+        let p1: serde_json::Value = serde_json::from_str(&msg1).unwrap();
+        let p2: serde_json::Value = serde_json::from_str(&msg2).unwrap();
+
+        assert_ne!(p1["headers"]["id"], p2["headers"]["id"]);
+        assert_ne!(p1["properties"]["delivery_tag"], p2["properties"]["delivery_tag"]);
+    }
+
+    #[test]
+    fn test_send_celery_task_lpushes_to_celery_queue() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mock = crate::MockRedisClient::new();
+            send_celery_task(
+                &mock,
+                "posthog.tasks.do_thing",
+                &serde_json::json!([1]),
+                &serde_json::json!({"key": "val"}),
+            )
+            .await
+            .unwrap();
+
+            let calls = mock.get_calls();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].op, "lpush");
+            assert_eq!(calls[0].key, "celery");
+        });
+    }
+}

--- a/rust/common/redis/src/celery.rs
+++ b/rust/common/redis/src/celery.rs
@@ -207,5 +207,4 @@ mod tests {
             assert_eq!(calls[0].key, "celery");
         });
     }
-
 }

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -510,6 +510,16 @@ impl Client for RedisClient {
         Ok(())
     }
 
+    async fn lpush(&self, key: String, value: String) -> Result<(), CustomRedisError> {
+        let mut conn = self.connection.clone();
+        redis::cmd("LPUSH")
+            .arg(&key)
+            .arg(value.as_bytes())
+            .query_async::<()>(&mut conn)
+            .await?;
+        Ok(())
+    }
+
     async fn execute_pipeline(
         &self,
         commands: Vec<PipelineCommand>,

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -270,6 +270,8 @@ pub trait Client: Send + Sync {
         ttl_seconds: usize,
     ) -> Result<Vec<bool>, CustomRedisError>;
     async fn batch_del(&self, keys: Vec<String>) -> Result<(), CustomRedisError>;
+    /// Push a value to the head of a Redis list (LPUSH).
+    async fn lpush(&self, key: String, value: String) -> Result<(), CustomRedisError>;
     /// Execute a batch of pipeline commands in a single round-trip.
     ///
     /// Returns a vector of results, one for each command in the same order.
@@ -311,6 +313,7 @@ pub trait ClientPipelineExt: Client + Clone {
 impl<T: Client + Clone> ClientPipelineExt for T {}
 
 // Module declarations
+pub mod celery;
 mod client;
 mod mock;
 mod pipeline;

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -530,6 +530,15 @@ impl Client for MockRedisClient {
         Ok(())
     }
 
+    async fn lpush(&self, key: String, value: String) -> Result<(), CustomRedisError> {
+        self.lock_calls().push(MockRedisCall {
+            op: "lpush".to_string(),
+            key,
+            value: MockRedisValue::String(value),
+        });
+        Ok(())
+    }
+
     async fn execute_pipeline(
         &self,
         commands: Vec<PipelineCommand>,

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -478,6 +478,10 @@ impl Client for ReadWriteClient {
         self.writer.batch_del(keys).await
     }
 
+    async fn lpush(&self, key: String, value: String) -> Result<(), CustomRedisError> {
+        self.writer.lpush(key, value).await
+    }
+
     /// Execute a pipeline of commands.
     ///
     /// All pipeline commands are routed to the primary (writer) since pipelines


### PR DESCRIPTION
Part of #49564 

## Summary
  - Add a `celery` module to `common-redis` that lets Rust services dispatch tasks to Django's Celery workers by pushing Celery v2 protocol messages directly to the Redis broker
  - Add `lpush` to the Redis `Client` trait (+ implementations for `RedisClient`, `MockRedisClient`, `ReadWriteClient`)
  - Add internal documentation at `docs/internal/feature-flags/celery-task-dispatch-from-rust.md`

## Why not Celery Beat?

  The original idea was to use Celery Beat polling Redis every second for new entries. We rejected this because:

  - **Celery Beat is designed for cron-like schedules, not sub-second dispatch.** PostHog's `CELERY_BEAT_MAX_LOOP_INTERVAL` is 30s.
  - **Polling adds unnecessary latency and overhead** compared to an event-driven approach.
  - **It reinvents what Celery already does.** Celery workers already block on `BRPOP` waiting for new messages — pushing directly to the broker queue is the native way to dispatch tasks.

  Instead, we produce Celery v2 protocol messages from Rust and `LPUSH` them to the same Redis list that Celery workers consume. No new processes, no polling, instant dispatch, and we get Celery's retry/monitoring infrastructure for free.

## Test plan
  - [x] `cargo test -p common-redis -- celery` — 6 unit tests covering message format (body encoding, headers, properties, content type, unique IDs, mock integration)
  - [x] Manual end-to-end: dispatched a task from Rust (`manual_dispatch` ignored test), verified it was received and executed by a local Celery worker

### Manual test

Run locally

`cargo test -p common-redis -- celery::tests::manual_dispatch --ignored
`
(`manual_dispatch` not included in the PR)

<img width="1256" height="362" alt="image" src="https://github.com/user-attachments/assets/5f9b1264-fdcd-4e39-8246-9a1e6ccb0a20" />

Verify result appears in Celery logs

(`posthog.tasks.tasks.rust_celery_test` not included in PR either)

<img width="1879" height="156" alt="image" src="https://github.com/user-attachments/assets/f3a69440-7df6-4f4c-9e28-a46a3512f7bc" />
