### PR TITLE
feat(mcp): add LLM prompt CRUD tools

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -851,5 +851,65 @@
             "openWorldHint": false,
             "readOnlyHint": true
         }
+    },
+    "prompt-list": {
+        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns summary info (id, name, version, timestamps) without full prompt content.",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "List all team prompts.",
+        "title": "List prompts",
+        "required_scopes": ["llm_prompt:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "prompt-get": {
+        "description": "Get a specific LLM prompt by name, including its full content. Uses the cached endpoint for fast retrieval.",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "Get a prompt by name.",
+        "title": "Get prompt",
+        "required_scopes": ["llm_prompt:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "prompt-create": {
+        "description": "Create a new LLM prompt for the current team. Requires a unique name and prompt content (string or JSON object).",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "Create a new prompt.",
+        "title": "Create prompt",
+        "required_scopes": ["llm_prompt:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "prompt-update": {
+        "description": "Update the content of an existing LLM prompt by name. Looks up the prompt by name, then patches its content. Name is immutable after creation.",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "Update an existing prompt.",
+        "title": "Update prompt",
+        "required_scopes": ["llm_prompt:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
     }
 }

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -2075,6 +2075,51 @@
             },
             "required": ["projectId"]
         },
+        "PromptCreateSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Unique name (letters, numbers, hyphens, underscores only)"
+                },
+                "prompt": {
+                    "description": "The prompt content (string or JSON object)"
+                }
+            },
+            "required": ["name", "prompt"]
+        },
+        "PromptGetSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the prompt to retrieve"
+                }
+            },
+            "required": ["name"]
+        },
+        "PromptListSchema": {
+            "type": "object",
+            "properties": {
+                "search": {
+                    "description": "Filter prompts by name",
+                    "type": "string"
+                }
+            }
+        },
+        "PromptUpdateSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the prompt to update"
+                },
+                "prompt": {
+                    "description": "The updated prompt content"
+                }
+            },
+            "required": ["name", "prompt"]
+        },
         "QueryRunInputSchema": {
             "type": "object",
             "properties": {

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -2080,6 +2080,7 @@
             "properties": {
                 "name": {
                     "type": "string",
+                    "pattern": "^[a-zA-Z0-9_-]+$",
                     "description": "Unique name (letters, numbers, hyphens, underscores only)"
                 },
                 "prompt": {
@@ -2093,7 +2094,14 @@
             "properties": {
                 "name": {
                     "type": "string",
+                    "pattern": "^[a-zA-Z0-9_-]+$",
                     "description": "The name of the prompt to retrieve"
+                },
+                "version": {
+                    "description": "Specific version number to retrieve. Omit for latest",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                 }
             },
             "required": ["name"]
@@ -2112,13 +2120,20 @@
             "properties": {
                 "name": {
                     "type": "string",
+                    "pattern": "^[a-zA-Z0-9_-]+$",
                     "description": "The name of the prompt to update"
                 },
                 "prompt": {
                     "description": "The updated prompt content"
+                },
+                "base_version": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991,
+                    "description": "The version number you are basing this update on (for conflict detection)"
                 }
             },
-            "required": ["name", "prompt"]
+            "required": ["name", "prompt", "base_version"]
         },
         "QueryRunInputSchema": {
             "type": "object",

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -86,6 +86,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'hog_flow:read',
     'insight:read',
     'insight:write',
+    'llm_prompt:read',
+    'llm_prompt:write',
     'logs:read',
     'organization:read',
     'project:read',

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -486,18 +486,28 @@ export const PromptListSchema = z.object({
     search: z.string().optional().describe('Filter prompts by name'),
 })
 
+const PromptNameSchema = z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+$/, 'Name must only contain letters, numbers, hyphens, or underscores')
+
 export const PromptGetSchema = z.object({
-    name: z.string().describe('The name of the prompt to retrieve'),
+    name: PromptNameSchema.describe('The name of the prompt to retrieve'),
+    version: z.number().int().positive().optional().describe('Specific version number to retrieve. Omit for latest'),
 })
 
 export const PromptCreateSchema = z.object({
-    name: z.string().describe('Unique name (letters, numbers, hyphens, underscores only)'),
+    name: PromptNameSchema.describe('Unique name (letters, numbers, hyphens, underscores only)'),
     prompt: z.any().describe('The prompt content (string or JSON object)'),
 })
 
 export const PromptUpdateSchema = z.object({
-    name: z.string().describe('The name of the prompt to update'),
+    name: PromptNameSchema.describe('The name of the prompt to update'),
     prompt: z.any().describe('The updated prompt content'),
+    base_version: z
+        .number()
+        .int()
+        .positive()
+        .describe('The version number you are basing this update on (for conflict detection)'),
 })
 
 // PostHog AI tools

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -481,6 +481,25 @@ export const DemoMcpUiAppsSchema = z.object({
     message: z.string().optional().describe('Optional message to include in the demo data'),
 })
 
+// Prompts
+export const PromptListSchema = z.object({
+    search: z.string().optional().describe('Filter prompts by name'),
+})
+
+export const PromptGetSchema = z.object({
+    name: z.string().describe('The name of the prompt to retrieve'),
+})
+
+export const PromptCreateSchema = z.object({
+    name: z.string().describe('Unique name (letters, numbers, hyphens, underscores only)'),
+    prompt: z.any().describe('The prompt content (string or JSON object)'),
+})
+
+export const PromptUpdateSchema = z.object({
+    name: z.string().describe('The name of the prompt to update'),
+    prompt: z.any().describe('The updated prompt content'),
+})
+
 // PostHog AI tools
 export const ExecuteSQLSchema = z.object({
     query: z.string().min(1).describe('The final SQL query to be executed.'),

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -62,6 +62,11 @@ import getProjects from './projects/getProjects'
 import getProperties from './projects/propertyDefinitions'
 import setActiveProject from './projects/setActive'
 import updateEventDefinition from './projects/updateEventDefinition'
+// Prompts
+import createPrompt from './prompts/create'
+import getPrompt from './prompts/get'
+import listPrompts from './prompts/list'
+import updatePrompt from './prompts/update'
 // Query
 import generateHogQLFromQuestion from './query/generateHogQLFromQuestion'
 import queryRun from './query/run'
@@ -170,6 +175,12 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Demo
     'demo-mcp-ui-apps': demoMcpUiApps,
+
+    // Prompts
+    'prompt-list': listPrompts,
+    'prompt-get': getPrompt,
+    'prompt-create': createPrompt,
+    'prompt-update': updatePrompt,
 
     // PostHog AI tools
     'execute-sql': executeSql,

--- a/services/mcp/src/tools/prompts/api.ts
+++ b/services/mcp/src/tools/prompts/api.ts
@@ -1,0 +1,19 @@
+import type { Context } from '@/tools/types'
+
+interface PromptApiOptions {
+    method?: 'GET' | 'POST' | 'PATCH'
+    body?: Record<string, unknown>
+    query?: Record<string, string>
+}
+
+export async function promptFetch<T = unknown>(context: Context, path: string, options?: PromptApiOptions): Promise<T> {
+    const projectId = await context.stateManager.getProjectId()
+    const basePath = `/api/environments/${projectId}/llm_prompts${path}`
+
+    return context.api.request<T>({
+        method: options?.method ?? 'GET',
+        path: basePath,
+        ...(options?.body ? { body: options.body } : {}),
+        ...(options?.query ? { query: options.query } : {}),
+    })
+}

--- a/services/mcp/src/tools/prompts/create.ts
+++ b/services/mcp/src/tools/prompts/create.ts
@@ -1,0 +1,25 @@
+import type { z } from 'zod'
+
+import { PromptCreateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { promptFetch } from './api'
+
+const schema = PromptCreateSchema
+
+type Params = z.infer<typeof schema>
+
+export const createHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    return promptFetch(context, '/', {
+        method: 'POST',
+        body: { name: params.name, prompt: params.prompt },
+    })
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'prompt-create',
+    schema,
+    handler: createHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/prompts/get.ts
+++ b/services/mcp/src/tools/prompts/get.ts
@@ -1,0 +1,22 @@
+import type { z } from 'zod'
+
+import { PromptGetSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { promptFetch } from './api'
+
+const schema = PromptGetSchema
+
+type Params = z.infer<typeof schema>
+
+export const getHandler: ToolBase<typeof schema>['handler'] = async (context: Context, { name }: Params) => {
+    return promptFetch(context, `/name/${name}/`)
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'prompt-get',
+    schema,
+    handler: getHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/prompts/get.ts
+++ b/services/mcp/src/tools/prompts/get.ts
@@ -9,8 +9,12 @@ const schema = PromptGetSchema
 
 type Params = z.infer<typeof schema>
 
-export const getHandler: ToolBase<typeof schema>['handler'] = async (context: Context, { name }: Params) => {
-    return promptFetch(context, `/name/${name}/`)
+export const getHandler: ToolBase<typeof schema>['handler'] = async (context: Context, { name, version }: Params) => {
+    const query: Record<string, string> = {}
+    if (version !== undefined) {
+        query.version = version.toString()
+    }
+    return promptFetch(context, `/name/${name}/`, { query })
 }
 
 const tool = (): ToolBase<typeof schema> => ({

--- a/services/mcp/src/tools/prompts/list.ts
+++ b/services/mcp/src/tools/prompts/list.ts
@@ -15,9 +15,19 @@ export const listHandler: ToolBase<typeof schema>['handler'] = async (context: C
         query.search = params.search
     }
 
-    const result = await promptFetch<{ results: any[] }>(context, '/', { query })
+    interface PromptSummary {
+        id: number
+        name: string
+        version: number
+        latest_version: number
+        version_count: number
+        created_at: string
+        updated_at: string
+    }
 
-    return (result.results ?? []).map((p: any) => ({
+    const result = await promptFetch<{ results: PromptSummary[] }>(context, '/', { query })
+
+    return (result.results ?? []).map((p) => ({
         id: p.id,
         name: p.name,
         version: p.version,

--- a/services/mcp/src/tools/prompts/list.ts
+++ b/services/mcp/src/tools/prompts/list.ts
@@ -17,10 +17,12 @@ export const listHandler: ToolBase<typeof schema>['handler'] = async (context: C
 
     const result = await promptFetch<{ results: any[] }>(context, '/', { query })
 
-    return (result.results ?? result).map((p: any) => ({
+    return (result.results ?? []).map((p: any) => ({
         id: p.id,
         name: p.name,
         version: p.version,
+        latest_version: p.latest_version,
+        version_count: p.version_count,
         created_at: p.created_at,
         updated_at: p.updated_at,
     }))

--- a/services/mcp/src/tools/prompts/list.ts
+++ b/services/mcp/src/tools/prompts/list.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod'
+
+import { PromptListSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { promptFetch } from './api'
+
+const schema = PromptListSchema
+
+type Params = z.infer<typeof schema>
+
+export const listHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const query: Record<string, string> = {}
+    if (params.search) {
+        query.search = params.search
+    }
+
+    const result = await promptFetch<{ results: any[] }>(context, '/', { query })
+
+    return (result.results ?? result).map((p: any) => ({
+        id: p.id,
+        name: p.name,
+        version: p.version,
+        created_at: p.created_at,
+        updated_at: p.updated_at,
+    }))
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'prompt-list',
+    schema,
+    handler: listHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/prompts/update.ts
+++ b/services/mcp/src/tools/prompts/update.ts
@@ -1,0 +1,26 @@
+import type { z } from 'zod'
+
+import { PromptUpdateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { promptFetch } from './api'
+
+const schema = PromptUpdateSchema
+
+type Params = z.infer<typeof schema>
+
+export const updateHandler: ToolBase<typeof schema>['handler'] = async (context: Context, { name, prompt }: Params) => {
+    const existing = await promptFetch<{ id: number }>(context, `/name/${name}/`)
+    return promptFetch(context, `/${existing.id}/`, {
+        method: 'PATCH',
+        body: { prompt },
+    })
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'prompt-update',
+    schema,
+    handler: updateHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/prompts/update.ts
+++ b/services/mcp/src/tools/prompts/update.ts
@@ -9,11 +9,13 @@ const schema = PromptUpdateSchema
 
 type Params = z.infer<typeof schema>
 
-export const updateHandler: ToolBase<typeof schema>['handler'] = async (context: Context, { name, prompt }: Params) => {
-    const existing = await promptFetch<{ id: number }>(context, `/name/${name}/`)
-    return promptFetch(context, `/${existing.id}/`, {
+export const updateHandler: ToolBase<typeof schema>['handler'] = async (
+    context: Context,
+    { name, prompt, base_version }: Params
+) => {
+    return promptFetch(context, `/name/${name}/`, {
         method: 'PATCH',
-        body: { prompt },
+        body: { prompt, base_version },
     })
 }
 


### PR DESCRIPTION
## Problem

MCP-connected agent surfaces (Claude Code, Cursor, etc.) have no way to read or manage team-scoped LLM prompts stored in PostHog. This means shared prompts/skills can only be managed through the web UI, not programmatically from agent workflows.

## Changes

Adds 4 MCP tools in `services/mcp/src/tools/prompts/` that wire directly to the existing LLM prompts API (with versioning support from #49900):

| Tool | Action | Endpoint |
|------|--------|----------|
| `prompt-list` | List team prompts (optional search) | `GET /api/environments/{id}/llm_prompts/` |
| `prompt-get` | Get prompt by name (optional version) | `GET /api/environments/{id}/llm_prompts/name/{name}/?version=N` |
| `prompt-create` | Create a new prompt (version 1) | `POST /api/environments/{id}/llm_prompts/` |
| `prompt-update` | Publish a new version (with conflict detection) | `PATCH /api/environments/{id}/llm_prompts/name/{name}/` |

Also:
- Adds Zod input schemas for all 4 tools
- Adds tool definitions with category "Prompts" and `llm_prompt:read`/`llm_prompt:write` scopes
- Registers `llm_prompt:read` and `llm_prompt:write` in `OAUTH_SCOPES_SUPPORTED`

No new Django models or API changes -- this reuses the existing `LLMPrompt` model and REST API from LLM Analytics prompt management.

### Versioning integration

- `prompt-get` supports optional `version` param to fetch a specific version (defaults to latest)
- `prompt-update` requires `base_version` for optimistic concurrency -- rejects with 409 if the prompt was updated since you last fetched it
- `prompt-list` returns `latest_version` and `version_count` metadata

## How did you test this code?

- `tsc --noEmit` passes clean
- `pnpm test` -- all 171 tests pass (including scope completeness check)
- Tested locally with `wrangler dev` connected to local PostHog Django:
  - `prompt-list` returns empty array, then shows created prompts
  - `prompt-create` creates prompts successfully
  - `prompt-get` retrieves full prompt by name
  - `prompt-update` publishes new version with conflict detection
- End-to-end test: created a Claude Code skill that discovers and runs prompts stored in PostHog via these MCP tools

## Publish to changelog?

no