### PR TITLE
feat(mcp): add workspaces get and list generated tools

### DIFF
--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -1,0 +1,40 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Workflows
+feature: hog_flows
+url_prefix: /workflows
+tools:
+    workflows-list:
+        operation: hog_flows_list
+        enabled: true
+        scopes:
+            - hog_flow:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List workflows
+        description: >
+            List all workflows (HogFlows) in the project. Returns workflows with their name,
+            description, status (draft/active/archived), version, trigger configuration,
+            and timestamps.
+        mcp_version: 1
+    workflows-get:
+        operation: hog_flows_retrieve
+        enabled: true
+        scopes:
+            - hog_flow:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get workflow
+        description: >
+            Get a specific workflow (HogFlow) by ID. Returns the full workflow definition
+            including trigger, edges, actions, exit condition, and variables.
+        mcp_version: 1

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -20,7 +20,7 @@ tools:
         list: true
         title: List workflows
         description: >
-            List all workflows (HogFlows) in the project. Returns workflows with their name,
+            List all workflows in the project. Returns workflows with their name,
             description, status (draft/active/archived), version, trigger configuration,
             and timestamps.
         mcp_version: 1
@@ -35,6 +35,6 @@ tools:
             idempotent: true
         title: Get workflow
         description: >
-            Get a specific workflow (HogFlow) by ID. Returns the full workflow definition
+            Get a specific workflow by ID. Returns the full workflow definition
             including trigger, edges, actions, exit condition, and variables.
         mcp_version: 1

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -133,5 +133,35 @@
             "openWorldHint": true,
             "readOnlyHint": false
         }
+    },
+    "workflows-list": {
+        "description": "List all workflows (HogFlows) in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
+        "category": "Workflows",
+        "feature": "hog_flows",
+        "summary": "List workflows",
+        "title": "List workflows",
+        "required_scopes": ["hog_flow:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "workflows-get": {
+        "description": "Get a specific workflow (HogFlow) by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
+        "category": "Workflows",
+        "feature": "hog_flows",
+        "summary": "Get workflow",
+        "title": "Get workflow",
+        "required_scopes": ["hog_flow:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -135,7 +135,7 @@
         }
     },
     "workflows-list": {
-        "description": "List all workflows (HogFlows) in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
+        "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",
         "feature": "hog_flows",
         "summary": "List workflows",
@@ -150,7 +150,7 @@
         }
     },
     "workflows-get": {
-        "description": "Get a specific workflow (HogFlow) by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
+        "description": "Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
         "category": "Workflows",
         "feature": "hog_flows",
         "summary": "Get workflow",

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -1,0 +1,232 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 2 ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+export const HogFlowsListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsListQueryParams = zod.object({
+    created_at: zod.string().datetime({}).optional(),
+    created_by: zod.number().optional(),
+    id: zod.string().uuid().optional(),
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    updated_at: zod.string().datetime({}).optional(),
+})
+
+export const hogFlowsListResponseResultsItemCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsListResponseResultsItemCreatedByOneFirstNameMax = 150
+
+export const hogFlowsListResponseResultsItemCreatedByOneLastNameMax = 150
+
+export const hogFlowsListResponseResultsItemCreatedByOneEmailMax = 254
+
+export const HogFlowsListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod.object({
+            id: zod.string().uuid(),
+            name: zod.string().nullable(),
+            description: zod.string(),
+            version: zod.number(),
+            status: zod
+                .enum(['draft', 'active', 'archived'])
+                .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+            created_at: zod.string().datetime({}),
+            created_by: zod.object({
+                id: zod.number(),
+                uuid: zod.string().uuid(),
+                distinct_id: zod.string().max(hogFlowsListResponseResultsItemCreatedByOneDistinctIdMax).nullish(),
+                first_name: zod.string().max(hogFlowsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
+                last_name: zod.string().max(hogFlowsListResponseResultsItemCreatedByOneLastNameMax).optional(),
+                email: zod.string().email().max(hogFlowsListResponseResultsItemCreatedByOneEmailMax),
+                is_email_verified: zod.boolean().nullish(),
+                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+                role_at_organization: zod
+                    .union([
+                        zod
+                            .enum([
+                                'engineering',
+                                'data',
+                                'product',
+                                'founder',
+                                'leadership',
+                                'marketing',
+                                'sales',
+                                'other',
+                            ])
+                            .describe(
+                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                            ),
+                        zod.enum(['']),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+            }),
+            updated_at: zod.string().datetime({}),
+            trigger: zod.unknown(),
+            trigger_masking: zod.unknown().nullable(),
+            conversion: zod.unknown().nullable(),
+            exit_condition: zod
+                .enum([
+                    'exit_on_conversion',
+                    'exit_on_trigger_not_matched',
+                    'exit_on_trigger_not_matched_or_conversion',
+                    'exit_only_at_end',
+                ])
+                .describe(
+                    '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                ),
+            edges: zod.unknown(),
+            actions: zod.unknown(),
+            abort_action: zod.string().nullable(),
+            variables: zod.unknown().nullable(),
+            billable_action_types: zod.unknown().nullable(),
+        })
+    ),
+})
+
+export const HogFlowsRetrieveParams = zod.object({
+    id: zod.string().uuid().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsRetrieveResponseNameMax = 400
+
+export const hogFlowsRetrieveResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsRetrieveResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsRetrieveResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsRetrieveResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsRetrieveResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsRetrieveResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsRetrieveResponseActionsItemNameMax = 400
+
+export const hogFlowsRetrieveResponseActionsItemDescriptionDefault = ``
+export const hogFlowsRetrieveResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsRetrieveResponseActionsItemTypeMax = 100
+
+export const HogFlowsRetrieveResponse = zod.object({
+    id: zod.string().uuid(),
+    name: zod.string().max(hogFlowsRetrieveResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string().uuid(),
+        distinct_id: zod.string().max(hogFlowsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsRetrieveResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsRetrieveResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsRetrieveResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsRetrieveResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsRetrieveResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsRetrieveResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsRetrieveResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsRetrieveResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsRetrieveResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -80,6 +80,7 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'experiment:write',
     'feature_flag:read',
     'feature_flag:write',
+    'hog_flow:read',
     'insight:read',
     'insight:write',
     'logs:read',

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -3,8 +3,10 @@ import type { ToolBase, ZodObjectAny } from '@/tools/types'
 // AUTO-GENERATED — do not edit
 import { GENERATED_TOOLS as cohorts } from './cohorts'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
+import { GENERATED_TOOLS as workflows } from './workflows'
 
 export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     ...cohorts,
     ...error_tracking,
+    ...workflows,
 }

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -1,0 +1,48 @@
+// AUTO-GENERATED from products/workflows/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import { HogFlowsListQueryParams, HogFlowsRetrieveParams } from '@/generated/workflows/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const WorkflowsListSchema = HogFlowsListQueryParams
+
+const workflowsList = (): ToolBase<typeof WorkflowsListSchema> => ({
+    name: 'workflows-list',
+    schema: WorkflowsListSchema,
+    handler: async (context: Context, params: z.infer<typeof WorkflowsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request({
+            method: 'GET',
+            path: `/api/projects/${projectId}/hog_flows/`,
+            query: {
+                created_at: params.created_at,
+                created_by: params.created_by,
+                id: params.id,
+                limit: params.limit,
+                offset: params.offset,
+                updated_at: params.updated_at,
+            },
+        })
+        return result
+    },
+})
+
+const WorkflowsGetSchema = HogFlowsRetrieveParams.omit({ project_id: true })
+
+const workflowsGet = (): ToolBase<typeof WorkflowsGetSchema> => ({
+    name: 'workflows-get',
+    schema: WorkflowsGetSchema,
+    handler: async (context: Context, params: z.infer<typeof WorkflowsGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request({
+            method: 'GET',
+            path: `/api/projects/${projectId}/hog_flows/${params.id}/`,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'workflows-list': workflowsList,
+    'workflows-get': workflowsGet,
+}

--- a/services/mcp/tests/tools/workflows.integration.test.ts
+++ b/services/mcp/tests/tools/workflows.integration.test.ts
@@ -69,7 +69,7 @@ describe('Workflows', { concurrent: false }, () => {
             const workflow = parseToolResponse(result)
 
             expect(workflow.id).toBe(firstId)
-            expect(typeof workflow.name === 'string' || workflow.name === null).toBe(true)
+            expect(workflow.name == null || typeof workflow.name === 'string').toBe(true)
             expect(typeof workflow.version).toBe('number')
             expect(['draft', 'active', 'archived']).toContain(workflow.status)
             expect(Array.isArray(workflow.actions)).toBe(true)

--- a/services/mcp/tests/tools/workflows.integration.test.ts
+++ b/services/mcp/tests/tools/workflows.integration.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    TEST_ORG_ID,
+    TEST_PROJECT_ID,
+    createTestClient,
+    createTestContext,
+    parseToolResponse,
+    setActiveProjectAndOrg,
+    validateEnvironmentVariables,
+} from '@/shared/test-utils'
+import { GENERATED_TOOLS } from '@/tools/generated/workflows'
+import type { Context } from '@/tools/types'
+
+describe('Workflows', { concurrent: false }, () => {
+    let context: Context
+
+    const listTool = GENERATED_TOOLS['workflows-list']!()
+    const getTool = GENERATED_TOOLS['workflows-get']!()
+
+    beforeAll(async () => {
+        validateEnvironmentVariables()
+        const client = createTestClient()
+        context = createTestContext(client)
+        await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
+    })
+
+    describe('workflows-list tool', () => {
+        it('should list workflows and return paginated structure', async () => {
+            const result = await listTool.handler(context, {})
+            const data = parseToolResponse(result)
+
+            expect(typeof data.count).toBe('number')
+            expect(Array.isArray(data.results)).toBe(true)
+        })
+
+        it('should respect the limit parameter', async () => {
+            const result = await listTool.handler(context, { limit: 1 })
+            const data = parseToolResponse(result)
+
+            expect(Array.isArray(data.results)).toBe(true)
+            expect(data.results.length).toBeLessThanOrEqual(1)
+        })
+
+        it('should respect the offset parameter', async () => {
+            const allResult = await listTool.handler(context, { limit: 100 })
+            const all = parseToolResponse(allResult)
+
+            const pagedResult = await listTool.handler(context, { offset: 1, limit: 100 })
+            const paged = parseToolResponse(pagedResult)
+
+            // Paging forward by one should yield at most (total − 1) results.
+            expect(paged.results.length).toBeLessThanOrEqual(Math.max(0, all.results.length - 1))
+        })
+    })
+
+    describe('workflows-get tool', () => {
+        it('should return a valid workflow when given a UUID from the list', async () => {
+            const listResult = await listTool.handler(context, {})
+            const { results: workflows } = parseToolResponse(listResult)
+
+            if (workflows.length === 0) {
+                // No workflows in this environment — nothing to fetch.
+                return
+            }
+
+            const firstId: string = workflows[0].id
+            const result = await getTool.handler(context, { id: firstId })
+            const workflow = parseToolResponse(result)
+
+            expect(workflow.id).toBe(firstId)
+            expect(typeof workflow.name === 'string' || workflow.name === null).toBe(true)
+            expect(typeof workflow.version).toBe('number')
+            expect(['draft', 'active', 'archived']).toContain(workflow.status)
+            expect(Array.isArray(workflow.actions)).toBe(true)
+            expect(workflow).toHaveProperty('trigger')
+            expect(workflow).toHaveProperty('edges')
+            expect(workflow).toHaveProperty('exit_condition')
+        })
+
+        it('should return an error for a non-existent UUID', async () => {
+            const absentId = crypto.randomUUID()
+
+            await expect(getTool.handler(context, { id: absentId })).rejects.toThrow()
+        })
+    })
+})


### PR DESCRIPTION
## Problem

There are no workflows MCP tools at all, so as the 1st phase just adding simple list and get tools.

## Changes

- Added new `mcp/tools.yml` definition to workflows product
- Generated new MCP workflows get and list tools
- Added basic integration tests for the new tools

## How did you test this code?

- tested manually running locally the MCP
- running `hogli build:openapi-mcp` and `hogli: build:openapi-mcp-tools` to make sure generation works fine
- added integration tests

## Publish to changelog?

no