### PR TITLE
Failing ci pipeline

### DIFF
--- a/products/tasks/backend/migrations/0022_task_signal_report_alter_task_origin_product.py
+++ b/products/tasks/backend/migrations/0022_task_signal_report_alter_task_origin_product.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ("signals", "0008_alter_signalsourceconfig_source_product_and_more"),
-        ("tasks", "0020_sandbox_environment"),
+        ("tasks", "0021_alter_task_origin_product"),
     ]
 
     operations = [
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
                     ("error_tracking", "Error Tracking"),
                     ("eval_clusters", "Eval Clusters"),
                     ("user_created", "User Created"),
+                    ("slack", "Slack"),
                     ("support_queue", "Support Queue"),
                     ("session_summaries", "Session Summaries"),
                     ("signal_report", "Signal Report"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The original PR (https://github.com/PostHog/posthog/pull/49497) was failing CI due to conflicting Django migrations in the `tasks` app. Specifically, migration `0022_task_signal_report_alter_task_origin_product` and `0021_alter_task_origin_product` both depended on `0020_sandbox_environment`, creating two leaf nodes in the migration graph. Additionally, the `slack` choice was missing from the `origin_product` field in migration `0022`.

## Changes

- Updated the dependency of `products/tasks/backend/migrations/0022_task_signal_report_alter_task_origin_product.py` from `0020_sandbox_environment` to `0021_alter_task_origin_product` to linearize the migration history.
- Added the `("slack", "Slack")` choice to the `origin_product` field in migration `0022` to align with changes introduced in `0021`.

## How did you test this code?

The fix addresses specific CI failures related to migration conflicts and missing choices. The agent identified the root cause by analyzing CI logs and the migration graph. No manual testing was performed by the agent.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/agents/bc-97f4d3af-35fd-483b-a7bd-9c91773b9ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f4d3af-35fd-483b-a7bd-9c91773b9ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->