### PR TITLE
feat(llma): promote Clusters tab from alpha to beta

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1128,7 +1128,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-llm-clusters-light)'] as FileSystemIconColor,
         href: urls.llmAnalyticsClusters(),
         flag: FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB,
-        tags: ['alpha'],
+        tags: ['beta'],
         sceneKey: 'LLMAnalyticsClusters',
         sceneKeys: [
             'LLMAnalytics',

--- a/products/llm_analytics/manifest.tsx
+++ b/products/llm_analytics/manifest.tsx
@@ -267,7 +267,7 @@ export const manifest: ProductManifest = {
             iconColor: ['var(--color-product-llm-clusters-light)'] as FileSystemIconColor,
             href: urls.llmAnalyticsClusters(),
             flag: FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB,
-            tags: ['alpha'],
+            tags: ['beta'],
             sceneKey: 'LLMAnalyticsClusters',
         },
         {


### PR DESCRIPTION
## Summary
- Promotes the LLM Analytics Clusters tab from alpha to beta status

## Test plan
- [ ] Verify the Clusters tab shows a Beta badge instead of Alpha in the sidebar and navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)