### PR TITLE
fix(approvals): improve expire task concurrency and scope

### DIFF
--- a/posthog/approvals/tasks.py
+++ b/posthog/approvals/tasks.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.db import transaction
 from django.utils import timezone
 
 from celery import shared_task
@@ -94,14 +95,20 @@ def expire_old_change_requests() -> dict[str, Any]:
     errors: list[str] = []
 
     pending_requests = ChangeRequest.objects.filter(
-        state=ChangeRequestState.PENDING,
+        state__in=[ChangeRequestState.PENDING, ChangeRequestState.APPROVED],
         expires_at__lte=now,
     )
 
     for change_request in pending_requests:
         try:
-            change_request.state = ChangeRequestState.EXPIRED
-            change_request.save(update_fields=["state"])
+            with transaction.atomic():
+                locked_cr = ChangeRequest.objects.select_for_update().get(pk=change_request.pk)
+                if locked_cr.state not in (ChangeRequestState.PENDING, ChangeRequestState.APPROVED):
+                    continue
+
+                locked_cr.state = ChangeRequestState.EXPIRED
+                locked_cr.save(update_fields=["state"])
+
             expired_count += 1
 
             logger.info(
@@ -112,7 +119,7 @@ def expire_old_change_requests() -> dict[str, Any]:
             )
 
             try:
-                send_approval_expired_notification(change_request)
+                send_approval_expired_notification(locked_cr)
             except Exception as notification_error:
                 logger.warning(
                     "expire_old_change_requests.notification_failed",

--- a/posthog/approvals/tests/test_tasks.py
+++ b/posthog/approvals/tests/test_tasks.py
@@ -75,8 +75,18 @@ class TestExpireOldChangeRequests(BaseTest):
         self.expired_request.refresh_from_db()
         self.assertEqual(self.expired_request.state, "pending")
 
-    def test_expire_task_skips_non_pending_requests(self):
+    def test_expire_task_expires_approved_requests(self):
         self.expired_request.state = "approved"
+        self.expired_request.save()
+
+        result = expire_old_change_requests()
+
+        self.assertEqual(result["expired_count"], 1)
+        self.expired_request.refresh_from_db()
+        self.assertEqual(self.expired_request.state, "expired")
+
+    def test_expire_task_skips_terminal_state_requests(self):
+        self.expired_request.state = "applied"
         self.expired_request.save()
 
         result = expire_old_change_requests()
@@ -87,4 +97,6 @@ class TestExpireOldChangeRequests(BaseTest):
     def test_expire_task_sends_notifications(self, mock_notification):
         expire_old_change_requests()
 
-        mock_notification.assert_called_once_with(self.expired_request)
+        mock_notification.assert_called_once()
+        notified_cr = mock_notification.call_args[0][0]
+        self.assertEqual(notified_cr.pk, self.expired_request.pk)

--- a/posthog/approvals/tests/test_tasks.py
+++ b/posthog/approvals/tests/test_tasks.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from posthog.approvals.models import ChangeRequest
 from posthog.approvals.tasks import expire_old_change_requests, validate_pending_change_requests
 
@@ -56,14 +58,6 @@ class TestExpireOldChangeRequests(BaseTest):
             expires_at=timezone.now() - timedelta(hours=1),
         )
 
-    def test_expire_task_expires_old_requests(self):
-        result = expire_old_change_requests()
-
-        self.assertEqual(result["expired_count"], 1)
-
-        self.expired_request.refresh_from_db()
-        self.assertEqual(self.expired_request.state, "expired")
-
     def test_expire_task_skips_future_requests(self):
         self.expired_request.expires_at = timezone.now() + timedelta(hours=1)
         self.expired_request.save()
@@ -75,23 +69,24 @@ class TestExpireOldChangeRequests(BaseTest):
         self.expired_request.refresh_from_db()
         self.assertEqual(self.expired_request.state, "pending")
 
-    def test_expire_task_expires_approved_requests(self):
-        self.expired_request.state = "approved"
+    @parameterized.expand(
+        [
+            ("pending", "expired", 1),
+            ("approved", "expired", 1),
+            ("applied", "applied", 0),
+            ("rejected", "rejected", 0),
+            ("expired", "expired", 0),
+        ]
+    )
+    def test_expire_task_state_transitions(self, initial_state, expected_state, expected_count):
+        self.expired_request.state = initial_state
         self.expired_request.save()
 
         result = expire_old_change_requests()
 
-        self.assertEqual(result["expired_count"], 1)
+        self.assertEqual(result["expired_count"], expected_count)
         self.expired_request.refresh_from_db()
-        self.assertEqual(self.expired_request.state, "expired")
-
-    def test_expire_task_skips_terminal_state_requests(self):
-        self.expired_request.state = "applied"
-        self.expired_request.save()
-
-        result = expire_old_change_requests()
-
-        self.assertEqual(result["expired_count"], 0)
+        self.assertEqual(self.expired_request.state, expected_state)
 
     @patch("posthog.approvals.tasks.send_approval_expired_notification")
     def test_expire_task_sends_notifications(self, mock_notification):


### PR DESCRIPTION
## Problem

- The expire task iterates over CRs without row-level locking, allowing concurrent runs to double-process
- Approved CRs past their expiry date were not being expired

## Changes

- Wrap each CR update in `transaction.atomic()` + `select_for_update()` with a state re-check
- Include `APPROVED` state in the expire query alongside `PENDING`
- Update tests to match

## How did you test this code?

- Updated and ran `test_tasks.py` — 9 tests pass

## Publish to changelog?

- [ ] No