### PR TITLE
fix(ci): restore correct hobby deploy condition

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -80,6 +80,7 @@ jobs:
             preview-mode: ${{ steps.check-preview.outputs.preview }}
             comment-id: ${{ steps.post-comment.outputs.comment-id }}
             deployment-id: ${{ steps.create-deployment.outputs.deployment-id }}
+            conclusion: ${{ steps.wait-for-image.outputs.conclusion }}
         steps:
             - name: 'Check for preview mode'
               id: check-preview


### PR DESCRIPTION
PR #49456 changed the hobby-test `if:` condition to check `needs.wait-for-docker-image.outputs.conclusion` but never added `conclusion` to the job's output declarations — only the step (`steps.wait-for-image.outputs.conclusion`) had it. The undeclared output always evaluated empty, so hobby deploys were permanently skipped on PRs.

Simply reverting to `.result` wouldn't work either: when the Docker build is skipped the "Check Docker image build result" step still exits 0, so the job result is `success` even without an image.

This adds the missing `conclusion` output to the `wait-for-docker-image` job, propagating the step-level value so the existing condition works as intended.