### PR TITLE
fix(toolbar): handle percent-encoded hash and preserve URL fragment in OAuth redirect

### DIFF
--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -2,7 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
-import { OAUTH_LOCALSTORAGE_KEY } from '~/toolbar/utils'
+import { OAUTH_LOCALSTORAGE_KEY, PKCE_STORAGE_KEY } from '~/toolbar/utils'
 
 global.fetch = jest.fn(() =>
     Promise.resolve({
@@ -231,6 +231,43 @@ describe('toolbar toolbarConfigLogic', () => {
             // Only one fetch call (no refresh)
             expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1)
             expect(logic.values.accessToken).toBe('access-token')
+        })
+    })
+
+    describe('authorization code extraction and hash cleanup', () => {
+        let replaceStateSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            replaceStateSpy = jest.spyOn(window.history, 'replaceState').mockImplementation(() => {})
+            sessionStorage.setItem(PKCE_STORAGE_KEY, JSON.stringify({ verifier: 'test-verifier', ts: Date.now() }))
+        })
+
+        afterEach(() => {
+            replaceStateSpy.mockRestore()
+            sessionStorage.clear()
+            window.history.pushState({}, '', '/')
+        })
+
+        it.each([
+            ['toolbar-only hash is fully removed', '#__posthog_toolbar=code:abc,client_id:xyz', '/'],
+            [
+                'preserves original fragment before toolbar param',
+                '#section1&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#section1',
+            ],
+            [
+                'preserves multi-part original fragment',
+                '#/dashboard&tab=1&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#/dashboard&tab=1',
+            ],
+            ['handles percent-encoded delimiters', '#__posthog_toolbar=code%3Aabc%2Cclient_id%3Axyz', '/'],
+        ])('%s', (_label, hash, expectedUrl) => {
+            window.history.pushState({}, '', `/${hash}`)
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', expectedUrl)
         })
     })
 })

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -179,14 +179,22 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
     })),
 
     afterMount(({ props, values, actions }) => {
-        // Handle authorization code from redirect fallback (URL hash)
-        const hash = window.location.hash
+        // Handle authorization code from redirect fallback (URL hash).
+        // Decode the hash: browsers and proxies may percent-encode the fragment
+        // delimiters (: and ,), so the regex must run against the decoded string.
+        let hash: string
+        try {
+            hash = decodeURIComponent(window.location.hash)
+        } catch {
+            hash = window.location.hash
+        }
         const codeMatch = hash.match(/__posthog_toolbar=code:([^,]+),client_id:([^&#]+)/)
         if (codeMatch) {
-            const code = decodeURIComponent(codeMatch[1])
-            const clientId = decodeURIComponent(codeMatch[2])
+            const code = codeMatch[1]
+            const clientId = codeMatch[2]
             const cleanHash = hash
                 .replace(/__posthog_toolbar=[^&#]*/, '')
+                .replace(/&$/, '')
                 .replace(/^#&/, '#')
                 .replace(/^#$/, '')
             history.replaceState(null, '', location.pathname + location.search + (cleanHash || ''))

--- a/posthog/api/test/test_toolbar_oauth_primitives.py
+++ b/posthog/api/test/test_toolbar_oauth_primitives.py
@@ -666,10 +666,10 @@ class TestToolbarOAuthCallbackExchange(APIBaseTest):
         self.team.app_urls = ["https://example.com"]
         self.team.save()
 
-    def _authorize_and_get_state(self) -> str:
+    def _authorize_and_get_state(self, redirect_url: str = "https://example.com/page") -> str:
         response = self.client.get(
             "/toolbar_oauth/authorize/",
-            {"redirect": "https://example.com/page", "code_challenge": "test_challenge_value"},
+            {"redirect": redirect_url, "code_challenge": "test_challenge_value"},
         )
         assert response.status_code == 302
 
@@ -686,6 +686,14 @@ class TestToolbarOAuthCallbackExchange(APIBaseTest):
         assert redirect_url.startswith("https://example.com/page#")
         assert "__posthog_toolbar=code:auth_code_123" in redirect_url
         assert "client_id:" in redirect_url
+
+    def test_callback_preserves_original_url_fragment(self):
+        state = self._authorize_and_get_state(redirect_url="https://example.com/page#section1")
+        response = self.client.get(f"/toolbar_oauth/callback?code=auth_code_123&state={state}")
+
+        assert response.status_code == 302
+        redirect_url = response["Location"]
+        assert "#section1&__posthog_toolbar=code:auth_code_123" in redirect_url
 
     def test_callback_without_redirect_flow_relays_code_and_state(self):
         response = self.client.get("/toolbar_oauth/callback?code=test_code&state=test_state")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -1035,10 +1035,15 @@ def toolbar_oauth_callback(request):
         # validated against the team's app_urls allowlist by validate_and_consume_toolbar_oauth_state.
         app_url = state_payload["app_url"]
         parsed = urllib.parse.urlparse(app_url)
+        original_fragment = parsed.fragment
         base_url = urllib.parse.urlunparse(parsed._replace(fragment=""))
         quoted_code = urllib.parse.quote(code, safe="")
         quoted_client_id = urllib.parse.quote(oauth_app.client_id, safe="")
-        fragment = f"__posthog_toolbar=code:{quoted_code},client_id:{quoted_client_id}"
+        toolbar_param = f"__posthog_toolbar=code:{quoted_code},client_id:{quoted_client_id}"
+        if original_fragment:
+            fragment = f"{original_fragment}&{toolbar_param}"
+        else:
+            fragment = toolbar_param
         return redirect(f"{base_url}#{fragment}")  # nosemgrep: open-redirect
 
     # posthog-js flow: relay code/state for client-side exchange


### PR DESCRIPTION
## Problem

The toolbar OAuth redirect flow (introduced in #49579) fails on production because browsers and proxies percent-encode the `:` and `,` delimiters in the URL hash fragment (`%3A` and `%2C`). The frontend regex that extracts the authorization code never matches, so the code exchange silently fails and the toolbar params stay in the URL.

Additionally, the backend callback discards any original URL fragment (e.g. `#section1` from SPA routes), breaking hash-based routing for customers.

## Changes

**Frontend** ([toolbarConfigLogic.ts](frontend/src/toolbar/toolbarConfigLogic.ts)):
- Decode `window.location.hash` with `decodeURIComponent()` (with try/catch fallback) before running the regex
- Remove redundant inner `decodeURIComponent()` calls on the matched groups (already decoded)
- Fix trailing `&` in hash cleanup chain when original fragment precedes toolbar param

**Backend** ([user.py](posthog/api/user.py)):
- Preserve the original URL fragment from `app_url` through the OAuth redirect, appending the toolbar param with `&` separator

**Tests**:
- Parameterized frontend tests for hash cleanup covering: toolbar-only hash, preceding fragment, multi-part fragment, and percent-encoded delimiters
- Backend test for fragment preservation through the callback redirect

## How did you test this code?

- Frontend: `pnpm --filter=@posthog/frontend jest frontend/src/toolbar/toolbarConfigLogic.test.ts` — 15/15 tests pass including 4 new parameterized hash cleanup tests
- Backend: added `test_callback_preserves_original_url_fragment` to `TestToolbarOAuthCallbackExchange`

## Publish to changelog?

no