### PR TITLE
chore(pipelines): Add disclaimer text

### DIFF
--- a/frontend/src/scenes/data-warehouse/FreeHistoricalSyncsBanner.tsx
+++ b/frontend/src/scenes/data-warehouse/FreeHistoricalSyncsBanner.tsx
@@ -18,7 +18,8 @@ export function FreeHistoricalSyncsBanner({ hideGetStarted }: { hideGetStarted?:
                 <div className="flex flex-col gap-1.5">
                     <div className="flex items-center gap-2">
                         <span className="text-sm">
-                            Sync all your historical data from any new source for free during the first 7 days
+                            Sync all your historical data from any new source for free during the first 7 days (100M
+                            rows limit for the free plan)
                         </span>
 
                         <LemonButton


### PR DESCRIPTION
## Problem

The message was clearly telling users it was free, unless they clicked `Learn more`. Free users might expect it to be free as well, since there is no disclaimer telling them otherwise.

## Changes

- New message still fits nicely 
<img width="918" height="326" alt="image" src="https://github.com/user-attachments/assets/d982c6ad-dc76-4ef9-94dd-f0b55cf67915" />


## How did you test this code?

Reloaded the page with the new copy.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no
