### PR TITLE
fix(rust): local dev macOS build caching

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -65,6 +65,7 @@ OPENSSL_INCLUDE_DIR = "$FLOX_ENV/include"
 LDFLAGS="-L$FLOX_ENV/lib"
 CPPFLAGS="-I$FLOX_ENV/include"
 UV_PROJECT_ENVIRONMENT = "$FLOX_ENV_CACHE/venv"
+RUSTC_WRAPPER = "sccache"
 
 # The `hook.on-activate` script is run by the *bash* shell immediately upon
 # activating an environment, and will not be invoked if Flox detects that the

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -225,6 +225,22 @@ else
   warn_step "Environment vars  ${C_DIM}(.env not found)${C_RESET}"
 fi
 
+# ── Step 5: Rust toolchain check ───────────────────────────────────
+_flox_rustc_ver=$(rustc --version 2>/dev/null | awk '{print $2}')
+_rustup_rustc="$HOME/.cargo/bin/rustc"
+if [[ -x "$_rustup_rustc" ]] && [[ -n "$_flox_rustc_ver" ]]; then
+  _rustup_rustc_ver=$("$_rustup_rustc" --version 2>/dev/null | awk '{print $2}')
+  if [[ -n "$_rustup_rustc_ver" ]] && [[ "$_flox_rustc_ver" != "$_rustup_rustc_ver" ]]; then
+    warn_step "Rust toolchain mismatch: flox has rustc ${_flox_rustc_ver}, rustup has ${_rustup_rustc_ver}"
+    echo -e "    ${C_DIM}Building outside flox will use a different compiler and invalidate the entire cargo cache.${C_RESET}"
+    echo -e "    ${C_DIM}Fix: ${C_BOLD}rustup toolchain remove stable${C_RESET}${C_DIM} or always build inside flox.${C_RESET}"
+  else
+    done_step "Rust toolchain (rustc ${_flox_rustc_ver})"
+  fi
+elif [[ -n "$_flox_rustc_ver" ]]; then
+  done_step "Rust toolchain (rustc ${_flox_rustc_ver})"
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────
 _activation_end=$(date +%s)
 _activation_time=$(( _activation_end - _activation_start ))

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,8 +1,18 @@
-[build]
 # Unlocks Tokio's unstable RuntimeMetrics API (per-worker poll counts, blocking pool stats, etc.).
 # Used by feature-flags/src/tokio_monitor.rs — no other crate calls unstable APIs.
-# Applies workspace-wide because Cargo doesn't support per-crate config within a workspace.
+#
+# Placed under [target.'cfg(all())'] instead of [build] so that target-specific
+# rustflags (like lld on macOS) can merge via Cargo's "all matching target entries
+# joined together" rule, rather than being silently ignored by [build].rustflags
+# which is mutually exclusive with target-level entries.
+# See: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+[target.'cfg(all())']
 rustflags = ["--cfg", "tokio_unstable"]
+
+# Use lld for linking on macOS dev builds. Flox provides lld (aarch64-darwin only).
+# clang's -fuse-ld=lld resolves to ld64.lld (Mach-O flavor) on macOS automatically.
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [env]
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -9,9 +9,10 @@
 [target.'cfg(all())']
 rustflags = ["--cfg", "tokio_unstable"]
 
-# Use lld for linking on macOS dev builds. Flox provides lld (aarch64-darwin only).
-# clang's -fuse-ld=lld resolves to ld64.lld (Mach-O flavor) on macOS automatically.
-[target.'cfg(target_os = "macos")']
+# Use lld for linking on Apple Silicon dev builds. Flox only installs lld for
+# aarch64-darwin, so we scope this to match. clang's -fuse-ld=lld resolves to
+# ld64.lld (Mach-O flavor) on macOS automatically.
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))']
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [env]


### PR DESCRIPTION
## Problem
Sometimes Claude gets sneaky and runs `cargo` or `rustc` without setting up Flox first. This is causing build cache thrashing when the local install is slightly different version than Flox's.

Another recent change to the global workspace config to support `tokio_unstable` has also caused cache thrashing on macOS.

Let's fix this stuff so Rust workspace builds are faster again
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Warn when local Rust install is used unintentionally in the workspace, and doesn't match Flox version
* Scope `tokio_unstable` rustflags for mac builds (bring in the right `lld`)
* Use `sccache` locally for `RUSTC_WRAPPER` (I'm on the fence about this, call out concerns pls)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Works On My Machine! ™️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
