### PR TITLE
fix(agent): add twig bot integration

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -265,6 +265,12 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 return preflight?.slack_service?.available
             },
         ],
+        twigSlackAvailable: [
+            (s) => [s.preflight],
+            (preflight) => {
+                return preflight?.twig_slack_service?.available
+            },
+        ],
         getGitHubRepositories: [
             (s) => [s.githubRepositories],
             (githubRepositories) => {

--- a/frontend/src/scenes/settings/environment/TwigSlackIntegration.tsx
+++ b/frontend/src/scenes/settings/environment/TwigSlackIntegration.tsx
@@ -7,7 +7,7 @@ import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
 
 export function TwigSlackIntegration(): JSX.Element {
-    const { twigSlackIntegrations, slackAvailable } = useValues(integrationsLogic)
+    const { twigSlackIntegrations, twigSlackAvailable } = useValues(integrationsLogic)
 
     return (
         <div>
@@ -19,7 +19,7 @@ export function TwigSlackIntegration(): JSX.Element {
                 ))}
 
                 <div>
-                    {slackAvailable ? (
+                    {twigSlackAvailable ? (
                         <Link to={api.integrations.authorizeUrl({ kind: 'slack-twig' })} disableClientSideRouting>
                             <img
                                 alt="Add to Slack"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4052,6 +4052,10 @@ export interface PreflightStatus {
         available: boolean
         client_id?: string
     }
+    twig_slack_service: {
+        available: boolean
+        client_id?: string
+    }
     data_warehouse_integrations: {
         hubspot: {
             client_id?: string


### PR DESCRIPTION
## Problem

Adding twig slack integration bot to trigger background agents from `prod`

<img width="522" height="122" alt="image" src="https://github.com/user-attachments/assets/8f61a5c9-8fc1-46b6-a3c3-e4b6e20f0c18" />
