### PR TITLE
feat(flags): add eval type label to latency metric

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -57,18 +57,24 @@ pub struct FlagEvaluationOverrides {
     pub request_hash_key_override: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum EvaluationType {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvaluationType {
     Sequential,
     Parallel,
 }
 
+impl EvaluationType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EvaluationType::Sequential => "sequential",
+            EvaluationType::Parallel => "parallel",
+        }
+    }
+}
+
 impl std::fmt::Display for EvaluationType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EvaluationType::Sequential => write!(f, "sequential"),
-            EvaluationType::Parallel => write!(f, "parallel"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -816,6 +822,16 @@ impl FeatureFlagMatcher {
         } else {
             EvaluationType::Sequential
         };
+
+        // Record evaluation type in canonical log for E2E latency metrics.
+        // Promote to Parallel if any dependency level triggers it.
+        with_canonical_log(|log| match eval_type {
+            EvaluationType::Parallel => log.evaluation_type = Some(EvaluationType::Parallel),
+            EvaluationType::Sequential if log.evaluation_type.is_none() => {
+                log.evaluation_type = Some(EvaluationType::Sequential)
+            }
+            _ => {}
+        });
 
         let labels = [("evaluation_type".to_string(), eval_type.to_string())];
         histogram(FLAG_BATCH_SIZE, &labels, flags_to_evaluate.len() as f64);

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -70,6 +70,17 @@ impl EvaluationType {
             EvaluationType::Parallel => "parallel",
         }
     }
+
+    /// Promote evaluation type across dependency levels:
+    /// None → Sequential, None → Parallel, Sequential → Parallel.
+    /// Parallel is sticky — once set, it never demotes back to Sequential.
+    pub fn promote(current: Option<Self>, level_type: Self) -> Option<Self> {
+        match (current, level_type) {
+            (_, Self::Parallel) => Some(Self::Parallel),
+            (None, Self::Sequential) => Some(Self::Sequential),
+            (current, Self::Sequential) => current,
+        }
+    }
 }
 
 impl std::fmt::Display for EvaluationType {
@@ -824,14 +835,13 @@ impl FeatureFlagMatcher {
         };
 
         // Record evaluation type in canonical log for E2E latency metrics.
-        // Promote to Parallel if any dependency level triggers it.
-        with_canonical_log(|log| match eval_type {
-            EvaluationType::Parallel => log.evaluation_type = Some(EvaluationType::Parallel),
-            EvaluationType::Sequential if log.evaluation_type.is_none() => {
-                log.evaluation_type = Some(EvaluationType::Sequential)
-            }
-            _ => {}
-        });
+        // Skip if no flags to evaluate (all deleted or already evaluated) — lets the
+        // metric label stay None → "none" rather than incorrectly reporting Sequential.
+        if !flags_to_evaluate.is_empty() {
+            with_canonical_log(|log| {
+                log.evaluation_type = EvaluationType::promote(log.evaluation_type, eval_type);
+            });
+        }
 
         let labels = [("evaluation_type".to_string(), eval_type.to_string())];
         histogram(FLAG_BATCH_SIZE, &labels, flags_to_evaluate.len() as f64);
@@ -2100,6 +2110,46 @@ impl FeatureFlagMatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_promote_evaluation_type_none_to_sequential() {
+        assert_eq!(
+            EvaluationType::promote(None, EvaluationType::Sequential),
+            Some(EvaluationType::Sequential)
+        );
+    }
+
+    #[test]
+    fn test_promote_evaluation_type_none_to_parallel() {
+        assert_eq!(
+            EvaluationType::promote(None, EvaluationType::Parallel),
+            Some(EvaluationType::Parallel)
+        );
+    }
+
+    #[test]
+    fn test_promote_evaluation_type_sequential_to_parallel() {
+        assert_eq!(
+            EvaluationType::promote(Some(EvaluationType::Sequential), EvaluationType::Parallel),
+            Some(EvaluationType::Parallel)
+        );
+    }
+
+    #[test]
+    fn test_promote_evaluation_type_parallel_stays_sticky() {
+        assert_eq!(
+            EvaluationType::promote(Some(EvaluationType::Parallel), EvaluationType::Sequential),
+            Some(EvaluationType::Parallel)
+        );
+    }
+
+    #[test]
+    fn test_promote_evaluation_type_sequential_stays_sequential() {
+        assert_eq!(
+            EvaluationType::promote(Some(EvaluationType::Sequential), EvaluationType::Sequential),
+            Some(EvaluationType::Sequential)
+        );
+    }
 
     #[test]
     fn test_panic_fallback_preserves_flag_identity() {

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -1,4 +1,5 @@
 use crate::api::errors::FlagError;
+use crate::flags::flag_matching::EvaluationType;
 use crate::metrics::consts::FLAG_DB_OPERATIONS_PER_REQUEST;
 use std::cell::RefCell;
 use std::future::Future;
@@ -186,6 +187,11 @@ pub struct FlagsCanonicalLogLine {
     /// - "found": query succeeded, overrides returned
     pub hash_key_override_status: Option<&'static str>,
 
+    /// Which evaluation strategy was used for this request.
+    /// Set to `Parallel` if any dependency level triggered parallel evaluation.
+    /// `None` if flags were not evaluated (disabled, quota limited, empty).
+    pub evaluation_type: Option<EvaluationType>,
+
     // Rate limiting
     pub rate_limited: bool,
 
@@ -234,6 +240,7 @@ impl Default for FlagsCanonicalLogLine {
             flags_errored: 0,
             dependency_graph_errors: 0,
             hash_key_override_status: None,
+            evaluation_type: None,
             rate_limited: false,
             team_cache_source: None,
             http_status: 200,
@@ -293,6 +300,7 @@ impl FlagsCanonicalLogLine {
             flags_errored = self.flags_errored,
             dependency_graph_errors = self.dependency_graph_errors,
             hash_key_override_status = self.hash_key_override_status,
+            evaluation_type = self.evaluation_type.map(|t| t.as_str()),
             rate_limited = self.rate_limited,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -16,7 +16,7 @@ pub use types::*;
 
 use crate::{
     api::{errors::FlagError, types::FlagsResponse},
-    flags::flag_service::FlagService,
+    flags::{flag_matching::EvaluationType, flag_service::FlagService},
     metrics::consts::{FLAG_REQUESTS_COUNTER, FLAG_REQUESTS_LATENCY, FLAG_REQUEST_FAULTS_COUNTER},
 };
 use std::collections::HashMap;
@@ -53,6 +53,7 @@ struct MetricsData {
     team_id: Option<i32>,
     flags_disabled: Option<bool>,
     library: Library,
+    evaluation_type: Option<EvaluationType>,
 }
 
 fn record_metrics(
@@ -72,10 +73,16 @@ fn record_metrics(
 
     let library = data.library.to_string();
 
+    let evaluation_type = data
+        .evaluation_type
+        .map_or("none", EvaluationType::as_str)
+        .to_string();
+
     let labels = [
         ("flags_disabled".to_string(), flags_disabled),
         ("team_id".to_string(), team_id.clone()),
         ("library".to_string(), library),
+        ("evaluation_type".to_string(), evaluation_type),
     ];
 
     inc(FLAG_REQUESTS_COUNTER, &labels, 1);
@@ -101,6 +108,7 @@ async fn process_request_inner(
         team_id: None,
         flags_disabled: None,
         library,
+        evaluation_type: None,
     };
 
     let result = async {
@@ -219,12 +227,13 @@ async fn process_request_inner(
             config_response_builder::build_response_from_cache(flags_response, &context, &team)
                 .await?;
 
-        // Populate canonical log with flag evaluation results
+        // Populate canonical log with flag evaluation results and read back evaluation_type
         with_canonical_log(|log| {
             log.flags_evaluated = response.flags.len();
             if response.quota_limited.is_some() {
                 log.quota_limited = true;
             }
+            metrics_data.evaluation_type = log.evaluation_type;
         });
 
         Ok(response)
@@ -318,6 +327,7 @@ mod metrics_tests {
             team_id: Some(123),
             flags_disabled: Some(false),
             library: Library::PosthogNode,
+            evaluation_type: Some(EvaluationType::Sequential),
         };
 
         // Call the real record_metrics function - it will use our test metrics functions
@@ -345,12 +355,18 @@ mod metrics_tests {
         assert!(counter
             .labels
             .contains(&("library".to_string(), "posthog-node".to_string())));
+        assert!(counter
+            .labels
+            .contains(&("evaluation_type".to_string(), "sequential".to_string())));
 
         // Check the histogram metric
         let histogram = &metrics[1];
         assert_eq!(histogram.name, FLAG_REQUESTS_LATENCY);
         assert_eq!(histogram.metric_type, MetricType::Histogram);
         assert_eq!(histogram.value, 100.0);
+        assert!(histogram
+            .labels
+            .contains(&("evaluation_type".to_string(), "sequential".to_string())));
     }
 
     #[test]
@@ -367,6 +383,7 @@ mod metrics_tests {
             team_id: None,
             flags_disabled: None,
             library: Library::Other,
+            evaluation_type: None,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(50));
@@ -374,7 +391,7 @@ mod metrics_tests {
         let metrics = get_recorded_metrics();
         assert_eq!(metrics.len(), 2);
 
-        // Both metrics should use "not_available" for missing values
+        // Both metrics should use "not_available" / "none" for missing values
         for metric in &metrics {
             assert!(metric
                 .labels
@@ -382,6 +399,9 @@ mod metrics_tests {
             assert!(metric
                 .labels
                 .contains(&("flags_disabled".to_string(), "not_available".to_string())));
+            assert!(metric
+                .labels
+                .contains(&("evaluation_type".to_string(), "none".to_string())));
         }
     }
 
@@ -394,6 +414,7 @@ mod metrics_tests {
             team_id: Some(456),
             flags_disabled: Some(true),
             library: Library::PosthogJs,
+            evaluation_type: Some(EvaluationType::Parallel),
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(200));
@@ -427,6 +448,7 @@ mod metrics_tests {
             team_id: None,
             flags_disabled: Some(false),
             library: Library::PosthogPython,
+            evaluation_type: None,
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(150));
@@ -456,6 +478,7 @@ mod metrics_tests {
             team_id: Some(789),
             flags_disabled: Some(false),
             library: Library::PosthogAndroid,
+            evaluation_type: Some(EvaluationType::Sequential),
         };
 
         record_metrics(&result, data, std::time::Duration::from_millis(75));

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -73,6 +73,8 @@ fn record_metrics(
 
     let library = data.library.to_string();
 
+    // "none" (not "not_available") because it means evaluation was intentionally skipped
+    // (flags disabled, quota limited, empty set), not that the value is unknown.
     let evaluation_type = data
         .evaluation_type
         .map_or("none", EvaluationType::as_str)
@@ -227,7 +229,10 @@ async fn process_request_inner(
             config_response_builder::build_response_from_cache(flags_response, &context, &team)
                 .await?;
 
-        // Populate canonical log with flag evaluation results and read back evaluation_type
+        // Populate canonical log with flag evaluation results and read back evaluation_type.
+        // If an earlier step errored (? above), we skip this and evaluation_type stays
+        // None → "none" in metrics. That's intentional: we don't need sequential/parallel
+        // breakdown for failed requests.
         with_canonical_log(|log| {
             log.flags_evaluated = response.flags.len();
             if response.quota_limited.is_some() {
@@ -437,6 +442,23 @@ mod metrics_tests {
         assert!(fault_counter
             .labels
             .contains(&("team_id".to_string(), "456".to_string())));
+
+        // Verify counter and histogram carry the correct evaluation_type label
+        let counter = metrics
+            .iter()
+            .find(|m| m.name == FLAG_REQUESTS_COUNTER)
+            .expect("Should have counter");
+        assert!(counter
+            .labels
+            .contains(&("evaluation_type".to_string(), "parallel".to_string())));
+
+        let histogram = metrics
+            .iter()
+            .find(|m| m.name == FLAG_REQUESTS_LATENCY)
+            .expect("Should have histogram");
+        assert!(histogram
+            .labels
+            .contains(&("evaluation_type".to_string(), "parallel".to_string())));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

We can't state "p99 end-to-end response time for requests with < 200 flags is X ms" at the moment, which would be a pretty helpful insight for customers.  The batch evaluation time metric (`flags_batch_evaluation_time_ms`) has an `evaluation_type` label, but the E2E request latency metric (`flags_requests_duration_ms`) does not. This forces us to estimate by summing sub-component percentiles, which is inaccurate (percentiles don't add linearly).

## Changes

Add an `evaluation_type` label (`"sequential"` / `"parallel"` / `"none"`) to `flags_requests_duration_ms` and `flags_requests_total`.

**`flags/flag_matching.rs`**

- Make `EvaluationType` public with `PartialEq`, `Eq` derives and a `const fn as_str()` method.
- Write evaluation type to canonical log during `evaluate_flags_in_level`. Promotes to `Parallel` if any dependency level triggers it (won't demote back to Sequential).

**`handler/canonical_log.rs`**

- Add `evaluation_type: Option<EvaluationType>` field to `FlagsCanonicalLogLine`.
- Emit it in the canonical log line.

**`handler/mod.rs`**

- Add `evaluation_type: Option<EvaluationType>` to `MetricsData`.
- Read it from the canonical log after evaluation completes.
- Include it in the label set for `FLAG_REQUESTS_COUNTER` and `FLAG_REQUESTS_LATENCY`.
- `None` (flags disabled, quota limited, empty) renders as `"none"`.

## Tradeoffs

**Cardinality**: worst case ~2x on `flags_requests_duration_ms` (currently 89K series → ~178K). In practice less than 2x because many teams never hit the parallel path. This is consistent with existing patterns — `flags_person_query_time_bucket` already carries a 2-value `pool` label, and `flags_db_operations_per_request_bucket` carries a 3-value `operation_type` label, both on `team_id`-bearing histograms. Total service footprint: ~248K → ~337K series (+36%).

**Third label value**: `"none"` is emitted for requests that skip evaluation entirely (flags disabled, quota limited, empty flag sets). This adds minimal cardinality since these paths already have `flags_disabled=true` or similar, and the combination count is small.

## How did you test this code?

- `cargo check -p feature-flags` passes.
- Existing `metrics_tests` updated to verify `evaluation_type` label is present with correct values (`Sequential`, `Parallel`, `None`).

## Enabled PromQL after rollout

```promql
histogram_quantile(0.99,
  sum by (le, evaluation_type) (
    rate(flags_requests_duration_ms_bucket{evaluation_type=~"sequential|parallel"}[5m])
  )
)
```
