### PR TITLE
fix(mcp): use 307 redirects for POST OAuth endpoints to preserve request body

### DIFF
--- a/services/mcp/src/lib/routing.ts
+++ b/services/mcp/src/lib/routing.ts
@@ -18,15 +18,17 @@ const AUTH_SERVER_REDIRECTS: AuthRedirect[] = [
     { match: '/.well-known/oauth-authorization-server', status: 302 },
     // JWKS endpoint for token verification
     { match: '/.well-known/jwks.json', status: 301 },
-    // OAuth endpoints (authorize, token, register, revoke, introspect, userinfo)
-    { prefix: '/oauth/', status: 301 },
-    // MCP 3/26 spec fallback endpoints - clients hit these directly when the authorization
-    // server metadata is not available. PostHog serves these under /oauth/ so we rewrite.
-    // /register and /token use 307 to preserve POST method and body across the redirect.
-    // /authorize uses 302 as it's a GET request.
+    // POST-sensitive OAuth endpoints use 307 to preserve method and body.
+    // 301 converts POST→GET per HTTP spec, dropping the body and causing
+    // invalid_client errors (e.g. Claude Desktop native connectors).
+    { match: '/oauth/token/', status: 307 },
+    { match: '/oauth/register/', status: 307 },
+    // MCP 3/26 spec fallback endpoints (without /oauth/ prefix)
     { match: '/register', status: 307, rewriteTo: '/oauth/register' },
-    { match: '/authorize', status: 302, rewriteTo: '/oauth/authorize' },
     { match: '/token', status: 307, rewriteTo: '/oauth/token' },
+    // GET-safe endpoints: authorize, revoke, introspect, userinfo, etc.
+    { match: '/authorize', status: 302, rewriteTo: '/oauth/authorize' },
+    { prefix: '/oauth/', status: 302 },
 ]
 
 export function matchAuthServerRedirect(pathname: string): AuthRedirect | undefined {

--- a/services/mcp/tests/unit/routing.test.ts
+++ b/services/mcp/tests/unit/routing.test.ts
@@ -6,12 +6,12 @@ describe('Authorization server redirects', () => {
     const redirectCases = [
         { pathname: '/.well-known/oauth-authorization-server', expectedStatus: 302 },
         { pathname: '/.well-known/jwks.json', expectedStatus: 301 },
-        { pathname: '/oauth/authorize/', expectedStatus: 301 },
-        { pathname: '/oauth/token/', expectedStatus: 301 },
-        { pathname: '/oauth/register/', expectedStatus: 301 },
-        { pathname: '/oauth/revoke/', expectedStatus: 301 },
-        { pathname: '/oauth/introspect/', expectedStatus: 301 },
-        { pathname: '/oauth/userinfo/', expectedStatus: 301 },
+        { pathname: '/oauth/token/', expectedStatus: 307 },
+        { pathname: '/oauth/register/', expectedStatus: 307 },
+        { pathname: '/oauth/authorize/', expectedStatus: 302 },
+        { pathname: '/oauth/revoke/', expectedStatus: 302 },
+        { pathname: '/oauth/introspect/', expectedStatus: 302 },
+        { pathname: '/oauth/userinfo/', expectedStatus: 302 },
     ]
 
     it.each(redirectCases)('redirects $pathname with status $expectedStatus', ({ pathname, expectedStatus }) => {


### PR DESCRIPTION
## Problem

MCP clients (e.g. Claude Desktop native connectors) sometimes hit OAuth endpoints directly on the MCP server (`mcp.posthog.com/oauth/token/`, `/oauth/register/`) instead of going to the authorization server directly.

The MCP server redirects these to `oauth.posthog.com`, but was using **301** for all `/oauth/` paths. Per HTTP spec, 301 converts POST→GET, which drops the request body containing `client_id` and other required fields. This causes `invalid_client` / `invalid_request` errors during token exchange and dynamic client registration.

Reproduced on production:
```
$ curl -s -D - -X POST 'https://mcp.posthog.com/oauth/token/'
HTTP/2 301                    ← converts POST to GET
location: https://oauth.posthog.com/oauth/token/
```

## Changes

- `/oauth/token/` and `/oauth/register/`: Changed from 301 → **307** (preserves POST method and body)
- Remaining `/oauth/*` catch-all: Changed from 301 → **302** (GET-safe endpoints like authorize, revoke, introspect)
- Updated tests to match new status codes

## How did you test this code

- Local reproduction with `wrangler dev`:
  - Before: `POST /oauth/token/` → 301 (body dropped on redirect)
  - After: `POST /oauth/token/` → 307 (body preserved)
- All 162 MCP server tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)