### PR TITLE
feat(dashboards): move the share button for dashboards to the Actions Panel

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -12,7 +12,6 @@ import {
     IconPencil,
     IconPlusSmall,
     IconScreen,
-    IconShare,
     IconTrash,
 } from '@posthog/icons'
 
@@ -28,6 +27,7 @@ import { SceneFile } from 'lib/components/Scenes/SceneFile'
 import { SceneFullscreen } from 'lib/components/Scenes/SceneFullscreen'
 import { SceneMetalyticsSummaryButton } from 'lib/components/Scenes/SceneMetalyticsSummaryButton'
 import { ScenePin } from 'lib/components/Scenes/ScenePin'
+import { SceneShareButton } from 'lib/components/Scenes/SceneShareButton'
 import { SceneSubscribeButton } from 'lib/components/Scenes/SceneSubscribeButton'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
@@ -230,6 +230,13 @@ export function DashboardHeader(): JSX.Element | null {
                 <ScenePanelActionsSection>
                     {dashboard && (
                         <>
+                            <SceneShareButton
+                                dataAttrKey={RESOURCE_TYPE}
+                                buttonProps={{
+                                    menuItem: true,
+                                    onClick: () => push(urls.dashboardSharing(dashboard.id)),
+                                }}
+                            />
                             <SceneDuplicate
                                 dataAttrKey={RESOURCE_TYPE}
                                 onClick={() => showDuplicateDashboardModal(dashboard.id, dashboard.name)}
@@ -533,15 +540,6 @@ export function DashboardHeader(): JSX.Element | null {
                             <>
                                 {dashboard && (
                                     <>
-                                        <LemonButton
-                                            type="secondary"
-                                            data-attr="dashboard-share-button"
-                                            onClick={() => push(urls.dashboardSharing(dashboard.id))}
-                                            size="small"
-                                            icon={<IconShare fontSize="16" />}
-                                            tooltip="Share"
-                                            tooltipPlacement="top"
-                                        />
                                         {canEditDashboard && hasTileRedesign && (
                                             <LemonButton
                                                 type="secondary"


### PR DESCRIPTION
## Problem

When trying to share dashboards, I expect to see it with the rest of the action buttons that are connected to dashboards.

At the moment, it currently sits by itself separately, which is confusing for new users. It also is only an icon without text.

## Changes

Moves the share button from the top, to the sidebar.

Before:
<img width="897" height="681" alt="image" src="https://github.com/user-attachments/assets/d4f7ec5e-473a-40bd-a2f7-29233037ac38" />


After:
<img width="1279" height="612" alt="image" src="https://github.com/user-attachments/assets/ee2a29e5-4732-4083-b99c-30c77796ea19" />


## How did you test this code?
Locally.