### PR TITLE
fix: handle event restrictions redis errors

### DIFF
--- a/rust/capture/src/event_restrictions/manager.rs
+++ b/rust/capture/src/event_restrictions/manager.rs
@@ -599,4 +599,186 @@ mod tests {
         let restrictions_after = service.get_restrictions("token1", &event_ctx_now()).await;
         assert!(restrictions_after.is_empty());
     }
+
+    // ========================================================================
+    // start_refresh_task tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_refresh_task_loads_restrictions() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let service_clone = service.clone();
+
+        let handle = tokio::spawn(async move {
+            service_clone
+                .start_refresh_task(
+                    move || {
+                        let cancel = cancel_clone.clone();
+                        async move {
+                            cancel.cancel();
+                            let repo = MockRestrictionsRepository::new();
+                            repo.set_entries(
+                                RestrictionType::DropEvent,
+                                Some(vec![make_entry("token1", vec!["analytics"])]),
+                            )
+                            .await;
+                            let result: Arc<dyn EventRestrictionsRepository> = Arc::new(repo);
+                            Ok(result)
+                        }
+                    },
+                    Duration::from_millis(5),
+                    cancel,
+                )
+                .await;
+        });
+
+        handle.await.unwrap();
+
+        let restrictions = service.get_restrictions("token1", &event_ctx_now()).await;
+        assert!(restrictions.contains(RestrictionType::DropEvent));
+
+        let unknown = service.get_restrictions("unknown", &event_ctx_now()).await;
+        assert!(unknown.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_task_retries_connection_while_fail_open() {
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let attempt_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = attempt_count.clone();
+
+        let service_clone = service.clone();
+        let handle = tokio::spawn(async move {
+            service_clone
+                .start_refresh_task(
+                    move || {
+                        let n = count_clone.fetch_add(1, Ordering::SeqCst);
+                        let cancel = cancel_clone.clone();
+                        async move {
+                            if n >= 2 {
+                                cancel.cancel();
+                            }
+                            Err(CustomRedisError::Timeout)
+                        }
+                    },
+                    Duration::from_millis(5),
+                    cancel,
+                )
+                .await;
+        });
+
+        handle.await.unwrap();
+
+        let restrictions = service.get_restrictions("token", &event_ctx_now()).await;
+        assert!(restrictions.is_empty());
+        assert!(
+            attempt_count.load(Ordering::SeqCst) >= 2,
+            "should have retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_refresh_task_reconnects_after_refresh_failure() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let connect_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = connect_count.clone();
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let service_clone = service.clone();
+
+        let handle = tokio::spawn(async move {
+            service_clone
+                .start_refresh_task(
+                    move || {
+                        let n = count_clone.fetch_add(1, Ordering::SeqCst);
+                        let cancel = cancel_clone.clone();
+                        async move {
+                            // First connection succeeds but repo returns all errors,
+                            // second connection triggers shutdown so we can assert.
+                            if n >= 1 {
+                                cancel.cancel();
+                            }
+                            let repo = MockRestrictionsRepository::new();
+                            for rt in RestrictionType::all() {
+                                repo.set_error(rt, CustomRedisError::Timeout).await;
+                            }
+                            let result: Arc<dyn EventRestrictionsRepository> = Arc::new(repo);
+                            Ok(result)
+                        }
+                    },
+                    Duration::from_millis(5),
+                    cancel,
+                )
+                .await;
+        });
+
+        handle.await.unwrap();
+
+        assert!(
+            connect_count.load(Ordering::SeqCst) >= 2,
+            "should have reconnected after refresh failure"
+        );
+        // Service never got a successful refresh, so it stays fail-open
+        let restrictions = service.get_restrictions("token", &event_ctx_now()).await;
+        assert!(restrictions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_task_fail_open_then_recover() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let attempt_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = attempt_count.clone();
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let service_clone = service.clone();
+
+        let handle = tokio::spawn(async move {
+            service_clone
+                .start_refresh_task(
+                    move || {
+                        let n = count_clone.fetch_add(1, Ordering::SeqCst);
+                        let cancel = cancel_clone.clone();
+                        async move {
+                            if n < 2 {
+                                // First two attempts fail (simulating Redis down)
+                                return Err(CustomRedisError::Timeout);
+                            }
+                            // Third attempt succeeds with restrictions
+                            cancel.cancel();
+                            let repo = MockRestrictionsRepository::new();
+                            repo.set_entries(
+                                RestrictionType::ForceOverflow,
+                                Some(vec![make_entry("token1", vec!["analytics"])]),
+                            )
+                            .await;
+                            let result: Arc<dyn EventRestrictionsRepository> = Arc::new(repo);
+                            Ok(result)
+                        }
+                    },
+                    Duration::from_millis(5),
+                    cancel,
+                )
+                .await;
+        });
+
+        handle.await.unwrap();
+
+        assert!(
+            attempt_count.load(Ordering::SeqCst) >= 3,
+            "should have attempted at least 3 times"
+        );
+        // After recovery, restrictions should be active
+        let restrictions = service.get_restrictions("token1", &event_ctx_now()).await;
+        assert!(
+            restrictions.contains(RestrictionType::ForceOverflow),
+            "restrictions should be active after recovery"
+        );
+    }
 }

--- a/rust/capture/src/event_restrictions/manager.rs
+++ b/rust/capture/src/event_restrictions/manager.rs
@@ -43,6 +43,9 @@ impl RestrictionManager {
     }
 
     /// Build a RestrictionManager from repository data for a specific pipeline.
+    ///
+    /// Returns an error if any restriction type fails to fetch, which signals
+    /// a likely dead Redis connection and triggers a reconnect.
     pub async fn from_repository(
         repository: &dyn EventRestrictionsRepository,
         pipeline: CaptureMode,
@@ -59,17 +62,19 @@ impl RestrictionManager {
 
         let results = join_all(fetch_futures).await;
 
+        let mut fetch_error: Option<CustomRedisError> = None;
+
         for (restriction_type, result) in results {
             let entries = match result {
                 Ok(Some(e)) => e,
                 Ok(None) => continue,
                 Err(e) => {
-                    // Log but continue - we want to be resilient to partial failures
                     warn!(
                         restriction_type = %restriction_type.as_str(),
                         error = %e,
                         "Failed to fetch restriction entries"
                     );
+                    fetch_error = Some(e);
                     continue;
                 }
             };
@@ -93,6 +98,10 @@ impl RestrictionManager {
                     .or_default()
                     .push(restriction);
             }
+        }
+
+        if let Some(e) = fetch_error {
+            return Err(e);
         }
 
         let total_restrictions: usize = manager.restrictions.values().map(|v| v.len()).sum();
@@ -129,16 +138,26 @@ impl EventRestrictionService {
         }
     }
 
-    /// Returns a future that refreshes restrictions periodically. Caller should spawn this.
-    /// The task will run until the cancellation token is triggered.
-    pub async fn start_refresh_task(
+    /// Refreshes restrictions periodically until the cancellation token is triggered.
+    ///
+    /// The repository is created lazily via `create_repository`. If Redis is unavailable
+    /// at startup, the service stays in fail-open mode and retries on each tick.
+    /// `tokio::time::interval` ticks immediately, so the first connection attempt
+    /// happens without delay.
+    pub async fn start_refresh_task<F, Fut>(
         &self,
-        repository: Arc<dyn EventRestrictionsRepository>,
+        create_repository: F,
         refresh_interval: Duration,
         cancel_token: CancellationToken,
-    ) {
+    ) where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<
+            Output = Result<Arc<dyn EventRestrictionsRepository>, common_redis::CustomRedisError>,
+        >,
+    {
         let pipeline_str = self.pipeline.as_pipeline_name();
         let mut interval = interval(refresh_interval);
+        let mut repository: Option<Arc<dyn EventRestrictionsRepository>> = None;
 
         loop {
             tokio::select! {
@@ -147,17 +166,38 @@ impl EventRestrictionService {
                     break;
                 }
                 _ = interval.tick() => {
-                    self.refresh_from_repository(&repository).await;
+                    if repository.is_none() {
+                        match create_repository().await {
+                            Ok(repo) => {
+                                info!(pipeline = %pipeline_str, "Event restrictions connected to Redis");
+                                repository = Some(repo);
+                            }
+                            Err(e) => {
+                                error!(
+                                    pipeline = %pipeline_str,
+                                    error = %e,
+                                    "Failed to connect to event restrictions Redis, will retry"
+                                );
+                                continue;
+                            }
+                        }
+                    }
+
+                    if !self.refresh_from_repository(repository.as_ref().unwrap().as_ref()).await {
+                        // All fetches failed — connection is likely dead, will reconnect next tick
+                        repository = None;
+                    }
                 }
             }
         }
     }
 
     /// Fetch restrictions from repository and update the local cache.
-    async fn refresh_from_repository(&self, repository: &Arc<dyn EventRestrictionsRepository>) {
+    /// Returns `true` on success, `false` if all fetches failed (dead connection).
+    async fn refresh_from_repository(&self, repository: &dyn EventRestrictionsRepository) -> bool {
         let pipeline_str = self.pipeline.as_pipeline_name();
 
-        match RestrictionManager::from_repository(repository.as_ref(), self.pipeline).await {
+        match RestrictionManager::from_repository(repository, self.pipeline).await {
             Ok(new_manager) => {
                 let total_restrictions: usize =
                     new_manager.restrictions.values().map(|v| v.len()).sum();
@@ -188,13 +228,16 @@ impl EventRestrictionService {
                     "pipeline" => pipeline_str.to_string()
                 )
                 .set(0.0);
+
+                true
             }
             Err(e) => {
                 error!(
                     pipeline = %pipeline_str,
                     error = %e,
-                    "Failed to refresh event restrictions"
+                    "Failed to refresh event restrictions, will reconnect"
                 );
+                false
             }
         }
     }
@@ -435,28 +478,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_manager_handles_repository_errors_gracefully() {
+    async fn test_manager_returns_error_when_any_fetch_fails() {
         let repo = MockRestrictionsRepository::new();
 
-        // One type returns an error
         repo.set_error(RestrictionType::DropEvent, CustomRedisError::Timeout)
             .await;
-
-        // Another type returns valid data
         repo.set_entries(
             RestrictionType::ForceOverflow,
             Some(vec![make_entry("token1", vec!["analytics"])]),
         )
         .await;
 
-        // Should still succeed and return the valid data
-        let manager = RestrictionManager::from_repository(&repo, CaptureMode::Events)
-            .await
-            .unwrap();
-
-        let event = EventContext::default();
-        let restrictions = manager.get_restrictions("token1", &event);
-        assert!(restrictions.contains(RestrictionType::ForceOverflow));
+        let result = RestrictionManager::from_repository(&repo, CaptureMode::Events).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -114,6 +114,80 @@ fn spawn_connection_handler(
     });
 }
 
+type EventRestrictionState = (
+    Option<EventRestrictionService>,
+    Option<CancellationToken>,
+    Option<JoinHandle<()>>,
+);
+
+fn create_event_restriction_service(config: &Config) -> EventRestrictionState {
+    if !config.event_restrictions_enabled {
+        return (None, None, None);
+    }
+
+    let Some(ref redis_url) = config.event_restrictions_redis_url else {
+        warn!("Event restrictions enabled but EVENT_RESTRICTIONS_REDIS_URL not set");
+        return (None, None, None);
+    };
+
+    let service = EventRestrictionService::new(
+        config.capture_mode,
+        Duration::from_secs(config.event_restrictions_fail_open_after_secs),
+    );
+
+    let cancel_token = CancellationToken::new();
+
+    let service_clone = service.clone();
+    let refresh_interval = Duration::from_secs(config.event_restrictions_refresh_interval_secs);
+    let task_cancel_token = cancel_token.clone();
+
+    // Capture values needed by the repository factory
+    let redis_url = redis_url.clone();
+    let response_timeout = if config.redis_response_timeout_ms == 0 {
+        None
+    } else {
+        Some(Duration::from_millis(config.redis_response_timeout_ms))
+    };
+    let connection_timeout = if config.redis_connection_timeout_ms == 0 {
+        None
+    } else {
+        Some(Duration::from_millis(config.redis_connection_timeout_ms))
+    };
+
+    let handle = tokio::spawn(async move {
+        service_clone
+            .start_refresh_task(
+                || {
+                    let url = redis_url.clone();
+                    async move {
+                        let repo = RedisRestrictionsRepository::new(
+                            url,
+                            response_timeout,
+                            connection_timeout,
+                        )
+                        .await?;
+                        let result: Arc<
+                            dyn crate::event_restrictions::EventRestrictionsRepository,
+                        > = Arc::new(repo);
+                        Ok(result)
+                    }
+                },
+                refresh_interval,
+                task_cancel_token,
+            )
+            .await;
+    });
+
+    info!(
+        pipeline = %config.capture_mode.as_pipeline_name(),
+        refresh_interval_secs = config.event_restrictions_refresh_interval_secs,
+        fail_open_after_secs = config.event_restrictions_fail_open_after_secs,
+        "Event restrictions enabled"
+    );
+
+    (Some(service), Some(cancel_token), Some(handle))
+}
+
 async fn create_sink(
     config: &Config,
     redis_client: Arc<RedisClient>,
@@ -334,65 +408,8 @@ where
             None
         };
 
-    // Create event restriction service if enabled and redis URL is configured
-    let (event_restriction_service, event_restrictions_cancel, event_restrictions_handle): (
-        Option<EventRestrictionService>,
-        Option<CancellationToken>,
-        Option<JoinHandle<()>>,
-    ) = if config.event_restrictions_enabled {
-        if let Some(ref redis_url) = config.event_restrictions_redis_url {
-            let repository = Arc::new(
-                RedisRestrictionsRepository::new(
-                    redis_url.clone(),
-                    if config.redis_response_timeout_ms == 0 {
-                        None
-                    } else {
-                        Some(Duration::from_millis(config.redis_response_timeout_ms))
-                    },
-                    if config.redis_connection_timeout_ms == 0 {
-                        None
-                    } else {
-                        Some(Duration::from_millis(config.redis_connection_timeout_ms))
-                    },
-                )
-                .await
-                .expect("failed to create event restrictions repository"),
-            );
-
-            let service = EventRestrictionService::new(
-                config.capture_mode,
-                Duration::from_secs(config.event_restrictions_fail_open_after_secs),
-            );
-
-            // Create cancellation token for graceful shutdown
-            let cancel_token = CancellationToken::new();
-
-            // Spawn background refresh task with cancellation support
-            let service_clone = service.clone();
-            let refresh_interval =
-                Duration::from_secs(config.event_restrictions_refresh_interval_secs);
-            let task_cancel_token = cancel_token.clone();
-            let handle = tokio::spawn(async move {
-                service_clone
-                    .start_refresh_task(repository, refresh_interval, task_cancel_token)
-                    .await;
-            });
-
-            info!(
-                pipeline = %config.capture_mode.as_pipeline_name(),
-                refresh_interval_secs = config.event_restrictions_refresh_interval_secs,
-                fail_open_after_secs = config.event_restrictions_fail_open_after_secs,
-                "Event restrictions enabled"
-            );
-
-            (Some(service), Some(cancel_token), Some(handle))
-        } else {
-            warn!("Event restrictions enabled but EVENT_RESTRICTIONS_REDIS_URL not set");
-            (None, None, None)
-        }
-    } else {
-        (None, None, None)
-    };
+    let (event_restriction_service, event_restrictions_cancel, event_restrictions_handle) =
+        create_event_restriction_service(&config);
 
     let app = router::router(
         crate::time::SystemTime {},


### PR DESCRIPTION
## Problem

Capture fails to start when the event restrictions redis can't be reached.

## Changes

Refactors the redis setup in the events restrictions service, so that:

1. It does not block on startup when the redis connection can't be established
2. Reconnects after losing the connection

## How did you test this code?

Extended the existing test suite