### PR TITLE
feat: use report_user_or_team_action for "query executed" event

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -817,6 +817,7 @@ class DashboardsViewSet(
                     query,
                     execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                     user=request.user if request.user.is_authenticated else None,
+                    request=request,
                 )
 
                 result_data = None

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1364,6 +1364,7 @@ When set, the specified dashboard's filters and date range override will be appl
                 query,
                 execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 user=request.user if request.user.is_authenticated else None,
+                request=request,
             )
             if isinstance(result_ctx, BaseModel):
                 result = result_ctx.model_dump()
@@ -1407,6 +1408,7 @@ When set, the specified dashboard's filters and date range override will be appl
                 query,
                 execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 user=request.user if request.user.is_authenticated else None,
+                request=request,
             )
             if isinstance(result_ctx, BaseModel):
                 result = result_ctx.model_dump()

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -162,6 +162,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 user=request.user,  # type: ignore[arg-type]
                 is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
                 limit_context=limit_context,
+                request=request,
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,9 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import structlog
 import pydantic_core
 from pydantic import BaseModel
 from rest_framework.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 
 from posthog.schema import (
     DashboardFilter,
@@ -53,6 +56,7 @@ def process_query_dict(
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
+    request: Optional["Request"] = None,
 ) -> dict | BaseModel:
     upgraded_query_json = upgrade(query_json)
     try:
@@ -101,6 +105,7 @@ def process_query_dict(
         insight_id=insight_id,
         dashboard_id=dashboard_id,
         is_query_service=is_query_service,
+        request=request,
     )
 
 
@@ -118,6 +123,7 @@ def process_query_model(
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
     cache_age_seconds: Optional[int] = None,
+    request: Optional["Request"] = None,
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
@@ -167,6 +173,7 @@ def process_query_model(
                 dashboard_id=dashboard_id,
                 is_query_service=is_query_service,
                 cache_age_seconds=cache_age_seconds,
+                request=request,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss
@@ -202,6 +209,7 @@ def process_query_model(
             insight_id=insight_id,
             dashboard_id=dashboard_id,
             cache_age_seconds=cache_age_seconds,
+            request=request,
         )
 
     return result

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -335,6 +335,40 @@ def report_user_action(
     )
 
 
+def report_user_or_team_action(
+    event: str,
+    properties: Optional[dict] = None,
+    *,
+    user: Optional[User] = None,
+    team: Optional[Team] = None,
+    organization: Optional[Organization] = None,
+    request: Optional["Request"] = None,
+):
+    if properties is None:
+        properties = {}
+    if request is not None:
+        properties = {**get_request_analytics_properties(request), **properties}
+
+    distinct_id = None
+    if user and user.distinct_id:
+        distinct_id = user.distinct_id
+    elif team:
+        distinct_id = str(team.uuid)
+
+    if not distinct_id:
+        return
+
+    org = organization or (user.current_organization if user else None)
+    tm = team or (user.current_team if user else None)
+
+    posthoganalytics.capture(
+        distinct_id=distinct_id,
+        event=event,
+        properties=properties,
+        groups=groups(org, tm),
+    )
+
+
 def report_organization_deleted(user: User, organization: Organization):
     if not user.distinct_id:
         return

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -318,6 +318,7 @@ def report_user_action(
     properties: Optional[dict] = None,
     *,
     team: Optional[Team] = None,
+    organization: Optional[Organization] = None,
     request: Optional["Request"] = None,
 ):
     if user is None or not user.distinct_id:
@@ -330,7 +331,7 @@ def report_user_action(
         distinct_id=user.distinct_id,
         event=event,
         properties=properties,
-        groups=groups(user.current_organization, team or user.current_team),
+        groups=groups(organization or user.current_organization, team or user.current_team),
     )
 
 

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -1,7 +1,10 @@
 import re
 import itertools
 from collections.abc import Iterator, Sequence
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 
 from posthoganalytics import feature_enabled
 
@@ -69,9 +72,10 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
         cache_age_seconds: Optional[int] = None,
+        request: Optional["Request"] = None,
     ):
         self.user = user
-        return super().run(execution_mode, user, query_id, insight_id, dashboard_id, cache_age_seconds)
+        return super().run(execution_mode, user, query_id, insight_id, dashboard_id, cache_age_seconds, request)
 
     @property
     def group_type_index(self) -> int | None:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -3,11 +3,26 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from time import perf_counter
 from types import UnionType
-from typing import Any, Generic, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Optional,
+    Protocol,
+    TypeGuard,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 import structlog
 import posthoganalytics
 from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
@@ -87,7 +102,7 @@ from posthog.clickhouse.client.limit import (
     get_org_app_concurrency_limit,
 )
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
-from posthog.event_usage import groups
+from posthog.event_usage import groups, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
@@ -1168,6 +1183,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
         cache_age_seconds: Optional[int] = None,
+        request: Optional["Request"] = None,
     ) -> CR | CacheMissResponse | QueryStatusResponse:
         # Set user for access control during query execution
         if user is not None:
@@ -1263,21 +1279,27 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                             "last_refresh": last_refresh.isoformat() if last_refresh else None,
                         }
 
-                    posthoganalytics.capture(
-                        distinct_id=user.distinct_id if user else str(self.team.uuid),
-                        event="query executed",
-                        properties={
-                            "insight_id": insight_id,
-                            "dashboard_id": dashboard_id,
-                            "execution_mode": execution_mode.value,
-                            "query_type": getattr(self.query, "kind", "Other"),
-                            "cache_key": cache_key,
-                            "cache_hit": True if isinstance(results, CachedResponse) else False,
-                            "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
-                            **cache_tracking_props,
-                        },
-                        groups=(groups(self.team.organization, self.team)),
-                    )
+                    query_executed_props = {
+                        "insight_id": insight_id,
+                        "dashboard_id": dashboard_id,
+                        "execution_mode": execution_mode.value,
+                        "query_type": getattr(self.query, "kind", "Other"),
+                        "cache_key": cache_key,
+                        "cache_hit": True if isinstance(results, CachedResponse) else False,
+                        "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
+                        **cache_tracking_props,
+                    }
+                    if user:
+                        report_user_action(
+                            user, "query executed", query_executed_props, team=self.team, request=request
+                        )
+                    else:
+                        posthoganalytics.capture(
+                            distinct_id=str(self.team.uuid),
+                            event="query executed",
+                            properties=query_executed_props,
+                            groups=(groups(self.team.organization, self.team)),
+                        )
 
                     return results
 
@@ -1334,23 +1356,27 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     target_age=target_age,
                 )
 
-            posthoganalytics.capture(
-                distinct_id=user.distinct_id if user else str(self.team.uuid),
-                event="query executed",
-                properties={
-                    "insight_id": insight_id,
-                    "dashboard_id": dashboard_id,
-                    "cache_hit": False,
-                    "cache_key": cache_key,
-                    "calculation_trigger": trigger,
-                    "execution_mode": execution_mode.value,
-                    "query_type": getattr(self.query, "kind", "Other"),
-                    "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
-                    "query_duration_ms": query_duration_ms,
-                    "has_error": has_error,
-                },
-                groups=(groups(self.team.organization, self.team)),
-            )
+            query_executed_props = {
+                "insight_id": insight_id,
+                "dashboard_id": dashboard_id,
+                "cache_hit": False,
+                "cache_key": cache_key,
+                "calculation_trigger": trigger,
+                "execution_mode": execution_mode.value,
+                "query_type": getattr(self.query, "kind", "Other"),
+                "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
+                "query_duration_ms": query_duration_ms,
+                "has_error": has_error,
+            }
+            if user:
+                report_user_action(user, "query executed", query_executed_props, team=self.team, request=request)
+            else:
+                posthoganalytics.capture(
+                    distinct_id=str(self.team.uuid),
+                    event="query executed",
+                    properties=query_executed_props,
+                    groups=(groups(self.team.organization, self.team)),
+                )
 
             return CachedResponse(**fresh_response_dict)
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -102,7 +102,7 @@ from posthog.clickhouse.client.limit import (
     get_org_app_concurrency_limit,
 )
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
-from posthog.event_usage import groups, report_user_action
+from posthog.event_usage import groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
@@ -1289,22 +1289,14 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                         "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
                         **cache_tracking_props,
                     }
-                    if user:
-                        report_user_action(
-                            user,
-                            "query executed",
-                            query_executed_props,
-                            team=self.team,
-                            organization=self.team.organization,
-                            request=request,
-                        )
-                    else:
-                        posthoganalytics.capture(
-                            distinct_id=str(self.team.uuid),
-                            event="query executed",
-                            properties=query_executed_props,
-                            groups=(groups(self.team.organization, self.team)),
-                        )
+                    report_user_or_team_action(
+                        "query executed",
+                        query_executed_props,
+                        user=user,
+                        team=self.team,
+                        organization=self.team.organization,
+                        request=request,
+                    )
 
                     return results
 
@@ -1373,22 +1365,14 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 "query_duration_ms": query_duration_ms,
                 "has_error": has_error,
             }
-            if user:
-                report_user_action(
-                    user,
-                    "query executed",
-                    query_executed_props,
-                    team=self.team,
-                    organization=self.team.organization,
-                    request=request,
-                )
-            else:
-                posthoganalytics.capture(
-                    distinct_id=str(self.team.uuid),
-                    event="query executed",
-                    properties=query_executed_props,
-                    groups=(groups(self.team.organization, self.team)),
-                )
+            report_user_or_team_action(
+                "query executed",
+                query_executed_props,
+                user=user,
+                team=self.team,
+                organization=self.team.organization,
+                request=request,
+            )
 
             return CachedResponse(**fresh_response_dict)
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1291,7 +1291,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     }
                     if user:
                         report_user_action(
-                            user, "query executed", query_executed_props, team=self.team, request=request
+                            user,
+                            "query executed",
+                            query_executed_props,
+                            team=self.team,
+                            organization=self.team.organization,
+                            request=request,
                         )
                     else:
                         posthoganalytics.capture(
@@ -1369,7 +1374,14 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 "has_error": has_error,
             }
             if user:
-                report_user_action(user, "query executed", query_executed_props, team=self.team, request=request)
+                report_user_action(
+                    user,
+                    "query executed",
+                    query_executed_props,
+                    team=self.team,
+                    organization=self.team.organization,
+                    request=request,
+                )
             else:
                 posthoganalytics.capture(
                     distinct_id=str(self.team.uuid),

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1223,6 +1223,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             user=cast(User, request.user),
             is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
             cache_age_seconds=cache_age_seconds,
+            request=request,
         )
 
         if isinstance(result, BaseModel):


### PR DESCRIPTION
## Problem

The "query executed" event in `QueryRunner.run()` is captured via raw `posthoganalytics.capture`, which means it lacks request-derived properties like `source`, `$current_url`, `$session_id`, `was_impersonated`, and `mcp_user_agent`. These properties are useful for understanding how queries are triggered (web, API, MCP, etc.).

## Changes

- Replace `posthoganalytics.capture` with `report_user_action` for the "query executed" event when a `user` is present, so request-derived properties are automatically included
- Fall back to `posthoganalytics.capture` when no user is available (celery tasks, cache warming, etc.)
- Plumb the `request` object from API views through `process_query_model` / `process_query_dict` to `QueryRunner.run()`
- Pass `request` from all API callers that have it: `QueryViewSet`, endpoints API, insight views, dashboard views

## How did you test this code?

I'm an agent — I ran the automated test suites and haven't tested this manually.

- `pytest posthog/hogql_queries/test/test_query_runner.py` — 35 passed
- `pytest posthog/api/test/test_query.py` — 45 passed

Callers that don't have a request (celery tasks, AI tools, tests) simply don't pass it, so behavior is unchanged for them.

## Publish to changelog?

No