### PR TITLE
fix(Insights): X-axis off by 1 edge case, depending on project TZ

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -184,6 +184,17 @@ describe('createXAxisTickCallback', () => {
             expect(callback('ignored', 1)).toBe('21:00')
             expect(callback('ignored', 2)).toBe('22:00')
         })
+
+        it('does not shift month labels across month boundaries', () => {
+            const callback = createXAxisTickCallback({
+                interval: 'month',
+                allDays: ['2023-06-01', '2023-07-01', '2023-08-01'],
+                timezone: 'America/New_York',
+            })
+            expect(callback('ignored', 0)).toBe('June')
+            expect(callback('ignored', 1)).toBe('July')
+            expect(callback('ignored', 2)).toBe('August')
+        })
     })
 
     describe('fallbacks', () => {

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -199,17 +199,6 @@ describe('createXAxisTickCallback', () => {
             expect(callback('ignored', 1)).toBe('July')
             expect(callback('ignored', 2)).toBe('August')
         })
-
-        it('does not shift month labels with datetime strings from ClickHouse', () => {
-            const callback = createXAxisTickCallback({
-                interval: 'month' as const,
-                allDays: ['2023-06-01 00:00:00', '2023-07-01 00:00:00', '2023-08-01 00:00:00'],
-                timezone: 'US/Pacific',
-            })
-            expect(callback('ignored', 0)).toBe('June')
-            expect(callback('ignored', 1)).toBe('July')
-            expect(callback('ignored', 2)).toBe('August')
-        })
     })
 
     describe('fallbacks', () => {

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -185,11 +185,26 @@ describe('createXAxisTickCallback', () => {
             expect(callback('ignored', 2)).toBe('22:00')
         })
 
-        it('does not shift month labels across month boundaries', () => {
+        it.each([
+            { interval: 'month' as const, desc: 'month interval' },
+            { interval: 'day' as const, desc: 'day interval' },
+            { interval: undefined, desc: 'inferred interval' },
+        ])('does not shift month labels across month boundaries ($desc)', ({ interval }) => {
             const callback = createXAxisTickCallback({
-                interval: 'month',
+                interval,
                 allDays: ['2023-06-01', '2023-07-01', '2023-08-01'],
-                timezone: 'America/New_York',
+                timezone: 'US/Pacific',
+            })
+            expect(callback('ignored', 0)).toBe('June')
+            expect(callback('ignored', 1)).toBe('July')
+            expect(callback('ignored', 2)).toBe('August')
+        })
+
+        it('does not shift month labels with datetime strings from ClickHouse', () => {
+            const callback = createXAxisTickCallback({
+                interval: 'month' as const,
+                allDays: ['2023-06-01 00:00:00', '2023-07-01 00:00:00', '2023-08-01 00:00:00'],
+                timezone: 'US/Pacific',
             })
             expect(callback('ignored', 0)).toBe('June')
             expect(callback('ignored', 1)).toBe('July')

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -25,17 +25,16 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    // Sub-day intervals have UTC timestamps that need timezone conversion.
-    // Day+ intervals are bucket labels (e.g. "2023-07-01" = July) — interpreting them
-    // as UTC and converting shifts midnight across day/month boundaries in behind-UTC
-    // timezones. Parse those directly in the target timezone instead.
+    // Only convert sub-day dates from UTC; converting day/week/month dates shifts labels across month boundaries.
     const isSubDay = interval === 'hour' || interval === 'minute' || interval === 'second'
     const parsedDates = allDays.map((d) => {
         if (isSubDay) {
             return dayjsUtcToTimezone(d, timezone, false)
         }
         try {
-            return dayjs.tz(d, timezone)
+            // Append time so JS doesn't parse date-only strings as UTC (ISO 8601 quirk)
+            const withTime = d.includes(' ') || d.includes('T') ? d : d + ' 00:00:00'
+            return dayjs.tz(withTime, timezone)
         } catch {
             return dayjs(null)
         }

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -25,16 +25,16 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    // Only convert sub-day dates from UTC; converting day/week/month dates shifts labels across month boundaries.
-    const isSubDay = interval === 'hour' || interval === 'minute' || interval === 'second'
+    // Datetime strings (with time component) are UTC from ClickHouse — convert to project timezone.
+    // Date-only strings are calendar bucket labels — parse as midnight in the project timezone
+    // so that e.g. "2023-07-01" stays July and doesn't drift to June in behind-UTC timezones.
     const parsedDates = allDays.map((d) => {
-        if (isSubDay) {
+        const hasTime = d.includes(' ') || d.includes('T')
+        if (hasTime) {
             return dayjsUtcToTimezone(d, timezone, false)
         }
         try {
-            // Append time so JS doesn't parse date-only strings as UTC (ISO 8601 quirk)
-            const withTime = d.includes(' ') || d.includes('T') ? d : d + ' 00:00:00'
-            return dayjs.tz(withTime, timezone)
+            return dayjs.tz(d + ' 00:00:00', timezone)
         } catch {
             return dayjs(null)
         }

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -25,13 +25,13 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    // Date strings with a time component (e.g. "2025-04-01 14:00:00") are UTC timestamps
-    // that need timezone conversion. Date-only strings (e.g. "2025-07-01") are bucket labels
-    // that should be interpreted in the target timezone to avoid shifting across day/month
-    // boundaries (e.g. July 1st UTC becoming June 30th in US timezones).
-    const hasTimeComponent = allDays[0].includes(' ') || allDays[0].includes('T')
+    // Sub-day intervals have UTC timestamps that need timezone conversion.
+    // Day+ intervals are bucket labels (e.g. "2023-07-01" = July) — interpreting them
+    // as UTC and converting shifts midnight across day/month boundaries in behind-UTC
+    // timezones. Parse those directly in the target timezone instead.
+    const isSubDay = interval === 'hour' || interval === 'minute' || interval === 'second'
     const parsedDates = allDays.map((d) => {
-        if (hasTimeComponent) {
+        if (isSubDay) {
             return dayjsUtcToTimezone(d, timezone, false)
         }
         try {

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -1,4 +1,4 @@
-import { Dayjs } from 'lib/dayjs'
+import { dayjs, Dayjs } from 'lib/dayjs'
 import { dayjsUtcToTimezone } from 'lib/dayjs'
 
 import { IntervalType } from '~/types'
@@ -25,7 +25,21 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    const parsedDates = allDays.map((d) => dayjsUtcToTimezone(d, timezone, false))
+    // Date strings with a time component (e.g. "2025-04-01 14:00:00") are UTC timestamps
+    // that need timezone conversion. Date-only strings (e.g. "2025-07-01") are bucket labels
+    // that should be interpreted in the target timezone to avoid shifting across day/month
+    // boundaries (e.g. July 1st UTC becoming June 30th in US timezones).
+    const hasTimeComponent = allDays[0].includes(' ') || allDays[0].includes('T')
+    const parsedDates = allDays.map((d) => {
+        if (hasTimeComponent) {
+            return dayjsUtcToTimezone(d, timezone, false)
+        }
+        try {
+            return dayjs.tz(d, timezone)
+        } catch {
+            return dayjs(null)
+        }
+    })
     const first = parsedDates[0]
     const last = parsedDates[parsedDates.length - 1]
 


### PR DESCRIPTION
## Problem
Reported that x-axis can show 1 month off the expected value, depending on the timezone set in your project. If you're on -8 UTC, then on a monthly SQL insight you sometimes see an October on the x-axis, but a date 2025-11-x on hover. 

## Changes

Use project timezone when working out x-axis ticks.

## How did you test this code?
- Set project timezone to -8 UTC
- Verified bug, then verified fix worked. 
Also a few tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
