### PR TITLE
feat: add search to user-facing feature previews

### DIFF
--- a/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
@@ -2,7 +2,7 @@ import { useActions, useAsyncActions, useValues } from 'kea'
 import { useLayoutEffect, useState } from 'react'
 
 import { IconBell, IconCheck } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonSwitch, LemonTextArea, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonInput, LemonSwitch, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { BasicCard } from 'lib/components/Cards/BasicCard'
 import { IconLink } from 'lib/lemon-ui/icons'
@@ -16,13 +16,15 @@ const hasPosthogJsFailedToLoadFeaturePreviews = (): boolean => !!window.POSTHOG_
 // Feature previews can be linked to by using hash in the url
 // example external link: https://app.posthog.com/settings/user-feature-previews#llm-analytics
 export function FeaturePreviews(): JSX.Element {
-    const { earlyAccessFeatures, rawEarlyAccessFeaturesLoading } = useValues(featurePreviewsLogic)
-    const { loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
+    const { filteredEarlyAccessFeatures, rawEarlyAccessFeaturesLoading, searchTerm } = useValues(featurePreviewsLogic)
+    const { loadEarlyAccessFeatures, setSearchTerm } = useActions(featurePreviewsLogic)
 
     useLayoutEffect(() => loadEarlyAccessFeatures(), [loadEarlyAccessFeatures])
 
-    const betaFeatures = earlyAccessFeatures.filter((f) => f.stage === 'beta')
-    const failedToLoadFeaturePreviews = earlyAccessFeatures.length === 0 && hasPosthogJsFailedToLoadFeaturePreviews()
+    const betaFeatures = filteredEarlyAccessFeatures.filter((f) => f.stage === 'beta')
+    const shouldShowEmptyState =
+        filteredEarlyAccessFeatures.length === 0 && !rawEarlyAccessFeaturesLoading && !searchTerm
+    const failedToLoadFeaturePreviews = shouldShowEmptyState && hasPosthogJsFailedToLoadFeaturePreviews()
 
     return (
         <div className="flex flex-col gap-2">
@@ -47,23 +49,38 @@ export function FeaturePreviews(): JSX.Element {
             {rawEarlyAccessFeaturesLoading ? (
                 <SpinnerOverlay />
             ) : (
-                betaFeatures.map((feature) => (
-                    <div key={feature.flagKey}>
-                        <FeaturePreview feature={feature} />
-                    </div>
-                ))
+                <>
+                    {!shouldShowEmptyState && (
+                        <LemonInput
+                            type="search"
+                            placeholder="Search feature previews..."
+                            value={searchTerm}
+                            onChange={setSearchTerm}
+                            allowClear
+                        />
+                    )}
+                    {betaFeatures.length === 0 && searchTerm.trim() ? (
+                        <p className="text-secondary text-center mt-4">No matching feature previews</p>
+                    ) : (
+                        betaFeatures.map((feature) => (
+                            <div key={feature.flagKey}>
+                                <FeaturePreview feature={feature} />
+                            </div>
+                        ))
+                    )}
+                </>
             )}
         </div>
     )
 }
 
 export function FeaturePreviewsComingSoon(): JSX.Element {
-    const { earlyAccessFeatures, rawEarlyAccessFeaturesLoading } = useValues(featurePreviewsLogic)
+    const { filteredEarlyAccessFeatures, rawEarlyAccessFeaturesLoading } = useValues(featurePreviewsLogic)
     const { loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
 
     useLayoutEffect(() => loadEarlyAccessFeatures(), [loadEarlyAccessFeatures])
 
-    const conceptFeatures = earlyAccessFeatures.filter((f) => f.stage === 'concept')
+    const conceptFeatures = filteredEarlyAccessFeatures.filter((f) => f.stage === 'concept')
 
     return (
         <div className="flex flex-col gap-2">

--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
@@ -7,6 +7,7 @@ import { FeatureFlagKey } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { createFeaturePreviewSearch } from 'lib/utils/fuseSearch'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -21,6 +22,8 @@ export interface EnrichedEarlyAccessFeature extends Omit<EarlyAccessFeature, 'fl
     payload: Record<string, any> | undefined
 }
 
+const search = createFeaturePreviewSearch<EnrichedEarlyAccessFeature>()
+
 export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
     path(['layout', 'FeaturePreviews', 'featurePreviewsLogic']),
     connect(() => ({
@@ -28,6 +31,7 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
         actions: [supportLogic, ['submitZendeskTicket'], teamLogic, ['addProductIntentForCrossSell']],
     })),
     actions({
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         updateEarlyAccessFeatureEnrollment: (flagKey: string, enabled: boolean, stage?: string) => ({
             flagKey,
             enabled,
@@ -74,6 +78,12 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
         ],
     })),
     reducers({
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+            },
+        ],
         activeFeedbackFlagKey: {
             beginEarlyAccessFeatureFeedback: (_, { flagKey }) => flagKey,
             cancelEarlyAccessFeatureFeedback: () => null,
@@ -136,6 +146,13 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
                     })
 
                 return result
+            },
+        ],
+
+        filteredEarlyAccessFeatures: [
+            (s) => [s.earlyAccessFeatures, s.searchTerm],
+            (earlyAccessFeatures: EnrichedEarlyAccessFeature[], searchTerm: string): EnrichedEarlyAccessFeature[] => {
+                return search(earlyAccessFeatures, searchTerm)
             },
         ],
     }),

--- a/frontend/src/lib/utils/fuseSearch.ts
+++ b/frontend/src/lib/utils/fuseSearch.ts
@@ -1,0 +1,20 @@
+import FuseClass from 'fuse.js'
+
+export type FuseSearch<T> = (items: T[], term: string) => T[]
+
+export function createFuseSearch<T>(keys: (keyof T & string)[], threshold = 0.3): FuseSearch<T> {
+    const fuse = new FuseClass<T>([], { keys, threshold })
+    return (items: T[], term: string): T[] => {
+        if (!term.trim()) {
+            return items
+        }
+        fuse.setCollection(items)
+        return fuse.search(term).map((r) => r.item)
+    }
+}
+
+export function createFeaturePreviewSearch<
+    T extends { name: string; description: string; stage: string },
+>(): FuseSearch<T> {
+    return createFuseSearch<T>(['name', 'description', 'stage'])
+}

--- a/products/early_access_features/frontend/earlyAccessFeaturesLogic.ts
+++ b/products/early_access_features/frontend/earlyAccessFeaturesLogic.ts
@@ -1,19 +1,15 @@
-import FuseClass from 'fuse.js'
 import { actions, afterMount, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
+import { createFeaturePreviewSearch } from 'lib/utils/fuseSearch'
 import { urls } from 'scenes/urls'
 
 import { Breadcrumb, EarlyAccessFeatureType } from '~/types'
 
 import type { earlyAccessFeaturesLogicType } from './earlyAccessFeaturesLogicType'
 
-export const earlyAccessFeaturesFuse = new FuseClass<EarlyAccessFeatureType>([], {
-    keys: ['name', 'description', 'stage'],
-    threshold: 0.3,
-})
+const search = createFeaturePreviewSearch<EarlyAccessFeatureType>()
 
 export const earlyAccessFeaturesLogic = kea<earlyAccessFeaturesLogicType>([
     path(['products', 'earlyAccessFeatures', 'frontend', 'earlyAccessFeaturesLogic']),
@@ -57,20 +53,9 @@ export const earlyAccessFeaturesLogic = kea<earlyAccessFeaturesLogicType>([
         filteredEarlyAccessFeatures: [
             (s) => [s.earlyAccessFeatures, s.searchTerm],
             (earlyAccessFeatures: EarlyAccessFeatureType[], searchTerm: string): EarlyAccessFeatureType[] => {
-                if (!searchTerm.trim()) {
-                    return earlyAccessFeatures
-                }
-
-                const results = earlyAccessFeaturesFuse.search(searchTerm)
-                return results.map((result) => result.item)
+                return search(earlyAccessFeatures, searchTerm)
             },
         ],
-    }),
-
-    subscriptions({
-        earlyAccessFeatures: (earlyAccessFeatures: EarlyAccessFeatureType[]) => {
-            earlyAccessFeaturesFuse.setCollection(earlyAccessFeatures || [])
-        },
     }),
 
     afterMount(({ actions }) => {


### PR DESCRIPTION
## Problem

The user-facing feature previews page (`/settings/user-feature-previews`) has no search, making it harder to find specific features as more get added.

<img width="917" height="685" alt="Screenshot 2026-03-03 at 17 37 52" src="https://github.com/user-attachments/assets/ff5319fd-28f5-476d-82fb-0bc918a1c3a4" />


## Changes

- Extracted a generic `createFuseSearch` utility and a `createFeaturePreviewSearch` specialization into `lib/utils/fuseSearch.ts`
- Refactored the admin early access features logic to use the shared utility instead of a manual Fuse instance
- Added search term state and filtered selector to `featurePreviewsLogic`
- Added a `LemonInput` search bar to the feature previews page that filters both beta and coming soon tabs

<img width="778" height="732" alt="image" src="https://github.com/user-attachments/assets/ddd3a80a-1fbd-467c-b2c8-793585d86e97" />


## How did you test this code?

- Existing `featurePreviewsLogic` tests pass
- Manual: search filters both beta and coming soon sections on `/settings/user-feature-previews`

## Publish to changelog?

No