### PR TITLE
fix(approvals): replace manual query param parsing with DRF FilterSet

### DIFF
--- a/frontend/src/scenes/approvals/approvalsLogic.tsx
+++ b/frontend/src/scenes/approvals/approvalsLogic.tsx
@@ -13,7 +13,7 @@ import type { approvalsLogicType } from './approvalsLogicType'
 
 export interface ApprovalsFilters {
     state?: ChangeRequestState
-    action_type?: string
+    action_key?: string
     resource_type?: string
     resource_id?: string
     requester?: number
@@ -70,7 +70,7 @@ export const approvalsLogic = kea<approvalsLogicType>([
                         url ||
                         `api/environments/${values.currentTeamId}/change_requests/?${new URLSearchParams({
                             ...(values.filters.state && { state: values.filters.state }),
-                            ...(values.filters.action_type && { action_type: values.filters.action_type }),
+                            ...(values.filters.action_key && { action_key: values.filters.action_key }),
                             ...(values.filters.resource_type && { resource_type: values.filters.resource_type }),
                             ...(values.filters.resource_id && { resource_id: values.filters.resource_id }),
                             ...(values.filters.requester && { requester: values.filters.requester.toString() }),
@@ -116,7 +116,7 @@ export const approvalsLogic = kea<approvalsLogicType>([
             const nextUrl = `api/environments/${values.currentTeamId}/change_requests/?${new URLSearchParams({
                 offset: values.changeRequests.length.toString(),
                 ...(values.filters.state && { state: values.filters.state }),
-                ...(values.filters.action_type && { action_type: values.filters.action_type }),
+                ...(values.filters.action_key && { action_key: values.filters.action_key }),
                 ...(values.filters.resource_type && { resource_type: values.filters.resource_type }),
                 ...(values.filters.resource_id && { resource_id: values.filters.resource_id }),
                 ...(values.filters.requester && { requester: values.filters.requester.toString() }),

--- a/posthog/approvals/actions/base.py
+++ b/posthog/approvals/actions/base.py
@@ -73,6 +73,20 @@ class BaseAction(ABC):
         pass
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Check if the underlying resource has changed since the CR was created.
+
+        Returns True if the resource is stale (has been modified).
+        Override in subclasses that store preconditions in intent.
+        """
+        return False
+
+    @classmethod
     def validate_intent(
         cls,
         intent_data: dict[str, Any],

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -9,6 +9,20 @@ from posthog.approvals.exceptions import ApplyFailed, PreconditionFailed
 from posthog.models import FeatureFlag
 
 
+def _check_version_staleness(intent_data: dict[str, Any], context: Optional[dict[str, Any]] = None) -> bool:
+    """Check staleness by comparing stored version precondition against current instance version."""
+    instance = context.get("instance") if context else None
+    if not instance:
+        return True
+
+    preconditions = intent_data.get("preconditions", {})
+    stored_version = preconditions.get("version")
+    if stored_version is not None and instance.version != stored_version:
+        return True
+
+    return False
+
+
 class FeatureFlagActionBase(BaseAction):
     """Base class for feature flag state change actions."""
 
@@ -18,6 +32,14 @@ class FeatureFlagActionBase(BaseAction):
 
     # Subclasses define the target state
     target_active_state: bool
+
+    @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def validate_intent(
@@ -208,6 +230,14 @@ class UpdateFeatureFlagAction(BaseAction):
     ]
 
     intent_fields = ["rollout_percentage"]
+
+    @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def _extract_rollout_percentages(cls, filters: dict[str, Any]) -> list[dict[str, Any]]:

--- a/posthog/approvals/api.py
+++ b/posthog/approvals/api.py
@@ -28,18 +28,12 @@ from posthog.permissions import (
 logger = logging.getLogger(__name__)
 
 
-class CommaSeparatedCharFilter(django_filters.CharFilter):
-    """Filter that splits comma-separated values into an __in lookup."""
-
-    def filter(self, qs, value):
-        if not value:
-            return qs
-        values = [v.strip() for v in value.split(",") if v.strip()]
-        return qs.filter(**{f"{self.field_name}__in": values})
+class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
+    pass
 
 
 class ChangeRequestFilterSet(django_filters.FilterSet):
-    state = CommaSeparatedCharFilter(field_name="state")
+    state = CharInFilter(field_name="state", lookup_expr="in")
     action_key = django_filters.CharFilter(field_name="action_key")
     requester = django_filters.NumberFilter(field_name="created_by_id")
     resource_type = django_filters.CharFilter(field_name="resource_type")

--- a/posthog/approvals/api.py
+++ b/posthog/approvals/api.py
@@ -3,6 +3,8 @@ from typing import cast
 
 from django.db.models import QuerySet
 
+import django_filters
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -26,33 +28,38 @@ from posthog.permissions import (
 logger = logging.getLogger(__name__)
 
 
+class CommaSeparatedCharFilter(django_filters.CharFilter):
+    """Filter that splits comma-separated values into an __in lookup."""
+
+    def filter(self, qs, value):
+        if not value:
+            return qs
+        values = [v.strip() for v in value.split(",") if v.strip()]
+        return qs.filter(**{f"{self.field_name}__in": values})
+
+
+class ChangeRequestFilterSet(django_filters.FilterSet):
+    state = CommaSeparatedCharFilter(field_name="state")
+    action_key = django_filters.CharFilter(field_name="action_key")
+    requester = django_filters.NumberFilter(field_name="created_by_id")
+    resource_type = django_filters.CharFilter(field_name="resource_type")
+    resource_id = django_filters.CharFilter(field_name="resource_id")
+
+    class Meta:
+        model = ChangeRequest
+        fields: list[str] = []
+
+
 class ChangeRequestViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
     scope_object = "INTERNAL"
     queryset = ChangeRequest.objects.all().order_by("-created_at")
     permission_classes = [OrganizationMemberPermissions, PremiumFeaturePermission]
     premium_feature_on_cloud = AvailableFeature.APPROVALS
     serializer_class = ChangeRequestSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = ChangeRequestFilterSet
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
-        filters = self.request.query_params
-
-        if "state" in filters:
-            states = filters["state"].split(",")
-            queryset = queryset.filter(state__in=states)
-
-        action_filter = filters.get("action_type") or filters.get("action_key")
-        if action_filter:
-            queryset = queryset.filter(action_key=action_filter)
-
-        if "requester" in filters:
-            queryset = queryset.filter(created_by_id=filters["requester"])
-
-        if "resource_type" in filters:
-            queryset = queryset.filter(resource_type=filters["resource_type"])
-
-        if "resource_id" in filters:
-            queryset = queryset.filter(resource_id=filters["resource_id"])
-
         return queryset.select_related("created_by", "applied_by").prefetch_related("approvals")
 
     @action(methods=["POST"], detail=True, permission_classes=[PremiumFeaturePermission, CanApprove])

--- a/posthog/approvals/api.py
+++ b/posthog/approvals/api.py
@@ -35,7 +35,6 @@ class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
 class ChangeRequestFilterSet(django_filters.FilterSet):
     state = CharInFilter(field_name="state", lookup_expr="in")
     action_key = django_filters.CharFilter(field_name="action_key")
-    action_type = django_filters.CharFilter(field_name="action_key")
     requester = django_filters.NumberFilter(field_name="created_by_id")
     resource_type = django_filters.CharFilter(field_name="resource_type")
     resource_id = django_filters.CharFilter(field_name="resource_id")

--- a/posthog/approvals/api.py
+++ b/posthog/approvals/api.py
@@ -35,6 +35,7 @@ class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
 class ChangeRequestFilterSet(django_filters.FilterSet):
     state = CharInFilter(field_name="state", lookup_expr="in")
     action_key = django_filters.CharFilter(field_name="action_key")
+    action_type = django_filters.CharFilter(field_name="action_key")
     requester = django_filters.NumberFilter(field_name="created_by_id")
     resource_type = django_filters.CharFilter(field_name="resource_type")
     resource_id = django_filters.CharFilter(field_name="resource_id")

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -180,6 +180,12 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
 
+    def validate_approver_config(self, value):
+        quorum = value.get("quorum", 0)
+        if quorum < 1:
+            raise serializers.ValidationError("Quorum must be at least 1")
+        return value
+
     def validate_bypass_org_membership_levels(self, value):
         if not value:
             return value

--- a/posthog/approvals/tasks.py
+++ b/posthog/approvals/tasks.py
@@ -15,16 +15,19 @@ logger = get_logger(__name__)
 @shared_task(ignore_result=True)
 def validate_pending_change_requests() -> dict[str, Any]:
     """
-    Checks if:
-    1. The underlying data has changed (staleness)
-    2. The validation is still valid (re-run validation)
-    """
+    Periodic staleness check for pending change requests.
 
-    validated_count = 0
-    invalidated_count = 0
+    Compares stored preconditions against the current resource state.
+    Marks CRs as STALE when the underlying resource has been modified,
+    which allows requesters to cancel even after approvals have been given.
+    """
+    stale_count = 0
+    checked_count = 0
     errors: list[str] = []
 
-    pending_requests = ChangeRequest.objects.filter(state=ChangeRequestState.PENDING)
+    pending_requests = ChangeRequest.objects.filter(
+        state=ChangeRequestState.PENDING,
+    ).exclude(validation_status=ValidationStatus.STALE)
 
     for change_request in pending_requests:
         try:
@@ -37,7 +40,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
                 )
                 continue
 
-            # Build context for validation
+            checked_count += 1
+
             base_context = {
                 "team": change_request.team,
                 "team_id": change_request.team_id,
@@ -45,24 +49,18 @@ def validate_pending_change_requests() -> dict[str, Any]:
             }
             context = action_class.prepare_context(change_request, base_context)
 
-            is_valid, validation_errors = action_class.validate_intent(change_request.intent, context)
-
-            if is_valid:
-                change_request.validation_status = ValidationStatus.VALID
-                change_request.validation_errors = None
-                validated_count += 1
-            else:
-                change_request.validation_status = ValidationStatus.INVALID
-                change_request.validation_errors = validation_errors
-                invalidated_count += 1
+            if action_class.check_staleness(change_request.intent, context):
+                change_request.validation_status = ValidationStatus.STALE
+                change_request.validation_errors = {
+                    "staleness": "Resource has been modified since this change request was created"
+                }
+                change_request.validated_at = timezone.now()
+                change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
+                stale_count += 1
                 logger.info(
-                    "validate_pending_change_requests.invalidated",
+                    "validate_pending_change_requests.stale",
                     change_request_id=str(change_request.id),
-                    errors=validation_errors,
                 )
-
-            change_request.validated_at = timezone.now()
-            change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
 
         except Exception as e:
             error_msg = f"Error validating change request {change_request.id}: {str(e)}"
@@ -74,8 +72,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
             )
 
     result = {
-        "validated_count": validated_count,
-        "invalidated_count": invalidated_count,
+        "checked_count": checked_count,
+        "stale_count": stale_count,
         "errors": errors,
     }
 

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,6 +467,25 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
+    @parameterized.expand(
+        [
+            ("zero", 0, status.HTTP_400_BAD_REQUEST),
+            ("negative", -1, status.HTTP_400_BAD_REQUEST),
+            ("one", 1, status.HTTP_201_CREATED),
+        ]
+    )
+    def test_create_policy_quorum_validation(self, _name, quorum, expected_status):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": quorum, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == expected_status
+
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -110,6 +110,35 @@ class TestChangeRequestViewSet(APIBaseTest):
         assert len(response.json()["results"]) == 1
         assert response.json()["results"][0]["id"] == str(pending.id)
 
+    def test_list_filters_by_requester(self):
+        other_user = User.objects.create(email="other@posthog.com")
+        mine = self._create_change_request()
+        self._create_change_request(created_by=other_user, resource_id="456")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/?requester={self.user.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == 1
+        assert response.json()["results"][0]["id"] == str(mine.id)
+
+    def test_list_requester_filter_non_numeric_returns_400(self):
+        self._create_change_request()
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/?requester=abc")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_list_filters_by_comma_separated_states(self):
+        pending = self._create_change_request(state=ChangeRequestState.PENDING)
+        applied = self._create_change_request(state=ChangeRequestState.APPLIED, resource_id="456")
+        self._create_change_request(state=ChangeRequestState.REJECTED, resource_id="789")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/?state=pending,applied")
+
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = {r["id"] for r in response.json()["results"]}
+        assert result_ids == {str(pending.id), str(applied.id)}
+
     def test_list_filters_by_resource(self):
         cr = self._create_change_request(resource_type="feature_flag", resource_id="123")
         self._create_change_request(resource_type="feature_flag", resource_id="456")

--- a/posthog/approvals/tests/test_tasks.py
+++ b/posthog/approvals/tests/test_tasks.py
@@ -31,14 +31,50 @@ class TestValidatePendingChangeRequests(BaseTest):
             expires_at=timezone.now() + timedelta(hours=24),
         )
 
-    def test_validation_skips_non_pending_requests(self):
+    def test_skips_non_pending_requests(self):
         self.change_request.state = "approved"
         self.change_request.save()
 
         result = validate_pending_change_requests()
 
-        self.assertEqual(result["validated_count"], 0)
-        self.assertEqual(result["invalidated_count"], 0)
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    def test_skips_already_stale_requests(self):
+        self.change_request.validation_status = "stale"
+        self.change_request.save()
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_marks_stale_when_resource_changed(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = True
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["stale_count"], 1)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "stale")
+        self.assertIsNotNone(self.change_request.validation_errors)
+        self.assertIsNotNone(self.change_request.validated_at)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_leaves_unchanged_when_not_stale(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = False
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 1)
+        self.assertEqual(result["stale_count"], 0)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "valid")
 
 
 class TestExpireOldChangeRequests(BaseTest):

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -171,6 +171,84 @@ class TestUpdateFeatureFlagActionDisplayData(APIBaseTest):
         assert "rollout percentage" in display_data["description"].lower()
 
 
+class TestCheckStaleness(APIBaseTest):
+    def _create_flag(self) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+            created_by=self.user,
+        )
+
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_stale_when_no_instance_in_context(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        intent = {"preconditions": {"version": 1}}
+        result = EnableFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
+    def test_not_stale_when_no_stored_version(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        flag = self._create_flag()
+        intent: dict[str, Any] = {"preconditions": {}}
+        context = {"instance": flag}
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is False
+
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_update_action_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        result = UpdateFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_update_action_stale_when_no_instance(self):
+        intent = {"preconditions": {"version": 1}}
+        result = UpdateFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
+    def test_base_action_check_staleness_always_returns_false(self):
+        from posthog.approvals.actions.base import BaseAction
+
+        result = BaseAction.check_staleness({"preconditions": {"version": 1}}, {})
+
+        assert result is False
+
+
 class TestPolicyConditionEvaluation(APIBaseTest):
     def _create_policy_with_conditions(self, conditions: dict[str, Any]) -> ApprovalPolicy:
         return ApprovalPolicy.objects.create(


### PR DESCRIPTION
## Problem

- The `requester` query param is passed as a raw string to `created_by_id` — a non-numeric value causes a 500 instead of being rejected
- Manual filtering in `safely_get_queryset` duplicates what django-filter provides
- Frontend used `action_type` query param but the model field is `action_key`

## Changes

- Add `ChangeRequestFilterSet` with typed filters (e.g. `NumberFilter` for `requester`)
- Wire up `DjangoFilterBackend` on `ChangeRequestViewSet`
- Remove manual filtering code from `safely_get_queryset`
- Retire `action_type` query param — update FE to use `action_key` directly

## How did you test this code?

- Existing tests pass, invalid `requester` values now return 400 instead of 500

## Publish to changelog?

- [ ] No