### PR TITLE
fix(cohorts): document persons endpoint openapi pagination schema

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -12,7 +12,8 @@ from django.db import DatabaseError
 from django.db.models import OuterRef, Prefetch, QuerySet, Subquery, prefetch_related_objects
 
 import structlog
-from drf_spectacular.utils import extend_schema, extend_schema_field
+from drf_spectacular.openapi import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
 from pydantic import (
@@ -332,6 +333,37 @@ class AddPersonsToStaticCohortRequestSerializer(serializers.Serializer):
 
 class RemovePersonRequestSerializer(serializers.Serializer):
     person_id = serializers.UUIDField(required=True, help_text="Person UUID to remove from the cohort")
+
+
+class CohortPersonEventInfoSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField()
+    timestamp = serializers.DateTimeField()
+    window_id = serializers.CharField()
+
+
+class CohortPersonMatchedRecordingSerializer(serializers.Serializer):
+    session_id = serializers.CharField()
+    events = CohortPersonEventInfoSerializer(many=True)
+
+
+class CohortPersonSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    id = serializers.UUIDField()
+    uuid = serializers.UUIDField()
+    created_at = serializers.DateTimeField(allow_null=True)
+    last_seen_at = serializers.DateTimeField(allow_null=True)
+    properties = serializers.DictField()
+    is_identified = serializers.BooleanField(allow_null=True)
+    name = serializers.CharField()
+    distinct_ids = serializers.ListField(child=serializers.CharField())
+    matched_recordings = CohortPersonMatchedRecordingSerializer(many=True)
+    value_at_data_point = serializers.FloatField(allow_null=True)
+
+
+class CohortPersonsResponseSerializer(serializers.Serializer):
+    results = CohortPersonSerializer(many=True)
+    next = serializers.URLField(allow_null=True)
+    previous = serializers.URLField(allow_null=True)
 
 
 class CohortCalculationHistorySerializer(serializers.ModelSerializer):
@@ -1127,6 +1159,13 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         return graph, behavioral_cohorts
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("limit", OpenApiTypes.INT, description="Number of results to return per page."),
+            OpenApiParameter("offset", OpenApiTypes.INT, description="The initial index from which to return results."),
+        ],
+        responses={200: CohortPersonsResponseSerializer},
+    )
     @action(
         methods=["GET"],
         detail=True,

--- a/posthog/api/test/test_api_docs.py
+++ b/posthog/api/test/test_api_docs.py
@@ -1,4 +1,6 @@
 import pytest
+from parameterized import parameterized
+
 from posthog.test.base import APIBaseTest
 
 
@@ -16,7 +18,10 @@ class TestAPIDocsSchema(APIBaseTest):
         assert schema_response.status_code == 200
         # the response does have data, but mypy doesn't know that
         assert isinstance(schema_response.data, dict)
-        assert schema_response.headers.get("Content-Type") == "application/vnd.oai.openapi; charset=utf-8"
+        assert (
+            schema_response.headers.get("Content-Type")
+            == "application/vnd.oai.openapi; charset=utf-8"
+        )
         assert int(str(schema_response.headers.get("Content-Length"))) > 0
 
     def test_api_docs_generation_warnings_snapshot(self) -> None:
@@ -30,3 +35,29 @@ class TestAPIDocsSchema(APIBaseTest):
         # we log lots of warnings when generating the schema
         warnings = self._capsys.readouterr().err.split("\n")
         assert sorted(warnings) == self._snapshot
+
+    def _get_cohort_persons_response_properties(self) -> dict:
+        self.client.logout()
+        schema_response = self.client.get("/api/schema/")
+        assert schema_response.status_code == 200
+        openapi_schema = schema_response.data
+        response_schema = openapi_schema["paths"][
+            "/api/projects/{project_id}/cohorts/{id}/persons/"
+        ]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+        while "$ref" in response_schema:
+            schema_name = response_schema["$ref"].split("/")[-1]
+            response_schema = openapi_schema["components"]["schemas"][schema_name]
+        return response_schema.get("properties", {})
+
+    @parameterized.expand(
+        [
+            ("results",),
+            ("next",),
+            ("previous",),
+        ]
+    )
+    def test_cohort_persons_endpoint_schema_has_pagination_field(
+        self, field: str
+    ) -> None:
+        properties = self._get_cohort_persons_response_properties()
+        assert field in properties


### PR DESCRIPTION
## Problem

The OpenAPI schema for `GET /api/projects/{project_id}/cohorts/{id}/persons/` did not clearly document pagination query params and paginated response fields, which made the endpoint contract less explicit for consumers.

Closes #18673

## Changes

- Added `@extend_schema` docs to `CohortViewSet.persons` in `posthog/api/cohort.py`
- Documented query parameters:
  - `limit`
  - `offset`
- Added explicit `200` response schema via `CohortPersonsResponseSerializer`
- Added/updated API docs tests in `posthog/api/test/test_api_docs.py` to assert paginated response fields are present in schema:
  - `results`
  - `next`
  - `previous`

## How did you test this code?

Ran in WSL with project venv:

- `python -m pytest -q posthog/api/test/test_api_docs.py -k "cohort_persons_endpoint_schema_has_pagination_field or can_generate_api_docs_schema"`

Result:
- `4 passed, 1 deselected`

Notes:
- The snapshot test in this file is environment-sensitive due to warning path differences (local vs CI paths), so snapshot updates were not included.

## Publish to changelog?

no