### PR TITLE
fix(approvals): re-check state inside select_for_update lock

### DIFF
--- a/posthog/approvals/services.py
+++ b/posthog/approvals/services.py
@@ -195,6 +195,9 @@ class ChangeRequestService:
         with transaction.atomic():
             change_request = ChangeRequest.objects.select_for_update().get(pk=self.change_request.pk)
 
+            if change_request.state != ChangeRequestState.PENDING:
+                raise InvalidStateError("Only pending change requests can be approved")
+
             approval, created = Approval.objects.get_or_create(
                 change_request=change_request,
                 created_by=self.user,
@@ -286,6 +289,9 @@ class ChangeRequestService:
 
         with transaction.atomic():
             change_request = ChangeRequest.objects.select_for_update().get(pk=self.change_request.pk)
+
+            if change_request.state != ChangeRequestState.PENDING:
+                raise InvalidStateError("Only pending change requests can be rejected")
 
             approval, created = Approval.objects.get_or_create(
                 change_request=change_request,

--- a/posthog/approvals/tests/test_services.py
+++ b/posthog/approvals/tests/test_services.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from posthog.approvals.exceptions import InvalidStateError
+from posthog.approvals.models import ChangeRequest, ChangeRequestState
+from posthog.approvals.services import ChangeRequestService
+
+
+class TestApproveRejectRaceCondition(BaseTest):
+    """Verify that state is re-checked inside the select_for_update lock."""
+
+    def setUp(self):
+        super().setUp()
+        self.change_request = ChangeRequest.objects.create(
+            team=self.team,
+            organization=self.organization,
+            created_by=self.user,
+            action_key="feature_flag.enable",
+            resource_type="feature_flag",
+            state=ChangeRequestState.PENDING,
+            intent={"gated_changes": {"active": True}},
+            intent_display={"description": "Enable feature flag"},
+            policy_snapshot={"quorum": 1, "users": [self.user.id], "allow_self_approve": True},
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+    def _locked_cr_with_state(self, state: str) -> MagicMock:
+        locked_qs = MagicMock()
+        cr_copy = ChangeRequest.objects.get(pk=self.change_request.pk)
+        cr_copy.state = state
+        locked_qs.get.return_value = cr_copy
+        return locked_qs
+
+    def test_approve_raises_when_state_changed_under_lock(self):
+        service = ChangeRequestService(self.change_request, self.user)
+
+        with patch.object(
+            ChangeRequest.objects,
+            "select_for_update",
+            return_value=self._locked_cr_with_state(ChangeRequestState.REJECTED),
+        ):
+            with self.assertRaises(InvalidStateError):
+                service.approve(reason="LGTM")
+
+    def test_reject_raises_when_state_changed_under_lock(self):
+        service = ChangeRequestService(self.change_request, self.user)
+
+        with patch.object(
+            ChangeRequest.objects,
+            "select_for_update",
+            return_value=self._locked_cr_with_state(ChangeRequestState.APPLIED),
+        ):
+            with self.assertRaises(InvalidStateError):
+                service.reject(reason="Not ready")

--- a/posthog/approvals/tests/test_services.py
+++ b/posthog/approvals/tests/test_services.py
@@ -5,14 +5,14 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from posthog.approvals.exceptions import InvalidStateError
 from posthog.approvals.models import ChangeRequest, ChangeRequestState
 from posthog.approvals.services import ChangeRequestService
 
 
 class TestApproveRejectRaceCondition(BaseTest):
-    """Verify that state is re-checked inside the select_for_update lock."""
-
     def setUp(self):
         super().setUp()
         self.change_request = ChangeRequest.objects.create(
@@ -35,24 +35,19 @@ class TestApproveRejectRaceCondition(BaseTest):
         locked_qs.get.return_value = cr_copy
         return locked_qs
 
-    def test_approve_raises_when_state_changed_under_lock(self):
+    @parameterized.expand(
+        [
+            ("approve", ChangeRequestState.REJECTED, "LGTM"),
+            ("reject", ChangeRequestState.APPLIED, "Not ready"),
+        ]
+    )
+    def test_raises_when_state_changed_under_lock(self, method_name, locked_state, reason):
         service = ChangeRequestService(self.change_request, self.user)
 
         with patch.object(
             ChangeRequest.objects,
             "select_for_update",
-            return_value=self._locked_cr_with_state(ChangeRequestState.REJECTED),
+            return_value=self._locked_cr_with_state(locked_state),
         ):
             with self.assertRaises(InvalidStateError):
-                service.approve(reason="LGTM")
-
-    def test_reject_raises_when_state_changed_under_lock(self):
-        service = ChangeRequestService(self.change_request, self.user)
-
-        with patch.object(
-            ChangeRequest.objects,
-            "select_for_update",
-            return_value=self._locked_cr_with_state(ChangeRequestState.APPLIED),
-        ):
-            with self.assertRaises(InvalidStateError):
-                service.reject(reason="Not ready")
+                getattr(service, method_name)(reason=reason)


### PR DESCRIPTION
## Problem

- The approve/reject methods check state before acquiring the row lock, but another request can change the state between the check and the lock acquisition

## Changes

- Re-check `change_request.state` inside the `select_for_update()` lock in both `approve()` and `reject()`

## How did you test this code?

- Existing approval tests continue to pass

## Publish to changelog?

- [ ] No