### PR TITLE
feat(dashboard): sync the search query in dashboards to query params

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { IconChevronDown, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
 import { LemonInput, Popover } from '@posthog/lemon-ui'
@@ -13,7 +14,11 @@ interface DashboardsFiltersBarProps {
 
 export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps): JSX.Element {
     const { filters, currentTab, filteredTags, tagSearch, showTagPopover } = useValues(dashboardsLogic)
-    const { setFilters, setTagSearch, setShowTagPopover } = useActions(dashboardsLogic)
+    const { setFilters, setTagSearch, setShowTagPopover, setSearch } = useActions(dashboardsLogic)
+
+    const debouncedSetSearch = useDebouncedCallback((value: string) => {
+        setSearch(value)
+    }, 300)
 
     const handleTagToggle = (tag: string): void => {
         const selected = new Set(filters.tags || [])
@@ -30,7 +35,10 @@ export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps
             <LemonInput
                 type="search"
                 placeholder="Search for dashboards"
-                onChange={(x) => setFilters({ search: x })}
+                onChange={(value) => {
+                    setFilters({ search: value })
+                    debouncedSetSearch(value)
+                }}
                 value={filters.search}
             />
             <div className="flex items-center gap-2 flex-wrap">

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -1,8 +1,10 @@
+import { router } from 'kea-router'
 import { expectLogic, truth } from 'kea-test-utils'
 
 import { DashboardsTab, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -162,6 +164,42 @@ describe('dashboardsLogic', () => {
             dashboards: truth((dashboards: DashboardType[]) => {
                 return dashboards.length === 1 && dashboards[0].name === 'needle'
             }),
+        })
+    })
+
+    it('syncs search to URL when setSearch is called', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setSearch('needle')
+        }).toMatchValues({
+            filters: expect.objectContaining({ search: 'needle' }),
+        })
+
+        expect(router.values.searchParams.search).toBe('needle')
+    })
+
+    it('removes search param from URL when search is cleared', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setSearch('needle')
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.setSearch('')
+        }).toMatchValues({
+            filters: expect.objectContaining({ search: '' }),
+        })
+
+        expect(router.values.searchParams.search).toBeUndefined()
+    })
+
+    it('loads search from URL into filters on mount', async () => {
+        // Recreate logic with URL containing a search param
+        logic.unmount()
+        router.actions.push(urls.dashboards(), { search: 'needle' })
+        logic = dashboardsLogic({ tabId: '1' })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            filters: expect.objectContaining({ search: 'needle' }),
         })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -170,8 +170,6 @@ describe('dashboardsLogic', () => {
     it('syncs search to URL when setSearch is called', async () => {
         await expectLogic(logic, () => {
             logic.actions.setSearch('needle')
-        }).toMatchValues({
-            filters: expect.objectContaining({ search: 'needle' }),
         })
 
         expect(router.values.searchParams.search).toBe('needle')
@@ -184,8 +182,6 @@ describe('dashboardsLogic', () => {
 
         await expectLogic(logic, () => {
             logic.actions.setSearch('')
-        }).toMatchValues({
-            filters: expect.objectContaining({ search: '' }),
         })
 
         expect(router.values.searchParams.search).toBeUndefined()

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -52,6 +52,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
     })),
     actions({
         setCurrentTab: (tab: DashboardsTab) => ({ tab }),
+        setSearch: (search: string) => ({ search }),
         setFilters: (filters: Partial<DashboardsFilters>) => ({
             filters,
         }),
@@ -83,6 +84,11 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                     objectClean({
                         ...state,
                         ...filters,
+                    }),
+                setSearch: (state, { search }) =>
+                    objectClean({
+                        ...state,
+                        search,
                     }),
             },
         ],
@@ -184,11 +190,25 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
 
             router.actions.push(router.values.location.pathname, { ...router.values.searchParams, tab })
         },
+        setSearch: () => {
+            const searchParams: Record<string, any> = { ...router.values.searchParams }
+
+            if (values.filters.search) {
+                searchParams['search'] = values.filters.search
+            } else {
+                delete searchParams['search']
+            }
+
+            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
+        },
     })),
     tabAwareUrlToAction(({ actions }) => ({
         '/dashboard': (_, searchParams) => {
-            const tab = searchParams['tab'] || DashboardsTab.All
+            const tab = (searchParams['tab'] as DashboardsTab | undefined) || DashboardsTab.All
             actions.setCurrentTab(tab)
+
+            const search = typeof searchParams['search'] === 'string' ? searchParams['search'] : ''
+            actions.setFilters({ search })
         },
     })),
 ])

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -85,11 +85,6 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                         ...state,
                         ...filters,
                     }),
-                setSearch: (state, { search }) =>
-                    objectClean({
-                        ...state,
-                        search,
-                    }),
             },
         ],
         tagSearch: [
@@ -190,11 +185,18 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
 
             router.actions.push(router.values.location.pathname, { ...router.values.searchParams, tab })
         },
-        setSearch: () => {
+        setSearch: ({ search }) => {
+            const nextSearch = search ?? ''
+            const currentSearch = (router.values.searchParams['search'] as string | undefined) ?? ''
+
+            if (nextSearch === currentSearch) {
+                return
+            }
+
             const searchParams: Record<string, any> = { ...router.values.searchParams }
 
-            if (values.filters.search) {
-                searchParams['search'] = values.filters.search
+            if (nextSearch) {
+                searchParams['search'] = nextSearch
             } else {
                 delete searchParams['search']
             }


### PR DESCRIPTION
## Problem

When changing the search query on the dashboard page, the search query does not persist on page reloads.

## Changes


https://github.com/user-attachments/assets/8a88ea1d-8a2a-4343-a34d-2b126212aef5

## How did you test this code?

Locally