### PR TITLE
fix: dragging tiles when browser is at half width

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -96,7 +96,7 @@ export function DashboardItems(): JSX.Element {
                     width={gridWrapperWidth}
                     className={className}
                     draggableHandle=".CardMeta,.TextCard__body"
-                    isDraggable={dashboardMode === DashboardMode.Edit && !isMobileView}
+                    isDraggable={dashboardMode === DashboardMode.Edit}
                     isResizable={dashboardMode === DashboardMode.Edit && !isMobileView}
                     layouts={layouts}
                     rowHeight={80}


### PR DESCRIPTION
## Problem

When the browser is at half width we remove the ability to drag and resize  tiles on a dashboard. 

## Changes

removed the check for dragging but kept resizing.

## How did you test this code?

locally 

## Publish to changelog?

no 
