### PR TITLE
fix: make pgbouncer server login error retriable

### DIFF
--- a/nodejs/src/utils/db/postgres.ts
+++ b/nodejs/src/utils/db/postgres.ts
@@ -1,5 +1,5 @@
 // Postgres
-import { Client, DatabaseError, Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
+import { Client, Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
 
 import { withSpan } from '~/common/tracing/tracing-utils'
 
@@ -167,9 +167,7 @@ export class PostgresRouter {
                 await client.query('ROLLBACK')
 
                 // if Postgres is down the ROLLBACK above won't work, but the transaction shouldn't be committed either
-                if (e.message && POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => e.message.includes(message))) {
-                    handlePostgresUnavailableError(e, usage)
-                }
+                handlePostgresError(e, usage)
 
                 throw e
             } finally {
@@ -215,12 +213,7 @@ function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
         try {
             return await client.query(queryConfig, values)
         } catch (error) {
-            if (
-                error.message &&
-                POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => error.message.includes(message))
-            ) {
-                handlePostgresUnavailableError(error, databaseUse)
-            }
+            handlePostgresError(error, databaseUse)
 
             logger[queryFailureLogLevel]('🔴', 'Postgres query error', {
                 query: queryConfig.text,
@@ -232,17 +225,13 @@ function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
     })
 }
 
-function handlePostgresUnavailableError(error: DatabaseError, databaseUse: PostgresUse) {
-    const databaseUseLabel = PostgresUse[databaseUse]
-    let errorType = 'other'
-
-    const matchedError = POSTGRES_UNAVAILABLE_ERROR_MESSAGES.find((message) => error.message.includes(message))
-    if (matchedError) {
-        errorType = matchedError
-    } else if (error.code) {
-        errorType = error.code
+/** Throws retriable DependencyUnavailableError for transient PG/PgBouncer errors, does nothing otherwise. */
+export function handlePostgresError(error: Error, databaseUse: PostgresUse): void {
+    const matchedMessage = POSTGRES_UNAVAILABLE_ERROR_MESSAGES.find((msg) => error.message?.includes(msg))
+    if (!matchedMessage) {
+        return
     }
 
-    postgresErrorCounter.inc({ error_type: errorType, database_use: databaseUseLabel })
+    postgresErrorCounter.inc({ error_type: matchedMessage, database_use: PostgresUse[databaseUse] })
     throw new DependencyUnavailableError(error.message, 'Postgres', error)
 }

--- a/nodejs/src/utils/db/postgres.ts
+++ b/nodejs/src/utils/db/postgres.ts
@@ -21,6 +21,7 @@ const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'ECONNREFUSED',
     'ETIMEDOUT',
     'query_wait_timeout', // Waiting on PG bouncer to give us a slot
+    'server login has been failing', // PgBouncer cannot authenticate with upstream PG
 ]
 
 export enum PostgresUse {

--- a/nodejs/tests/utils/db/postgres.test.ts
+++ b/nodejs/tests/utils/db/postgres.test.ts
@@ -1,0 +1,34 @@
+import { DependencyUnavailableError } from '../../../src/utils/db/error'
+import { PostgresUse, handlePostgresError } from '../../../src/utils/db/postgres'
+
+describe('handlePostgresError', () => {
+    it.each([
+        ['connection to server at "pg:5432" refused'],
+        ['could not translate host name "pg" to address'],
+        ['server conn crashed'],
+        ['no more connections allowed (max_client_conn)'],
+        ['server closed the connection unexpectedly'],
+        ['getaddrinfo EAI_AGAIN pg'],
+        ['Connection terminated unexpectedly'],
+        ['connect ECONNREFUSED 127.0.0.1:5432'],
+        ['connect ETIMEDOUT 10.0.0.1:5432'],
+        ['query_wait_timeout'],
+        ['server login has been failing, try again later (server_login_retry)'],
+    ])('throws retriable DependencyUnavailableError for "%s"', (message) => {
+        try {
+            handlePostgresError(new Error(message), PostgresUse.COMMON_WRITE)
+            fail('expected to throw')
+        } catch (e) {
+            expect(e).toBeInstanceOf(DependencyUnavailableError)
+            expect((e as DependencyUnavailableError).isRetriable).toBe(true)
+        }
+    })
+
+    it.each([
+        ['duplicate key value violates unique constraint'],
+        ['relation "table" does not exist'],
+        ['syntax error at or near "SELECT"'],
+    ])('does not throw for non-transient error "%s"', (message) => {
+        expect(() => handlePostgresError(new Error(message), PostgresUse.COMMON_WRITE)).not.toThrow()
+    })
+})


### PR DESCRIPTION
## Problem

We're DLQ-ing messages that get `server login has been failing` instead of retrying them.

## Changes

Adds the error to the `POSTGRES_UNAVAILABLE_ERROR_MESSAGES` list, making it retriable.

## How did you test this code?

Added a test for the error mapping function.