### PR TITLE
fix(llma): handle malformed $ai_input in sentiment data fetching

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/data.py
+++ b/posthog/temporal/llm_analytics/sentiment/data.py
@@ -63,7 +63,10 @@ def fetch_generations(
         raw_ai_input = row[1]
         if isinstance(raw_ai_input, str):
             fetch.total_input_bytes += len(raw_ai_input.encode("utf-8"))
-            ai_input = json.loads(raw_ai_input)
+            try:
+                ai_input = json.loads(raw_ai_input)
+            except (json.JSONDecodeError, ValueError):
+                continue
         else:
             ai_input = raw_ai_input
         fetch.rows_by_trace.setdefault(row_trace_id, []).append((str(row[0]), ai_input))
@@ -110,7 +113,10 @@ def fetch_generations_by_uuid(
         raw_ai_input = row[1]
         if isinstance(raw_ai_input, str):
             total_input_bytes += len(raw_ai_input.encode("utf-8"))
-            ai_input = json.loads(raw_ai_input)
+            try:
+                ai_input = json.loads(raw_ai_input)
+            except (json.JSONDecodeError, ValueError):
+                continue
         else:
             ai_input = raw_ai_input
         rows.append((str(row[0]), ai_input))


### PR DESCRIPTION
## Summary
- Skip `$ai_generation` events with malformed (non-JSON) `$ai_input` instead of crashing the entire sentiment workflow
- Fixes both `fetch_generations` (trace-level) and `fetch_generations_by_uuid` (generation-level)

**Root cause:** Some SDKs/instrumentations send `$ai_input` values that aren't valid JSON. The bare `json.loads()` call crashes the Temporal activity with `JSONDecodeError`, failing the whole batch.

**Example failure:** https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/llma-sentiment-297697-1772665233932-83439089/72b9546e-fbad-4256-b4ce-6fc9a81346d9/timeline

## Test plan
- [ ] Verify sentiment still works for valid `$ai_input` data
- [ ] Confirm malformed generations are skipped without crashing