### PR TITLE
fix: increase rate limits on check access

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -737,7 +737,12 @@ class RestoreRedeemThrottle(SimpleRateThrottle):
 
 class CodeInviteRedeemThrottle(UserRateThrottle):
     scope = "code_invite_redeem"
-    rate = "10/hour"
+    rate = "20/hour"
+
+
+class CodeInviteCheckAccessThrottle(UserRateThrottle):
+    scope = "code_invite_check_access"
+    rate = "20000/hour"
 
 
 class ToolbarOAuthRefreshThrottle(IPThrottle):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -735,13 +735,8 @@ class RestoreRedeemThrottle(SimpleRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": self.get_ident(request)}
 
 
-class CodeInviteRedeemThrottle(UserRateThrottle):
-    scope = "code_invite_redeem"
-    rate = "20/hour"
-
-
-class CodeInviteCheckAccessThrottle(UserRateThrottle):
-    scope = "code_invite_check_access"
+class CodeInviteThrottle(UserRateThrottle):
+    scope = "code_invite"
     rate = "20000/hour"
 
 

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -26,7 +26,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.permissions import APIScopePermission
-from posthog.rate_limit import CodeInviteCheckAccessThrottle, CodeInviteRedeemThrottle
+from posthog.rate_limit import CodeInviteThrottle
 from posthog.storage import object_storage
 
 from .models import CodeInvite, CodeInviteRedemption, Task, TaskRun
@@ -942,11 +942,7 @@ class CodeInviteViewSet(viewsets.ViewSet):
     scope_object = "task"
 
     http_method_names = ["get", "post", "head", "options"]
-
-    def get_throttles(self):
-        if self.action == "check_access":
-            return [CodeInviteCheckAccessThrottle()]
-        return [CodeInviteRedeemThrottle()]
+    throttle_classes = [CodeInviteThrottle]
 
     def get_permissions(self):
         # Both endpoints are user-account-level operations (not project data).

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -26,7 +26,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.permissions import APIScopePermission
-from posthog.rate_limit import CodeInviteRedeemThrottle
+from posthog.rate_limit import CodeInviteCheckAccessThrottle, CodeInviteRedeemThrottle
 from posthog.storage import object_storage
 
 from .models import CodeInvite, CodeInviteRedemption, Task, TaskRun
@@ -941,8 +941,12 @@ class CodeInviteViewSet(viewsets.ViewSet):
 
     scope_object = "task"
 
-    throttle_classes = [CodeInviteRedeemThrottle]
     http_method_names = ["get", "post", "head", "options"]
+
+    def get_throttles(self):
+        if self.action == "check_access":
+            return [CodeInviteCheckAccessThrottle()]
+        return [CodeInviteRedeemThrottle()]
 
     def get_permissions(self):
         # Both endpoints are user-account-level operations (not project data).


### PR DESCRIPTION
## Problem

Rate limit on check access was too low, meaning I can't use PostHog Code

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- bump code invite redemption throttle to 20/h
- bump code invite check access throttle to 20.000/h
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no