### PR TITLE
fix(proxy): make Cloudflare rate limit errors retryable

### DIFF
--- a/posthog/temporal/proxy_service/cloudflare.py
+++ b/posthog/temporal/proxy_service/cloudflare.py
@@ -27,6 +27,9 @@ class CloudflareAPIError(Exception):
         super().__init__(message)
         self.errors = errors or []
 
+    def is_rate_limited(self) -> bool:
+        return any(err.get("code") == 10000 for err in self.errors) or "rate limit" in str(self).lower()
+
 
 class CustomHostnameSSLStatus(str, Enum):
     """SSL certificate status for a Custom Hostname."""

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -310,6 +310,7 @@ async def create_cloudflare_worker_route(inputs: CreateCloudflareProxyInputs):
             logger.info("Cloudflare Worker Route already exists for domain %s", inputs.domain)
             return
         if e.is_rate_limited():
+            # Rate limited by Cloudflare — re-raise to let Temporal retry with backoff
             raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
 

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -348,6 +348,7 @@ async def wait_for_cloudflare_certificate(inputs: CreateCloudflareProxyInputs):
 
     except CloudflareAPIError as e:
         if e.is_rate_limited():
+            # Rate limited by Cloudflare — re-raise to let Temporal retry with backoff
             raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
     except ApplicationError:

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -280,6 +280,7 @@ async def create_cloudflare_custom_hostname(inputs: CreateCloudflareProxyInputs)
             logger.info("Cloudflare Custom Hostname already exists for domain %s", inputs.domain)
             return
         if e.is_rate_limited():
+            # Rate limited by Cloudflare — re-raise to let Temporal retry with backoff
             raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
 

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -279,6 +279,8 @@ async def create_cloudflare_custom_hostname(inputs: CreateCloudflareProxyInputs)
             # Custom hostname already exists
             logger.info("Cloudflare Custom Hostname already exists for domain %s", inputs.domain)
             return
+        if e.is_rate_limited():
+            raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
 
 
@@ -306,6 +308,8 @@ async def create_cloudflare_worker_route(inputs: CreateCloudflareProxyInputs):
             # Route already exists
             logger.info("Cloudflare Worker Route already exists for domain %s", inputs.domain)
             return
+        if e.is_rate_limited():
+            raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
 
 
@@ -341,6 +345,8 @@ async def wait_for_cloudflare_certificate(inputs: CreateCloudflareProxyInputs):
         raise ApplicationError(f"Certificate not yet ready, status: {hostname_info.ssl.status.value}")
 
     except CloudflareAPIError as e:
+        if e.is_rate_limited():
+            raise
         raise NonRetriableException(f"Cloudflare API error: {e}") from e
     except ApplicationError:
         raise

--- a/posthog/temporal/proxy_service/test/test_cloudflare.py
+++ b/posthog/temporal/proxy_service/test/test_cloudflare.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.temporal.proxy_service.cloudflare import CloudflareAPIError
+
+
+class TestCloudflareAPIErrorIsRateLimited(TestCase):
+    @parameterized.expand(
+        [
+            ("error_code_10000", "Rate limited", [{"code": 10000}], True),
+            ("rate_limit_in_message", "Rate limited. Please wait", [], True),
+            ("rate_limit_case_insensitive", "RATE LIMIT exceeded", [], True),
+            ("unrelated_error_code", "Some API error", [{"code": 1234}], False),
+            ("empty_errors_no_rate_limit", "Cloudflare API error", [], False),
+        ]
+    )
+    def test_is_rate_limited(self, _name, message, errors, expected):
+        error = CloudflareAPIError(message, errors=errors)
+        self.assertEqual(error.is_rate_limited(), expected)


### PR DESCRIPTION


## Problem

Rate limit errors from Cloudflare API (code 10000) were being wrapped in NonRetriableException, causing workflows to fail permanently on a transient condition. Now re-raised to let Temporal retry with backoff.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
