### PR TITLE
chore(replay): add Prometheus metrics for delete-recordings workflows

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -14,6 +14,11 @@ from posthog.temporal.common.combined_metrics_server import CombinedMetricsServe
 from posthog.temporal.common.liveness_tracker import LivenessInterceptor
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
+from posthog.temporal.delete_recordings.metrics import (
+    DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS,
+    DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
+    DeleteRecordingsMetricsInterceptor,
+)
 from posthog.temporal.llm_analytics.metrics import EvalsMetricsInterceptor
 from posthog.temporal.llm_analytics.sentiment.metrics import (
     SENTIMENT_LATENCY_HISTOGRAM_BUCKETS,
@@ -223,6 +228,12 @@ async def create_worker(
                         itertools.repeat(SENTIMENT_LATENCY_HISTOGRAM_BUCKETS),
                     )
                 )
+                | dict(
+                    zip(
+                        DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
+                        itertools.repeat(DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS),
+                    )
+                )
                 | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},
             ),
         )
@@ -250,6 +261,7 @@ async def create_worker(
                 LivenessInterceptor(),
                 PostHogClientInterceptor(),
                 BatchExportsMetricsInterceptor(),
+                DeleteRecordingsMetricsInterceptor(),
                 EvalsMetricsInterceptor(),
                 SummarizationMetricsInterceptor(),
                 ClusteringMetricsInterceptor(),
@@ -278,6 +290,7 @@ async def create_worker(
                 LivenessInterceptor(),
                 PostHogClientInterceptor(),
                 BatchExportsMetricsInterceptor(),
+                DeleteRecordingsMetricsInterceptor(),
                 EvalsMetricsInterceptor(),
                 SummarizationMetricsInterceptor(),
                 ClusteringMetricsInterceptor(),

--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -1,0 +1,162 @@
+import typing
+import datetime as dt
+
+from temporalio import activity, workflow
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+from posthog.temporal.llm_analytics.metrics import ExecutionTimeRecorder, get_metric_meter
+
+# ---------------------------------------------------------------------------
+# Histogram bucket config (imported by common/worker.py for PrometheusConfig)
+# ---------------------------------------------------------------------------
+
+DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS = (
+    "delete_recordings_activity_execution_latency",
+    "delete_recordings_activity_schedule_to_start_latency",
+    "delete_recordings_workflow_execution_latency",
+)
+DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS = [
+    1_000.0,  # 1 second
+    5_000.0,  # 5 seconds
+    10_000.0,  # 10 seconds
+    30_000.0,  # 30 seconds
+    60_000.0,  # 1 minute
+    120_000.0,  # 2 minutes
+    300_000.0,  # 5 minutes
+    600_000.0,  # 10 minutes
+    1_800_000.0,  # 30 minutes
+    3_600_000.0,  # 1 hour
+]
+
+# ---------------------------------------------------------------------------
+# Activity / workflow type sets for the interceptor
+# ---------------------------------------------------------------------------
+
+DELETE_RECORDINGS_ACTIVITY_TYPES = {
+    "load-recordings-with-person",
+    "load-recordings-with-team-id",
+    "load-recordings-with-query",
+    "load-session-id-chunk",
+    "cleanup-session-id-chunks",
+    "delete-recordings",
+    "purge-deleted-metadata",
+}
+
+DELETE_RECORDINGS_WORKFLOW_TYPES = {
+    "delete-recordings-with-person",
+    "delete-recordings-with-team",
+    "delete-recordings-with-query",
+    "delete-recordings-with-session-ids",
+    "purge-deleted-recording-metadata",
+}
+
+# ---------------------------------------------------------------------------
+# Counter helpers (called from workflow code)
+# ---------------------------------------------------------------------------
+
+
+def increment_recordings_deleted(count: int) -> None:
+    if count <= 0:
+        return
+    meter = get_metric_meter()
+    meter.create_counter(
+        "delete_recordings_total_deleted",
+        "Total recordings successfully deleted",
+    ).add(count)
+
+
+def increment_recordings_failed(count: int) -> None:
+    if count <= 0:
+        return
+    meter = get_metric_meter()
+    meter.create_counter(
+        "delete_recordings_total_failed",
+        "Total recordings that failed to delete",
+    ).add(count)
+
+
+# ---------------------------------------------------------------------------
+# Interceptor
+# ---------------------------------------------------------------------------
+
+
+class DeleteRecordingsMetricsInterceptor(Interceptor):
+    def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
+        return _DeleteRecordingsActivityInterceptor(super().intercept_activity(next))
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> type[WorkflowInboundInterceptor] | None:
+        return _DeleteRecordingsWorkflowInterceptor
+
+
+class _DeleteRecordingsActivityInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
+        activity_info = activity.info()
+        activity_type = activity_info.activity_type
+
+        if activity_type not in DELETE_RECORDINGS_ACTIVITY_TYPES:
+            return await super().execute_activity(input)
+
+        scheduled_time = activity_info.scheduled_time
+        started_time = activity_info.started_time
+        if scheduled_time and started_time:
+            schedule_to_start_ms = int((started_time - scheduled_time).total_seconds() * 1000)
+            meter = get_metric_meter({"activity_type": activity_type})
+            meter.create_histogram_timedelta(
+                name="delete_recordings_activity_schedule_to_start_latency",
+                description="Time between activity scheduling and start",
+                unit="ms",
+            ).record(dt.timedelta(milliseconds=schedule_to_start_ms))
+
+        with ExecutionTimeRecorder(
+            "delete_recordings_activity_execution_latency",
+            description="Execution latency for delete-recordings activities",
+            histogram_attributes={"activity_type": activity_type},
+        ):
+            return await super().execute_activity(input)
+
+
+class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> typing.Any:
+        workflow_info = workflow.info()
+        workflow_type = workflow_info.workflow_type
+
+        if workflow_type not in DELETE_RECORDINGS_WORKFLOW_TYPES:
+            return await super().execute_workflow(input)
+
+        meter = get_metric_meter({"workflow_type": workflow_type})
+        meter.create_counter(
+            "delete_recordings_workflow_started",
+            "Delete-recordings workflows started",
+        ).add(1)
+
+        with ExecutionTimeRecorder(
+            "delete_recordings_workflow_execution_latency",
+            description="End-to-end workflow execution latency",
+            histogram_attributes={"workflow_type": workflow_type},
+        ):
+            status = "completed"
+            try:
+                result = await super().execute_workflow(input)
+                meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
+                meter.create_counter(
+                    "delete_recordings_workflow_finished",
+                    "Delete-recordings workflows finished",
+                ).add(1)
+                return result
+            except Exception:
+                status = "failed"
+                meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
+                meter.create_counter(
+                    "delete_recordings_workflow_finished",
+                    "Delete-recordings workflows finished",
+                ).add(1)
+                raise

--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -143,7 +143,7 @@ class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
             description="End-to-end workflow execution latency",
             histogram_attributes={"workflow_type": workflow_type},
         ):
-            status = "completed"
+            status = "COMPLETED"
             try:
                 result = await super().execute_workflow(input)
                 meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
@@ -153,7 +153,7 @@ class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
                 ).add(1)
                 return result
             except Exception:
-                status = "failed"
+                status = "FAILED"
                 meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
                 meter.create_counter(
                     "delete_recordings_workflow_finished",

--- a/posthog/temporal/delete_recordings/workflows.py
+++ b/posthog/temporal/delete_recordings/workflows.py
@@ -16,6 +16,7 @@ from posthog.temporal.delete_recordings.activities import (
     load_session_id_chunk,
     purge_deleted_metadata,
 )
+from posthog.temporal.delete_recordings.metrics import increment_recordings_deleted, increment_recordings_failed
 from posthog.temporal.delete_recordings.types import (
     CleanupChunksInput,
     DeleteRecordingsInput,
@@ -60,6 +61,8 @@ async def _delete_page(
             )
             progress.total_deleted += len(result.deleted)
             progress.total_failed += result.failed_count
+            increment_recordings_deleted(len(result.deleted))
+            increment_recordings_failed(result.failed_count)
 
             if config.max_deletions_per_second > 0:
                 elapsed = (workflow.now() - batch_start).total_seconds()

--- a/posthog/temporal/tests/delete_recordings/test_metrics.py
+++ b/posthog/temporal/tests/delete_recordings/test_metrics.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.temporal.delete_recordings.metrics import (
+    DELETE_RECORDINGS_ACTIVITY_TYPES,
+    DELETE_RECORDINGS_WORKFLOW_TYPES,
+    DeleteRecordingsMetricsInterceptor,
+    increment_recordings_deleted,
+    increment_recordings_failed,
+)
+
+
+class TestTypesSets:
+    @parameterized.expand(
+        [
+            ("load-recordings-with-person",),
+            ("load-recordings-with-team-id",),
+            ("load-recordings-with-query",),
+            ("load-session-id-chunk",),
+            ("cleanup-session-id-chunks",),
+            ("delete-recordings",),
+            ("purge-deleted-metadata",),
+        ]
+    )
+    def test_activity_types(self, activity_type):
+        assert activity_type in DELETE_RECORDINGS_ACTIVITY_TYPES
+
+    @parameterized.expand(
+        [
+            ("delete-recordings-with-person",),
+            ("delete-recordings-with-team",),
+            ("delete-recordings-with-query",),
+            ("delete-recordings-with-session-ids",),
+            ("purge-deleted-recording-metadata",),
+        ]
+    )
+    def test_workflow_types(self, workflow_type):
+        assert workflow_type in DELETE_RECORDINGS_WORKFLOW_TYPES
+
+
+class TestCounterHelpers:
+    @parameterized.expand(
+        [
+            ("deleted", increment_recordings_deleted, 5),
+            ("failed", increment_recordings_failed, 3),
+        ]
+    )
+    def test_counter_emits_in_temporal_context(self, _name, fn, count):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+
+        with patch(
+            "posthog.temporal.delete_recordings.metrics.get_metric_meter",
+            return_value=mock_meter,
+        ):
+            fn(count)
+
+        mock_counter.add.assert_called_once_with(count)
+
+    @parameterized.expand(
+        [
+            ("deleted_zero", increment_recordings_deleted, 0),
+            ("deleted_negative", increment_recordings_deleted, -1),
+            ("failed_zero", increment_recordings_failed, 0),
+            ("failed_negative", increment_recordings_failed, -1),
+        ]
+    )
+    def test_counter_noops_for_non_positive(self, _name, fn, count):
+        with patch(
+            "posthog.temporal.delete_recordings.metrics.get_metric_meter",
+        ) as mock_get_meter:
+            fn(count)
+            mock_get_meter.assert_not_called()
+
+
+class TestInterceptorStructure:
+    def test_creates_activity_interceptor(self):
+        interceptor = DeleteRecordingsMetricsInterceptor()
+        result = interceptor.intercept_activity(MagicMock())
+        assert result is not None
+
+    def test_returns_workflow_interceptor_class(self):
+        interceptor = DeleteRecordingsMetricsInterceptor()
+        result = interceptor.workflow_interceptor_class(MagicMock())
+        assert result is not None


### PR DESCRIPTION
## Summary

- Adds a metrics interceptor for delete-recordings Temporal workflows, following the same pattern as batch exports, LLM analytics clustering, etc.
- Emits workflow started/finished counters (with `workflow_type` and `status` labels), execution latency histograms, activity latency histograms, and schedule-to-start latency
- Adds manual counters for `delete_recordings_total_deleted` and `delete_recordings_total_failed` in the `_delete_page` helper

## Metrics

| Metric | Type | Labels |
|---|---|---|
| `delete_recordings_workflow_started` | Counter | `workflow_type` |
| `delete_recordings_workflow_finished` | Counter | `workflow_type`, `status` |
| `delete_recordings_workflow_execution_latency` | Histogram | `workflow_type`, `status` |
| `delete_recordings_activity_execution_latency` | Histogram | `activity_type`, `status` |
| `delete_recordings_activity_schedule_to_start_latency` | Histogram | `activity_type` |
| `delete_recordings_total_deleted` | Counter | — |
| `delete_recordings_total_failed` | Counter | — |

## Next steps (after deploy)

- Add Grafana dashboard panels for workflow throughput, success rate, and latency
- Add alert rule: fire when success rate is 0% for 30min while workflows are actively running

## Test plan

- [x] New unit tests for metrics module (20 tests passing)
- [x] Existing workflow tests still pass (27 tests)
- [ ] After deploy, trigger a test deletion and verify metrics on worker `/metrics` endpoint