### PR TITLE
fix(database): disable sqlx max_lifetime to prevent thundering herd

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -105,7 +105,8 @@ pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sql
         .min_connections(config.min_connections)
         .max_connections(config.max_connections)
         .acquire_timeout(config.acquire_timeout)
-        .test_before_acquire(config.test_before_acquire);
+        .test_before_acquire(config.test_before_acquire)
+        .max_lifetime(None);
 
     if let Some(idle_timeout) = config.idle_timeout {
         options = options.idle_timeout(idle_timeout);

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -106,6 +106,10 @@ pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sql
         .max_connections(config.max_connections)
         .acquire_timeout(config.acquire_timeout)
         .test_before_acquire(config.test_before_acquire)
+        // Disable sqlx's default 30-min max_lifetime. Without this explicit None,
+        // connections created together (e.g. during pod scale-up) all expire at the
+        // same instant, causing a thundering herd of TLS reconnects that saturates
+        // the database. Connection health is handled by test_before_acquire instead.
         .max_lifetime(None);
 
     if let Some(idle_timeout) = config.idle_timeout {


### PR DESCRIPTION
## Problem

The feature-flags service has been experiencing recurring CPU saturation spikes on the persons Aurora reader since mid-February, with at least 12 incidents over 15 days escalating in severity (most recent: 1,393 active sessions on a 96-vCPU instance on Mar 3).

A contributing factor is a thundering herd from sqlx's `max_lifetime` connection recycling. PR #40264 (Oct 2025) intended to disable `max_lifetime` by removing the explicit configuration, but this caused the code to fall back to sqlx's built-in default of 30 minutes — the same recycling frequency as before, just without the jitter that previously spread reconnections over a 30–60 minute window.

When many connections are created within a narrow window (e.g. during a scale-up), they all expire simultaneously 30 minutes later. Each expired connection is closed and recreated synchronously (TCP + TLS + auth + `SET statement_timeout`), creating a TLS handshake storm that saturates the database CPU.

## Changes

One-line change in `get_pool_with_config()`: explicitly set `.max_lifetime(None)` to disable connection recycling.

This is safe because:
- `test_before_acquire: true` already validates every connection before use, catching stale or broken connections on demand
- `idle_timeout` (5 minutes) already cleans up unused connections
- PostgreSQL handles long-lived connections well; the sqlx docs note the concern is "memory/resource leaks on the database-side" which is a minor risk compared to the thundering herd

## How did you test this code?

- Verified the crate compiles cleanly (`cargo check -p common-database`)
- Confirmed via [sqlx source](https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/pool/options.rs) that the default `max_lifetime` is `Some(Duration::from_secs(30 * 60))` and that `None` disables it
- No behavioral test needed — this removes a timer, it doesn't add logic

## Publish to changelog?

No