### PR TITLE
fix: personless groups

### DIFF
--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -31,7 +31,7 @@ describe('normalizeProcessPersonFlagStep', () => {
     const normalizeStep = createNormalizeProcessPersonFlagStep()
 
     describe('$process_person_profile=false', () => {
-        it.each(['$identify', '$create_alias', '$merge_dangerously', '$groupidentify'])(
+        it.each(['$identify', '$create_alias', '$merge_dangerously'])(
             'drops event %s when $process_person_profile=false',
             async (eventName) => {
                 const input: PerDistinctIdPipelineInput = {
@@ -58,6 +58,25 @@ describe('normalizeProcessPersonFlagStep', () => {
                 })
             }
         )
+
+        it('allows $groupidentify when $process_person_profile=false', async () => {
+            const input: PerDistinctIdPipelineInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$groupidentify',
+                    properties: { $process_person_profile: false },
+                },
+            }
+
+            const result = await normalizeStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.forceDisablePersonProcessing).toBe(false)
+            }
+        })
 
         it('allows regular events when $process_person_profile=false', async () => {
             const input: PerDistinctIdPipelineInput = {

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
@@ -42,7 +42,7 @@ export function createNormalizeProcessPersonFlagStep<TInput extends NormalizePro
                     // Only a boolean `false` disables person processing.
                     processPerson = false
 
-                    if (['$identify', '$create_alias', '$merge_dangerously', '$groupidentify'].includes(event.event)) {
+                    if (['$identify', '$create_alias', '$merge_dangerously'].includes(event.event)) {
                         warnings.push({
                             type: 'invalid_event_when_process_person_profile_is_false',
                             details: {

--- a/nodejs/src/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/src/ingestion/ingestion-e2e.test.ts
@@ -945,6 +945,7 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
             {},
             async (ingester, hub, team) => {
                 const distinctId = new UUIDT().toString()
+                const groupKey = 'group_key'
                 const timestamp = DateTime.now().toMillis()
                 await ingester.handleKafkaBatch(
                     createKafkaMessages([
@@ -961,7 +962,7 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                             .withProperties({
                                 distinctId: distinctId,
                                 $process_person_profile: false,
-                                $group_0: 'group_key',
+                                $groups: { organization: groupKey },
                                 $set: {
                                     c: 3,
                                 },
@@ -995,8 +996,56 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                     expect(events[0].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
                     expect(events[1].event).toEqual('custom event')
                     expect(events[1].person_properties).toEqual({})
+                    // Group properties should be populated even with $process_person_profile=false
+                    expect(events[1].properties.$group_0).toEqual(groupKey)
                     expect(events[2].event).toEqual('custom event')
                     expect(events[2].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
+                })
+            }
+        )
+
+        testWithTeamIngester(
+            '$groupidentify is processed when $process_person_profile=false',
+            {},
+            async (ingester, hub, team) => {
+                const distinctId = new UUIDT().toString()
+                const groupKey = 'group_key'
+                const timestamp = DateTime.now().toMillis()
+
+                await ingester.handleKafkaBatch(
+                    createKafkaMessages([
+                        new EventBuilder(team, distinctId)
+                            .withEvent('$groupidentify')
+                            .withGroupProperties('organization', groupKey, { name: 'Acme Corp' })
+                            .withProperties({
+                                $process_person_profile: false,
+                                $group_type: 'organization',
+                                $group_key: groupKey,
+                                $group_set: { name: 'Acme Corp' },
+                            })
+                            .withTimestamp(timestamp)
+                            .build(),
+                    ])
+                )
+
+                await waitForKafkaMessages(hub)
+
+                await waitForExpect(async () => {
+                    const events = await fetchEvents(hub, team.id)
+                    expect(events.length).toEqual(1)
+                    expect(events[0].event).toEqual('$groupidentify')
+                })
+
+                await waitForExpect(async () => {
+                    const group = await hub.groupRepository.fetchGroup(team.id, 0, groupKey)
+                    expect(group).toEqual(
+                        expect.objectContaining({
+                            team_id: team.id,
+                            group_type_index: 0,
+                            group_properties: { name: 'Acme Corp' },
+                            group_key: groupKey,
+                        })
+                    )
                 })
             }
         )

--- a/nodejs/src/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/src/ingestion/ingestion-e2e.test.ts
@@ -945,7 +945,6 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
             {},
             async (ingester, hub, team) => {
                 const distinctId = new UUIDT().toString()
-                const groupKey = 'group_key'
                 const timestamp = DateTime.now().toMillis()
                 await ingester.handleKafkaBatch(
                     createKafkaMessages([
@@ -962,7 +961,7 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                             .withProperties({
                                 distinctId: distinctId,
                                 $process_person_profile: false,
-                                $groups: { organization: groupKey },
+                                $group_0: 'group_key',
                                 $set: {
                                     c: 3,
                                 },
@@ -996,8 +995,8 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                     expect(events[0].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
                     expect(events[1].event).toEqual('custom event')
                     expect(events[1].person_properties).toEqual({})
-                    // Group properties should be populated even with $process_person_profile=false
-                    expect(events[1].properties.$group_0).toEqual(groupKey)
+                    // Group properties should be preserved even with $process_person_profile=false
+                    expect(events[1].properties.$group_0).toEqual('group_key')
                     expect(events[2].event).toEqual('custom event')
                     expect(events[2].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
                 })
@@ -1016,7 +1015,6 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                     createKafkaMessages([
                         new EventBuilder(team, distinctId)
                             .withEvent('$groupidentify')
-                            .withGroupProperties('organization', groupKey, { name: 'Acme Corp' })
                             .withProperties({
                                 $process_person_profile: false,
                                 $group_type: 'organization',

--- a/nodejs/src/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/src/ingestion/ingestion-e2e.test.ts
@@ -995,8 +995,6 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
                     expect(events[0].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
                     expect(events[1].event).toEqual('custom event')
                     expect(events[1].person_properties).toEqual({})
-                    // Group properties should be preserved even with $process_person_profile=false
-                    expect(events[1].properties.$group_0).toEqual('group_key')
                     expect(events[2].event).toEqual('custom event')
                     expect(events[2].person_properties).toEqual(expect.objectContaining({ prop: 'value' }))
                 })

--- a/nodejs/src/worker/ingestion/process-event.ts
+++ b/nodejs/src/worker/ingestion/process-event.ts
@@ -107,13 +107,11 @@ export class EventsProcessor {
             }
         }
 
-        if (processPerson) {
-            // Adds group_0 etc values to properties
-            properties = await addGroupProperties(team.id, team.project_id, properties, this.groupTypeManager)
+        // Adds group_0 etc values to properties — independent of person processing
+        properties = await addGroupProperties(team.id, team.project_id, properties, this.groupTypeManager)
 
-            if (event === '$groupidentify') {
-                await this.upsertGroup(team.id, team.project_id, properties, timestamp, groupStore)
-            }
+        if (event === '$groupidentify') {
+            await this.upsertGroup(team.id, team.project_id, properties, timestamp, groupStore)
         }
 
         return {

--- a/nodejs/src/worker/ingestion/process-event.ts
+++ b/nodejs/src/worker/ingestion/process-event.ts
@@ -107,7 +107,6 @@ export class EventsProcessor {
             }
         }
 
-        // Adds group_0 etc values to properties — independent of person processing
         properties = await addGroupProperties(team.id, team.project_id, properties, this.groupTypeManager)
 
         if (event === '$groupidentify') {


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                 
Group analytics silently breaks when `$process_person_profile=false` (anonymous/cookieless mode). All group processing -  `addGroupProperties()`, `upsertGroup()`, and `$groupidentify` events — is gated behind person processing, even though groups are conceptually independent from persons.
                                                                                                                                             
This means customers using cookieless mode or `person_profiles='never'` get no group analytics at all. There is no way to send an event that belongs to a group without it belonging to a person.

## Changes
Changed the behavior to allow group identifies in personless events.

  ## Publish to changelog?

  No — this is a backend-only change. The corresponding posthog-js SDK changes (allowing the SDK to send group events without person processing) will be in a separate PR.
