### PR TITLE
fix(action-filter): display correct icons

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/defaults.ts
+++ b/frontend/src/queries/nodes/InsightQuery/defaults.ts
@@ -1,4 +1,4 @@
-import { getDefaultEventName } from 'lib/utils/getAppContext'
+import { getDefaultEventLabel, getDefaultEventName } from 'lib/utils/getAppContext'
 
 import {
     FunnelsQuery,
@@ -15,12 +15,13 @@ import { BaseMathType, ChartDisplayType, FunnelVizType, PathType, RetentionPerio
 
 function getTrendsQueryDefault(): TrendsQuery {
     const defaultEvent = getDefaultEventName()
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.TrendsQuery,
         series: [
             {
                 kind: NodeKind.EventsNode,
-                name: defaultEvent === null ? 'All events' : defaultEvent,
+                name: defaultLabel,
                 event: defaultEvent,
                 math: BaseMathType.TotalCount,
             },
@@ -31,12 +32,13 @@ function getTrendsQueryDefault(): TrendsQuery {
 
 function getCalendarHeatmapQueryDefault(): TrendsQuery {
     const defaultEvent = getDefaultEventName()
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.TrendsQuery,
         series: [
             {
                 kind: NodeKind.EventsNode,
-                name: defaultEvent === null ? 'All events' : defaultEvent,
+                name: defaultLabel,
                 event: defaultEvent,
                 math: BaseMathType.TotalCount,
             },
@@ -49,12 +51,13 @@ function getCalendarHeatmapQueryDefault(): TrendsQuery {
 
 function getFunnelsQueryDefault(): FunnelsQuery {
     const defaultEvent = getDefaultEventName()
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.FunnelsQuery,
         series: [
             {
                 kind: NodeKind.EventsNode,
-                name: defaultEvent === null ? 'All events' : defaultEvent,
+                name: defaultLabel,
                 event: defaultEvent,
             },
         ],
@@ -66,7 +69,7 @@ function getFunnelsQueryDefault(): FunnelsQuery {
 
 function getRetentionQueryDefault(): RetentionQuery {
     const defaultEvent = getDefaultEventName()
-    const eventName = defaultEvent === null ? 'All events' : defaultEvent
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.RetentionQuery,
         retentionFilter: {
@@ -74,12 +77,12 @@ function getRetentionQueryDefault(): RetentionQuery {
             totalIntervals: 8,
             targetEntity: {
                 id: defaultEvent ?? undefined,
-                name: eventName,
+                name: defaultLabel,
                 type: 'events',
             },
             returningEntity: {
                 id: defaultEvent ?? undefined,
-                name: eventName,
+                name: defaultLabel,
                 type: 'events',
             },
             retentionType: 'retention_first_time',
@@ -108,12 +111,13 @@ function getPathsQueryDefault(): PathsQuery {
 
 function getStickinessQueryDefault(): StickinessQuery {
     const defaultEvent = getDefaultEventName()
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.StickinessQuery,
         series: [
             {
                 kind: NodeKind.EventsNode,
-                name: defaultEvent === null ? 'All events' : defaultEvent,
+                name: defaultLabel,
                 event: defaultEvent,
                 math: BaseMathType.UniqueUsers,
             },
@@ -126,12 +130,13 @@ function getStickinessQueryDefault(): StickinessQuery {
 
 function getLifecycleQueryDefault(): LifecycleQuery {
     const defaultEvent = getDefaultEventName()
+    const defaultLabel = getDefaultEventLabel()
     return {
         kind: NodeKind.LifecycleQuery,
         series: [
             {
                 kind: NodeKind.EventsNode,
-                name: defaultEvent === null ? 'All events' : defaultEvent,
+                name: defaultLabel,
                 event: defaultEvent,
             },
         ],

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -66,7 +66,7 @@ export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.E
 
 export function getEventDefinitionIcon(definition: EventDefinition & { value?: string | null }): JSX.Element {
     // Rest are events
-    if (definition.name === '$pageview' || definition.name === '$screen') {
+    if (definition.id === '$pageview' || definition.id === '$screen') {
         return (
             <IconWithBadge
                 icon={<IconEye />}
@@ -77,7 +77,7 @@ export function getEventDefinitionIcon(definition: EventDefinition & { value?: s
             />
         )
     }
-    if (definition.name === '$pageleave') {
+    if (definition.id === '$pageleave') {
         return (
             <IconWithBadge
                 icon={<IconLeave />}
@@ -88,7 +88,7 @@ export function getEventDefinitionIcon(definition: EventDefinition & { value?: s
             />
         )
     }
-    if (definition.name === '$autocapture') {
+    if (definition.id === '$autocapture') {
         return (
             <IconWithBadge
                 icon={<IconBolt />}
@@ -99,7 +99,7 @@ export function getEventDefinitionIcon(definition: EventDefinition & { value?: s
             />
         )
     }
-    if (definition.name && !!CORE_FILTER_DEFINITIONS_BY_GROUP.events[definition.name]) {
+    if (definition.id && !!CORE_FILTER_DEFINITIONS_BY_GROUP.events[definition.id]) {
         return (
             <IconWithBadge
                 icon={<IconLogomark />}

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -81,7 +81,7 @@ describe('insightNavLogic', () => {
                             {
                                 event: '$pageview',
                                 kind: 'EventsNode',
-                                name: '$pageview',
+                                name: 'Pageview',
                             },
                         ],
                     },


### PR DESCRIPTION
## Problem

Icons for steps added with "Add step" were wrong. See https://posthog.slack.com/archives/C0ACRAMJUAG/p1772620041730049.

## Changes

- Uses `id` to determine icon, not `name`.
- Creates default insights with a label and not just the repeated event.

## How did you test this code?

Locally