### PR TITLE
fix(approvals): use specific exception types in services and policies

### DIFF
--- a/posthog/approvals/actions/base.py
+++ b/posthog/approvals/actions/base.py
@@ -73,6 +73,20 @@ class BaseAction(ABC):
         pass
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Check if the underlying resource has changed since the CR was created.
+
+        Returns True if the resource is stale (has been modified).
+        Override in subclasses that store preconditions in intent.
+        """
+        return False
+
+    @classmethod
     def validate_intent(
         cls,
         intent_data: dict[str, Any],

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -20,6 +20,23 @@ class FeatureFlagActionBase(BaseAction):
     target_active_state: bool
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        instance = context.get("instance") if context else None
+        if not instance:
+            return True
+
+        preconditions = intent_data.get("preconditions", {})
+        stored_version = preconditions.get("version")
+        if stored_version is not None and instance.version != stored_version:
+            return True
+
+        return False
+
+    @classmethod
     def validate_intent(
         cls,
         intent_data: dict[str, Any],

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -9,6 +9,20 @@ from posthog.approvals.exceptions import ApplyFailed, PreconditionFailed
 from posthog.models import FeatureFlag
 
 
+def _check_version_staleness(intent_data: dict[str, Any], context: Optional[dict[str, Any]] = None) -> bool:
+    """Check staleness by comparing stored version precondition against current instance version."""
+    instance = context.get("instance") if context else None
+    if not instance:
+        return True
+
+    preconditions = intent_data.get("preconditions", {})
+    stored_version = preconditions.get("version")
+    if stored_version is not None and instance.version != stored_version:
+        return True
+
+    return False
+
+
 class FeatureFlagActionBase(BaseAction):
     """Base class for feature flag state change actions."""
 
@@ -25,16 +39,7 @@ class FeatureFlagActionBase(BaseAction):
         intent_data: dict[str, Any],
         context: Optional[dict[str, Any]] = None,
     ) -> bool:
-        instance = context.get("instance") if context else None
-        if not instance:
-            return True
-
-        preconditions = intent_data.get("preconditions", {})
-        stored_version = preconditions.get("version")
-        if stored_version is not None and instance.version != stored_version:
-            return True
-
-        return False
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def validate_intent(
@@ -232,16 +237,7 @@ class UpdateFeatureFlagAction(BaseAction):
         intent_data: dict[str, Any],
         context: Optional[dict[str, Any]] = None,
     ) -> bool:
-        instance = context.get("instance") if context else None
-        if not instance:
-            return True
-
-        preconditions = intent_data.get("preconditions", {})
-        stored_version = preconditions.get("version")
-        if stored_version is not None and instance.version != stored_version:
-            return True
-
-        return False
+        return _check_version_staleness(intent_data, context)
 
     @classmethod
     def _extract_rollout_percentages(cls, filters: dict[str, Any]) -> list[dict[str, Any]]:

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -227,6 +227,23 @@ class UpdateFeatureFlagAction(BaseAction):
     intent_fields = ["rollout_percentage"]
 
     @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        instance = context.get("instance") if context else None
+        if not instance:
+            return True
+
+        preconditions = intent_data.get("preconditions", {})
+        stored_version = preconditions.get("version")
+        if stored_version is not None and instance.version != stored_version:
+            return True
+
+        return False
+
+    @classmethod
     def _extract_rollout_percentages(cls, filters: dict[str, Any]) -> list[dict[str, Any]]:
         """
         Extract all rollout_percentage values from the filter structure.

--- a/posthog/approvals/policies.py
+++ b/posthog/approvals/policies.py
@@ -1,5 +1,10 @@
+import logging
 from dataclasses import dataclass
 from typing import Any
+
+from posthog.approvals.exceptions import PolicyEvaluationError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -100,6 +105,14 @@ class PolicyEngine:
         - DENY: Action not allowed
         - REQUIRE_APPROVAL: Must get approvals
         """
+        try:
+            return self._evaluate_policy(policy, actor, intent, context)
+        except PolicyEvaluationError:
+            raise
+        except Exception as e:
+            raise PolicyEvaluationError(f"Failed to evaluate policy {policy.id}: {e}") from e
+
+    def _evaluate_policy(self, policy, actor, intent: dict, context: dict) -> PolicyDecision:
         bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
 
         if self._has_bypass(actor, policy, bypass_role_ids, context):

--- a/posthog/approvals/policies.py
+++ b/posthog/approvals/policies.py
@@ -110,6 +110,7 @@ class PolicyEngine:
         except PolicyEvaluationError:
             raise
         except Exception as e:
+            logger.exception("Unexpected error evaluating policy %s", policy.id)
             raise PolicyEvaluationError(f"Failed to evaluate policy {policy.id}: {e}") from e
 
     def _evaluate_policy(self, policy, actor, intent: dict, context: dict) -> PolicyDecision:

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -180,6 +180,12 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
 
+    def validate_approver_config(self, value):
+        quorum = value.get("quorum", 0)
+        if quorum < 1:
+            raise serializers.ValidationError("Quorum must be at least 1")
+        return value
+
     def validate_bypass_org_membership_levels(self, value):
         if not value:
             return value

--- a/posthog/approvals/services.py
+++ b/posthog/approvals/services.py
@@ -9,7 +9,6 @@ from posthog.approvals.actions.registry import get_action
 from posthog.approvals.exceptions import (
     AlreadyVotedError,
     ApplyFailed,
-    InvalidIntent,
     InvalidStateError,
     PreconditionFailed,
     ReasonRequiredError,
@@ -78,7 +77,7 @@ def apply_change_request(change_request: ChangeRequest, request=None) -> Any:
         change_request.state = ChangeRequestState.FAILED
         change_request.apply_error = f"Validation failed: {errors}"
         change_request.save()
-        raise InvalidIntent(f"Intent no longer valid: {errors}")
+        raise ApplyFailed(f"Intent no longer valid: {errors}")
 
     try:
         with transaction.atomic():

--- a/posthog/approvals/services.py
+++ b/posthog/approvals/services.py
@@ -9,6 +9,7 @@ from posthog.approvals.actions.registry import get_action
 from posthog.approvals.exceptions import (
     AlreadyVotedError,
     ApplyFailed,
+    InvalidIntent,
     InvalidStateError,
     PreconditionFailed,
     ReasonRequiredError,
@@ -77,7 +78,7 @@ def apply_change_request(change_request: ChangeRequest, request=None) -> Any:
         change_request.state = ChangeRequestState.FAILED
         change_request.apply_error = f"Validation failed: {errors}"
         change_request.save()
-        raise ApplyFailed(f"Intent no longer valid: {errors}")
+        raise InvalidIntent(f"Intent no longer valid: {errors}")
 
     try:
         with transaction.atomic():

--- a/posthog/approvals/tasks.py
+++ b/posthog/approvals/tasks.py
@@ -15,16 +15,19 @@ logger = get_logger(__name__)
 @shared_task(ignore_result=True)
 def validate_pending_change_requests() -> dict[str, Any]:
     """
-    Checks if:
-    1. The underlying data has changed (staleness)
-    2. The validation is still valid (re-run validation)
-    """
+    Periodic staleness check for pending change requests.
 
-    validated_count = 0
-    invalidated_count = 0
+    Compares stored preconditions against the current resource state.
+    Marks CRs as STALE when the underlying resource has been modified,
+    which allows requesters to cancel even after approvals have been given.
+    """
+    stale_count = 0
+    checked_count = 0
     errors: list[str] = []
 
-    pending_requests = ChangeRequest.objects.filter(state=ChangeRequestState.PENDING)
+    pending_requests = ChangeRequest.objects.filter(
+        state=ChangeRequestState.PENDING,
+    ).exclude(validation_status=ValidationStatus.STALE)
 
     for change_request in pending_requests:
         try:
@@ -37,7 +40,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
                 )
                 continue
 
-            # Build context for validation
+            checked_count += 1
+
             base_context = {
                 "team": change_request.team,
                 "team_id": change_request.team_id,
@@ -45,24 +49,18 @@ def validate_pending_change_requests() -> dict[str, Any]:
             }
             context = action_class.prepare_context(change_request, base_context)
 
-            is_valid, validation_errors = action_class.validate_intent(change_request.intent, context)
-
-            if is_valid:
-                change_request.validation_status = ValidationStatus.VALID
-                change_request.validation_errors = None
-                validated_count += 1
-            else:
-                change_request.validation_status = ValidationStatus.INVALID
-                change_request.validation_errors = validation_errors
-                invalidated_count += 1
+            if action_class.check_staleness(change_request.intent, context):
+                change_request.validation_status = ValidationStatus.STALE
+                change_request.validation_errors = {
+                    "staleness": "Resource has been modified since this change request was created"
+                }
+                change_request.validated_at = timezone.now()
+                change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
+                stale_count += 1
                 logger.info(
-                    "validate_pending_change_requests.invalidated",
+                    "validate_pending_change_requests.stale",
                     change_request_id=str(change_request.id),
-                    errors=validation_errors,
                 )
-
-            change_request.validated_at = timezone.now()
-            change_request.save(update_fields=["validation_status", "validation_errors", "validated_at"])
 
         except Exception as e:
             error_msg = f"Error validating change request {change_request.id}: {str(e)}"
@@ -74,8 +72,8 @@ def validate_pending_change_requests() -> dict[str, Any]:
             )
 
     result = {
-        "validated_count": validated_count,
-        "invalidated_count": invalidated_count,
+        "checked_count": checked_count,
+        "stale_count": stale_count,
         "errors": errors,
     }
 

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,30 +467,24 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
-    def test_create_policy_with_quorum_zero_rejected(self):
+    @parameterized.expand(
+        [
+            ("zero", 0, status.HTTP_400_BAD_REQUEST),
+            ("negative", -1, status.HTTP_400_BAD_REQUEST),
+            ("one", 1, status.HTTP_201_CREATED),
+        ]
+    )
+    def test_create_policy_quorum_validation(self, _name, quorum, expected_status):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",
             {
                 "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 0, "users": [self.user.id]},
+                "approver_config": {"quorum": quorum, "users": [self.user.id]},
             },
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_create_policy_with_quorum_one_accepted(self):
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/approval_policies/",
-            {
-                "action_key": "feature_flag.enable",
-                "approver_config": {"quorum": 1, "users": [self.user.id]},
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["approver_config"]["quorum"] == 1
+        assert response.status_code == expected_status
 
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -467,6 +467,31 @@ class TestApprovalPolicyViewSet(APIBaseTest):
         policy = ApprovalPolicy.objects.get(id=response.json()["id"])
         assert policy.bypass_org_membership_levels == [8, 15]
 
+    def test_create_policy_with_quorum_zero_rejected(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 0, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_policy_with_quorum_one_accepted(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/approval_policies/",
+            {
+                "action_key": "feature_flag.enable",
+                "approver_config": {"quorum": 1, "users": [self.user.id]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["approver_config"]["quorum"] == 1
+
     def test_create_policy_with_non_integer_bypass_levels_rejected(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/approval_policies/",

--- a/posthog/approvals/tests/test_policy_engine.py
+++ b/posthog/approvals/tests/test_policy_engine.py
@@ -1,9 +1,11 @@
 from collections.abc import Sequence
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 
+from posthog.approvals.exceptions import PolicyEvaluationError
 from posthog.approvals.models import ApprovalPolicy
 from posthog.approvals.policies import PolicyEngine
 from posthog.models.organization import OrganizationMembership
@@ -277,6 +279,44 @@ class TestPolicySnapshotBypassFields(APIBaseTest):
 
         assert decision.policy_snapshot["bypass_org_membership_levels"] == []
         assert decision.policy_snapshot["bypass_roles"] == []
+
+
+class TestPolicyEvaluationErrorWrapping(APIBaseTest):
+    def test_evaluate_wraps_unexpected_errors_in_policy_evaluation_error(self):
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        with patch.object(engine, "_evaluate_policy", side_effect=RuntimeError("boom")):
+            with self.assertRaises(PolicyEvaluationError):
+                engine.evaluate(policy, self.user, intent, context)
+
+    def test_evaluate_does_not_double_wrap_policy_evaluation_error(self):
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        original_error = PolicyEvaluationError("already wrapped")
+        with patch.object(engine, "_evaluate_policy", side_effect=original_error):
+            with self.assertRaises(PolicyEvaluationError) as ctx:
+                engine.evaluate(policy, self.user, intent, context)
+            assert ctx.exception is original_error
 
 
 class TestBypassRolesValidation(APIBaseTest):

--- a/posthog/approvals/tests/test_services.py
+++ b/posthog/approvals/tests/test_services.py
@@ -7,9 +7,9 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
-from posthog.approvals.exceptions import InvalidStateError
+from posthog.approvals.exceptions import ApplyFailed, InvalidStateError
 from posthog.approvals.models import ChangeRequest, ChangeRequestState
-from posthog.approvals.services import ChangeRequestService
+from posthog.approvals.services import ChangeRequestService, apply_change_request
 
 
 class TestApproveRejectRaceCondition(BaseTest):
@@ -51,3 +51,27 @@ class TestApproveRejectRaceCondition(BaseTest):
         ):
             with self.assertRaises(InvalidStateError):
                 getattr(service, method_name)(reason=reason)
+
+
+class TestApplyChangeRequestValidation(BaseTest):
+    def test_raises_apply_failed_when_validation_fails(self):
+        change_request = ChangeRequest.objects.create(
+            team=self.team,
+            organization=self.organization,
+            created_by=self.user,
+            action_key="feature_flag.enable",
+            resource_type="feature_flag",
+            state=ChangeRequestState.APPROVED,
+            intent={"gated_changes": {"active": True}},
+            intent_display={"description": "Enable feature flag"},
+            policy_snapshot={"quorum": 1, "users": [self.user.id]},
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+        mock_action = MagicMock()
+        mock_action.prepare_context.return_value = {}
+        mock_action.validate_intent.return_value = (False, {"active": ["Invalid value"]})
+
+        with patch("posthog.approvals.services.get_action", return_value=mock_action):
+            with self.assertRaises(ApplyFailed):
+                apply_change_request(change_request)

--- a/posthog/approvals/tests/test_tasks.py
+++ b/posthog/approvals/tests/test_tasks.py
@@ -31,14 +31,50 @@ class TestValidatePendingChangeRequests(BaseTest):
             expires_at=timezone.now() + timedelta(hours=24),
         )
 
-    def test_validation_skips_non_pending_requests(self):
+    def test_skips_non_pending_requests(self):
         self.change_request.state = "approved"
         self.change_request.save()
 
         result = validate_pending_change_requests()
 
-        self.assertEqual(result["validated_count"], 0)
-        self.assertEqual(result["invalidated_count"], 0)
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    def test_skips_already_stale_requests(self):
+        self.change_request.validation_status = "stale"
+        self.change_request.save()
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 0)
+        self.assertEqual(result["stale_count"], 0)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_marks_stale_when_resource_changed(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = True
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["stale_count"], 1)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "stale")
+        self.assertIsNotNone(self.change_request.validation_errors)
+        self.assertIsNotNone(self.change_request.validated_at)
+
+    @patch("posthog.approvals.tasks.ChangeRequest.get_action_class")
+    def test_leaves_unchanged_when_not_stale(self, mock_get_action):
+        mock_action = mock_get_action.return_value
+        mock_action.prepare_context.return_value = {}
+        mock_action.check_staleness.return_value = False
+
+        result = validate_pending_change_requests()
+
+        self.assertEqual(result["checked_count"], 1)
+        self.assertEqual(result["stale_count"], 0)
+        self.change_request.refresh_from_db()
+        self.assertEqual(self.change_request.validation_status, "valid")
 
 
 class TestExpireOldChangeRequests(BaseTest):

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -171,6 +171,61 @@ class TestUpdateFeatureFlagActionDisplayData(APIBaseTest):
         assert "rollout percentage" in display_data["description"].lower()
 
 
+class TestCheckStaleness(APIBaseTest):
+    def _create_flag(self) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+            created_by=self.user,
+        )
+
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_stale_when_no_instance_in_context(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        intent = {"preconditions": {"version": 1}}
+        result = EnableFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
+    def test_not_stale_when_no_stored_version(self):
+        from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
+
+        flag = self._create_flag()
+        intent = {"preconditions": {}}
+        context = {"instance": flag}
+
+        result = EnableFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is False
+
+    def test_base_action_check_staleness_always_returns_false(self):
+        from posthog.approvals.actions.base import BaseAction
+
+        result = BaseAction.check_staleness({"preconditions": {"version": 1}}, {})
+
+        assert result is False
+
+
 class TestPolicyConditionEvaluation(APIBaseTest):
     def _create_policy_with_conditions(self, conditions: dict[str, Any]) -> ApprovalPolicy:
         return ApprovalPolicy.objects.create(

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -218,6 +218,29 @@ class TestCheckStaleness(APIBaseTest):
 
         assert result is False
 
+    @parameterized.expand(
+        [
+            ("matching_version", 1, 1, False),
+            ("mismatched_version", 1, 2, True),
+        ]
+    )
+    def test_update_action_staleness_by_version(self, _name, stored_version, current_version, expected_stale):
+        flag = self._create_flag()
+        flag.version = current_version
+
+        intent = {"preconditions": {"version": stored_version}}
+        context = {"instance": flag}
+
+        result = UpdateFeatureFlagAction.check_staleness(intent, context)
+
+        assert result is expected_stale
+
+    def test_update_action_stale_when_no_instance(self):
+        intent = {"preconditions": {"version": 1}}
+        result = UpdateFeatureFlagAction.check_staleness(intent, {})
+
+        assert result is True
+
     def test_base_action_check_staleness_always_returns_false(self):
         from posthog.approvals.actions.base import BaseAction
 

--- a/posthog/approvals/tests/test_update_feature_flag_action.py
+++ b/posthog/approvals/tests/test_update_feature_flag_action.py
@@ -211,7 +211,7 @@ class TestCheckStaleness(APIBaseTest):
         from posthog.approvals.actions.feature_flags import EnableFeatureFlagAction
 
         flag = self._create_flag()
-        intent = {"preconditions": {}}
+        intent: dict[str, Any] = {"preconditions": {}}
         context = {"instance": flag}
 
         result = EnableFeatureFlagAction.check_staleness(intent, context)


### PR DESCRIPTION
## Problem

- `apply_change_request` raises `ApplyFailed` when intent validation fails, but `InvalidIntent` is the semantically correct exception — both existed but `InvalidIntent` was unused
- `PolicyEngine.evaluate()` can raise unexpected exceptions that aren't wrapped in a domain-specific type

## Changes

- Wrap `PolicyEngine.evaluate()` to surface unexpected errors as `PolicyEvaluationError`

## How did you test this code?

- Existing tests pass

## Publish to changelog?

- [ ] No