### PR TITLE
fix(replay): make disabled tooltip interactive for learn more links

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { useActions, useValues } from 'kea'
-import { ReactNode, useEffect } from 'react'
+import { isValidElement, ReactNode, useEffect } from 'react'
 
 import { IconWarning } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
@@ -147,6 +147,7 @@ export default function ViewRecordingButton({
         return (
             <LemonButton
                 disabledReason={disabledReason}
+                disabledReasonInteractive={isValidElement(disabledReason)}
                 onClick={onClick}
                 icon={sideIcon}
                 tooltip="View recording"
@@ -158,7 +159,13 @@ export default function ViewRecordingButton({
     }
 
     return (
-        <LemonButton disabledReason={disabledReason} onClick={onClick} sideIcon={sideIcon} {...props}>
+        <LemonButton
+            disabledReason={disabledReason}
+            disabledReasonInteractive={isValidElement(disabledReason)}
+            onClick={onClick}
+            sideIcon={sideIcon}
+            {...props}
+        >
             <div className="flex items-center gap-2 whitespace-nowrap">
                 <span>{label ? label : 'View recording'}</span>
                 {maybeUnwatchedIndicator}

--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { isValidElement, ReactNode } from 'react'
 
 import { IconRewindPlay } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, Tooltip } from '@posthog/lemon-ui'
@@ -42,6 +42,7 @@ export default function ViewRecordingsPlaylistButton({
             sideIcon={<IconRewindPlay />}
             disabled={disabled}
             disabledReason={disabledReason}
+            disabledReasonInteractive={isValidElement(disabledReason)}
             {...buttonProps}
         >
             {label}


### PR DESCRIPTION
## Problem

When the View Recording button is disabled due to replay not being active, the tooltip contains a "Learn why" link. Previously this link was impossible to click because the tooltip closed when moving the mouse away from the button.

https://posthog.slack.com/archives/C0ACRAMJUAG/p1772639107893769?thread_ts=1772639077.317379&cid=C0ACRAMJUAG

## Changes

Fixes for both `ViewRecordingButton` and `ViewRecordingsPlaylistButton`.