### PR TITLE
chore(workflows): clarify wait until condition and conversion goals

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -40,6 +40,7 @@ export interface PropertyFiltersProps {
     addText?: string | null
     editable?: boolean
     buttonText?: string
+    buttonClassName?: string
     buttonSize?: 'xsmall' | 'small' | 'medium'
     hasRowOperator?: boolean
     sendAllKeyUpdates?: boolean
@@ -75,6 +76,7 @@ export function PropertyFilters({
     propertyGroupType = null,
     addText = null,
     buttonText = 'Filter',
+    buttonClassName = '',
     editable = true,
     buttonSize,
     hasRowOperator = true,
@@ -135,6 +137,7 @@ export function PropertyFilters({
                                     showConditionBadge={showConditionBadge}
                                     disablePopover={disablePopover || orFiltering}
                                     label={buttonText}
+                                    labelClassName={buttonClassName}
                                     size={buttonSize}
                                     onRemove={remove}
                                     orFiltering={orFiltering}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -120,7 +120,11 @@ export function PropertyFilters({
                         return (
                             <React.Fragment key={displayedFilterIds[index]}>
                                 {logicalRowDivider && index > 0 && index !== displayedFilters.length - 1 && (
-                                    <LogicalRowDivider logicalOperator={FilterLogicalOperator.And} />
+                                    <LogicalRowDivider
+                                        logicalOperator={
+                                            orFiltering ? FilterLogicalOperator.Or : FilterLogicalOperator.And
+                                        }
+                                    />
                                 )}
                                 <FilterRow
                                     item={item}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -122,11 +122,7 @@ export function PropertyFilters({
                         return (
                             <React.Fragment key={displayedFilterIds[index]}>
                                 {logicalRowDivider && index > 0 && index !== displayedFilters.length - 1 && (
-                                    <LogicalRowDivider
-                                        logicalOperator={
-                                            orFiltering ? FilterLogicalOperator.Or : FilterLogicalOperator.And
-                                        }
-                                    />
+                                    <LogicalRowDivider logicalOperator={FilterLogicalOperator.And} />
                                 )}
                                 <FilterRow
                                     item={item}

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -44,6 +44,7 @@ export const FilterRow = React.memo(function FilterRow({
     openOnInsert = false,
     filterComponent,
     label,
+    labelClassName,
     onRemove,
     orFiltering,
     errorMessage,
@@ -106,7 +107,7 @@ export const FilterRow = React.memo(function FilterRow({
                         ) : !disabledReason ? (
                             <LemonButton
                                 onClick={() => setOpen(!open)}
-                                className="new-prop-filter grow"
+                                className={clsx('new-prop-filter grow', labelClassName)}
                                 data-attr={'new-prop-filter-' + pageKey}
                                 type="secondary"
                                 size={size}

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -24,6 +24,7 @@ interface FilterRowProps {
     disablePopover?: boolean
     filterComponent: (onComplete: () => void) => JSX.Element
     label: string
+    labelClassName?: string
     openOnInsert?: boolean
     onRemove: (index: number) => void
     orFiltering?: boolean
@@ -44,7 +45,7 @@ export const FilterRow = React.memo(function FilterRow({
     openOnInsert = false,
     filterComponent,
     label,
-    labelClassName,
+    labelClassName = '',
     onRemove,
     orFiltering,
     errorMessage,

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -298,10 +298,7 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
         if conversion is not None:
             filters = conversion.get("filters")
             if filters:
-                serializer = HogFunctionFiltersSerializer(
-                    data={"properties": filters},
-                    context={**self.context, "property_combiner": "OR"},
-                )
+                serializer = HogFunctionFiltersSerializer(data={"properties": filters}, context=self.context)
                 if self.context.get("is_draft"):
                     if serializer.is_valid():
                         compiled_filters = serializer.validated_data

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -298,7 +298,10 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
         if conversion is not None:
             filters = conversion.get("filters")
             if filters:
-                serializer = HogFunctionFiltersSerializer(data={"properties": filters}, context=self.context)
+                serializer = HogFunctionFiltersSerializer(
+                    data={"properties": filters},
+                    context={**self.context, "property_combiner": "OR"},
+                )
                 if self.context.get("is_draft"):
                     if serializer.is_valid():
                         compiled_filters = serializer.validated_data

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -725,7 +725,7 @@ function ConversionGoalSection(): JSX.Element {
                 <div className="flex flex-col gap-1 items-start">
                     <LemonLabel>Detect conversion from property changes</LemonLabel>
                     <PropertyFilters
-                        buttonText="Add property conversion"
+                        addText="Add property conversion"
                         propertyFilters={workflow.conversion?.filters ?? []}
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.PersonProperties,
@@ -746,8 +746,9 @@ function ConversionGoalSection(): JSX.Element {
                         <LemonTag>Coming soon</LemonTag>
                     </LemonLabel>
                     <LemonButton
+                        className="ml-10"
                         type="secondary"
-                        size="small"
+                        size="medium"
                         icon={<IconPlusSmall />}
                         onClick={() => {
                             posthog.capture('workflows workflow event conversion clicked')

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -706,21 +706,9 @@ function FrequencySection(): JSX.Element {
     )
 }
 
-function conversionUsesAndLogic(conversion: { filters?: any[]; bytecode?: (string | number)[] } | undefined): boolean {
-    const filters = conversion?.filters
-    const bytecode = conversion?.bytecode
-    if (!filters || filters.length <= 1 || !bytecode || bytecode.length < 2) {
-        return false
-    }
-    // Hog bytecode AND opcode is 3, appearing as second-to-last element followed by the operand count
-    return bytecode[bytecode.length - 2] === 3 && bytecode[bytecode.length - 1] === filters.length
-}
-
 function ConversionGoalSection(): JSX.Element {
     const { setWorkflowValue } = useActions(workflowLogic)
     const { workflow } = useValues(workflowLogic)
-
-    const useOrFiltering = !conversionUsesAndLogic(workflow.conversion)
 
     return (
         <div className="flex flex-col py-2 w-full">
@@ -729,10 +717,8 @@ function ConversionGoalSection(): JSX.Element {
                 <span className="text-md font-semibold">Conversion goal (optional)</span>
             </span>
             <p>
-                Define what a user must do to be considered converted.{' '}
-                {useOrFiltering
-                    ? 'If any condition is met, the user will be considered converted.'
-                    : 'All conditions must be met for the user to be considered converted.'}
+                Define what a user must do to be considered converted. All conditions must be met for the user to be
+                considered converted.
             </p>
 
             <div className="flex flex-col gap-4 max-w-240">
@@ -749,7 +735,6 @@ function ConversionGoalSection(): JSX.Element {
                         pageKey="workflow-conversion-properties"
                         hideBehavioralCohorts
                         operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
-                        orFiltering={useOrFiltering}
                         logicalRowDivider
                     />
                 </div>

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -721,11 +721,12 @@ function ConversionGoalSection(): JSX.Element {
                 considered converted.
             </p>
 
-            <div className="flex flex-col gap-4 max-w-240">
+            <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1 items-start">
                     <LemonLabel>Detect conversion from property changes</LemonLabel>
                     <PropertyFilters
                         buttonText="Add property conversion"
+                        buttonClassName="grow-0"
                         propertyFilters={workflow.conversion?.filters ?? []}
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.PersonProperties,

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -716,7 +716,10 @@ function ConversionGoalSection(): JSX.Element {
                 <IconTarget className="text-lg" />
                 <span className="text-md font-semibold">Conversion goal (optional)</span>
             </span>
-            <p>Define what a user must do to be considered converted.</p>
+            <p>
+                Define what a user must do to be considered converted. If any condition is met, the user will be
+                considered converted.
+            </p>
 
             <div className="flex flex-col gap-4 max-w-240">
                 <div className="flex flex-col gap-1 items-start">
@@ -732,6 +735,7 @@ function ConversionGoalSection(): JSX.Element {
                         pageKey="workflow-conversion-properties"
                         hideBehavioralCohorts
                         operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
+                        orFiltering
                     />
                 </div>
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -725,7 +725,7 @@ function ConversionGoalSection(): JSX.Element {
                 <div className="flex flex-col gap-1 items-start">
                     <LemonLabel>Detect conversion from property changes</LemonLabel>
                     <PropertyFilters
-                        addText="Add property conversion"
+                        buttonText="Add property conversion"
                         propertyFilters={workflow.conversion?.filters ?? []}
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.PersonProperties,
@@ -745,9 +745,7 @@ function ConversionGoalSection(): JSX.Element {
                         <LemonTag>Coming soon</LemonTag>
                     </LemonLabel>
                     <LemonButton
-                        className="ml-10"
                         type="secondary"
-                        size="medium"
                         icon={<IconPlusSmall />}
                         onClick={() => {
                             posthog.capture('workflows workflow event conversion clicked')

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -736,6 +736,7 @@ function ConversionGoalSection(): JSX.Element {
                         hideBehavioralCohorts
                         operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
                         orFiltering
+                        logicalRowDivider
                     />
                 </div>
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -706,9 +706,21 @@ function FrequencySection(): JSX.Element {
     )
 }
 
+function conversionUsesAndLogic(conversion: { filters?: any[]; bytecode?: (string | number)[] } | undefined): boolean {
+    const filters = conversion?.filters
+    const bytecode = conversion?.bytecode
+    if (!filters || filters.length <= 1 || !bytecode || bytecode.length < 2) {
+        return false
+    }
+    // Hog bytecode AND opcode is 3, appearing as second-to-last element followed by the operand count
+    return bytecode[bytecode.length - 2] === 3 && bytecode[bytecode.length - 1] === filters.length
+}
+
 function ConversionGoalSection(): JSX.Element {
     const { setWorkflowValue } = useActions(workflowLogic)
     const { workflow } = useValues(workflowLogic)
+
+    const useOrFiltering = !conversionUsesAndLogic(workflow.conversion)
 
     return (
         <div className="flex flex-col py-2 w-full">
@@ -717,8 +729,10 @@ function ConversionGoalSection(): JSX.Element {
                 <span className="text-md font-semibold">Conversion goal (optional)</span>
             </span>
             <p>
-                Define what a user must do to be considered converted. If any condition is met, the user will be
-                considered converted.
+                Define what a user must do to be considered converted.{' '}
+                {useOrFiltering
+                    ? 'If any condition is met, the user will be considered converted.'
+                    : 'All conditions must be met for the user to be considered converted.'}
             </p>
 
             <div className="flex flex-col gap-4 max-w-240">
@@ -735,7 +749,7 @@ function ConversionGoalSection(): JSX.Element {
                         pageKey="workflow-conversion-properties"
                         hideBehavioralCohorts
                         operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
-                        orFiltering
+                        orFiltering={useOrFiltering}
                         logicalRowDivider
                     />
                 </div>

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -31,7 +31,7 @@ export function StepWaitUntilConditionConfiguration({
             <StepSchemaErrors />
 
             <div className="flex flex-col gap-1">
-                <LemonLabel>Wait time</LemonLabel>
+                <LemonLabel>Condition check frequency</LemonLabel>
                 <HogFlowDuration
                     value={max_wait_duration}
                     onChange={(value) => {

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -49,7 +49,7 @@ export function StepWaitUntilConditionConfiguration({
             </div>
 
             <div className="flex flex-col gap-1">
-                <LemonLabel>Condition check frequency</LemonLabel>
+                <LemonLabel>Max time to wait for condition</LemonLabel>
                 <HogFlowDuration
                     value={max_wait_duration}
                     onChange={(value) => {

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -31,16 +31,6 @@ export function StepWaitUntilConditionConfiguration({
             <StepSchemaErrors />
 
             <div className="flex flex-col gap-1">
-                <LemonLabel>Condition check frequency</LemonLabel>
-                <HogFlowDuration
-                    value={max_wait_duration}
-                    onChange={(value) => {
-                        partialSetWorkflowActionConfig(action.id, { max_wait_duration: value })
-                    }}
-                />
-            </div>
-
-            <div className="flex flex-col gap-1">
                 <LemonLabel>Conditions to wait for</LemonLabel>
                 <LemonInput
                     value={localConditionName || ''}
@@ -55,6 +45,16 @@ export function StepWaitUntilConditionConfiguration({
                         partialSetWorkflowActionConfig(action.id, { condition: { ...condition, filters } })
                     }
                     typeKey="workflow-wait-until-condition"
+                />
+            </div>
+
+            <div className="flex flex-col gap-1">
+                <LemonLabel>Condition check frequency</LemonLabel>
+                <HogFlowDuration
+                    value={max_wait_duration}
+                    onChange={(value) => {
+                        partialSetWorkflowActionConfig(action.id, { max_wait_duration: value })
+                    }}
                 />
             </div>
         </>


### PR DESCRIPTION
## Problem

Addressing two recent customer confusions:
- "Wait time" not clear enough on the Wait until condition node
- Conversion goals being AND'd together is not called out well in the UX.

## Changes

- "Wait time" -> "Condition check frequency"
- callout AND logic

<img width="617" height="253" alt="image" src="https://github.com/user-attachments/assets/71bb116e-a5f9-4fac-ae7b-d3a978fbec7c" />

<img width="570" height="275" alt="image" src="https://github.com/user-attachments/assets/834a8ec9-bbf3-4946-aeb3-7c2f3bb6bd78" />



## How did you test this code?

Confirmed copy changes showing up as expected and bytecode being generated to OR conversion goal filters

## Publish to changelog?

No