### PR TITLE
feat(storage): swap objectstorage to seaweedfs compatibly

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -205,13 +205,38 @@ services:
             DYNAMIC_CONFIG_ENABLED: 'true'
 
     objectstorage:
-        image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+        image: chrislusf/seaweedfs:4.03
         restart: on-failure
-        environment:
-            MINIO_ROOT_USER: object_storage_root_user
-            MINIO_ROOT_PASSWORD: object_storage_root_password
-        entrypoint: sh
-        command: -c 'mkdir -p /data/posthog /data/ducklake-dev /data/ai-blobs && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog', 'ducklake-dev', and 'ai-blobs' buckets before starting the service
+        volumes:
+            - ./docker/seaweedfs/s3.conf:/etc/seaweedfs/s3.conf:ro
+        entrypoint:
+            - /bin/sh
+            - -c
+            - |
+                /usr/bin/weed "$$@" &
+                WEED_PID=$$!
+                BUCKETS="posthog ducklake-dev ai-blobs"
+                echo "Waiting for objectstorage SeaweedFS to initialize..."
+                while true; do
+                    sleep 3
+                    LIST_OUTPUT=$$(echo "s3.bucket.list" | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
+                    MISSING=0
+                    for bucket in $$BUCKETS; do
+                        if ! echo "$$LIST_OUTPUT" | grep -q "$$bucket"; then
+                            MISSING=1
+                            echo "Creating bucket $$bucket..."
+                            echo "s3.bucket.create -name $$bucket" | /usr/bin/weed shell -master=localhost:19001 2>&1 || true
+                        fi
+                    done
+                    if [ "$$MISSING" -eq 0 ]; then
+                        echo "Objectstorage SeaweedFS ready with required buckets"
+                        break
+                    fi
+                done
+                wait $$WEED_PID
+            - --
+        command:
+            ['server', '-master.port=19001', '-s3', '-s3.port=19000', '-s3.config=/etc/seaweedfs/s3.conf', '-dir=/data']
 
     objectstorage-azure:
         image: mcr.microsoft.com/azure-storage/azurite:3.35.0
@@ -575,6 +600,8 @@ services:
     seaweedfs:
         container_name: '${SEAWEEDFS_DOCKER_NAME:-seaweedfs-main}'
         image: chrislusf/seaweedfs:4.03
+        volumes:
+            - ./docker/seaweedfs/s3.conf:/etc/seaweedfs/s3.conf:ro
         ports:
             - '127.0.0.1:8333:8333' # S3 API
             - '127.0.0.1:9333:9333' # Master server (for admin UI)
@@ -599,7 +626,7 @@ services:
                 echo "SeaweedFS ready with posthog bucket"
                 wait $$WEED_PID
             - --
-        command: ['server', '-s3', '-s3.port=8333', '-dir=/data']
+        command: ['server', '-s3', '-s3.port=8333', '-s3.config=/etc/seaweedfs/s3.conf', '-dir=/data']
 
 networks:
     otel_network:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -190,11 +190,15 @@ services:
             - web
             - livestream
     objectstorage:
-        extends:
-            file: docker-compose.base.yml
-            service: objectstorage
-
+        # Transitional legacy MinIO source for hobby migrations.
+        # Dev/CI stacks use SeaweedFS-backed objectstorage from docker-compose.base.yml.
+        image: minio/minio:RELEASE.2025-04-22T22-12-26Z
         restart: on-failure
+        environment:
+            MINIO_ROOT_USER: object_storage_root_user
+            MINIO_ROOT_PASSWORD: object_storage_root_password
+        entrypoint: sh
+        command: -c 'mkdir -p /data/posthog /data/ducklake-dev /data/ai-blobs && minio server --address ":19000" --console-address ":19001" /data'
         volumes:
             - objectstorage:/data
         ports:

--- a/docker/seaweedfs/s3.conf
+++ b/docker/seaweedfs/s3.conf
@@ -1,0 +1,24 @@
+{
+  "identities": [
+    {
+      "name": "posthog-local",
+      "credentials": [
+        {
+          "accessKey": "object_storage_root_user",
+          "secretKey": "object_storage_root_password"
+        },
+        {
+          "accessKey": "any",
+          "secretKey": "any"
+        }
+      ],
+      "actions": [
+        "Admin",
+        "Read",
+        "List",
+        "Tagging",
+        "Write"
+      ]
+    }
+  ]
+}

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -49,16 +49,41 @@ services:
             retries: 10
 
     objectstorage:
-        image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+        image: chrislusf/seaweedfs:4.03
         restart: on-failure
         ports:
             - '127.0.0.1:19000:19000'
             - '127.0.0.1:19001:19001'
-        environment:
-            MINIO_ROOT_USER: object_storage_root_user
-            MINIO_ROOT_PASSWORD: object_storage_root_password
-        entrypoint: sh
-        command: -c 'mkdir -p /data/capture && minio server --address ":19000" --console-address ":19001" /data' # create the 'capture' bucket before starting the service
+        volumes:
+            - ../docker/seaweedfs/s3.conf:/etc/seaweedfs/s3.conf:ro
+        entrypoint:
+            - /bin/sh
+            - -c
+            - |
+                /usr/bin/weed "$$@" &
+                WEED_PID=$$!
+                BUCKETS="capture posthog"
+                echo "Waiting for objectstorage SeaweedFS to initialize..."
+                while true; do
+                    sleep 3
+                    LIST_OUTPUT=$$(echo "s3.bucket.list" | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
+                    MISSING=0
+                    for bucket in $$BUCKETS; do
+                        if ! echo "$$LIST_OUTPUT" | grep -q "$$bucket"; then
+                            MISSING=1
+                            echo "Creating bucket $$bucket..."
+                            echo "s3.bucket.create -name $$bucket" | /usr/bin/weed shell -master=localhost:19001 2>&1 || true
+                        fi
+                    done
+                    if [ "$$MISSING" -eq 0 ]; then
+                        echo "Objectstorage SeaweedFS ready with required buckets"
+                        break
+                    fi
+                done
+                wait $$WEED_PID
+            - --
+        command:
+            ['server', '-master.port=19001', '-s3', '-s3.port=19000', '-s3.config=/etc/seaweedfs/s3.conf', '-dir=/data']
 
     kafka-ui:
         image: provectuslabs/kafka-ui:latest


### PR DESCRIPTION
## Summary
- switch objectstorage service in base compose from MinIO to SeaweedFS while preserving the existing objectstorage:19000 contract
- add SeaweedFS S3 identity config that accepts both legacy MinIO-style credentials and any/any
- bootstrap required buckets on startup (posthog, ducklake-dev, ai-blobs in main stack; capture, posthog in rust stack)
- keep hobby objectstorage on MinIO as a transitional override so existing hobby migration scripts still have a MinIO source

## Why
This unblocks migration away from MinIO in dev/CI with minimal code churn and without forcing endpoint/credential updates across tests and services in the same PR.

## Validation
- docker compose -f docker-compose.dev.yml config
- docker compose -f docker-compose.hobby.yml config
- docker compose -f rust/docker-compose.yml config
- brought up objectstorage in dev and rust stacks and verified S3 bucket listing on http://127.0.0.1:19000 using both credential pairs:
  - object_storage_root_user/object_storage_root_password
  - any/any
