### PR TITLE
fix(phai): Add frontmatter metadata to AI documentation pages

### DIFF
--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -1,4 +1,7 @@
 ---
+title: Implementing MCP tools
+sidebar: Docs
+showTitle: true
 docs: true
 ---
 

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -2,7 +2,6 @@
 title: Implementing MCP tools
 sidebar: Docs
 showTitle: true
-docs: true
 ---
 
 # Implementing MCP tools

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -4,8 +4,6 @@ sidebar: Docs
 showTitle: true
 ---
 
-# Implementing MCP tools
-
 MCP tools are atomic capabilities – CRUD operations and simple actions that agents compose into workflows.
 Every product should be accessible through the MCP server.
 Tools answer "what can I do?" (list feature flags, execute SQL, create a survey).

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -1,3 +1,7 @@
+---
+docs: true
+---
+
 # Implementing MCP tools
 
 MCP tools are atomic capabilities – CRUD operations and simple actions that agents compose into workflows.

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -4,8 +4,6 @@ sidebar: Docs
 showTitle: true
 ---
 
-# Writing skills
-
 Skills are job-to-be-done templates that teach agents _how_ to use capabilities to achieve a goal.
 They should read like how an experienced person would approach a job,
 not like a rigid script of commands to run.

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -2,7 +2,6 @@
 title: Writing skills
 sidebar: Docs
 showTitle: true
-docs: true
 ---
 
 # Writing skills

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -1,4 +1,7 @@
 ---
+title: Writing skills
+sidebar: Docs
+showTitle: true
 docs: true
 ---
 

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -1,3 +1,7 @@
+---
+docs: true
+---
+
 # Writing skills
 
 Skills are job-to-be-done templates that teach agents _how_ to use capabilities to achieve a goal.


### PR DESCRIPTION
## Problem

The documentation pages for MCP tools and skills are missing frontmatter metadata that is required for proper rendering and organization in the documentation site. This metadata is needed to ensure these pages are correctly indexed, titled, and displayed in the sidebar navigation.

## Changes

Added YAML frontmatter to two documentation files:
- `docs/published/handbook/engineering/ai/implementing-mcp-tools.md`
- `docs/published/handbook/engineering/ai/writing-skills.md`

Each file now includes:
- `title`: Page title for display
- `sidebar`: Navigation section (Docs)
- `showTitle`: Flag to display the title

## How did you test this code?

No testing needed. This is a documentation metadata configuration change that adds required frontmatter to markdown files. The changes are straightforward YAML additions that follow the existing documentation structure.

## Publish to changelog?

No

https://claude.ai/code/session_018AsPG6MiCCN4BMVVj2TcUD