### PR TITLE
feat(approvals): add periodic staleness detection for change requests

### DIFF
--- a/posthog/approvals/actions/base.py
+++ b/posthog/approvals/actions/base.py
@@ -73,6 +73,20 @@ class BaseAction(ABC):
         pass
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Check if the underlying resource has changed since the CR was created.
+
+        Returns True if the resource is stale (has been modified).
+        Override in subclasses that store preconditions in intent.
+        """
+        return False
+
+    @classmethod
     def validate_intent(
         cls,
         intent_data: dict[str, Any],

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -20,6 +20,23 @@ class FeatureFlagActionBase(BaseAction):
     target_active_state: bool
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        instance = context.get("instance") if context else None
+        if not instance:
+            return True
+
+        preconditions = intent_data.get("preconditions", {})
+        stored_version = preconditions.get("version")
+        if stored_version is not None and instance.version != stored_version:
+            return True
+
+        return False
+
+    @classmethod
     def validate_intent(
         cls,
         intent_data: dict[str, Any],

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -9,6 +9,20 @@ from posthog.approvals.exceptions import ApplyFailed, PreconditionFailed
 from posthog.models import FeatureFlag
 
 
+def _check_version_staleness(intent_data: dict[str, Any], context: Optional[dict[str, Any]] = None) -> bool:
+    """Check staleness by comparing stored version precondition against current instance version."""
+    instance = context.get("instance") if context else None
+    if not instance:
+        return True
+
+    preconditions = intent_data.get("preconditions", {})
+    stored_version = preconditions.get("version")
+    if stored_version is not None and instance.version != stored_version:
+        return True
+
+    return False
+
+
 class FeatureFlagActionBase(BaseAction):
     """Base class for feature flag state change actions."""
 
@@ -25,16 +39,7 @@ class FeatureFlagActionBase(BaseAction):
         intent_data: dict[str, Any],
         context: Optional[dict[str, Any]] = None,
     ) -> bool:
-        instance = context.get("instance") if context else None
-        if not instance:
-            return True
-
-        preconditions = intent_data.get("preconditions", {})
-        stored_version = preconditions.get("version")
-        if stored_version is not None and instance.version != stored_version:
-            return True
-
-        return False
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def validate_intent(
@@ -232,16 +237,7 @@ class UpdateFeatureFlagAction(BaseAction):
         intent_data: dict[str, Any],
         context: Optional[dict[str, Any]] = None,
     ) -> bool:
-        instance = context.get("instance") if context else None
-        if not instance:
-            return True
-
-        preconditions = intent_data.get("preconditions", {})
-        stored_version = preconditions.get("version")
-        if stored_version is not None and instance.version != stored_version:
-            return True
-
-        return False
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def _extract_rollout_percentages(cls, filters: dict[str, Any]) -> list[dict[str, Any]]:

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -227,6 +227,23 @@ class UpdateFeatureFlagAction(BaseAction):
     intent_fields = ["rollout_percentage"]
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        instance = context.get("instance") if context else None
+        if not instance:
+            return True
+
+        preconditions = intent_data.get("preconditions", {})
+        stored_version = preconditions.get("version")
+        if stored_version is not None and instance.version != stored_version:
+            return True
+
+        return False
+
+    @classmethod
     def _extract_rollout_percentages(cls, filters: dict[str, Any]) -> list[dict[str, Any]]:
         """
         Extract all rollout_percentage values from the filter structure.

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -180,6 +180,12 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
 
+    def validate_approver_config(self, value):
+        quorum = value.get("quorum", 0)
+        if quorum < 1:
+            raise serializers.ValidationError("Quorum must be at least 1")
+        return value
+
     def validate_bypass_org_membership_levels(self, value):
         if not value:
             return value

--- a/posthog/approvals/tasks.py
+++ b/posthog/approvals/tasks.py
@@ -15,16 +15,19 @@ logger = get_logger(__name__)
 @shared_task(ignore_result=True)
 def validate_pending_change_requests() -> dict[str, Any]:
     """
-    Checks if:
-    1. The underlying data has changed (staleness)
-    2. The validation is still valid (re-run validation)
-    """
+    Periodic staleness check for pending change requests.
 
-    validated_count = 0
-    invalidated_count = 0
+    Compares stored preconditions against the current resource state.
+    Marks CRs as STALE when the underlying resource has been modified,
+    which allows requesters to cancel even after approvals have been given.
+    """
+    stale_count = 0
+    checked_count = 0
     errors: list[str] = []
 
-    pending_requests = ChangeRequest.objects.filter(state=ChangeRequestState.PENDING)
+    pending_requests = ChangeRequest.objects.filter(
+        state=ChangeRequestState.PENDING,
+    ).exclude(validation_status=ValidationStatus.STALE)
 
     for change_request in pending_requests:
         try:
@@ -37,7 +40,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
                 )
                 continue
 
-            # Build context for validation
+            checked_count += 1
+
             base_context = {
                 "team": change_request.team,
                 "team_id": change_request.team_id,
@@ -45,24 +49,18 @@ def validate_pending_change_requests() -> dict[str, Any]:
             }
             context = action_class.prepare_context(change_request, base_context)
 
-            is_valid, validation_errors = action_class.validate_intent(change_request.intent, context)
-
-            if is_valid:
-                change_request.validation_status = ValidationStatus.VALID
-                change_request.validation_errors = None
-                validated_count += 1
-            else:
-                change_request.validation_status = ValidationStatus.INVALID
-                change_request.validation_errors = validation_errors
-                invalidated_count += 1
+            if action_class.check_staleness(change_request.intent, context):
+                change_request.validation_status = ValidationStatus.STALE
+                change_request.validation_errors = {
+                    "staleness": "Resource has been modified since this change request was created"
+                }
+                change_request.validated_at = timezone.now()
+                change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
+                stale_count += 1
                 logger.info(
-                    "validate_pending_change_requests.invalidated",
+                    "validate_pending_change_requests.stale",
                     change_request_id=str(change_request.id),
-                    errors=validation_errors,
                 )
-
-            change_request.validated_at = timezone.now()
-            change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
 
         except Exception as e:
             error_msg = f"Error validating change request {change_request.id}: {str(e)}"
@@ -74,8 +72,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
             )
 
     result = {
-        "validated_count": validated_count,
-        "invalidated_count": invalidated_count,
+        "checked_count": checked_count,
+        "stale_count": stale_count,
         "errors": errors,
     }
 

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,30 +467,24 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
-    def test_create_policy_with_quorum_zero_rejected(self):
+    @parameterized.expand(
+        [
+            ("zero", 0, status.HTTP_400_BAD_REQUEST),
+            ("negative", -1, status.HTTP_400_BAD_REQUEST),
+            ("one", 1, status.HTTP_201_CREATED),
+        ]
+    )
+    def test_create_policy_quorum_validation(self, _name, quorum, expected_status):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",
             {
                 "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 0, "users": [self.user.id]},
+                "approver_config": {"quorum": quorum, "users": [self.user.id]},
             },
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_create_policy_with_quorum_one_accepted(self):
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/approval_policies/",
-            {
-                "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 1, "users": [self.user.id]},
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["approver_config"]["quorum"] == 1
+        assert response.status_code == expected_status
 
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,6 +467,31 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
+    def test_create_policy_with_quorum_zero_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 0, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_policy_with_quorum_one_accepted(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 1, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["approver_config"]["quorum"] == 1
+
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",

--- a/posthog/approvals/tests/test_tasks.py
+++ b/posthog/approvals/tests/test_tasks.py
@@ -31,14 +31,50 @@ class TestValidatePendingChangeRequests(BaseTest):
             expires_at=timezone.now() + timedelta(hours=24),
         )
 
-    def test_validation_skips_non_pending_requests(self):
+    def test_skips_non_pending_requests(self):
         self.change_request.state = "approved"
         self.change_request.save()
 
         result = validate_pending_change_requests()
 
-        self.assertEqual(result["validated_count"], 0)
-        self.assertEqual(result["invalidated_count"], 0)
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    def test_skips_already_stale_requests(self):
+        self.change_request.validation_status = "stale"
+        self.change_request.save()
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_marks_stale_when_resource_changed(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = True
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["stale_count"], 1)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "stale")
+        self.assertIsNotNone(self.change_request.validation_errors)
+        self.assertIsNotNone(self.change_request.validated_at)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_leaves_unchanged_when_not_stale(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = False
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 1)
+        self.assertEqual(result["stale_count"], 0)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "valid")
 
 
 class TestExpireOldChangeRequests(BaseTest):

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -171,6 +171,61 @@ class TestUpdateFeatureFlagActionDisplayData(APIBaseTest):
         assert "rollout percentage" in display_data["description"].lower()
 
 
+class TestCheckStaleness(APIBaseTest):
+    def _create_flag(self) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+            created_by=self.user,
+        )
+
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_stale_when_no_instance_in_context(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        intent = {"preconditions": {"version": 1}}
+        result = EnableFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
+    def test_not_stale_when_no_stored_version(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        flag = self._create_flag()
+        intent = {"preconditions": {}}
+        context = {"instance": flag}
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is False
+
+    def test_base_action_check_staleness_always_returns_false(self):
+        from posthog.approvals.actions.base import BaseAction
+
+        result = BaseAction.check_staleness({"preconditions": {"version": 1}}, {})
+
+        assert result is False
+
+
 class TestPolicyConditionEvaluation(APIBaseTest):
     def _create_policy_with_conditions(self, conditions: dict[str, Any]) -> ApprovalPolicy:
         return ApprovalPolicy.objects.create(

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -218,6 +218,29 @@ class TestCheckStaleness(APIBaseTest):
 
         assert result is False
 
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_update_action_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        result = UpdateFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_update_action_stale_when_no_instance(self):
+        intent = {"preconditions": {"version": 1}}
+        result = UpdateFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
     def test_base_action_check_staleness_always_returns_false(self):
         from posthog.approvals.actions.base import BaseAction
 

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -211,7 +211,7 @@ class TestCheckStaleness(APIBaseTest):
         from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
 
         flag = self._create_flag()
-        intent = {"preconditions": {}}
+        intent: dict[str, Any] = {"preconditions": {}}
         context = {"instance": flag}
 
         result = EnableFeatureFlagAction.check_staleness(intent, context)


### PR DESCRIPTION
## Problem

- The periodic validation task re-ran full intent validation, which was not actionable — the VALID/INVALID statuses are informational only and don't gate any behavior
- No mechanism to detect when the underlying resource has changed since a CR was created

## Changes

- Add `check_staleness()` to `BaseAction` (default: not stale)
- Implement `check_staleness()` on `FeatureFlagActionBase` — compares `preconditions.version` from intent against current flag version
- Simplify `validate_pending_change_requests` to only perform staleness detection
- Skip already-stale CRs to avoid redundant work
- Rewrite tests to cover the new staleness flow

## How did you test this code?

- 9 tests pass in `test_tasks.py` covering stale/not-stale/skip scenarios

## Publish to changelog?

- [ ] No