### PR TITLE
fix: Improve feature flag diff sentences

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
@@ -596,61 +596,34 @@ describe('the activity log logic', () => {
             expect(text).not.toContain('control: 50%')
         })
 
-        it('does not mention payload change on multivariate flag when payload is unchanged', async () => {
+        it.each([
+            {
+                name: 'multivariate flag',
+                payloads: { control: 'old-payload' },
+                multivariate: {
+                    variants: [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'test', rollout_percentage: 50 },
+                    ],
+                },
+            },
+            {
+                name: 'boolean flag',
+                payloads: { true: 'my-payload' },
+                multivariate: null,
+            },
+        ])('does not mention payload change when payload is unchanged on $name', async ({ payloads, multivariate }) => {
             const logic = await featureFlagsTestSetup('test flag', 'updated', [
                 {
                     type: ActivityScope.FEATURE_FLAG,
                     action: 'changed',
                     field: 'filters',
-                    before: {
-                        groups: [{ properties: [], rollout_percentage: 50 }],
-                        payloads: { control: 'old-payload' },
-                        multivariate: {
-                            variants: [
-                                { key: 'control', rollout_percentage: 50 },
-                                { key: 'test', rollout_percentage: 50 },
-                            ],
-                        },
-                    },
-                    after: {
-                        groups: [{ properties: [], rollout_percentage: 80 }],
-                        payloads: { control: 'old-payload' },
-                        multivariate: {
-                            variants: [
-                                { key: 'control', rollout_percentage: 50 },
-                                { key: 'test', rollout_percentage: 50 },
-                            ],
-                        },
-                    },
+                    before: { groups: [{ properties: [], rollout_percentage: 50 }], payloads, multivariate },
+                    after: { groups: [{ properties: [], rollout_percentage: 80 }], payloads, multivariate },
                 },
             ])
 
-            const actual = logic.values.humanizedActivity
-            const text = render(<>{actual[0].description}</>).container.textContent
-            expect(text).not.toContain('changed payload')
-        })
-
-        it('does not mention payload change on boolean flag when payload is unchanged', async () => {
-            const logic = await featureFlagsTestSetup('test flag', 'updated', [
-                {
-                    type: ActivityScope.FEATURE_FLAG,
-                    action: 'changed',
-                    field: 'filters',
-                    before: {
-                        groups: [{ properties: [], rollout_percentage: 50 }],
-                        payloads: { true: 'my-payload' },
-                        multivariate: null,
-                    },
-                    after: {
-                        groups: [{ properties: [], rollout_percentage: 80 }],
-                        payloads: { true: 'my-payload' },
-                        multivariate: null,
-                    },
-                },
-            ])
-
-            const actual = logic.values.humanizedActivity
-            const text = render(<>{actual[0].description}</>).container.textContent
+            const text = render(<>{logic.values.humanizedActivity[0].description}</>).container.textContent
             expect(text).not.toContain('changed payload')
         })
 

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.feature-flag.test.tsx
@@ -513,6 +513,147 @@ describe('the activity log logic', () => {
             )
         })
 
+        it('does not mention variant rollout when only release conditions changed', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'filters',
+                    before: {
+                        groups: [{ variant: null, properties: [], rollout_percentage: 0 }],
+                        payloads: {},
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 100 },
+                                { key: 'variant', rollout_percentage: 0 },
+                            ],
+                        },
+                    },
+                    after: {
+                        groups: [
+                            {
+                                variant: 'variant',
+                                properties: [
+                                    {
+                                        key: 'created_at_timestamp',
+                                        type: 'person',
+                                        value: '1771344031000',
+                                        operator: 'gt',
+                                    },
+                                ],
+                                rollout_percentage: 20,
+                            },
+                        ],
+                        payloads: {},
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 100 },
+                                { key: 'variant', rollout_percentage: 0 },
+                            ],
+                        },
+                    },
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            const text = render(<>{actual[0].description}</>).container.textContent
+            expect(text).not.toContain('changed the rollout percentage for the variants')
+        })
+
+        it('only lists variants whose rollout percentage actually changed', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'filters',
+                    before: {
+                        groups: [{ properties: [], rollout_percentage: 75 }],
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 50 },
+                                { key: 'test-1', rollout_percentage: 25 },
+                                { key: 'test-2', rollout_percentage: 25 },
+                            ],
+                        },
+                    },
+                    after: {
+                        groups: [{ properties: [], rollout_percentage: 75 }],
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 50 },
+                                { key: 'test-1', rollout_percentage: 40 },
+                                { key: 'test-2', rollout_percentage: 10 },
+                            ],
+                        },
+                    },
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            const text = render(<>{actual[0].description}</>).container.textContent
+            expect(text).toContain('test-1: 40%')
+            expect(text).toContain('test-2: 10%')
+            expect(text).not.toContain('control: 50%')
+        })
+
+        it('does not mention payload change on multivariate flag when payload is unchanged', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'filters',
+                    before: {
+                        groups: [{ properties: [], rollout_percentage: 50 }],
+                        payloads: { control: 'old-payload' },
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 50 },
+                                { key: 'test', rollout_percentage: 50 },
+                            ],
+                        },
+                    },
+                    after: {
+                        groups: [{ properties: [], rollout_percentage: 80 }],
+                        payloads: { control: 'old-payload' },
+                        multivariate: {
+                            variants: [
+                                { key: 'control', rollout_percentage: 50 },
+                                { key: 'test', rollout_percentage: 50 },
+                            ],
+                        },
+                    },
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            const text = render(<>{actual[0].description}</>).container.textContent
+            expect(text).not.toContain('changed payload')
+        })
+
+        it('does not mention payload change on boolean flag when payload is unchanged', async () => {
+            const logic = await featureFlagsTestSetup('test flag', 'updated', [
+                {
+                    type: ActivityScope.FEATURE_FLAG,
+                    action: 'changed',
+                    field: 'filters',
+                    before: {
+                        groups: [{ properties: [], rollout_percentage: 50 }],
+                        payloads: { true: 'my-payload' },
+                        multivariate: null,
+                    },
+                    after: {
+                        groups: [{ properties: [], rollout_percentage: 80 }],
+                        payloads: { true: 'my-payload' },
+                        multivariate: null,
+                    },
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            const text = render(<>{actual[0].description}</>).container.textContent
+            expect(text).not.toContain('changed payload')
+        })
+
         it('can handle changing variants from a multivariate flag', async () => {
             const logic = await featureFlagsTestSetup('test flag', 'updated', [
                 {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -82,10 +82,16 @@ const featureFlagActionsMapping: Record<
                 changes.push(<>changed the filter conditions to apply to no users</>)
             } else {
                 filtersAfter.payloads &&
-                    Object.keys(filtersAfter.payloads).forEach((key: string) => {
-                        const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
-                        changes.push(<SentenceList listParts={[changedPayload]} prefix="changed payload to" />)
-                    })
+                    Object.keys(filtersAfter.payloads)
+                        .filter((key) => {
+                            const before = filtersBefore?.payloads?.[key]?.toString() || null
+                            const after = filtersAfter.payloads?.[key]?.toString() || null
+                            return before !== after
+                        })
+                        .forEach((key: string) => {
+                            const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
+                            changes.push(<SentenceList listParts={[changedPayload]} prefix="changed payload to" />)
+                        })
 
                 const groupAdditions: (string | JSX.Element | null)[] = []
                 const groupRemovals: (string | JSX.Element | null)[] = []
@@ -177,40 +183,54 @@ const featureFlagActionsMapping: Record<
             )
         } else if (isMultivariateFlag) {
             filtersAfter.payloads &&
-                Object.keys(filtersAfter.payloads).forEach((key: string) => {
-                    const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
-                    changes.push(
-                        <SentenceList
-                            listParts={[
-                                <span key={key} className="highlighted-activity">
-                                    {changedPayload}
-                                </span>,
-                            ]}
-                            prefix={
-                                <span>
-                                    changed payload on <b>variant: {key}</b> to
-                                </span>
-                            }
-                        />
-                    )
-                })
+                Object.keys(filtersAfter.payloads)
+                    .filter((key) => {
+                        const before = filtersBefore?.payloads?.[key]?.toString() || null
+                        const after = filtersAfter.payloads?.[key]?.toString() || null
+                        return before !== after
+                    })
+                    .forEach((key: string) => {
+                        const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
+                        changes.push(
+                            <SentenceList
+                                listParts={[
+                                    <span key={key} className="highlighted-activity">
+                                        {changedPayload}
+                                    </span>,
+                                ]}
+                                prefix={
+                                    <span>
+                                        changed payload on <b>variant: {key}</b> to
+                                    </span>
+                                }
+                            />
+                        )
+                    })
 
             // Identify removed variants
             const beforeVariants = new Set((filtersBefore?.multivariate?.variants || []).map((v) => v.key))
             const afterVariants = new Set((filtersAfter?.multivariate?.variants || []).map((v) => v.key))
             const removedVariants = [...beforeVariants].filter((key) => !afterVariants.has(key))
 
-            // First add the rollout percentage changes
-            changes.push(
-                <SentenceList
-                    listParts={(filtersAfter.multivariate?.variants || []).map((v) => (
-                        <div key={v.key} className="highlighted-activity">
-                            {v.key}: <strong>{v.rollout_percentage}%</strong>
-                        </div>
-                    ))}
-                    prefix="changed the rollout percentage for the variants to"
-                />
+            // Only show rollout percentage changes if they actually changed
+            const beforeVariantMap = new Map(
+                (filtersBefore?.multivariate?.variants || []).map((v) => [v.key, v.rollout_percentage])
             )
+            const changedVariants = (filtersAfter.multivariate?.variants || []).filter(
+                (v) => beforeVariantMap.get(v.key) !== v.rollout_percentage
+            )
+            if (changedVariants.length > 0) {
+                changes.push(
+                    <SentenceList
+                        listParts={changedVariants.map((v) => (
+                            <div key={v.key} className="highlighted-activity">
+                                {v.key}: <strong>{v.rollout_percentage}%</strong>
+                            </div>
+                        ))}
+                        prefix="changed the rollout percentage for the variants to"
+                    />
+                )
+            }
 
             // Then add removed variants if any
             if (removedVariants.length > 0) {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -25,6 +25,16 @@ import {
     FeatureFlagType,
 } from '~/types'
 
+const getChangedPayloadKeys = (
+    filtersBefore: FeatureFlagFilters | undefined,
+    filtersAfter: FeatureFlagFilters
+): string[] =>
+    Object.keys(filtersAfter.payloads ?? {}).filter((key) => {
+        const before = filtersBefore?.payloads?.[key]?.toString() || null
+        const after = filtersAfter.payloads?.[key]?.toString() || null
+        return before !== after
+    })
+
 const nameOrLinkToFlag = (id: string | undefined, name: string | null | undefined): string | JSX.Element => {
     const displayName = name || '(empty string)'
     return id ? <Link to={urls.featureFlag(id)}>{displayName}</Link> : displayName
@@ -81,17 +91,10 @@ const featureFlagActionsMapping: Record<
                 // there are no rollout groups or all are at 0%
                 changes.push(<>changed the filter conditions to apply to no users</>)
             } else {
-                filtersAfter.payloads &&
-                    Object.keys(filtersAfter.payloads)
-                        .filter((key) => {
-                            const before = filtersBefore?.payloads?.[key]?.toString() || null
-                            const after = filtersAfter.payloads?.[key]?.toString() || null
-                            return before !== after
-                        })
-                        .forEach((key: string) => {
-                            const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
-                            changes.push(<SentenceList listParts={[changedPayload]} prefix="changed payload to" />)
-                        })
+                getChangedPayloadKeys(filtersBefore, filtersAfter).forEach((key) => {
+                    const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
+                    changes.push(<SentenceList listParts={[changedPayload]} prefix="changed payload to" />)
+                })
 
                 const groupAdditions: (string | JSX.Element | null)[] = []
                 const groupRemovals: (string | JSX.Element | null)[] = []
@@ -182,30 +185,23 @@ const featureFlagActionsMapping: Record<
                 />
             )
         } else if (isMultivariateFlag) {
-            filtersAfter.payloads &&
-                Object.keys(filtersAfter.payloads)
-                    .filter((key) => {
-                        const before = filtersBefore?.payloads?.[key]?.toString() || null
-                        const after = filtersAfter.payloads?.[key]?.toString() || null
-                        return before !== after
-                    })
-                    .forEach((key: string) => {
-                        const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
-                        changes.push(
-                            <SentenceList
-                                listParts={[
-                                    <span key={key} className="highlighted-activity">
-                                        {changedPayload}
-                                    </span>,
-                                ]}
-                                prefix={
-                                    <span>
-                                        changed payload on <b>variant: {key}</b> to
-                                    </span>
-                                }
-                            />
-                        )
-                    })
+            getChangedPayloadKeys(filtersBefore, filtersAfter).forEach((key) => {
+                const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
+                changes.push(
+                    <SentenceList
+                        listParts={[
+                            <span key={key} className="highlighted-activity">
+                                {changedPayload}
+                            </span>,
+                        ]}
+                        prefix={
+                            <span>
+                                changed payload on <b>variant: {key}</b> to
+                            </span>
+                        }
+                    />
+                )
+            })
 
             // Identify removed variants
             const beforeVariants = new Set((filtersBefore?.multivariate?.variants || []).map((v) => v.key))


### PR DESCRIPTION
## Problem

We weren't properly accounting for whether before/after had actually changed for some elements of the feature flag diff.

https://posthoghelp.zendesk.com/agent/tickets/52406 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53739)

## Changes

Check the before/after in more places, and don't report it in the humanized sentence if no real change.

There's probably an argument that some of this shouldn't even be in the diff if there's not an actual change but that feels like it would be a much bigger change, whereas this is fairly straightforward to handle in the UI.

## How did you test this code?

Added unit tests to cover.