### PR TITLE
fix(exports): use EXPORT limit context for PNG image exports

### DIFF
--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -52,6 +52,7 @@ def calculate_for_query_based_insight(
     filters_override: Optional[dict] = None,
     variables_override: Optional[dict] = None,
     tile_filters_override: Optional[dict] = None,
+    limit_context: LimitContext = LimitContext.QUERY_ASYNC,
 ) -> "InsightResult":
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
     from posthog.caching.insight_cache import update_cached_state
@@ -82,8 +83,7 @@ def calculate_for_query_based_insight(
         user=user,
         insight_id=insight.pk,
         dashboard_id=dashboard.pk if dashboard else None,
-        # QUERY_ASYNC provides extended max execution time for insight queries
-        limit_context=LimitContext.QUERY_ASYNC,
+        limit_context=limit_context,
     )
 
     if isinstance(process_response, BaseModel):

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -23,6 +23,8 @@ from webdriver_manager.core.os_manager import ChromeType
 
 from posthog.schema import FunnelLayout, NodeKind
 
+from posthog.hogql.constants import LimitContext
+
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.exceptions_capture import capture_exception
@@ -444,6 +446,7 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
                         user=None,
                         variables_override=dashboard_variables,
                         tile_filters_override=tile_filters_override,
+                        limit_context=LimitContext.EXPORT,
                     )
                     if result.cache_key:
                         insight_cache_keys[exported_asset.insight.id] = result.cache_key
@@ -476,6 +479,7 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
                             user=None,
                             variables_override=dashboard_variables,
                             tile_filters_override=tile.filters_overrides,
+                            limit_context=LimitContext.EXPORT,
                         )
                         if result.cache_key:
                             insight_cache_keys[insight.id] = result.cache_key

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -7,6 +7,8 @@ from unittest.mock import mock_open, patch
 from boto3 import resource
 from botocore.client import Config
 
+from posthog.hogql.constants import LimitContext
+
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.fetch_from_cache import InsightResult
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -312,3 +314,76 @@ class TestImageExporter(APIBaseTest):
             assert call_kwargs["tile_filters_override"] == tile_filters, (
                 "tile_filters_override should match tile filters"
             )
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
+    def test_export_uses_export_limit_context_for_all_breakdowns(
+        self,
+        mock_calculate: Any,
+        *args: Any,
+    ) -> None:
+        mock_calculate.return_value = make_insight_result("test_key")
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Breakdown Insight",
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                "breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"},
+            },
+        )
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+        )
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(exported_asset)
+
+        assert mock_calculate.call_count == 1
+        call_kwargs = mock_calculate.call_args[1]
+        assert call_kwargs["limit_context"] == LimitContext.EXPORT, (
+            f"Image export should use EXPORT limit context for higher breakdown limits, got {call_kwargs['limit_context']}"
+        )
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
+    def test_dashboard_export_uses_export_limit_context(
+        self,
+        mock_calculate: Any,
+        *args: Any,
+    ) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Dashboard Insight",
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                "breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"},
+            },
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        dashboard_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            dashboard=dashboard,
+        )
+
+        mock_calculate.return_value = make_insight_result("test_key")
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(dashboard_asset)
+
+        assert mock_calculate.call_count == 1
+        call_kwargs = mock_calculate.call_args[1]
+        assert call_kwargs["limit_context"] == LimitContext.EXPORT, (
+            f"Dashboard image export should use EXPORT limit context, got {call_kwargs['limit_context']}"
+        )


### PR DESCRIPTION
## Problem

PNG exports were using LimitContext.QUERY_ASYNC which defaults to 25 breakdowns. This meant insights with many breakdowns would be truncated in exported images. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Now uses LimitContext.EXPORT (matching CSV exports) which allows up to 512 breakdowns.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
