### PR TITLE
feat: Add short number formatting style to data visualization

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -121,6 +121,13 @@ export const SeriesTab = (): JSX.Element => {
     )
 }
 
+const FORMATTING_STYLE_LABELS: Record<string, string> = {
+    none: 'None',
+    number: 'Number',
+    short: 'Short Number',
+    percent: 'Percentage',
+}
+
 const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number }): JSX.Element => {
     const { columns, numericalColumns, responseLoading, dataVisualizationProps, showTableSettings } =
         useValues(dataVisualizationLogic)
@@ -146,6 +153,11 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
                 <LemonTag className="ml-2" type="default">
                     {type.name}
                 </LemonTag>
+                {series.settings?.formatting?.style && series.settings.formatting.style !== 'none' && (
+                    <LemonTag className="ml-1" type="secondary">
+                        {FORMATTING_STYLE_LABELS[series.settings.formatting.style] || series.settings.formatting.style}
+                    </LemonTag>
+                )}
             </div>
         ),
     }))
@@ -214,11 +226,10 @@ const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSerie
             {ySeriesLogicProps.series.column.type.isNumerical && (
                 <LemonField name="style" label="Style" className="gap-1">
                     <LemonSelect
-                        options={[
-                            { value: 'none', label: 'None' },
-                            { value: 'number', label: 'Number' },
-                            { value: 'percent', label: 'Percentage' },
-                        ]}
+                        options={['none', 'number', 'short', 'percent'].map((value) => ({
+                            value,
+                            label: FORMATTING_STYLE_LABELS[value] ?? value,
+                        }))}
                     />
                 </LemonField>
             )}

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -154,7 +154,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
                     {type.name}
                 </LemonTag>
                 {series.settings?.formatting?.style && series.settings.formatting.style !== 'none' && (
-                    <LemonTag className="ml-1" type="secondary">
+                    <LemonTag className="ml-1" type="default">
                         {FORMATTING_STYLE_LABELS[series.settings.formatting.style] || series.settings.formatting.style}
                     </LemonTag>
                 )}
@@ -221,6 +221,8 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
 }
 
 const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLogicProps }): JSX.Element => {
+    const { formatting } = useValues(ySeriesLogic(ySeriesLogicProps))
+
     return (
         <Form logic={ySeriesLogic} props={ySeriesLogicProps} formKey="formatting" className="deprecated-space-y-4">
             {ySeriesLogicProps.series.column.type.isNumerical && (
@@ -241,7 +243,15 @@ const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSerie
             </LemonField>
             {ySeriesLogicProps.series.column.type.isNumerical && (
                 <LemonField name="decimalPlaces" label="Decimal places">
-                    <LemonInput type="number" min={0} />
+                    <LemonInput
+                        type="number"
+                        min={0}
+                        disabledReason={
+                            formatting.style === 'short'
+                                ? 'Decimal places has no effect when using short number format'
+                                : undefined
+                        }
+                    />
                 </LemonField>
             )}
         </Form>

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -16,7 +16,7 @@ import { subscriptions } from 'kea-subscriptions'
 import mergeObject from 'lodash.merge'
 
 import { dayjs } from 'lib/dayjs'
-import { RGBToHex, lightenDarkenColor, objectsEqual, uuid } from 'lib/utils'
+import { RGBToHex, compactNumber, lightenDarkenColor, objectsEqual, uuid } from 'lib/utils'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -138,6 +138,10 @@ export const formatDataWithSettings = (
 
         if (settings?.formatting?.style === 'number') {
             dataAsString = data.toLocaleString(undefined, { maximumFractionDigits: decimalPlaces })
+        }
+
+        if (settings?.formatting?.style === 'short') {
+            dataAsString = compactNumber(data)
         }
 
         if (settings?.formatting?.style === 'percent') {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8238,7 +8238,7 @@
                     "type": "string"
                 },
                 "style": {
-                    "enum": ["none", "number", "percent"],
+                    "enum": ["none", "number", "short", "percent"],
                     "type": "string"
                 },
                 "suffix": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -372,7 +372,7 @@
             "type": "string"
         },
         "AggregationAxisFormat": {
-            "enum": ["numeric", "duration", "duration_ms", "percentage", "percentage_scaled", "currency"],
+            "enum": ["numeric", "duration", "duration_ms", "percentage", "percentage_scaled", "currency", "short"],
             "type": "string"
         },
         "AlertCalculationInterval": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1015,7 +1015,7 @@ export interface ChartAxis {
 export interface ChartSettingsFormatting {
     prefix?: string
     suffix?: string
-    style?: 'none' | 'number' | 'percent'
+    style?: 'none' | 'number' | 'short' | 'percent'
     decimalPlaces?: number
 }
 

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -4,7 +4,7 @@ import { humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, perc
 import { TrendsFilter } from '~/queries/schema/schema-general'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
-const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled', 'currency'] as const
+const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled', 'currency', 'short'] as const
 export type AggregationAxisFormat = (typeof formats)[number]
 
 export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[] = [

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,5 +1,5 @@
 import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
-import { humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
+import { compactNumber, humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 
 import { TrendsFilter } from '~/queries/schema/schema-general'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
@@ -14,6 +14,7 @@ export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[
     { value: 'percentage', label: 'Percent (0-100)' },
     { value: 'percentage_scaled', label: 'Percent (0-1)' },
     { value: 'currency', label: 'Currency ($)' },
+    { value: 'short', label: 'Short Number' },
 ]
 
 // this function needs to support a trendsFilter as part of an insight query and
@@ -54,6 +55,9 @@ export const formatAggregationAxisValue = (
                 break
             case 'currency':
                 formattedValue = humanFriendlyCurrency(value)
+                break
+            case 'short':
+                formattedValue = compactNumber(value)
                 break
             case 'numeric': // numeric is default
             default:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -58,6 +58,7 @@ class AggregationAxisFormat(StrEnum):
     PERCENTAGE = "percentage"
     PERCENTAGE_SCALED = "percentage_scaled"
     CURRENCY = "currency"
+    SHORT = "short"
 
 
 class AlertCalculationInterval(StrEnum):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -729,6 +729,7 @@ class ChartSettingsDisplay(BaseModel):
 class Style(StrEnum):
     NONE = "none"
     NUMBER = "number"
+    SHORT = "short"
     PERCENT = "percent"
 
 

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -1698,6 +1698,7 @@ export const AggregationAxisFormatApi = {
     Percentage: 'percentage',
     PercentageScaled: 'percentage_scaled',
     Currency: 'currency',
+    Short: 'short',
 } as const
 
 export type DetailedResultsAggregationTypeApi =


### PR DESCRIPTION
## Problem

Data visualization users need a way to display large numbers in a more readable, compact format. Currently, the formatting options only include "None", "Number", and "Percentage", but there's no option to show abbreviated numbers (like 1.2K, 1.5M, etc.) which is essential for displaying large values in charts and visualizations.

![image.png](https://app.graphite.com/user-attachments/assets/c0753598-be57-478b-8396-c2a204de76ed.png)

## Changes

- Added "Short Number" formatting style option to the data visualization series formatting
- Implemented compact number formatting using the existing `compactNumber` utility function
- Added visual indicator tags in the series tab to show when formatting is applied
- Updated the formatting style dropdown to include the new "Short Number" option
- Updated schema definitions across frontend TypeScript and backend Python to support the new "short" formatting style

The "Short Number" option will display numbers in abbreviated format (e.g., 1,200 becomes "1.2K", 1,500,000 becomes "1.5M").

## How did you test this code?

As an AI agent, I have not manually tested this code. The changes include:
- Schema updates to support the new formatting option
- Frontend UI changes to display the new option and formatting indicators
- Logic implementation to handle the compact number formatting
- Consistent updates across TypeScript interfaces and Python enums

Manual testing should verify:
- The "Short Number" option appears in the formatting dropdown
- Numbers are properly formatted when this option is selected
- The formatting tag displays correctly in the series tab
- The compact number formatting works correctly for various number ranges

## Publish to changelog?

Yes - this adds a new user-facing feature for better number formatting in data visualizations.