### PR TITLE
feat(flags): add soft-delete manager to FeatureFlag

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -872,9 +872,7 @@ class EnterpriseExperimentsViewSet(
         # If so, we need to update parameters.feature_flag_variants to match the new flag
         parameters = deepcopy(source_experiment.parameters) or {}
         if feature_flag_key != source_experiment.feature_flag.key:
-            existing_flag = FeatureFlag.objects.filter(
-                key=feature_flag_key, team_id=self.team_id, deleted=False
-            ).first()
+            existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team_id=self.team_id).first()
             if existing_flag and existing_flag.filters.get("multivariate", {}).get("variants"):
                 parameters["feature_flag_variants"] = existing_flag.filters["multivariate"]["variants"]
 
@@ -1044,7 +1042,7 @@ class EnterpriseExperimentsViewSet(
         except ValueError:
             return Response({"error": "Invalid limit or offset"}, status=400)
 
-        queryset = FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False)
+        queryset = FeatureFlag.objects.filter(team__project_id=self.project_id)
 
         # Filter for multivariate flags with at least 2 variants and first variant is "control"
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (static SQL, no user input)

--- a/ee/hogai/context/feature_flag/context.py
+++ b/ee/hogai/context/feature_flag/context.py
@@ -31,9 +31,9 @@ class FeatureFlagContext:
         """Fetch the feature flag from the database."""
         try:
             if self._flag_id is not None:
-                return await FeatureFlag.objects.aget(id=self._flag_id, team=self._team, deleted=False)
+                return await FeatureFlag.objects.aget(id=self._flag_id, team=self._team)
             elif self._flag_key is not None:
-                return await FeatureFlag.objects.aget(key=self._flag_key, team=self._team, deleted=False)
+                return await FeatureFlag.objects.aget(key=self._flag_key, team=self._team)
             return None
         except FeatureFlag.DoesNotExist:
             return None

--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -34,7 +34,9 @@ class ExperimentAdminForm(ModelForm):
             if "holdout" in self.fields:
                 self.fields["holdout"].queryset = ExperimentHoldout.objects.filter(team=self.instance.team)  # type: ignore
             if "feature_flag" in self.fields:
-                self.fields["feature_flag"].queryset = FeatureFlag.objects.filter(team=self.instance.team)  # type: ignore
+                self.fields["feature_flag"].queryset = FeatureFlag.objects_including_soft_deleted.filter(  # type: ignore[attr-defined]
+                    team=self.instance.team
+                )
 
 
 def has_legacy_metric(metrics):

--- a/posthog/admin/admins/feature_flag_admin.py
+++ b/posthog/admin/admins/feature_flag_admin.py
@@ -20,6 +20,9 @@ class FeatureFlagAdmin(admin.ModelAdmin):
     readonly_fields = ("usage_dashboard",)
     ordering = ("-created_at",)
 
+    def get_queryset(self, request):
+        return FeatureFlag.objects_including_soft_deleted.all()
+
     @admin.display(description="Team")
     def team_link(self, flag: FeatureFlag):
         return format_html(

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -806,7 +806,7 @@ class CohortSerializer(serializers.ModelSerializer):
         instance = cast(Cohort, self.instance)
         cohort_id = instance.pk
 
-        flags = FeatureFlag.objects.filter(team__project_id=self.context["project_id"], active=True, deleted=False)
+        flags = FeatureFlag.objects.filter(team__project_id=self.context["project_id"], active=True)
         cohort_used_in_flags = len([flag for flag in flags if cohort_id in flag.get_cohort_ids()]) > 0
 
         if not cohort_used_in_flags:
@@ -865,9 +865,7 @@ class CohortSerializer(serializers.ModelSerializer):
         is_deletion_change = deleted_state is not None and cohort.deleted != deleted_state
         if is_deletion_change:
             if deleted_state:
-                flags_using_cohort = FeatureFlag.objects.filter(
-                    team__project_id=cohort.team.project_id, active=True, deleted=False
-                )
+                flags_using_cohort = FeatureFlag.objects.filter(team__project_id=cohort.team.project_id, active=True)
                 flags_with_cohort = [flag for flag in flags_using_cohort if cohort.id in flag.get_cohort_ids()]
                 if flags_with_cohort:
                     flag_names = [flag.name or flag.key for flag in flags_with_cohort]
@@ -1457,7 +1455,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
     except FeatureFlag.DoesNotExist:
         return []
 
-    if not feature_flag.active or feature_flag.deleted or feature_flag.aggregation_group_type_index is not None:
+    if not feature_flag.active or feature_flag.aggregation_group_type_index is not None:
         return []
 
     cohort = Cohort.objects.get(pk=cohort_id, team__project_id=project_id)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1220,6 +1220,13 @@ class FeatureFlagSerializer(
             if instance.experiment_set.filter(deleted=True).exists():
                 validated_data["key"] = f"{instance.key}:deleted:{instance.id}"
 
+        if "deleted" in validated_data and validated_data["deleted"] is False:
+            # Restoring a soft-deleted flag — if the key was renamed during
+            # soft-delete, restore the original key.
+            deleted_suffix = f":deleted:{instance.id}"
+            if instance.key.endswith(deleted_suffix):
+                validated_data["key"] = instance.key[: -len(deleted_suffix)]
+
         # Check for dependency conflicts when disabling a flag
         if "active" in validated_data and validated_data["active"] is False and instance.active is True:
             # Check for other flags that depend on this flag
@@ -1266,8 +1273,10 @@ class FeatureFlagSerializer(
         version = request.data.get("version", -1)
 
         with transaction.atomic():
-            # select_for_update locks the database row so we ensure version updates are atomic
-            locked_instance = FeatureFlag.objects.select_for_update().get(pk=instance.pk)
+            # select_for_update locks the database row so we ensure version updates are atomic.
+            # Uses objects_including_soft_deleted so that restoring a soft-deleted flag
+            # (setting deleted=False) can acquire the lock.
+            locked_instance = FeatureFlag.objects_including_soft_deleted.select_for_update().get(pk=instance.pk)
             locked_version = locked_instance.version or 0
 
             # NOW check for conflicts after all transformations

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -146,7 +146,7 @@ def find_dependent_flags(flag_to_check: FeatureFlag) -> list[FeatureFlag]:
     """Find all active flags that depend on the given flag via flag-type filter properties."""
     return list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=flag_to_check.team, deleted=False, active=True)
+        FeatureFlag.objects.filter(team=flag_to_check.team, active=True)
         .exclude(id=flag_to_check.id)
         .extra(
             where=[
@@ -186,7 +186,7 @@ def find_dependent_flags_batch(
 
     dependent_flags = list(
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-        FeatureFlag.objects.filter(team=team, deleted=False, active=True)
+        FeatureFlag.objects.filter(team=team, active=True)
         .exclude(id__in=flag_ids)
         .extra(
             where=[
@@ -272,7 +272,7 @@ def check_flag_limits_for_team(
         return
 
     count_limit = settings.MAX_FEATURE_FLAGS_PER_TEAM
-    flag_count = FeatureFlag.objects.filter(team_id=team_id, deleted=False).count()
+    flag_count = FeatureFlag.objects.filter(team_id=team_id).count()
 
     if flag_count >= count_limit:
         raise serializers.ValidationError(
@@ -732,7 +732,7 @@ class FeatureFlagSerializer(
             exclude_kwargs = {"pk": cast(FeatureFlag, self.instance).pk}
 
         if (
-            FeatureFlag.objects.filter(key=value, team__project_id=self.context["project_id"], deleted=False)
+            FeatureFlag.objects.filter(key=value, team__project_id=self.context["project_id"])
             .exclude(**exclude_kwargs)
             .exists()
         ):
@@ -1015,7 +1015,7 @@ class FeatureFlagSerializer(
             )
 
         try:
-            flag = FeatureFlag.objects.get(id=flag_id, team__project_id=self.context["project_id"], deleted=False)
+            flag = FeatureFlag.objects.get(id=flag_id, team__project_id=self.context["project_id"])
 
             # Check if the referenced flag is active
             if not flag.active:
@@ -1084,7 +1084,6 @@ class FeatureFlagSerializer(
                 flag = FeatureFlag.objects.get(
                     key=flag_key,
                     team__project_id=self.context["project_id"],
-                    deleted=False,
                 )
                 flag_deps = self._extract_flag_dependencies(flag.filters or {})
                 for dep_key in flag_deps:
@@ -1132,7 +1131,7 @@ class FeatureFlagSerializer(
         encrypt_flag_payloads(validated_data)
 
         try:
-            FeatureFlag.objects.filter(
+            FeatureFlag.objects_including_soft_deleted.filter(
                 key=validated_data["key"],
                 team__project_id=self.context["project_id"],
                 deleted=True,
@@ -1405,7 +1404,6 @@ class FeatureFlagSerializer(
             FeatureFlag.objects.filter(
                 team=flag_to_check.team,
                 id__in=dependency_ids,
-                deleted=False,
                 active=False,
             ).order_by("key")
         )
@@ -1663,7 +1661,10 @@ class FeatureFlagViewSet(
     """
 
     scope_object = "feature_flag"
-    queryset = FeatureFlag.objects.all()
+    # Use the unfiltered manager so non-list actions (retrieve, update, etc.)
+    # can access soft-deleted flags. The list action applies its own
+    # deleted=False filter in safely_get_queryset.
+    queryset = FeatureFlag.objects_including_soft_deleted.all()
     serializer_class = FeatureFlagSerializer
 
     def _filter_request(self, request: request.Request, queryset: QuerySet) -> QuerySet:
@@ -1962,7 +1963,7 @@ class FeatureFlagViewSet(
         ).values_list("internal_targeting_flag_id", flat=True)
 
         feature_flags = list(
-            FeatureFlag.objects.filter(team__project_id=self.project_id, deleted=False)
+            FeatureFlag.objects.filter(team__project_id=self.project_id)
             .exclude(Q(id__in=survey_flag_ids))
             .exclude(Q(id__in=product_tour_internal_targeting_flags))
             .order_by("-created_at")
@@ -2048,9 +2049,7 @@ class FeatureFlagViewSet(
             response_data["warning"] = f"Invalid flag IDs ignored: {invalid_ids}"
 
         # Fetch flags by IDs
-        flags = FeatureFlag.objects.filter(
-            id__in=flag_ids, team__project_id=self.project_id, deleted=False
-        ).values_list("id", "key")
+        flags = FeatureFlag.objects.filter(id__in=flag_ids, team__project_id=self.project_id).values_list("id", "key")
 
         # Create mapping of ID to key
         keys_mapping = {str(flag_id): key for flag_id, key in flags}
@@ -2719,9 +2718,9 @@ class FeatureFlagViewSet(
                 },
             }
 
-        disabled_flags = FeatureFlag.objects.filter(
-            team__project_id=self.project_id, active=False, deleted=False
-        ).values_list("key", flat=True)
+        disabled_flags = FeatureFlag.objects.filter(team__project_id=self.project_id, active=False).values_list(
+            "key", flat=True
+        )
 
         for flag_key in disabled_flags:
             flags_with_evaluation_reasons[flag_key] = {
@@ -2864,7 +2863,7 @@ class FeatureFlagViewSet(
         page = request.validated_query_data["page"]
 
         item_id = kwargs["pk"]
-        if not FeatureFlag.objects.filter(id=item_id, team__project_id=self.project_id).exists():
+        if not FeatureFlag.objects_including_soft_deleted.filter(id=item_id, team__project_id=self.project_id).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1222,10 +1222,21 @@ class FeatureFlagSerializer(
 
         if "deleted" in validated_data and validated_data["deleted"] is False:
             # Restoring a soft-deleted flag — if the key was renamed during
-            # soft-delete, restore the original key.
+            # soft-delete, restore the original key. If the original key has
+            # been claimed by another flag, append a numeric suffix.
             deleted_suffix = f":deleted:{instance.id}"
             if instance.key.endswith(deleted_suffix):
-                validated_data["key"] = instance.key[: -len(deleted_suffix)]
+                original_key = instance.key[: -len(deleted_suffix)]
+                candidate = original_key
+                counter = 2
+                while (
+                    FeatureFlag.objects.filter(key=candidate, team__project_id=self.context["project_id"])
+                    .exclude(pk=instance.pk)
+                    .exists()
+                ):
+                    candidate = f"{original_key}-{counter}"
+                    counter += 1
+                validated_data["key"] = candidate
 
         # Check for dependency conflicts when disabling a flag
         if "active" in validated_data and validated_data["active"] is False and instance.active is True:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1230,7 +1230,9 @@ class FeatureFlagSerializer(
                 candidate = original_key
                 counter = 2
                 while (
-                    FeatureFlag.objects.filter(key=candidate, team__project_id=self.context["project_id"])
+                    FeatureFlag.objects_including_soft_deleted.filter(
+                        key=candidate, team__project_id=self.context["project_id"]
+                    )
                     .exclude(pk=instance.pk)
                     .exists()
                 ):

--- a/posthog/api/flag_value.py
+++ b/posthog/api/flag_value.py
@@ -60,7 +60,7 @@ class FlagValueViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             return response.Response({"error": "Invalid flag ID - must be a valid integer"}, status=400)
 
         try:
-            flag = FeatureFlag.objects.get(team=self.team, id=flag_id_int, deleted=False)
+            flag = FeatureFlag.objects.get(team=self.team, id=flag_id_int)
         except FeatureFlag.DoesNotExist:
             return response.Response({"error": "Feature flag not found"}, status=404)
 

--- a/posthog/api/my_notifications.py
+++ b/posthog/api/my_notifications.py
@@ -69,9 +69,9 @@ class MyNotificationsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 )
             )
             my_feature_flags = list(
-                FeatureFlag.objects.filter(created_by=user, team__project_id=self.team.project_id).values_list(
-                    "id", flat=True
-                )
+                FeatureFlag.objects_including_soft_deleted.filter(
+                    created_by=user, team__project_id=self.team.project_id
+                ).values_list("id", flat=True)
             )
             my_notebooks = list(
                 Notebook.objects.filter(created_by=user, team__project_id=self.team.project_id).values_list(

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -43,7 +43,6 @@ class OrganizationFeatureFlagView(
         flags = FeatureFlag.objects.filter(
             key=feature_flag_key,
             team_id__in=team_ids,
-            deleted=False,
         )
         flags_data = [
             {
@@ -226,9 +225,7 @@ class OrganizationFeatureFlagView(
                 "is_remote_configuration": flag_to_copy.is_remote_configuration,
                 "has_encrypted_payloads": flag_to_copy.has_encrypted_payloads,
             }
-            existing_flag = FeatureFlag.objects.filter(
-                key=feature_flag_key, team__project_id=target_project_id, deleted=False
-            ).first()
+            existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team__project_id=target_project_id).first()
 
             context = {
                 "request": request,

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -462,7 +462,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -715,7 +716,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature-new'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -954,7 +956,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -1207,7 +1210,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature-new'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -1378,7 +1382,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature2'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -1853,7 +1858,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'some-feature'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'some-feature'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -196,7 +196,7 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
          AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
@@ -208,7 +208,7 @@
   SELECT 1 AS "a"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
          AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 1
@@ -219,14 +219,14 @@
   SELECT COUNT(*) AS "__count"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT "posthog_featureflag"."deleted")
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999)))
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.14
@@ -1159,7 +1159,8 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_featureflag"."key" = 'copied-flag-key'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'copied-flag-key'
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
@@ -2400,7 +2401,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''
@@ -2924,7 +2926,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 9608}'::jsonb)
   LIMIT 1
   '''
 # ---
@@ -2943,14 +2945,6 @@
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.78
-  '''
-  SELECT "posthog_tag"."name"
-  FROM "posthog_taggeditem"
-  INNER JOIN "posthog_tag" ON ("posthog_taggeditem"."tag_id" = "posthog_tag"."id")
-  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.79
   '''
   SELECT "posthog_tag"."name"
   FROM "posthog_taggeditem"
@@ -3212,7 +3206,7 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE (NOT "posthog_featureflag"."deleted"
+  WHERE (NOT ("posthog_featureflag"."deleted")
          AND "posthog_featureflag"."key" = 'key-1'
          AND "posthog_featureflag"."team_id" IN (1,
                                                  2,

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2926,7 +2926,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 9608}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2695,6 +2695,36 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert response.status_code == 201
         assert response.json()["key"] == "flag1"
 
+    def test_soft_delete_can_be_reversed_by_patch(self):
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="undo-flag")
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": True})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.deleted is True
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": False})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.deleted is False
+        assert flag.key == "undo-flag"
+
+    def test_soft_delete_undo_restores_renamed_key(self):
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="renamed-flag")
+        exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)
+        exp.deleted = True
+        exp.save()
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": True})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.key == f"renamed-flag:deleted:{flag.id}"
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": False})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.deleted is False
+        assert flag.key == "renamed-flag"
+
     def test_soft_delete_flag_blocked_with_active_experiment(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="flag2")
         exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2725,6 +2725,28 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert flag.deleted is False
         assert flag.key == "renamed-flag"
 
+    def test_soft_delete_undo_suffixes_key_when_original_is_taken(self):
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="taken-flag")
+        exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)
+        exp.deleted = True
+        exp.save()
+
+        # Soft-delete renames the key to free it up
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": True})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.key == f"taken-flag:deleted:{flag.id}"
+
+        # Another flag claims the original key
+        FeatureFlag.objects.create(team=self.team, created_by=self.user, key="taken-flag")
+
+        # Restoring falls back to a suffixed key instead of crashing
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": False})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.deleted is False
+        assert flag.key == "taken-flag-2"
+
     def test_soft_delete_flag_blocked_with_active_experiment(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="flag2")
         exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2704,7 +2704,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": False})
         assert response.status_code == 200
-        flag.refresh_from_db()
+        flag = FeatureFlag.objects_including_soft_deleted.get(pk=flag.pk)
         assert flag.deleted is False
         assert flag.key == "undo-flag"
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2747,6 +2747,32 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert flag.deleted is False
         assert flag.key == "taken-flag-2"
 
+    def test_soft_delete_undo_suffixes_key_when_original_held_by_soft_deleted_flag(self):
+        """The unique constraint covers all rows including soft-deleted ones,
+        so restoring a flag must check against soft-deleted flags too."""
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="held-flag")
+        exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)
+        exp.deleted = True
+        exp.save()
+
+        # Soft-delete renames the key
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": True})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.key == f"held-flag:deleted:{flag.id}"
+
+        # Another flag claims the original key and is then soft-deleted itself
+        blocker = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="held-flag")
+        blocker.deleted = True
+        blocker.save()
+
+        # Restoring must still suffix because the DB constraint spans all rows
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"deleted": False})
+        assert response.status_code == 200
+        flag.refresh_from_db()
+        assert flag.deleted is False
+        assert flag.key == "held-flag-2"
+
     def test_soft_delete_flag_blocked_with_active_experiment(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="flag2")
         exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)

--- a/posthog/management/commands/fix_invalid_flag_property_types.py
+++ b/posthog/management/commands/fix_invalid_flag_property_types.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         # Only fetch flags that have invalid property types (efficient DB-level filter)
         # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (INVALID_FLAGS_SQL is a static constant, admin-only command)
-        flags = FeatureFlag.objects.filter(deleted=False, active=True).extra(where=[f"EXISTS ({INVALID_FLAGS_SQL})"])
+        flags = FeatureFlag.objects.filter(active=True).extra(where=[f"EXISTS ({INVALID_FLAGS_SQL})"])
         if team_id:
             flags = flags.filter(team_id=team_id)
             self.stdout.write(f"Filtering to team_id={team_id}")

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -61,14 +61,20 @@ class Command(BaseCommand):
 
         first_user = cast(User, User.objects.first())
         for team in Team.objects.all():
-            existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
-            deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
+            existing_flags = set(
+                FeatureFlag.objects_including_soft_deleted.filter(team=team).values_list("key", flat=True)
+            )
+            deleted_flags = set(
+                FeatureFlag.objects_including_soft_deleted.filter(team=team, deleted=True).values_list("key", flat=True)
+            )
             for flag in flags.keys():
                 flag_type = flags[flag]
                 is_enabled = flag not in INACTIVE_FLAGS
 
                 if flag in deleted_flags:
-                    ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
+                    ff = FeatureFlag.objects_including_soft_deleted.filter(team=team, key=flag).first()
+                    if not ff:
+                        continue
                     ff.deleted = False
                     ff.active = is_enabled
                     ff.save()

--- a/posthog/management/commands/sync_feature_flags_from_api.py
+++ b/posthog/management/commands/sync_feature_flags_from_api.py
@@ -54,9 +54,13 @@ def sync_feature_flags_from_api(
         output_fn(f"\nProcessing project {project.id} - {project.name or ''}")
         output_fn("=" * 50)
 
-        existing_flags = FeatureFlag.objects.filter(team__project_id=project.id).values_list("key", flat=True)
-        deleted_flags = FeatureFlag.objects.filter(team__project_id=project.id, deleted=True).values_list(
-            "key", flat=True
+        existing_flags = set(
+            FeatureFlag.objects_including_soft_deleted.filter(team__project_id=project.id).values_list("key", flat=True)
+        )
+        deleted_flags = set(
+            FeatureFlag.objects_including_soft_deleted.filter(team__project_id=project.id, deleted=True).values_list(
+                "key", flat=True
+            )
         )
 
         enabled_flags = sum(1 for flag_data in data["flags"].values() if flag_data.get("enabled", False))
@@ -70,7 +74,7 @@ def sync_feature_flags_from_api(
         for flag_key, flag_data in data["flags"].items():
             is_enabled = flag_data.get("enabled", False)
             if flag_key in deleted_flags and is_enabled:
-                ff = FeatureFlag.objects.get(team__project_id=project.id, key=flag_key)
+                ff = FeatureFlag.objects_including_soft_deleted.get(team__project_id=project.id, key=flag_key)
                 ff.deleted = False
                 ff.active = True
                 ff.save()

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -254,7 +254,7 @@ class AutoProjectMiddleware:
                 feature_flag_id = path_parts[1]
                 if feature_flag_id.isnumeric():
                     # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
-                    return FeatureFlag.objects.filter(deleted=False, id=feature_flag_id)
+                    return FeatureFlag.objects.filter(id=feature_flag_id)
             elif path_parts[0] == "action":
                 action_id = path_parts[1]
                 if action_id.isnumeric():

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -23,7 +23,7 @@ from posthog.models.file_system.file_system_representation import FileSystemRepr
 from posthog.models.property import GroupTypeIndex
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.signals import mutable_receiver
-from posthog.models.utils import RootTeamMixin, UUIDModel
+from posthog.models.utils import RootTeamManager, RootTeamMixin, UUIDModel
 
 FIVE_DAYS = 60 * 60 * 24 * 5  # 5 days in seconds
 
@@ -32,6 +32,11 @@ logger = structlog.get_logger(__name__)
 if TYPE_CHECKING:
     from posthog.models.tag import Tag
     from posthog.models.team import Team
+
+
+class FeatureFlagManager(RootTeamManager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(deleted=True)
 
 
 class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.Model):
@@ -117,6 +122,9 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
         blank=True,
         help_text="Last time this feature flag was called (from $feature_flag_called events)",
     )
+
+    objects = FeatureFlagManager()  # type: ignore
+    objects_including_soft_deleted: models.Manager["FeatureFlag"] = RootTeamManager()
 
     class Meta:
         constraints = [models.UniqueConstraint(fields=["team", "key"], name="unique key for team")]
@@ -574,8 +582,7 @@ def get_feature_flags(
         raise ValueError("Either team or project_id must be provided")
 
     # Include disabled flags (active=False) so flag dependencies can reference them
-    # and evaluate them as false, rather than raising DependencyNotFound errors
-    filter_kwargs.update({"deleted": False})
+    # and evaluate them as false, rather than raising DependencyNotFound errors.
 
     # Build queryset with evaluation tags aggregated
     # Single-shot query: flags plus evaluation tag names aggregated to a string array.

--- a/posthog/models/feature_flag/flag_status.py
+++ b/posthog/models/feature_flag/flag_status.py
@@ -45,7 +45,11 @@ class FeatureFlagStatusChecker:
             return FeatureFlagStatus.UNKNOWN, "Must provide feature flag or feature flag id"
 
         try:
-            flag = FeatureFlag.objects.get(pk=self.feature_flag_id) if self.feature_flag_id else self.feature_flag
+            flag = (
+                FeatureFlag.objects_including_soft_deleted.get(pk=self.feature_flag_id)
+                if self.feature_flag_id
+                else self.feature_flag
+            )
         except FeatureFlag.DoesNotExist:
             return FeatureFlagStatus.UNKNOWN, "Flag could not be found"
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -129,7 +129,6 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         FeatureFlag.objects.filter(
             ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
             team__in=teams,
-            deleted=False,
         ).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
@@ -384,7 +383,7 @@ def _get_team_ids_with_flags() -> set[int]:
     {"flags": []}.
     """
     start_time = time.time()
-    result = set(FeatureFlag.objects.filter(active=True, deleted=False).values_list("team_id", flat=True).distinct())
+    result = set(FeatureFlag.objects.filter(active=True).values_list("team_id", flat=True).distinct())
     duration_ms = (time.time() - start_time) * 1000
 
     logger.info(
@@ -421,7 +420,7 @@ def _get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
 
     cutoff = timezone.now() - timedelta(minutes=grace_period_minutes)
     return set(
-        FeatureFlag.objects.filter(team_id__in=team_ids, updated_at__gte=cutoff, active=True, deleted=False)
+        FeatureFlag.objects.filter(team_id__in=team_ids, updated_at__gte=cutoff, active=True)
         .values_list("team_id", flat=True)
         .distinct()
     )

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -533,7 +533,6 @@ def _get_flags_response_for_local_evaluation_batch(
         .filter(
             ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
             team_id__in=team_ids,
-            deleted=False,
         )
         .exclude(id__in=survey_flag_ids)
         .annotate(

--- a/posthog/models/feature_flag/test/test_feature_flag_manager.py
+++ b/posthog/models/feature_flag/test/test_feature_flag_manager.py
@@ -1,0 +1,14 @@
+from posthog.test.base import BaseTest
+
+from posthog.models import FeatureFlag
+
+
+class TestFeatureFlagManager(BaseTest):
+    def test_default_manager_excludes_soft_deleted_flags(self):
+        FeatureFlag.objects.create(team=self.team, key="live", created_by=self.user)
+        FeatureFlag.objects_including_soft_deleted.create(
+            team=self.team, key="deleted", created_by=self.user, deleted=True
+        )
+
+        assert FeatureFlag.objects.filter(team=self.team).count() == 1
+        assert FeatureFlag.objects_including_soft_deleted.filter(team=self.team).count() == 2

--- a/posthog/models/feature_flag/test/test_feature_flag_manager.py
+++ b/posthog/models/feature_flag/test/test_feature_flag_manager.py
@@ -6,9 +6,13 @@ from posthog.models import FeatureFlag
 class TestFeatureFlagManager(BaseTest):
     def test_default_manager_excludes_soft_deleted_flags(self):
         FeatureFlag.objects.create(team=self.team, key="live", created_by=self.user)
-        FeatureFlag.objects_including_soft_deleted.create(
+        deleted_flag = FeatureFlag.objects_including_soft_deleted.create(
             team=self.team, key="deleted", created_by=self.user, deleted=True
         )
 
         assert FeatureFlag.objects.filter(team=self.team).count() == 1
         assert FeatureFlag.objects_including_soft_deleted.filter(team=self.team).count() == 2
+
+        with self.assertRaises(FeatureFlag.DoesNotExist):
+            FeatureFlag.objects.get(pk=deleted_flag.pk)
+        assert FeatureFlag.objects_including_soft_deleted.get(pk=deleted_flag.pk) == deleted_flag

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -143,7 +143,7 @@ class RemoteConfig(UUIDTModel):
         config = {
             "token": team.api_token,
             "supportedCompression": ["gzip", "gzip-js"],
-            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True, deleted=False).count() > 0,
+            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True).count() > 0,
             "captureDeadClicks": bool(team.capture_dead_clicks),
             "capturePerformance": (
                 {

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -217,7 +217,7 @@ def compute_feature_flag_metrics(self: PushGatewayTask) -> None:
         registry=self.metrics_registry,
     )
 
-    base_qs = FeatureFlag.objects.filter(deleted=False, active=True)
+    base_qs = FeatureFlag.objects.filter(active=True)
 
     # Top 5 by flag count (secondary sort by team_id for deterministic ordering on ties)
     top_by_count = list(

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -640,8 +640,7 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE (NOT ("posthog_featureflag"."deleted")
-         AND "posthog_featureflag"."id" = 99999)
+  WHERE "posthog_featureflag"."id" = 99999
   LIMIT 21
   FOR
   UPDATE
@@ -1397,8 +1396,7 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE (NOT ("posthog_featureflag"."deleted")
-         AND "posthog_featureflag"."id" = 99999)
+  WHERE "posthog_featureflag"."id" = 99999
   LIMIT 21
   FOR
   UPDATE

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -425,13 +425,14 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''
@@ -639,7 +640,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   FOR
   UPDATE
@@ -670,7 +672,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''
@@ -742,13 +745,14 @@
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_featureflag"."team_id" =
-            (SELECT U0."parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_featureflag"."team_id" = 99999))
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
          AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   '''
@@ -1223,59 +1227,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."key" = 'flag-1'
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.46
-  '''
-  SELECT "posthog_scheduledchange"."id",
-         "posthog_scheduledchange"."record_id",
-         "posthog_scheduledchange"."model_name",
-         "posthog_scheduledchange"."payload",
-         "posthog_scheduledchange"."scheduled_at",
-         "posthog_scheduledchange"."executed_at",
-         "posthog_scheduledchange"."failure_reason",
-         "posthog_scheduledchange"."failure_count",
-         "posthog_scheduledchange"."is_recurring",
-         "posthog_scheduledchange"."recurrence_interval",
-         "posthog_scheduledchange"."last_executed_at",
-         "posthog_scheduledchange"."end_date",
-         "posthog_scheduledchange"."team_id",
-         "posthog_scheduledchange"."created_at",
-         "posthog_scheduledchange"."created_by_id",
-         "posthog_scheduledchange"."updated_at"
-  FROM "posthog_scheduledchange"
-  WHERE "posthog_scheduledchange"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.47
-  '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."updated_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime",
-         "posthog_featureflag"."bucketing_identifier",
-         "posthog_featureflag"."last_called_at"
-  FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."key" = 'flag-1'
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'flag-1')
   LIMIT 21
   '''
 # ---
@@ -1444,7 +1397,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   LIMIT 21
   FOR
   UPDATE
@@ -1475,7 +1429,8 @@
          "posthog_featureflag"."bucketing_identifier",
          "posthog_featureflag"."last_called_at"
   FROM "posthog_featureflag"
-  WHERE "posthog_featureflag"."id" = 99999
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1876,13 +1876,10 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             .order_by("team_id")
         ),
         "teams_with_ff_count": list(
-            FeatureFlag.objects.filter(deleted=False).values("team_id").annotate(total=Count("id")).order_by("team_id")
+            FeatureFlag.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
         ),
         "teams_with_ff_active_count": list(
-            FeatureFlag.objects.filter(active=True, deleted=False)
-            .values("team_id")
-            .annotate(total=Count("id"))
-            .order_by("team_id")
+            FeatureFlag.objects.filter(active=True).values("team_id").annotate(total=Count("id")).order_by("team_id")
         ),
         "teams_with_issues_created_total": list(
             ErrorTrackingIssue.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")

--- a/posthog/temporal/weekly_digest/queries.py
+++ b/posthog/temporal/weekly_digest/queries.py
@@ -101,7 +101,6 @@ def query_new_feature_flags(period_start: datetime, period_end: datetime) -> Que
         FeatureFlag.objects.filter(
             created_at__gt=period_start,
             created_at__lte=period_end,
-            deleted=False,
         )
         .exclude(name__contains="Feature Flag for Experiment")
         .exclude(name__contains="Targeting flag for survey")

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -152,7 +152,7 @@ class ExperimentService:
         serializer_context: dict | None,
     ) -> tuple[FeatureFlag, list[dict]]:
         """Resolve existing flag or create a new one. Returns (flag, variants_used)."""
-        existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team_id=self.team.id, deleted=False).first()
+        existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team_id=self.team.id).first()
 
         if existing_flag:
             self._validate_existing_flag(existing_flag)

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -122,7 +122,7 @@ class CreateExperimentTool(MaxTool):
                 raise ValueError(f"An experiment with name '{name}' already exists")
 
             try:
-                feature_flag = FeatureFlag.objects.get(team=self._team, key=feature_flag_key, deleted=False)
+                feature_flag = FeatureFlag.objects.get(team=self._team, key=feature_flag_key)
             except FeatureFlag.DoesNotExist:
                 raise ValueError(f"Feature flag '{feature_flag_key}' does not exist")
 

--- a/products/feature_flags/backend/max_tools.py
+++ b/products/feature_flags/backend/max_tools.py
@@ -292,7 +292,7 @@ class CreateFeatureFlagTool(MaxTool):
 
                     @database_sync_to_async
                     def get_existing_flag():
-                        return FeatureFlag.objects.filter(team=self._team, key=flag_schema.key, deleted=False).first()
+                        return FeatureFlag.objects.filter(team=self._team, key=flag_schema.key).first()
 
                     existing = await get_existing_flag()
                     if existing:


### PR DESCRIPTION
## Problem

Every query for feature flags must remember to include `deleted=False` to exclude soft-deleted flags. This is error-prone and easy to forget. If a single query forgets the filter, deleted flags leak into results. We've already seen this cause bugs (such as this [recently fixed one](https://github.com/PostHog/posthog/pull/49457))

## Changes

Add a custom default manager (`FeatureFlagManager`) that automatically excludes soft-deleted flags from all queries via `FeatureFlag.objects`. An unfiltered manager (`objects_including_soft_deleted`) is available for the few cases that need access to deleted flags.

This is based on the existing pattern with the `Dashboard` and `Insight models`. Both use the same pattern: a custom default manager that excludes `deleted=True`, plus `objects_including_soft_deleted = RootTeamManager()` for unfiltered access.

- posthog/models/dashboard.py:99-100
- posthog/models/insight.py:108-109

**New managers on FeatureFlag:**
- `objects` — default manager, excludes `deleted=True`
- `objects_including_soft_deleted` — no filtering, for cases that need deleted flags

**Places that use `objects_including_soft_deleted`:**
- Viewset queryset — so retrieve/update endpoints can access deleted flags (e.g., viewing a deleted flag's detail page shows "deleted" status)
- Activity log endpoint — so activity history is visible for deleted flags
- Flag status checker — so deleted flags correctly report their "deleted" status
- Notification queries — so users still see the "deleted" activity notification for flags they created
- Create flow — so re-creating a flag with a previously deleted key can clean up the old record

**Redundant `deleted=False` filters removed** from ~15 call sites across the codebase that are now handled by the default manager.

### Explicit behavior changes

The following code paths previously had **no** `deleted=False` filter and now implicitly exclude deleted flags. All were audited and the new behavior is correct:

| Location | What changed |
|----------|-------------|
| `organization_feature_flag.py` — `copy_flags` | Won't copy a deleted flag (returns DoesNotExist) |
| `survey.py` — validate linked/targeting flag | Won't link surveys to deleted flags |
| `scheduled_change.py` — permission check | Won't schedule changes to deleted flags |
| `approvals/actions/feature_flags.py` — prepare_context, apply | Approvals for deleted flags will fail |
| `auto_rollback_feature_flag.py` — check conditions | Won't check rollback conditions on deleted flags |
| `tasks/tasks.py` — last_called_at sync | Won't sync timestamps for deleted flags |
| `flag_analytics.py` — enriched analytics | Won't enrich analytics for deleted flags |
| `product_intent.py` — activation check | Excludes deleted flags from product intent count |
| `early_access_features/backend/api.py` — validate flag | Won't link early access features to deleted flags |
| `product_tours/backend/api/product_tour.py` — validate flag | Won't link product tours to deleted flags |
| `cohort.py` — get_cohort_actors_for_feature_flag | Deleted flags now 404 (removed dead `feature_flag.deleted` check) |

## How did you test this code?

- New unit test (`test_feature_flag_manager.py`) verifies the default manager excludes soft-deleted flags and `objects_including_soft_deleted` includes them
- All existing tests pass with updated query snapshots
- Systematic audit of every `FeatureFlag.objects` call site in production code to verify correctness
- Manual testing of key scenarios
  - [x] Deleted a flag (does not show up in list, but you can still navigate to it and see the deleted status)
  - [x] Deleted flag belonging to experiment (Experiment page still renders. Link to flag still works).
  - [x] Deleted a flag and then clicked "Undo" in the toast notification.

## Publish to changelog?

No