### PR TITLE
feat(batch-exports): support persons model for backfill estimates

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -89,6 +89,9 @@ class UpdateBatchExportBackfillInputs:
 
     id: str
     adjusted_start_at: str | None = None
+    # Kept for backwards compatibility with running workflows
+    # TODO: Remove later
+    total_records_count: int | None = None
     estimated_records_count: int | None = None
     status: str | None = None
     finished: bool = False
@@ -105,7 +108,11 @@ async def update_batch_export_backfill_model(inputs: UpdateBatchExportBackfillIn
     logger = LOGGER.bind()
 
     finished_at = None
-    total_records_count = inputs.estimated_records_count
+    # TODO: Remove use of total_records_count once existing workflows have completed
+    estimated_records_count = (
+        inputs.estimated_records_count if inputs.estimated_records_count is not None else inputs.total_records_count
+    )
+    total_records_count = estimated_records_count
 
     if inputs.finished:
         # Calculate actual total from completed runs when finished,
@@ -117,7 +124,7 @@ async def update_batch_export_backfill_model(inputs: UpdateBatchExportBackfillIn
                 BatchExportBackfill.Status.FAILED,
                 BatchExportBackfill.Status.CANCELLED,
             )
-            and inputs.estimated_records_count != 0
+            and estimated_records_count != 0
         ):
             result = await database_sync_to_async(
                 lambda: BatchExportRun.objects.filter(
@@ -127,10 +134,10 @@ async def update_batch_export_backfill_model(inputs: UpdateBatchExportBackfillIn
             )()
             total_records_count = result["total"]
 
-            if inputs.estimated_records_count is not None:
+            if estimated_records_count is not None:
                 logger.info(
                     "Backfill records count: estimated vs actual",
-                    estimated_records_count=inputs.estimated_records_count,
+                    estimated_records_count=estimated_records_count,
                     actual_records_count=total_records_count,
                 )
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -332,8 +332,8 @@ async def _get_backfill_info_for_persons(
 ) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for persons model.
 
-    Queries both `person` and `person_distinct_id2` tables. Uses the same
-    CTE pattern as the export queries to count deduplicated distinct_ids.
+    Queries both `person` and `person_distinct_id2` tables. The count uses
+    `uniq()` for an approximate count to reduce memory usage on large teams.
 
     Returns:
         A tuple of (adjusted_start_at, estimated_records_count).
@@ -406,32 +406,21 @@ async def _get_backfill_info_for_persons(
             SELECT id
             FROM person
             WHERE team_id = %(team_id)s
-                AND id IN (
-                    SELECT id FROM person
-                    WHERE team_id = %(team_id)s
-                        AND _timestamp > '2000-01-01'
-                        {date_conditions}
-                )
             GROUP BY id
             HAVING argMax(_timestamp, version) > '2000-01-01'
                 {having_date_conditions}
         ),
         distinct_ids AS (
+
             -- new distinct_ids
             SELECT distinct_id
             FROM person_distinct_id2
             WHERE team_id = %(team_id)s
-                AND distinct_id IN (
-                    SELECT distinct_id FROM person_distinct_id2
-                    WHERE team_id = %(team_id)s
-                        AND _timestamp > '2000-01-01'
-                        {date_conditions}
-                )
             GROUP BY distinct_id
             HAVING argMax(_timestamp, version) > '2000-01-01'
                 {having_date_conditions}
 
-            UNION DISTINCT
+            UNION ALL
 
             -- existing distinct_ids for new/updated persons
             SELECT DISTINCT distinct_id
@@ -439,9 +428,10 @@ async def _get_backfill_info_for_persons(
             WHERE team_id = %(team_id)s
                 AND person_id IN new_persons
         )
-        SELECT count() AS record_count
+        SELECT uniq(distinct_id) AS record_count
         FROM distinct_ids
         FORMAT JSONEachRow
+        SETTINGS optimize_uniq_to_count = 0
     """
 
     async with get_client(team_id=team_id) as client:

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -89,7 +89,7 @@ class UpdateBatchExportBackfillInputs:
 
     id: str
     adjusted_start_at: str | None = None
-    total_records_count: int | None = None
+    estimated_records_count: int | None = None
     status: str | None = None
     finished: bool = False
 
@@ -98,33 +98,41 @@ class UpdateBatchExportBackfillInputs:
 async def update_batch_export_backfill_model(inputs: UpdateBatchExportBackfillInputs) -> None:
     """Activity that updates a BatchExportBackfill.
 
-    When finished=True, this also sets finished_at and calculates the actual
-    total_records_count from completed runs if total_records_count is not provided.
+    When finished=True, this also sets finished_at and calculates the actual total_records_count
+    from completed runs.
     """
     bind_contextvars(id=inputs.id, status=inputs.status)
     logger = LOGGER.bind()
 
     finished_at = None
-    total_records_count = inputs.total_records_count
+    total_records_count = inputs.estimated_records_count
 
     if inputs.finished:
-        # Calculate actual total from completed runs when finished successfully or not,
-        # but only if total_records_count was not explicitly provided (e.g. early exit with 0 records)
-        if inputs.status in (
-            BatchExportBackfill.Status.COMPLETED,
-            BatchExportBackfill.Status.FAILED,
-            BatchExportBackfill.Status.CANCELLED,
+        # Calculate actual total from completed runs when finished,
+        # but skip if estimated count is 0 (early exit, no runs to aggregate)
+        if (
+            inputs.status
+            in (
+                BatchExportBackfill.Status.COMPLETED,
+                BatchExportBackfill.Status.FAILED,
+                BatchExportBackfill.Status.CANCELLED,
+            )
+            and inputs.estimated_records_count != 0
         ):
-            if inputs.total_records_count is None:
-                result = await database_sync_to_async(
-                    lambda: BatchExportRun.objects.filter(
-                        backfill_id=inputs.id,
-                        status=BatchExportRun.Status.COMPLETED,
-                    ).aggregate(total=Sum("records_completed"))
-                )()
-                total_records_count = result["total"]
-            else:
-                total_records_count = inputs.total_records_count
+            result = await database_sync_to_async(
+                lambda: BatchExportRun.objects.filter(
+                    backfill_id=inputs.id,
+                    status=BatchExportRun.Status.COMPLETED,
+                ).aggregate(total=Sum("records_completed"))
+            )()
+            total_records_count = result["total"]
+
+            if inputs.estimated_records_count is not None:
+                logger.info(
+                    "Backfill records count: estimated vs actual",
+                    estimated_records_count=inputs.estimated_records_count,
+                    actual_records_count=total_records_count,
+                )
 
         finished_at = dt.datetime.now(dt.UTC)
 
@@ -310,6 +318,124 @@ async def _get_backfill_info_for_events(
     return earliest_start, record_count
 
 
+async def _get_backfill_info_for_persons(
+    batch_export: BatchExport,
+    start_at: dt.datetime | None,
+    end_at: dt.datetime | None,
+) -> tuple[dt.datetime | None, int]:
+    """Get adjusted start time and estimated record count for persons model.
+
+    Queries both `person` and `person_distinct_id2` tables. Uses the same
+    CTE pattern as the export queries to count deduplicated distinct_ids.
+
+    Returns:
+        A tuple of (adjusted_start_at, estimated_records_count).
+        If no data exists, returns (None, 0).
+    """
+    team_id = batch_export.team_id
+
+    date_conditions = ""
+    having_date_conditions = ""
+    query_parameters: dict[str, typing.Any] = {"team_id": team_id}
+
+    if start_at is not None:
+        date_conditions += "AND _timestamp >= %(start_at)s "
+        having_date_conditions += "AND argMax(_timestamp, version) >= %(start_at)s "
+        query_parameters["start_at"] = start_at.astimezone(dt.UTC)
+    if end_at is not None:
+        date_conditions += "AND _timestamp < %(end_at)s "
+        having_date_conditions += "AND argMax(_timestamp, version) < %(end_at)s "
+        query_parameters["end_at"] = end_at.astimezone(dt.UTC)
+
+    min_timestamp_query = f"""
+        SELECT MIN(_timestamp) as min_timestamp
+        FROM person
+        WHERE team_id = %(team_id)s
+        AND _timestamp > '2000-01-01'
+        {date_conditions}
+
+        UNION ALL
+
+        SELECT MIN(_timestamp) as min_timestamp
+        FROM person_distinct_id2
+        WHERE team_id = %(team_id)s
+        AND _timestamp > '2000-01-01'
+        {date_conditions}
+        FORMAT JSONEachRow
+    """
+
+    count_query = f"""
+        WITH new_persons AS (
+            SELECT id
+            FROM person
+            WHERE team_id = %(team_id)s
+                AND id IN (
+                    SELECT id FROM person
+                    WHERE team_id = %(team_id)s
+                        AND _timestamp > '2000-01-01'
+                        {date_conditions}
+                )
+            GROUP BY id
+            HAVING argMax(_timestamp, version) > '2000-01-01'
+                {having_date_conditions}
+        ),
+        distinct_ids AS (
+            -- new distinct_ids
+            SELECT distinct_id
+            FROM person_distinct_id2
+            WHERE team_id = %(team_id)s
+                AND distinct_id IN (
+                    SELECT distinct_id FROM person_distinct_id2
+                    WHERE team_id = %(team_id)s
+                        AND _timestamp > '2000-01-01'
+                        {date_conditions}
+                )
+            GROUP BY distinct_id
+            HAVING argMax(_timestamp, version) > '2000-01-01'
+                {having_date_conditions}
+
+            UNION DISTINCT
+
+            -- existing distinct_ids for new/updated persons
+            SELECT DISTINCT distinct_id
+            FROM person_distinct_id2
+            WHERE team_id = %(team_id)s
+                AND person_id IN new_persons
+        )
+        SELECT count() AS record_count
+        FROM distinct_ids
+        FORMAT JSONEachRow
+    """
+
+    async with get_client(team_id=team_id) as client:
+        min_timestamp_results = await client.read_query_as_jsonl(min_timestamp_query, query_parameters=query_parameters)
+        count_results = await client.read_query_as_jsonl(count_query, query_parameters=query_parameters)
+
+    # Find the earliest valid timestamp across both tables
+    earliest_timestamp: dt.datetime | None = None
+    for row in min_timestamp_results:
+        ts_str = row["min_timestamp"]
+        ts = dt.datetime.fromisoformat(ts_str)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.UTC)
+        else:
+            ts = ts.astimezone(dt.UTC)
+
+        if ts.year == 1970:
+            continue
+
+        if earliest_timestamp is None or ts < earliest_timestamp:
+            earliest_timestamp = ts
+
+    if earliest_timestamp is None:
+        return None, 0
+
+    record_count = int(count_results[0]["record_count"])
+    earliest_start = _align_timestamp_to_interval(earliest_timestamp, batch_export)
+
+    return earliest_start, record_count
+
+
 @temporalio.activity.defn
 async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOutputs:
     """Validate backfill parameters and estimate record count.
@@ -363,51 +489,14 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             filters_str=filters_str,
             extra_query_parameters=extra_query_parameters,
         )
-
-        if adjusted_start_at is None:
-            logger.info(
-                "No data exists for backfill",
-                team_id=inputs.team_id,
-                batch_export_id=inputs.batch_export_id,
-                model=model,
-            )
-            return GetBackfillInfoOutputs(
-                adjusted_start_at=inputs.start_at,
-                total_records_count=0,
-                interval_seconds=interval_seconds,
-            )
-
-        adjusted_start_at_str = inputs.start_at
-        if start_at is not None and adjusted_start_at != start_at:
-            adjusted_start_at_str = adjusted_start_at.astimezone(start_at.tzinfo).isoformat()
-            logger.info(
-                "Narrowing backfill start to earliest available data",
-                original_start_at=inputs.start_at,
-                adjusted_start_at=adjusted_start_at_str,
-            )
-
-        return GetBackfillInfoOutputs(
-            adjusted_start_at=adjusted_start_at_str,
-            total_records_count=record_count,
-            interval_seconds=interval_seconds,
+    elif model == "persons":
+        adjusted_start_at, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=start_at,
+            end_at=end_at,
         )
-
     else:
-        # For persons/sessions, we don't support estimation yet.
-        # Just return None for the count and let the workflow proceed normally.
-        #
-        # TODO: When implementing persons model support, note:
-        # - Need to check 2 tables: `person` and `person_distinct_id2`
-        # - Query both tables separately and take the minimum timestamp (more efficient than joining)
-        # - Use `_timestamp` field (not `timestamp`)
-        # - Filter invalid timestamps with `_timestamp > '2000-01-01'`
-        # - Example query pattern:
-        #     SELECT toStartOfInterval(MIN(_timestamp), INTERVAL X SECONDS)
-        #     FROM person WHERE team_id = Y AND _timestamp > '2000-01-01'
-        #     UNION ALL
-        #     SELECT toStartOfInterval(MIN(_timestamp), INTERVAL X SECONDS)
-        #     FROM person_distinct_id2 WHERE team_id = Y AND _timestamp > '2000-01-01'
-        #   Then take min() of results, excluding any 1970 dates (no data indicator).
+        # For sessions and other models, proceed without estimation
         logger.info(
             "Backfill info not yet implemented for model, skipping estimation",
             model=model,
@@ -417,6 +506,34 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             total_records_count=None,
             interval_seconds=interval_seconds,
         )
+
+    if adjusted_start_at is None:
+        logger.info(
+            "No data exists for backfill",
+            team_id=inputs.team_id,
+            batch_export_id=inputs.batch_export_id,
+            model=model,
+        )
+        return GetBackfillInfoOutputs(
+            adjusted_start_at=inputs.start_at,
+            total_records_count=0,
+            interval_seconds=interval_seconds,
+        )
+
+    adjusted_start_at_str = inputs.start_at
+    if start_at is not None and adjusted_start_at != start_at:
+        adjusted_start_at_str = adjusted_start_at.astimezone(start_at.tzinfo).isoformat()
+        logger.info(
+            "Narrowing backfill start to earliest available data",
+            original_start_at=inputs.start_at,
+            adjusted_start_at=adjusted_start_at_str,
+        )
+
+    return GetBackfillInfoOutputs(
+        adjusted_start_at=adjusted_start_at_str,
+        total_records_count=record_count,
+        interval_seconds=interval_seconds,
+    )
 
 
 @dataclasses.dataclass
@@ -715,7 +832,8 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             )
 
             # Step 3: Update backfill with adjusted start and estimated count
-            # If total_records_count is 0, complete early; if None (non-events), proceed normally
+            # If estimated count is 0, complete early; if None (non-events), proceed normally
+            update_inputs.estimated_records_count = backfill_info.total_records_count
             should_complete_early = backfill_info.total_records_count == 0
 
             await temporalio.workflow.execute_activity(
@@ -723,7 +841,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
                 UpdateBatchExportBackfillInputs(
                     id=backfill_id,
                     adjusted_start_at=backfill_info.adjusted_start_at,
-                    total_records_count=backfill_info.total_records_count,
+                    estimated_records_count=backfill_info.total_records_count,
                     status=(
                         BatchExportBackfill.Status.COMPLETED
                         if should_complete_early

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -263,7 +263,7 @@ async def _get_backfill_info_for_events(
     exclude_events: list[str],
     filters_str: str,
     extra_query_parameters: dict[str, typing.Any],
-) -> tuple[dt.datetime | None, int]:
+) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for events model.
 
     Returns:

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -839,7 +839,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             )
 
             # Step 3: Update backfill with adjusted start and estimated count
-            # If estimated count is 0, complete early; if None (non-events), proceed normally
+            # If estimated count is 0, complete early; if None (sessions/other models), proceed normally
             update_inputs.estimated_records_count = backfill_info.total_records_count
             should_complete_early = backfill_info.total_records_count == 0
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -329,7 +329,7 @@ async def _get_backfill_info_for_persons(
     batch_export: BatchExport,
     start_at: dt.datetime | None,
     end_at: dt.datetime | None,
-) -> tuple[dt.datetime | None, int]:
+) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for persons model.
 
     Queries both `person` and `person_distinct_id2` tables. Uses the same
@@ -338,8 +338,11 @@ async def _get_backfill_info_for_persons(
     Returns:
         A tuple of (adjusted_start_at, estimated_records_count).
         If no data exists, returns (None, 0).
+        For limited export teams, returns (adjusted_start_at, None) since
+        the count would not reflect the actual export behavior.
     """
     team_id = batch_export.team_id
+    is_limited_export = str(team_id) in settings.BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS
 
     date_conditions = ""
     having_date_conditions = ""
@@ -370,6 +373,33 @@ async def _get_backfill_info_for_persons(
         {date_conditions}
         FORMAT JSONEachRow
     """
+
+    async with get_client(team_id=team_id) as client:
+        min_timestamp_results = await client.read_query_as_jsonl(min_timestamp_query, query_parameters=query_parameters)
+
+    # Find the earliest valid timestamp across both tables
+    earliest_timestamp: dt.datetime | None = None
+    for row in min_timestamp_results:
+        ts_str = row["min_timestamp"]
+        ts = dt.datetime.fromisoformat(ts_str)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.UTC)
+        else:
+            ts = ts.astimezone(dt.UTC)
+
+        if ts.year == 1970:
+            continue
+
+        if earliest_timestamp is None or ts < earliest_timestamp:
+            earliest_timestamp = ts
+
+    if earliest_timestamp is None:
+        return None, 0
+
+    earliest_start = _align_timestamp_to_interval(earliest_timestamp, batch_export)
+
+    if is_limited_export:
+        return earliest_start, None
 
     count_query = f"""
         WITH new_persons AS (
@@ -415,30 +445,9 @@ async def _get_backfill_info_for_persons(
     """
 
     async with get_client(team_id=team_id) as client:
-        min_timestamp_results = await client.read_query_as_jsonl(min_timestamp_query, query_parameters=query_parameters)
         count_results = await client.read_query_as_jsonl(count_query, query_parameters=query_parameters)
 
-    # Find the earliest valid timestamp across both tables
-    earliest_timestamp: dt.datetime | None = None
-    for row in min_timestamp_results:
-        ts_str = row["min_timestamp"]
-        ts = dt.datetime.fromisoformat(ts_str)
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=dt.UTC)
-        else:
-            ts = ts.astimezone(dt.UTC)
-
-        if ts.year == 1970:
-            continue
-
-        if earliest_timestamp is None or ts < earliest_timestamp:
-            earliest_timestamp = ts
-
-    if earliest_timestamp is None:
-        return None, 0
-
     record_count = int(count_results[0]["record_count"])
-    earliest_start = _align_timestamp_to_interval(earliest_timestamp, batch_export)
 
     return earliest_start, record_count
 
@@ -839,8 +848,8 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             )
 
             # Step 3: Update backfill with adjusted start and estimated count
-            # If estimated count is 0, complete early; if None (sessions/other models), proceed normally
             update_inputs.estimated_records_count = backfill_info.total_records_count
+            # If estimated count is 0, complete early; if None (sessions/other models), proceed normally
             should_complete_early = backfill_info.total_records_count == 0
 
             await temporalio.workflow.execute_activity(

--- a/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
+++ b/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
@@ -31,10 +31,17 @@ from products.batch_exports.backend.temporal.backfill_batch_export import (
     BackfillBatchExportWorkflow,
     BackfillScheduleInputs,
     _get_backfill_info_for_events,
+    _get_backfill_info_for_persons,
     backfill_range,
     backfill_schedule,
 )
-from products.batch_exports.backend.tests.temporal.utils.clickhouse import truncate_events
+from products.batch_exports.backend.tests.temporal.utils.clickhouse import truncate_events, truncate_persons
+from products.batch_exports.backend.tests.temporal.utils.persons import (
+    generate_test_person_distinct_id2,
+    generate_test_persons_in_clickhouse,
+    insert_person_distinct_id2_values_in_clickhouse,
+    insert_person_values_in_clickhouse,
+)
 from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_client, delete_all_from_s3
 
 
@@ -1417,3 +1424,359 @@ class TestGetBackfillInfoForEvents:
         # Event is before 1am PST, so it falls in previous day's interval
         # 1am PST on Jan 14 = 9am UTC on Jan 14
         assert earliest_start == dt.datetime(2021, 1, 14, 9, 0, 0, tzinfo=dt.UTC)
+
+
+class TestGetBackfillInfoForPersons:
+    """Tests for the _get_backfill_info_for_persons function."""
+
+    @pytest.fixture(autouse=True)
+    async def truncate_persons_tables(self, clickhouse_client):
+        await truncate_persons(clickhouse_client)
+
+    @pytest.fixture
+    def make_batch_export(self, ateam):
+        def _make(
+            interval: str = "hour",
+            interval_offset: int | None = None,
+            timezone: str = "UTC",
+        ) -> BatchExport:
+            destination = BatchExportDestination(type="S3", config={})
+            return BatchExport(
+                team_id=ateam.pk,
+                name="Test Batch Export",
+                destination=destination,
+                interval=interval,
+                interval_offset=interval_offset,
+                timezone=timezone,
+                model="persons",
+            )
+
+        return _make
+
+    @pytest.fixture
+    def generate_persons(self, clickhouse_client, ateam):
+        async def _generate(
+            start_time: dt.datetime,
+            end_time: dt.datetime | None = None,
+            count: int = 10,
+            count_other_team: int = 0,
+        ):
+            persons, _ = await generate_test_persons_in_clickhouse(
+                client=clickhouse_client,
+                team_id=ateam.pk,
+                start_time=start_time,
+                end_time=end_time or start_time + dt.timedelta(hours=1),
+                count=count,
+                count_other_team=count_other_team,
+            )
+            return persons
+
+        return _generate
+
+    @pytest.fixture
+    def generate_person_distinct_ids(self, clickhouse_client, ateam):
+        async def _generate(
+            timestamp: dt.datetime,
+            count: int = 10,
+            person_ids: list[str] | None = None,
+        ):
+            pdi_values = []
+            for i in range(count):
+                person_id = uuid.UUID(person_ids[i]) if person_ids and i < len(person_ids) else None
+                pdi = generate_test_person_distinct_id2(
+                    count=1,
+                    team_id=ateam.pk,
+                    timestamp=timestamp + dt.timedelta(seconds=i),
+                    distinct_id=f"distinct-id-{uuid.uuid4()}",
+                    person_id=person_id,
+                )
+                pdi_values.append(pdi)
+            await insert_person_distinct_id2_values_in_clickhouse(client=clickhouse_client, persons=pdi_values)
+            return pdi_values
+
+        return _generate
+
+    async def test_returns_earliest_start_and_count_when_data_exists(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        person_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        persons = await generate_persons(start_time=person_time, count=5, count_other_team=3)
+        person_ids = [p["id"] for p in persons]
+        await generate_person_distinct_ids(timestamp=person_time, count=5, person_ids=person_ids)
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 5
+
+    async def test_returns_none_and_zero_when_no_data_exists(self, ateam, make_batch_export):
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        assert earliest_start is None
+        assert record_count == 0
+
+    async def test_takes_minimum_timestamp_across_both_tables(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        earlier_time = dt.datetime(2021, 1, 10, 5, 0, 0, tzinfo=dt.UTC)
+        later_time = dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
+
+        # Persons at later time, distinct_ids at earlier time
+        persons = await generate_persons(start_time=later_time, count=3)
+        person_ids = [p["id"] for p in persons]
+        await generate_person_distinct_ids(timestamp=earlier_time, count=3, person_ids=person_ids)
+
+        batch_export = make_batch_export()
+        earliest_start, _ = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        # Should use the earlier timestamp from person_distinct_id2
+        assert earliest_start == dt.datetime(2021, 1, 10, 5, 0, 0, tzinfo=dt.UTC)
+
+    async def test_count_includes_distinct_ids_from_changed_persons(
+        self, ateam, clickhouse_client, generate_person_distinct_ids, make_batch_export
+    ):
+        """When a person changes, all their existing distinct_ids should be counted."""
+        # Create a person with 3 distinct_ids at an old timestamp
+        old_time = dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+        new_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+
+        person_id = uuid.uuid4()
+
+        # Insert person at old time (version 1) and new time (version 2)
+        await insert_person_values_in_clickhouse(
+            client=clickhouse_client,
+            persons=[
+                {
+                    "id": str(person_id),
+                    "created_at": old_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "team_id": ateam.pk,
+                    "properties": None,
+                    "is_identified": True,
+                    "is_deleted": False,
+                    "version": 1,
+                    "_timestamp": old_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+                {
+                    "id": str(person_id),
+                    "created_at": old_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "team_id": ateam.pk,
+                    "properties": None,
+                    "is_identified": True,
+                    "is_deleted": False,
+                    "version": 2,
+                    "_timestamp": new_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            ],
+        )
+
+        # Create 3 distinct_ids for this person at old time (not in the query range)
+        await generate_person_distinct_ids(timestamp=old_time, count=3, person_ids=[str(person_id)] * 3)
+
+        batch_export = make_batch_export()
+        # Query range only covers new_time — person changed but distinct_ids didn't
+        _, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 16, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        # All 3 distinct_ids should be counted via the UNION DISTINCT branch
+        assert record_count == 3
+
+    async def test_count_deduplicates_by_latest_version(self, ateam, clickhouse_client, make_batch_export):
+        """Only count distinct_ids/persons whose latest version is in range."""
+
+        old_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        new_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+
+        distinct_id = f"distinct-id-{uuid.uuid4()}"
+        person_id = uuid.uuid4()
+
+        # Insert person with v1 in range and v2 outside range
+        # argMax(_timestamp, version) will return new_time (v2), which is outside the query range
+        await insert_person_values_in_clickhouse(
+            client=clickhouse_client,
+            persons=[
+                {
+                    "id": str(person_id),
+                    "created_at": old_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "team_id": ateam.pk,
+                    "properties": None,
+                    "is_identified": True,
+                    "is_deleted": False,
+                    "version": 1,
+                    "_timestamp": old_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+                {
+                    "id": str(person_id),
+                    "created_at": old_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "team_id": ateam.pk,
+                    "properties": None,
+                    "is_identified": True,
+                    "is_deleted": False,
+                    "version": 2,
+                    "_timestamp": new_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            ],
+        )
+
+        # Insert distinct_id with v1 in range and v2 outside range
+        await insert_person_distinct_id2_values_in_clickhouse(
+            client=clickhouse_client,
+            persons=[
+                {
+                    "team_id": ateam.pk,
+                    "distinct_id": distinct_id,
+                    "person_id": str(person_id),
+                    "is_deleted": False,
+                    "version": 1,
+                    "_timestamp": old_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+                {
+                    "team_id": ateam.pk,
+                    "distinct_id": distinct_id,
+                    "person_id": str(person_id),
+                    "is_deleted": False,
+                    "version": 2,
+                    "_timestamp": new_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            ],
+        )
+
+        batch_export = make_batch_export()
+
+        # Query range covers only old_time — but latest versions are at new_time for both
+        _, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        # Neither person nor distinct_id has latest version in range, so count should be 0
+        assert record_count == 0
+
+    async def test_counts_only_records_after_start_at(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+
+        early_persons = await generate_persons(start_time=early_time, count=5)
+        await generate_person_distinct_ids(timestamp=early_time, count=5, person_ids=[p["id"] for p in early_persons])
+
+        late_persons = await generate_persons(start_time=late_time, count=8)
+        await generate_person_distinct_ids(timestamp=late_time, count=8, person_ids=[p["id"] for p in late_persons])
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=None,
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 8
+
+    async def test_counts_only_records_before_end_at(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+
+        early_persons = await generate_persons(start_time=early_time, count=5)
+        await generate_person_distinct_ids(timestamp=early_time, count=5, person_ids=[p["id"] for p in early_persons])
+
+        late_persons = await generate_persons(start_time=late_time, count=8)
+        await generate_person_distinct_ids(timestamp=late_time, count=8, person_ids=[p["id"] for p in late_persons])
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 5
+
+    async def test_counts_only_records_in_range(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        times = [
+            dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 25, 0, 0, 0, tzinfo=dt.UTC),
+        ]
+        counts = [3, 7, 4]
+
+        for t, c in zip(times, counts):
+            persons = await generate_persons(start_time=t, count=c)
+            await generate_person_distinct_ids(timestamp=t, count=c, person_ids=[p["id"] for p in persons])
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 7
+
+    async def test_earliest_start_aligned_to_interval(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        person_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
+        persons = await generate_persons(
+            start_time=person_time, count=3, end_time=person_time + dt.timedelta(minutes=1)
+        )
+        await generate_person_distinct_ids(timestamp=person_time, count=3, person_ids=[p["id"] for p in persons])
+
+        # Hourly interval — should align to 10:00
+        batch_export = make_batch_export(interval="hour")
+        earliest_start, _ = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
+
+        # 5-minute interval — should align to 10:35
+        batch_export = make_batch_export(interval="every 5 minutes")
+        earliest_start, _ = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)
+
+    async def test_ignores_data_from_other_teams(
+        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+    ):
+        person_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        # Generate persons for this team AND other team — only other team data
+        await generate_persons(start_time=person_time, count=0, count_other_team=10)
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_persons(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        assert earliest_start is None
+        assert record_count == 0

--- a/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
+++ b/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
@@ -78,6 +78,7 @@ async def truncate_events(clickhouse_client):
 
 async def truncate_persons(clickhouse_client):
     await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS person_distinct_id2")
+    await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS person")
 
 
 async def truncate_sessions(clickhouse_client):


### PR DESCRIPTION
## Problem

Backfill estimation (adjusting start time and counting expected records) only works for the `events` model.

## Changes

- Add backfill estimation for the `persons` model:
    - Add `_get_backfill_info_for_persons()` that queries both `person` and `person_distinct_id2` tables to find the earliest timestamp and count deduplicated distinct_ids using the same CTE pattern as the actual export queries
- Rename `total_records_count` to `estimated_records_count` in `UpdateBatchExportBackfillInputs` to clarify semantics — this is an estimate, the actual count is always computed from completed runs when the backfill finishes
    - we can then use this estimate to log estimated vs actual for observability purposes, just to ensure our estimations are reasonably accurate
    - have kept `total_records_count` for now for compatibility; can remove later


## How did you test this code?

- Added tests for the new `_get_backfill_info_for_persons()` function

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No