### PR TITLE
fix(flags): fix permissions and duplicate toast for default release conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/defaultReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/defaultReleaseConditionsLogic.ts
@@ -79,9 +79,6 @@ export const defaultReleaseConditionsLogic = kea<defaultReleaseConditionsLogicTy
         saveDefaultReleaseConditionsSuccess: () => {
             lemonToast.success('Default release conditions saved')
         },
-        saveDefaultReleaseConditionsFailure: ({ error }) => {
-            lemonToast.error(error || 'Failed to save default release conditions')
-        },
         discardChanges: () => {
             const saved = values.defaultReleaseConditions
             actions.setLocalEnabled(saved?.enabled ?? false)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1093,6 +1093,13 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
                 if not non_team_config_fields:
                     return ["project:read"]
 
+        # Team-level config actions that any member should be able to edit via the UI.
+        # Only downgrade for session auth to preserve read-only API key semantics.
+        if self.action in ("default_release_conditions", "default_evaluation_tags"):
+            is_session_auth = isinstance(request.successful_authenticator, SessionAuthentication)
+            if is_session_auth:
+                return ["project:read"]
+
         # Fall back to the default behavior
         return None
 
@@ -1300,7 +1307,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     @action(
         methods=["GET", "PUT"],
         detail=True,
-        permission_classes=[TeamMemberStrictManagementPermission],
+        permission_classes=[TeamMemberLightManagementPermission],
         url_path="default_release_conditions",
     )
     def default_release_conditions(self, request: request.Request, id: str, **kwargs) -> response.Response:

--- a/posthog/api/test/test_team_default_release_conditions.py
+++ b/posthog/api/test/test_team_default_release_conditions.py
@@ -113,7 +113,7 @@ class TestTeamDefaultReleaseConditions(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.json()["default_groups"][0]["rollout_percentage"])
 
-    def test_non_admin_can_read_but_not_write(self):
+    def test_non_admin_can_read_and_write(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
@@ -121,7 +121,7 @@ class TestTeamDefaultReleaseConditions(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.put(self.url, {"enabled": True, "default_groups": []}, format="json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_returns_previously_saved_config(self):
         config = get_or_create_team_extension(self.team, TeamFeatureFlagDefaultsConfig)


### PR DESCRIPTION
## Problem

The non-boolean settings on the feature flags settings page (default release conditions, default evaluation contexts) are broken — any attempt to save returns a 403 "You do not have admin access to this resource."

<img width="449" height="207" alt="image" src="https://github.com/user-attachments/assets/0d3c20d7-7bd9-4562-a1a4-8a55a8595024" />

The root cause is that these settings use custom `@action` endpoints on TeamViewSet (`default_release_conditions`, `default_evaluation_tags`), which don't have the RBAC scope downgrade that the boolean toggle settings get via `partial_update`. The `AccessControlPermission` RBAC layer requires "admin" project access for any write operation on the `project` scope by default. The boolean toggles work because `partial_update` explicitly downgrades to `["project:read"]` for team config fields.

This likely regressed after #46963 ("Consolidate API scopes"), which tightened how `AccessControlPermission` evaluates scopes for the TeamViewSet.

Additionally, the `default_release_conditions` failure listener was showing a duplicate error toast (the global kea-loaders `onFailure` handler already shows one).

## Changes

- Downgrade RBAC scope to `["project:read"]` for `default_release_conditions`
  and `default_evaluation_tags` actions, guarded behind `SessionAuthentication`
  to preserve read-only API key semantics (matching the existing `partial_update`
  pattern)
- Downgrade action-level permission for `default_release_conditions` from
  `TeamMemberStrictManagementPermission` to `TeamMemberLightManagementPermission`
- Remove duplicate error toast from `saveDefaultReleaseConditionsFailure` listener

## Test plan

- [x] All existing tests passing (21/21 across both test files)
- [x] Manually verified single toast on error via fake 403
- [x] Verify saving default release conditions works
- [x] Verify adding/removing default evaluation tags works