### PR TITLE
chore: debug info for ingestion acceptance tests

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/__main__.py
+++ b/posthog/temporal/ingestion_acceptance_test/__main__.py
@@ -8,7 +8,7 @@ import posthoganalytics
 
 from posthog.temporal.ingestion_acceptance_test.client import PostHogClient
 from posthog.temporal.ingestion_acceptance_test.config import Config
-from posthog.temporal.ingestion_acceptance_test.runner import run_tests
+from posthog.temporal.ingestion_acceptance_test.runner import RunningTests, run_tests
 from posthog.temporal.ingestion_acceptance_test.terminal_report import format_terminal_report
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import discover_tests
 
@@ -27,6 +27,6 @@ if __name__ == "__main__":
     tests = discover_tests()
     client = PostHogClient(config, posthog_sdk)
     with ThreadPoolExecutor() as executor:
-        result = run_tests(config, tests, client, executor)
+        result = run_tests(config, tests, client, executor, RunningTests())
     logger.info(format_terminal_report(result))
     sys.exit(0 if result.success else 1)

--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -10,7 +10,7 @@ import temporalio.activity
 from posthog.temporal.ingestion_acceptance_test.client import PostHogClient
 from posthog.temporal.ingestion_acceptance_test.config import Config
 from posthog.temporal.ingestion_acceptance_test.results import TestSuiteResult
-from posthog.temporal.ingestion_acceptance_test.runner import run_tests
+from posthog.temporal.ingestion_acceptance_test.runner import RunningTests, run_tests
 from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification, send_slack_timeout_notification
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import discover_tests
 
@@ -54,14 +54,15 @@ async def run_ingestion_acceptance_tests() -> dict:
 
     tests = discover_tests()
     client = PostHogClient(config, posthog_sdk)
+    running_tests = RunningTests()
     try:
         with ThreadPoolExecutor() as executor:
             result: TestSuiteResult = await asyncio.wait_for(
-                asyncio.to_thread(run_tests, config, tests, client, executor),
+                asyncio.to_thread(run_tests, config, tests, client, executor, running_tests),
                 timeout=config.activity_timeout_seconds,
             )
     except TimeoutError:
-        send_slack_timeout_notification(config)
+        send_slack_timeout_notification(config, running_tests=running_tests.snapshot())
         raise
 
     logger.info(

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -147,11 +147,13 @@ class PostHogClient:
             sdk_host=self.config.api_host,
         )
 
+        all_properties = {"$ignore_sent_at": True, **(properties or {})}
+
         self._retry_on_error(
             lambda: self._posthog.capture(
                 distinct_id=distinct_id,
                 event=event_name,
-                properties=properties or {},
+                properties=all_properties,
                 uuid=event_uuid,
             ),
             description=f"capture event {event_uuid}",
@@ -208,7 +210,7 @@ class PostHogClient:
             lambda: self._posthog.capture(
                 distinct_id=merge_into_distinct_id,
                 event="$merge_dangerously",
-                properties={"alias": merge_from_distinct_id},
+                properties={"alias": merge_from_distinct_id, "$ignore_sent_at": True},
                 uuid=event_uuid,
             ),
             description=f"merge dangerously {merge_from_distinct_id} -> {merge_into_distinct_id}",
@@ -268,7 +270,7 @@ class PostHogClient:
 
     # Polling configuration
     POLL_BACKOFF_FACTOR = 1.5
-    POLL_MAX_INTERVAL_SECONDS = 300.0
+    POLL_MAX_INTERVAL_SECONDS = 60.0
 
     def _poll_until_found(
         self,

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -220,6 +220,7 @@ class PostHogClient:
 
     def query_event_by_uuid(self, event_uuid: str) -> CapturedEvent | None:
         """Query for an event by UUID, polling until found or timeout."""
+        logger.info("Querying for event", event_uuid=event_uuid)
         return self._poll_until_found(
             fetch_fn=lambda: self._fetch_event_by_uuid(event_uuid),
             description=f"event UUID '{event_uuid}'",
@@ -234,6 +235,7 @@ class PostHogClient:
                 property is >= this value. This helps ensure eventual consistency by
                 waiting for person updates to propagate.
         """
+        logger.info("Querying for person", distinct_id=distinct_id, min_timestamp=min_timestamp)
         return self._poll_until_found(
             fetch_fn=lambda: _person_has_min_timestamp(self._fetch_person_by_distinct_id(distinct_id), min_timestamp),
             description=f"person with distinct_id '{distinct_id}'",
@@ -249,6 +251,11 @@ class PostHogClient:
         Returns:
             List of events if all expected UUIDs are found, None if timeout.
         """
+        logger.info(
+            "Querying for events by person",
+            person_id=person_id,
+            expected_event_uuids=expected_event_uuids,
+        )
         return self._poll_until_found(
             fetch_fn=lambda: self._fetch_events_by_person_id(person_id, expected_event_uuids),
             description=f"events for person '{person_id}'",
@@ -276,12 +283,30 @@ class PostHogClient:
         """
         start_time = time.time()
         current_interval = self.config.poll_interval_seconds
+        attempt = 0
 
         while time.time() - start_time < self.config.event_timeout_seconds:
+            attempt += 1
             time.sleep(current_interval)
+            if attempt > 1:
+                elapsed = time.time() - start_time
+                logger.info(
+                    "Polling attempt",
+                    attempt=attempt,
+                    description=description,
+                    elapsed_seconds=round(elapsed, 1),
+                    next_interval_seconds=round(current_interval, 1),
+                )
             try:
                 result = fetch_fn()
                 if result is not None:
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        "Polling succeeded",
+                        description=description,
+                        attempt=attempt,
+                        elapsed_seconds=round(elapsed, 1),
+                    )
                     return result
             except requests.exceptions.RequestException as e:
                 logger.warning(
@@ -289,6 +314,7 @@ class PostHogClient:
                     error=str(e),
                     error_type=type(e).__name__,
                     description=description,
+                    attempt=attempt,
                 )
             current_interval = min(
                 current_interval * self.POLL_BACKOFF_FACTOR,
@@ -296,7 +322,12 @@ class PostHogClient:
                 self.config.event_timeout_seconds - (time.time() - start_time),
             )
 
-        logger.warning("Polling timed out", description=description, timeout_seconds=self.config.event_timeout_seconds)
+        logger.warning(
+            "Polling timed out",
+            description=description,
+            timeout_seconds=self.config.event_timeout_seconds,
+            attempts=attempt,
+        )
         return None
 
     def _execute_hogql_query(self, query: str, values: dict[str, Any]) -> dict[str, Any] | None:

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -147,7 +147,7 @@ class PostHogClient:
             sdk_host=self.config.api_host,
         )
 
-        all_properties = {"$ignore_sent_at": True, **(properties or {})}
+        all_properties = {**(properties or {}), "$ignore_sent_at": True}
 
         self._retry_on_error(
             lambda: self._posthog.capture(

--- a/posthog/temporal/ingestion_acceptance_test/runner.py
+++ b/posthog/temporal/ingestion_acceptance_test/runner.py
@@ -1,15 +1,40 @@
 """Test runner for acceptance tests without pytest dependency."""
 
 import time
+import threading
 import traceback
 from concurrent.futures import Executor, as_completed
 from dataclasses import dataclass
 from typing import Literal
 
+import structlog
+
 from .client import CapturedEvent, PostHogClient
 from .config import Config
 from .results import TestResult, TestSuiteResult
 from .test_cases_discovery import TestCase
+
+logger = structlog.get_logger(__name__)
+
+
+class RunningTests:
+    """Thread-safe tracker for currently running tests."""
+
+    def __init__(self) -> None:
+        self._tests: set[str] = set()
+        self._lock = threading.Lock()
+
+    def add(self, test_name: str) -> None:
+        with self._lock:
+            self._tests.add(test_name)
+
+    def remove(self, test_name: str) -> None:
+        with self._lock:
+            self._tests.discard(test_name)
+
+    def snapshot(self) -> list[str]:
+        with self._lock:
+            return sorted(self._tests)
 
 
 @dataclass
@@ -54,8 +79,11 @@ class AcceptanceTest:
 def _run_single_test(
     test_case: TestCase,
     ctx: TestContext,
+    running_tests: RunningTests,
 ) -> TestResult:
     """Run a single test and return its result."""
+    logger.info("Test starting", test_name=test_case.full_name)
+    running_tests.add(test_case.full_name)
     start_time = time.time()
     status: Literal["passed", "failed", "error"] = "passed"
     error_message = None
@@ -82,7 +110,14 @@ def _run_single_test(
             "traceback": traceback.format_exc(),
         }
 
+    running_tests.remove(test_case.full_name)
     duration = time.time() - start_time
+    logger.info(
+        "Test finished",
+        test_name=test_case.full_name,
+        status=status,
+        duration_seconds=round(duration, 1),
+    )
 
     return TestResult(
         test_name=test_case.method_name,
@@ -99,6 +134,7 @@ def run_tests(
     tests: list[TestCase],
     client: PostHogClient,
     executor: Executor,
+    running_tests: RunningTests,
 ) -> TestSuiteResult:
     """Run all acceptance tests and return structured results.
 
@@ -107,6 +143,7 @@ def run_tests(
         tests: List of test cases to run.
         client: PostHog client for API interactions.
         executor: Executor for running tests in parallel.
+        running_tests: Thread-safe tracker for currently running tests.
 
     Returns:
         TestSuiteResult with all test outcomes.
@@ -117,7 +154,7 @@ def run_tests(
     try:
         ctx = TestContext(client=client, config=config)
 
-        futures = {executor.submit(_run_single_test, test_case, ctx): test_case for test_case in tests}
+        futures = {executor.submit(_run_single_test, test_case, ctx, running_tests): test_case for test_case in tests}
         for future in as_completed(futures):
             results.append(future.result())
 

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -117,11 +117,12 @@ def _build_context_block(config: Config, result: TestSuiteResult) -> dict[str, A
     }
 
 
-def send_slack_timeout_notification(config: Config) -> bool:
+def send_slack_timeout_notification(config: Config, running_tests: list[str] | None = None) -> bool:
     """Send a timeout notification to Slack via incoming webhook.
 
     Args:
         config: Configuration containing the Slack webhook URL.
+        running_tests: List of test names that were still running when the timeout occurred.
 
     Returns:
         True if notification was sent successfully or skipped, False on send failure.
@@ -152,6 +153,18 @@ def send_slack_timeout_notification(config: Config) -> bool:
             ],
         },
     ]
+
+    if running_tests:
+        test_list = "\n".join(f"• {name}" for name in running_tests)
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f":red_circle: *Still running ({len(running_tests)}):*\n{test_list}",
+                },
+            }
+        )
 
     try:
         response = external_requests.post(

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_alias.py
@@ -3,7 +3,11 @@
 import time
 import uuid
 
+import structlog
+
 from ..runner import AcceptanceTest
+
+logger = structlog.get_logger(__name__)
 
 
 class TestAlias(AcceptanceTest):
@@ -12,33 +16,44 @@ class TestAlias(AcceptanceTest):
     def test_alias_merges_events_from_different_distinct_ids(self) -> None:
         """Send events with two distinct IDs, alias them, and verify both events belong to the same person."""
         event_name = "$test_alias"
-        distinct_id_1 = str(uuid.uuid4())
-        distinct_id_2 = str(uuid.uuid4())
+        distinct_id_a = str(uuid.uuid4())  # Person A - will be aliased to
+        distinct_id_b = str(uuid.uuid4())  # Person B - will be aliased from
 
         # Capture both events before polling to reduce wall-clock time
+        logger.info("test_alias: capturing event for Person A", distinct_id=distinct_id_a)
         first_timestamp = time.time()
         first_event_uuid = self.client.capture_event(
-            event_name, distinct_id_1, {"$set": {"source": "first", "$test_timestamp": first_timestamp}}
+            event_name, distinct_id_a, {"$set": {"source": "first", "$test_timestamp": first_timestamp}}
         )
+
+        logger.info("test_alias: capturing event for Person B", distinct_id=distinct_id_b)
         second_timestamp = time.time()
         second_event_uuid = self.client.capture_event(
-            event_name, distinct_id_2, {"$set": {"source": "second", "$test_timestamp": second_timestamp}}
+            event_name, distinct_id_b, {"$set": {"source": "second", "$test_timestamp": second_timestamp}}
         )
 
         # Poll for both events
+        logger.info("test_alias: querying for Person A event", event_uuid=first_event_uuid)
         found_first = self.client.query_event_by_uuid(first_event_uuid)
-        self.assert_event(found_first, first_event_uuid, event_name, distinct_id_1)
+        self.assert_event(found_first, first_event_uuid, event_name, distinct_id_a)
+
+        logger.info("test_alias: querying for Person B event", event_uuid=second_event_uuid)
         found_second = self.client.query_event_by_uuid(second_event_uuid)
-        self.assert_event(found_second, second_event_uuid, event_name, distinct_id_2)
+        self.assert_event(found_second, second_event_uuid, event_name, distinct_id_b)
 
-        # Create alias: link distinct_id_2 to distinct_id_1
-        alias_event_uuid = self.client.alias(distinct_id_2, distinct_id_1)
+        # Create alias: link Person B to Person A
+        logger.info(
+            "test_alias: creating alias from Person B to Person A", alias=distinct_id_b, distinct_id=distinct_id_a
+        )
+        alias_event_uuid = self.client.alias(distinct_id_b, distinct_id_a)
 
-        # Wait for alias to propagate and query person by distinct_id_1
-        person = self.client.query_person_by_distinct_id(distinct_id_1, min_timestamp=second_timestamp)
+        # Wait for alias to propagate and query person by Person A's distinct_id
+        logger.info("test_alias: querying for Person A after alias", distinct_id=distinct_id_a)
+        person = self.client.query_person_by_distinct_id(distinct_id_a, min_timestamp=second_timestamp)
         assert person is not None, "Alias not propagated within time budget"
 
         # Query all events for this person - should have all 3 specific events
+        logger.info("test_alias: querying events by person", person_id=person.id)
         expected_uuids = {first_event_uuid, second_event_uuid, alias_event_uuid}
         events = self.client.query_events_by_person_id(person.id, expected_event_uuids=expected_uuids)
         assert events is not None, "Expected events not found for person after alias within time budget"

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_basic_capture.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_basic_capture.py
@@ -2,7 +2,11 @@
 
 import uuid
 
+import structlog
+
 from ..runner import AcceptanceTest
+
+logger = structlog.get_logger(__name__)
 
 
 class TestBasicCapture(AcceptanceTest):
@@ -13,7 +17,10 @@ class TestBasicCapture(AcceptanceTest):
         event_name = "$test_basic_capture"
         distinct_id = str(uuid.uuid4())
 
+        logger.info("test_capture_event: capturing event", event_name=event_name, distinct_id=distinct_id)
         event_uuid = self.client.capture_event(event_name, distinct_id)
+
+        logger.info("test_capture_event: querying for event", event_uuid=event_uuid)
         found_event = self.client.query_event_by_uuid(event_uuid)
         self.assert_event(found_event, event_uuid, event_name, distinct_id)
 
@@ -27,7 +34,12 @@ class TestBasicCapture(AcceptanceTest):
             "referrer": "google",
         }
 
+        logger.info(
+            "test_capture_event_with_properties: capturing event", event_name=event_name, distinct_id=distinct_id
+        )
         event_uuid = self.client.capture_event(event_name, distinct_id, properties)
+
+        logger.info("test_capture_event_with_properties: querying for event", event_uuid=event_uuid)
         found_event = self.client.query_event_by_uuid(event_uuid)
         found_event = self.assert_event(found_event, event_uuid, event_name, distinct_id)
         self.assert_properties_contain(found_event.properties, properties)

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_event_person_properties_capture.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_event_person_properties_capture.py
@@ -3,7 +3,11 @@
 import time
 import uuid
 
+import structlog
+
 from ..runner import AcceptanceTest
+
+logger = structlog.get_logger(__name__)
 
 
 class TestPersonPropertiesCapture(AcceptanceTest):
@@ -16,9 +20,12 @@ class TestPersonPropertiesCapture(AcceptanceTest):
         timestamp = time.time()
         expected_person_props = {"email": "test@example.com", "name": "Test User"}
 
+        logger.info("test_set_person_properties: capturing event", distinct_id=distinct_id)
         event_uuid = self.client.capture_event(
             event_name, distinct_id, {"$set": {**expected_person_props, "$test_timestamp": timestamp}}
         )
+
+        logger.info("test_set_person_properties: querying for event", event_uuid=event_uuid)
         found_event = self.client.query_event_by_uuid(event_uuid)
         found_event = self.assert_event(found_event, event_uuid, event_name, distinct_id)
 
@@ -26,6 +33,7 @@ class TestPersonPropertiesCapture(AcceptanceTest):
         assert set_props is not None, "$set properties not found in event"
         self.assert_properties_contain(set_props, expected_person_props, "event $set")
 
+        logger.info("test_set_person_properties: querying for person", distinct_id=distinct_id)
         person = self.client.query_person_by_distinct_id(distinct_id)
         assert person is not None, "Person not found within time budget"
         self.assert_properties_contain(person.properties, expected_person_props, "person")
@@ -37,18 +45,23 @@ class TestPersonPropertiesCapture(AcceptanceTest):
         initial_props = {"initial_referrer": "google"}
 
         # First event: set initial values with $set_once
+        logger.info("test_set_once: capturing first event", distinct_id=distinct_id)
         first_timestamp = time.time()
         first_event_uuid = self.client.capture_event(
             event_name, distinct_id, {"$set_once": initial_props, "$set": {"$test_timestamp": first_timestamp}}
         )
+
+        logger.info("test_set_once: querying for first event", event_uuid=first_event_uuid)
         found_first = self.client.query_event_by_uuid(first_event_uuid)
         self.assert_event(found_first, first_event_uuid, event_name, distinct_id)
 
+        logger.info("test_set_once: querying for person after first event", distinct_id=distinct_id)
         person = self.client.query_person_by_distinct_id(distinct_id)
         assert person is not None, "Person not found within time budget"
         self.assert_properties_contain(person.properties, initial_props, "person after first event")
 
         # Second event: try to overwrite with $set_once (should not change existing)
+        logger.info("test_set_once: capturing second event", distinct_id=distinct_id)
         second_timestamp = time.time()
         second_props = {
             "$set_once": {
@@ -58,9 +71,12 @@ class TestPersonPropertiesCapture(AcceptanceTest):
             "$set": {"$test_timestamp": second_timestamp},
         }
         second_event_uuid = self.client.capture_event(event_name, distinct_id, second_props)
+
+        logger.info("test_set_once: querying for second event", event_uuid=second_event_uuid)
         found_second = self.client.query_event_by_uuid(second_event_uuid)
         self.assert_event(found_second, second_event_uuid, event_name, distinct_id)
 
+        logger.info("test_set_once: querying for person after second event", distinct_id=distinct_id)
         person_after = self.client.query_person_by_distinct_id(distinct_id, min_timestamp=second_timestamp)
         assert person_after is not None, "Person updates not found within time budget"
         # Original values preserved, new property added
@@ -78,26 +94,34 @@ class TestPersonPropertiesCapture(AcceptanceTest):
         }
 
         # First event: set initial properties
+        logger.info("test_unset: capturing first event", distinct_id=distinct_id)
         first_timestamp = time.time()
         first_event_uuid = self.client.capture_event(
             event_name, distinct_id, {"$set": {**initial_props, "$test_timestamp": first_timestamp}}
         )
+
+        logger.info("test_unset: querying for first event", event_uuid=first_event_uuid)
         found_first = self.client.query_event_by_uuid(first_event_uuid)
         self.assert_event(found_first, first_event_uuid, event_name, distinct_id)
 
+        logger.info("test_unset: querying for person after first event", distinct_id=distinct_id)
         person = self.client.query_person_by_distinct_id(distinct_id)
         assert person is not None, "Person not found after first event"
         self.assert_properties_contain(person.properties, initial_props, "person after first event")
 
         # Second event: unset specific properties
+        logger.info("test_unset: capturing second event with $unset", distinct_id=distinct_id)
         second_timestamp = time.time()
         second_event_uuid = self.client.capture_event(
             event_name, distinct_id, {"$unset": ["temporary_flag"], "$set": {"$test_timestamp": second_timestamp}}
         )
+
+        logger.info("test_unset: querying for second event", event_uuid=second_event_uuid)
         found_second = self.client.query_event_by_uuid(second_event_uuid)
         self.assert_event(found_second, second_event_uuid, event_name, distinct_id)
 
         # Verify properties are removed, others remain
+        logger.info("test_unset: querying for person after $unset", distinct_id=distinct_id)
         person_after = self.client.query_person_by_distinct_id(distinct_id, min_timestamp=second_timestamp)
         assert person_after is not None, "$unset event not propagated within time budget"
         assert person_after.properties.get("temporary_flag") is None, "$unset should remove the property"
@@ -110,21 +134,26 @@ class TestPersonPropertiesCapture(AcceptanceTest):
         distinct_id = str(uuid.uuid4())
 
         # First event: set initial properties
+        logger.info("test_combined: capturing first event", distinct_id=distinct_id)
         first_timestamp = time.time()
         first_props = {
             "$set": {"plan": "free", "to_remove": "temporary", "$test_timestamp": first_timestamp},
             "$set_once": {"first_plan": "free"},
         }
         first_event_uuid = self.client.capture_event(event_name, distinct_id, first_props)
+
+        logger.info("test_combined: querying for first event", event_uuid=first_event_uuid)
         found_first = self.client.query_event_by_uuid(first_event_uuid)
         self.assert_event(found_first, first_event_uuid, event_name, distinct_id)
 
+        logger.info("test_combined: querying for person after first event", distinct_id=distinct_id)
         person = self.client.query_person_by_distinct_id(distinct_id)
         assert person is not None, "Person not found after first event"
         expected_after_first = {"plan": "free", "first_plan": "free"}
         self.assert_properties_contain(person.properties, expected_after_first)
 
         # Second event: combine all three operations
+        logger.info("test_combined: capturing second event", distinct_id=distinct_id)
         second_timestamp = time.time()
         second_props = {
             "$set": {"plan": "enterprise", "$test_timestamp": second_timestamp},
@@ -132,9 +161,12 @@ class TestPersonPropertiesCapture(AcceptanceTest):
             "$unset": ["to_remove"],
         }
         second_event_uuid = self.client.capture_event(event_name, distinct_id, second_props)
+
+        logger.info("test_combined: querying for second event", event_uuid=second_event_uuid)
         found_second = self.client.query_event_by_uuid(second_event_uuid)
         self.assert_event(found_second, second_event_uuid, event_name, distinct_id)
 
+        logger.info("test_combined: querying for person after combined operations", distinct_id=distinct_id)
         person_after = self.client.query_person_by_distinct_id(distinct_id, min_timestamp=second_timestamp)
         assert person_after is not None, "Combined $set/$set_once/$unset not propagated within time budget"
 

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_merge.py
@@ -3,7 +3,11 @@
 import time
 import uuid
 
+import structlog
+
 from ..runner import AcceptanceTest
+
+logger = structlog.get_logger(__name__)
 
 
 class TestMergeDangerously(AcceptanceTest):
@@ -16,10 +20,13 @@ class TestMergeDangerously(AcceptanceTest):
         distinct_id_b = str(uuid.uuid4())  # Person B - will be merged into A
 
         # Capture both events before polling to reduce wall-clock time
+        logger.info("test_merge: capturing event for Person A", distinct_id=distinct_id_a)
         timestamp_a = time.time()
         event_uuid_a = self.client.capture_event(
             event_name, distinct_id_a, {"$set": {"name": "Person A", "$test_timestamp": timestamp_a}}
         )
+
+        logger.info("test_merge: capturing event for Person B", distinct_id=distinct_id_b)
         timestamp_b = time.time()
         event_uuid_b = self.client.capture_event(
             event_name,
@@ -28,32 +35,45 @@ class TestMergeDangerously(AcceptanceTest):
         )
 
         # Poll for both events
+        logger.info("test_merge: querying for Person A event", event_uuid=event_uuid_a)
         found_a = self.client.query_event_by_uuid(event_uuid_a)
         self.assert_event(found_a, event_uuid_a, event_name, distinct_id_a)
+
+        logger.info("test_merge: querying for Person B event", event_uuid=event_uuid_b)
         found_b = self.client.query_event_by_uuid(event_uuid_b)
         self.assert_event(found_b, event_uuid_b, event_name, distinct_id_b)
 
         # Verify both persons exist
+        logger.info("test_merge: querying for Person A", distinct_id=distinct_id_a)
         person_a = self.client.query_person_by_distinct_id(distinct_id_a)
         assert person_a is not None, "Person A not found within time budget"
+
+        logger.info("test_merge: querying for Person B", distinct_id=distinct_id_b)
         person_b = self.client.query_person_by_distinct_id(distinct_id_b)
         assert person_b is not None, "Person B not found within time budget"
 
         # Merge Person B into Person A
+        logger.info("test_merge: merging Person B into Person A", merge_into=distinct_id_a, merge_from=distinct_id_b)
         merge_event_uuid = self.client.merge_dangerously(distinct_id_a, distinct_id_b)
+
+        logger.info("test_merge: querying for merge event", event_uuid=merge_event_uuid)
         found_merge = self.client.query_event_by_uuid(merge_event_uuid)
         assert found_merge is not None, "Merge event not found within time budget"
 
         # Wait for merge to propagate - Person A should have updated timestamp
         # We need to set a new timestamp on Person A to detect when merge completes
+        logger.info("test_merge: capturing post-merge event", distinct_id=distinct_id_a)
         post_merge_timestamp = time.time()
         post_merge_event_uuid = self.client.capture_event(
             "$test_post_merge", distinct_id_a, {"$set": {"$test_timestamp": post_merge_timestamp}}
         )
+
+        logger.info("test_merge: querying for post-merge event", event_uuid=post_merge_event_uuid)
         found_post_merge = self.client.query_event_by_uuid(post_merge_event_uuid)
         assert found_post_merge is not None, "Post-merge event not found within time budget"
 
         # Query Person A with the post-merge timestamp to ensure merge has propagated
+        logger.info("test_merge: querying for merged person", distinct_id=distinct_id_a)
         merged_person = self.client.query_person_by_distinct_id(distinct_id_a, min_timestamp=post_merge_timestamp)
         assert merged_person is not None, "Person not updated after merge within time budget"
 
@@ -63,6 +83,7 @@ class TestMergeDangerously(AcceptanceTest):
         assert merged_person.properties.get("extra_prop") == "from_b", "Person B's extra_prop should be merged"
 
         # Query all events for the merged person - should have events from both A and B
+        logger.info("test_merge: querying events for merged person", person_id=merged_person.id)
         expected_uuids = {event_uuid_a, event_uuid_b, merge_event_uuid, post_merge_event_uuid}
         events = self.client.query_events_by_person_id(merged_person.id, expected_event_uuids=expected_uuids)
         assert events is not None, "Expected events not found for merged person after merge within time budget"

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
@@ -51,7 +51,7 @@ class TestRunIngestionAcceptanceTestsTimeout:
         with pytest.raises(asyncio.TimeoutError):
             await run_ingestion_acceptance_tests()
 
-        mock_send_timeout.assert_called_once_with(config)
+        mock_send_timeout.assert_called_once_with(config, running_tests=[])
         mock_send_slack.assert_not_called()
 
     @patch("posthog.temporal.ingestion_acceptance_test.activities.send_slack_timeout_notification")

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -49,7 +49,7 @@ class TestCaptureEvent:
         mock_posthog_sdk.capture.assert_called_once_with(
             distinct_id="user_123",
             event="test_event",
-            properties=properties,
+            properties={"$ignore_sent_at": True, **properties},
             uuid=event_uuid,
         )
 
@@ -57,7 +57,7 @@ class TestCaptureEvent:
         client.capture_event(event_name="test_event", distinct_id="user_123")
 
         call_kwargs = mock_posthog_sdk.capture.call_args[1]
-        assert call_kwargs["properties"] == {}
+        assert call_kwargs["properties"] == {"$ignore_sent_at": True}
 
 
 class TestFetchEventByUuid:

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ingestion_acceptance_test.config import Config
-from posthog.temporal.ingestion_acceptance_test.runner import AcceptanceTest, TestContext, run_tests
+from posthog.temporal.ingestion_acceptance_test.runner import AcceptanceTest, RunningTests, TestContext, run_tests
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import TestCase
 
 
@@ -28,9 +28,14 @@ def executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=4)
 
 
+@pytest.fixture
+def running_tests() -> RunningTests:
+    return RunningTests()
+
+
 class TestRunTests:
     def test_instantiates_class_calls_setup_and_runs_method(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         call_order = []
 
@@ -46,12 +51,12 @@ class TestRunTests:
 
         tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
 
-        run_tests(config, tests, mock_client, executor)
+        run_tests(config, tests, mock_client, executor, running_tests)
 
         assert call_order == ["init", "setup", "test_method"]
 
     def test_returns_passed_status_and_correct_names(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         class FakeTest(AcceptanceTest):
             def test_method(self) -> None:
@@ -59,7 +64,7 @@ class TestRunTests:
 
         tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
 
-        result = run_tests(config, tests, mock_client, executor)
+        result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.passed_count == 1
         assert result.results[0].status == "passed"
@@ -67,7 +72,7 @@ class TestRunTests:
         assert result.results[0].test_file == "test_mod::FakeTest::test_method"
 
     def test_returns_failed_status_for_assertion_error(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         class FakeTest(AcceptanceTest):
             def test_method(self) -> None:
@@ -75,7 +80,7 @@ class TestRunTests:
 
         tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
 
-        result = run_tests(config, tests, mock_client, executor)
+        result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.failed_count == 1
         assert result.results[0].status == "failed"
@@ -85,7 +90,7 @@ class TestRunTests:
         assert result.results[0].error_details["type"] == "AssertionError"
 
     def test_returns_error_status_for_unexpected_exception(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         class FakeTest(AcceptanceTest):
             def test_method(self) -> None:
@@ -93,7 +98,7 @@ class TestRunTests:
 
         tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
 
-        result = run_tests(config, tests, mock_client, executor)
+        result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.error_count == 1
         assert result.results[0].status == "error"
@@ -103,7 +108,7 @@ class TestRunTests:
         assert result.results[0].error_details["type"] == "ValueError"
 
     def test_runs_multiple_tests_and_aggregates_results(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         class PassingTest(AcceptanceTest):
             def test_pass(self) -> None:
@@ -118,25 +123,14 @@ class TestRunTests:
             TestCase(module_name="test_mod", test_class=FailingTest, method_name="test_fail"),
         ]
 
-        result = run_tests(config, tests, mock_client, executor)
+        result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.total_count == 2
         assert result.passed_count == 1
         assert result.failed_count == 1
 
-    def test_calls_client_shutdown(self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor) -> None:
-        class FakeTest(AcceptanceTest):
-            def test_method(self) -> None:
-                pass
-
-        tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
-
-        run_tests(config, tests, mock_client, executor)
-
-        mock_client.shutdown.assert_called_once()
-
-    def test_returns_environment_from_config(
-        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor
+    def test_calls_client_shutdown(
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
     ) -> None:
         class FakeTest(AcceptanceTest):
             def test_method(self) -> None:
@@ -144,14 +138,27 @@ class TestRunTests:
 
         tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
 
-        result = run_tests(config, tests, mock_client, executor)
+        run_tests(config, tests, mock_client, executor, running_tests)
+
+        mock_client.shutdown.assert_called_once()
+
+    def test_returns_environment_from_config(
+        self, config: Config, mock_client: MagicMock, executor: ThreadPoolExecutor, running_tests: RunningTests
+    ) -> None:
+        class FakeTest(AcceptanceTest):
+            def test_method(self) -> None:
+                pass
+
+        tests = [TestCase(module_name="test_mod", test_class=FakeTest, method_name="test_method")]
+
+        result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.environment["api_host"] == "https://test.posthog.com"
         assert result.environment["project_id"] == "12345"
 
     @patch("posthog.temporal.ingestion_acceptance_test.runner.as_completed")
     def test_submits_all_tests_to_executor(
-        self, mock_as_completed: MagicMock, config: Config, mock_client: MagicMock
+        self, mock_as_completed: MagicMock, config: Config, mock_client: MagicMock, running_tests: RunningTests
     ) -> None:
         mock_executor = MagicMock()
         mock_futures = [MagicMock(), MagicMock(), MagicMock()]
@@ -178,6 +185,6 @@ class TestRunTests:
             TestCase(module_name="test_mod", test_class=FakeTest3, method_name="test_three"),
         ]
 
-        run_tests(config, tests, mock_client, mock_executor)
+        run_tests(config, tests, mock_client, mock_executor, running_tests)
 
         assert mock_executor.submit.call_count == 3


### PR DESCRIPTION
## Problem

At times, the tests are running for an hour without terminating. The reason for that is constantly polling for an event that meets some criteria and that cannot be found. This either means we are indeed taking ~1h to process a given event (unlikely) or that at times, the conditions we are expecting aren't being met (for unknown reasons).

## Changes

Adding many log lines to keep track of what is being attempted at any given point in time plus keeping a list of tests still running so that when tests timeout, we also know which test exactly timed out.

Additionally, setting the $ignore_sent_at to keep timestamps as created by the sdk in case this is relevant in debugging.

## How did you test this code?

Unit tests


## Publish to changelog?