### PR TITLE
feat(insights): Allow searching dashboards when moving insights

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -12,9 +12,10 @@ import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { LemonTableLoader } from 'lib/lemon-ui/LemonTable/LemonTableLoader'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -50,6 +51,7 @@ import {
 
 import { InsightCardProps } from './InsightCard'
 import { InsightDetails } from './InsightDetails'
+import { InsightMoveToDashboardMenu } from './InsightMoveToDashboardMenu'
 
 interface InsightMetaProps extends Pick<
     InsightCardProps,
@@ -134,6 +136,8 @@ export function InsightMeta({
         resolvedDateRange: insightData?.resolved_date_range,
     }
 
+    const summary = useSummarizeInsight()(insight.query)
+
     const otherDashboards = nameSortedDashboards.filter((d) => !dashboards?.includes(d.id))
 
     const canViewInsight = insight.user_access_level
@@ -157,8 +161,6 @@ export function InsightMeta({
               AccessControlLevel.Editor
           )
         : true
-
-    const summary = useSummarizeInsight()(insight.query)
 
     // Feedback buttons for Customer Analytics
     const feedbackButtons =
@@ -345,58 +347,38 @@ export function InsightMeta({
                                 </LemonButton>
                             )}
                             {updateColor && (
-                                <LemonButtonWithDropdown
-                                    dropdown={{
-                                        overlay: Object.values(InsightColor).map((availableColor) => (
-                                            <LemonButton
-                                                key={availableColor}
-                                                active={availableColor === (ribbonColor || InsightColor.White)}
-                                                onClick={() => updateColor(availableColor)}
-                                                icon={
-                                                    availableColor !== InsightColor.White ? (
-                                                        <Splotch color={availableColor as string as SplotchColor} />
-                                                    ) : null
-                                                }
-                                                fullWidth
-                                            >
-                                                {availableColor !== InsightColor.White
-                                                    ? capitalizeFirstLetter(availableColor)
-                                                    : 'No color'}
-                                            </LemonButton>
-                                        )),
-                                        placement: 'right-start',
-                                        fallbackPlacements: ['left-start'],
-                                        actionable: true,
-                                        closeParentPopoverOnClickInside: true,
-                                    }}
-                                    fullWidth
+                                <LemonMenu
+                                    items={Object.values(InsightColor).map((availableColor) => ({
+                                        label: (
+                                            <span className="flex items-center gap-2">
+                                                {availableColor !== InsightColor.White ? (
+                                                    <Splotch color={availableColor as string as SplotchColor} />
+                                                ) : null}
+                                                <span>
+                                                    {availableColor !== InsightColor.White
+                                                        ? capitalizeFirstLetter(availableColor)
+                                                        : 'No color'}
+                                                </span>
+                                            </span>
+                                        ),
+                                        key: availableColor,
+                                        active: availableColor === (ribbonColor || InsightColor.White),
+                                        onClick: () => {
+                                            updateColor?.(availableColor)
+                                        },
+                                    }))}
+                                    placement="right-start"
+                                    fallbackPlacements={['left-start']}
+                                    closeParentPopoverOnClickInside
                                 >
-                                    Set color
-                                </LemonButtonWithDropdown>
+                                    <LemonButton fullWidth>Set color</LemonButton>
+                                </LemonMenu>
                             )}
                             {moveToDashboard && otherDashboards.length > 0 && (
-                                <LemonButtonWithDropdown
-                                    dropdown={{
-                                        overlay: otherDashboards.map((otherDashboard) => (
-                                            <LemonButton
-                                                key={otherDashboard.id}
-                                                onClick={() => {
-                                                    moveToDashboard(otherDashboard)
-                                                }}
-                                                fullWidth
-                                            >
-                                                {otherDashboard.name || <i>Untitled</i>}
-                                            </LemonButton>
-                                        )),
-                                        placement: 'right-start',
-                                        fallbackPlacements: ['left-start'],
-                                        actionable: true,
-                                        closeParentPopoverOnClickInside: true,
-                                    }}
-                                    fullWidth
-                                >
-                                    Move to
-                                </LemonButtonWithDropdown>
+                                <InsightMoveToDashboardMenu
+                                    otherDashboards={otherDashboards}
+                                    onMoveToDashboard={moveToDashboard}
+                                />
                             )}
                             {removeFromDashboard && (
                                 <LemonButton status="danger" onClick={removeFromDashboard} fullWidth>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -15,11 +15,13 @@ export function InsightMoveToDashboardMenu({
     otherDashboards,
     onMoveToDashboard,
 }: InsightMoveToDashboardMenuProps): JSX.Element | null {
-    const [searchTerm, setSearchTerm] = useState('')
+    const [searchTerm, setSearchTermState] = useState('')
+    const searchTermRef = useRef(searchTerm)
 
-    if (!otherDashboards.length) {
-        return null
-    }
+    const handleSearchChange = useCallback((value: string) => {
+        searchTermRef.current = value
+        setSearchTermState(value)
+    }, [])
 
     const filteredDashboards =
         searchTerm.trim() === ''
@@ -28,15 +30,14 @@ export function InsightMoveToDashboardMenu({
                   (dashboard.name || 'Untitled').toLowerCase().includes(searchTerm.toLowerCase())
               )
 
-    const searchItem: LemonMenuItem = {
-        custom: true,
-        label: () => (
+    const SearchInputLabel = useCallback(() => {
+        return (
             <div className="px-2 pt-2 pb-1">
                 <LemonInput
                     type="search"
                     placeholder="Search dashboards"
-                    value={searchTerm}
-                    onChange={setSearchTerm}
+                    value={searchTermRef.current}
+                    onChange={handleSearchChange}
                     size="small"
                     fullWidth
                     allowClear
@@ -44,7 +45,12 @@ export function InsightMoveToDashboardMenu({
                     autoFocus
                 />
             </div>
-        ),
+        )
+    }, [handleSearchChange])
+
+    const searchItem: LemonMenuItem = {
+        custom: true,
+        label: SearchInputLabel,
     }
 
     const items: LemonMenuItems =
@@ -57,7 +63,7 @@ export function InsightMoveToDashboardMenu({
                           key: dashboard.id,
                           onClick: () => {
                               onMoveToDashboard(dashboard)
-                              setSearchTerm('')
+                              setSearchTermState('')
                           },
                       })),
                   },
@@ -68,13 +74,15 @@ export function InsightMoveToDashboardMenu({
                           searchItem,
                           {
                               label: 'No dashboards match this search',
-                              disabledReason: 'No dashboards match this search',
-                              onClick: () => {},
                               key: 'no-results',
                           },
                       ],
                   },
               ]
+
+    if (!otherDashboards.length) {
+        return null
+    }
 
     return (
         <LemonMenu

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonMenu, LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
+
+import type { DashboardBasicType } from '~/types'
+
+interface InsightMoveToDashboardMenuProps {
+    otherDashboards: DashboardBasicType[]
+    onMoveToDashboard: (dashboard: DashboardBasicType) => void
+}
+
+export function InsightMoveToDashboardMenu({
+    otherDashboards,
+    onMoveToDashboard,
+}: InsightMoveToDashboardMenuProps): JSX.Element | null {
+    const [searchTerm, setSearchTerm] = useState('')
+
+    if (!otherDashboards.length) {
+        return null
+    }
+
+    const filteredDashboards =
+        searchTerm.trim() === ''
+            ? otherDashboards
+            : otherDashboards.filter((dashboard) =>
+                  (dashboard.name || 'Untitled').toLowerCase().includes(searchTerm.toLowerCase())
+              )
+
+    const searchItem: LemonMenuItem = {
+        custom: true,
+        label: () => (
+            <div className="px-2 pt-2 pb-1">
+                <LemonInput
+                    type="search"
+                    placeholder="Search dashboards"
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    size="small"
+                    fullWidth
+                    allowClear
+                    onClick={(e) => e.stopPropagation()}
+                    autoFocus
+                />
+            </div>
+        ),
+    }
+
+    const items: LemonMenuItems =
+        filteredDashboards.length > 0
+            ? [
+                  { items: [searchItem] },
+                  {
+                      items: filteredDashboards.map((dashboard) => ({
+                          label: dashboard.name || <i>Untitled</i>,
+                          key: dashboard.id,
+                          onClick: () => {
+                              onMoveToDashboard(dashboard)
+                              setSearchTerm('')
+                          },
+                      })),
+                  },
+              ]
+            : [
+                  {
+                      items: [
+                          searchItem,
+                          {
+                              label: 'No dashboards match this search',
+                              disabledReason: 'No dashboards match this search',
+                              onClick: () => {},
+                              key: 'no-results',
+                          },
+                      ],
+                  },
+              ]
+
+    return (
+        <LemonMenu
+            items={items}
+            placement="right-start"
+            fallbackPlacements={['left-start']}
+            closeParentPopoverOnClickInside
+        >
+            <LemonButton fullWidth>Move to</LemonButton>
+        </LemonMenu>
+    )
+}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -16,10 +16,8 @@ export function InsightMoveToDashboardMenu({
     onMoveToDashboard,
 }: InsightMoveToDashboardMenuProps): JSX.Element | null {
     const [searchTerm, setSearchTermState] = useState('')
-    const searchTermRef = useRef(searchTerm)
 
     const handleSearchChange = useCallback((value: string) => {
-        searchTermRef.current = value
         setSearchTermState(value)
     }, [])
 
@@ -36,7 +34,7 @@ export function InsightMoveToDashboardMenu({
                 <LemonInput
                     type="search"
                     placeholder="Search dashboards"
-                    value={searchTermRef.current}
+                    value={searchTerm}
                     onChange={handleSearchChange}
                     size="small"
                     fullWidth

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMoveToDashboardMenu.tsx
@@ -44,7 +44,7 @@ export function InsightMoveToDashboardMenu({
                 />
             </div>
         )
-    }, [handleSearchChange])
+    }, [handleSearchChange, searchTerm])
 
     const searchItem: LemonMenuItem = {
         custom: true,


### PR DESCRIPTION
## Problem

As a user managing many dashboards, I want to more easily move insights between dashboards via searching if i have a lot of dashboards.


## Changes

- Moves the old code into a separate file component
- adds search for the dashboards
- Replaced the deprecated `LemonButtonWithDropdown`-based “Set color” dropdown in `InsightMeta` with a `LemonMenu` of color options (including `Splotch` icon, active state, and “No color” option).

Before
<img width="380" height="212" alt="image" src="https://github.com/user-attachments/assets/17b37b71-5d02-4088-b231-c1796cf9f64c" />


After
<img width="522" height="520" alt="image" src="https://github.com/user-attachments/assets/7ed3b5a2-cdb1-422a-9f84-ed73cb885df9" />

## How did you test this code?

Locally
