### PR TITLE
chore: add .agents/ to CODEOWNERS-soft for team-devex

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -226,6 +226,7 @@ CODEOWNERS @PostHog/team-devex
 CLAUDE.md @PostHog/team-devex
 AGENTS.md @PostHog/team-devex
 .claude/ @PostHog/team-devex
+.agents/ @PostHog/team-devex
 .claude/agents/ingestion/ @PostHog/team-ingestion
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion


### PR DESCRIPTION
Skills moved from `.claude/skills/` to `.agents/skills/` (with a symlink back), but `.agents/` itself wasn't listed in CODEOWNERS-soft — changes there bypassed soft review.