### PR TITLE
feat(hogql): add hog flows to system schema

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -280,6 +280,26 @@ actions: PostgresTable = PostgresTable(
     },
 )
 
+hog_flows: PostgresTable = PostgresTable(
+    name="hog_flows",
+    postgres_table_name="posthog_hogflow",
+    access_scope="hog_flow",
+    fields={
+        "id": StringDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "name": StringDatabaseField(name="name"),
+        "description": StringDatabaseField(name="description"),
+        "status": StringDatabaseField(name="status"),
+        "version": IntegerDatabaseField(name="version"),
+        "exit_condition": StringDatabaseField(name="exit_condition"),
+        "trigger": StringJSONDatabaseField(name="trigger"),
+        "edges": StringJSONDatabaseField(name="edges"),
+        "actions": StringJSONDatabaseField(name="actions"),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+        "updated_at": DateTimeDatabaseField(name="updated_at"),
+    },
+)
+
 notebooks: PostgresTable = PostgresTable(
     name="notebooks",
     postgres_table_name="posthog_notebook",
@@ -330,6 +350,7 @@ class SystemTables(TableNode):
         "feature_flags": TableNode(name="feature_flags", table=feature_flags),
         "groups": TableNode(name="groups", table=groups),
         "group_type_mappings": TableNode(name="group_type_mappings", table=group_type_mappings),
+        "hog_flows": TableNode(name="hog_flows", table=hog_flows),
         "ingestion_warnings": TableNode(name="ingestion_warnings", table=IngestionWarningsTable()),
         "insight_variables": TableNode(name="insight_variables", table=insight_variables),
         "insights": TableNode(name="insights", table=insights),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -25,6 +25,7 @@ from posthog.models import (
     Team,
 )
 from posthog.models.cohort.calculation_history import CohortCalculationHistory
+from posthog.models.hog_flow.hog_flow import HogFlow
 from posthog.models.project import Project
 
 from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
@@ -113,6 +114,10 @@ def _create_error_tracking_issue(team: Team, label: str) -> ErrorTrackingIssue:
     return ErrorTrackingIssue.objects.create(team=team, name=f"issue_{label}", status="active")
 
 
+def _create_hog_flow(team: Team, label: str) -> HogFlow:
+    return HogFlow.objects.create(team=team, name=f"flow_{label}")
+
+
 def _create_experiment(team: Team, label: str) -> Experiment:
     flag = FeatureFlag.objects.create(team=team, key=f"flag_for_exp_{label}")
     return Experiment.objects.create(team=team, name=f"experiment_{label}", feature_flag=flag)
@@ -169,6 +174,7 @@ SYSTEM_TABLE_FACTORIES = [
     ("feature_flags", _create_feature_flag),
     ("groups", _create_group),
     ("group_type_mappings", _create_group_type_mapping),
+    ("hog_flows", _create_hog_flow),
     ("insights", _create_insight),
     ("insight_variables", _create_insight_variable),
     ("notebooks", _create_notebook),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -3474,6 +3474,124 @@
           "row_count": null,
           "type": "system"
       },
+      "system.hog_flows": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "version",
+                  "id": null,
+                  "name": "version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "exit_condition": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "exit_condition",
+                  "id": null,
+                  "name": "exit_condition",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "trigger": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "trigger",
+                  "id": null,
+                  "name": "trigger",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "edges": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "edges",
+                  "id": null,
+                  "name": "edges",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "actions": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "actions",
+                  "id": null,
+                  "name": "actions",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.hog_flows",
+          "name": "system.hog_flows",
+          "row_count": null,
+          "type": "system"
+      },
       "system.ingestion_warnings": {
           "fields": {
               "source": {
@@ -6585,6 +6703,124 @@
           },
           "id": "system.group_type_mappings",
           "name": "system.group_type_mappings",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.hog_flows": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "name",
+                  "id": null,
+                  "name": "name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "description": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "description",
+                  "id": null,
+                  "name": "description",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "version": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "version",
+                  "id": null,
+                  "name": "version",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "exit_condition": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "exit_condition",
+                  "id": null,
+                  "name": "exit_condition",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "trigger": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "trigger",
+                  "id": null,
+                  "name": "trigger",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "edges": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "edges",
+                  "id": null,
+                  "name": "edges",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "actions": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "actions",
+                  "id": null,
+                  "name": "actions",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.hog_flows",
+          "name": "system.hog_flows",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -56,6 +56,7 @@ class TestAccessControlSystemTables(BaseTest):
         assert "surveys" not in system_node.children
         assert "data_warehouse_sources" not in system_node.children
         assert "actions" not in system_node.children
+        assert "hog_flows" not in system_node.children
         assert "notebooks" not in system_node.children
         assert "error_tracking_issues" not in system_node.children
         # But tracked in denied list for clear error messages
@@ -66,6 +67,7 @@ class TestAccessControlSystemTables(BaseTest):
         assert "system.surveys" in database._denied_tables
         assert "system.data_warehouse_sources" in database._denied_tables
         assert "system.actions" in database._denied_tables
+        assert "system.hog_flows" in database._denied_tables
         assert "system.notebooks" in database._denied_tables
         assert "system.error_tracking_issues" in database._denied_tables
         # Unscoped tables remain

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.

--- a/products/posthog_ai/skills/query-examples/SKILL.md
+++ b/products/posthog_ai/skills/query-examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-examples
-description: 'HogQL query examples and reference material for PostHog data. Read when writing SQL queries to find patterns for analytics (trends, funnels, retention, lifecycle, paths, stickiness, web analytics, error tracking, logs, sessions, LLM traces) and system data (insights, dashboards, cohorts, feature flags, experiments, surveys, data warehouse). Includes HogQL syntax differences, system model schemas, and available functions.'
+description: 'HogQL query examples and reference material for PostHog data. Read when writing SQL queries to find patterns for analytics (trends, funnels, retention, lifecycle, paths, stickiness, web analytics, error tracking, logs, sessions, LLM traces) and system data (insights, dashboards, cohorts, feature flags, experiments, surveys, hog flows, data warehouse). Includes HogQL syntax differences, system model schemas, and available functions.'
 ---
 
 # Querying data in PostHog
@@ -18,6 +18,7 @@ Schema reference for PostHog's core system models, organized by domain:
 - [Error Tracking](./references/models-error-tracking.md)
 - [Flags & Experiments](./references/models-flags-experiments.md)
 - [Groups](./references/models-groups.md)
+- [Hog Flows](./references/models-hog-flows.md)
 - [Notebooks](./references/models-notebooks.md)
 - [Surveys](./references/models-surveys.md)
 - [SQL Variables](./references/models-variables.md)

--- a/products/posthog_ai/skills/query-examples/references/models-hog-flows.md
+++ b/products/posthog_ai/skills/query-examples/references/models-hog-flows.md
@@ -1,0 +1,56 @@
+# Hog Flows
+
+## Hog Flow (`system.hog_flows`)
+
+Hog flows are automated user journeys — multi-step workflows that trigger actions (emails, webhooks, etc.) based on user behavior.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | string (UUID) | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Owning team
+`name` | varchar(400) | NULL | Display name
+`description` | text | NOT NULL | Description of the flow
+`status` | varchar(20) | NOT NULL | `draft`, `active`, or `archived`
+`version` | integer | NOT NULL | Version number (incremented on each publish)
+`exit_condition` | varchar(100) | NOT NULL | When a user exits the flow (see values below)
+`trigger` | jsonb | NOT NULL | Entry trigger configuration
+`edges` | jsonb | NOT NULL | Graph edges connecting flow steps
+`actions` | jsonb | NOT NULL | Action definitions for each step
+`created_at` | timestamp with tz | NOT NULL | Creation timestamp
+`updated_at` | timestamp with tz | NOT NULL | Last update timestamp
+
+### Status Values
+
+- `draft` — not yet published, not running
+- `active` — published and evaluating users
+- `archived` — disabled and hidden from default views
+
+### Exit Condition Values
+
+- `exit_on_conversion` — user exits when they convert (complete the goal)
+- `exit_on_trigger_not_matched` — user exits if they no longer match the trigger
+- `exit_on_trigger_not_matched_or_conversion` — user exits on either condition
+- `exit_only_at_end` — user always completes the full flow
+
+### Query Examples
+
+```sql
+-- Count flows by status
+SELECT status, count() AS total
+FROM system.hog_flows
+GROUP BY status
+ORDER BY total DESC
+
+-- List active flows with their names
+SELECT id, name, version, created_at
+FROM system.hog_flows
+WHERE status = 'active'
+ORDER BY created_at DESC
+
+-- Find flows updated in the last 7 days
+SELECT id, name, status, updated_at
+FROM system.hog_flows
+WHERE updated_at > now() - toIntervalDay(7)
+ORDER BY updated_at DESC
+```


### PR DESCRIPTION
## Problem

There is no query support for worfkflows (hog_flows).

## Changes

- Added new `hog_flows` `PostgresTable` to system schema
- Extending already existing tests for system tables so it covers the newly added `hog_flows`

## How did you test this code?

- Extended tests
- Manual tests from SQL Editor and via `execute_sql` MCP tool

## Publish to changelog?

no