### PR TITLE
fix(mcp): improve tool discovery hints in MCP instructions

### DIFF
--- a/products/posthog_ai/skills/query-examples/references/guidelines.md
+++ b/products/posthog_ai/skills/query-examples/references/guidelines.md
@@ -122,16 +122,38 @@ Follow this workflow:
 1. **Only then write the query** - Once you've confirmed the data exists, write and execute your analytical query
 
 <example>
-User: Find AI traces with human feedback
+User: how many times the tool search was used?
 Assistant:
 1. First, verify the events exist:
-   - Call `posthog:read-data-schema` with `schema_type: "events"`
-   - Check if `$ai_trace`, `$ai_generation`, `$ai_feedback` events are in the results
+   - Call `posthog:read-data-schema` with `kind: events`
+   - Look for events/actions matching the request
 2. If required events don't exist, inform the user immediately instead of running queries that will return empty results
-3. If events exist, verify the properties:
-   - Call `posthog:read-data-schema` with `schema_type: "event_properties"` and `event_name: "$ai_trace"`
-   - Check if `$ai_feedback`, `$ai_trace_id` properties exist
-4. Only then execute the analytical query
+3. If events exist, like "tool executed", verify the properties:
+   - Call `posthog:read-data-schema` with `kind: event_properties` and `event_name: tool executed`
+   - Look for properties indicating a tool
+4. Check other events/actions or return if required properties don't exist
+5. If events exist, like "tool_name", verify the property values:
+   - Call `posthog:read-data-schema` with `kind: event_property_values`, `event_name: tool executed`, and `property_name: tool_name`
+   - Follow the pattern from the sample or dig deeper into existing properties with SQL queries.
+6. Only then write and execute the analytical SQL query
+
+<reasoning>
+Assistant should verify the data schema to write a correct SQL query, as the data schema varies over time.
+</reasoning>
+</example>
+
+<example>
+User: how many users have chatted with the AI assistant from the US?
+Assistant: I'll help you find the number of users who have chatted with the AI assistant from the US. Let me create a todo list to track this implementation.
+1. Find the relevant events to "chatted with the AI assistant"
+2. Find the relevant properties of the events and persons to narrow down data to users from specific country
+3. Retrieve the sample property values for found properties
+4. Create the insight schema by using the data retrieved in the previous steps
+5. Generate the insight
+6. Analyze retrieved data
+<reasoning>
+The task list helps the assistant to stay on track.
+</reasoning>
 </example>
 
 This prevents wasted API calls and gives users immediate feedback when the data they're looking for doesn't exist.

--- a/services/mcp/src/templates/instructions-v2.md
+++ b/services/mcp/src/templates/instructions-v2.md
@@ -20,8 +20,11 @@ Created data is used by the user on the PostHog's website to perform business ac
 - Dashboards – visual and textual representations of the collected data aggregated by different types.
 - Cohorts – groups of persons or groups of persons that the user creates to segment the collected data.
 - Feature flags – feature flags that the user creates to control the feature rollout in their product.
+- Experiments – A/B tests that the user creates to measure the impact of changes.
 - Notebooks – notebooks that the user creates to perform business analysis.
 - Error tracking issues – issues that the user creates to track errors in their product.
+- Logs – log entries collected from the user's application with severity, service, and trace information.
+- Workflows – automated workflows with triggers, actions, and conditions.
 - Activity logs – a record of changes made to project entities (who changed what, when, and how).
 
 IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for any PostHog tasks.
@@ -33,6 +36,29 @@ If you cannot answer the user's PostHog related request or question using other 
 ### Tool search
 
 PostHog tools have lowercase kebab-case naming and always have a domain.
+Available domains (the list is incomplete):
+
+- execute-sql
+- read-data-schema
+- action
+- cohorts
+- dashboard
+- insight
+- feature-flag
+- experiment
+- survey
+- error-tracking
+- logs
+- workflows
+- organization
+- projects
+- docs
+- llm
+Typical action names:
+- create
+- update
+- delete
+Example regex for search: execute-sql or experiment.
 
 {guidelines}
 


### PR DESCRIPTION
## Problem

The MCP agent sometimes struggles to discover the right tools because the instructions lacked guidance on tool naming conventions and available domains. The query examples also used outdated parameter names (`schema_type` instead of `kind`).

## Changes

- Added a "Tool search" section to `instructions-v2.md` with available tool domains, naming conventions, and search examples
- Added missing entity types (Experiments, Logs, Workflows) to the created data list
- Updated the schema verification example in `guidelines.md` to use correct `read-data-schema` parameter names (`kind`, `event_name`, `property_name`)
- Made the example more generic and instructive (step-by-step tool discovery workflow)

## How did you test this code?

Verified the instructions render correctly and match the actual MCP tool naming/parameter conventions.

## Publish to changelog?

no