### PR TITLE
fix(workflows): draft auto saving kicking in too early

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -205,7 +205,7 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                 disabledReason={
                                     workflowHasErrors
                                         ? 'Some fields still need work'
-                                        : isCreatedFromTemplate
+                                        : isCreatedFromTemplate || !isSavedWorkflow
                                           ? undefined
                                           : workflowContentChanged
                                             ? undefined

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -1002,6 +1002,9 @@ export const workflowLogic = kea<workflowLogicType>([
             }, 2000)
         },
         softDeleteAction: () => {
+            if (props.id === 'new') {
+                return
+            }
             if (cache.autosaveTimer) {
                 clearTimeout(cache.autosaveTimer)
             }
@@ -1010,6 +1013,9 @@ export const workflowLogic = kea<workflowLogicType>([
             }, 10000)
         },
         restoreAction: () => {
+            if (props.id === 'new') {
+                return
+            }
             if (cache.autosaveTimer) {
                 clearTimeout(cache.autosaveTimer)
             }
@@ -1019,6 +1025,9 @@ export const workflowLogic = kea<workflowLogicType>([
         },
         // Autosave: debounce 5s after changes
         setWorkflowValues: () => {
+            if (props.id === 'new') {
+                return
+            }
             if (cache.autosaveTimer) {
                 clearTimeout(cache.autosaveTimer)
             }

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -1002,7 +1002,7 @@ export const workflowLogic = kea<workflowLogicType>([
             }, 2000)
         },
         softDeleteAction: () => {
-            if (props.id === 'new') {
+            if (!props.id || props.id === 'new') {
                 return
             }
             if (cache.autosaveTimer) {
@@ -1013,7 +1013,7 @@ export const workflowLogic = kea<workflowLogicType>([
             }, 10000)
         },
         restoreAction: () => {
-            if (props.id === 'new') {
+            if (!props.id || props.id === 'new') {
                 return
             }
             if (cache.autosaveTimer) {
@@ -1025,7 +1025,7 @@ export const workflowLogic = kea<workflowLogicType>([
         },
         // Autosave: debounce 5s after changes
         setWorkflowValues: () => {
-            if (props.id === 'new') {
+            if (!props.id || props.id === 'new') {
                 return
             }
             if (cache.autosaveTimer) {


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/48268 introduced drafts + auto-saving, but it is a bit confusing when setting up a new workflow

When creating a new workflow, the "Create as draft" button remains disabled with "No changes to save" as the reason. It then just automatically creates a new workflow after sitting on the page for a bit, which feels unexpected and is not at all obvious in the UX

## Changes

Disable the autosaving functionality on unsaved workflows + allow creating a new workflow only by pressing the button manually

## How did you test this code?

Validated expected behavior locally

## Publish to changelog?

No