### PR TITLE
fix: skip pre-aggregated tables for recent relative date ranges

### DIFF
--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Optional
 
 from posthog.hogql import ast
@@ -36,7 +37,26 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             if hasattr(prop, "key") and prop.key not in self.supported_props_filters:
                 return False
 
+        if self._is_recent_relative_date_range():
+            return False
+
         return True
+
+    def _is_recent_relative_date_range(self) -> bool:
+        """Returns True if the query covers a short relative date range (6 hours or less ending at 'now').
+
+        Pre-aggregated tables are updated periodically and may not contain the most recent data,
+        so we fall back to raw event tables for recent time windows.
+        """
+        date_range = getattr(self.runner.query, "dateRange", None)
+
+        # Only applies when date_to is not explicitly set (meaning the query ends at "now")
+        if date_range and date_range.date_to:
+            return False
+
+        date_from = self.runner.query_date_range.date_from()
+        date_to = self.runner.query_date_range.date_to()
+        return (date_to - date_from) <= timedelta(hours=6)
 
     def _get_channel_type_expr(self) -> ast.Expr:
         def _wrap_with_null_if_empty(expr: ast.Expr) -> ast.Expr:

--- a/posthog/hogql_queries/web_analytics/test/test_trends_pre_aggregated_query_builder.py
+++ b/posthog/hogql_queries/web_analytics/test/test_trends_pre_aggregated_query_builder.py
@@ -1,12 +1,10 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Optional, cast
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock
 
-from parameterized import parameterized
-
-from posthog.schema import DateRange, HogQLQueryModifiers, IntervalType, WebTrendsMetric, WebTrendsQuery
+from posthog.schema import HogQLQueryModifiers, IntervalType, WebTrendsMetric, WebTrendsQuery
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -265,57 +263,3 @@ class TestTrendsPreAggregatedQueryBuilder(ClickhouseTestMixin, APIBaseTest):
         # Test month interval
         runner.query.interval = IntervalType.MONTH
         self.assertEqual(builder._get_interval_function(), "toStartOfMonth")
-
-    @parameterized.expand(
-        [
-            # (name, hours_delta, explicit_date_to, expected_is_recent)
-            ("1_hour_no_explicit_date_to", 1, False, True),
-            ("6_hours_no_explicit_date_to", 6, False, True),
-            ("7_hours_no_explicit_date_to", 7, False, False),
-            ("24_hours_no_explicit_date_to", 24, False, False),
-            ("1_hour_with_explicit_date_to", 1, True, False),
-            ("6_hours_with_explicit_date_to", 6, True, False),
-        ]
-    )
-    def test_is_recent_relative_date_range(self, _name, hours_delta, explicit_date_to, expected_is_recent):
-        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
-        date_from = now - timedelta(hours=hours_delta)
-
-        query = WebTrendsQuery(
-            interval=IntervalType.DAY,
-            metrics=[WebTrendsMetric.UNIQUE_USERS],
-            properties=[],
-            dateRange=DateRange(date_to=now.isoformat() if explicit_date_to else None),
-        )
-
-        runner = self._create_mock_runner(query)
-        runner.query_date_range.date_from.return_value = date_from
-        runner.query_date_range.date_to.return_value = now
-
-        builder = TrendsPreAggregatedQueryBuilder(runner)
-
-        self.assertEqual(builder._is_recent_relative_date_range(), expected_is_recent)
-
-    def test_can_use_preaggregated_tables_rejects_recent_relative_date_range(self):
-        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
-        date_from = now - timedelta(hours=3)
-
-        query = WebTrendsQuery(
-            interval=IntervalType.DAY,
-            metrics=[WebTrendsMetric.UNIQUE_USERS],
-            properties=[],
-            dateRange=DateRange(),  # No explicit date_to means query ends at "now"
-        )
-
-        modifiers = HogQLQueryModifiers(
-            useWebAnalyticsPreAggregatedTables=True,
-            convertToProjectTimezone=False,
-        )
-
-        runner = self._create_mock_runner(query, modifiers)
-        runner.query_date_range.date_from.return_value = date_from
-        runner.query_date_range.date_to.return_value = now
-
-        builder = TrendsPreAggregatedQueryBuilder(runner)
-
-        self.assertFalse(builder.can_use_preaggregated_tables())

--- a/posthog/hogql_queries/web_analytics/test/test_trends_pre_aggregated_query_builder.py
+++ b/posthog/hogql_queries/web_analytics/test/test_trends_pre_aggregated_query_builder.py
@@ -1,10 +1,12 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Optional, cast
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock
 
-from posthog.schema import HogQLQueryModifiers, IntervalType, WebTrendsMetric, WebTrendsQuery
+from parameterized import parameterized
+
+from posthog.schema import DateRange, HogQLQueryModifiers, IntervalType, WebTrendsMetric, WebTrendsQuery
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -263,3 +265,57 @@ class TestTrendsPreAggregatedQueryBuilder(ClickhouseTestMixin, APIBaseTest):
         # Test month interval
         runner.query.interval = IntervalType.MONTH
         self.assertEqual(builder._get_interval_function(), "toStartOfMonth")
+
+    @parameterized.expand(
+        [
+            # (name, hours_delta, explicit_date_to, expected_is_recent)
+            ("1_hour_no_explicit_date_to", 1, False, True),
+            ("6_hours_no_explicit_date_to", 6, False, True),
+            ("7_hours_no_explicit_date_to", 7, False, False),
+            ("24_hours_no_explicit_date_to", 24, False, False),
+            ("1_hour_with_explicit_date_to", 1, True, False),
+            ("6_hours_with_explicit_date_to", 6, True, False),
+        ]
+    )
+    def test_is_recent_relative_date_range(self, _name, hours_delta, explicit_date_to, expected_is_recent):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=hours_delta)
+
+        query = WebTrendsQuery(
+            interval=IntervalType.DAY,
+            metrics=[WebTrendsMetric.UNIQUE_USERS],
+            properties=[],
+            dateRange=DateRange(date_to=now.isoformat() if explicit_date_to else None),
+        )
+
+        runner = self._create_mock_runner(query)
+        runner.query_date_range.date_from.return_value = date_from
+        runner.query_date_range.date_to.return_value = now
+
+        builder = TrendsPreAggregatedQueryBuilder(runner)
+
+        self.assertEqual(builder._is_recent_relative_date_range(), expected_is_recent)
+
+    def test_can_use_preaggregated_tables_rejects_recent_relative_date_range(self):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=3)
+
+        query = WebTrendsQuery(
+            interval=IntervalType.DAY,
+            metrics=[WebTrendsMetric.UNIQUE_USERS],
+            properties=[],
+            dateRange=DateRange(),  # No explicit date_to means query ends at "now"
+        )
+
+        modifiers = HogQLQueryModifiers(
+            useWebAnalyticsPreAggregatedTables=True,
+            convertToProjectTimezone=False,
+        )
+
+        runner = self._create_mock_runner(query, modifiers)
+        runner.query_date_range.date_from.return_value = date_from
+        runner.query_date_range.date_to.return_value = now
+
+        builder = TrendsPreAggregatedQueryBuilder(runner)
+
+        self.assertFalse(builder.can_use_preaggregated_tables())

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -974,3 +974,60 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         runner = WebOverviewQueryRunner(team=self.team, query=query)
         assert runner.query_date_range._interval == expected_interval
+
+    @parameterized.expand(
+        [
+            # (name, hours_delta, explicit_date_to, expected_is_recent)
+            ("1_hour_no_explicit_date_to", 1, False, True),
+            ("6_hours_no_explicit_date_to", 6, False, True),
+            ("7_hours_no_explicit_date_to", 7, False, False),
+            ("24_hours_no_explicit_date_to", 24, False, False),
+            ("1_hour_with_explicit_date_to", 1, True, False),
+            ("6_hours_with_explicit_date_to", 6, True, False),
+        ]
+    )
+    def test_is_recent_relative_date_range(self, _name, hours_delta, explicit_date_to, expected_is_recent):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=hours_delta)
+
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_to=now.isoformat() if explicit_date_to else None),
+            properties=[],
+        )
+
+        runner = MagicMock()
+        runner.query = query
+        runner.team = self.team
+        runner.modifiers = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True, convertToProjectTimezone=False)
+
+        mock_date_range = MagicMock()
+        mock_date_range.date_from.return_value = date_from
+        mock_date_range.date_to.return_value = now
+        runner.query_date_range = mock_date_range
+        runner.query_compare_to_date_range = None
+
+        builder = WebOverviewPreAggregatedQueryBuilder(runner)
+        self.assertEqual(builder._is_recent_relative_date_range(), expected_is_recent)
+
+    def test_can_use_preaggregated_tables_rejects_recent_relative_date_range(self):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=3)
+
+        query = WebOverviewQuery(
+            dateRange=DateRange(),  # No explicit date_to means query ends at "now"
+            properties=[],
+        )
+
+        runner = MagicMock()
+        runner.query = query
+        runner.team = self.team
+        runner.modifiers = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True, convertToProjectTimezone=False)
+
+        mock_date_range = MagicMock()
+        mock_date_range.date_from.return_value = date_from
+        mock_date_range.date_to.return_value = now
+        runner.query_date_range = mock_date_range
+        runner.query_compare_to_date_range = None
+
+        builder = WebOverviewPreAggregatedQueryBuilder(runner)
+        self.assertFalse(builder.can_use_preaggregated_tables())

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_pre_aggregated.py
@@ -1,5 +1,10 @@
+from datetime import UTC, datetime, timedelta
+
 from freezegun import freeze_time
 from posthog.test.base import _create_event, _create_person, flush_persons_and_events, snapshot_clickhouse_queries
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
 
 from posthog.schema import (
     DateRange,
@@ -404,3 +409,62 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
                 assert not regular_response.usedPreAggregatedTables
 
                 assert self._sort_results(preagg_response.results) == self._sort_results(regular_response.results)
+
+    @parameterized.expand(
+        [
+            # (name, hours_delta, explicit_date_to, expected_is_recent)
+            ("1_hour_no_explicit_date_to", 1, False, True),
+            ("6_hours_no_explicit_date_to", 6, False, True),
+            ("7_hours_no_explicit_date_to", 7, False, False),
+            ("24_hours_no_explicit_date_to", 24, False, False),
+            ("1_hour_with_explicit_date_to", 1, True, False),
+            ("6_hours_with_explicit_date_to", 6, True, False),
+        ]
+    )
+    def test_is_recent_relative_date_range(self, _name, hours_delta, explicit_date_to, expected_is_recent):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=hours_delta)
+
+        query = WebStatsTableQuery(
+            dateRange=DateRange(date_to=now.isoformat() if explicit_date_to else None),
+            properties=[],
+            breakdownBy=WebStatsBreakdown.DEVICE_TYPE,
+        )
+
+        runner = MagicMock()
+        runner.query = query
+        runner.team = self.team
+        runner.modifiers = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True, convertToProjectTimezone=False)
+
+        mock_date_range = MagicMock()
+        mock_date_range.date_from.return_value = date_from
+        mock_date_range.date_to.return_value = now
+        runner.query_date_range = mock_date_range
+        runner.query_compare_to_date_range = None
+
+        builder = StatsTablePreAggregatedQueryBuilder(runner)
+        self.assertEqual(builder._is_recent_relative_date_range(), expected_is_recent)
+
+    def test_can_use_preaggregated_tables_rejects_recent_relative_date_range(self):
+        now = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(hours=3)
+
+        query = WebStatsTableQuery(
+            dateRange=DateRange(),  # No explicit date_to means query ends at "now"
+            properties=[],
+            breakdownBy=WebStatsBreakdown.DEVICE_TYPE,
+        )
+
+        runner = MagicMock()
+        runner.query = query
+        runner.team = self.team
+        runner.modifiers = HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True, convertToProjectTimezone=False)
+
+        mock_date_range = MagicMock()
+        mock_date_range.date_from.return_value = date_from
+        mock_date_range.date_to.return_value = now
+        runner.query_date_range = mock_date_range
+        runner.query_compare_to_date_range = None
+
+        builder = StatsTablePreAggregatedQueryBuilder(runner)
+        self.assertFalse(builder.can_use_preaggregated_tables())


### PR DESCRIPTION
## Problem

Pre-aggregated tables are updated periodically and may not contain the most recent data. We have some conditions to check if there is data there, but for cases where we have DB overloaded or some errors on Dagster runs, we might fall behind shortly.

## Changes

When querying a relative date range of 6 hours or less, let's fall back to raw event tables to ensure fresh results.

## How did you test this code?

Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.