### PR TITLE
chore: add docs and skills for MCP tools and skill writing

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -66,7 +66,7 @@ tools:
       destructive: false
       idempotent: true
     # Optional:
-    mcp_version: 1 # 2 for CUD ops, 1 for read/list if available via HogQL
+    mcp_version: 1 # 2 for create/update/delete ops, 1 for read/list if available via HogQL
     title: List things
     description: >
       Human-friendly description for the LLM.
@@ -120,6 +120,6 @@ and register it in [`products/posthog_ai/skills/query-examples/SKILL.md`](produc
 ## Two MCP versions
 
 - **v1 (legacy)**: all CRUD tools exposed, for clients without skill support.
-- **v2 (SQL-first)**: read/list tools replaced by HogQL, CUD tools kept. For coding agents.
+- **v2 (SQL-first)**: read/list tools replaced by HogQL, create/update/delete tools kept. For coding agents.
 
 Control per-tool availability with `mcp_version: 1/2` in the YAML definition.

--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -66,7 +66,7 @@ tools:
       destructive: false
       idempotent: true
     # Optional:
-    new_mcp: true # true for CUD ops, false for read/list if available via HogQL
+    mcp_version: 1 # 2 for CUD ops, 1 for read/list if available via HogQL
     title: List things
     description: >
       Human-friendly description for the LLM.
@@ -110,7 +110,7 @@ This lets agents query data via SQL in v2 of the MCP.
 
 Each system table **must include a `team_id` column** for data isolation.
 
-Use `new_mcp: false` on read/list YAML tools when a system table covers the same data —
+Use `mcp_version: 1` on read/list YAML tools when a system table covers the same data —
 v2 agents use SQL instead.
 
 When adding a system table, also add a model reference file
@@ -122,4 +122,4 @@ and register it in [`products/posthog_ai/skills/query-examples/SKILL.md`](produc
 - **v1 (legacy)**: all CRUD tools exposed, for clients without skill support.
 - **v2 (SQL-first)**: read/list tools replaced by HogQL, CUD tools kept. For coding agents.
 
-Control per-tool availability with `new_mcp: true/false` in the YAML definition.
+Control per-tool availability with `mcp_version: 1/2` in the YAML definition.

--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: implementing-mcp-tools
+description: 'Guide for exposing PostHog product endpoints as MCP tools. Use when creating new or updating API endpoints, adding MCP tool definitions, scaffolding YAML configs, or writing serializers with good descriptions. Covers the full pipeline from Django serializer to generated TypeScript tool handler.'
+---
+
+# Implementing MCP tools
+
+Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-tools.md](docs/published/handbook/engineering/ai/implementing-mcp-tools.md).
+
+## Quick workflow
+
+```sh
+# 1. Scaffold a starter YAML with all operations disabled
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
+
+# 2. Configure the YAML — enable tools, add scopes, annotations, descriptions
+#    Place in products/<product>/mcp/*.yaml (preferred) or services/mcp/definitions/*.yaml
+
+# 3. Add a HogQL system table in posthog/hogql/database/schema/system.py
+#    and a model reference in products/posthog_ai/skills/query-examples/references/
+
+# 4. Generate handlers and schemas
+hogli build:openapi
+```
+
+## When to add MCP tools
+
+When a product exposes API endpoints that agents should be able to call.
+MCP tools are atomic capabilities (list, get, create, update, delete) — not workflows.
+
+If you're adding a new endpoint, check whether it should be agent-accessible.
+If yes, add a YAML definition and generate the tool.
+
+## Tool design
+
+Tools should be **basic capabilities** — atomic CRUD operations and simple actions.
+Agents compose these primitives into higher-level workflows.
+
+Good: "List feature flags", "Get experiment by ID", "Create a survey".
+Bad: "Search for session recordings of an experiment" — bundles multiple concerns.
+
+## YAML definitions
+
+YAML files configure which operations are exposed as MCP tools.
+See existing definitions for patterns:
+
+- `products/<product>/mcp/*.yaml` — preferred, keeps config close to the code
+- `services/mcp/definitions/*.yaml` — shared location
+
+The build pipeline discovers YAML files from both paths.
+
+### Key fields
+
+```yaml
+category: Human readable name
+feature: snake_case_name
+url_prefix: /path
+tools:
+  your-tool-name: # kebab-case
+    operation: operationId_from_openapi
+    enabled: true
+    scopes:
+      - your_product:read
+    annotations:
+      readOnly: true
+      destructive: false
+      idempotent: true
+    # Optional:
+    new_mcp: true # true for CUD ops, false for read/list if available via HogQL
+    title: List things
+    description: >
+      Human-friendly description for the LLM.
+    list: true
+    enrich_url: '{id}'
+    param_overrides:
+      name:
+        description: Custom description for the LLM
+```
+
+Unknown keys are rejected at build time (Zod `.strict()`).
+
+### Syncing after endpoint changes
+
+```sh
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+```
+
+Idempotent and non-destructive — adds new operations as `enabled: false`, removes stale ones.
+
+## Serializer descriptions
+
+Descriptions flow through the entire pipeline:
+
+```text
+Django serializer field → OpenAPI spec → Zod schema → MCP tool description
+```
+
+These descriptions are what agents read to understand tool parameters.
+
+- Use `help_text` on serializer fields — it becomes the OpenAPI description.
+- Use `param_overrides` in YAML to override generated descriptions with imperative instructions.
+- Be specific about formats, constraints, and valid values.
+- Avoid jargon that an LLM wouldn't understand without context.
+
+## HogQL system tables
+
+Every list/get endpoint should have a corresponding HogQL system table
+in [`posthog/hogql/database/schema/system.py`](posthog/hogql/database/schema/system.py).
+This lets agents query data via SQL in v2 of the MCP.
+
+Each system table **must include a `team_id` column** for data isolation.
+
+Use `new_mcp: false` on read/list YAML tools when a system table covers the same data —
+v2 agents use SQL instead.
+
+When adding a system table, also add a model reference file
+(`models-<domain>.md`) in [`products/posthog_ai/skills/query-examples/references/`](products/posthog_ai/skills/query-examples/references/)
+and register it in [`products/posthog_ai/skills/query-examples/SKILL.md`](products/posthog_ai/skills/query-examples/SKILL.md) under **Data Schema**.
+
+## Two MCP versions
+
+- **v1 (legacy)**: all CRUD tools exposed, for clients without skill support.
+- **v2 (SQL-first)**: read/list tools replaced by HogQL, CUD tools kept. For coding agents.
+
+Control per-tool availability with `new_mcp: true/false` in the YAML definition.

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: writing-skills
+description: 'Guide for writing PostHog agent skills — job-to-be-done templates that teach agents how to use MCP tools to achieve a goal. Use when adding new product functionality that agents should know how to work with, creating a new skill, or updating existing skills in products/*/skills/.'
+---
+
+# Writing skills for PostHog agents
+
+Read the full guide at [docs/published/handbook/engineering/ai/writing-skills.md](docs/published/handbook/engineering/ai/writing-skills.md).
+
+## Quick workflow
+
+```sh
+# 1. Scaffold
+hogli init:skill
+
+# 2. Write your skill in products/{product}/skills/{skill-name}/SKILL.md
+
+# 3. Lint
+hogli lint:skills
+
+# 4. Build to verify
+hogli build:skills
+```
+
+Distribution is automatic after merge — CI publishes to [PostHog/skills](https://github.com/PostHog/skills).
+
+## When to write a skill
+
+When new functionality is added to a product and agents need to know how to work with it.
+A skill is not about what tools exist (that's the MCP server) —
+it's about how an experienced person would approach a job using those tools.
+
+Ask: "If a customer asked an agent to do X with my feature, would the agent know the right approach?"
+If not, write a skill.
+
+## Key rules
+
+- **Name**: lowercase kebab-case, prefer gerund form (`analyzing-llm-traces`, not `llm-analytics`). Never prefix with `posthog-*`.
+- **Description**: third person, specific, include trigger terms and when to use it. Max 1024 chars.
+- **Structure**: `SKILL.md` entry point + `references/` for detailed content. Keep `SKILL.md` under 500 lines.
+- **Frontmatter**: `name` and `description` are required.
+- **Tone**: describe the workflow and reasoning, not a rigid script. Trust the agent to adapt.
+- **Conciseness**: the agent is smart — only include context it doesn't already have.
+
+## Skill structure
+
+```text
+products/{product}/skills/{skill-name}/
+    SKILL.md                         # entry point (required)
+    references/                      # optional
+        guidelines.md
+        models-foo.md
+        example-bar.md.j2            # Jinja2 template, rendered at build time
+    scripts/                         # optional
+        setup.sh
+```
+
+Only `references/` and `scripts/` subdirectories are collected. Others are ignored.
+
+## Template functions
+
+Files ending in `.j2` are rendered with Jinja2 at build time
+by [`products/posthog_ai/scripts/build_skills.py`](products/posthog_ai/scripts/build_skills.py).
+Extend the build pipeline so the monorepo stays the source of truth —
+when domain knowledge lives in code (Pydantic models, query runners, function registries),
+add a template function rather than duplicating it as static markdown that drifts.
+
+Available functions:
+
+- `pydantic_schema("dotted.path.to.Model")` — renders a Pydantic model's JSON Schema
+- `render_hogql_example({"kind": "TrendsQuery", ...})` — renders a query spec to HogQL SQL
+- `hogql_functions()` — returns all available HogQL function names
+
+## Good example: `query-examples`
+
+- Clear entry point linking to 30+ reference files
+- Progressive disclosure — agents load only what they need
+- Mix of static `.md` and generated `.md.j2` content
+- See [`products/posthog_ai/skills/query-examples/SKILL.md`](products/posthog_ai/skills/query-examples/SKILL.md)
+
+## Bad example: `llm-analytics`
+
+An umbrella skill covering traces, experiments, evaluations, cost tracking, prompt management.
+Too broad — agents can't determine when to activate it. Break into focused skills instead.

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -1,0 +1,273 @@
+# Implementing MCP tools
+
+MCP tools are atomic capabilities — CRUD operations and simple actions that agents compose into workflows.
+Every product should be accessible through the MCP server.
+Tools answer "what can I do?" (list feature flags, execute SQL, create a survey).
+
+For teaching agents _how_ to use these capabilities in combination,
+see [Writing skills](/handbook/engineering/ai/writing-skills).
+
+## TL;DR
+
+```sh
+# 1. Scaffold a starter YAML with all operations disabled
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
+
+# 2. Configure the YAML — enable tools, add scopes, annotations, descriptions
+#    Place in products/<product>/mcp/*.yaml (preferred) or services/mcp/definitions/*.yaml
+
+# 3. Add a HogQL system table in posthog/hogql/database/schema/system.py
+#    and a model reference in products/posthog_ai/skills/query-examples/references/
+
+# 4. Generate handlers and schemas
+hogli build:openapi
+
+# 5. Merge to master — CI builds and distributes automatically
+```
+
+## Tool design principles
+
+MCP tools should be **basic capabilities** — atomic CRUD operations and simple actions.
+Agents compose these primitives into higher-level workflows.
+
+**Good tools**:
+
+- List feature flags
+- Get an experiment by ID
+- Create a survey
+- Summarize a session recording
+
+**Bad tools**:
+
+- "Search for session recordings of an experiment" — this bundles multiple concerns.
+  Instead, expose four composable tools:
+  list experiments, get experiment, search session recordings, summarize sessions.
+
+The reasoning: agents are better at composing simple tools than navigating complex ones,
+and simple tools are reusable across many workflows.
+
+## Two MCP server versions
+
+Clients must support two main capabilities: MCPs and skills.
+MCP support is widespread; however, skills support is still very early
+and mostly coding agents support them.
+To mitigate this, the MCP server ships two versions controlled via the
+`x-posthog-mcp-version: <version_number>` header.
+
+### Legacy MCP (v1)
+
+For clients that don't support skills.
+Exposes the full set of CRUD tools with simple instructions (list, read, create, update, delete).
+
+Primarily oriented toward vibe-coding web tools.
+
+### SQL-first MCP for clients supporting skills (v2)
+
+v2 instructs the agent to read data through a unified HogQL interface
+(list and get tools are generally excluded),
+which unlocks flexibility in data retrieval, search, and manipulation.
+Additionally, the consumer has access to a skill that provides schema references and example patterns,
+giving it richer context about PostHog's data model.
+
+Primarily oriented toward coding agents (PostHog Code, PostHog AI, Claude Code).
+
+## SQL-first MCP: HogQL system tables
+
+Every list/get endpoint exposed as an MCP tool must have a corresponding HogQL system table.
+This lets agents query PostHog data via SQL in addition to (or instead of) the REST API tools.
+
+System tables are defined in [`posthog/hogql/database/schema/system.py`](https://github.com/PostHog/posthog/blob/master/posthog/hogql/database/schema/system.py) as `PostgresTable` instances.
+Each table must include a `team_id` column for data isolation.
+
+Use `new_mcp: true/false` to control availability of retrieval tools in v2 of the MCP.
+
+Example from the codebase:
+
+```python
+feature_flags: PostgresTable = PostgresTable(
+    name="feature_flags",
+    postgres_table_name="posthog_featureflag",
+    fields={
+        "id": IntegerDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        # ...
+    },
+)
+```
+
+Agents query these tables with the `system.` prefix:
+
+```sql
+SELECT id, key, name FROM system.feature_flags WHERE active = 1 LIMIT 10
+```
+
+### Extending query examples
+
+When you add a new system table,
+also add a model reference file to [`products/posthog_ai/skills/query-examples/references/`](https://github.com/PostHog/posthog/tree/master/products/posthog_ai/skills/query-examples/references).
+The naming convention is `models-<domain>.md`.
+
+Existing references:
+
+- `models-actions.md`
+- `models-cohorts.md`
+- `models-dashboards-insights.md`
+- `models-data-warehouse.md`
+- `models-error-tracking.md`
+- `models-flags-experiments.md`
+- `models-groups.md`
+- `models-notebooks.md`
+- `models-surveys.md`
+- `models-variables.md`
+
+Each file documents the table's columns, types, nullability, and notable structures (like JSON fields).
+See [`models-flags-experiments.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/references/models-flags-experiments.md) for a good example.
+Register your new reference in [`products/posthog_ai/skills/query-examples/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md) under **Data Schema**.
+
+## Code generation pipeline
+
+The pipeline turns Django serializers into MCP tool handlers via OpenAPI.
+Run the full pipeline with:
+
+```sh
+hogli build:openapi
+```
+
+### Pipeline steps
+
+```text
+build:openapi-schema     Django → OpenAPI JSON (frontend/tmp/openapi.json)
+        │
+        ▼
+build:openapi-types      OpenAPI → TypeScript API types (frontend)
+        │
+        ▼
+build:openapi-mcp        OpenAPI → Zod schemas for MCP (Orval)
+        │
+        ▼
+build:openapi-mcp-tools  YAML definitions + Zod schemas → TypeScript tool handlers
+```
+
+### YAML definitions
+
+YAML definitions are the configuration layer.
+They can live in two locations:
+
+- **`products/<product>/mcp/*.yaml`** — preferred for product-owned definitions, keeps config close to the code.
+- **`services/mcp/definitions/*.yaml`** — shared location.
+
+The build pipeline discovers YAML files from both paths.
+Product teams own their definitions and control which operations are exposed as MCP tools.
+
+**Workflow: scaffold, configure, generate.**
+
+1. **Scaffold** a starter YAML with all operations disabled.
+   Operations are discovered by matching URL paths against product names
+   (e.g., `error_tracking` matches all paths containing `/error_tracking/`).
+
+   ```sh
+   pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
+   # or output directly into a product folder:
+   pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product \
+       --output ../../products/your_product/mcp/tools.yaml
+   ```
+
+2. **Configure** the YAML — enable tools, add scopes, annotations, and descriptions.
+   Each YAML file has a top-level structure validated by Zod ([`scripts/yaml-config-schema.ts`](https://github.com/PostHog/posthog/blob/master/services/mcp/scripts/yaml-config-schema.ts)):
+
+   ```yaml
+   category: Human readable name # shown in tool registry
+   feature: snake_case_name # product identifier
+   url_prefix: /path # base URL for enrich_url links
+   tools:
+     your-tool-name: # tool name, kebab-case
+       operation: your_product_endpoint_list # must match an OpenAPI operationId
+       enabled: true # false excludes from generation
+       # --- required when enabled: ---
+       scopes: # API scopes
+         - your_product:read
+       annotations:
+         readOnly: true
+         destructive: false
+         idempotent: true
+       # --- optional: ---
+       new_mcp: true # true for CUD operations, false for read/list if available via HogQL
+       title: List things # human-friendly title (used in UI)
+       description: > # instructions for the LLM
+         Human-friendly description for the LLM.
+       list: true # marks as a list endpoint
+       enrich_url: '{id}' # appended to url_prefix for result URLs
+       exclude_params: [field] # hide params from tool input
+       include_params: [field] # whitelist params (excludes all others)
+       param_overrides: # override Orval-generated param descriptions
+         name:
+           description: Custom description for the LLM
+   ```
+
+   Unknown keys are rejected at build time (Zod `.strict()`) to catch typos early.
+   See [supported annotations](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations) for the full list.
+
+3. **Generate** handlers and schemas:
+
+   ```sh
+   hogli build:openapi
+   ```
+
+### Keeping definitions in sync
+
+When backend API endpoints change, sync the YAML definitions:
+
+```sh
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+```
+
+This is idempotent and non-destructive —
+it only adds newly discovered operations (with `enabled: false`) and removes stale ones.
+All hand-authored configuration is preserved.
+CI runs this as a drift check.
+
+See [`services/mcp/definitions/README.md`](https://github.com/PostHog/posthog/blob/master/services/mcp/definitions/README.md) for the full YAML schema reference
+and [`services/mcp/scripts/yaml-config-schema.ts`](https://github.com/PostHog/posthog/blob/master/services/mcp/scripts/yaml-config-schema.ts) for the Zod validation source.
+
+## Serializer best practices
+
+Descriptions flow through the entire pipeline:
+
+```text
+Django serializer field → OpenAPI spec → Zod schema → MCP tool description
+```
+
+Product teams should **type and describe** their serializer fields.
+These descriptions are what agents read to understand tool parameters —
+vague or missing descriptions lead to worse agent behavior.
+
+**Tips:**
+
+- Use `help_text` on serializer fields — it becomes the OpenAPI description.
+  Be careful when using imperative language in `help_text`,
+  as the same annotations are used in the API docs.
+- Use `param_overrides` in YAML definitions to override Orval-generated descriptions.
+  This is useful when you want to add imperative instructions for specific fields.
+- Be specific about formats, constraints, and valid values.
+- Avoid jargon that an LLM wouldn't understand without context.
+
+## HogQL query schemas (WIP)
+
+[`frontend/src/queries/schema/schema-assistant-queries.ts`](https://github.com/PostHog/posthog/blob/master/frontend/src/queries/schema/schema-assistant-queries.ts) defines structured query types
+for the AI assistant (trends, funnels, retention, etc.).
+
+These schemas describe the shape of analytical queries with rich JSDoc comments
+that help agents generate correct HogQL.
+The cleaner and better-described these schemas are,
+the better agents perform at query generation.
+
+This is a work in progress —
+the goal is to make it easier to generate HogQL queries from typed schemas
+than from freeform SQL.
+A `schema.json` integration into the codegen pipeline is planned.
+
+## Agent skills that support the MCP server
+
+- **`query-examples`** — HogQL query patterns, system model schemas, and available functions.
+  Extend this skill to explain how agents should use your HogQL-exposed tables and queries.
+  See [`products/posthog_ai/skills/query-examples/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md).

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -1,6 +1,6 @@
 # Implementing MCP tools
 
-MCP tools are atomic capabilities — CRUD operations and simple actions that agents compose into workflows.
+MCP tools are atomic capabilities – CRUD operations and simple actions that agents compose into workflows.
 Every product should be accessible through the MCP server.
 Tools answer "what can I do?" (list feature flags, execute SQL, create a survey).
 
@@ -13,7 +13,7 @@ see [Writing skills](/handbook/engineering/ai/writing-skills).
 # 1. Scaffold a starter YAML with all operations disabled
 pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
 
-# 2. Configure the YAML — enable tools, add scopes, annotations, descriptions
+# 2. Configure the YAML – enable tools, add scopes, annotations, descriptions
 #    Place in products/<product>/mcp/*.yaml (preferred) or services/mcp/definitions/*.yaml
 
 # 3. Add a HogQL system table in posthog/hogql/database/schema/system.py
@@ -22,12 +22,12 @@ pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
 # 4. Generate handlers and schemas
 hogli build:openapi
 
-# 5. Merge to master — CI builds and distributes automatically
+# 5. Merge to master – CI builds and distributes automatically
 ```
 
 ## Tool design principles
 
-MCP tools should be **basic capabilities** — atomic CRUD operations and simple actions.
+MCP tools should be **basic capabilities** – atomic CRUD operations and simple actions.
 Agents compose these primitives into higher-level workflows.
 
 **Good tools**:
@@ -39,7 +39,7 @@ Agents compose these primitives into higher-level workflows.
 
 **Bad tools**:
 
-- "Search for session recordings of an experiment" — this bundles multiple concerns.
+- "Search for session recordings of an experiment" – this bundles multiple concerns.
   Instead, expose four composable tools:
   list experiments, get experiment, search session recordings, summarize sessions.
 
@@ -153,8 +153,8 @@ build:openapi-mcp-tools  YAML definitions + Zod schemas → TypeScript tool hand
 YAML definitions are the configuration layer.
 They can live in two locations:
 
-- **`products/<product>/mcp/*.yaml`** — preferred for product-owned definitions, keeps config close to the code.
-- **`services/mcp/definitions/*.yaml`** — shared location.
+- **`products/<product>/mcp/*.yaml`** – preferred for product-owned definitions, keeps config close to the code.
+- **`services/mcp/definitions/*.yaml`** – shared location.
 
 The build pipeline discovers YAML files from both paths.
 Product teams own their definitions and control which operations are exposed as MCP tools.
@@ -172,7 +172,7 @@ Product teams own their definitions and control which operations are exposed as 
        --output ../../products/your_product/mcp/tools.yaml
    ```
 
-2. **Configure** the YAML — enable tools, add scopes, annotations, and descriptions.
+2. **Configure** the YAML – enable tools, add scopes, annotations, and descriptions.
    Each YAML file has a top-level structure validated by Zod ([`scripts/yaml-config-schema.ts`](https://github.com/PostHog/posthog/blob/master/services/mcp/scripts/yaml-config-schema.ts)):
 
    Tool names follow a **`domain-action`** convention in kebab-case,
@@ -225,7 +225,7 @@ When backend API endpoints change, sync the YAML definitions:
 pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
 ```
 
-This is idempotent and non-destructive —
+This is idempotent and non-destructive –
 it only adds newly discovered operations (with `enabled: false`) and removes stale ones.
 All hand-authored configuration is preserved.
 CI runs this as a drift check.
@@ -242,12 +242,12 @@ Django serializer field → OpenAPI spec → Zod schema → MCP tool description
 ```
 
 Product teams should **type and describe** their serializer fields.
-These descriptions are what agents read to understand tool parameters —
+These descriptions are what agents read to understand tool parameters –
 vague or missing descriptions lead to worse agent behavior.
 
 **Tips:**
 
-- Use `help_text` on serializer fields — it becomes the OpenAPI description.
+- Use `help_text` on serializer fields – it becomes the OpenAPI description.
   Be careful when using imperative language in `help_text`,
   as the same annotations are used in the API docs.
 - Use `param_overrides` in YAML definitions to override Orval-generated descriptions.
@@ -265,13 +265,13 @@ that help agents generate correct HogQL.
 The cleaner and better-described these schemas are,
 the better agents perform at query generation.
 
-This is a work in progress —
+This is a work in progress –
 the goal is to make it easier to generate HogQL queries from typed schemas
 than from freeform SQL.
 A `schema.json` integration into the codegen pipeline is planned.
 
 ## Agent skills that support the MCP server
 
-- **`query-examples`** — HogQL query patterns, system model schemas, and available functions.
+- **`query-examples`** – HogQL query patterns, system model schemas, and available functions.
   Extend this skill to explain how agents should use your HogQL-exposed tables and queries.
   See [`products/posthog_ai/skills/query-examples/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md).

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -233,6 +233,11 @@ CI runs this as a drift check.
 See [`services/mcp/definitions/README.md`](https://github.com/PostHog/posthog/blob/master/services/mcp/definitions/README.md) for the full YAML schema reference
 and [`services/mcp/scripts/yaml-config-schema.ts`](https://github.com/PostHog/posthog/blob/master/services/mcp/scripts/yaml-config-schema.ts) for the Zod validation source.
 
+## Testing
+
+See [How to develop and test](/handbook/engineering/ai/implementation#how-to-develop-and-test)
+for instructions on running the MCP server locally and verifying tools end-to-end.
+
 ## Serializer best practices
 
 Descriptions flow through the entire pipeline:

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -79,7 +79,7 @@ This lets agents query PostHog data via SQL in addition to (or instead of) the R
 System tables are defined in [`posthog/hogql/database/schema/system.py`](https://github.com/PostHog/posthog/blob/master/posthog/hogql/database/schema/system.py) as `PostgresTable` instances.
 Each table must include a `team_id` column for data isolation.
 
-Use `new_mcp: true/false` to control availability of retrieval tools in v2 of the MCP.
+Use `mcp_version: 1/2` to control availability of retrieval tools in v2 of the MCP.
 
 Example from the codebase:
 
@@ -175,12 +175,16 @@ Product teams own their definitions and control which operations are exposed as 
 2. **Configure** the YAML — enable tools, add scopes, annotations, and descriptions.
    Each YAML file has a top-level structure validated by Zod ([`scripts/yaml-config-schema.ts`](https://github.com/PostHog/posthog/blob/master/services/mcp/scripts/yaml-config-schema.ts)):
 
+   Tool names follow a **`domain-action`** convention in kebab-case,
+   e.g. `feature-flags-list`, `experiments-create`, `surveys-delete`.
+   The domain groups related tools together and the action describes the operation.
+
    ```yaml
    category: Human readable name # shown in tool registry
    feature: snake_case_name # product identifier
    url_prefix: /path # base URL for enrich_url links
    tools:
-     your-tool-name: # tool name, kebab-case
+     domain-action: # e.g. feature-flags-list, experiments-create
        operation: your_product_endpoint_list # must match an OpenAPI operationId
        enabled: true # false excludes from generation
        # --- required when enabled: ---
@@ -191,7 +195,7 @@ Product teams own their definitions and control which operations are exposed as 
          destructive: false
          idempotent: true
        # --- optional: ---
-       new_mcp: true # true for CUD operations, false for read/list if available via HogQL
+       mcp_version: 2 # 2 for create/update/delete operations or not available through SQL for retrieval, 1 for read/list if available via HogQL
        title: List things # human-friendly title (used in UI)
        description: > # instructions for the LLM
          Human-friendly description for the LLM.

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -3,7 +3,7 @@
 Skills are job-to-be-done templates that teach agents _how_ to use capabilities to achieve a goal.
 They should read like how an experienced person would approach a job,
 not like a rigid script of commands to run.
-Describe the workflow, the reasoning behind each step, and what to watch out for —
+Describe the workflow, the reasoning behind each step, and what to watch out for –
 then trust the agent to adapt.
 Overly strict instructions break when context changes;
 a well-explained approach generalizes.
@@ -26,12 +26,12 @@ hogli lint:skills
 # 4. Build locally to verify rendered output
 hogli build:skills
 
-# 5. Merge to master — CI builds and distributes automatically
+# 5. Merge to master – CI builds and distributes automatically
 ```
 
 ## Skills vs tools
 
-**Tools** are atomic capabilities — CRUD operations and simple actions exposed via the MCP server.
+**Tools** are atomic capabilities – CRUD operations and simple actions exposed via the MCP server.
 They answer "what can I do?" (list feature flags, execute SQL, create a survey).
 
 **Skills** answer "how do I accomplish X?"
@@ -72,7 +72,7 @@ products/{product}/skills/{skill-name}/
 ```
 
 The skill name is the directory name.
-Only `references/` and `scripts/` subdirectories are included in the output —
+Only `references/` and `scripts/` subdirectories are included in the output –
 other subdirectories are ignored.
 
 ### Frontmatter
@@ -91,11 +91,11 @@ Both fields are required and validated at build time.
 ### Progressive disclosure
 
 `SKILL.md` serves as an overview that points agents to detailed materials as needed.
-Reference files are loaded on demand — only the entry point is read initially.
+Reference files are loaded on demand – only the entry point is read initially.
 Keep `SKILL.md` under 500 lines and split detailed content into `references/`.
 
 See [`query-examples/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md)
-for how this works in practice —
+for how this works in practice –
 the entry point links to 30+ reference files
 covering model schemas, query patterns, and HogQL extensions.
 
@@ -122,7 +122,7 @@ The `name` field: lowercase letters, numbers, and hyphens only. Max 64 character
 
 ### Writing descriptions
 
-The `description` field is critical for skill discovery —
+The `description` field is critical for skill discovery –
 agents use it to decide which skill to activate from potentially many available skills.
 Max 1024 characters.
 
@@ -130,7 +130,7 @@ Max 1024 characters.
 
 - Write in **third person** ("Analyzes LLM traces...", not "I can help you analyze...").
 - Include both **what** the skill does and **when** to use it.
-- Be specific — include key terms agents would match against.
+- Be specific – include key terms agents would match against.
 
 **Good descriptions:**
 
@@ -153,10 +153,10 @@ description: >
 **Bad descriptions:**
 
 ```yaml
-# Too vague — agents can't determine when to use it
+# Too vague – agents can't determine when to use it
 description: 'Helps with LLM analytics'
 
-# Too broad — an umbrella for everything isn't a skill
+# Too broad – an umbrella for everything isn't a skill
 description: 'Everything about PostHog AI features'
 ```
 
@@ -182,13 +182,13 @@ A reference skill with a clear entry point and 30+ reference files:
   links to model schemas, query patterns, and HogQL extensions.
 - Guidelines file ([`references/guidelines.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/references/guidelines.md))
   explains schema verification workflow, time ranges, joins, and HogQL differences.
-- Uses progressive disclosure — agents load only the references they need.
+- Uses progressive disclosure – agents load only the references they need.
 
 ### Bad: `llm-analytics`
 
 An umbrella skill that tries to cover everything:
 traces, experiments, evaluations, cost tracking, prompt management.
-Too broad to be useful — agents can't determine _when_ to activate it
+Too broad to be useful – agents can't determine _when_ to activate it
 and the instructions are too generic to guide any specific workflow.
 Break it into focused skills instead.
 
@@ -312,7 +312,7 @@ and consumed via plugins for coding agents at [PostHog/ai-plugin](https://github
 PostHog Code already consumes skills automatically.
 PostHog AI will consume the same set of skills.
 
-Product teams don't need to handle distribution —
+Product teams don't need to handle distribution –
 the pipeline and CI take care of it.
 
 ## Writing effective skills

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -47,7 +47,10 @@ but need guidance on _which_ tools to use, in _what order_, with _what constrain
 
 ## Skill structure
 
-Skills live in `products/*/skills/` and come in two forms:
+Skills live in `products/*/skills/` and come in two forms.
+If your product hasn't moved to the `products/` folder yet,
+create a product folder and add skills there –
+skills are designed to work from within the products folder structure.
 
 ### Simple skill (single file)
 
@@ -314,6 +317,11 @@ PostHog AI will consume the same set of skills.
 
 Product teams don't need to handle distribution –
 the pipeline and CI take care of it.
+
+## Testing
+
+See [How to develop and test](/handbook/engineering/ai/implementation#how-to-develop-and-test)
+for instructions on running the MCP server locally and verifying skills end-to-end.
 
 ## Writing effective skills
 

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -1,0 +1,328 @@
+# Writing skills
+
+Skills are job-to-be-done templates that teach agents _how_ to use capabilities to achieve a goal.
+They should read like how an experienced person would approach a job,
+not like a rigid script of commands to run.
+Describe the workflow, the reasoning behind each step, and what to watch out for —
+then trust the agent to adapt.
+Overly strict instructions break when context changes;
+a well-explained approach generalizes.
+
+This page covers what skills are, how to write them, and how the build pipeline works.
+For adding MCP tools (the capabilities themselves), see [Adding tools to the MCP server](/handbook/engineering/ai/implementing-mcp-tools).
+
+## TL;DR
+
+```sh
+# 1. Scaffold a new skill in your product
+hogli init:skill
+
+# 2. Write your skill in products/{product}/skills/{skill-name}/SKILL.md
+#    Add references/ for detailed content, use .md.j2 for templates
+
+# 3. Lint (fast, no Django needed)
+hogli lint:skills
+
+# 4. Build locally to verify rendered output
+hogli build:skills
+
+# 5. Merge to master — CI builds and distributes automatically
+```
+
+## Skills vs tools
+
+**Tools** are atomic capabilities — CRUD operations and simple actions exposed via the MCP server.
+They answer "what can I do?" (list feature flags, execute SQL, create a survey).
+
+**Skills** answer "how do I accomplish X?"
+They combine tools, domain knowledge, query patterns, and step-by-step workflows
+into a template that agents follow to solve a class of problems.
+
+A skill might reference multiple tools, include HogQL query examples,
+explain what data to verify before querying,
+and describe the desired outcome for the customer.
+
+This separation matters because agents are good at composing simple tools
+but need guidance on _which_ tools to use, in _what order_, with _what constraints_.
+
+## Skill structure
+
+Skills live in `products/*/skills/` and come in two forms:
+
+### Simple skill (single file)
+
+```text
+products/{product}/skills/
+    analyzing-llm-traces.md          # or .md.j2 for Jinja2 templates
+```
+
+The skill name is the filename stem.
+
+### Directory skill (with references)
+
+```text
+products/{product}/skills/{skill-name}/
+    SKILL.md                         # entry point (required)
+    references/                      # optional, collected recursively
+        guidelines.md
+        models-actions.md
+        example-trends.md.j2
+    scripts/                         # optional, collected recursively
+        setup.sh
+```
+
+The skill name is the directory name.
+Only `references/` and `scripts/` subdirectories are included in the output —
+other subdirectories are ignored.
+
+### Frontmatter
+
+Every skill entry point must have YAML frontmatter with `name` and `description`:
+
+```yaml
+---
+name: query-examples
+description: 'HogQL query examples and reference material for PostHog data. Read when writing SQL queries...'
+---
+```
+
+Both fields are required and validated at build time.
+
+### Progressive disclosure
+
+`SKILL.md` serves as an overview that points agents to detailed materials as needed.
+Reference files are loaded on demand — only the entry point is read initially.
+Keep `SKILL.md` under 500 lines and split detailed content into `references/`.
+
+See [`query-examples/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md)
+for how this works in practice —
+the entry point links to 30+ reference files
+covering model schemas, query patterns, and HogQL extensions.
+
+## Naming and description guidelines
+
+Follow [Anthropic's skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
+Key points are summarized below.
+
+### Naming conventions
+
+Use lowercase kebab-case. Prefer gerund form (verb + -ing):
+
+| Pattern                   | Examples                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| Gerund form (preferred)   | `analyzing-llm-traces`, `writing-hogql-queries`, `managing-feature-flags` |
+| Noun phrases (acceptable) | `query-examples`, `error-tracking-guide`                                  |
+
+Skills **must not** be prefixed with `posthog-*`.
+The `posthog-` prefix is added automatically depending on the consumer agent.
+
+Skills also **must not** contain the reserved words `anthropic` or `claude` in the name.
+
+The `name` field: lowercase letters, numbers, and hyphens only. Max 64 characters.
+
+### Writing descriptions
+
+The `description` field is critical for skill discovery —
+agents use it to decide which skill to activate from potentially many available skills.
+Max 1024 characters.
+
+**Rules:**
+
+- Write in **third person** ("Analyzes LLM traces...", not "I can help you analyze...").
+- Include both **what** the skill does and **when** to use it.
+- Be specific — include key terms agents would match against.
+
+**Good descriptions:**
+
+```yaml
+# Specific, includes triggers and key terms
+description: >
+  HogQL query examples and reference material for PostHog data.
+  Read when writing SQL queries to find patterns for analytics
+  (trends, funnels, retention, lifecycle, paths, stickiness,
+  web analytics, error tracking, logs, sessions, LLM traces)
+  and system data (insights, dashboards, cohorts, feature flags,
+  experiments, surveys, data warehouse).
+
+description: >
+  Step-by-step guide for analyzing LLM traces in PostHog.
+  Use when inspecting AI generation latency, token usage,
+  human feedback, or trace hierarchies.
+```
+
+**Bad descriptions:**
+
+```yaml
+# Too vague — agents can't determine when to use it
+description: 'Helps with LLM analytics'
+
+# Too broad — an umbrella for everything isn't a skill
+description: 'Everything about PostHog AI features'
+```
+
+## Good and bad skill examples
+
+### Good: `analyzing-llm-traces`
+
+A focused skill that guides the agent through a specific workflow:
+
+- Starts by verifying that `$ai_trace`, `$ai_generation`, `$ai_feedback` events exist.
+- Provides HogQL queries to retrieve trace data with the right properties.
+- Explains how to join generations to traces via `$ai_trace_id`.
+- Describes the desired outcome (latency analysis, feedback summary, cost breakdown).
+
+The agent knows what tools to use (execute-sql, read-data-schema),
+in what order, and what a successful result looks like.
+
+### Good: `query-examples`
+
+A reference skill with a clear entry point and 30+ reference files:
+
+- Entry point ([`SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/SKILL.md))
+  links to model schemas, query patterns, and HogQL extensions.
+- Guidelines file ([`references/guidelines.md`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/skills/query-examples/references/guidelines.md))
+  explains schema verification workflow, time ranges, joins, and HogQL differences.
+- Uses progressive disclosure — agents load only the references they need.
+
+### Bad: `llm-analytics`
+
+An umbrella skill that tries to cover everything:
+traces, experiments, evaluations, cost tracking, prompt management.
+Too broad to be useful — agents can't determine _when_ to activate it
+and the instructions are too generic to guide any specific workflow.
+Break it into focused skills instead.
+
+### Bad: poor descriptions
+
+```yaml
+# Name is vague
+name: helper
+description: 'Helps with stuff'
+
+# Name uses reserved prefix
+name: posthog-queries
+description: 'Query helper'
+```
+
+## Template engine
+
+Skills support [Jinja2](https://jinja.palletsprojects.com/) templates.
+Any file ending in `.j2` is rendered at build time,
+and the `.j2` suffix is stripped from the output path.
+Plain `.md` files pass through unchanged.
+
+The Jinja2 environment uses `StrictUndefined` (undefined variables raise errors),
+`lstrip_blocks`, and `trim_blocks` for clean whitespace handling.
+
+### Built-in template functions
+
+Three global functions are available in all `.j2` templates:
+
+#### `pydantic_schema(dotted_path, indent=2)`
+
+Imports a Pydantic model by its fully-qualified path and returns its JSON Schema:
+
+```jinja2
+{{ pydantic_schema("products.feature_flags.backend.max_tools.FeatureFlagCreationSchema") }}
+```
+
+Changes to the Pydantic model automatically update the skill output on the next build.
+
+#### `render_hogql_example(query_dict)`
+
+Takes a PostHog query spec and renders it to HogQL SQL:
+
+```jinja2
+{{ render_hogql_example({"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}], "dateRange": {"date_from": "-7d"}}) }}
+```
+
+Time is frozen to `2025-12-10T00:00:00` for deterministic output.
+
+#### `hogql_functions()`
+
+Returns a sorted list of all public HogQL function names:
+
+```jinja2
+{% for fn in hogql_functions() %}
+{{ fn }}
+{% endfor %}
+```
+
+### Extending the template engine
+
+The build pipeline should be extended so the monorepo remains the source of truth
+for all skill content.
+When domain knowledge lives in code (Pydantic models, query runners, function registries),
+add a template function to extract it at build time
+rather than duplicating it as static markdown that drifts.
+
+To add a new template function:
+
+1. Create a module under `products/posthog_ai/scripts/`
+   (follow existing patterns like `pydantic_schema/`, `hogql_example/`).
+2. Register it in `SkillRenderer.__init__()`
+   by adding to `self.env.globals` via `_create_jinja_env(**extra_globals)`.
+
+## Build pipeline
+
+The pipeline discovers, renders, and packages skills.
+Source of truth: [`products/posthog_ai/scripts/build_skills.py`](https://github.com/PostHog/posthog/blob/master/products/posthog_ai/scripts/build_skills.py).
+
+### Pipeline steps
+
+```text
+Discovery     Scan products/*/skills/ for skills (loose files or directories with SKILL.md)
+    │
+    ▼
+Rendering     Render .j2 files through Jinja2, pass .md files through unchanged
+    │
+    ▼
+Building      Collect entry point + references/scripts into SkillResource with frontmatter metadata
+    │
+    ▼
+Output        Write to dist/skills/{skill-name}/ and package into dist/skills.zip
+```
+
+### CLI commands
+
+```sh
+hogli build:skills          # Build all skills and create dist/skills.zip
+hogli build:skills --list   # List discovered skills without building
+hogli lint:skills           # Validate skill sources (no Django required)
+hogli init:skill            # Scaffold a new skill directory
+```
+
+`lint:skills` validates syntax, frontmatter, binary file detection, and duplicate names.
+It runs without Django, so it's fast in CI.
+
+`build:skills` requires the full Python environment
+because template functions import Django models and Pydantic schemas.
+
+### Output
+
+Built skills are written to `products/posthog_ai/dist/skills/` (gitignored)
+and packaged into `dist/skills.zip` with deterministic timestamps for reproducible builds.
+
+## Distribution
+
+Distribution is automatic.
+Built skills are published through the [posthog/skills](https://github.com/PostHog/skills) repo
+and consumed via plugins for coding agents at [PostHog/ai-plugin](https://github.com/PostHog/ai-plugin).
+
+PostHog Code already consumes skills automatically.
+PostHog AI will consume the same set of skills.
+
+Product teams don't need to handle distribution —
+the pipeline and CI take care of it.
+
+## Writing effective skills
+
+The context window is a shared resource.
+Your skill competes with the system prompt, conversation history, other skills, and the user's request.
+
+**Default assumption:** the agent is already very smart.
+Only include context it doesn't already have.
+Challenge each piece of information: does the agent really need this explanation?
+
+See [Anthropic's full best practices guide](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+for detailed advice on progressive disclosure, feedback loops, workflows, and evaluation-driven development.


### PR DESCRIPTION
## Problem

Engineers adding new MCP tools or writing agent skills don't have a clear guide to follow. This leads to inconsistent implementations and repeated questions about conventions.

## Changes

- Add `implementing-mcp-tools` skill and full handbook doc covering the pipeline from Django serializer to generated TypeScript tool handler
- Add `writing-skills` skill and full handbook doc covering how to write job-to-be-done templates for agents
- Skills provide quick-reference checklists; handbook docs provide the full guide with examples

## How did you test this code?

Documentation-only change. Verified markdown renders correctly and links between docs are consistent.

## Publish to changelog?

No