### PR TITLE
fix: pass disabled reasons to button for add to notebook

### DIFF
--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
@@ -24,7 +24,11 @@ export function SceneAddToNotebookDropdownMenu({
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild disabled={isDisabled}>
-                <ButtonPrimitive menuItem data-attr={`${dataAttrKey}-add-to-dropdown-menu`}>
+                <ButtonPrimitive
+                    menuItem
+                    data-attr={`${dataAttrKey}-add-to-dropdown-menu`}
+                    disabledReasons={disabledReasons}
+                >
                     <IconPlusSmall />
                     Add to notebook
                     <MenuOpenIndicator className="ml-auto" />


### PR DESCRIPTION
## Problem

Missing tooltip for add to notebook when disabled

## Changes

<img width="547" height="212" alt="image" src="https://github.com/user-attachments/assets/896e41a8-d057-49a4-8b36-ed06397bb1f8" />

## How did you test this code?
Locally

