### PR TITLE
fix(persons): improve distinct ID display, error handling, and HogQL row parsing

### DIFF
--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -26,8 +26,9 @@ export type PersonPreviewProps = {
 }
 
 export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
-    const { loadPerson, loadPersonUUID } = useActions(personsLogic({ syncWithUrl: false }))
-    const { person, personLoading } = useValues(personsLogic({ syncWithUrl: false }))
+    const logicProps = { syncWithUrl: false, urlId: props.distinctId || props.personId }
+    const { loadPerson, loadPersonUUID } = useActions(personsLogic(logicProps))
+    const { person, personLoading } = useValues(personsLogic(logicProps))
 
     useEffect(() => {
         if (props.distinctId) {

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -188,7 +188,7 @@ export function PersonScene(): JSX.Element | null {
     const { user } = useValues(userLogic)
 
     if (personError) {
-        throw new Error(personError)
+        return <NotFound object="person" meta={{ urlId }} />
     }
     if (!person) {
         return personLoading ? <SpinnerOverlay sceneLevel /> : <NotFound object="person" meta={{ urlId }} />

--- a/frontend/src/scenes/persons/person-utils.test.ts
+++ b/frontend/src/scenes/persons/person-utils.test.ts
@@ -3,7 +3,14 @@ import { urls } from 'scenes/urls'
 
 import { PersonType } from '~/types'
 
-import { asDisplay, asLink, coercePropertyValue, getPersonColorIndex } from './person-utils'
+import {
+    asDisplay,
+    asLink,
+    coercePropertyValue,
+    getPersonColorIndex,
+    parsePersonFromHogQLRow,
+    scoreDistinctId,
+} from './person-utils'
 
 describe('coercePropertyValue', () => {
     it.each<{ input: Parameters<typeof coercePropertyValue>[0]; expected: ReturnType<typeof coercePropertyValue> }>([
@@ -225,5 +232,55 @@ describe('the person header', () => {
             const uniqueIndices = new Set([index1, index2, index3])
             expect(uniqueIndices.size).toBe(3)
         })
+    })
+})
+
+describe('parsePersonFromHogQLRow', () => {
+    it('parses a complete row into a PersonType', () => {
+        const row = ['uuid-1', ['did-1', 'did-2'], '{"email":"a@b.com"}', true, '2024-01-01', '2024-06-01']
+        const person = parsePersonFromHogQLRow(row)
+        expect(person).toEqual({
+            id: 'uuid-1',
+            uuid: 'uuid-1',
+            distinct_ids: ['did-1', 'did-2'],
+            properties: { email: 'a@b.com' },
+            is_identified: true,
+            created_at: '2024-01-01',
+            last_seen_at: '2024-06-01',
+        })
+    })
+
+    it('handles empty/null properties gracefully', () => {
+        const row = ['uuid-1', [], '', false, null, null]
+        const person = parsePersonFromHogQLRow(row)
+        expect(person.properties).toEqual({})
+        expect(person.is_identified).toBe(false)
+    })
+
+    it('handles malformed JSON properties gracefully', () => {
+        const row = ['uuid-1', [], '{not valid json', false, null, null]
+        const person = parsePersonFromHogQLRow(row)
+        expect(person.properties).toEqual({})
+    })
+})
+
+describe('scoreDistinctId', () => {
+    it.each([
+        { id: 'user@example.com', expected: 2, label: 'email gets highest score' },
+        { id: 'juliatusk@gmail.com', expected: 2, label: 'gmail email gets highest score' },
+        {
+            id: '03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c',
+            expected: 0,
+            label: 'posthog-js anon ID gets lowest score',
+        },
+        { id: 'user123', expected: 1, label: 'custom ID gets middle score' },
+        { id: 'my-custom-id', expected: 1, label: 'hyphenated custom ID gets middle score' },
+        {
+            id: '550e8400-e29b-41d4-a716-446655440000',
+            expected: 1,
+            label: 'standard UUID (36 chars) gets middle score',
+        },
+    ])('$label: $id → $expected', ({ id, expected }) => {
+        expect(scoreDistinctId(id)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -8,6 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { HogQLQueryString, hogql } from '~/queries/utils'
+import { PersonType } from '~/types'
 
 /**
  * Generates a stable color index from a string using djb2 hash.
@@ -43,7 +44,7 @@ const EMAIL_REGEX = /.+@.+\..+/i
 /** Very rough UUID format. It's loose around length, because the posthog-js UUID util returns non-normative IDs. */
 const BROWSER_ANON_ID_REGEX = /^(?:[a-fA-F0-9]+-){4}[a-fA-F0-9]+$/i
 /** Score distinct IDs for display: UUID-like (i.e. anon ID) gets 0, custom format gets 1, email-like gets 2. */
-function scoreDistinctId(id: string): number {
+export function scoreDistinctId(id: string): number {
     if (EMAIL_REGEX.test(id)) {
         return 2
     }
@@ -138,6 +139,27 @@ export const asLink = (person?: PersonPropType | null): string | undefined =>
           : person?.id
             ? urls.personByUUID(person.id)
             : undefined
+
+/**
+ * Parse a row from the HogQL person query into a PersonType.
+ * Column order matches getHogqlQueryStringForPersonId:
+ * [id, distinct_ids, properties, is_identified, created_at, last_seen_at]
+ */
+export function parsePersonFromHogQLRow(row: any[]): PersonType {
+    let properties = {}
+    try {
+        properties = JSON.parse(row[2] || '{}')
+    } catch {}
+    return {
+        id: row[0],
+        uuid: row[0],
+        distinct_ids: row[1],
+        properties,
+        is_identified: !!row[3],
+        created_at: row[4],
+        last_seen_at: row[5],
+    }
+}
 
 export const getHogqlQueryStringForPersonId = (): HogQLQueryString => {
     return hogql`SELECT

--- a/frontend/src/scenes/persons/personLogic.tsx
+++ b/frontend/src/scenes/persons/personLogic.tsx
@@ -13,7 +13,7 @@ import { Breadcrumb, PersonType } from '~/types'
 import { CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS } from 'products/customer_analytics/frontend/constants'
 import { revenueAnalyticsLogic } from 'products/revenue_analytics/frontend/revenueAnalyticsLogic'
 
-import { getHogqlQueryStringForPersonId } from './person-utils'
+import { getHogqlQueryStringForPersonId, parsePersonFromHogQLRow } from './person-utils'
 import type { personLogicType } from './personLogicType'
 
 export interface PersonLogicProps {
@@ -81,16 +81,7 @@ export const personLogic = kea<personLogicType>([
                     if (row == null) {
                         return null
                     }
-                    const queryPerson: PersonType = {
-                        id: row[0],
-                        uuid: row[0],
-                        distinct_ids: row[1],
-                        properties: JSON.parse(row[2] || '{}'),
-                        is_identified: !!row[3],
-                        created_at: row[4],
-                        last_seen_at: row[5],
-                    }
-                    return queryPerson
+                    return parsePersonFromHogQLRow(row)
                 },
             },
         ],

--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -372,17 +372,26 @@ describe('personsLogic', () => {
     describe('primaryDistinctId selector', () => {
         it.each([
             {
-                name: 'prefers non-UUID distinct IDs',
-                distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'alice@example.com'],
+                name: 'prefers email over anon ID',
+                distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c', 'alice@example.com'],
                 expected: 'alice@example.com',
             },
             {
-                name: 'returns first non-UUID when multiple exist',
-                distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'user123', 'alice@example.com'],
+                name: 'prefers email over custom ID',
+                distinctIds: [
+                    '03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c',
+                    'user123',
+                    'alice@example.com',
+                ],
+                expected: 'alice@example.com',
+            },
+            {
+                name: 'prefers custom ID over anon ID',
+                distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c', 'user123'],
                 expected: 'user123',
             },
             {
-                name: 'falls back to first distinct ID when all look like UUIDs',
+                name: 'falls back to first when all score equally',
                 distinctIds: ['550e8400-e29b-41d4-a716-446655440000', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'],
                 expected: '550e8400-e29b-41d4-a716-446655440000',
             },
@@ -390,11 +399,6 @@ describe('personsLogic', () => {
                 name: 'returns null when person has no distinct IDs',
                 distinctIds: [],
                 expected: null,
-            },
-            {
-                name: 'handles hyphenated non-UUID strings',
-                distinctIds: ['my-custom-id-with-hyphens', '550e8400-e29b-41d4-a716-446655440000'],
-                expected: 'my-custom-id-with-hyphens',
             },
         ])('$name', async ({ distinctIds, expected }) => {
             const person: PersonType = {

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -31,7 +31,13 @@ import {
     PersonsTabType,
 } from '~/types'
 
-import { asDisplay, coercePropertyValue, getHogqlQueryStringForPersonId } from './person-utils'
+import {
+    asDisplay,
+    coercePropertyValue,
+    getHogqlQueryStringForPersonId,
+    parsePersonFromHogQLRow,
+    scoreDistinctId,
+} from './person-utils'
 import type { personsLogicType } from './personsLogicType'
 
 export interface PersonsLogicProps {
@@ -157,7 +163,7 @@ export const personsLogic = kea<personsLogicType>([
                             result = { ...(await api.persons.list(newFilters)), offset: 0 }
                         }
                     } else {
-                        result = { ...(await api.get(url)), offset: parseInt(decodeParams(url).offset) }
+                        result = { ...(await api.get(url)), offset: parseInt(decodeParams(url).offset) || 0 }
                     }
                     return result
                 },
@@ -190,14 +196,7 @@ export const personsLogic = kea<personsLogicType>([
                     const response = await hogqlQuery(getHogqlQueryStringForPersonId(), { id: uuid }, 'blocking')
                     const row = response?.results?.[0]
                     if (row) {
-                        const person: PersonType = {
-                            id: row[0],
-                            uuid: row[0],
-                            distinct_ids: row[1],
-                            properties: JSON.parse(row[2] || '{}'),
-                            is_identified: !!row[3],
-                            created_at: row[4],
-                        }
+                        const person = parsePersonFromHogQLRow(row)
                         actions.reportPersonDetailViewed(person)
                         if (person.id != null) {
                             const eventsQuery = createInitialEventsPayload(person.id)
@@ -387,19 +386,10 @@ export const personsLogic = kea<personsLogicType>([
         primaryDistinctId: [
             (s) => [s.person],
             (person): string | null => {
-                // We do not track which distinct ID was created through identify, but we can try to guess
-                const nonUuidDistinctIds = person?.distinct_ids.filter((id) => id?.split('-').length !== 5)
-
-                if (nonUuidDistinctIds && nonUuidDistinctIds?.length >= 1) {
-                    /**
-                     * If there are one or more distinct IDs that are not a UUID, one of them is most likely
-                     * the identified ID. In most cases, there would be only one non-UUID distinct ID.
-                     */
-                    return nonUuidDistinctIds[0]
+                if (!person?.distinct_ids.length) {
+                    return null
                 }
-
-                // Otherwise, just fall back to the default first distinct ID
-                return person?.distinct_ids[0] || null
+                return person.distinct_ids.slice().sort((a, b) => scoreDistinctId(b) - scoreDistinctId(a))[0]
             },
         ],
     })),


### PR DESCRIPTION
## Problem

A few more things to improve in the persons feature:

- When a person failed to load, PersonScene threw an error that hit the error boundary. 
- The HogQL row → PersonType parsing was copied between personLogic and personsLogic but personsLogic copy was missing last_seen_at.
- loadPersons could set offset to NaN when URL params were absent.

## Changes

- Scope PersonPreview's kea logic with urlId so each preview gets its own instance
- Show \<NotFound> instead of throwing on person load errors
- Replace the split-by-hyphens distinctId logic with scoreDistinctId (email → 2, custom → 1, anon → 0) and sort
- Extract a common parsePersonFromHogQLRow into a util with a try/catch for bad JSON, also picks up the missing last_seen_at
- Add || 0 fallback for parsed offset in loadPersons

## How did you test this code?

Added some unit tests for the new utils

## Publish to changelog?

No