### PR TITLE
fix: ensure feature flag lookups are scoped

### DIFF
--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -73,7 +73,11 @@ class OrganizationFeatureFlagView(
 
         # Fetch the flag to copy
         try:
-            flag_to_copy = FeatureFlag.objects.get(key=feature_flag_key, team__project_id=from_project)
+            flag_to_copy = FeatureFlag.objects.get(
+                key=feature_flag_key,
+                team__project_id=from_project,
+                team__organization_id=self.organization_id,
+            )
         except FeatureFlag.DoesNotExist:
             return Response({"error": "Feature flag to copy does not exist."}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -1161,6 +1161,7 @@
   INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE (NOT ("posthog_featureflag"."deleted")
          AND "posthog_featureflag"."key" = 'copied-flag-key'
+         AND "posthog_team"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
          AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''

--- a/posthog/api/test/test_organization_feature_flag.py
+++ b/posthog/api/test/test_organization_feature_flag.py
@@ -446,6 +446,24 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("error", response.json())
 
+    def test_copy_feature_flag_from_other_org_returns_not_found(self):
+        from posthog.models.organization import Organization
+
+        other_org = Organization.objects.create(name="other org")
+        other_team = Team.objects.create(organization=other_org)
+        FeatureFlag.objects.create(team=other_team, created_by=self.user, key="other-org-flag")
+
+        url = f"/api/organizations/{self.organization.id}/feature_flags/copy_flags"
+        data = {
+            "feature_flag_key": "other-org-flag",
+            "from_project": other_team.id,
+            "target_project_ids": [self.team_2.id],
+        }
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["error"], "Feature flag to copy does not exist.")
+
     def test_copy_feature_flag_to_nonexistent_target(self):
         url = f"/api/organizations/{self.organization.id}/feature_flags/copy_flags"
         nonexistent_project_id = 999


### PR DESCRIPTION
Previously we responded with a 403 on cross-org flag lookups, but now we always respond with 400.