### PR TITLE
fix(insights): handle non-string days in X-axis tick formatter

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -219,7 +219,7 @@ describe('createXAxisTickCallback', () => {
         it('returns raw value when days are numbers (stickiness insights)', () => {
             const callback = createXAxisTickCallback({
                 interval: 'day',
-                allDays: [1, 2, 3, 4, 5] as unknown as string[],
+                allDays: [1, 2, 3, 4, 5],
                 timezone: 'UTC',
             })
             expect(callback(1, 0)).toBe('1')

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -216,6 +216,16 @@ describe('createXAxisTickCallback', () => {
             expect(callback('some-label', 5)).toBe('some-label')
         })
 
+        it('returns raw value when days are numbers (stickiness insights)', () => {
+            const callback = createXAxisTickCallback({
+                interval: 'day',
+                allDays: [1, 2, 3, 4, 5] as unknown as string[],
+                timezone: 'UTC',
+            })
+            expect(callback(1, 0)).toBe('1')
+            expect(callback(3, 2)).toBe('3')
+        })
+
         it('returns raw value for unparseable dates', () => {
             const callback = createXAxisTickCallback({
                 interval: 'day',

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -21,7 +21,7 @@ export function createXAxisTickCallback({
     allDays,
     timezone,
 }: CreateXAxisTickCallbackArgs): (value: string | number, index: number) => string | null {
-    if (allDays.length === 0) {
+    if (allDays.length === 0 || typeof allDays[0] !== 'string') {
         return (value) => String(value)
     }
 
@@ -29,12 +29,13 @@ export function createXAxisTickCallback({
     // Date-only strings are calendar bucket labels — parse as midnight in the project timezone
     // so that e.g. "2023-07-01" stays July and doesn't drift to June in behind-UTC timezones.
     const parsedDates = allDays.map((d) => {
-        const hasTime = d.includes(' ') || d.includes('T')
+        const s = String(d)
+        const hasTime = s.includes(' ') || s.includes('T')
         if (hasTime) {
-            return dayjsUtcToTimezone(d, timezone, false)
+            return dayjsUtcToTimezone(s, timezone, false)
         }
         try {
-            return dayjs.tz(d + ' 00:00:00', timezone)
+            return dayjs.tz(s + ' 00:00:00', timezone)
         } catch {
             return dayjs(null)
         }

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -5,7 +5,7 @@ import { IntervalType } from '~/types'
 
 interface CreateXAxisTickCallbackArgs {
     interval?: IntervalType
-    allDays: string[]
+    allDays: (string | number)[]
     timezone: string
 }
 


### PR DESCRIPTION
## Problem

Users with the `DASHBOARD_TILE_REDESIGN` feature flag enabled see a crash (`TypeError: d.includes is not a function`) when viewing dashboards containing stickiness insights. This affects 168 users across 650 occurrences.

The issue was introduced in [#48690](https://github.com/PostHog/posthog/pull/48690), which added `createXAxisTickCallback` — a new X-axis tick formatter that assumes `days` is always a `string[]` of date strings. Stickiness insights return numeric interval counts (`[1, 2, 3, ...]`) in the `days` field instead, causing `.includes()` to fail on numbers.

## Changes

- Added a type guard in `createXAxisTickCallback` to fall back to the identity formatter (`String(value)`) when `days` contains non-string values
- Added `String(d)` coercion as defense-in-depth for any other non-string edge cases
- Added a test case covering the stickiness numeric `days` scenario

## How did you test this code?

NOTE: I didn't test this manually, but I did add a test that should cover the issue.

Here's how I think it could be tested manually
1. Enable the `DASHBOARD_TILE_REDESIGN` feature flag
2. Create or view a dashboard containing a stickiness insight
3. Verify the chart renders without crashing and the X-axis shows interval counts (1, 2, 3, etc.)
4. Verify that regular trends/lifecycle insights still display properly formatted date labels

## Publish to changelog?

No