### PR TITLE
fix(approvals): normalize bypass membership level comparison

### DIFF
--- a/posthog/approvals/policies.py
+++ b/posthog/approvals/policies.py
@@ -286,7 +286,7 @@ class PolicyEngine:
         # Check bypass_org_membership_levels
         if policy.bypass_org_membership_levels:
             membership = actor.organization_memberships.filter(organization=org).first()
-            if membership and str(membership.level) in policy.bypass_org_membership_levels:
+            if membership and membership.level in [int(lvl) for lvl in policy.bypass_org_membership_levels]:
                 return True
 
         # Check bypass_roles (RBAC roles)

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -180,6 +180,14 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
 
+    def validate_bypass_org_membership_levels(self, value):
+        if not value:
+            return value
+        try:
+            return [int(lvl) for lvl in value]
+        except (ValueError, TypeError):
+            raise serializers.ValidationError("All membership levels must be integers")
+
     def validate_bypass_roles(self, value):
         if not value:
             return value

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -417,6 +417,40 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already exists" in response.json()["detail"]
 
+    @parameterized.expand(
+        [
+            ("string_levels", ["8", "15"]),
+            ("integer_levels", [8, 15]),
+        ]
+    )
+    def test_create_policy_with_bypass_org_membership_levels(self, _name, levels):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 1, "users": [self.user.id]},
+                "bypass_org_membership_levels": levels,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        policy = ApprovalPolicy.objects.get(id=response.json()["id"])
+        assert policy.bypass_org_membership_levels == [8, 15]
+
+    def test_create_policy_with_non_integer_bypass_levels_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 1, "users": [self.user.id]},
+                "bypass_org_membership_levels": ["admin", "owner"],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_create_policy_with_nonexistent_bypass_role_returns_error(self):
         import uuid
 

--- a/posthog/approvals/tests/test_policy_engine.py
+++ b/posthog/approvals/tests/test_policy_engine.py
@@ -34,6 +34,9 @@ class TestPolicyEngineBypass(APIBaseTest):
             (OrganizationMembership.Level.ADMIN, ["15"], False),
             (OrganizationMembership.Level.OWNER, ["15"], True),
             (OrganizationMembership.Level.ADMIN, [], False),
+            # integer-typed levels should also work
+            (OrganizationMembership.Level.ADMIN, [8, 15], True),
+            (OrganizationMembership.Level.MEMBER, [8, 15], False),
         ]
     )
     def test_bypass_org_membership_levels(

--- a/posthog/approvals/tests/test_policy_engine.py
+++ b/posthog/approvals/tests/test_policy_engine.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from posthog.test.base import APIBaseTest
 
 from parameterized import parameterized
@@ -10,7 +12,7 @@ from posthog.models.organization import OrganizationMembership
 class TestPolicyEngineBypass(APIBaseTest):
     def _create_policy(
         self,
-        bypass_org_membership_levels: list[str] | None = None,
+        bypass_org_membership_levels: Sequence[str | int] | None = None,
         bypass_role_ids: list[str] | None = None,
     ) -> ApprovalPolicy:
         policy = ApprovalPolicy.objects.create(
@@ -42,7 +44,7 @@ class TestPolicyEngineBypass(APIBaseTest):
     def test_bypass_org_membership_levels(
         self,
         user_level: int,
-        bypass_levels: list[str],
+        bypass_levels: Sequence[str | int],
         expected_bypass: bool,
     ):
         self.organization_membership.level = user_level
@@ -145,7 +147,7 @@ class TestPolicyEngineBypass(APIBaseTest):
 class TestPolicyEngineEvaluateBypass(APIBaseTest):
     def _create_policy(
         self,
-        bypass_org_membership_levels: list[str] | None = None,
+        bypass_org_membership_levels: Sequence[str | int] | None = None,
         bypass_role_ids: list[str] | None = None,
     ) -> ApprovalPolicy:
         policy = ApprovalPolicy.objects.create(
@@ -211,7 +213,7 @@ class TestPolicyEngineEvaluateBypass(APIBaseTest):
 class TestPolicySnapshotBypassFields(APIBaseTest):
     def _create_policy(
         self,
-        bypass_org_membership_levels: list[str] | None = None,
+        bypass_org_membership_levels: Sequence[str | int] | None = None,
         bypass_role_ids: list[str] | None = None,
     ) -> ApprovalPolicy:
         policy = ApprovalPolicy.objects.create(


### PR DESCRIPTION
## Problem

- `bypass_org_membership_levels` stores values as strings in a JSONField, but `membership.level` is an integer — the `str(level) in list` comparison works but is fragile if the stored format varies

## Changes

- Compare as integers at runtime: `membership.level in [int(lvl) for lvl in ...]`
- Add `validate_bypass_org_membership_levels` to the serializer to coerce and validate on write

## How did you test this code?

- Existing tests pass

## Publish to changelog?

- [ ] No