### PR TITLE
feat(cdp): Added groups loading to batch exports api

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -29,6 +29,7 @@ import { BatchExportHogFunctionService, NotFoundError, ParseError } from './serv
 import { HogExecutorExecuteAsyncOptions, HogExecutorService, MAX_ASYNC_STEPS } from './services/hog-executor.service'
 import { HogFlowExecutorService, createHogFlowInvocation } from './services/hogflows/hogflow-executor.service'
 import { HogFlowManagerService } from './services/hogflows/hogflow-manager.service'
+import { GroupsManagerService } from './services/managers/groups-manager.service'
 import { HogFunctionManagerService } from './services/managers/hog-function-manager.service'
 import { EmailTrackingService } from './services/messaging/email-tracking.service'
 import { RecipientTokensService } from './services/messaging/recipient-tokens.service'
@@ -89,6 +90,7 @@ export class CdpApi {
         this.batchExportHogFunctionService = new BatchExportHogFunctionService(
             config.SITE_URL,
             deps.teamManager,
+            new GroupsManagerService(deps.teamManager, deps.groupRepository),
             this.hogFunctionManager,
             this.hogExecutor,
             this.hogWatcher,

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -288,9 +288,7 @@ describe('BatchExportHogFunctionService', () => {
     describe('groups enrichment', () => {
         beforeEach(() => {
             // Clear cached group data between tests
-            const groupsManager = api['batchExportHogFunctionService']['groupsManager']
-            groupsManager['groupTypesLoader'].clear()
-            groupsManager['groupPropertiesLoader'].clear()
+            api['batchExportHogFunctionService']['groupsManager'].clear()
         })
 
         const setupGroups = async () => {

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -2,6 +2,7 @@ import { mockProducerObserver } from '~/tests/helpers/mocks/producer.mock'
 import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { Server } from 'http'
+import { DateTime } from 'luxon'
 import supertest from 'supertest'
 import express from 'ultimate-express'
 
@@ -10,7 +11,7 @@ import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '~/cdp/_
 import { insertHogFunction as _insertHogFunction, insertBatchExport } from '~/cdp/_tests/fixtures'
 import { CdpApi } from '~/cdp/cdp-api'
 import { HogFunctionType } from '~/cdp/types'
-import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
+import { getFirstTeam, resetTestDatabase, updateOrganizationAvailableFeatures } from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
 import { UUIDT } from '~/utils/utils'
@@ -281,6 +282,114 @@ describe('BatchExportHogFunctionService', () => {
                     }),
                 ])
             )
+        })
+    })
+
+    describe('groups enrichment', () => {
+        beforeEach(() => {
+            // Clear cached group data between tests
+            const groupsManager = api['batchExportHogFunctionService']['groupsManager']
+            groupsManager['groupTypesLoader'].clear()
+            groupsManager['groupPropertiesLoader'].clear()
+        })
+
+        const setupGroups = async () => {
+            await updateOrganizationAvailableFeatures(hub.postgres, team.organization_id, [
+                { key: 'data_pipelines', name: 'Data Pipelines' },
+                { key: 'group_analytics', name: 'Group Analytics' },
+            ])
+            // Clear cached team data so the new features are picked up
+            hub.teamManager['lazyLoader'].clear()
+
+            await hub.groupRepository.insertGroupType(team.id, team.id as any, 'company', 0)
+
+            await hub.groupRepository.insertGroup(
+                team.id,
+                0 as any,
+                'acme-inc',
+                { name: 'Acme Inc', industry: 'Tech' },
+                DateTime.now(),
+                {},
+                {}
+            )
+        }
+
+        it('enriches globals with group properties when event has $groups', async () => {
+            await setupGroups()
+
+            clickhouseEvent.properties = JSON.stringify({
+                $lib_version: '1.0.0',
+                $groups: { company: 'acme-inc' },
+            })
+
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+
+            const fetchBody = parseJSON(mockFetch.mock.calls[0][1].body)
+            expect(fetchBody.groups).toMatchObject({
+                company: expect.objectContaining({
+                    id: 'acme-inc',
+                    type: 'company',
+                    properties: { name: 'Acme Inc', industry: 'Tech' },
+                }),
+            })
+        })
+
+        it('returns empty groups when event has no $groups property', async () => {
+            await setupGroups()
+
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+
+            const fetchBody = parseJSON(mockFetch.mock.calls[0][1].body)
+            expect(fetchBody.groups).toEqual({})
+        })
+
+        it('returns empty groups when team lacks group_analytics feature', async () => {
+            clickhouseEvent.properties = JSON.stringify({
+                $lib_version: '1.0.0',
+                $groups: { company: 'acme-inc' },
+            })
+
+            mockFetch.mockImplementationOnce(() =>
+                Promise.resolve({
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                    json: () => Promise.resolve({ ok: true }),
+                    text: () => Promise.resolve(JSON.stringify({ ok: true })),
+                    dump: () => Promise.resolve(),
+                })
+            )
+
+            const res = await postInvocation({ clickhouse_event: clickhouseEvent })
+
+            expect(res.status).toEqual(200)
+
+            const fetchBody = parseJSON(mockFetch.mock.calls[0][1].body)
+            expect(fetchBody.groups).toEqual({})
         })
     })
 })

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -14,6 +14,7 @@ import {
 import { convertToHogFunctionInvocationGlobals } from '../utils'
 import { createInvocation } from '../utils/invocation-utils'
 import { HogExecutorService } from './hog-executor.service'
+import { GroupsManagerService } from './managers/groups-manager.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
 import { HogWatcherService } from './monitoring/hog-watcher.service'
@@ -41,6 +42,7 @@ export class BatchExportHogFunctionService {
     constructor(
         private siteUrl: string,
         private teamManager: TeamManager,
+        private groupsManager: GroupsManagerService,
         private hogFunctionManager: HogFunctionManagerService,
         private hogExecutor: HogExecutorService,
         private hogWatcher: HogWatcherService,
@@ -80,6 +82,7 @@ export class BatchExportHogFunctionService {
         }
 
         const globals = this.buildRequestGlobals(clickhouse_event as RawClickHouseEvent, hogFunction, team)
+        await this.groupsManager.addGroupsToGlobals(globals)
 
         const globalsWithInputs = await this.hogExecutor.buildInputsWithGlobals(hogFunction, globals)
         const invocation = createInvocation(globalsWithInputs, hogFunction)
@@ -113,8 +116,6 @@ export class BatchExportHogFunctionService {
                 name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
                 url: `${projectUrl}/functions/${hogFunction.id}`,
             },
-            // NOTE: Groups are currently not added - we could load them the same way we do for normal hog functions via the GroupsManagerService
-            groups: {},
         }
     }
 


### PR DESCRIPTION
## Problem

Final missing piece for batch exports api to have the full payload that hog functions otherwise have.

## Changes

* Adds the groups loading

## How did you test this code?

* Tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
