### PR TITLE
Temporal workflow comment

### DIFF
--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -106,7 +106,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             sandbox_output = await self._get_sandbox_for_repository()
             sandbox_id = sandbox_output.sandbox_id
 
-            # TODO: Re-enable snapshot creation
+            # TODO(noop): Re-enable snapshot creation
             # if sandbox_output.should_create_snapshot:
             #     await self._trigger_snapshot_workflow()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

This PR serves as a no-op change to trigger a redeployment of the Temporal workflow for `products/tasks`.

## Changes

A minor comment edit in `products/tasks/backend/temporal/process_task/workflow.py` (line 109: `# TODO:` -> `# TODO(noop):`).

## How did you test this code?

This is a no-op change intended solely to trigger a deployment. No functional testing was performed or is required.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/agents/bc-3cbfa426-90c0-45d8-bd35-cc14682d18e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cbfa426-90c0-45d8-bd35-cc14682d18e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->