### PR TITLE
feat(capture): no op sink

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -59,6 +59,9 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub print_sink: bool,
 
+    #[envconfig(default = "false")]
+    pub noop_sink: bool,
+
     #[envconfig(default = "127.0.0.1:3000")]
     pub address: SocketAddr,
 

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -34,6 +34,7 @@ use crate::router;
 use crate::router::BATCH_BODY_SIZE;
 use crate::sinks::fallback::FallbackSink;
 use crate::sinks::kafka::KafkaSink;
+use crate::sinks::noop::NoOpSink;
 use crate::sinks::print::PrintSink;
 use crate::sinks::s3::S3Sink;
 use crate::sinks::Event;
@@ -202,6 +203,15 @@ async fn create_sink(
             .await;
 
         Ok(Box::new(PrintSink {}))
+    } else if config.noop_sink {
+        liveness
+            .register("noop_sink".to_string(), Duration::from_secs(30))
+            .await
+            .report_healthy()
+            .await;
+
+        info!("NoOpSink enabled, events will be silently dropped");
+        Ok(Box::new(NoOpSink {}))
     } else {
         let sink_liveness = liveness
             .register("rdkafka".to_string(), Duration::from_secs(30))

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -204,12 +204,6 @@ async fn create_sink(
 
         Ok(Box::new(PrintSink {}))
     } else if config.noop_sink {
-        liveness
-            .register("noop_sink".to_string(), Duration::from_secs(30))
-            .await
-            .report_healthy()
-            .await;
-
         info!("NoOpSink enabled, events will be silently dropped");
         Ok(Box::new(NoOpSink {}))
     } else {

--- a/rust/capture/src/sinks/mod.rs
+++ b/rust/capture/src/sinks/mod.rs
@@ -4,6 +4,7 @@ use crate::{api::CaptureError, v0_request::ProcessedEvent};
 
 pub mod fallback;
 pub mod kafka;
+pub mod noop;
 pub mod print;
 pub mod producer;
 pub mod s3;

--- a/rust/capture/src/sinks/noop.rs
+++ b/rust/capture/src/sinks/noop.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+
+use metrics::{counter, histogram};
+
+use crate::api::CaptureError;
+use crate::sinks::Event;
+use crate::v0_request::ProcessedEvent;
+
+pub struct NoOpSink {}
+
+#[async_trait]
+impl Event for NoOpSink {
+    async fn send(&self, _event: ProcessedEvent) -> Result<(), CaptureError> {
+        counter!("capture_events_ingested_total").increment(1);
+        Ok(())
+    }
+    async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        histogram!("capture_event_batch_size").record(events.len() as f64);
+        counter!("capture_events_ingested_total").increment(events.len() as u64);
+        Ok(())
+    }
+}

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -34,6 +34,7 @@ use limiters::redis::{QuotaResource, OVERFLOW_LIMITER_CACHE_KEY, QUOTA_LIMITER_C
 
 pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     print_sink: false,
+    noop_sink: false,
     address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
     redis_url: "redis://localhost:6379/".to_string(),
     redis_response_timeout_ms: 100,


### PR DESCRIPTION
## Problem
When smoke testing on full traffic in `capture-mirrored` we should be able to disable event publishing entirely if the test isn't validating event output. `events_blackhole` in MSK isn't free! 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add `NOOP_SINK` option in app cfg, overriding Kafka sink if set
* Implement `NoOpSink`
* Misc. test and plumbing updates to accommodate this
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will be using in `capture-mirrored` prior to ramping traffic back up there
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
