### PR TITLE
fix(ma): add legacy table name fallback to frontend for Google Ads

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ExternalDataSourceConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/ExternalDataSourceConfiguration.tsx
@@ -30,6 +30,7 @@ import {
     NonNativeMarketingSource,
     VALID_NON_NATIVE_MARKETING_SOURCES,
     VALID_SELF_MANAGED_MARKETING_SOURCES,
+    findSchemaByFieldName,
 } from '../../logic/utils'
 import { AddIntegrationButton } from '../MarketingAnalyticsFilters/AddIntegrationButton'
 import { ColumnMappingModal } from './ColumnMappingModal'
@@ -72,7 +73,7 @@ export function ExternalDataSourceConfiguration(): JSX.Element {
         }
 
         const syncingTables = requiredFields.filter((field) => {
-            const schema = source.schemas?.find((s) => s.name === field)
+            const schema = findSchemaByFieldName(source.schemas, field, source.source_type)
             return schema?.should_sync ?? false
         })
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -37,6 +37,7 @@ import { externalAdsCostTile } from './marketingCostTile'
 import {
     MarketingDashboardMapper,
     NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS,
+    findSchemaByFieldName,
     generateUniqueName,
     validColumnsForTiles,
 } from './utils'
@@ -62,7 +63,7 @@ function getSourceStatus(
             ] || []
         const schemaStatuses = requiredFields
             .map((fieldName) => {
-                const schema = nativeSource.schemas?.find((schema) => schema.name === fieldName)
+                const schema = findSchemaByFieldName(nativeSource.schemas, fieldName, nativeSource.source_type)
                 return schema?.status
             })
             .filter(Boolean)
@@ -475,7 +476,7 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
                         NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS[source.source_type as NativeMarketingSource] || []
 
                     const syncingSchemas = requiredFields.filter((fieldName) => {
-                        const schema = source.schemas?.find((s) => s.name === fieldName)
+                        const schema = findSchemaByFieldName(source.schemas, fieldName, source.source_type)
                         return schema?.should_sync ?? false
                     })
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.test.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.test.ts
@@ -13,6 +13,7 @@ import {
 import { NativeSource } from './marketingAnalyticsLogic'
 import {
     createMarketingTile,
+    findSchemaByFieldName,
     getEnabledNativeMarketingSources,
     getOrderBy,
     getSortedColumnsByArray,
@@ -416,6 +417,37 @@ describe('marketing analytics utils', () => {
             const source = makeMockSource(sourceType, minimalSourceFields[sourceType])
             const result = createMarketingTile(source, column, 'USD')
             expect(result).toMatchSnapshot()
+        })
+    })
+
+    describe('findSchemaByFieldName', () => {
+        const schemas = [
+            { name: 'campaign', status: 'Completed' },
+            { name: 'campaign_stats', status: 'Completed' },
+        ]
+
+        it.each([
+            ['exact match returns schema', schemas, 'campaign', 'GoogleAds', 'campaign'],
+            [
+                'Google Ads falls back from campaign_overview_stats to campaign_stats',
+                schemas,
+                'campaign_overview_stats',
+                'GoogleAds',
+                'campaign_stats',
+            ],
+            ['non-Google Ads source has no fallback', schemas, 'campaign_overview_stats', 'LinkedinAds', undefined],
+            ['returns undefined when no match and no fallback', schemas, 'nonexistent', 'GoogleAds', undefined],
+            ['returns undefined for undefined schemas', undefined, 'campaign', 'GoogleAds', undefined],
+            [
+                'prefers exact match over fallback',
+                [...schemas, { name: 'campaign_overview_stats', status: 'Running' }],
+                'campaign_overview_stats',
+                'GoogleAds',
+                'campaign_overview_stats',
+            ],
+        ])('%s', (_name, testSchemas, fieldName, sourceType, expectedName) => {
+            const result = findSchemaByFieldName(testSchemas, fieldName, sourceType)
+            expect(result?.name).toBe(expectedName)
         })
     })
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -61,6 +61,38 @@ export const NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS: Record<NativeMarketin
     ])
 ) as Record<NativeMarketingSource, string[]>
 
+// Legacy table name fallbacks for native sources.
+// When a source's stats table was renamed, old syncs may still use the legacy name.
+// Mirrors the fallback logic in backend factory.py _create_googleads_config.
+const LEGACY_TABLE_NAME_FALLBACKS: Partial<Record<NativeMarketingSource, Record<string, string[]>>> = {
+    GoogleAds: {
+        campaign_overview_stats: ['campaign_stats'],
+    },
+}
+
+/** Find a schema by field name, falling back to legacy table names if needed */
+export function findSchemaByFieldName<T extends { name: string }>(
+    schemas: T[] | undefined,
+    fieldName: string,
+    sourceType: string
+): T | undefined {
+    const schema = schemas?.find((s) => s.name === fieldName)
+    if (schema) {
+        return schema
+    }
+
+    const fallbacks = LEGACY_TABLE_NAME_FALLBACKS[sourceType as NativeMarketingSource]?.[fieldName]
+    if (fallbacks) {
+        for (const fallbackName of fallbacks) {
+            const fallbackSchema = schemas?.find((s) => s.name === fallbackName)
+            if (fallbackSchema) {
+                return fallbackSchema
+            }
+        }
+    }
+    return undefined
+}
+
 export const MAX_ATTRIBUTION_WINDOW_DAYS = 90
 export const MIN_ATTRIBUTION_WINDOW_DAYS = 1
 export const DEFAULT_ATTRIBUTION_WINDOW_DAYS = 90

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -75,7 +75,7 @@ export function findSchemaByFieldName<T extends { name: string }>(
     schemas: T[] | undefined,
     fieldName: string,
     sourceType: string
-): T | undefined {
+): T | null {
     const schema = schemas?.find((s) => s.name === fieldName)
     if (schema) {
         return schema
@@ -90,7 +90,7 @@ export function findSchemaByFieldName<T extends { name: string }>(
             }
         }
     }
-    return undefined
+    return null
 }
 
 export const MAX_ATTRIBUTION_WINDOW_DAYS = 90


### PR DESCRIPTION
## Problem

In #46472 we renamed the Google Ads stats table from `campaign_stats` to `campaign_overview_stats` and added a backend fallback in `factory.py` so users with the old table still get data. However, the frontend was not updated with the same fallback — it does exact name matching against `campaign_overview_stats`, so users who only have the legacy `campaign_stats` table synced don't see Google Ads as a valid source in the Marketing analytics UI, even though the backend handles it correctly.

## Changes

- Added `findSchemaByFieldName()` helper in `utils.ts` that mirrors the backend fallback logic: tries exact match first, then falls back to legacy table names (`campaign_overview_stats` → `campaign_stats` for Google Ads)
- Updated 3 call sites that did exact `schema.name === fieldName` matching:
  - `getSourceStatus()` in `marketingAnalyticsLogic.ts` — determines source readiness status
  - `validNativeSources` selector in `marketingAnalyticsLogic.ts` — filters which sources appear in the UI
  - `getSourceSyncInfo()` in `ExternalDataSourceConfiguration.tsx` — shows sync status in settings
- Added parameterized tests for the new helper

## How did you test this code?

- Added 6 parameterized test cases covering: exact match, legacy fallback, no fallback for non-Google sources, missing schemas, and preferring exact match over fallback
- All 111 existing tests continue to pass

## Publish to changelog?

No