### PR TITLE
feat(cli): promote dsym, hermes, and proguard to top-level commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # posthog-cli
 
+# 0.7.0
+
+- feat: promote dsym, hermes, and proguard commands from experimental to top-level
+- feat: keep backward-compat aliases under `exp` (hidden from help)
+
 # 0.6.2
 
 - fix: endpoints now save to YAML with proper newlines

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.6.2"
+version = "0.7.0"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -49,6 +49,24 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: SourcemapCommand,
     },
+
+    #[command(about = "Upload Apple dSYM debug symbol files to PostHog")]
+    Dsym {
+        #[command(subcommand)]
+        cmd: DsymSubcommand,
+    },
+
+    #[command(about = "Upload hermes sourcemaps to PostHog")]
+    Hermes {
+        #[command(subcommand)]
+        cmd: HermesSubcommand,
+    },
+
+    #[command(about = "Upload proguard mapping files to PostHog")]
+    Proguard {
+        #[command(subcommand)]
+        cmd: ProguardSubcommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -76,19 +94,20 @@ pub enum ExpCommand {
         cmd: EndpointCommand,
     },
 
-    #[command(about = "Upload hermes sourcemaps to PostHog")]
+    // TODO(sept 2026): remove these backward-compat aliases, they moved to top-level commands
+    #[command(about = "Upload hermes sourcemaps to PostHog", hide = true)]
     Hermes {
         #[command(subcommand)]
         cmd: HermesSubcommand,
     },
 
-    #[command(about = "Upload proguard mapping files to PostHog")]
+    #[command(about = "Upload proguard mapping files to PostHog", hide = true)]
     Proguard {
         #[command(subcommand)]
         cmd: ProguardSubcommand,
     },
 
-    #[command(about = "Upload iOS/macOS dSYM files to PostHog")]
+    #[command(about = "Upload iOS/macOS dSYM files to PostHog", hide = true)]
     Dsym {
         #[command(subcommand)]
         cmd: DsymSubcommand,
@@ -162,6 +181,27 @@ impl Cli {
                     crate::sourcemaps::plain::upload::upload(&upload)?;
                 }
             },
+            Commands::Dsym { cmd } => match cmd {
+                DsymSubcommand::Upload(args) => {
+                    crate::dsym::upload::upload(&args)?;
+                }
+            },
+            Commands::Hermes { cmd } => match cmd {
+                HermesSubcommand::Inject(args) => {
+                    crate::sourcemaps::hermes::inject::inject(&args)?;
+                }
+                HermesSubcommand::Upload(args) => {
+                    crate::sourcemaps::hermes::upload::upload(&args)?;
+                }
+                HermesSubcommand::Clone(args) => {
+                    crate::sourcemaps::hermes::clone::clone(&args)?;
+                }
+            },
+            Commands::Proguard { cmd } => match cmd {
+                ProguardSubcommand::Upload(args) => {
+                    crate::proguard::upload::upload(&args)?;
+                }
+            },
             Commands::Exp { cmd } => match cmd {
                 ExpCommand::Task {
                     cmd,
@@ -175,6 +215,7 @@ impl Cli {
                 ExpCommand::Endpoints { cmd } => {
                     cmd.run()?;
                 }
+                // TODO(sept 2026): remove these backward-compat aliases
                 ExpCommand::Hermes { cmd } => match cmd {
                     HermesSubcommand::Inject(args) => {
                         crate::sourcemaps::hermes::inject::inject(&args)?;


### PR DESCRIPTION
## Problem

The `dsym`, `hermes`, and `proguard` CLI commands are behind the `exp` (experimental) subcommand, making them harder to discover and use. These commands are stable enough to be promoted.

## Changes

- Moved `dsym`, `hermes`, and `proguard` from `posthog-cli exp <cmd>` to `posthog-cli <cmd>`
- Kept hidden backward-compat aliases under `exp` so existing scripts/docs continue to work
- Updated dSYM description from "iOS/macOS" to "Apple" to cover all Apple platforms
- Bumped version to 0.7.0

## How did you test this code?

- `cargo check` passes
- Verified both top-level and `exp` paths compile and route to the same handlers

## Publish to changelog?

no