### PR TITLE
fix(data-warehouse): remove configuration from DatabaseSchemaQuery response

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -143,7 +143,6 @@ def process_query_model(
                         "joining_table_name": join.joining_table_name,
                         "joining_table_key": join.joining_table_key,
                         "field_name": join.field_name,
-                        "configuration": join.configuration,
                         "created_at": join.created_at.isoformat(),
                     }
                 )


### PR DESCRIPTION
## Problem

`DatabaseSchemaQuery` requests return 500 in production. PR #49567 removed `configuration` from the Pydantic `DataWarehouseViewLink` model but missed the caller in `query.py`. Since the model uses `extra="forbid"`, validation fails.

## Changes

Stop passing `configuration` to `DataWarehouseViewLink.model_validate()` in `query.py`.

## How did you test this code?

Traced the error from Loki logs (`posthog-query-django`) back to the Pydantic validation failure.