### PR TITLE
fix(hogql): handle KeyError in lazy table resolution with CTE projection pushdown

### DIFF
--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3443,6 +3443,19 @@ class TestPrinter(BaseTest):
             )
         self.assertIn("not supported", str(ctx.exception))
 
+    def test_projection_pushdown_cte_with_lazy_table_join(self):
+        modifiers = HogQLQueryModifiers(optimizeProjections=True)
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, modifiers=modifiers)
+        # Pruning the CTE should not leave stale LazyTableType references
+        # in SelectQueryType.columns that cause KeyError during lazy table resolution
+        self._select(
+            """
+            WITH combined AS (SELECT * FROM persons LIMIT 10)
+            SELECT 1 FROM events AS e LEFT JOIN combined AS c ON e.distinct_id = c.id
+            """,
+            context=context,
+        )
+
 
 @snapshot_clickhouse_queries
 class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -241,6 +241,13 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
 
         if pruned_select:
             node.select = pruned_select
+            # Sync SelectQueryType.columns to match the pruned select list.
+            # Without this, stale LazyTableType references on pruned columns
+            # leak through type traversal (e.g. CTETableType → SelectQueryType.columns)
+            # and cause KeyErrors in the lazy table resolver.
+            if isinstance(node.type, ast.SelectQueryType):
+                kept_names = {self._get_column_name(expr) for expr in pruned_select}
+                node.type.columns = {k: v for k, v in node.type.columns.items() if k in kept_names}
 
     def _get_column_name(self, expr: ast.Expr) -> str | None:
         """Extract column name from expression"""

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -240,14 +240,21 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
                     pruned_select.append(expr)
 
         if pruned_select:
+            # Collect the names of asterisk columns we're about to drop
+            dropped_names: set[str] = set()
+            for expr in node.select:
+                if self._is_from_asterisk(expr) and expr not in pruned_select:
+                    col_name = self._get_column_name(expr)
+                    if col_name:
+                        dropped_names.add(col_name)
+
             node.select = pruned_select
-            # Sync SelectQueryType.columns to match the pruned select list.
+            # Remove dropped asterisk columns from SelectQueryType.columns.
             # Without this, stale LazyTableType references on pruned columns
             # leak through type traversal (e.g. CTETableType → SelectQueryType.columns)
             # and cause KeyErrors in the lazy table resolver.
-            if isinstance(node.type, ast.SelectQueryType):
-                kept_names = {self._get_column_name(expr) for expr in pruned_select}
-                node.type.columns = {k: v for k, v in node.type.columns.items() if k in kept_names}
+            if dropped_names and isinstance(node.type, ast.SelectQueryType):
+                node.type.columns = {k: v for k, v in node.type.columns.items() if k not in dropped_names}
 
     def _get_column_name(self, expr: ast.Expr) -> str | None:
         """Extract column name from expression"""


### PR DESCRIPTION
## Problem

Projection pushdown prunes asterisk-expanded columns from a CTE's node.select but leaves stale LazyTableType references in SelectQueryType.columns. During lazy table resolution, type traversal through CTETableType → SelectQueryType → columns discovers these stale references and adds them to the outer query's field collector, causing a KeyError when looking up the lazy table name in the outer query's scope.
## Changes

Sync SelectQueryType.columns after pruning node.select in the projection pushdown optimizer, removing entries for columns that were pruned.

## How did you test this code?

Unit tests and CMD+Enter

## Publish to changelog?

No