### PR TITLE
feat: update default dashboard template to include screen events

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -358,8 +358,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_AI_INSIGHT_ANALYSIS: 'product-analytics-ai-insight-analysis', // owner: #team-analytics-platform, used to show AI analysis section in insights
     PRODUCT_ANALYTICS_AUTONAME_INSIGHTS_WITH_AI: 'autoname-insights-with-ai', // owner: @gesh #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
-    PRODUCT_ANALYTICS_EVENTS_COMBINATION_IN_TRENDS: 'events-combination-in-trends', // owner: @gesh #team-product-analytics
-    PRODUCT_ANALYTICS_EVENTS_COMBINATION_IN_FUNNELS: 'events-combination-in-funnels', // owner: @gesh #team-product-analytics
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_SIMPLE_EDITOR: 'product-analytics-simple-editor', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -270,3 +270,45 @@ class TestTeam(BaseTest):
         with self.is_cloud(is_cloud):
             team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
             assert getattr(team, field) == expected
+
+    @parameterized.expand(
+        [
+            ("Daily active users (DAUs)",),
+            ("Weekly active users (WAUs)",),
+        ]
+    )
+    def test_default_dashboard_dau_wau_tiles_use_group_node(self, tile_name):
+        team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+        tile = DashboardTile.objects.get(
+            dashboard=team.primary_dashboard,
+            insight__name=tile_name,
+        )
+        assert tile.insight is not None
+        assert tile.insight.query is not None
+        series = tile.insight.query["source"]["series"]
+        assert len(series) == 1
+        assert series[0]["kind"] == "GroupNode"
+        assert series[0]["operator"] == "OR"
+        assert series[0]["math"] == "dau"
+        assert {n["event"] for n in series[0]["nodes"]} == {"$pageview", "$screen"}
+
+    @parameterized.expand(
+        [
+            ("Retention", "RetentionQuery"),
+            ("Growth accounting", "LifecycleQuery"),
+            ("Referring domain (last 14 days)", "TrendsQuery"),
+            ("Pageview funnel, by browser", "FunnelsQuery"),
+        ]
+    )
+    def test_default_dashboard_pageview_only_tiles(self, tile_name, expected_kind):
+        team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+        tile = DashboardTile.objects.get(
+            dashboard=team.primary_dashboard,
+            insight__name=tile_name,
+        )
+        assert tile.insight is not None
+        assert tile.insight.query is not None
+        source = tile.insight.query["source"]
+        assert source["kind"] == expected_kind
+        assert "GroupNode" not in str(source)
+        assert "$pageview" in str(source)

--- a/products/dashboards/backend/models/dashboard_templates.py
+++ b/products/dashboards/backend/models/dashboard_templates.py
@@ -80,7 +80,16 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "source": {
                             "kind": "TrendsQuery",
                             "series": [
-                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                                {
+                                    "kind": "GroupNode",
+                                    "operator": "OR",
+                                    "nodes": [
+                                        {"kind": "EventsNode", "event": "$pageview", "name": "$pageview"},
+                                        {"kind": "EventsNode", "event": "$screen", "name": "$screen"},
+                                    ],
+                                    "math": "dau",
+                                    "name": "Pageview or screen",
+                                }
                             ],
                             "interval": "day",
                             "dateRange": {"date_from": "-30d", "explicitDate": False},
@@ -103,7 +112,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 5, "minW": 3},
                     },
-                    "description": "Shows the number of unique users that use your app every day.",
+                    "description": "Shows the number of unique users that view a page or screen in your app every day.",
                 },
                 {
                     "name": "Weekly active users (WAUs)",
@@ -114,7 +123,16 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "source": {
                             "kind": "TrendsQuery",
                             "series": [
-                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                                {
+                                    "kind": "GroupNode",
+                                    "operator": "OR",
+                                    "nodes": [
+                                        {"kind": "EventsNode", "event": "$pageview", "name": "$pageview"},
+                                        {"kind": "EventsNode", "event": "$screen", "name": "$screen"},
+                                    ],
+                                    "math": "dau",
+                                    "name": "Pageview or screen",
+                                }
                             ],
                             "interval": "week",
                             "dateRange": {"date_from": "-90d", "explicitDate": False},
@@ -137,7 +155,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 5, "minH": 5, "minW": 3},
                     },
-                    "description": "Shows the number of unique users that use your app every week.",
+                    "description": "Shows the number of unique users that view a page or screen in your app every week.",
                 },
                 {
                     "name": "Retention",
@@ -163,7 +181,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 10, "minH": 5, "minW": 3},
                     },
-                    "description": "Weekly retention of your users.",
+                    "description": "Weekly retention of your users based on pageviews.",
                 },
                 {
                     "name": "Growth accounting",
@@ -185,7 +203,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 15, "minH": 5, "minW": 3},
                     },
-                    "description": "How many of your users are new, returning, resurrecting, or dormant each week.",
+                    "description": "How many of your users are new, returning, resurrecting, or dormant each week based on pageviews.",
                 },
                 {
                     "name": "Referring domain (last 14 days)",
@@ -219,7 +237,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 20, "minH": 5, "minW": 3},
                     },
-                    "description": "Shows the most common referring domains for your users over the past 14 days.",
+                    "description": "Shows the most common referring domains for your users over the past 14 days. Pageviews only.",
                 },
                 {
                     "name": "Pageview funnel, by browser",
@@ -270,7 +288,7 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3},
                         "xs": {"h": 5, "w": 1, "x": 0, "y": 25, "minH": 5, "minW": 3},
                     },
-                    "description": "This example funnel shows how many of your users have completed 3 page views, broken down by browser.",
+                    "description": "This example funnel shows how many of your users have completed 3 page views, broken down by browser. Pageviews only.",
                 },
             ],
             tags=[],


### PR DESCRIPTION
## Problem

Mobile app users see an empty or low-value default dashboard because all tiles only track `$pageview` events. Mobile apps fire `$screen` events instead, so the default "Product analytics" dashboard should include both where possible.

## Changes

Updates the default dashboard template so DAU and WAU tiles use `GroupNode` to combine `$pageview` OR `$screen` events. Other tiles stay `$pageview`-only because their query types don't support `GroupNode`:

| Tile | Query type | Events |
|---|---|---|
| Daily active users | TrendsQuery | `$pageview` OR `$screen` (GroupNode) |
| Weekly active users | TrendsQuery | `$pageview` OR `$screen` (GroupNode) |
| Retention | RetentionQuery | `$pageview` only |
| Growth accounting | LifecycleQuery | `$pageview` only |
| Referring domain | TrendsQuery (web-only breakdown) | `$pageview` only |
| Pageview funnel | FunnelsQuery (web-only concept) | `$pageview` only |

Descriptions updated to clarify which tiles cover both event types vs pageview-only.

Also removes the unused `events-combination-in-trends` and `events-combination-in-funnels` feature flag definitions from constants since GroupNode is now relied upon by the default template.

No Action creation — the template is purely declarative.

## How did you test this code?

Added parameterized tests in `posthog/test/test_team.py`:
- DAU/WAU tiles assert GroupNode with `$pageview` and `$screen` nodes
- Retention, Growth accounting, Referring domain, Pageview funnel tiles assert `$pageview`-only with no GroupNode

All 22 tests pass.

This PR was authored by an agent — no manual testing was performed.

## Publish to changelog?

No

## Docs update

No docs changes needed.

## LLM context

Takes over from an earlier approach that created an Action at team creation time. This is simpler because GroupNode is a first-class schema concept for TrendsQuery, avoiding runtime side effects.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*