### PR TITLE
Max migration conflict dependencies

### DIFF
--- a/products/tasks/backend/migrations/0024_task_signal_report_alter_task_origin_product.py
+++ b/products/tasks/backend/migrations/0024_task_signal_report_alter_task_origin_product.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ("signals", "0008_alter_signalsourceconfig_source_product_and_more"),
-        ("tasks", "0021_alter_task_origin_product"),
+        ("tasks", "0023_alter_codeinvite_id_alter_codeinviteredemption_id"),
     ]
 
     operations = [

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_task_signal_report_alter_task_origin_product
+0024_task_signal_report_alter_task_origin_product


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A migration conflict existed in `products/tasks/backend/migrations/`. The local `0022_task_signal_report_alter_task_origin_product` migration conflicted with existing `0022` and `0023` migrations on `master`.

## Changes

- Renamed `products/tasks/backend/migrations/0022_task_signal_report_alter_task_origin_product.py` to `0024_task_signal_report_alter_task_origin_product.py`.
- Updated the dependency in the renamed migration file to `("tasks", "0023_alter_codeinvite_id_alter_codeinviteredemption_id")`.
- Updated `products/tasks/backend/migrations/max_migration.txt` to `0024_task_signal_report_alter_task_origin_product`.

## How did you test this code?

The agent verified the file renames and content changes using terminal commands (`ls`, `cat`) and confirmed `max_migration.txt` was updated correctly. As an agent, I have not performed manual testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

---
<p><a href="https://cursor.com/agents/bc-07b4cff1-555b-4c91-adf7-138718e29023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07b4cff1-555b-4c91-adf7-138718e29023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->