### PR TITLE
fix(oauth-proxy): rewrite client_secret for confidential EU clients

### DIFF
--- a/services/oauth-proxy/src/handlers/token.ts
+++ b/services/oauth-proxy/src/handlers/token.ts
@@ -79,13 +79,20 @@ async function proxyWithMapping(
         if (mapping) {
             const regionalClientId = region === 'eu' ? mapping.eu_client_id : mapping.us_client_id
             if (regionalClientId) {
+                const proxySecret = mapping.us_client_secret
+                const regionalSecret = region === 'eu' ? mapping.eu_client_secret : mapping.us_client_secret
+                let clientSecretRewrite: { from: string; to: string } | undefined
+                if (proxySecret && regionalSecret && proxySecret !== regionalSecret) {
+                    clientSecretRewrite = { from: proxySecret, to: regionalSecret }
+                }
                 return proxyPostWithClientId(
                     request,
                     region,
                     '/oauth/token/',
                     proxyClientId,
                     regionalClientId,
-                    redirectUriRewrite
+                    redirectUriRewrite,
+                    clientSecretRewrite
                 )
             }
         }

--- a/services/oauth-proxy/src/lib/proxy.ts
+++ b/services/oauth-proxy/src/lib/proxy.ts
@@ -27,7 +27,8 @@ export async function proxyPostWithClientId(
     path: string,
     proxyClientId: string,
     regionalClientId: string,
-    redirectUriRewrite?: { from: string; to: string }
+    redirectUriRewrite?: { from: string; to: string },
+    clientSecretRewrite?: { from: string; to: string }
 ): Promise<Response> {
     const contentType = request.headers.get('content-type') || ''
     let body: string
@@ -40,6 +41,9 @@ export async function proxyPostWithClientId(
         if (redirectUriRewrite && json.redirect_uri === redirectUriRewrite.from) {
             json.redirect_uri = redirectUriRewrite.to
         }
+        if (clientSecretRewrite && json.client_secret === clientSecretRewrite.from) {
+            json.client_secret = clientSecretRewrite.to
+        }
         body = JSON.stringify(json)
     } else {
         // form-urlencoded
@@ -50,6 +54,9 @@ export async function proxyPostWithClientId(
         }
         if (redirectUriRewrite && params.get('redirect_uri') === redirectUriRewrite.from) {
             params.set('redirect_uri', redirectUriRewrite.to)
+        }
+        if (clientSecretRewrite && params.get('client_secret') === clientSecretRewrite.from) {
+            params.set('client_secret', clientSecretRewrite.to)
         }
         body = params.toString()
     }

--- a/services/oauth-proxy/tests/token.test.ts
+++ b/services/oauth-proxy/tests/token.test.ts
@@ -75,14 +75,12 @@ describe('handleToken', () => {
 
         vi.stubGlobal(
             'fetch',
-            vi
-                .fn()
-                .mockResolvedValue(
-                    new Response(JSON.stringify({ access_token: 'pha_eu_token', token_type: 'bearer' }), {
-                        status: 200,
-                        headers: { 'Content-Type': 'application/json' },
-                    })
-                )
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ access_token: 'pha_eu_token', token_type: 'bearer' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            )
         )
 
         const request = new Request('https://oauth.posthog.com/oauth/token/', {
@@ -101,6 +99,53 @@ describe('handleToken', () => {
         const sentBody = new URLSearchParams(fetchCall[1]!.body as string)
         expect(sentBody.get('redirect_uri')).toBe('https://oauth.posthog.com/oauth/callback/')
         expect(sentBody.get('client_id')).toBe('eu_real_id')
+    })
+
+    it('rewrites client_secret for confidential clients', async () => {
+        mockKVGet(mockKV, (key: string, type?: unknown) => {
+            if (key === 'region:proxy_client_789') {
+                return Promise.resolve('eu')
+            }
+            if (key === 'callback:proxy_client_789') {
+                return Promise.resolve('https://claude.ai/api/mcp/auth_callback')
+            }
+            if (key === 'client:proxy_client_789' && type === 'json') {
+                return Promise.resolve({
+                    us_client_id: 'proxy_client_789',
+                    eu_client_id: 'eu_real_id',
+                    us_client_secret: 'us_secret_abc',
+                    eu_client_secret: 'eu_secret_xyz',
+                    redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+                    created_at: Date.now(),
+                })
+            }
+            return Promise.resolve(null)
+        })
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ access_token: 'pha_eu_token', token_type: 'bearer' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            )
+        )
+
+        const request = new Request('https://oauth.posthog.com/oauth/token/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'grant_type=authorization_code&code=test_code&client_id=proxy_client_789&client_secret=us_secret_abc&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback',
+        })
+
+        const response = await handleToken(request, mockKV)
+        expect(response.status).toBe(200)
+
+        const fetchCall = vi.mocked(fetch).mock.calls[0]!
+        const sentBody = new URLSearchParams(fetchCall[1]!.body as string)
+        expect(sentBody.get('client_id')).toBe('eu_real_id')
+        expect(sentBody.get('client_secret')).toBe('eu_secret_xyz')
+        expect(sentBody.get('redirect_uri')).toBe('https://oauth.posthog.com/oauth/callback/')
     })
 
     it('returns error for authorization_code grant when region is unknown', async () => {


### PR DESCRIPTION
## Problem

Confidential OAuth clients (e.g. Claude Desktop) authenticate via `client_secret_post`, sending `client_secret` in the token exchange body. The oauth-proxy already rewrites `client_id` and `redirect_uri` when forwarding to the regional server, but was **not** rewriting `client_secret`.

When an EU user connects, the proxy forwards the EU `client_id` paired with the US `client_secret` → EU server returns `invalid_client`.

## Changes

- `proxyPostWithClientId` in `proxy.ts` now accepts an optional `clientSecretRewrite` parameter and swaps `client_secret` in both JSON and form-encoded bodies
- `proxyWithMapping` in `token.ts` computes the secret rewrite from the KV client mapping (US secret → regional secret) and passes it through
- Added test for confidential client secret rewrite

## How did you test this code?

- Added failing test first, confirmed it fails with `expected 'us_secret_abc' to be 'eu_secret_xyz'`
- Applied fix, all 24 tests pass
- Reproduced locally end-to-end: registered confidential client through proxy, authorized with EU region, token exchange with US secret returns `invalid_grant` (correct — fake auth code) instead of `invalid_client` (the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)