### PR TITLE
feat(surveys): add tab widget to survey guided editor

### DIFF
--- a/frontend/src/scenes/surveys/wizard/MaxTip.tsx
+++ b/frontend/src/scenes/surveys/wizard/MaxTip.tsx
@@ -37,20 +37,22 @@ const TIPS_BY_STEP: Record<WizardStep, Tip[]> = {
         { text: 'Every field is friction. Only ask what you truly need to know.', Hog: DetectiveHog },
     ],
     where: [
-        { text: 'Surveys work best after someone takes an action — signup, purchase, feature use.', Hog: StarHog },
         { text: "Landing pages are usually too early. Users haven't formed opinions yet.", Hog: DetectiveHog },
         { text: 'Returning visitors are more likely to respond than first-time visitors.', Hog: ProfessorHog },
         {
             text: 'Exit-intent surveys on pricing pages can capture valuable "why not buy" feedback.',
             Hog: DetectiveHog,
         },
-        { text: 'Show NPS surveys after users have experienced value, not immediately after signup.', Hog: StarHog },
         {
             text: 'Dashboard and settings pages catch users who are already engaged with your product.',
             Hog: MicrophoneHog,
         },
     ],
     when: [
+        {
+            text: 'Feedback buttons work great for always-available surveys. Pop-ups are better for targeted moments.',
+            Hog: ProfessorHog,
+        },
         {
             text: 'Give users a moment to orient before showing a survey. Immediate popups get dismissed reflexively.',
             Hog: ProfessorHog,

--- a/frontend/src/scenes/surveys/wizard/SurveyThemeSelector.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyThemeSelector.tsx
@@ -31,21 +31,21 @@ function ThemePreviewCard({
             className={clsx(
                 'group relative flex flex-col rounded-lg border-2 p-2 text-left transition-all duration-200',
                 'hover:scale-[1.02] active:scale-[0.98]',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-3000 focus-visible:ring-offset-2',
                 isSelected
-                    ? 'border-primary bg-primary/5 shadow-md'
-                    : 'border-border bg-bg-light hover:border-primary/50 hover:shadow-sm',
+                    ? 'border-primary-3000 bg-fill-primary-highlight shadow-md'
+                    : 'border-border bg-bg-light hover:border-primary-3000 hover:shadow-sm',
                 disabled && 'cursor-not-allowed opacity-50'
             )}
         >
             {/* Selection indicator */}
             <div
                 className={clsx(
-                    'absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full transition-all duration-200',
-                    isSelected ? 'scale-100 bg-primary' : 'scale-0 bg-transparent'
+                    'absolute -right-1.5 -top-1.5 flex h-6 w-6 items-center justify-center rounded-full transition-all duration-200 shadow-sm',
+                    isSelected ? 'scale-100 bg-primary-3000' : 'scale-0 bg-transparent'
                 )}
             >
-                <IconCheck className="h-3 w-3 text-primary-inverse" />
+                <IconCheck className="h-3.5 w-3.5 text-primary-inverse" />
             </div>
 
             {/* Mini survey preview */}
@@ -110,7 +110,7 @@ export function SurveyThemeSelector({
         <div className="space-y-2">
             <div>
                 <h3 className="font-medium m-0">Choose a theme</h3>
-                <p className="text-sm text-muted">Start with a preset and customize colors below</p>
+                <p className="text-xs text-muted">Start with a preset and customize colors below</p>
             </div>
 
             <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -15,7 +15,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { SurveyQuestionBranchingType } from '~/types'
+import { SurveyQuestionBranchingType, SurveyType } from '~/types'
 
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { NewSurvey } from '../constants'
@@ -156,6 +156,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     const getConditionsSummary = (): string[] => {
         const conditions = survey.conditions
         const summary: string[] = []
+
+        summary.push(survey.type === SurveyType.Widget ? 'Appears as a feedback button' : 'Appears as a pop-up')
 
         if (conditions?.url) {
             summary.push(`URL ${conditions.urlMatchType === 'exact' ? 'is exactly' : 'contains'} "${conditions.url}"`)
@@ -375,7 +377,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                         <div>
                             {currentStep === 'questions' && <QuestionsStep />}
                             {currentStep === 'where' && <WhereStep onOpenFullEditor={handleCustomizeMore} />}
-                            {currentStep === 'when' && <WhenStep />}
+                            {currentStep === 'when' && <WhenStep onOpenFullEditor={handleCustomizeMore} />}
                         </div>
 
                         <div className="flex items-center justify-end pt-4 border-t border-border">

--- a/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
+++ b/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
@@ -13,8 +13,8 @@ interface Step {
 
 const STEPS: Step[] = [
     { key: 'questions', label: 'Questions' },
-    { key: 'where', label: 'Where' },
-    { key: 'when', label: 'When' },
+    { key: 'where', label: 'Audience' },
+    { key: 'when', label: 'Presentation' },
     { key: 'appearance', label: 'Customize', optional: true },
 ]
 

--- a/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
@@ -18,6 +18,8 @@ import {
     SurveyPosition,
     SurveyQuestionBranchingType,
     SurveyQuestionType,
+    SurveyTabPosition,
+    SurveyType,
 } from '~/types'
 
 import { NewSurvey, SurveyTheme, WEB_SAFE_FONTS, defaultSurveyAppearance, surveyThemes } from '../../constants'
@@ -156,6 +158,15 @@ export function AppearanceStep(): JSX.Element {
                                 </LemonField.Pure>
                             </>
                         )}
+                        {survey.type === SurveyType.Widget && (
+                            <LemonField.Pure label="Button color" className="gap-1">
+                                <ColorInput
+                                    value={appearance.widgetColor}
+                                    onChange={(widgetColor) => onAppearanceChange({ widgetColor })}
+                                    disabled={!surveysStylingAvailable}
+                                />
+                            </LemonField.Pure>
+                        )}
                     </div>
                 </WizardSection>
 
@@ -184,24 +195,45 @@ export function AppearanceStep(): JSX.Element {
                             content: (
                                 <div className="space-y-3">
                                     <div className="grid grid-cols-2 gap-x-4 gap-y-2">
-                                        <LemonField.Pure label="Position" className="gap-1">
-                                            <LemonSelect
-                                                value={appearance.position}
-                                                onChange={(position) => onAppearanceChange({ position })}
-                                                options={[
-                                                    { label: 'Bottom right', value: SurveyPosition.Right },
-                                                    { label: 'Bottom left', value: SurveyPosition.Left },
-                                                    { label: 'Bottom center', value: SurveyPosition.Center },
-                                                    { label: 'Top right', value: SurveyPosition.TopRight },
-                                                    { label: 'Top left', value: SurveyPosition.TopLeft },
-                                                    { label: 'Top center', value: SurveyPosition.TopCenter },
-                                                    { label: 'Middle right', value: SurveyPosition.MiddleRight },
-                                                    { label: 'Middle left', value: SurveyPosition.MiddleLeft },
-                                                    { label: 'Middle center', value: SurveyPosition.MiddleCenter },
-                                                ]}
-                                                fullWidth
-                                                disabled={!surveysStylingAvailable}
-                                            />
+                                        <LemonField.Pure
+                                            label={survey.type === SurveyType.Widget ? 'Button position' : 'Position'}
+                                            className="gap-1"
+                                        >
+                                            {survey.type === SurveyType.Widget ? (
+                                                <LemonSelect
+                                                    value={appearance.tabPosition ?? SurveyTabPosition.Right}
+                                                    onChange={(tabPosition) => onAppearanceChange({ tabPosition })}
+                                                    options={[
+                                                        { label: 'Right', value: SurveyTabPosition.Right },
+                                                        { label: 'Left', value: SurveyTabPosition.Left },
+                                                        { label: 'Top', value: SurveyTabPosition.Top },
+                                                        { label: 'Bottom', value: SurveyTabPosition.Bottom },
+                                                    ]}
+                                                    fullWidth
+                                                    disabled={!surveysStylingAvailable}
+                                                />
+                                            ) : (
+                                                <LemonSelect
+                                                    value={appearance.position}
+                                                    onChange={(position) => onAppearanceChange({ position })}
+                                                    options={[
+                                                        { label: 'Bottom right', value: SurveyPosition.Right },
+                                                        { label: 'Bottom left', value: SurveyPosition.Left },
+                                                        { label: 'Bottom center', value: SurveyPosition.Center },
+                                                        { label: 'Top right', value: SurveyPosition.TopRight },
+                                                        { label: 'Top left', value: SurveyPosition.TopLeft },
+                                                        { label: 'Top center', value: SurveyPosition.TopCenter },
+                                                        { label: 'Middle right', value: SurveyPosition.MiddleRight },
+                                                        { label: 'Middle left', value: SurveyPosition.MiddleLeft },
+                                                        {
+                                                            label: 'Middle center',
+                                                            value: SurveyPosition.MiddleCenter,
+                                                        },
+                                                    ]}
+                                                    fullWidth
+                                                    disabled={!surveysStylingAvailable}
+                                                />
+                                            )}
                                         </LemonField.Pure>
                                         <LemonField.Pure label="Font family" className="gap-1">
                                             <LemonSelect

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -1,10 +1,12 @@
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
-import { IconX } from '@posthog/icons'
+import { IconCheck, IconX } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { AddEventButton } from 'scenes/surveys/AddEventButton'
 
@@ -13,7 +15,10 @@ import {
     SurveyAppearance,
     SurveyDisplayConditions,
     SurveyEventsWithProperties,
+    SurveyPosition,
     SurveySchedule,
+    SurveyTabPosition,
+    SurveyType,
 } from '~/types'
 
 import {
@@ -34,7 +39,7 @@ const FREQUENCY_OPTIONS: { value: string; days: number | undefined; label: strin
     { value: 'monthly', days: 30, label: 'Every month' },
 ]
 
-export function WhenStep(): JSX.Element {
+export function WhenStep({ onOpenFullEditor }: { onOpenFullEditor: () => void }): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
     const { recommendedFrequency } = useValues(surveyWizardLogic({ id: survey.id || 'new' }))
@@ -46,24 +51,29 @@ export function WhenStep(): JSX.Element {
     const triggerMode = conditions.events !== null && conditions.events !== undefined ? 'event' : 'pageview'
     const repeatedActivation = conditions.events?.repeatedActivation ?? false
     const delaySeconds = appearance.surveyPopupDelaySeconds ?? 0
+    const isWidget = survey.type === SurveyType.Widget
     const excludedObjectProperties = useExcludedObjectProperties()
+
     const daysToFrequency = (days: number | undefined): string => {
         const option = FREQUENCY_OPTIONS.find((opt) => opt.days === days)
         return option?.value || 'monthly'
     }
     const frequency = daysToFrequency(conditions.seenSurveyWaitPeriodInDays)
 
+    const onAppearanceChange = (updates: Partial<SurveyAppearance>): void => {
+        setSurveyValue('appearance', { ...appearance, ...updates })
+    }
+
     const setTriggerMode = (mode: 'pageview' | 'event'): void => {
         if (mode === 'pageview') {
             setSurveyValue('conditions', { ...conditions, events: null })
         } else {
-            // Initialize empty events structure to switch to event mode
             setSurveyValue('conditions', { ...conditions, events: { values: [], repeatedActivation: false } })
         }
     }
 
     const setDelaySeconds = (seconds: number): void => {
-        setSurveyValue('appearance', { ...appearance, surveyPopupDelaySeconds: seconds })
+        onAppearanceChange({ surveyPopupDelaySeconds: seconds })
     }
 
     const setFrequency = (value: string): void => {
@@ -121,135 +131,210 @@ export function WhenStep(): JSX.Element {
         })
     }
 
+    const showFrequency = !isWidget && (triggerMode === 'pageview' || (triggerMode === 'event' && !repeatedActivation))
+
     return (
         <WizardStepLayout>
             <WizardSection
-                title="When should this appear?"
-                description="Choose when to show this survey to your users"
+                title="How should this survey appear?"
+                description={
+                    <>
+                        Looking for hosted surveys?{' '}
+                        <button type="button" onClick={onOpenFullEditor} className="text-link hover:underline">
+                            Open full editor
+                        </button>
+                    </>
+                }
                 descriptionClassName="text-sm"
             >
-                <LemonRadio
-                    value={triggerMode}
-                    onChange={setTriggerMode}
-                    options={[
-                        {
-                            value: 'pageview',
-                            label: 'On page load',
-                            description: 'Shows when the user visits the page',
-                        },
-                        {
-                            value: 'event',
-                            label: 'When an event is captured',
-                            description: 'Trigger the survey after specific events occur',
-                        },
-                    ]}
-                />
+                <div className="grid grid-cols-2 gap-3">
+                    <PresentationCard
+                        selected={!isWidget}
+                        onClick={() => {
+                            setSurveyValue('type', SurveyType.Popover)
+                            setSurveyValue('schedule', SurveySchedule.Once)
+                            onAppearanceChange({ position: SurveyPosition.Right })
+                        }}
+                        title="Pop-up"
+                        description="Appears in a corner of the page"
+                        illustration={<PopupIllustration />}
+                    />
+                    <PresentationCard
+                        selected={isWidget}
+                        onClick={() => {
+                            setSurveyValue('type', SurveyType.Widget)
+                            setSurveyValue('schedule', SurveySchedule.Always)
+                            setSurveyValue('conditions', {
+                                ...conditions,
+                                events: null,
+                                seenSurveyWaitPeriodInDays: undefined,
+                            })
+                            onAppearanceChange({
+                                position: SurveyPosition.NextToTrigger,
+                                tabPosition: SurveyTabPosition.Right,
+                                surveyPopupDelaySeconds: 0,
+                            })
+                        }}
+                        title="Feedback button"
+                        description="Persistent tab on the edge of the page"
+                        illustration={<WidgetIllustration />}
+                    />
+                </div>
+            </WizardSection>
 
-                {triggerMode === 'event' && (
-                    <div className="ml-6 space-y-2.5 mt-2">
-                        {triggerEvents.length > 0 && (
-                            <div className="space-y-2.5">
-                                <div className="text-xs text-muted">
-                                    Each event can be narrowed with optional property filters right below it.
+            {isWidget && (
+                <div className="space-y-2">
+                    <LemonField.Pure label="Button label" className="gap-1">
+                        <LemonInput
+                            value={appearance.widgetLabel}
+                            onChange={(widgetLabel) => onAppearanceChange({ widgetLabel })}
+                            placeholder="Feedback"
+                        />
+                    </LemonField.Pure>
+                </div>
+            )}
+
+            {!isWidget && (
+                <>
+                    <WizardSection
+                        title="When should this appear?"
+                        description="Choose when to show this survey to your users"
+                        descriptionClassName="text-sm"
+                    >
+                        <LemonRadio
+                            value={triggerMode}
+                            onChange={setTriggerMode}
+                            options={[
+                                {
+                                    value: 'pageview',
+                                    label: 'On page load',
+                                    description: 'Shows when the user visits the page',
+                                },
+                                {
+                                    value: 'event',
+                                    label: 'When an event is captured',
+                                    description: 'Trigger the survey after specific events occur',
+                                },
+                            ]}
+                        />
+
+                        {triggerMode === 'event' && (
+                            <div className="ml-6 space-y-2.5 mt-2">
+                                {triggerEvents.length > 0 && (
+                                    <div className="space-y-2.5">
+                                        <div className="text-xs text-muted">
+                                            Each event can be narrowed with optional property filters right below it.
+                                        </div>
+                                        {triggerEvents.map((event) => {
+                                            const propertyFilterCount = getEventPropertyFilterCount(
+                                                event.propertyFilters
+                                            )
+
+                                            return (
+                                                <WizardPanel key={event.name} className="bg-bg-light">
+                                                    <div className="flex items-start justify-between gap-3 mb-3">
+                                                        <div className="space-y-1">
+                                                            <div className="flex flex-wrap items-center gap-2">
+                                                                <code className="text-sm font-mono">{event.name}</code>
+                                                                <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
+                                                                    {propertyFilterCount > 0
+                                                                        ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
+                                                                        : 'No filters yet'}
+                                                                </span>
+                                                            </div>
+                                                            <div className="text-xs text-muted">
+                                                                Show the survey only when this event matches the
+                                                                properties below.
+                                                            </div>
+                                                        </div>
+                                                        <LemonButton
+                                                            size="xsmall"
+                                                            icon={<IconX />}
+                                                            onClick={() => removeTriggerEvent(event.name)}
+                                                            type="tertiary"
+                                                        />
+                                                    </div>
+                                                    <PropertyFilters
+                                                        propertyFilters={convertPropertyFiltersToArray(
+                                                            event.propertyFilters
+                                                        )}
+                                                        onChange={(filters: AnyPropertyFilter[]) =>
+                                                            updateTriggerEventFilters(event, filters)
+                                                        }
+                                                        pageKey={`survey-wizard-event-${event.name}`}
+                                                        taxonomicGroupTypes={[
+                                                            TaxonomicFilterGroupType.EventProperties,
+                                                        ]}
+                                                        excludedProperties={excludedObjectProperties}
+                                                        eventNames={[event.name]}
+                                                        buttonText="Add property filter"
+                                                        buttonSize="small"
+                                                        operatorAllowlist={SUPPORTED_OPERATORS}
+                                                    />
+                                                    <div className="text-xs text-muted mt-2">
+                                                        Only primitive types are supported here. Array and object
+                                                        properties are excluded.
+                                                    </div>
+                                                </WizardPanel>
+                                            )
+                                        })}
+                                    </div>
+                                )}
+                                <AddEventButton onEventSelect={addTriggerEvent} addButtonText="Add event" />
+                                <div className="pt-1">
+                                    <LemonCheckbox
+                                        checked={repeatedActivation}
+                                        onChange={setRepeatedActivation}
+                                        label="Show every time the event is captured"
+                                    />
                                 </div>
-                                {triggerEvents.map((event) => {
-                                    const propertyFilterCount = getEventPropertyFilterCount(event.propertyFilters)
-
-                                    return (
-                                        <WizardPanel key={event.name} className="bg-bg-light">
-                                            <div className="flex items-start justify-between gap-3 mb-3">
-                                                <div className="space-y-1">
-                                                    <div className="flex flex-wrap items-center gap-2">
-                                                        <code className="text-sm font-mono">{event.name}</code>
-                                                        <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
-                                                            {propertyFilterCount > 0
-                                                                ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
-                                                                : 'No filters yet'}
-                                                        </span>
-                                                    </div>
-                                                    <div className="text-xs text-muted">
-                                                        Show the survey only when this event matches the properties
-                                                        below.
-                                                    </div>
-                                                </div>
-                                                <LemonButton
-                                                    size="xsmall"
-                                                    icon={<IconX />}
-                                                    onClick={() => removeTriggerEvent(event.name)}
-                                                    type="tertiary"
-                                                />
-                                            </div>
-                                            <PropertyFilters
-                                                propertyFilters={convertPropertyFiltersToArray(event.propertyFilters)}
-                                                onChange={(filters: AnyPropertyFilter[]) =>
-                                                    updateTriggerEventFilters(event, filters)
-                                                }
-                                                pageKey={`survey-wizard-event-${event.name}`}
-                                                taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
-                                                excludedProperties={excludedObjectProperties}
-                                                eventNames={[event.name]}
-                                                buttonText="Add property filter"
-                                                buttonSize="small"
-                                                operatorAllowlist={SUPPORTED_OPERATORS}
-                                            />
-                                            <div className="text-xs text-muted mt-2">
-                                                Only primitive types are supported here. Array and object properties are
-                                                excluded.
-                                            </div>
-                                        </WizardPanel>
-                                    )
-                                })}
                             </div>
                         )}
-                        <AddEventButton onEventSelect={addTriggerEvent} addButtonText="Add event" />
-                        <div className="pt-1">
-                            <LemonCheckbox
-                                checked={repeatedActivation}
-                                onChange={setRepeatedActivation}
-                                label="Show every time the event is captured"
+                    </WizardSection>
+
+                    {showFrequency && (
+                        <WizardSection
+                            title="How often can the same person see this?"
+                            description="Control how frequently the same person can be shown this survey again."
+                            descriptionClassName="text-sm"
+                        >
+                            <LemonSegmentedButton
+                                value={frequency}
+                                onChange={setFrequency}
+                                options={FREQUENCY_OPTIONS.map((opt) => ({
+                                    ...opt,
+                                    tooltip:
+                                        opt.value === recommendedFrequency.value
+                                            ? `Recommended for this survey type`
+                                            : undefined,
+                                }))}
+                                fullWidth
                             />
+
+                            {recommendedFrequency.value === frequency && (
+                                <p className="text-sm text-success mt-3">{recommendedFrequency.reason}</p>
+                            )}
+                        </WizardSection>
+                    )}
+
+                    <section className="space-y-2 border-t border-border pt-5">
+                        <label className="text-sm font-medium">Delay before showing</label>
+                        <div className="flex items-center gap-2">
+                            <LemonInput
+                                type="number"
+                                min={0}
+                                value={delaySeconds}
+                                onChange={(val) => setDelaySeconds(Number(val) || 0)}
+                                className="w-20"
+                            />
+                            <span className="text-secondary text-sm">seconds after conditions are met</span>
                         </div>
-                    </div>
-                )}
-            </WizardSection>
-
-            <WizardSection
-                title="How often can the same person see this?"
-                description="Control how frequently the same person can be shown this survey again."
-                descriptionClassName="text-sm"
-            >
-                <LemonSegmentedButton
-                    value={frequency}
-                    onChange={setFrequency}
-                    options={FREQUENCY_OPTIONS.map((opt) => ({
-                        ...opt,
-                        tooltip:
-                            opt.value === recommendedFrequency.value ? `Recommended for this survey type` : undefined,
-                    }))}
-                    fullWidth
-                />
-
-                {recommendedFrequency.value === frequency && (
-                    <p className="text-sm text-success mt-3">{recommendedFrequency.reason}</p>
-                )}
-            </WizardSection>
-
-            <section className="space-y-2 border-t border-border pt-5">
-                <label className="text-sm font-medium">Delay before showing</label>
-                <div className="flex items-center gap-2">
-                    <LemonInput
-                        type="number"
-                        min={0}
-                        value={delaySeconds}
-                        onChange={(val) => setDelaySeconds(Number(val) || 0)}
-                        className="w-20"
-                    />
-                    <span className="text-secondary text-sm">seconds after conditions are met</span>
-                </div>
-                <p className="text-muted text-xs">
-                    Once a user matches the targeting conditions, wait this long before displaying the survey
-                </p>
-            </section>
+                        <p className="text-muted text-xs">
+                            Once a user matches the targeting conditions, wait this long before displaying the survey
+                        </p>
+                    </section>
+                </>
+            )}
 
             <section className="space-y-2">
                 <label className="text-sm font-medium">Response limit</label>
@@ -273,5 +358,143 @@ export function WhenStep(): JSX.Element {
                 </p>
             </section>
         </WizardStepLayout>
+    )
+}
+
+function PresentationCard({
+    selected,
+    onClick,
+    title,
+    description,
+    illustration,
+}: {
+    selected: boolean
+    onClick: () => void
+    title: string
+    description: string
+    illustration: JSX.Element
+}): JSX.Element {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={clsx(
+                'group relative flex flex-col items-center gap-2 rounded-lg border-2 p-3 text-center transition-all duration-200',
+                'hover:scale-[1.02] active:scale-[0.98]',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-3000 focus-visible:ring-offset-2',
+                selected
+                    ? 'border-primary-3000 bg-fill-primary-highlight shadow-md'
+                    : 'border-border bg-bg-light hover:border-primary-3000 hover:shadow-sm'
+            )}
+        >
+            <div
+                className={clsx(
+                    'absolute -right-1.5 -top-1.5 flex h-6 w-6 items-center justify-center rounded-full transition-all duration-200 shadow-sm',
+                    selected ? 'scale-100 bg-primary-3000' : 'scale-0 bg-transparent'
+                )}
+            >
+                <IconCheck className="h-3.5 w-3.5 text-primary-inverse" />
+            </div>
+            {illustration}
+            <div>
+                <div className="text-sm font-medium">{title}</div>
+                <div className="text-xs text-muted">{description}</div>
+            </div>
+        </button>
+    )
+}
+
+function PopupIllustration(): JSX.Element {
+    return (
+        <svg width="80" height="52" viewBox="0 0 80 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect
+                x="0.5"
+                y="0.5"
+                width="79"
+                height="51"
+                rx="4"
+                fill="currentColor"
+                fillOpacity={0.03}
+                stroke="currentColor"
+                strokeOpacity={0.15}
+            />
+            <rect
+                x="0.5"
+                y="0.5"
+                width="79"
+                height="8"
+                rx="4"
+                fill="currentColor"
+                fillOpacity={0.05}
+                stroke="currentColor"
+                strokeOpacity={0.15}
+            />
+            <circle cx="7" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <circle cx="12" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <circle cx="17" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <rect x="6" y="14" width="30" height="2" rx="1" fill="currentColor" fillOpacity={0.08} />
+            <rect x="6" y="19" width="22" height="2" rx="1" fill="currentColor" fillOpacity={0.06} />
+            <rect
+                x="44"
+                y="22"
+                width="30"
+                height="25"
+                rx="3"
+                fill="var(--primary-3000)"
+                fillOpacity={0.12}
+                stroke="var(--primary-3000)"
+                strokeOpacity={0.4}
+            />
+            <rect x="48" y="26" width="16" height="1.5" rx="0.75" fill="var(--primary-3000)" fillOpacity={0.5} />
+            <rect x="48" y="30" width="22" height="1.5" rx="0.75" fill="var(--primary-3000)" fillOpacity={0.3} />
+            <rect x="48" y="33" width="18" height="1.5" rx="0.75" fill="var(--primary-3000)" fillOpacity={0.3} />
+            <rect x="48" y="39" width="22" height="5" rx="2" fill="var(--primary-3000)" fillOpacity={0.35} />
+        </svg>
+    )
+}
+
+function WidgetIllustration(): JSX.Element {
+    return (
+        <svg width="80" height="52" viewBox="0 0 80 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect
+                x="0.5"
+                y="0.5"
+                width="79"
+                height="51"
+                rx="4"
+                fill="currentColor"
+                fillOpacity={0.03}
+                stroke="currentColor"
+                strokeOpacity={0.15}
+            />
+            <rect
+                x="0.5"
+                y="0.5"
+                width="79"
+                height="8"
+                rx="4"
+                fill="currentColor"
+                fillOpacity={0.05}
+                stroke="currentColor"
+                strokeOpacity={0.15}
+            />
+            <circle cx="7" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <circle cx="12" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <circle cx="17" cy="5" r="1.5" fill="currentColor" fillOpacity={0.2} />
+            <rect x="6" y="14" width="30" height="2" rx="1" fill="currentColor" fillOpacity={0.08} />
+            <rect x="6" y="19" width="22" height="2" rx="1" fill="currentColor" fillOpacity={0.06} />
+            <rect
+                x="64"
+                y="20"
+                width="16"
+                height="24"
+                rx="3"
+                fill="var(--primary-3000)"
+                fillOpacity={0.12}
+                stroke="var(--primary-3000)"
+                strokeOpacity={0.4}
+            />
+            <rect x="68" y="28" width="2" height="8" rx="1" fill="var(--primary-3000)" fillOpacity={0.5} />
+        </svg>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -405,7 +405,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
         return () => {
             actions.resetWizard()
-            if (props.id === 'new') {
+            if (props.id === 'new' && !router.values.searchParams.fromTemplate) {
                 actions.resetSurvey()
             }
         }


### PR DESCRIPTION
## Problem

feedback button widget is missing from the guided editor

data: 8.5% of surveys launched in t12m (1,025 / 12,123) are widget type

```sql
WITH counts AS (
    SELECT type, COUNT(*) AS cnt
    FROM posthog_survey
    WHERE start_date IS NOT NULL
        AND team_id != 2
        AND start_date >= NOW() - INTERVAL '12 months'
    GROUP BY type
)
SELECT type, cnt, ROUND(100.0 * cnt / SUM(cnt) OVER (), 1) AS pct
FROM counts
UNION ALL
SELECT 'TOTAL', SUM(cnt), 100.0
FROM counts
ORDER BY cnt DESC

```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

reworks the flow slightly to support feedback button widget:

- where -> "audience"
    - right now this is only URL conditions; in a followup PR, this will include user targeting
- when -> "presentation"
    - pop-up vs. widget
        - if widget: only show button label. auto-sets frequency to "always" and 0 delay
        - if pop-up: show event triggers, frequency, and pop-up delay

also attempts to fix a bug with survey data getting wiped when going from guided -> full editor by adding a guard to not reset survey data if url param fromTemplate exists

| where step | where w/ URL |
| --- | --- |
| ![Screenshot 2026-03-03 at 1.08.55 PM.png](https://app.graphite.com/user-attachments/assets/cbce1af7-3a36-48af-9eab-51f275838f07.png)<br> | ![Screenshot 2026-03-03 at 1.08.58 PM.png](https://app.graphite.com/user-attachments/assets/5c0c6e4a-e44b-483f-a9f3-cc3be28d4ba6.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

| presentation w/ pop-up | presentation w/ widget button |
| --- | --- |
| ![Screenshot 2026-03-03 at 1.47.36 PM.png](https://app.graphite.com/user-attachments/assets/ed1c99a2-d411-474f-9a2c-a3884e96f676.png)<br><br> | ![Screenshot 2026-03-03 at 1.47.37 PM.png](https://app.graphite.com/user-attachments/assets/4887aaaa-8864-438b-8c6d-022a1820fa74.png)<br><br> |

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->