### PR TITLE
fix(cdp): deduplicate cohort membership batch before postgres upsert

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
@@ -235,6 +235,40 @@ describe('CdpCohortMembershipConsumer', () => {
             expect(kafkaMessages[0].value).toEqual(reEnterEvent)
         })
 
+        it('should deduplicate batch entries for the same (team_id, cohort_id, person_id), keeping last in Kafka order', async () => {
+            const testEvents = createCohortMembershipEvents([
+                {
+                    person_id: personId1,
+                    cohort_id: 456,
+                    team_id: 1,
+                    status: 'entered',
+                },
+                {
+                    person_id: personId1,
+                    cohort_id: 456,
+                    team_id: 1,
+                    status: 'left',
+                },
+            ])
+
+            const messages = testEvents.map((event, index) =>
+                createKafkaMessage(event, { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: index })
+            )
+
+            const cohortMembershipChanges = consumer['_parseAndValidateBatch'](messages)
+            await consumer['persistCohortMembershipChanges'](cohortMembershipChanges)
+
+            const result = await hub.postgres.query(
+                PostgresUse.BEHAVIORAL_COHORTS_RW,
+                'SELECT * FROM cohort_membership WHERE team_id = $1 AND person_id = $2 AND cohort_id = $3',
+                [1, personId1, 456],
+                'testQuery'
+            )
+
+            expect(result.rows).toHaveLength(1)
+            expect(result.rows[0].in_cohort).toBe(false) // Last event was 'left'
+        })
+
         it('should reject entire batch when invalid messages are present', async () => {
             const validEvent = {
                 person_id: personId1,

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -63,14 +63,13 @@ export class CdpCohortMembershipConsumer extends CdpConsumerBase {
             for (const change of changes) {
                 deduped.set(`${change.team_id}:${change.cohort_id}:${change.person_id}`, change)
             }
-            const uniqueChanges = Array.from(deduped.values())
 
             // Build the VALUES clause for batch upsert
             const values: any[] = []
             const placeholders: string[] = []
             let paramIndex = 1
 
-            for (const change of uniqueChanges) {
+            for (const change of deduped.values()) {
                 const inCohort = change.status === 'entered'
                 placeholders.push(
                     `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, CURRENT_TIMESTAMP)`

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -58,12 +58,19 @@ export class CdpCohortMembershipConsumer extends CdpConsumerBase {
         }
 
         try {
+            // Deduplicate by (team_id, cohort_id, person_id), keeping last in Kafka order
+            const deduped = new Map<string, CohortMembershipChange>()
+            for (const change of changes) {
+                deduped.set(`${change.team_id}:${change.cohort_id}:${change.person_id}`, change)
+            }
+            const uniqueChanges = Array.from(deduped.values())
+
             // Build the VALUES clause for batch upsert
             const values: any[] = []
             const placeholders: string[] = []
             let paramIndex = 1
 
-            for (const change of changes) {
+            for (const change of uniqueChanges) {
                 const inCohort = change.status === 'entered'
                 placeholders.push(
                     `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, CURRENT_TIMESTAMP)`


### PR DESCRIPTION
 ### Summary                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  - The cohort membership consumer was failing with Postgres error ON CONFLICT DO UPDATE command cannot affect row a second time when a Kafka batch contained multiple messages for the same (team_id, cohort_id, person_id)                        
  - This happens because the consumer builds a single INSERT...ON CONFLICT DO UPDATE statement for the entire batch, and Postgres doesn't allow the same row to be touched twice in one statement                                                   
  - Duplicate messages in a batch can occur from Kafka rebalancing, retries, or concurrent cohort recalculations                                                                                                                                    
  - Fix: deduplicate the batch before building the query, keeping the last message per key (which is the most recent per Kafka partition ordering)

### Tests

  - Added test: two events for the same person/cohort/team in one batch correctly resolves to a single row with the last status
  - Existing tests pass unchanged