### PR TITLE
feat(ph-ai): save notebook artifacts to database

### DIFF
--- a/ee/hogai/artifacts/handlers/base.py
+++ b/ee/hogai/artifacts/handlers/base.py
@@ -27,6 +27,7 @@ class EnrichmentContext:
 
     team: Team
     state_messages: Sequence[AssistantMessageUnion] | None = None
+    artifact_id: str | None = None
 
 
 class ArtifactHandler(ABC, Generic[T_Stored, T_Enriched]):

--- a/ee/hogai/artifacts/handlers/notebook.py
+++ b/ee/hogai/artifacts/handlers/notebook.py
@@ -9,6 +9,8 @@ from posthog.schema import ArtifactContentType, ErrorBlock, NotebookArtifactCont
 
 from posthog.models import Team
 
+from products.notebooks.backend.models import Notebook
+
 from ee.hogai.artifacts.handlers.base import (
     ArtifactHandler,
     EnrichmentContext,
@@ -121,9 +123,14 @@ class NotebookHandler(ArtifactHandler[StoredNotebookArtifactContent, NotebookArt
                 # Pass through other block types unchanged
                 enriched_blocks.append(block)
 
+        is_saved = False
+        if context.artifact_id:
+            is_saved = await Notebook.objects.filter(team=context.team, short_id=context.artifact_id).aexists()
+
         return NotebookArtifactContent(
             blocks=enriched_blocks,
             title=content.title,
+            is_saved=is_saved,
         )
 
     def get_metadata(self, content: StoredNotebookArtifactContent) -> dict[str, Any]:

--- a/ee/hogai/artifacts/manager.py
+++ b/ee/hogai/artifacts/manager.py
@@ -128,7 +128,7 @@ class ArtifactManager(
 
         # Use handler for enrichment (generic for all types)
         handler = get_handler_for_content_class(type(stored_content))
-        context = EnrichmentContext(team=self._team)
+        context = EnrichmentContext(team=self._team, artifact_id=artifact_id)
         content: ArtifactContent = await handler.aenrich(stored_content, context)
 
         if expected_type is not None and not isinstance(content, expected_type):
@@ -208,7 +208,7 @@ class ArtifactManager(
             stored_content = handler.validate(artifact.data)
 
             # Use handler for enrichment (generic for all types)
-            context = EnrichmentContext(team=self._team)
+            context = EnrichmentContext(team=self._team, artifact_id=artifact.short_id)
             content: ArtifactContent = await handler.aenrich(stored_content, context)
 
             result.append(
@@ -294,7 +294,6 @@ class ArtifactManager(
 
         # Fetch and enrich using handlers
         result: dict[str, ArtifactContent] = {}
-        context = EnrichmentContext(team=self._team, state_messages=messages)
 
         for content_type, artifact_ids in ids_by_content_type.items():
             handler = get_handler_for_content_type(content_type)
@@ -306,7 +305,8 @@ class ArtifactManager(
             for artifact_id, fetch_result in zip(artifact_ids, fetch_results):
                 if fetch_result is None:
                     continue
-                enriched: ArtifactContent = await handler.aenrich(fetch_result.content, context)
+                enrich_ctx = EnrichmentContext(team=self._team, state_messages=messages, artifact_id=artifact_id)
+                enriched: ArtifactContent = await handler.aenrich(fetch_result.content, enrich_ctx)
                 agg_id = aggregation_map.get(artifact_id)
                 if agg_id is not None:
                     result[agg_id] = enriched

--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -19,6 +19,7 @@ from ee.hogai.registry import get_contextual_tool_class
 from ee.hogai.tool import MaxTool
 from ee.hogai.tools import (
     CreateFormTool,
+    CreateNotebookTool,
     ListDataTool,
     ManageMemoriesTool,
     ReadDataTool,
@@ -46,6 +47,7 @@ DEFAULT_TOOLS: list[type[MaxTool]] = [
     ListDataTool,
     TodoWriteTool,
     SwitchModeTool,
+    CreateNotebookTool,
 ]
 
 TASK_TOOLS: list[type[MaxTool]] = [

--- a/ee/hogai/tools/create_notebook/helpers.py
+++ b/ee/hogai/tools/create_notebook/helpers.py
@@ -1,8 +1,14 @@
+from collections.abc import Sequence
 from enum import Enum
 
+from posthog.models import Team, User
+
+from products.notebooks.backend.models import Notebook
+
 from ee.hogai.artifacts.manager import ArtifactManager
-from ee.hogai.artifacts.types import StoredNotebookArtifactContent
+from ee.hogai.artifacts.types import StoredBlock, StoredNotebookArtifactContent, VisualizationRefBlock
 from ee.hogai.tools.create_notebook.parsing import parse_notebook_content_for_storage
+from ee.hogai.tools.create_notebook.tiptap import blocks_to_tiptap_doc
 from ee.models.assistant import AgentArtifact
 
 
@@ -17,18 +23,12 @@ async def create_or_update_notebook_artifact(
     content: str,
     title: str,
     artifact_id: str | None = None,
-) -> tuple[AgentArtifact, ArtifactStatus]:
+) -> tuple[AgentArtifact, ArtifactStatus, list[StoredBlock]]:
     """
     Parse markdown content and create or update a notebook artifact.
 
-    Args:
-        artifacts_manager: The ArtifactManager instance to use for persistence
-        content: Markdown content with optional <insight>artifact_id</insight> tags
-        title: Title for the notebook artifact
-        artifact_id: Optional ID of existing artifact to update
-
     Returns:
-        tuple[AgentArtifact, ArtifactStatus] with the artifact and status
+        tuple of (artifact, status, parsed_blocks)
     """
     blocks = parse_notebook_content_for_storage(content, title=title)
     artifact_content = StoredNotebookArtifactContent(blocks=blocks, title=title)
@@ -48,4 +48,65 @@ async def create_or_update_notebook_artifact(
         if status != ArtifactStatus.FAILED_TO_UPDATE:
             status = ArtifactStatus.CREATED
 
-    return artifact, status
+    return artifact, status, blocks
+
+
+async def save_notebook_to_db(
+    team: Team,
+    user: User,
+    artifact: AgentArtifact,
+    blocks: Sequence[StoredBlock],
+    title: str,
+) -> Notebook:
+    """
+    Save or update a real Notebook record with the same short_id as the artifact.
+
+    If a Notebook with the artifact's short_id already exists, update its content.
+    Otherwise, create a new Notebook.
+    """
+    # Pre-fetch all referenced visualization artifacts to avoid sync ORM calls in the closure
+    ref_ids = [block.artifact_id for block in blocks if isinstance(block, VisualizationRefBlock)]
+    viz_lookup: dict[str, dict] = {}
+    if ref_ids:
+        viz_artifacts = AgentArtifact.objects.filter(short_id__in=ref_ids, team=team)
+        async for viz_artifact in viz_artifacts:
+            data = viz_artifact.data
+            if data.get("content_type") != "visualization":
+                continue
+            query = data.get("query")
+            name = data.get("name")
+            if not query:
+                continue
+            kind = query.get("kind", "")
+            if kind == "HogQLQuery" or "HogQL" in kind:
+                notebook_query = {"kind": "DataVisualizationNode", "source": query}
+            else:
+                notebook_query = {"kind": "InsightVizNode", "source": query}
+            viz_lookup[viz_artifact.short_id] = {"query": notebook_query, "name": name}
+
+    def resolve_visualization(artifact_id: str) -> dict | None:
+        return viz_lookup.get(artifact_id)
+
+    tiptap_doc = blocks_to_tiptap_doc(blocks, title=title, resolve_visualization=resolve_visualization)
+
+    notebook, created = await Notebook.objects.aget_or_create(
+        team=team,
+        short_id=artifact.short_id,
+        defaults={
+            "created_by": user,
+            "last_modified_by": user,
+            "title": title,
+            "content": tiptap_doc,
+        },
+    )
+    if not created:
+        notebook.content = tiptap_doc
+        notebook.title = title
+        notebook.last_modified_by = user
+        await notebook.asave(update_fields=["content", "title", "last_modified_by", "last_modified_at"])
+
+    return notebook
+
+
+async def notebook_exists_for_artifact(team: Team, short_id: str) -> bool:
+    return await Notebook.objects.filter(team=team, short_id=short_id).aexists()

--- a/ee/hogai/tools/create_notebook/test/test_tool.py
+++ b/ee/hogai/tools/create_notebook/test/test_tool.py
@@ -3,6 +3,8 @@ from posthog.test.base import BaseTest
 from asgiref.sync import async_to_sync
 from langchain_core.runnables import RunnableConfig
 
+from products.notebooks.backend.models import Notebook
+
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.tools.create_notebook.tool import CreateNotebookTool
 from ee.hogai.utils.types.base import AssistantState, NodePath
@@ -85,7 +87,7 @@ class TestCreateNotebookTool(BaseTest):
             title="Original Notebook",
             content="# Original",
         )
-        original_artifact_id = create_artifact.messages[1].content.split("artifact_id: ")[1]
+        original_artifact_id = create_artifact.messages[1].content.split("artifact_id: ")[1].split(".")[0]
 
         update_result, update_artifact = async_to_sync(self.tool._arun_impl)(
             title="Updated Notebook",
@@ -98,3 +100,72 @@ class TestCreateNotebookTool(BaseTest):
         tool_call_message = update_artifact.messages[1]
         assert "has been updated" in tool_call_message.content
         assert "Failed" not in tool_call_message.content
+
+    def test_transient_notebook_message_mentions_transient(self):
+        result, artifact = async_to_sync(self.tool._arun_impl)(
+            title="Test Notebook",
+            content="# Hello World",
+        )
+
+        assert artifact is not None
+        tool_call_message = artifact.messages[1]
+        assert "transient" in tool_call_message.content
+        assert Notebook.objects.filter(team=self.team).count() == 0
+
+    def test_save_to_notebook_creates_real_notebook(self):
+        result, artifact = async_to_sync(self.tool._arun_impl)(
+            title="Saved Notebook",
+            content="# Hello World",
+            save_to_notebook=True,
+        )
+
+        assert artifact is not None
+        tool_call_message = artifact.messages[1]
+        assert "saved" in tool_call_message.content.lower()
+        assert "/notebooks/" in tool_call_message.content
+
+        notebooks = Notebook.objects.filter(team=self.team)
+        assert notebooks.count() == 1
+        notebook = notebooks.first()
+        assert notebook.title == "Saved Notebook"
+        assert notebook.content is not None
+        assert notebook.content["type"] == "doc"
+
+    def test_save_to_notebook_uses_artifact_short_id(self):
+        result, artifact = async_to_sync(self.tool._arun_impl)(
+            title="Linked Notebook",
+            content="# Hello",
+            save_to_notebook=True,
+        )
+
+        assert artifact is not None
+        from ee.models.assistant import AgentArtifact
+
+        agent_artifact = AgentArtifact.objects.filter(team=self.team).last()
+        notebook = Notebook.objects.filter(team=self.team).first()
+        assert notebook is not None
+        assert agent_artifact is not None
+        assert notebook.short_id == agent_artifact.short_id
+
+    def test_update_already_saved_notebook_auto_updates_db(self):
+        # First create and save
+        _, create_artifact = async_to_sync(self.tool._arun_impl)(
+            title="Original",
+            content="# Original",
+            save_to_notebook=True,
+        )
+        short_id = create_artifact.messages[1].content.split("short_id: ")[1].split(".")[0]
+
+        # Now update without save_to_notebook -- should auto-update because already saved
+        _, update_artifact = async_to_sync(self.tool._arun_impl)(
+            title="Updated",
+            content="# Updated Content",
+            artifact_id=short_id,
+        )
+
+        assert update_artifact is not None
+        tool_call_message = update_artifact.messages[1]
+        assert "updated" in tool_call_message.content.lower()
+
+        notebook = Notebook.objects.get(team=self.team, short_id=short_id)
+        assert notebook.title == "Updated"

--- a/ee/hogai/tools/create_notebook/tool.py
+++ b/ee/hogai/tools/create_notebook/tool.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel, Field
 from posthog.schema import ArtifactContentType, ArtifactSource, AssistantTool, AssistantToolCallMessage
 
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
-from ee.hogai.tools.create_notebook.helpers import ArtifactStatus, create_or_update_notebook_artifact
+from ee.hogai.tools.create_notebook.helpers import (
+    ArtifactStatus,
+    create_or_update_notebook_artifact,
+    notebook_exists_for_artifact,
+    save_notebook_to_db,
+)
 
 CREATE_NOTEBOOK_PROMPT = """
 Use this tool to create a notebook document with rich content.
@@ -66,6 +71,11 @@ Our signup funnel shows the following conversion rates:
 # Updating existing notebooks:
 - If you want to update an existing notebook, use the `artifact_id` parameter to specify the ID of the existing artifact
 - *IMPORTANT*: Updating a notebook will replace the existing content with the new content
+
+# Transient vs saved notebooks:
+- By default, notebooks are created as transient artifacts visible only in this conversation. Do NOT share URLs or references to notebook pages for transient artifacts.
+- Set save_to_notebook=True ONLY when the user explicitly asks to save, persist, or create a permanent notebook.
+- When updating an artifact that is already saved to the database, the saved notebook is automatically updated too.
 """
 
 
@@ -82,6 +92,10 @@ class CreateNotebookToolArgs(BaseModel):
     artifact_id: str | None = Field(
         default=None, description="The ID of an existing notebook artifact that you want to update."
     )
+    save_to_notebook: bool = Field(
+        default=False,
+        description="Set to true ONLY when the user explicitly asks to save/persist the notebook to the database.",
+    )
 
 
 class CreateNotebookTool(MaxTool):
@@ -95,6 +109,7 @@ class CreateNotebookTool(MaxTool):
         content: str | None = None,
         draft_content: str | None = None,
         artifact_id: str | None = None,
+        save_to_notebook: bool = False,
     ) -> tuple[str, Any]:
         if content is not None and draft_content is not None:
             return "Error: Cannot provide both 'content' and 'draft_content'. Use exactly one.", None
@@ -106,18 +121,46 @@ class CreateNotebookTool(MaxTool):
         notebook_content = draft_content if is_draft else content
         assert notebook_content is not None
 
-        artifact, status = await create_or_update_notebook_artifact(
+        artifact, status, blocks = await create_or_update_notebook_artifact(
             artifacts_manager=self._context_manager.artifacts,
             content=notebook_content,
             title=title,
             artifact_id=artifact_id,
         )
 
-        message = f"The notebook artifact has been created with artifact_id: {artifact.short_id}"
-        if status == ArtifactStatus.FAILED_TO_UPDATE:
-            message = f"Failed to update the existing notebook artifact. A new artifact has been created with artifact_id: {artifact.short_id}"
-        elif status == ArtifactStatus.UPDATED:
-            message = f"The notebook artifact with artifact_id {artifact_id} has been updated"
+        # Check if this artifact already has a saved notebook
+        is_already_saved = await notebook_exists_for_artifact(self._team, artifact.short_id)
+
+        # Save to DB if explicitly requested or if updating an already-saved notebook
+        if save_to_notebook or is_already_saved:
+            await save_notebook_to_db(
+                team=self._team,
+                user=self._user,
+                artifact=artifact,
+                blocks=blocks,
+                title=title,
+            )
+
+        # Build response message
+        if save_to_notebook or is_already_saved:
+            if status == ArtifactStatus.UPDATED:
+                message = f"The notebook artifact and saved notebook have been updated (short_id: {artifact.short_id})."
+            else:
+                message = f"The notebook has been saved with short_id: {artifact.short_id}. It is accessible at /notebooks/{artifact.short_id}."
+        else:
+            message = (
+                f"The notebook artifact has been created with artifact_id: {artifact.short_id}. "
+                "This is a transient artifact visible only in this conversation. "
+                "The user can save it by clicking 'Create notebook' in the UI, or ask you to save it."
+            )
+            if status == ArtifactStatus.FAILED_TO_UPDATE:
+                message = (
+                    f"Failed to update the existing notebook artifact. "
+                    f"A new artifact has been created with artifact_id: {artifact.short_id}. "
+                    "This is a transient artifact visible only in this conversation."
+                )
+            elif status == ArtifactStatus.UPDATED:
+                message = f"The notebook artifact with artifact_id {artifact_id} has been updated."
 
         if is_draft:
             return message, None

--- a/ee/hogai/tools/finalize_plan/tool.py
+++ b/ee/hogai/tools/finalize_plan/tool.py
@@ -97,7 +97,7 @@ class FinalizePlanTool(MaxTool):
         plan: str,
         artifact_id: str | None = None,
     ) -> tuple[str, Any]:
-        artifact, status = await create_or_update_notebook_artifact(
+        artifact, status, _blocks = await create_or_update_notebook_artifact(
             artifacts_manager=self._context_manager.artifacts,
             content=plan,
             title="PostHog AI's plan: " + title,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4043,7 +4043,9 @@ const api = {
                 .get()
         },
         async create(
-            data?: Pick<NotebookType, 'content' | 'text_content' | 'title' | '_create_in_folder'>
+            data?: Pick<NotebookType, 'content' | 'text_content' | 'title' | '_create_in_folder'> & {
+                short_id?: string
+            }
         ): Promise<NotebookType> {
             return await new ApiRequest().notebooks().create({ data })
         },

--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -67,12 +67,14 @@ export const notebooksModel = kea<notebooksModelType>([
             location: NotebookTarget,
             title?: string,
             content?: JSONContent[],
-            onCreate?: (notebook: BuiltLogic<notebookLogicType>) => void
+            onCreate?: (notebook: BuiltLogic<notebookLogicType>) => void,
+            shortId?: string
         ) => ({
             title,
             location,
             content,
             onCreate,
+            shortId,
         }),
         receiveNotebookUpdate: (notebook: NotebookListItemType) => ({ notebook }),
         loadNotebooks: true,
@@ -91,11 +93,12 @@ export const notebooksModel = kea<notebooksModelType>([
         notebooks: [
             [] as NotebookListItemType[],
             {
-                createNotebook: async ({ title, location, content, onCreate }) => {
+                createNotebook: async ({ title, location, content, onCreate, shortId }) => {
                     const notebook = await api.notebooks.create({
                         title,
                         content: defaultNotebookContent(title, content),
                         _create_in_folder: getLastNewFolder(),
+                        ...(shortId ? { short_id: shortId } : {}),
                     })
 
                     await openNotebook(notebook.short_id, location, 'end', (logic) => {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22659,6 +22659,10 @@
                     "description": "Notebook",
                     "type": "string"
                 },
+                "is_saved": {
+                    "description": "Whether this notebook has been saved to the database (not stored, set during enrichment)",
+                    "type": "boolean"
+                },
                 "title": {
                     "description": "Title for the notebook",
                     "type": ["string", "null"]

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -342,6 +342,8 @@ export interface NotebookArtifactContent {
     blocks: DocumentBlock[]
     /** Title for the notebook */
     title?: string | null
+    /** Whether this notebook has been saved to the database (not stored, set during enrichment) */
+    is_saved?: boolean
 }
 
 export type ArtifactContent = VisualizationArtifactContent | NotebookArtifactContent

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -403,6 +403,7 @@ function Message({
                                         dashboards={message.ui_context.dashboards}
                                         events={message.ui_context.events}
                                         actions={message.ui_context.actions}
+                                        notebooks={message.ui_context.notebooks}
                                         useCurrentPageContext={false}
                                     />
                                 )}
@@ -617,7 +618,12 @@ function Message({
                             )
                         } else if (isNotebookArtifactContent(message.content)) {
                             return (
-                                <NotebookArtifactAnswer key={key} content={message.content} status={message.status} />
+                                <NotebookArtifactAnswer
+                                    key={key}
+                                    content={message.content}
+                                    status={message.status}
+                                    artifactId={message.artifact_id}
+                                />
                             )
                         }
                         return null

--- a/frontend/src/scenes/max/messages/NotebookArtifactAnswer.tsx
+++ b/frontend/src/scenes/max/messages/NotebookArtifactAnswer.tsx
@@ -44,14 +44,20 @@ import { MessageTemplate } from './MessageTemplate'
 interface NotebookArtifactAnswerProps {
     content: NotebookArtifactContent
     status?: MessageStatus
+    artifactId?: string
 }
 
 const MAX_COLLAPSED_HEIGHT_PX = 400
 
-export function NotebookArtifactAnswer({ content, status }: NotebookArtifactAnswerProps): JSX.Element | null {
+export function NotebookArtifactAnswer({
+    content,
+    status,
+    artifactId,
+}: NotebookArtifactAnswerProps): JSX.Element | null {
     const { createNotebook } = useActions(notebooksModel)
     const [isExpanded, setIsExpanded] = useState(false)
     const [needsExpansion, setNeedsExpansion] = useState(false)
+    const [localIsSaved, setLocalIsSaved] = useState(content.is_saved ?? false)
     const contentRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
@@ -59,6 +65,12 @@ export function NotebookArtifactAnswer({ content, status }: NotebookArtifactAnsw
             setNeedsExpansion(contentRef.current.scrollHeight > MAX_COLLAPSED_HEIGHT_PX)
         }
     }, [content.blocks, status])
+
+    useEffect(() => {
+        if (content.is_saved) {
+            setLocalIsSaved(true)
+        }
+    }, [content.is_saved])
 
     const isStreaming = status !== 'completed'
     const hasContent = content.blocks.length > 0
@@ -82,7 +94,14 @@ export function NotebookArtifactAnswer({ content, status }: NotebookArtifactAnsw
         // Convert blocks to tiptap JSONContent[] format
         const tiptapContent = blocksToTiptapContent(content.blocks)
 
-        createNotebook(NotebookTarget.Scene, content.title || 'AI Generated Notebook', tiptapContent)
+        createNotebook(
+            NotebookTarget.Scene,
+            content.title || 'AI Generated Notebook',
+            tiptapContent,
+            undefined,
+            artifactId
+        )
+        setLocalIsSaved(true)
     }
 
     const handleExpandClick = (): void => {
@@ -118,15 +137,26 @@ export function NotebookArtifactAnswer({ content, status }: NotebookArtifactAnsw
                 </div>
 
                 <div className="mt-4 flex justify-end">
-                    <LemonButton
-                        onClick={handleCreateNotebook}
-                        type="primary"
-                        size="small"
-                        icon={<IconOpenInNew />}
-                        disabledReason={isStreaming ? 'Wait for notebook to finish generating' : null}
-                    >
-                        Create notebook
-                    </LemonButton>
+                    {localIsSaved && artifactId ? (
+                        <LemonButton
+                            to={urls.notebook(artifactId)}
+                            type="primary"
+                            size="small"
+                            icon={<IconOpenInNew />}
+                        >
+                            Open and save notebook
+                        </LemonButton>
+                    ) : (
+                        <LemonButton
+                            onClick={handleCreateNotebook}
+                            type="primary"
+                            size="small"
+                            icon={<IconOpenInNew />}
+                            disabledReason={isStreaming ? 'Wait for notebook to finish generating' : null}
+                        >
+                            Create notebook
+                        </LemonButton>
+                    )}
                 </div>
             </div>
         </MessageTemplate>

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2931,7 +2931,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 63}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/api/test/notebooks/test_notebook.py
+++ b/posthog/api/test/notebooks/test_notebook.py
@@ -332,3 +332,38 @@ class TestNotebooks(APIBaseTest, QueryMatchingTest):
         fs_entry = FileSystem.objects.filter(team=self.team, ref=notebook_short_id, type="notebook").first()
         assert fs_entry is not None
         assert "Notebooks/Special Team Folder" in fs_entry.path
+
+    def test_create_notebook_with_custom_short_id(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks",
+            {"title": "From Artifact", "short_id": "abcd"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["short_id"] == "abcd"
+
+        notebook = Notebook.objects.get(team=self.team, short_id="abcd")
+        assert notebook.title == "From Artifact"
+
+    def test_create_notebook_without_short_id_auto_generates(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks",
+            {"title": "Auto ID"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.json()["short_id"]) > 0
+
+    @parameterized.expand(
+        [
+            ("too long", "a" * 13),
+            ("non alphanumeric", "ab-cd!"),
+        ]
+    )
+    def test_create_notebook_rejects_invalid_short_id(self, _name, bad_id):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks",
+            {"title": "Bad ID", "short_id": bad_id},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -18193,6 +18193,10 @@ class NotebookArtifactContent(BaseModel):
         ..., description="Structured blocks for the notebook content"
     )
     content_type: Literal["notebook"] = Field(default="notebook", description="Notebook")
+    is_saved: bool | None = Field(
+        default=None,
+        description=("Whether this notebook has been saved to the database (not stored, set during enrichment)"),
+    )
     title: str | None = Field(default=None, description="Title for the notebook")
 
 


### PR DESCRIPTION
## Problem

Notebook artifacts created by PostHog AI are transient — they only exist in the conversation and disappear once the session ends. Users have no way to persist them as real notebooks, and updates to already-saved notebooks aren't synced back to the database.

## Changes

**Backend:**
- `CreateNotebookTool` now supports a `save_to_notebook` parameter that persists the artifact as a real `Notebook` record using the artifact's `short_id`
- When updating an artifact that's already saved, the database notebook is automatically updated too
- New `save_notebook_to_db` and `notebook_exists_for_artifact` helpers in `create_notebook/helpers.py`
- `EnrichmentContext` now carries `artifact_id`, allowing `NotebookHandler` to set `is_saved` on enriched content
- Notebook API accepts an optional `short_id` on creation (with validation) so artifacts and notebooks share the same ID

**Frontend:**
- `NotebookArtifactAnswer` shows "Open and save notebook" linking to `/notebooks/{id}` when the notebook is already saved, otherwise shows "Create notebook"
- "Create notebook" button passes the artifact's `short_id` through to the notebooks API so the IDs stay linked
- `NotebookArtifactContent` schema gains `is_saved` boolean field
- `notebooksModel.createNotebook` accepts an optional `shortId` parameter

**Tests:**
- New tests for `CreateNotebookTool`: transient vs saved flow, short_id linkage, auto-update on re-edit
- New tests for notebook API: custom `short_id` creation, auto-generation, invalid ID rejection

There are frontend changes — screenshots should be added manually.

## How did you test this code?

- Backend tests in `ee/hogai/tools/create_notebook/test/test_tool.py` cover save, update, and transient flows
- API tests in `posthog/api/test/notebooks/test_notebook.py` cover custom `short_id` creation and validation
- Manual tests

## Publish to changelog?

No