### PR TITLE
feat: ticket_number instead of id in URL

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -61,6 +61,33 @@ class TestTicketAPI(APIBaseTest):
         self.assertEqual(response.json()["id"], str(self.ticket.id))
         self.assertEqual(response.json()["status"], Status.NEW)
 
+    def test_retrieve_ticket_by_ticket_number(self, mock_on_commit):
+        """Test retrieving a ticket by ticket_number instead of UUID."""
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/{self.ticket.ticket_number}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(self.ticket.id))
+        self.assertEqual(response.json()["ticket_number"], self.ticket.ticket_number)
+
+    def test_retrieve_ticket_by_uuid_still_works(self, mock_on_commit):
+        """Test that UUID lookup still works for backward compatibility."""
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/{self.ticket.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(self.ticket.id))
+
+    def test_retrieve_ticket_invalid_identifier_returns_404(self, mock_on_commit):
+        """Test that invalid identifier returns 404."""
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/invalid/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_ticket_by_ticket_number(self, mock_on_commit):
+        """Test updating a ticket using ticket_number."""
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/conversations/tickets/{self.ticket.ticket_number}/",
+            {"status": "resolved"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], "resolved")
+
     def test_retrieve_ticket_marks_as_read(self, mock_on_commit):
         self.ticket.unread_team_count = 5
         self.ticket.save()

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -236,7 +236,10 @@ class TicketViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         Support looking up tickets by either UUID or ticket_number.
         This allows URLs like /tickets/123/ (ticket_number) alongside /tickets/<uuid>/ for backward compatibility.
         """
-        lookup_value = self.kwargs.get("pk")
+        lookup_value: str | None = self.kwargs.get("pk")
+
+        if not lookup_value:
+            raise Http404("Ticket not found")
 
         # Try to parse as UUID first
         try:
@@ -254,7 +257,7 @@ class TicketViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     return queryset.get(ticket_number=ticket_num)
                 except Ticket.DoesNotExist:
                     raise Http404("Ticket not found")
-            except ValueError:
+            except (ValueError, TypeError):
                 # Neither UUID nor integer
                 raise Http404("Ticket not found")
 

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from django.db import transaction
 from django.db.models import Prefetch, Q, QuerySet, Sum
+from django.http import Http404
 from django.utils import timezone
 
 import structlog
@@ -229,6 +230,33 @@ class TicketViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             order_by = "-updated_at"
 
         return queryset.order_by(order_by)
+
+    def safely_get_object(self, queryset):
+        """
+        Support looking up tickets by either UUID or ticket_number.
+        This allows URLs like /tickets/123/ (ticket_number) alongside /tickets/<uuid>/ for backward compatibility.
+        """
+        lookup_value = self.kwargs.get("pk")
+
+        # Try to parse as UUID first
+        try:
+            uuid.UUID(lookup_value)
+            # It's a valid UUID - look up by id
+            try:
+                return queryset.get(id=lookup_value)
+            except Ticket.DoesNotExist:
+                raise Http404("Ticket not found")
+        except (ValueError, AttributeError):
+            # Not a UUID - try as ticket_number (integer)
+            try:
+                ticket_num = int(lookup_value)
+                try:
+                    return queryset.get(ticket_number=ticket_num)
+                except Ticket.DoesNotExist:
+                    raise Http404("Ticket not found")
+            except ValueError:
+                # Neither UUID nor integer
+                raise Http404("Ticket not found")
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/products/conversations/frontend/scenes/ticket/PreviousTicketsPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/PreviousTicketsPanel.tsx
@@ -40,7 +40,7 @@ export function PreviousTicketsPanel({
                                     {previousTickets.map((ticket) => (
                                         <Link
                                             key={ticket.id}
-                                            to={urls.supportTicketDetail(ticket.id)}
+                                            to={urls.supportTicketDetail(ticket.ticket_number)}
                                             className="block p-2 mb-2 rounded border border-primary hover:bg-accent-3000 transition-colors hover:border-secondary"
                                         >
                                             <div className="flex items-center justify-between mb-1">

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -398,6 +398,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 const isUuid = props.id.toString().includes('-')
                 if (isUuid && ticket.ticket_number) {
                     router.actions.replace(urls.supportTicketDetail(ticket.ticket_number))
+                    return
                 }
 
                 actions.setTicket(ticket)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1,8 +1,11 @@
 import { JSONContent } from '@tiptap/core'
 import { actions, afterMount, beforeUnmount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
 
 import api from '~/lib/api'
 import { PERSON_DISPLAY_NAME_COLUMN_NAME } from '~/lib/constants'
@@ -390,6 +393,13 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             }
             try {
                 const ticket = await api.conversationsTickets.get(props.id.toString())
+
+                // If accessed via UUID, redirect to ticket_number URL for cleaner URLs
+                const isUuid = props.id.toString().includes('-')
+                if (isUuid && ticket.ticket_number) {
+                    router.actions.replace(urls.supportTicketDetail(ticket.ticket_number))
+                }
+
                 actions.setTicket(ticket)
                 actions.loadMessages()
 
@@ -445,14 +455,14 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             }
         },
         loadMessages: async () => {
-            if (props.id === 'new') {
+            if (props.id === 'new' || !values.ticket?.id) {
                 actions.setMessages([])
                 return
             }
             try {
                 const response = await api.comments.list({
                     scope: 'conversations_ticket',
-                    item_id: props.id.toString(),
+                    item_id: values.ticket.id,
                 })
                 // Reverse to show oldest first (bottom = newest)
                 actions.setMessages((response.results || []).reverse())
@@ -463,7 +473,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         },
         loadOlderMessages: async () => {
             const currentMessages = values.messages
-            if (props.id === 'new' || currentMessages.length === 0 || !values.hasMoreMessages) {
+            if (props.id === 'new' || !values.ticket?.id || currentMessages.length === 0 || !values.hasMoreMessages) {
                 actions.setOlderMessagesLoading(false)
                 actions.setHasMoreMessages(false)
                 return
@@ -473,7 +483,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 const oldestMessage = currentMessages[0]
                 const response = await api.comments.list({
                     scope: 'conversations_ticket',
-                    item_id: props.id.toString(),
+                    item_id: values.ticket.id,
                 })
 
                 const allMessages = response.results || []
@@ -513,7 +523,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             }
         },
         sendMessage: async ({ content, richContent, isPrivate, onSuccess }) => {
-            if (props.id === 'new') {
+            if (props.id === 'new' || !values.ticket?.id) {
                 actions.setMessageSending(false)
                 return
             }
@@ -523,7 +533,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                         content,
                         rich_content: richContent,
                         scope: 'conversations_ticket',
-                        item_id: props.id.toString(),
+                        item_id: values.ticket.id,
                         item_context: {
                             author_type: 'support',
                             is_private: isPrivate,

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -261,7 +261,7 @@ export function SupportTicketsScene(): JSX.Element {
                             : undefined,
                 }}
                 onRow={(ticket) => {
-                    const ticketUrl = urls.supportTicketDetail(ticket.id)
+                    const ticketUrl = urls.supportTicketDetail(ticket.ticket_number)
                     return {
                         onClick: (e: React.MouseEvent) => {
                             if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
## Problem

Right now we use ticket id (uuid) in url, so we have /support/tickets/{uuid}
More natural way is to use ticket_number (which is a digit), so we have /support/tickets/{ticket_number}

## Changes

Change the URLs, add also check if it's a uuid -> redirect to ticket_number (in case someone saved the link)

<img width="1005" height="474" alt="Screenshot 2026-03-04 at 15 14 13" src="https://github.com/user-attachments/assets/865b08a8-7533-4a30-98ea-917d6b71fe6e" />
