### PR TITLE
feat(surveys): add user targeting to guided survey wizard

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -64,7 +64,12 @@ import {
 } from '~/types'
 
 import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
+import {
+    DEFAULT_TARGETING_FLAG_FILTERS,
+    SURVEY_TYPE_LABEL_MAP,
+    SurveyMatchTypeLabels,
+    defaultSurveyFieldValues,
+} from './constants'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 import { HTMLEditor, PresentationTypeCard } from './SurveyAppearanceUtils'
@@ -1203,17 +1208,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           type="secondary"
                                                                           className="w-max"
                                                                           onClick={() => {
-                                                                              setSurveyValue('targeting_flag_filters', {
-                                                                                  groups: [
-                                                                                      {
-                                                                                          properties: [],
-                                                                                          rollout_percentage: 100,
-                                                                                          variant: null,
-                                                                                      },
-                                                                                  ],
-                                                                                  multivariate: null,
-                                                                                  payloads: {},
-                                                                              })
+                                                                              setSurveyValue(
+                                                                                  'targeting_flag_filters',
+                                                                                  DEFAULT_TARGETING_FLAG_FILTERS
+                                                                              )
                                                                               setSurveyValue(
                                                                                   'remove_targeting_flag',
                                                                                   false

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -5,6 +5,7 @@ import { allOperatorsMapping } from 'lib/utils'
 
 import {
     AccessControlLevel,
+    FeatureFlagFilters,
     Survey,
     SurveyAppearance,
     SurveyMatchType,
@@ -804,3 +805,9 @@ export const surveyThemes: SurveyTheme[] = [
         },
     },
 ]
+
+export const DEFAULT_TARGETING_FLAG_FILTERS: FeatureFlagFilters = {
+    groups: [{ properties: [], rollout_percentage: 100, variant: null }],
+    multivariate: null,
+    payloads: {},
+}

--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -1,9 +1,12 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { LemonInputSelect } from '@posthog/lemon-ui'
 
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
+import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
+import { DEFAULT_TARGETING_FLAG_FILTERS } from 'scenes/surveys/constants'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
@@ -11,7 +14,7 @@ import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType } from
 import { surveyLogic } from '../../surveyLogic'
 
 export function WhereStep(): JSX.Element {
-    const { survey } = useValues(surveyLogic)
+    const { survey, targetingFlagFilters } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
 
     const { options } = useValues(propertyDefinitionsModel)
@@ -21,6 +24,7 @@ export function WhereStep(): JSX.Element {
     const conditions: Partial<SurveyDisplayConditions> = survey.conditions || {}
     const targetingMode = conditions.urlMatchType ? 'specific' : 'all'
     const urlPattern = conditions.url || ''
+    const userTargetingMode = targetingFlagFilters ? 'specific' : 'all'
 
     useEffect(() => {
         if (targetingMode === 'specific' && urlOptions?.status !== 'loading' && urlOptions?.status !== 'loaded') {
@@ -45,6 +49,17 @@ export function WhereStep(): JSX.Element {
 
     const setUrlPattern = (pattern: string): void => {
         setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType: SurveyMatchType.Contains })
+    }
+
+    const setUserTargetingMode = (mode: 'all' | 'specific'): void => {
+        if (mode === 'all') {
+            setSurveyValue('targeting_flag_filters', null)
+            setSurveyValue('targeting_flag', null)
+            setSurveyValue('remove_targeting_flag', true)
+        } else {
+            setSurveyValue('targeting_flag_filters', DEFAULT_TARGETING_FLAG_FILTERS)
+            setSurveyValue('remove_targeting_flag', false)
+        }
     }
 
     return (
@@ -117,6 +132,50 @@ export function WhereStep(): JSX.Element {
                         <p className="text-xs text-muted mt-2">
                             Select from your most visited pages or type a custom pattern
                         </p>
+                    </div>
+                )}
+            </div>
+
+            {/* User targeting */}
+            <div>
+                <h2 className="text-xl font-semibold mb-2">Who should see this?</h2>
+                <p className="text-secondary mb-6">Target specific users based on their properties</p>
+
+                <LemonRadio
+                    value={userTargetingMode}
+                    onChange={setUserTargetingMode}
+                    options={[
+                        {
+                            value: 'all',
+                            label: 'All users',
+                            description: 'Any user can see this survey',
+                        },
+                        {
+                            value: 'specific',
+                            label: 'Users matching conditions',
+                            description: 'Only show to users that match property filters',
+                        },
+                    ]}
+                />
+
+                {userTargetingMode === 'specific' && (
+                    <div className="mt-4 ml-6">
+                        <BindLogic
+                            logic={featureFlagLogic}
+                            props={{ id: survey.targeting_flag?.id ? String(survey.targeting_flag.id) : 'new' }}
+                        >
+                            <FeatureFlagReleaseConditions
+                                id={survey.targeting_flag?.id ? String(survey.targeting_flag.id) : 'new'}
+                                excludeTitle
+                                hideMatchOptions
+                                filters={targetingFlagFilters || DEFAULT_TARGETING_FLAG_FILTERS}
+                                onChange={(filters) => {
+                                    setSurveyValue('targeting_flag_filters', filters)
+                                }}
+                                showTrashIconWithOneCondition
+                                removedLastConditionCallback={() => setUserTargetingMode('all')}
+                            />
+                        </BindLogic>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Problem

survey wizard is missing user targeting

data: of the 12,124 surveys launched in t12m, ~18% (2,216) have user targeting

```sql
WITH recent AS (
    SELECT *
    FROM posthog_survey
    WHERE start_date IS NOT NULL
        AND team_id != 2
        AND start_date >= NOW() - INTERVAL '12 months'
)
SELECT
    COUNT(*) AS total,
    COUNT(*) FILTER (WHERE conditions->>'url' IS NOT NULL AND conditions->>'url' != '') AS with_url,
    COUNT(*) FILTER (WHERE targeting_flag_id IS NOT NULL) AS with_user_targeting,
    COUNT(*) FILTER (WHERE linked_flag_id IS NOT NULL) AS with_linked_flag,
    COUNT(*) FILTER (WHERE conditions->'events'->'values' IS NOT NULL
        AND jsonb_array_length(conditions->'events'->'values') > 0) AS with_events,
    COUNT(*) FILTER (WHERE EXISTS (
        SELECT 1
        FROM jsonb_array_elements(conditions->'events'->'values') AS ev
        WHERE ev ? 'propertyFilters'
            AND jsonb_typeof(ev->'propertyFilters') = 'object'
            AND ev->'propertyFilters' != '{}'::jsonb
    )) AS with_event_property_filters
FROM recent
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds user targeting (standard feature flag component) to the guided editor "audience" section

| all users | specific users |
| --- | --- |
| ![Screenshot 2026-03-03 at 1.13.09 PM.png](https://app.graphite.com/user-attachments/assets/a1a5fc56-d8eb-470c-8b77-16d23393ea82.png)<br> | ![Screenshot 2026-03-03 at 1.13.10 PM.png](https://app.graphite.com/user-attachments/assets/95ac3e60-600f-4a2c-9959-6696fa28a777.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->