### PR TITLE
fix(endpoints): toggle materialization when it's running

### DIFF
--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -84,7 +84,7 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
     const effectiveSyncFrequency = syncFrequency ?? freshMaterialization?.sync_frequency
 
     const canMaterialize = freshMaterialization?.can_materialize ?? endpoint.materialization?.can_materialize ?? false
-    const isMaterialized = effectiveIsMaterialized || materializationStatus?.toLowerCase() === 'running'
+    const isMaterialized = effectiveIsMaterialized || effectiveMaterializationStatus?.toLowerCase() === 'running'
     const materializationStatus = effectiveMaterializationStatus
     const lastMaterializedAt = effectiveLastMaterializedAt
 

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -84,7 +84,7 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
     const effectiveSyncFrequency = syncFrequency ?? freshMaterialization?.sync_frequency
 
     const canMaterialize = freshMaterialization?.can_materialize ?? endpoint.materialization?.can_materialize ?? false
-    const isMaterialized = effectiveIsMaterialized
+    const isMaterialized = effectiveIsMaterialized || materializationStatus?.toLowerCase() === 'running'
     const materializationStatus = effectiveMaterializationStatus
     const lastMaterializedAt = effectiveLastMaterializedAt
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The materialization toggle in the Endpoints product's configuration scene did not correctly reflect a "running" materialization status, remaining off even when materialization was in progress. This led to an inaccurate UI state and hid relevant information.

## Changes

Modified the `isMaterialized` constant in `EndpointConfiguration.tsx` to also check if `materializationStatus` is 'running'. This ensures the materialization toggle is on when materialization is active, making the status panel and sync frequency options visible during the process.

## How did you test this code?

As an agent, I have not manually tested this change.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/agents/bc-98643679-de20-4ebc-9404-4a5bc6fb105f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98643679-de20-4ebc-9404-4a5bc6fb105f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->