### PR TITLE
feat(devex): personhog local dev setup

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -154,6 +154,18 @@ procs:
             bin/start-rust-service batch-import-worker
         capability: batch_imports
 
+    personhog-replica:
+        shell: |-
+            bin/wait-for-docker && \
+            bin/start-rust-service personhog-replica
+        capability: personhog
+
+    personhog-router:
+        shell: |-
+            bin/wait-for-docker && \
+            bin/start-rust-service personhog-router
+        capability: personhog
+
     llm-gateway:
         shell: 'bin/wait-for-docker && bin/start-llm-gateway'
         autostart: true

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -152,6 +152,24 @@ case "$RS_SVC" in
     export DEBUG=1
     ;;
 
+  personhog-replica)
+    SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
+    export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL
+    export RUST_BACKTRACE=1
+    export GRPC_ADDRESS=127.0.0.1:50051
+    export PRIMARY_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export METRICS_PORT=9100
+    ;;
+
+  personhog-router)
+    export RUST_LOG=debug
+    export RUST_BACKTRACE=1
+    export GRPC_ADDRESS=127.0.0.1:50052
+    export REPLICA_URL=http://127.0.0.1:50051
+    export BACKEND_TIMEOUT_MS=5000
+    export METRICS_PORT=9101
+    ;;
+
   *)
     echo "ERROR unknown posthog/rust service '$RS_SVC' please register in: $0" >&2
     exit 1

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -161,6 +161,10 @@ class MprocsGenerator(ConfigGenerator):
             if name == "nodejs":
                 proc_config = self._add_nodejs_capability_groups(proc_config, resolved)
 
+            # Special handling for backend - wire up personhog env vars when capability is active
+            if name == "backend":
+                proc_config = self._add_personhog_env(proc_config, resolved)
+
             # Add logging wrapper if enabled
             if source_config and source_config.log_to_files:
                 proc_config = self._add_logging(proc_config, name)
@@ -285,6 +289,20 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         original_shell = proc_config.get("shell", "")
         if original_shell:
             proc_config["shell"] = f"export NODEJS_CAPABILITY_GROUPS='{groups_value}' && {original_shell}"
+
+        return proc_config
+
+    def _add_personhog_env(self, proc_config: dict[str, Any], resolved: ResolvedEnvironment) -> dict[str, Any]:
+        """Add PERSONHOG_* env vars to backend when personhog capability is active."""
+        if "personhog" not in resolved.capabilities:
+            return proc_config
+
+        original_shell = proc_config.get("shell", "")
+        if original_shell:
+            env_exports = (
+                "export PERSONHOG_ADDR='127.0.0.1:50052' PERSONHOG_ENABLED='true' PERSONHOG_ROLLOUT_PERCENTAGE='100'"
+            )
+            proc_config["shell"] = f"{env_exports} && {original_shell}"
 
         return proc_config
 

--- a/common/hogli/tests/test_devenv.py
+++ b/common/hogli/tests/test_devenv.py
@@ -557,3 +557,55 @@ class TestInfoProcess:
 
         assert "hogli dev:setup" in shell
         assert "hogli dev:explain" in shell
+
+
+class TestPersonhogEnvInjection:
+    """Test that personhog env vars are injected into backend when capability is active."""
+
+    def _make_fixtures(self, *, with_personhog: bool):
+        capabilities = {
+            "core_infra": Capability(name="core_infra", description="Core", requires=[]),
+            "flag_evaluation": Capability(name="flag_evaluation", description="Flags", requires=["core_infra"]),
+        }
+        intents = {
+            "feature_flags": Intent(name="feature_flags", description="Flags", capabilities=["flag_evaluation"]),
+        }
+        capability_units = {
+            "core_infra": ["docker-compose"],
+            "flag_evaluation": ["feature-flags"],
+        }
+
+        if with_personhog:
+            capabilities["personhog"] = Capability(name="personhog", description="PersonHog", requires=["core_infra"])
+            intents["personhog"] = Intent(name="personhog", description="PersonHog", capabilities=["personhog"])
+            capability_units["personhog"] = ["personhog-replica", "personhog-router"]
+
+        intent_map = IntentMap(
+            version="1.0",
+            capabilities=capabilities,
+            intents=intents,
+            always_required=["backend"],
+        )
+        registry = MockRegistry(capability_units)
+        registry._processes["backend"] = {"shell": "./bin/start-backend", "capability": ""}
+        return intent_map, registry
+
+    def test_personhog_env_injected_when_capability_active(self) -> None:
+        intent_map, registry = self._make_fixtures(with_personhog=True)
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["personhog"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        shell = config.procs["backend"]["shell"]
+        assert "PERSONHOG_ADDR" in shell
+        assert "PERSONHOG_ENABLED" in shell
+        assert "PERSONHOG_ROLLOUT_PERCENTAGE" in shell
+
+    def test_personhog_env_not_injected_without_capability(self) -> None:
+        intent_map, registry = self._make_fixtures(with_personhog=False)
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["feature_flags"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        shell = config.procs["backend"]["shell"]
+        assert "PERSONHOG_ADDR" not in shell

--- a/common/hogli/tests/test_devenv.py
+++ b/common/hogli/tests/test_devenv.py
@@ -590,22 +590,21 @@ class TestPersonhogEnvInjection:
         registry._processes["backend"] = {"shell": "./bin/start-backend", "capability": ""}
         return intent_map, registry
 
-    def test_personhog_env_injected_when_capability_active(self) -> None:
-        intent_map, registry = self._make_fixtures(with_personhog=True)
+    @parameterized.expand(
+        [
+            (True, ["personhog"], True),
+            (False, ["feature_flags"], False),
+        ]
+    )
+    def test_personhog_env_injection(self, with_personhog: bool, intents: list[str], should_inject: bool) -> None:
+        intent_map, registry = self._make_fixtures(with_personhog=with_personhog)
         resolver = IntentResolver(intent_map, registry)
-        resolved = resolver.resolve(["personhog"])
+        resolved = resolver.resolve(intents)
         config = MprocsGenerator(registry).generate(resolved)
 
         shell = config.procs["backend"]["shell"]
-        assert "PERSONHOG_ADDR" in shell
-        assert "PERSONHOG_ENABLED" in shell
-        assert "PERSONHOG_ROLLOUT_PERCENTAGE" in shell
-
-    def test_personhog_env_not_injected_without_capability(self) -> None:
-        intent_map, registry = self._make_fixtures(with_personhog=False)
-        resolver = IntentResolver(intent_map, registry)
-        resolved = resolver.resolve(["feature_flags"])
-        config = MprocsGenerator(registry).generate(resolved)
-
-        shell = config.procs["backend"]["shell"]
-        assert "PERSONHOG_ADDR" not in shell
+        for var in ["PERSONHOG_ADDR", "PERSONHOG_ENABLED", "PERSONHOG_ROLLOUT_PERCENTAGE"]:
+            if should_inject:
+                assert var in shell
+            else:
+                assert var not in shell

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -129,6 +129,11 @@ capabilities:
         requires: [event_ingestion]
         docker_profiles: []
 
+    personhog:
+        description: 'PersonHog gRPC service (router + replica) for person data access'
+        requires: [core_infra]
+        docker_profiles: []
+
     observability:
         description: 'OpenTelemetry tracing with Jaeger'
         requires: [core_infra]
@@ -244,6 +249,11 @@ intents:
     stripe:
         description: 'Stripe app for PostHog integration'
         capabilities: [stripe_app]
+
+    personhog:
+        description: 'PersonHog gRPC service for person data access (replaces direct DB queries)'
+        capabilities: [personhog]
+
     endpoints:
         description: 'Endpoints (the product)'
         capabilities: [event_ingestion, property_definitions, celery_workers, temporal_workflows, duckgres]


### PR DESCRIPTION
## Problem

To test the personhog service in local dev we need the `personhog-replica` and `personhog-router` Rust services running in the local dev environment. There was no way to build and run these services via `bin/start` or `hogli dev:setup`.

## Changes

When choosing the personhog intent, both personhog services will get built and we'll wire up the correct env vars for the django application to use the personhog client.

- `bin/start-rust-service` — Added env configs for `personhog-replica` (gRPC `:50051`, metrics `:9100`) and `personhog-router` (gRPC `:50052`, connects to replica, metrics `:9101`).
- `bin/mprocs.yaml` — Registered both services gated on the `personhog` capability.
- `devenv/intent-map.yaml` — Added `personhog` capability (requires `core_infra`) and `personhog` intent. Not included in any other intent, so nothing changes by default.
- `common/hogli/devenv/generator.py` — When the `personhog` capability is active, automatically injects `PERSONHOG_ADDR`, `PERSONHOG_ENABLED`, and `PERSONHOG_ROLLOUT_PERCENTAGE` env vars into the backend process shell command. Follows the same pattern as the nodejs capability groups injection.
- `common/hogli/tests/test_devenv.py` — Two tests verifying env vars are injected when the capability is active, and not injected when inactive.


## How did you test this code?

- `pytest common/hogli/tests/test_devenv.py` — all 37 tests pass, including the 2 new ones for personhog env injection.
- Verified no port conflicts with existing services (50051, 50052, 9100, 9101 are all unused).
- Tested locally
