### PR TITLE
chore(ph-ai): skip throttling on research mode for team 2

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -32,6 +32,7 @@ from posthog.rate_limit import (
     AIResearchBurstRateThrottle,
     AIResearchSustainedRateThrottle,
     AISustainedRateThrottle,
+    is_team_exempt_from_ai_rate_limit,
 )
 from posthog.temporal.ai.chat_agent import (
     CHAT_AGENT_STREAM_MAX_LENGTH,
@@ -256,6 +257,8 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         is_research = self._is_research_request(request)
 
         if is_research:
+            if is_team_exempt_from_ai_rate_limit(self.team_id):
+                return
             throttles = [AIResearchBurstRateThrottle(), AIResearchSustainedRateThrottle()]
         else:
             # Skip throttling for paying customers

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -705,6 +705,34 @@ class TestConversation(APIBaseTest):
                 self.assertIn("Research mode", response_data["detail"])
 
     @override_settings(DEBUG=False)
+    @patch("posthog.utils.get_instance_region", return_value="US")
+    def test_research_rate_limit_exempt_team_bypasses_throttle(self, _mock_region):
+        """Test that teams listed in the posthog-ai-rate-limit-exemptions flag bypass research rate limits."""
+        with patch(
+            "posthoganalytics.get_feature_flag_payload",
+            return_value={"US": [self.team.id]},
+        ):
+            with patch(
+                "ee.hogai.core.executor.AgentExecutor.astream",
+                return_value=_async_generator(),
+            ):
+                with patch(
+                    "ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response
+                ):
+                    # Should exceed the 3/minute burst limit without being throttled
+                    for i in range(5):
+                        response = self.client.post(
+                            f"/api/environments/{self.team.id}/conversations/",
+                            {
+                                "content": f"test query {i}",
+                                "trace_id": str(uuid.uuid4()),
+                                "conversation": str(uuid.uuid4()),
+                                "agent_mode": AgentMode.RESEARCH.value,
+                            },
+                        )
+                        self.assertEqual(response.status_code, status.HTTP_200_OK, f"Request {i} should succeed")
+
+    @override_settings(DEBUG=False)
     def test_normal_ai_has_standard_rate_limits(self):
         """Test that normal AI conversations have standard rate limits (10/minute)."""
         with patch(

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1,4 +1,5 @@
 import re
+import json
 import time
 import hashlib
 from contextlib import suppress
@@ -395,6 +396,32 @@ class AIResearchSustainedRateThrottle(_AIThrottleBase):
     scope = "ai_research_sustained"
     rate = "10/day"
     action_name = "ai research sustained rate limited"
+
+
+def is_team_exempt_from_ai_rate_limit(team_id: int) -> bool:
+    """Check if a team is exempt from AI rate limits via the posthog-ai-rate-limit-exemptions feature flag."""
+    import posthoganalytics
+
+    from posthog.utils import get_instance_region
+
+    region = get_instance_region()
+    if not region:
+        return False
+
+    raw_payload = posthoganalytics.get_feature_flag_payload("posthog-ai-rate-limit-exemptions", "internal_rate_limits")
+    if raw_payload is None:
+        return False
+
+    try:
+        payload = json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+    if not isinstance(payload, dict):
+        return False
+
+    exempt_team_ids = payload.get(region, [])
+    return team_id in exempt_team_ids
 
 
 class LLMProxyBurstRateThrottle(UserRateThrottle):


### PR DESCRIPTION
Let's bypass throttling on `research` mode just for team 2 in `us` for now.
Re-used [this FF](https://us.posthog.com/project/2/feature_flags/249322).