### PR TITLE
fix(hogql): add missing visit_select_set_query methods to timestamp visitors

### DIFF
--- a/posthog/hogql/helpers/timestamp_visitor.py
+++ b/posthog/hogql/helpers/timestamp_visitor.py
@@ -30,6 +30,9 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
         return False
 
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> bool:
+        return False
+
     def visit_field(self, node: ast.Field) -> bool:
         if node.type and isinstance(node.type, ast.FieldType):
             resolved_field = node.type.resolve_database_field(self.context)
@@ -176,6 +179,9 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
         return False
 
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> bool:
+        return False
+
     def visit_compare_operation(self, node: ast.CompareOperation) -> bool:
         return self.visit(node.left) and self.visit(node.right)
 
@@ -256,6 +262,9 @@ class IsStartOfPeriodConstantVisitor(Visitor[bool], ABC):
         return self.check_parsed(parsed)
 
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
+        return False
+
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> bool:
         return False
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> bool:
@@ -397,6 +406,9 @@ class IsEndOfPeriodConstantVisitor(Visitor[bool], ABC):
         return self.check_parsed(parsed)
 
     def visit_select_query(self, node: ast.SelectQuery) -> bool:
+        return False
+
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> bool:
         return False
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> bool:


### PR DESCRIPTION
## Problem

Cohorts are failing to load persons for team 2 with `NotImplementedError: IsTimeOrIntervalConstantVisitor has no method visit_select_set_query`.

This was introduced yesterday when PR #49175 added CTE USING KEY support, introducing SelectSetQuery AST nodes but not updating timestamp visitor classes.

https://grafana.prod-us.posthog.dev/goto/aff0ymq4xtbeoc?orgId=1

## Changes

Added missing visit_select_set_query method to 4 visitor classes in posthog/hogql/helpers/timestamp_visitor.py.

Each returns False since SelectSetQuery operations are not time/interval constants.

## How did you test this code?

Haven't been able to reproduce this locally, will test in prod.