### PR TITLE
feat(surveys): add url match type to guided editor

### DIFF
--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { LemonInputSelect } from '@posthog/lemon-ui'
+import { LemonInputSelect, LemonSelect } from '@posthog/lemon-ui'
 
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
@@ -11,6 +11,7 @@ import { DEFAULT_TARGETING_FLAG_FILTERS } from 'scenes/surveys/constants'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
 
+import { SurveyMatchTypeLabels } from '../../constants'
 import { surveyLogic } from '../../surveyLogic'
 
 export function WhereStep(): JSX.Element {
@@ -47,8 +48,14 @@ export function WhereStep(): JSX.Element {
         }
     }
 
+    const urlMatchType = conditions.urlMatchType || SurveyMatchType.Contains
+
     const setUrlPattern = (pattern: string): void => {
-        setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType: SurveyMatchType.Contains })
+        setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType })
+    }
+
+    const setUrlMatchType = (matchType: SurveyMatchType): void => {
+        setSurveyValue('conditions', { ...conditions, urlMatchType: matchType })
     }
 
     const setUserTargetingMode = (mode: 'all' | 'specific'): void => {
@@ -87,51 +94,61 @@ export function WhereStep(): JSX.Element {
                 />
 
                 {targetingMode === 'specific' && (
-                    <div className="mt-4 ml-6">
-                        <LemonInputSelect
-                            mode="single"
-                            value={urlPattern ? [urlPattern] : []}
-                            onChange={(val) => setUrlPattern(val[0] || '')}
-                            onInputChange={(newInput) => {
-                                loadPropertyValues({
-                                    type: PropertyDefinitionType.Event,
-                                    endpoint: undefined,
-                                    propertyKey: '$current_url',
-                                    newInput: newInput.trim(),
-                                    eventNames: [],
-                                    properties: [],
-                                })
-                            }}
-                            placeholder="Select a page or type a path like /pricing"
-                            allowCustomValues
-                            loading={urlOptions?.status === 'loading'}
-                            options={(() => {
-                                const seen = new Set<string>()
-                                return (urlOptions?.values || [])
-                                    .map(({ name }) => {
-                                        const url = String(name)
-                                        let path = url
-                                        try {
-                                            const parsed = new URL(url)
-                                            path = parsed.pathname
-                                        } catch {
-                                            // Keep as-is if not a valid URL
-                                        }
-                                        return path
+                    <div className="mt-4 ml-6 space-y-2">
+                        <div className="flex items-center gap-2">
+                            <span className="text-sm whitespace-nowrap">URL</span>
+                            <LemonSelect
+                                value={urlMatchType}
+                                onChange={setUrlMatchType}
+                                options={Object.entries(SurveyMatchTypeLabels).map(([key, label]) => ({
+                                    label,
+                                    value: key as SurveyMatchType,
+                                }))}
+                                size="small"
+                            />
+                            <LemonInputSelect
+                                className="flex-1"
+                                mode="single"
+                                value={urlPattern ? [urlPattern] : []}
+                                onChange={(val) => setUrlPattern(val[0] || '')}
+                                onInputChange={(newInput) => {
+                                    loadPropertyValues({
+                                        type: PropertyDefinitionType.Event,
+                                        endpoint: undefined,
+                                        propertyKey: '$current_url',
+                                        newInput: newInput.trim(),
+                                        eventNames: [],
+                                        properties: [],
                                     })
-                                    .filter((path) => {
-                                        if (seen.has(path)) {
-                                            return false
-                                        }
-                                        seen.add(path)
-                                        return true
-                                    })
-                                    .map((path) => ({ key: path, label: path }))
-                            })()}
-                        />
-                        <p className="text-xs text-muted mt-2">
-                            Select from your most visited pages or type a custom pattern
-                        </p>
+                                }}
+                                placeholder="e.g. /pricing"
+                                allowCustomValues
+                                loading={urlOptions?.status === 'loading'}
+                                options={(() => {
+                                    const seen = new Set<string>()
+                                    return (urlOptions?.values || [])
+                                        .map(({ name }) => {
+                                            const url = String(name)
+                                            let path = url
+                                            try {
+                                                const parsed = new URL(url)
+                                                path = parsed.pathname
+                                            } catch {
+                                                // Keep as-is if not a valid URL
+                                            }
+                                            return path
+                                        })
+                                        .filter((path) => {
+                                            if (seen.has(path)) {
+                                                return false
+                                            }
+                                            seen.add(path)
+                                            return true
+                                        })
+                                        .map((path) => ({ key: path, label: path }))
+                                })()}
+                            />
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Problem

guided editor only allows url match type 'contains'

~10% (1,160 of 12,164) of launched surveys in t12m use a match type other than `contains`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds match type dropdown

![Screenshot 2026-03-04 at 11.14.49 AM.png](https://app.graphite.com/user-attachments/assets/6b69123f-e800-4c85-a314-0048ed049d0d.png)



<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->