### PR TITLE
fix(web-analytics): remove filters from URL params when no filters applied

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2195,6 +2195,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             // spreading from their individual dropdowns to the global filters list
             if (rawWebAnalyticsFilters.length > 0) {
                 urlParams.set('filters', JSON.stringify(rawWebAnalyticsFilters))
+            } else {
+                urlParams.delete('filters')
             }
             if (conversionGoal) {
                 if ('actionId' in conversionGoal) {


### PR DESCRIPTION
## Problem

When a user removes all web analytics filters, the `filters` URL parameter is not deleted — it's simply not re-set. This means the old filter value persists in the URL. When any other state change triggers `urlToAction` (e.g., switching tabs), the stale `filters` param is read back and the removed filter gets re-applied.

## Changes

- Add `urlParams.delete('filters')` when `rawWebAnalyticsFilters` is empty, so the URL stays in sync with the actual filter state

## How did you test this code?

1. Apply a filter (e.g., click a Channel Type row like "Organic Search")
2. Remove the filter via the X button
3. Switch tabs (e.g., from UTM Source to UTM Medium)
4. Verify the removed filter does NOT reappear