### PR TITLE
feat: Add currency formatting support to insight visualizations

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
@@ -9,6 +9,7 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownLabel, getTrendResultCustomizationKey } from 'scenes/insights/utils'
 import { formatCompareLabel } from 'scenes/insights/views/InsightsTable/columns/SeriesColumn'
+import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -23,6 +24,7 @@ type InsightLegendRowProps = {
 export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
     const { allCohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    const { baseCurrency } = useValues(teamLogic)
 
     const { insightProps, highlightedSeries, editingDisabledReason } = useValues(insightLogic)
     const {
@@ -115,7 +117,7 @@ export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
             </div>
             {display === ChartDisplayType.ActionsPie && (
                 <div className="text-secondary grow-0">
-                    {formatAggregationAxisValue(trendsFilter, item.aggregated_value)}
+                    {formatAggregationAxisValue(trendsFilter, item.aggregated_value, baseCurrency)}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,3 +1,5 @@
+import posthog from 'posthog-js'
+
 import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
 import { compactNumber, humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 import { formatCurrency } from 'lib/utils/geography/currency'
@@ -56,7 +58,14 @@ export const formatAggregationAxisValue = (
                 formattedValue = percentage(value, maxDecimalPlaces)
                 break
             case 'currency':
-                formattedValue = currency ? formatCurrency(value, currency) : humanFriendlyCurrency(value)
+                // In the rare case where we get an error because we have an invalid currency code
+                // let's make sure we fallback to the human friendly one
+                try {
+                    formattedValue = currency ? formatCurrency(value, currency) : humanFriendlyCurrency(value)
+                } catch (error) {
+                    posthog.captureException(error, { value, currency })
+                    formattedValue = humanFriendlyCurrency(value)
+                }
                 break
             case 'short':
                 formattedValue = compactNumber(value)

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -2,8 +2,7 @@ import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
 import { compactNumber, humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 import { formatCurrency } from 'lib/utils/geography/currency'
 
-import { TrendsFilter } from '~/queries/schema/schema-general'
-import { CurrencyCode } from '~/queries/schema/schema-general'
+import { CurrencyCode, TrendsFilter } from '~/queries/schema/schema-general'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled', 'currency', 'short'] as const

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,7 +1,9 @@
 import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
 import { compactNumber, humanFriendlyCurrency, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
+import { formatCurrency } from 'lib/utils/geography/currency'
 
 import { TrendsFilter } from '~/queries/schema/schema-general'
+import { CurrencyCode } from '~/queries/schema/schema-general'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled', 'currency', 'short'] as const
@@ -21,7 +23,8 @@ export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[
 // legacy trend filters, as we still return these as part of a data response
 export const formatAggregationAxisValue = (
     trendsFilter: TrendsFilter | null | undefined | Partial<TrendsFilterType>,
-    value: number | string
+    value: number | string,
+    currency?: CurrencyCode
 ): string => {
     value = Number(value)
     const maxDecimalPlaces =
@@ -54,7 +57,7 @@ export const formatAggregationAxisValue = (
                 formattedValue = percentage(value, maxDecimalPlaces)
                 break
             case 'currency':
-                formattedValue = humanFriendlyCurrency(value)
+                formattedValue = currency ? formatCurrency(value, currency) : humanFriendlyCurrency(value)
                 break
             case 'short':
                 formattedValue = compactNumber(value)
@@ -70,13 +73,15 @@ export const formatAggregationAxisValue = (
 export const formatPercentStackAxisValue = (
     trendsFilter: TrendsFilter | null | undefined | Partial<TrendsFilterType>,
     value: number | string,
-    isPercentStackView: boolean
+    isPercentStackView: boolean,
+    currency?: CurrencyCode
 ): string => {
     if (isPercentStackView) {
         value = Number(value)
         return percentage(value / 100)
     }
-    return formatAggregationAxisValue(trendsFilter, value)
+
+    return formatAggregationAxisValue(trendsFilter, value, currency)
 }
 
 export const axisLabel = (chartDisplayType: ChartDisplayType | null | undefined): string => {

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -1,5 +1,6 @@
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
+import { CurrencyCode } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 describe('formatAggregationAxisValue', () => {
@@ -34,6 +35,17 @@ describe('formatAggregationAxisValue', () => {
             },
             expected: '£3,940💖',
         },
+        {
+            candidate: 3940,
+            filters: { aggregation_axis_format: 'currency' },
+            expected: '$3,940.00',
+        },
+        {
+            candidate: 3940,
+            filters: { aggregation_axis_format: 'currency' },
+            currency: 'EUR' as CurrencyCode,
+            expected: '€3,940.00',
+        },
         { candidate: 0.8709423, filters: {}, expected: '0.87' },
         { candidate: 0.8709423, filters: { decimal_places: 2 }, expected: '0.87' },
         { candidate: 0.8709423, filters: { decimal_places: 3 }, expected: '0.871' },
@@ -41,13 +53,18 @@ describe('formatAggregationAxisValue', () => {
         { candidate: 0.8709423, filters: { decimal_places: 9 }, expected: '0.8709423' },
         { candidate: 0.8709423, filters: { decimal_places: -1 }, expected: '0.87' }, // Fall back to default for unsupported values
     ]
+
     formatTestcases.forEach((testcase) => {
         it(`correctly formats "${testcase.candidate}" as ${testcase.expected} when filters are ${JSON.stringify(
             testcase.filters
         )}`, () => {
-            expect(formatAggregationAxisValue(testcase.filters as Partial<FilterType>, testcase.candidate)).toEqual(
-                testcase.expected
-            )
+            expect(
+                formatAggregationAxisValue(
+                    testcase.filters as Partial<FilterType>,
+                    testcase.candidate,
+                    testcase.currency
+                )
+            ).toEqual(testcase.expected)
         })
     })
 })

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -16,6 +16,7 @@ import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -65,6 +66,7 @@ function useBoldNumberTooltip({
     const { insightProps } = useValues(insightLogic)
     const { series, insightData, trendsFilter, breakdownFilter } = useValues(insightVizDataLogic(insightProps))
     const { aggregationLabel } = useValues(groupsModel)
+    const { baseCurrency } = useValues(teamLogic)
 
     const divRef = useRef<HTMLDivElement>(null)
 
@@ -79,7 +81,7 @@ function useBoldNumberTooltip({
 
         tooltipRoot.render(
             <InsightTooltip
-                renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value)}</>}
+                renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value, baseCurrency)}</>}
                 seriesData={[
                     {
                         dataIndex: 1,
@@ -118,6 +120,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
     const { insightData, trendsFilter, compareFilter, querySource, hasDataWarehouseSeries } = useValues(
         insightVizDataLogic(insightProps)
     )
+    const { baseCurrency } = useValues(teamLogic)
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const valueRef = useBoldNumberTooltip({
@@ -160,7 +163,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
                 onMouseEnter={() => setIsTooltipShown(true)}
             >
                 <Textfit min={32} max={64}>
-                    {formatAggregationAxisValue(trendsFilter, resultSeries.aggregated_value)}
+                    {formatAggregationAxisValue(trendsFilter, resultSeries.aggregated_value, baseCurrency)}
                 </Textfit>
             </div>
             {showComparison && <BoldNumberComparison showPersonsModal={showPersonsModal} context={context} />}

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -96,7 +96,7 @@ export function InsightsTable({
         insightsTableDataLogic(insightProps)
     )
     const { setDetailedResultsAggregationType, toggleColumnPin } = useActions(insightsTableDataLogic(insightProps))
-    const { weekStartDay, timezone } = useValues(teamLogic)
+    const { weekStartDay, timezone, baseCurrency } = useValues(teamLogic)
     const [maxVisibleColumns, setMaxVisibleColumns] = useState(MAX_VALUE_COLUMNS)
 
     const handleSeriesEditClick = (item: IndexedTrendResult): void => {
@@ -341,8 +341,8 @@ export function InsightsTable({
     }
 
     const renderCount = useCallback(
-        (value: number) => formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value),
-        [trendsFilter]
+        (value: number) => formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value, baseCurrency),
+        [trendsFilter, baseCurrency]
     )
 
     const valueColumns: LemonTableColumn<IndexedTrendResult, any>[] = useMemo(() => {

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/AggregationColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/AggregationColumn.tsx
@@ -9,6 +9,7 @@ import { average, median } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { formatAggregationValue } from 'scenes/insights/utils'
+import { teamLogic } from 'scenes/teamLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -77,6 +78,7 @@ export function AggregationColumnItem({
     trendsFilter,
 }: AggregationColumnItemProps): JSX.Element {
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    const { baseCurrency } = useValues(teamLogic)
 
     let value: number | undefined = undefined
     if (aggregation === 'total' || isNonTimeSeriesDisplay) {
@@ -96,7 +98,8 @@ export function AggregationColumnItem({
                 ? formatAggregationValue(
                       item.action?.math_property,
                       value,
-                      (value) => formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value),
+                      (value) =>
+                          formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value, baseCurrency),
                       formatPropertyValueForDisplay
                   )
                 : 'Unknown'}

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -45,6 +45,7 @@ import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { createXAxisTickCallback } from 'scenes/insights/views/LineGraph/formatXAxisTick'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
 import { createTooltipData } from 'scenes/insights/views/LineGraph/tooltip-data'
+import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -294,6 +295,7 @@ export function LineGraph_({
     const { aggregationLabel } = useValues(groupsModel)
     const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { baseCurrency } = useValues(teamLogic)
 
     const { insightProps, insight } = useValues(insightLogic)
     const { timezone, isTrends, isFunnels, breakdownFilter, interval, insightData } = useValues(
@@ -456,7 +458,7 @@ export function LineGraph_({
         if (showPercentView) {
             return `${Number(value).toFixed(1)}%`
         }
-        return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView)
+        return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
     }
 
     function generateYaxesForLineGraph(
@@ -671,7 +673,8 @@ export function LineGraph_({
                             return formatPercentStackAxisValue(
                                 trendsFilter,
                                 percentageValue || value,
-                                isPercentStackView
+                                isPercentStackView,
+                                baseCurrency
                             )
                         },
                         borderWidth: 2,
@@ -810,14 +813,15 @@ export function LineGraph_({
                                                         if (originalValue !== undefined && originalValue !== null) {
                                                             return `${value.toFixed(1)}% (${formatAggregationAxisValue(
                                                                 trendsFilter,
-                                                                originalValue
+                                                                originalValue,
+                                                                baseCurrency
                                                             )})`
                                                         }
                                                     }
                                                 }
 
                                                 if (!isPercentStackView) {
-                                                    return formatAggregationAxisValue(trendsFilter, value)
+                                                    return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
                                                 }
 
                                                 const total = seriesData.reduce((a, b) => a + b.count, 0)
@@ -828,12 +832,13 @@ export function LineGraph_({
                                                 const isNaN = Number.isNaN(percentageLabel)
 
                                                 if (isNaN) {
-                                                    return formatAggregationAxisValue(trendsFilter, value)
+                                                    return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
                                                 }
 
                                                 return `${formatAggregationAxisValue(
                                                     trendsFilter,
-                                                    value
+                                                    value,
+                                                    baseCurrency
                                                 )} (${percentageLabel}%)`
                                             })
                                         }
@@ -939,7 +944,12 @@ export function LineGraph_({
                             display: !hideYAxis,
                             precision,
                             callback: (value) => {
-                                return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView)
+                                return formatPercentStackAxisValue(
+                                    trendsFilter,
+                                    value,
+                                    isPercentStackView,
+                                    baseCurrency
+                                )
                             },
                         },
                         grid: gridOptions,
@@ -996,7 +1006,12 @@ export function LineGraph_({
                             ...tickOptions,
                             precision,
                             callback: (value) => {
-                                return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView)
+                                return formatPercentStackAxisValue(
+                                    trendsFilter,
+                                    value,
+                                    isPercentStackView,
+                                    baseCurrency
+                                )
                             },
                         },
                         grid: gridOptions,

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -23,6 +23,7 @@ import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { LineGraphProps, onChartClick } from 'scenes/insights/views/LineGraph/LineGraph'
 import { createTooltipData } from 'scenes/insights/views/LineGraph/tooltip-data'
+import { teamLogic } from 'scenes/teamLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -70,6 +71,7 @@ export function PieChart({
     const { aggregationLabel } = useValues(groupsModel)
     const { highlightSeries } = useActions(insightLogic)
     const { getTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
+    const { baseCurrency } = useValues(teamLogic)
 
     const { canvasRef } = useChart<'pie'>({
         getConfig: () => {
@@ -154,7 +156,7 @@ export function PieChart({
                                     return `${percentage.toFixed(1)}%`
                                 }
 
-                                return formatAggregationAxisValue(trendsFilter, value)
+                                return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
                             },
                             font: {
                                 weight: 500,
@@ -238,7 +240,8 @@ export function PieChart({
                                                     )
                                                     return `${formatAggregationAxisValue(
                                                         trendsFilter,
-                                                        value
+                                                        value,
+                                                        baseCurrency
                                                     )} (${percentageLabel}%)`
                                                 })
                                             }

--- a/frontend/src/scenes/insights/views/RegionMap/RegionMap.tsx
+++ b/frontend/src/scenes/insights/views/RegionMap/RegionMap.tsx
@@ -10,6 +10,7 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -45,6 +46,7 @@ function useRegionMapTooltip(showPersonsModal: boolean): React.RefObject<HTMLDiv
     const { series, trendsFilter, breakdownFilter, isTooltipShown, currentTooltip, tooltipCoordinates } =
         useValues(logic)
     const { aggregationLabel } = useValues(groupsModel)
+    const { baseCurrency } = useValues(teamLogic)
 
     const containerRef = useRef<HTMLDivElement>(null)
     const { getTooltip } = useInsightTooltip()
@@ -84,7 +86,7 @@ function useRegionMapTooltip(showPersonsModal: boolean): React.RefObject<HTMLDiv
                         </div>
                     )
                 }
-                renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value)}</>}
+                renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value, baseCurrency)}</>}
                 showHeader={false}
                 hideColorCol
                 hideInspectActorsSection={!showPersonsModal || aggregatedValue === 0}

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -10,6 +10,7 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -32,6 +33,7 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
         worldMapLogic(insightProps)
     )
     const { aggregationLabel } = useValues(groupsModel)
+    const { baseCurrency } = useValues(teamLogic)
 
     const svgRef = useRef<SVGSVGElement>(null)
 
@@ -68,7 +70,9 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
                                     </div>
                                 )
                             }
-                            renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value)}</>}
+                            renderCount={(value: number) => (
+                                <>{formatAggregationAxisValue(trendsFilter, value, baseCurrency)}</>
+                            )}
                             showHeader={false}
                             hideColorCol
                             hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -7,6 +7,7 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
+import { teamLogic } from 'scenes/teamLogic'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
@@ -24,6 +25,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const { insightProps } = useValues(insightLogic)
+    const { baseCurrency } = useValues(teamLogic)
     const {
         indexedResults,
         labelGroupType,
@@ -139,7 +141,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
                     </div>
                     {showAggregation && (
                         <div className="text-7xl text-center font-bold m-0">
-                            {formatAggregationAxisValue(trendsFilter, total)}
+                            {formatAggregationAxisValue(trendsFilter, total, baseCurrency)}
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
## Problem

Currency values in insights are displayed using a generic currency formatter instead of respecting the team's configured base currency setting. This results in inconsistent currency formatting across different visualization types and components.

## Changes

- Added `baseCurrency` from `teamLogic` to all insight visualization components
- Updated `formatAggregationAxisValue` and `formatPercentStackAxisValue` functions to accept an optional `currency` parameter
- Modified currency formatting to use `formatCurrency` with the team's base currency when available, falling back to the generic `humanFriendlyCurrency` formatter
- Applied currency formatting consistently across:
  - Insight legend rows
  - Bold number displays
  - Insights tables and aggregation columns
  - Line graphs and pie charts
  - World map and region map visualizations
  - Actions pie charts

## How did you test this code?

As an agent, I have not manually tested this code. The changes maintain backward compatibility by making the currency parameter optional and providing fallback behavior. Unit tests should verify that currency formatting works correctly with different currency codes and falls back appropriately when no currency is provided.

## Publish to changelog?

No