### PR TITLE
perf(batch-exports): Make 'limited' persons batch export query more efficient

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -58,6 +58,7 @@ from products.batch_exports.backend.temporal.sql import (
     EXPORT_TO_S3_FROM_EVENTS_WORKFLOWS,
     EXPORT_TO_S3_FROM_PERSONS,
     EXPORT_TO_S3_FROM_PERSONS_BACKFILL,
+    EXPORT_TO_S3_FROM_PERSONS_LIMITED,
     get_s3_function_call,
 )
 from products.batch_exports.backend.temporal.utils import set_status_to_running_task
@@ -334,23 +335,11 @@ async def _get_query(
             query_template = EXPORT_TO_S3_FROM_PERSONS_BACKFILL
             query = query_template.safe_substitute(s3_function=s3_function)
         else:
-            query_template = EXPORT_TO_S3_FROM_PERSONS
             if str(team_id) in settings.BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS:
-                filter_distinct_ids = """
-                HAVING
-                    (
-                        _timestamp >= {interval_start}::DateTime64
-                    )
-                    AND (
-                        _timestamp < {interval_end}::DateTime64
-                    )
-                """
+                query_template = EXPORT_TO_S3_FROM_PERSONS_LIMITED
             else:
-                filter_distinct_ids = ""
-            query = query_template.safe_substitute(
-                s3_function=s3_function,
-                filter_distinct_ids=filter_distinct_ids,
-            )
+                query_template = EXPORT_TO_S3_FROM_PERSONS
+            query = query_template.safe_substitute(s3_function=s3_function)
     else:
         if parameters.get("exclude_events", None):
             parameters["exclude_events"] = list(parameters["exclude_events"])

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -978,30 +978,7 @@ SELECT
     persons._inserted_at AS _inserted_at,
     persons.is_deleted AS is_deleted
 FROM (
-    WITH new_persons AS (
-        SELECT
-            id
-        FROM
-            person
-        WHERE
-            team_id = {team_id}::Int64
-            AND id in (
-                SELECT
-                    id
-                FROM
-                    person
-                WHERE
-                    team_id = {team_id}::Int64
-                    AND _timestamp >= {interval_start}::DateTime64
-                    AND _timestamp < {interval_end}::DateTime64
-            )
-        GROUP BY
-            id
-        HAVING
-            argMax(_timestamp, person.version) >= {interval_start}::DateTime64
-            AND argMax(_timestamp, person.version) < {interval_end}::DateTime64
-    ),
-    distinct_ids AS (
+    WITH distinct_ids AS (
         SELECT
             distinct_id
         FROM

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -898,7 +898,147 @@ FROM (
             AND distinct_id IN distinct_ids
         GROUP BY
             distinct_id
-        $filter_distinct_ids
+    ),
+    latest_person_versions AS (
+        SELECT
+            id,
+            max(version) AS version,
+            max(_timestamp) AS _timestamp
+        FROM
+            person
+        WHERE
+            team_id = {team_id}::Int64
+            AND
+            id IN (
+                SELECT
+                    DISTINCT person_id2
+                FROM
+                    latest_distinct_ids
+            )
+        GROUP BY
+            id
+    )
+    SELECT
+        p.team_id AS team_id,
+        pd.distinct_id AS distinct_id,
+        toString(pd.person_id2) AS person_id,
+        p.version AS person_version,
+        pd.version AS person_distinct_id_version,
+        p.properties AS properties,
+        p.created_at AS created_at,
+        toBool(p.is_deleted) AS is_deleted,
+        multiIf(
+            (
+                pd._timestamp >= {interval_start}::DateTime64
+                AND pd._timestamp < {interval_end}::DateTime64
+            )
+            AND NOT (
+                p._timestamp >= {interval_start}::DateTime64
+                AND p._timestamp < {interval_end}::DateTime64
+            ),
+            pd._timestamp,
+            (
+                p._timestamp >= {interval_start}::DateTime64
+                AND p._timestamp < {interval_end}::DateTime64
+            )
+            AND NOT (
+                pd._timestamp >= {interval_start}::DateTime64
+                AND pd._timestamp < {interval_end}::DateTime64
+            ),
+            p._timestamp,
+            least(p._timestamp, pd._timestamp)
+        ) AS _inserted_at
+    FROM
+        person p
+        INNER JOIN latest_distinct_ids pd
+            ON p.id = pd.person_id2
+    WHERE
+        p.team_id = {team_id}::Int64
+        AND (p.id, p.version, p._timestamp) in latest_person_versions
+) AS persons
+SETTINGS
+    max_bytes_before_external_group_by=50000000000,
+    max_bytes_before_external_sort=50000000000,
+    optimize_aggregation_in_order=1,
+    log_comment={log_comment}
+""")
+
+# Limited export variant: only exports distinct_ids that were themselves created/updated in the
+# interval, omitting the UNION that fetches existing distinct_ids for updated persons.
+EXPORT_TO_S3_FROM_PERSONS_LIMITED = Template("""
+INSERT INTO FUNCTION $s3_function
+SELECT
+    persons.team_id AS team_id,
+    persons.distinct_id AS distinct_id,
+    persons.person_id AS person_id,
+    persons.properties AS properties,
+    persons.person_distinct_id_version AS person_distinct_id_version,
+    persons.person_version AS person_version,
+    persons.created_at AS created_at,
+    persons._inserted_at AS _inserted_at,
+    persons.is_deleted AS is_deleted
+FROM (
+    WITH new_persons AS (
+        SELECT
+            id
+        FROM
+            person
+        WHERE
+            team_id = {team_id}::Int64
+            AND id in (
+                SELECT
+                    id
+                FROM
+                    person
+                WHERE
+                    team_id = {team_id}::Int64
+                    AND _timestamp >= {interval_start}::DateTime64
+                    AND _timestamp < {interval_end}::DateTime64
+            )
+        GROUP BY
+            id
+        HAVING
+            argMax(_timestamp, person.version) >= {interval_start}::DateTime64
+            AND argMax(_timestamp, person.version) < {interval_end}::DateTime64
+    ),
+    distinct_ids AS (
+        SELECT
+            distinct_id
+        FROM
+            person_distinct_id2
+        WHERE
+            team_id = {team_id}::Int64
+            AND distinct_id in (
+                SELECT
+                    distinct_id
+                FROM
+                    person_distinct_id2
+                WHERE
+                    team_id = {team_id}::Int64
+                    AND _timestamp >= {interval_start}::DateTime64
+                    AND _timestamp < {interval_end}::DateTime64
+            )
+        GROUP BY
+            distinct_id
+        HAVING
+            argMax(_timestamp, person_distinct_id2.version) >= {interval_start}::DateTime64
+            AND argMax(_timestamp, person_distinct_id2.version) < {interval_end}::DateTime64
+
+        -- no UNION DISTINCT here
+    ),
+    latest_distinct_ids AS (
+        SELECT
+            distinct_id,
+            argMax(person_id, person_distinct_id2.version) AS person_id2,
+            max(version) AS version,
+            argMax(_timestamp, person_distinct_id2.version) AS _timestamp
+        FROM
+            person_distinct_id2
+        WHERE
+            team_id = {team_id}::Int64
+            AND distinct_id IN distinct_ids
+        GROUP BY
+            distinct_id
     ),
     latest_person_versions AS (
         SELECT


### PR DESCRIPTION
## Problem

We have a 'limited data' mode for persons batch export where we don't export all changes; we only export distinct ids that have changed within the interval (and not all distinct ids for person versions that have been updated, as we do for the regular export).

The query that does this is actually more expensive than the regular query, as it is also identical, with the addition of an extra `HAVING` clause.

## Changes

The query can actually be made simpler than the regular persons batch export query: we can simply remove the

```sql
        UNION DISTINCT
        -- existing distinct_ids for new/updated persons
        SELECT
            DISTINCT distinct_id
        FROM
            person_distinct_id2
        WHERE
            team_id = {team_id}::Int64
            AND person_id IN new_persons
```

from the `distinct_ids` CTE.

I wasn't sure the best way to do this. In the end I created a separate `EXPORT_TO_S3_FROM_PERSONS_LIMITED` query, which is identical to the `EXPORT_TO_S3_FROM_PERSONS` query, minus the above `UNION`. I did think about extracting this `UNION` into a variable and inserting into the query conditionally, but wasn't sure it was worth making the query harder to read for the most common case.

## How did you test this code?

- Existing unit tests in `products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py`
- Also ran some queries against production to ensure the results with both old and new versions of the query return the same results
    - in the test I used, the old query consumed 7.3GB of memory, while the new one only used 691MB

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.
