### PR TITLE
feat(dashboard): refactors dashboard filter to separate component and use pin filled icon

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
@@ -1,0 +1,158 @@
+import { IconChevronDown, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
+import { LemonInput, Popover } from '@posthog/lemon-ui'
+
+import { MemberSelect } from 'lib/components/MemberSelect'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { DashboardsFilters, DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
+
+interface DashboardsFiltersBarProps {
+    filters: DashboardsFilters
+    currentTab: DashboardsTab
+    showTagPopover: boolean
+    setShowTagPopover: (visible: boolean) => void
+    tagSearch: string
+    setTagSearch: (value: string) => void
+    filteredTags: string[]
+    setFilters: (filters: Partial<DashboardsFilters>) => void
+    handleTagToggle: (tag: string) => void
+    extraActions?: JSX.Element | JSX.Element[]
+}
+
+export function DashboardsFiltersBar({
+    filters,
+    currentTab,
+    showTagPopover,
+    setShowTagPopover,
+    tagSearch,
+    setTagSearch,
+    filteredTags,
+    setFilters,
+    handleTagToggle,
+    extraActions,
+}: DashboardsFiltersBarProps): JSX.Element {
+    return (
+        <div className="flex justify-between gap-2 flex-wrap mb-4">
+            <LemonInput
+                type="search"
+                placeholder="Search for dashboards"
+                onChange={(x) => setFilters({ search: x })}
+                value={filters.search}
+            />
+            <div className="flex items-center gap-2 flex-wrap">
+                <div className="flex items-center gap-2">
+                    <span>Filter to:</span>
+                    {currentTab !== DashboardsTab.Pinned && (
+                        <div className="flex items-center gap-2">
+                            <LemonButton
+                                active={filters.pinned}
+                                type="secondary"
+                                size="small"
+                                onClick={() => setFilters({ pinned: !filters.pinned })}
+                                icon={filters.pinned ? <IconPinFilled /> : <IconPin />}
+                            >
+                                Pinned
+                            </LemonButton>
+                        </div>
+                    )}
+                    <Popover
+                        visible={showTagPopover}
+                        onClickOutside={() => setShowTagPopover(false)}
+                        overlay={
+                            <div className="max-w-100 deprecated-space-y-2">
+                                <LemonInput
+                                    type="search"
+                                    placeholder="Search tags"
+                                    autoFocus
+                                    value={tagSearch}
+                                    onChange={setTagSearch}
+                                    fullWidth
+                                    className="max-w-full"
+                                />
+                                <ul className="deprecated-space-y-px">
+                                    {filteredTags.map((tag: string) => (
+                                        <li key={tag}>
+                                            <LemonButton
+                                                fullWidth
+                                                role="menuitem"
+                                                size="small"
+                                                onClick={() => handleTagToggle(tag)}
+                                            >
+                                                <span className="flex items-center justify-between gap-2 flex-1">
+                                                    <span className="flex items-center gap-2 max-w-full">
+                                                        <input
+                                                            type="checkbox"
+                                                            className="cursor-pointer"
+                                                            checked={filters.tags?.includes(tag) || false}
+                                                            readOnly
+                                                        />
+                                                        <span>{tag}</span>
+                                                    </span>
+                                                </span>
+                                            </LemonButton>
+                                        </li>
+                                    ))}
+                                    {filteredTags.length === 0 ? (
+                                        <div className="p-2 text-secondary italic truncate border-t">
+                                            {tagSearch ? <span>No matching tags</span> : <span>No tags</span>}
+                                        </div>
+                                    ) : null}
+                                    {(filters.tags?.length || 0) > 0 && (
+                                        <>
+                                            <div className="my-1 border-t" />
+                                            <li>
+                                                <LemonButton
+                                                    fullWidth
+                                                    role="menuitem"
+                                                    size="small"
+                                                    onClick={() => setFilters({ tags: [] })}
+                                                    type="tertiary"
+                                                >
+                                                    Clear selection
+                                                </LemonButton>
+                                            </li>
+                                        </>
+                                    )}
+                                </ul>
+                            </div>
+                        }
+                    >
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconChevronDown />}
+                            sideIcon={null}
+                            active={(filters.tags?.length || 0) > 0}
+                            onClick={() => setShowTagPopover(!showTagPopover)}
+                        >
+                            Tags
+                            {(filters.tags?.length || 0) > 0 && (
+                                <span className="ml-1 text-xs">({filters.tags?.length})</span>
+                            )}
+                        </LemonButton>
+                    </Popover>
+                    <div className="flex items-center gap-2">
+                        <LemonButton
+                            active={filters.shared}
+                            type="secondary"
+                            size="small"
+                            onClick={() => setFilters({ shared: !filters.shared })}
+                            icon={<IconShare />}
+                        >
+                            Shared
+                        </LemonButton>
+                    </div>
+                </div>
+                {currentTab !== DashboardsTab.Yours && (
+                    <div className="flex items-center gap-2">
+                        <span>Created by:</span>
+                        <MemberSelect
+                            value={filters.createdBy === 'All users' ? null : filters.createdBy}
+                            onChange={(user) => setFilters({ createdBy: user?.uuid || 'All users' })}
+                        />
+                    </div>
+                )}
+                {extraActions}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
@@ -1,35 +1,30 @@
+import { useActions, useValues } from 'kea'
+
 import { IconChevronDown, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
 import { LemonInput, Popover } from '@posthog/lemon-ui'
 
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { DashboardsFilters, DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { DashboardsTab, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
 
 interface DashboardsFiltersBarProps {
-    filters: DashboardsFilters
-    currentTab: DashboardsTab
-    showTagPopover: boolean
-    setShowTagPopover: (visible: boolean) => void
-    tagSearch: string
-    setTagSearch: (value: string) => void
-    filteredTags: string[]
-    setFilters: (filters: Partial<DashboardsFilters>) => void
-    handleTagToggle: (tag: string) => void
     extraActions?: JSX.Element | JSX.Element[]
 }
 
-export function DashboardsFiltersBar({
-    filters,
-    currentTab,
-    showTagPopover,
-    setShowTagPopover,
-    tagSearch,
-    setTagSearch,
-    filteredTags,
-    setFilters,
-    handleTagToggle,
-    extraActions,
-}: DashboardsFiltersBarProps): JSX.Element {
+export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps): JSX.Element {
+    const { filters, currentTab, filteredTags, tagSearch, showTagPopover } = useValues(dashboardsLogic)
+    const { setFilters, setTagSearch, setShowTagPopover } = useActions(dashboardsLogic)
+
+    const handleTagToggle = (tag: string): void => {
+        const selected = new Set(filters.tags || [])
+        if (selected.has(tag)) {
+            selected.delete(tag)
+        } else {
+            selected.add(tag)
+        }
+        setFilters({ tags: Array.from(selected) })
+    }
+
     return (
         <div className="flex justify-between gap-2 flex-wrap mb-4">
             <LemonInput

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
-import { DashboardsFilters, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
 import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -36,14 +36,13 @@ import { DashboardsFiltersBar } from './DashboardsFiltersBar'
 
 export function DashboardsTableContainer(): JSX.Element {
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { dashboards, filters } = useValues(dashboardsLogic)
+    const { dashboards } = useValues(dashboardsLogic)
 
-    return <DashboardsTable dashboards={dashboards} dashboardsLoading={dashboardsLoading} filters={filters} />
+    return <DashboardsTable dashboards={dashboards} dashboardsLoading={dashboardsLoading} />
 }
 
 interface DashboardsTableProps {
     dashboards: DashboardBasicType[]
-    filters: DashboardsFilters
     dashboardsLoading: boolean
     extraActions?: JSX.Element | JSX.Element[]
     hideActions?: boolean
@@ -52,26 +51,15 @@ interface DashboardsTableProps {
 export function DashboardsTable({
     dashboards,
     dashboardsLoading,
-    filters,
     extraActions,
     hideActions,
 }: DashboardsTableProps): JSX.Element {
     const { unpinDashboard, pinDashboard } = useActions(dashboardsModel)
-    const { setFilters, tableSortingChanged, setTagSearch, setShowTagPopover } = useActions(dashboardsLogic)
-    const { tableSorting, currentTab, filteredTags, tagSearch, showTagPopover } = useValues(dashboardsLogic)
+    const { tableSortingChanged } = useActions(dashboardsLogic)
+    const { tableSorting } = useValues(dashboardsLogic)
     const { currentTeam } = useValues(teamLogic)
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
-
-    const handleTagToggle = (tag: string): void => {
-        const selected = new Set(filters.tags || [])
-        if (selected.has(tag)) {
-            selected.delete(tag)
-        } else {
-            selected.add(tag)
-        }
-        setFilters({ tags: Array.from(selected) })
-    }
 
     const columns: LemonTableColumns<DashboardType> = [
         {
@@ -234,18 +222,7 @@ export function DashboardsTable({
 
     return (
         <>
-            <DashboardsFiltersBar
-                filters={filters}
-                currentTab={currentTab}
-                showTagPopover={showTagPopover}
-                setShowTagPopover={setShowTagPopover}
-                tagSearch={tagSearch}
-                setTagSearch={setTagSearch}
-                filteredTags={filteredTags}
-                setFilters={setFilters}
-                handleTagToggle={handleTagToggle}
-                extraActions={extraActions}
-            />
+            <DashboardsFiltersBar extraActions={extraActions} />
             <LemonTable
                 data-attr="dashboards-table"
                 pagination={{ pageSize: 100 }}

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -1,10 +1,8 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown, IconHome, IconLock, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
-import { LemonInput, Popover } from '@posthog/lemon-ui'
+import { IconHome, IconLock, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { MemberSelect } from 'lib/components/MemberSelect'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -18,7 +16,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
-import { DashboardsFilters, DashboardsTab, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { DashboardsFilters, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
 import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -34,6 +32,7 @@ import {
 } from '~/types'
 
 import { DASHBOARD_CANNOT_EDIT_MESSAGE } from '../DashboardHeader'
+import { DashboardsFiltersBar } from './DashboardsFiltersBar'
 
 export function DashboardsTableContainer(): JSX.Element {
     const { dashboardsLoading } = useValues(dashboardsModel)
@@ -235,129 +234,18 @@ export function DashboardsTable({
 
     return (
         <>
-            <div className="flex justify-between gap-2 flex-wrap mb-4">
-                <LemonInput
-                    type="search"
-                    placeholder="Search for dashboards"
-                    onChange={(x) => setFilters({ search: x })}
-                    value={filters.search}
-                />
-                <div className="flex items-center gap-2 flex-wrap">
-                    <div className="flex items-center gap-2">
-                        <span>Filter to:</span>
-                        {currentTab !== DashboardsTab.Pinned && (
-                            <div className="flex items-center gap-2">
-                                <LemonButton
-                                    active={filters.pinned}
-                                    type="secondary"
-                                    size="small"
-                                    onClick={() => setFilters({ pinned: !filters.pinned })}
-                                    icon={<IconPin />}
-                                >
-                                    Pinned
-                                </LemonButton>
-                            </div>
-                        )}
-                        <Popover
-                            visible={showTagPopover}
-                            onClickOutside={() => setShowTagPopover(false)}
-                            overlay={
-                                <div className="max-w-100 deprecated-space-y-2">
-                                    <LemonInput
-                                        type="search"
-                                        placeholder="Search tags"
-                                        autoFocus
-                                        value={tagSearch}
-                                        onChange={setTagSearch}
-                                        fullWidth
-                                        className="max-w-full"
-                                    />
-                                    <ul className="deprecated-space-y-px">
-                                        {filteredTags.map((tag: string) => (
-                                            <li key={tag}>
-                                                <LemonButton
-                                                    fullWidth
-                                                    role="menuitem"
-                                                    size="small"
-                                                    onClick={() => handleTagToggle(tag)}
-                                                >
-                                                    <span className="flex items-center justify-between gap-2 flex-1">
-                                                        <span className="flex items-center gap-2 max-w-full">
-                                                            <input
-                                                                type="checkbox"
-                                                                className="cursor-pointer"
-                                                                checked={filters.tags?.includes(tag) || false}
-                                                                readOnly
-                                                            />
-                                                            <span>{tag}</span>
-                                                        </span>
-                                                    </span>
-                                                </LemonButton>
-                                            </li>
-                                        ))}
-                                        {filteredTags.length === 0 ? (
-                                            <div className="p-2 text-secondary italic truncate border-t">
-                                                {tagSearch ? <span>No matching tags</span> : <span>No tags</span>}
-                                            </div>
-                                        ) : null}
-                                        {(filters.tags?.length || 0) > 0 && (
-                                            <>
-                                                <div className="my-1 border-t" />
-                                                <li>
-                                                    <LemonButton
-                                                        fullWidth
-                                                        role="menuitem"
-                                                        size="small"
-                                                        onClick={() => setFilters({ tags: [] })}
-                                                        type="tertiary"
-                                                    >
-                                                        Clear selection
-                                                    </LemonButton>
-                                                </li>
-                                            </>
-                                        )}
-                                    </ul>
-                                </div>
-                            }
-                        >
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                icon={<IconChevronDown />}
-                                sideIcon={null}
-                                active={(filters.tags?.length || 0) > 0}
-                                onClick={() => setShowTagPopover(!showTagPopover)}
-                            >
-                                Tags
-                                {(filters.tags?.length || 0) > 0 && (
-                                    <span className="ml-1 text-xs">({filters.tags?.length})</span>
-                                )}
-                            </LemonButton>
-                        </Popover>
-                        <div className="flex items-center gap-2">
-                            <LemonButton
-                                active={filters.shared}
-                                type="secondary"
-                                size="small"
-                                onClick={() => setFilters({ shared: !filters.shared })}
-                                icon={<IconShare />}
-                            >
-                                Shared
-                            </LemonButton>
-                        </div>
-                    </div>
-                    {currentTab !== DashboardsTab.Yours && (
-                        <div className="flex items-center gap-2">
-                            <span>Created by:</span>
-                            <MemberSelect
-                                value={filters.createdBy === 'All users' ? null : filters.createdBy}
-                                onChange={(user) => setFilters({ createdBy: user?.uuid || 'All users' })}
-                            />
-                        </div>
-                    )}
-                    {extraActions}
-                </div>
-            </div>
+            <DashboardsFiltersBar
+                filters={filters}
+                currentTab={currentTab}
+                showTagPopover={showTagPopover}
+                setShowTagPopover={setShowTagPopover}
+                tagSearch={tagSearch}
+                setTagSearch={setTagSearch}
+                filteredTags={filteredTags}
+                setFilters={setFilters}
+                handleTagToggle={handleTagToggle}
+                extraActions={extraActions}
+            />
             <LemonTable
                 data-attr="dashboards-table"
                 pagination={{ pageSize: 100 }}


### PR DESCRIPTION
## Problem

In the dashboard filters, when the pin filter is selected, it's not super clear that it is, other than the background color change.

## Changes
Refactors the dashboard filter into a separate file, and then uses the pin filled icon when its selected


Before
<img width="1489" height="418" alt="image" src="https://github.com/user-attachments/assets/751b5ab0-730b-4888-9aa0-ff4c2625ff50" />


After
<img width="1259" height="308" alt="image" src="https://github.com/user-attachments/assets/a762e97b-3844-4072-8b49-11821145a410" />


## How did you test this code?

Test locally
