### PR TITLE
fix(llma): make migration 0018 idempotent to fix deploy

### DIFF
--- a/products/llm_analytics/backend/migrations/0018_migrate_clustering_configs_to_jobs.py
+++ b/products/llm_analytics/backend/migrations/0018_migrate_clustering_configs_to_jobs.py
@@ -2,18 +2,25 @@ from django.db import migrations
 
 
 def migrate_clustering_configs_to_jobs(apps, schema_editor):
-    """Convert each existing ClusteringConfig into two ClusteringJob rows."""
+    """Convert each existing ClusteringConfig into two ClusteringJob rows.
+
+    Uses get_or_create so re-running is safe (this migration was renamed
+    from 0018_alter_clusteringjob_id → 0018_migrate_clustering_configs_to_jobs
+    and some environments already applied it under the old name).
+    """
     ClusteringConfig = apps.get_model("llm_analytics", "ClusteringConfig")
     ClusteringJob = apps.get_model("llm_analytics", "ClusteringJob")
 
     for config in ClusteringConfig.objects.all():
         for level, suffix in [("trace", "traces"), ("generation", "generations")]:
-            ClusteringJob.objects.create(
+            ClusteringJob.objects.get_or_create(
                 team_id=config.team_id,
                 name=f"Default ({suffix})",
-                analysis_level=level,
-                event_filters=config.event_filters,
-                enabled=True,
+                defaults={
+                    "analysis_level": level,
+                    "event_filters": config.event_filters,
+                    "enabled": True,
+                },
             )
 
 


### PR DESCRIPTION
## Summary

- Migration `0018` was renamed from `0018_alter_clusteringjob_id` to `0018_migrate_clustering_configs_to_jobs` in #49526, causing Django to treat it as a new migration and re-run it
- Re-running hits `IntegrityError: duplicate key value violates unique constraint "unique_clustering_job_name_per_team"` because the data already exists
- This blocks the deploy and causes worker pod restarts (summarization stalled)
- Fix: use `get_or_create` instead of `create` so the migration is idempotent and safe to re-run

**Note**: someone with DB access also needs to clean up the stale `django_migrations` row for the old name:
```sql
DELETE FROM django_migrations WHERE app = 'llm_analytics' AND name = '0018_alter_clusteringjob_id';
```

## Test plan

- [ ] Deploy succeeds without IntegrityError
- [ ] Summarization workflows resume