### PR TITLE
fix: Add inner retry loop for quota exceeded errors

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -721,7 +721,13 @@ class BigQueryClient:
         while True:
             try:
                 result = await asyncio.to_thread(self._run_load_job, file, bq_table, job_config=job_config)
-            except (TooManyRequests, ServiceUnavailable, GatewayTimeout, InternalServerError) as err:
+            except (
+                TooManyRequests,
+                ServiceUnavailable,
+                GatewayTimeout,
+                InternalServerError,
+                BigQueryQuotaExceededError,
+            ) as err:
                 backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
                 self.logger.exception(
                     "LoadJob transient error encountered", attempt=attempt, backoff=backoff, error_code=err.code
@@ -778,6 +784,8 @@ class BigQueryQuotaExceededError(Exception):
     This error indicates that we have been exporting too much data and need to
     slow down. This error is retryable.
     """
+
+    code = 403  # BigQuery reports quota errors as 403 Forbidden.
 
     def __init__(self, message: str):
         super().__init__(f"A BigQuery quota has been exceeded. Error: {message}")


### PR DESCRIPTION
## Problem

Retry on quota exceeded errors in bigquery batch export as quota is restored over time.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Moving the retry to the inner loop so that we don't have to restart the whole batch export.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
