### PR TITLE
feat(capture): NoOpSink should report liveness

### DIFF
--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -205,7 +205,14 @@ async fn create_sink(
         Ok(Box::new(PrintSink {}))
     } else if config.noop_sink {
         info!("NoOpSink enabled, events will be silently dropped");
-        Ok(Box::new(NoOpSink {}))
+        // NoOpSink is used for mirror traffic when we don't need to evaluate the output
+        // events and don't want to waste cost on MSK for nothing. The 12 hour period on
+        // the liveness check is unimportant as the sink does nothing. This is safer than
+        // nerfing the liveness check entirely when NoOpSink is enabled
+        let sink_liveness = liveness
+            .register("noop_sink".to_string(), Duration::from_secs(60 * 60 * 12))
+            .await;
+        Ok(Box::new(NoOpSink::new(sink_liveness).await))
     } else {
         let sink_liveness = liveness
             .register("rdkafka".to_string(), Duration::from_secs(30))

--- a/rust/capture/src/sinks/noop.rs
+++ b/rust/capture/src/sinks/noop.rs
@@ -1,20 +1,45 @@
-use async_trait::async_trait;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use async_trait::async_trait;
+use health::HealthHandle;
 use metrics::{counter, histogram};
 
 use crate::api::CaptureError;
 use crate::sinks::Event;
 use crate::v0_request::ProcessedEvent;
 
-pub struct NoOpSink {}
+const HEALTH_REPORT_INTERVAL: u64 = 100_000;
+
+pub struct NoOpSink {
+    health: HealthHandle,
+    counter: AtomicU64,
+}
+
+impl NoOpSink {
+    pub async fn new(health: HealthHandle) -> Self {
+        health.report_healthy().await;
+        Self {
+            health,
+            counter: AtomicU64::new(0),
+        }
+    }
+}
 
 #[async_trait]
 impl Event for NoOpSink {
     async fn send(&self, _event: ProcessedEvent) -> Result<(), CaptureError> {
+        let count = self.counter.fetch_add(1, Ordering::Relaxed);
+        if count.is_multiple_of(HEALTH_REPORT_INTERVAL) {
+            self.health.report_healthy().await;
+        }
         counter!("capture_events_ingested_total").increment(1);
         Ok(())
     }
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        let count = self.counter.fetch_add(1, Ordering::Relaxed);
+        if count.is_multiple_of(HEALTH_REPORT_INTERVAL) {
+            self.health.report_healthy().await;
+        }
         histogram!("capture_event_batch_size").record(events.len() as f64);
         counter!("capture_events_ingested_total").increment(events.len() as u64);
         Ok(())


### PR DESCRIPTION
## Problem
The capture liveness checks require at least one component to be registered not to fail. When `NoOpSink` is enabled, none are registered.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Quick and dirty fix to unblock testing: dummy liveness reporting in `NoOpSink`
* Long-term fix: replace `common/health` with `common/lifecycle` (already on my TODO list)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Soon in mirror deploy too
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
