### PR TITLE
fix(approvals): validate quorum >= 1 in policy serializer

### DIFF
--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -180,6 +180,12 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
 
+    def validate_approver_config(self, value):
+        quorum = value.get("quorum", 0)
+        if quorum < 1:
+            raise serializers.ValidationError("Quorum must be at least 1")
+        return value
+
     def validate_bypass_org_membership_levels(self, value):
         if not value:
             return value

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,30 +467,24 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
-    def test_create_policy_with_quorum_zero_rejected(self):
+    @parameterized.expand(
+        [
+            ("zero", 0, status.HTTP_400_BAD_REQUEST),
+            ("negative", -1, status.HTTP_400_BAD_REQUEST),
+            ("one", 1, status.HTTP_201_CREATED),
+        ]
+    )
+    def test_create_policy_quorum_validation(self, _name, quorum, expected_status):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",
             {
                 "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 0, "users": [self.user.id]},
+                "approver_config": {"quorum": quorum, "users": [self.user.id]},
             },
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_create_policy_with_quorum_one_accepted(self):
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/approval_policies/",
-            {
-                "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 1, "users": [self.user.id]},
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["approver_config"]["quorum"] == 1
+        assert response.status_code == expected_status
 
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,6 +467,31 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
+    def test_create_policy_with_quorum_zero_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 0, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_policy_with_quorum_one_accepted(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 1, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["approver_config"]["quorum"] == 1
+
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",


### PR DESCRIPTION
## Problem

- A policy with `quorum: 0` would cause change requests to auto-apply with zero approvals

## Changes

- Add `validate_approver_config` to `ApprovalPolicySerializer` that rejects `quorum < 1`

## How did you test this code?

- Existing tests pass

## Publish to changelog?

- [ ] No