### PR TITLE
feat(llma): add clustering jobs observability

### DIFF
--- a/posthog/temporal/llm_analytics/coordinator_metrics.py
+++ b/posthog/temporal/llm_analytics/coordinator_metrics.py
@@ -35,5 +35,5 @@ def record_jobs_dispatched(count: int, pipeline: str, analysis_level: str) -> No
     meter = get_metric_meter({"pipeline": pipeline, "analysis_level": analysis_level})
     meter.create_counter(
         "llma_coordinator_jobs_dispatched",
-        "Clustering jobs dispatched to child workflows",
+        "Jobs dispatched to child workflows per coordinator run",
     ).add(count)

--- a/posthog/temporal/llm_analytics/coordinator_metrics.py
+++ b/posthog/temporal/llm_analytics/coordinator_metrics.py
@@ -29,3 +29,11 @@ def increment_team_failed(pipeline: str, analysis_level: str) -> None:
         "llma_coordinator_team_failed",
         "Teams that failed processing",
     ).add(1)
+
+
+def record_jobs_dispatched(count: int, pipeline: str, analysis_level: str) -> None:
+    meter = get_metric_meter({"pipeline": pipeline, "analysis_level": analysis_level})
+    meter.create_counter(
+        "llma_coordinator_jobs_dispatched",
+        "Clustering jobs dispatched to child workflows",
+    ).add(count)

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -37,6 +37,7 @@ with temporalio.workflow.unsafe.imports_passed_through():
     from posthog.temporal.llm_analytics.coordinator_metrics import (
         increment_team_failed,
         increment_team_succeeded,
+        record_jobs_dispatched,
         record_teams_discovered,
     )
     from posthog.temporal.llm_analytics.shared_activities import (
@@ -230,6 +231,9 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
                         parent_close_policy=temporalio.workflow.ParentClosePolicy.TERMINATE,
                     )
                     workflow_handles.append((team_id, handle))
+
+            if workflow_handles:
+                record_jobs_dispatched(len(workflow_handles), "clustering", inputs.analysis_level)
 
             # Wait for all workflows in batch to complete
             for team_id, handle in workflow_handles:

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -50,6 +50,7 @@ with temporalio.workflow.unsafe.imports_passed_through():
     from posthog.temporal.llm_analytics.coordinator_metrics import (
         increment_team_failed,
         increment_team_succeeded,
+        record_jobs_dispatched,
         record_teams_discovered,
     )
     from posthog.temporal.llm_analytics.shared_activities import (
@@ -247,6 +248,9 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                         parent_close_policy=temporalio.workflow.ParentClosePolicy.TERMINATE,
                     )
                     workflow_handles.append((team_id, handle))
+
+            if workflow_handles:
+                record_jobs_dispatched(len(workflow_handles), "summarization", inputs.analysis_level)
 
             # Wait for all workflows in batch to complete
             for team_id, handle in workflow_handles:

--- a/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusteringJobsPanel.tsx
@@ -67,7 +67,7 @@ function JobEditor({
                 <PropertyFilters
                     propertyFilters={eventFilters}
                     onChange={(properties) => setEventFilters(properties)}
-                    pageKey={`clustering-job-editor-${job.id ?? 'new'}`}
+                    pageKey={`llma-clustering-job-editor-${job.id ?? 'new'}`}
                     taxonomicGroupTypes={[
                         TaxonomicFilterGroupType.EventProperties,
                         TaxonomicFilterGroupType.EventMetadata,
@@ -83,11 +83,12 @@ function JobEditor({
                 <span className="text-sm">Enabled</span>
             </div>
             <div className="flex justify-end gap-2">
-                <LemonButton type="secondary" onClick={onCancel}>
+                <LemonButton type="secondary" data-attr="llma-clustering-job-cancel" onClick={onCancel}>
                     Cancel
                 </LemonButton>
                 <LemonButton
                     type="primary"
+                    data-attr="llma-clustering-job-save"
                     disabled={!name.trim()}
                     loading={saving}
                     onClick={() =>
@@ -149,7 +150,12 @@ export function ClusteringJobsPanel(): JSX.Element {
                                 {!job.enabled && <span className="text-xs text-muted">Disabled</span>}
                             </div>
                             <div className="flex items-center gap-1">
-                                <LemonButton size="small" type="secondary" onClick={() => setEditingJob(job)}>
+                                <LemonButton
+                                    size="small"
+                                    type="secondary"
+                                    data-attr="llma-clustering-job-edit"
+                                    onClick={() => setEditingJob(job)}
+                                >
                                     Edit
                                 </LemonButton>
                                 <LemonButton
@@ -157,6 +163,7 @@ export function ClusteringJobsPanel(): JSX.Element {
                                     type="secondary"
                                     status="danger"
                                     icon={<IconTrash />}
+                                    data-attr="llma-clustering-job-delete"
                                     onClick={() => {
                                         LemonDialog.open({
                                             title: 'Delete clustering job?',
@@ -190,6 +197,7 @@ export function ClusteringJobsPanel(): JSX.Element {
                     <LemonButton
                         type="secondary"
                         icon={<IconPlus />}
+                        data-attr="llma-clustering-job-add"
                         onClick={() => setEditingJob({})}
                         disabled={jobs.length >= MAX_JOBS}
                         tooltip={jobs.length >= MAX_JOBS ? `Maximum of ${MAX_JOBS} jobs` : undefined}

--- a/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
@@ -78,7 +78,7 @@ export const clusteringJobsLogic = kea<clusteringJobsLogicType>([
             }
         },
         createJobSuccess: ({ jobs }) => {
-            posthog.capture('llma clustering job created', { jobs_count: jobs.length })
+            posthog.capture('llma clustering job created', { total_jobs_count: jobs.length })
             actions.setEditingJob(null)
         },
         updateJobSuccess: () => {

--- a/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusteringJobsLogic.ts
@@ -1,5 +1,6 @@
 import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -63,19 +64,25 @@ export const clusteringJobsLogic = kea<clusteringJobsLogicType>([
     }),
 
     listeners(({ actions }) => ({
+        openJobsPanel: () => {
+            posthog.capture('llma clustering jobs panel opened')
+        },
         deleteJob: async ({ jobId }) => {
             try {
                 await api.delete(API_PATH + '/' + jobId + '/')
                 lemonToast.success('Clustering job deleted')
+                posthog.capture('llma clustering job deleted', { job_id: jobId })
                 actions.loadJobs()
             } catch {
                 lemonToast.error('Failed to delete clustering job')
             }
         },
-        createJobSuccess: () => {
+        createJobSuccess: ({ jobs }) => {
+            posthog.capture('llma clustering job created', { jobs_count: jobs.length })
             actions.setEditingJob(null)
         },
         updateJobSuccess: () => {
+            posthog.capture('llma clustering job updated')
             actions.setEditingJob(null)
         },
     })),


### PR DESCRIPTION
## Problem

After merging the clustering jobs feature (#49524, #49525, #49526), we have no visibility into how users interact with jobs in the UI or how many jobs are dispatched per coordinator run.

## Changes

**Frontend (clusteringJobsLogic.ts):**
- Add `posthog.capture` events: `llma clustering jobs panel opened`, `llma clustering job created`, `llma clustering job updated`, `llma clustering job deleted`

**Frontend (ClusteringJobsPanel.tsx):**
- Add `data-attr` tags with `llma-` prefix to all interactive buttons (edit, delete, add, save, cancel)

**Backend (coordinator_metrics.py):**
- Add new `llma_coordinator_jobs_dispatched` Prometheus counter with `pipeline` and `analysis_level` labels

**Backend (clustering + summarization coordinators):**
- Emit `llma_coordinator_jobs_dispatched` after dispatching child workflows in each batch

## How did you test this code?

This is an agent-authored PR. Changes are observability-only (event capture calls and Prometheus counter increments) with no functional impact. No manual testing was performed.

## Publish to changelog?

No