### PR TITLE
fix(vercel): auto-redirect popup to Vercel after linking existing account

### DIFF
--- a/frontend/src/scenes/authentication/VercelConnect.tsx
+++ b/frontend/src/scenes/authentication/VercelConnect.tsx
@@ -97,7 +97,7 @@ export function VercelConnect(): JSX.Element {
                 setSuccess(true)
                 setLinking(false)
 
-                const returnUrl = nextUrl || sessionInfo?.next_url
+                const returnUrl = sessionInfo?.next_url || nextUrl
                 if (returnUrl) {
                     window.location.href = returnUrl
                 }
@@ -108,7 +108,7 @@ export function VercelConnect(): JSX.Element {
             })
     }
 
-    const redirectUrl = nextUrl || sessionInfo?.next_url
+    const redirectUrl = sessionInfo?.next_url || nextUrl
 
     if (loading) {
         return (

--- a/frontend/src/scenes/authentication/VercelConnect.tsx
+++ b/frontend/src/scenes/authentication/VercelConnect.tsx
@@ -96,6 +96,11 @@ export function VercelConnect(): JSX.Element {
                 setLinkedOrgName(data.organization_name)
                 setSuccess(true)
                 setLinking(false)
+
+                const returnUrl = nextUrl || sessionInfo?.next_url
+                if (returnUrl) {
+                    window.location.href = returnUrl
+                }
             })
             .catch((err) => {
                 setError(err.message || 'Failed to link organization')

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -675,14 +675,14 @@ class Fix204Middleware:
 
 class ToolbarOAuthCoopMiddleware:
     """
-    Override Cross-Origin-Opener-Policy for toolbar OAuth popup pages.
+    Override Cross-Origin-Opener-Policy for popup pages that need cross-origin communication.
 
     Django's SecurityMiddleware sets COOP to "same-origin" by default. This severs
-    window.opener when a cross-origin popup navigates to our OAuth pages — breaking
-    the postMessage flow that sends tokens back to the toolbar.
+    window.opener when a cross-origin popup navigates to our pages — breaking
+    the postMessage flow or Vercel's popup monitoring.
 
-    We set COOP to "unsafe-none" on the specific paths involved in the toolbar
-    OAuth popup flow so the opener reference is preserved.
+    We set COOP to "unsafe-none" on the specific paths involved in popup flows
+    so the opener reference is preserved.
     """
 
     def __init__(self, get_response):
@@ -693,7 +693,8 @@ class ToolbarOAuthCoopMiddleware:
         is_toolbar_flow = request.path.startswith("/toolbar_oauth/") or (
             request.path.startswith("/oauth/authorize") and request.session.get("toolbar_oauth_redirect_flow")
         )
-        if is_toolbar_flow:
+        is_vercel_connect = request.path.startswith("/connect/vercel/")
+        if is_toolbar_flow or is_vercel_connect:
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 


### PR DESCRIPTION
## Problem

When using the "Link Existing Account" flow in the Vercel Marketplace integration, PostHog successfully links the org but Vercel's "Completing Installation" popup spinner hangs indefinitely. This is because Vercel monitors the popup window and expects it to redirect back to the `next` URL to signal completion.

## Changes

- **Auto-redirect after linking**: After the `/api/vercel/connect/complete` call succeeds, the popup now immediately redirects to the Vercel `next` URL instead of showing a success page with a manual "Return to Vercel" button. The success page still renders as a fallback.
- **COOP header for Vercel routes**: Added `/connect/vercel/` paths to the `Cross-Origin-Opener-Policy: unsafe-none` middleware override, so Vercel's parent window can monitor the popup state (Django defaults to `same-origin` which severs this).

## How did you test this code?

- Set up local dev environment with ngrok tunnel and local Vercel integration credentials
- Triggered the "Link Existing Account" flow from Vercel Marketplace
- Verified the popup auto-redirects back to Vercel after successful linking
- Verified Vercel's "Completing Installation" spinner resolves correctly

## Changelog

No