### PR TITLE
feat(posthog-ai): Include posthog code user agents

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -267,9 +267,13 @@ class EventSource(StrEnum):
     WEB = "web"
     API = "api"
     POSTHOG_AI = "posthog_ai"
+    POSTHOG_CODE = "posthog_code"
     TERRAFORM = "terraform"
     MCP = "mcp"
     WIZARD = "wizard"
+
+
+_POSTHOG_CODE_UA_RE = re.compile(r"posthog/(code|[\w.-]+\.hog\.dev)")
 
 
 def get_event_source(request) -> EventSource:
@@ -279,6 +283,8 @@ def get_event_source(request) -> EventSource:
         return EventSource.TERRAFORM
     if "posthog/wizard" in user_agent:
         return EventSource.WIZARD
+    if _POSTHOG_CODE_UA_RE.search(user_agent):
+        return EventSource.POSTHOG_CODE
     if "posthog/mcp-server" in user_agent:
         return EventSource.MCP
     if isinstance(getattr(request, "successful_authenticator", None), SessionAuthentication):

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from parameterized import parameterized
 from rest_framework.test import APIRequestFactory
 
-from posthog.event_usage import _sanitize_user_agent, report_user_action
+from posthog.event_usage import EventSource, _sanitize_user_agent, get_event_source, report_user_action
 
 
 class TestReportUserAction(BaseTest):
@@ -98,6 +98,23 @@ class TestReportUserAction(BaseTest):
         mock_capture.assert_called_once()
         assert mock_capture.call_args[1]["properties"] == {"key": "val"}
 
+
+class TestGetEventSource(BaseTest):
+    @parameterized.expand(
+        [
+            ("terraform", "posthog/terraform-provider 1.0", EventSource.TERRAFORM),
+            ("wizard", "posthog/wizard 1.0", EventSource.WIZARD),
+            ("posthog_code", "posthog/code 1.2.3", EventSource.POSTHOG_CODE),
+            ("hog_dev_subdomain", "posthog/desktop.hog.dev 0.1.0", EventSource.POSTHOG_CODE),
+            ("hog_dev_complex", "posthog/my-app.hog.dev", EventSource.POSTHOG_CODE),
+            ("mcp_server", "posthog/mcp-server 1.0", EventSource.MCP),
+            ("unknown_ua_falls_through_to_api", "some-random-agent/1.0", EventSource.API),
+        ]
+    )
+    def test_get_event_source(self, _name, user_agent, expected):
+        factory = APIRequestFactory()
+        request = factory.get("/fake", HTTP_USER_AGENT=user_agent)
+        assert get_event_source(request) == expected
 
 class TestSanitizeUserAgent(BaseTest):
     @parameterized.expand(

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -116,6 +116,7 @@ class TestGetEventSource(BaseTest):
         request = factory.get("/fake", HTTP_USER_AGENT=user_agent)
         assert get_event_source(request) == expected
 
+
 class TestSanitizeUserAgent(BaseTest):
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

We aren't included Posthog Code user agents in get_event_source

## Changes
Add the current one (which is hog.dev) but also include PostHog Code

## How did you test this code?

Added some unit tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
