### PR TITLE
fix: configurable limit for showing apply filters and preview

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -360,6 +360,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
+    DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_TILE_REDESIGN: 'dashboard-tile-redesign', // owner: @sam #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     PRODUCT_TOURS: 'product-tours-2025', // owner: @adboio #team-surveys

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -11,6 +11,7 @@ import { NotFound } from 'lib/components/NotFound'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { DashboardEditBar } from 'scenes/dashboard/DashboardEditBar'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { DashboardLogicProps, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -72,10 +73,20 @@ function DashboardScene(): JSX.Element {
         hasVariables,
         refreshAnalysisResult,
         analysisRating,
+        showEditBarApplyPopover,
+        loadingPreview,
+        cancellingPreview,
+        hasUrlFilters,
     } = useValues(dashboardLogic)
     const { currentTeamId } = useValues(teamLogic)
-    const { reportDashboardViewed, abortAnyRunningQuery, setRefreshAnalysisResult, setAnalysisRating } =
-        useActions(dashboardLogic)
+    const {
+        reportDashboardViewed,
+        abortAnyRunningQuery,
+        setRefreshAnalysisResult,
+        setAnalysisRating,
+        applyFilters,
+        setDashboardMode,
+    } = useActions(dashboardLogic)
     const { addInsightToDashboardModalVisible } = useValues(addInsightToDashboardLogic)
 
     useFileSystemLogView({
@@ -143,6 +154,37 @@ function DashboardScene(): JSX.Element {
                                         />
                                     </>
                                 )}
+                            </div>
+                        </LemonBanner>
+                    )}
+
+                    {showEditBarApplyPopover && (
+                        <LemonBanner type="info" className="mb-2">
+                            <div className="flex items-center justify-between gap-2">
+                                <span>Filters are not automatically applied on large dashboards.</span>
+                                <div className="flex gap-2 shrink-0">
+                                    <LemonButton
+                                        onClick={() =>
+                                            setDashboardMode(
+                                                hasUrlFilters ? dashboardMode : null,
+                                                DashboardEventSource.DashboardHeaderDiscardChanges
+                                            )
+                                        }
+                                        loading={cancellingPreview}
+                                        type="secondary"
+                                        size="small"
+                                    >
+                                        Cancel
+                                    </LemonButton>
+                                    <LemonButton
+                                        onClick={applyFilters}
+                                        loading={loadingPreview}
+                                        type="primary"
+                                        size="small"
+                                    >
+                                        Apply filters
+                                    </LemonButton>
+                                </div>
                             </div>
                         </LemonBanner>
                     )}

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -73,7 +73,7 @@ function DashboardScene(): JSX.Element {
         hasVariables,
         refreshAnalysisResult,
         analysisRating,
-        showEditBarApplyPopover,
+        showApplyFiltersBanner,
         loadingPreview,
         cancellingPreview,
         hasUrlFilters,
@@ -158,7 +158,7 @@ function DashboardScene(): JSX.Element {
                         </LemonBanner>
                     )}
 
-                    {showEditBarApplyPopover && (
+                    {showApplyFiltersBanner && (
                         <LemonBanner type="info" className="mb-2">
                             <div className="flex items-center justify-between gap-2">
                                 <span>Filters are not automatically applied on large dashboards.</span>

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCalendar } from '@posthog/icons'
-import { LemonButton, Popover } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
@@ -11,7 +10,6 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
@@ -24,17 +22,8 @@ import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
 import { DashboardMode, InsightLogicProps } from '~/types'
 
 export function DashboardEditBar(): JSX.Element {
-    const {
-        dashboard,
-        dashboardMode,
-        hasVariables,
-        effectiveEditBarFilters,
-        showEditBarApplyPopover,
-        loadingPreview,
-        cancellingPreview,
-        hasUrlFilters,
-    } = useValues(dashboardLogic)
-    const { setDates, setProperties, setBreakdownFilter, setDashboardMode, applyFilters } = useActions(dashboardLogic)
+    const { dashboard, dashboardMode, hasVariables, effectiveEditBarFilters } = useValues(dashboardLogic)
+    const { setDates, setProperties, setBreakdownFilter, setDashboardMode } = useActions(dashboardLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const { featureFlags } = useValues(featureFlagLogic)
@@ -55,129 +44,98 @@ export function DashboardEditBar(): JSX.Element {
     }
 
     return (
-        // Only show preview button for large dashboards where we don't automatically preview filter changes */
-        <Popover
-            visible={showEditBarApplyPopover}
-            overlay={
-                <div className="flex items-center gap-2 m-1">
-                    <LemonButton
-                        onClick={() =>
-                            setDashboardMode(
-                                hasUrlFilters ? dashboardMode : null,
-                                DashboardEventSource.DashboardHeaderDiscardChanges
-                            )
-                        }
-                        loading={cancellingPreview}
-                        type="secondary"
-                        size="small"
-                    >
-                        Cancel
-                    </LemonButton>
-                    <LemonButton onClick={applyFilters} loading={loadingPreview} type="primary" size="small">
-                        Apply filters and preview
-                    </LemonButton>
-                </div>
-            }
-            placement="bottom"
-            showArrow
+        <div
+            className={clsx(
+                'flex gap-2 items-end flex-wrap border md:[&>*]:grow-0 [&>*]:grow',
+                dashboardMode === DashboardMode.Edit
+                    ? '-m-1.5 p-1.5 border-primary border-dashed rounded-lg'
+                    : 'border-transparent'
+            )}
         >
-            <div
-                className={clsx(
-                    'flex gap-2 items-end flex-wrap border md:[&>*]:grow-0 [&>*]:grow',
-                    dashboardMode === DashboardMode.Edit
-                        ? '-m-1.5 p-1.5 border-primary border-dashed rounded-lg'
-                        : 'border-transparent'
-                )}
-            >
-                <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
-                    <AppShortcut
-                        name="DashboardDateFilter"
-                        keybind={[keyBinds.dateFilter]}
-                        intent="Date filter"
-                        interaction="click"
-                        scope={Scene.Dashboard}
-                    >
-                        <DateFilter
-                            showCustom
-                            showExplicitDateToggle={canAccessExplicitDateToggle}
-                            allowTimePrecision
-                            allowFixedRangeWithTime
-                            dateFrom={effectiveEditBarFilters.date_from}
-                            dateTo={effectiveEditBarFilters.date_to}
-                            explicitDate={effectiveEditBarFilters.explicitDate}
-                            onChange={(from_date, to_date, explicitDate) => {
-                                if (dashboardMode !== DashboardMode.Edit) {
-                                    setDashboardMode(DashboardMode.Edit, null)
-                                }
-                                setDates(from_date, to_date, explicitDate)
-                            }}
-                            makeLabel={(key) => (
-                                <>
-                                    <IconCalendar />
-                                    <span className="hide-when-small"> {key}</span>
-                                </>
-                            )}
-                        />
-                    </AppShortcut>
-                </div>
-                <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
-                    <PropertyFilters
-                        onChange={(properties) => {
+            <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                <AppShortcut
+                    name="DashboardDateFilter"
+                    keybind={[keyBinds.dateFilter]}
+                    intent="Date filter"
+                    interaction="click"
+                    scope={Scene.Dashboard}
+                >
+                    <DateFilter
+                        showCustom
+                        showExplicitDateToggle={canAccessExplicitDateToggle}
+                        allowTimePrecision
+                        allowFixedRangeWithTime
+                        dateFrom={effectiveEditBarFilters.date_from}
+                        dateTo={effectiveEditBarFilters.date_to}
+                        explicitDate={effectiveEditBarFilters.explicitDate}
+                        onChange={(from_date, to_date, explicitDate) => {
                             if (dashboardMode !== DashboardMode.Edit) {
                                 setDashboardMode(DashboardMode.Edit, null)
                             }
-                            setProperties(properties)
+                            setDates(from_date, to_date, explicitDate)
                         }}
-                        pageKey={'dashboard_' + dashboard?.id}
-                        propertyFilters={effectiveEditBarFilters.properties}
-                        taxonomicGroupTypes={[
-                            TaxonomicFilterGroupType.EventProperties,
-                            TaxonomicFilterGroupType.PersonProperties,
-                            TaxonomicFilterGroupType.EventFeatureFlags,
-                            TaxonomicFilterGroupType.EventMetadata,
-                            ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
-                            ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
-                            TaxonomicFilterGroupType.EmailAddresses,
-                            ...groupsTaxonomicTypes,
-                            TaxonomicFilterGroupType.Cohorts,
-                            TaxonomicFilterGroupType.Elements,
-                            TaxonomicFilterGroupType.SessionProperties,
-                            TaxonomicFilterGroupType.HogQLExpression,
-                            TaxonomicFilterGroupType.DataWarehousePersonProperties,
-                        ]}
+                        makeLabel={(key) => (
+                            <>
+                                <IconCalendar />
+                                <span className="hide-when-small"> {key}</span>
+                            </>
+                        )}
                     />
-                </div>
-                <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
-                    <BindLogic logic={insightLogic} props={insightProps}>
-                        <TaxonomicBreakdownFilter
-                            insightProps={insightProps}
-                            breakdownFilter={effectiveEditBarFilters.breakdown_filter}
-                            isTrends={false}
-                            showLabel={false}
-                            updateBreakdownFilter={(breakdown_filter) => {
-                                if (dashboardMode !== DashboardMode.Edit) {
-                                    setDashboardMode(DashboardMode.Edit, null)
-                                }
-                                let saved_breakdown_filter: BreakdownFilter | null = breakdown_filter
-                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
-                                if (
-                                    breakdown_filter &&
-                                    !breakdown_filter.breakdown_type &&
-                                    !breakdown_filter.breakdowns
-                                ) {
-                                    saved_breakdown_filter = null
-                                }
-                                setBreakdownFilter(saved_breakdown_filter)
-                            }}
-                            updateDisplay={() => {}}
-                            disablePropertyInfo
-                            size="small"
-                        />
-                    </BindLogic>
-                </div>
-
-                <VariablesForDashboard />
+                </AppShortcut>
             </div>
-        </Popover>
+            <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                <PropertyFilters
+                    onChange={(properties) => {
+                        if (dashboardMode !== DashboardMode.Edit) {
+                            setDashboardMode(DashboardMode.Edit, null)
+                        }
+                        setProperties(properties)
+                    }}
+                    pageKey={'dashboard_' + dashboard?.id}
+                    propertyFilters={effectiveEditBarFilters.properties}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                        TaxonomicFilterGroupType.EventFeatureFlags,
+                        TaxonomicFilterGroupType.EventMetadata,
+                        ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
+                        ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
+                        TaxonomicFilterGroupType.EmailAddresses,
+                        ...groupsTaxonomicTypes,
+                        TaxonomicFilterGroupType.Cohorts,
+                        TaxonomicFilterGroupType.Elements,
+                        TaxonomicFilterGroupType.SessionProperties,
+                        TaxonomicFilterGroupType.HogQLExpression,
+                        TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                    ]}
+                />
+            </div>
+            <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                <BindLogic logic={insightLogic} props={insightProps}>
+                    <TaxonomicBreakdownFilter
+                        insightProps={insightProps}
+                        breakdownFilter={effectiveEditBarFilters.breakdown_filter}
+                        isTrends={false}
+                        showLabel={false}
+                        updateBreakdownFilter={(breakdown_filter) => {
+                            if (dashboardMode !== DashboardMode.Edit) {
+                                setDashboardMode(DashboardMode.Edit, null)
+                            }
+                            let saved_breakdown_filter: BreakdownFilter | null = breakdown_filter
+                            // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                            if (breakdown_filter && !breakdown_filter.breakdown_type && !breakdown_filter.breakdowns) {
+                                saved_breakdown_filter = null
+                            }
+                            setBreakdownFilter(saved_breakdown_filter)
+                        }}
+                        updateDisplay={() => {}}
+                        disablePropertyInfo
+                        size="small"
+                    />
+                </BindLogic>
+            </div>
+
+            <VariablesForDashboard />
+        </div>
     )
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -27,7 +27,7 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Dayjs, dayjs, now } from 'lib/dayjs'
 import { Link } from 'lib/lemon-ui/Link'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic, getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
 import { clearDOMTextSelection, getJSHeapMemory, shouldCancelQuery, toParams, uuid } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -82,7 +82,7 @@ import {
     BREAKPOINT_COLUMN_COUNTS,
     DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES,
     IS_TEST_MODE,
-    MAX_TILES_FOR_AUTOPREVIEW,
+    DEFAULT_AUTO_PREVIEW_TILE_LIMIT,
     SEARCH_PARAM_FILTERS_KEY,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
     combineDashboardFilters,
@@ -940,7 +940,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         canAutoPreview: [
             (s) => [s.dashboard],
-            (dashboard) => (dashboard?.tiles.length || 0) < MAX_TILES_FOR_AUTOPREVIEW,
+            (dashboard) => {
+                const payload = getFeatureFlagPayload(FEATURE_FLAGS.DASHBOARD_AUTO_PREVIEW_LIMIT)
+                const limit = typeof payload === 'number' ? payload : DEFAULT_AUTO_PREVIEW_TILE_LIMIT
+                return (dashboard?.tiles.length || 0) < limit
+            },
         ],
         hasIntermittentFilters: [
             (s) => [s.intermittentFilters],

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -939,8 +939,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         canAutoPreview: [
-            (s) => [s.dashboard],
-            (dashboard) => {
+            (s) => [s.dashboard, s.featureFlags],
+            (dashboard, _featureFlags) => {
                 const payload = getFeatureFlagPayload(FEATURE_FLAGS.DASHBOARD_AUTO_PREVIEW_LIMIT)
                 const limit = typeof payload === 'number' ? payload : DEFAULT_AUTO_PREVIEW_TILE_LIMIT
                 return (dashboard?.tiles.length || 0) < limit

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -939,8 +939,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         canAutoPreview: [
-            (s) => [s.dashboard, s.featureFlags],
-            (dashboard, _featureFlags) => {
+            (s) => [s.dashboard],
+            (dashboard) => {
                 const payload = getFeatureFlagPayload(FEATURE_FLAGS.DASHBOARD_AUTO_PREVIEW_LIMIT)
                 const limit = typeof payload === 'number' ? payload : DEFAULT_AUTO_PREVIEW_TILE_LIMIT
                 return (dashboard?.tiles.length || 0) < limit
@@ -954,7 +954,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (s) => [s.urlFilters],
             (urlFilters) => Object.values(urlFilters).some((filter) => filter !== undefined),
         ],
-        showEditBarApplyPopover: [
+        showApplyFiltersBanner: [
             (s) => [s.canAutoPreview, s.hasIntermittentFilters],
             (canAutoPreview, hasIntermittentFilters) => !canAutoPreview && hasIntermittentFilters,
         ],

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -36,12 +36,7 @@ export const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 export const SEARCH_PARAM_QUERY_VARIABLES_KEY = 'query_variables'
 export const SEARCH_PARAM_FILTERS_KEY = 'query_filters'
 
-/**
- * Once a dashboard has more tiles than this,
- * we don't automatically preview dashboard date/filter/breakdown changes.
- * Users will need to click the 'Apply and preview filters' button.
- */
-export const MAX_TILES_FOR_AUTOPREVIEW = 5
+export const DEFAULT_AUTO_PREVIEW_TILE_LIMIT = 10
 
 const RATE_LIMIT_ERROR_MESSAGE = 'concurrency_limit_exceeded'
 


### PR DESCRIPTION
when someone edits a dashboard with more than 5 insights we show a popover that says "apply filters and preview"

it gives me a sad every time i see it

i never understood why it was there - and didn't realise a dashboard with fewer than 5 insights wouldn't show it

the popover would also overlap with the filters as they were edited



![CleanShot 2026-03-04 at 19.58.13@2x.png](https://app.graphite.com/user-attachments/assets/c4b797f4-1e9a-41a8-bc79-5c992315022c.png)



let's make the limit configurable and raise it to above the p90 for insights on a dashboard
and make it a banner with an explanation

it feels like the kind of change that doesn't actually help with query performance but does make the UI feel hostile

![CleanShot 2026-03-04 at 19.54.18@2x.png](https://app.graphite.com/user-attachments/assets/685727e2-50f9-4934-a180-7528f2a90722.png)

tested that i get the banner and then that i could change the flag payload and not get the banner