### PR TITLE
fix(signals): Paginate fetch_video_segment_rows

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a2_fetch_segments.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a2_fetch_segments.py
@@ -18,7 +18,7 @@ from posthog.temporal.ai.video_segment_clustering.models import (
 from posthog.temporal.ai.video_segment_clustering.object_storage import generate_storage_key, store_fetch_result
 from posthog.temporal.common.logger import get_logger
 
-from ..data import fetch_video_segment_rows
+from ..data import fetch_video_segment_rows_paginated
 
 logger = get_logger(__name__)
 
@@ -33,7 +33,7 @@ async def fetch_segments_activity(inputs: FetchSegmentsActivityInputs) -> FetchS
     """
 
     team = await Team.objects.aget(id=inputs.team_id)
-    video_segment_rows = await fetch_video_segment_rows(
+    video_segment_rows = await fetch_video_segment_rows_paginated(
         team=team,
         lookback_hours=inputs.lookback_hours,
     )

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -91,7 +91,7 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
                     lookback_hours=inputs.lookback_hours,
                 )
             ],
-            start_to_close_timeout=timedelta(minutes=10),
+            start_to_close_timeout=timedelta(minutes=30),
             retry_policy=RetryPolicy(
                 maximum_attempts=3,
                 initial_interval=timedelta(seconds=1),

--- a/posthog/temporal/ai/video_segment_clustering/data.py
+++ b/posthog/temporal/ai/video_segment_clustering/data.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 from asgiref.sync import sync_to_async
 
 from posthog.hogql import ast
@@ -9,6 +11,7 @@ from posthog.models.team import Team
 from posthog.temporal.ai.session_summary.activities.a5_embed_and_store_segments import SESSION_SEGMENTS_EMBEDDING_MODEL
 
 MAX_SEGMENTS_RETURNED = 50_000
+PAGE_SIZE = 5_000
 
 
 def count_distinct_persons(team: Team, distinct_ids: list[str]) -> int:
@@ -32,36 +35,55 @@ def count_distinct_persons(team: Team, distinct_ids: list[str]) -> int:
     return result.results[0][0] if result.results and len(result.results) > 0 else 0
 
 
+def _fetch_video_segment_rows_paginated(team: Team, lookback_hours: int) -> Iterator[list]:
+    """Fetch recent video segments (metadata + embeddings) from ClickHouse in pages.
+
+    Yields pages of up to PAGE_SIZE rows to avoid transferring all embeddings in a single query.
+    """
+    for offset in range(0, MAX_SEGMENTS_RETURNED, PAGE_SIZE):
+        page_size = min(PAGE_SIZE, MAX_SEGMENTS_RETURNED - offset)
+        with tags_context(product=Product.SESSION_SUMMARY):
+            result = execute_hogql_query(
+                query_type="VideoSegmentsForClustering",
+                query=parse_select(
+                    """
+                    SELECT
+                        document_id,
+                        content,
+                        metadata,
+                        embedding
+                    FROM document_embeddings
+                    WHERE timestamp >= now() - INTERVAL {lookback_hours} HOUR
+                        AND model_name = {model_name}
+                        AND product = {product}
+                        AND document_type = {document_type}
+                        AND rendering = {rendering}
+                    ORDER BY timestamp ASC
+                    LIMIT {page_size}
+                    OFFSET {offset}"""
+                ),
+                placeholders={
+                    "lookback_hours": ast.Constant(value=lookback_hours),
+                    "model_name": ast.Constant(value=SESSION_SEGMENTS_EMBEDDING_MODEL.value),
+                    "product": ast.Constant(value="session-replay"),
+                    "document_type": ast.Constant(value="video-segment"),
+                    "rendering": ast.Constant(value="video-analysis"),
+                    "page_size": ast.Constant(value=page_size),
+                    "offset": ast.Constant(value=offset),
+                },
+                team=team,
+            )
+        rows = result.results or []
+        if rows:
+            yield rows
+        if len(rows) < page_size:
+            break
+
+
 @sync_to_async
-def fetch_video_segment_rows(team: Team, lookback_hours: int):
-    """Fetch recent video segments (metadata + embeddings) from ClickHouse."""
-    with tags_context(product=Product.SESSION_SUMMARY):
-        result = execute_hogql_query(
-            query_type="VideoSegmentsForClustering",
-            query=parse_select(
-                """
-                SELECT
-                    document_id,
-                    content,
-                    metadata,
-                    embedding
-                FROM document_embeddings
-                WHERE timestamp >= now() - INTERVAL {lookback_hours} HOUR
-                    AND model_name = {model_name}
-                    AND product = {product}
-                    AND document_type = {document_type}
-                    AND rendering = {rendering}
-                ORDER BY timestamp ASC
-                LIMIT {max_segments_returned}"""
-            ),
-            placeholders={
-                "lookback_hours": ast.Constant(value=lookback_hours),
-                "model_name": ast.Constant(value=SESSION_SEGMENTS_EMBEDDING_MODEL.value),
-                "product": ast.Constant(value="session-replay"),
-                "document_type": ast.Constant(value="video-segment"),
-                "rendering": ast.Constant(value="video-analysis"),
-                "max_segments_returned": ast.Constant(value=MAX_SEGMENTS_RETURNED),
-            },
-            team=team,
-        )
-    return result.results or []
+def fetch_video_segment_rows_paginated(team: Team, lookback_hours: int) -> list:
+    """Fetch recent video segments (metadata + embeddings) from ClickHouse with pagination."""
+    all_rows: list = []
+    for page in _fetch_video_segment_rows_paginated(team, lookback_hours):
+        all_rows.extend(page)
+    return all_rows

--- a/posthog/temporal/ai/video_segment_clustering/data.py
+++ b/posthog/temporal/ai/video_segment_clustering/data.py
@@ -58,7 +58,7 @@ def _fetch_video_segment_rows_paginated(team: Team, lookback_hours: int) -> Iter
                         AND product = {product}
                         AND document_type = {document_type}
                         AND rendering = {rendering}
-                    ORDER BY timestamp ASC
+                    ORDER BY timestamp ASC, document_id ASC
                     LIMIT {page_size}
                     OFFSET {offset}"""
                 ),


### PR DESCRIPTION
## Problem

`fetch_segments_activity` times out for large projects because it fetches up to 50k embeddings (~600 MB) in a single ClickHouse query. That should be 25 s per query. Example of timeout **here**.

## Changes

For now, let's keep the query, but paginate it into batches of 5000 embeddings. Also increasing `start_to_close_timeout` from 10 to 30 minutes as a safety margin.

## How did you test this code?

Existing tests pass (`pytest posthog/temporal/ai/video_segment_clustering/`). Will verify on the affected production team.

## Publish to changelog?

no