### PR TITLE
feat(flags): add connection creation counter and pool size gauge

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2046,6 +2046,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "metrics",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/common/database/Cargo.toml
+++ b/rust/common/database/Cargo.toml
@@ -12,3 +12,4 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+metrics = { workspace = true }

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -1,5 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
+/// Metric name for the counter incremented each time a new physical database connection
+/// is established. Labeled with `pool` when `PoolConfig::pool_name` is set.
+pub const DB_CONNECTION_CREATED_COUNTER: &str = "db_connection_created_total";
+
 use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::{
@@ -49,6 +53,10 @@ pub struct PoolConfig {
     /// PostgreSQL statement_timeout to set on each connection (in milliseconds)
     /// Set to None to use the database default
     pub statement_timeout_ms: Option<u64>,
+    /// Optional pool name used to label the `db_connection_created_total` counter.
+    /// When set, each new connection triggers a counter increment labeled with this name,
+    /// enabling visibility into connection churn per pool.
+    pub pool_name: Option<String>,
 }
 
 impl Default for PoolConfig {
@@ -62,6 +70,7 @@ impl Default for PoolConfig {
             idle_timeout: Some(Duration::from_secs(300)), // Close idle connections after 5 minutes
             test_before_acquire: true,                    // Test connection health before use
             statement_timeout_ms: None,                   // Use database default
+            pool_name: None,
         }
     }
 }
@@ -116,15 +125,26 @@ pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sql
         options = options.idle_timeout(idle_timeout);
     }
 
-    // If statement_timeout is configured, set it via after_connect hook
-    if let Some(timeout_ms) = config.statement_timeout_ms {
+    let pool_name = config.pool_name;
+    let statement_timeout_ms = config.statement_timeout_ms;
+
+    if pool_name.is_some() || statement_timeout_ms.is_some() {
         options = options.after_connect(move |conn, _meta| {
+            let pool_name = pool_name.clone();
             Box::pin(async move {
-                // Note: SET statement_timeout does not support parameterized queries ($1),
-                // so we use format!(). This is safe because timeout_ms is typed as u64.
-                sqlx::query(&format!("SET statement_timeout = {timeout_ms}"))
-                    .execute(&mut *conn)
-                    .await?;
+                if let Some(name) = pool_name {
+                    metrics::counter!(DB_CONNECTION_CREATED_COUNTER, "pool" => name)
+                        .increment(1);
+                }
+
+                if let Some(timeout_ms) = statement_timeout_ms {
+                    // Note: SET statement_timeout does not support parameterized queries ($1),
+                    // so we use format!(). This is safe because timeout_ms is typed as u64.
+                    sqlx::query(&format!("SET statement_timeout = {timeout_ms}"))
+                        .execute(&mut *conn)
+                        .await?;
+                }
+
                 Ok(())
             })
         });

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -133,8 +133,7 @@ pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sql
             let pool_name = pool_name.clone();
             Box::pin(async move {
                 if let Some(name) = pool_name {
-                    metrics::counter!(DB_CONNECTION_CREATED_COUNTER, "pool" => name)
-                        .increment(1);
+                    metrics::counter!(DB_CONNECTION_CREATED_COUNTER, "pool" => name).increment(1);
                 }
 
                 if let Some(timeout_ms) = statement_timeout_ms {

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -132,16 +132,16 @@ pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sql
         options = options.after_connect(move |conn, _meta| {
             let pool_name = pool_name.clone();
             Box::pin(async move {
-                if let Some(name) = pool_name {
-                    metrics::counter!(DB_CONNECTION_CREATED_COUNTER, "pool" => name).increment(1);
-                }
-
                 if let Some(timeout_ms) = statement_timeout_ms {
                     // Note: SET statement_timeout does not support parameterized queries ($1),
                     // so we use format!(). This is safe because timeout_ms is typed as u64.
                     sqlx::query(&format!("SET statement_timeout = {timeout_ms}"))
                         .execute(&mut *conn)
                         .await?;
+                }
+
+                if let Some(name) = pool_name {
+                    metrics::counter!(DB_CONNECTION_CREATED_COUNTER, "pool" => name).increment(1);
                 }
 
                 Ok(())

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -25,6 +25,7 @@ impl DatabasePools {
         base: &PoolConfig,
         min_connections: u32,
         statement_timeout_ms: u64,
+        pool_name: &str,
     ) -> PoolConfig {
         PoolConfig {
             min_connections,
@@ -33,6 +34,7 @@ impl DatabasePools {
             } else {
                 None
             },
+            pool_name: Some(pool_name.to_string()),
             ..base.clone()
         }
     }
@@ -118,6 +120,7 @@ impl DatabasePools {
             },
             test_before_acquire: *config.test_before_acquire,
             statement_timeout_ms: None, // Set per pool type below
+            pool_name: None,            // Set per pool type below
         };
 
         // Non-persons reader pool config (may allow longer queries for analytics)
@@ -125,6 +128,7 @@ impl DatabasePools {
             &base_pool_config,
             min_non_persons_reader_connections,
             config.non_persons_reader_statement_timeout_ms,
+            "non_persons_reader",
         );
         info!(
             pool = "non_persons_reader",
@@ -137,6 +141,7 @@ impl DatabasePools {
             &base_pool_config,
             min_persons_reader_connections,
             config.persons_reader_statement_timeout_ms,
+            "persons_reader",
         );
         info!(
             pool = "persons_reader",
@@ -149,6 +154,7 @@ impl DatabasePools {
             &base_pool_config,
             min_non_persons_writer_connections,
             config.writer_statement_timeout_ms,
+            "non_persons_writer",
         );
 
         // Persons writer pool config (should be fast transactional operations)
@@ -156,6 +162,7 @@ impl DatabasePools {
             &base_pool_config,
             min_persons_writer_connections,
             config.writer_statement_timeout_ms,
+            "persons_writer",
         );
         info!(
             pool = "writer",
@@ -268,7 +275,27 @@ impl DatabasePools {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use common_database::PoolConfig;
     use std::sync::Arc;
+
+    #[test]
+    fn test_build_pool_config_sets_pool_name_and_timeout() {
+        let base = PoolConfig::default();
+        let config = DatabasePools::build_pool_config(&base, 3, 5000, "persons_reader");
+
+        assert_eq!(config.min_connections, 3);
+        assert_eq!(config.statement_timeout_ms, Some(5000));
+        assert_eq!(config.pool_name, Some("persons_reader".to_string()));
+    }
+
+    #[test]
+    fn test_build_pool_config_zero_timeout_is_none() {
+        let base = PoolConfig::default();
+        let config = DatabasePools::build_pool_config(&base, 0, 0, "non_persons_writer");
+
+        assert_eq!(config.statement_timeout_ms, None);
+        assert_eq!(config.pool_name, Some("non_persons_writer".to_string()));
+    }
 
     #[tokio::test]
     async fn test_database_routing_disabled() {

--- a/rust/feature-flags/src/database_pools.rs
+++ b/rust/feature-flags/src/database_pools.rs
@@ -275,7 +275,6 @@ impl DatabasePools {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use common_database::PoolConfig;
     use std::sync::Arc;
 
     #[test]

--- a/rust/feature-flags/src/db_monitor.rs
+++ b/rust/feature-flags/src/db_monitor.rs
@@ -98,6 +98,7 @@ impl DatabasePoolMonitor {
         let pool_size = pool.size();
         let pool_idle = pool.num_idle();
         let pool_max = pool.options().get_max_connections();
+        let pool_active = pool_size.saturating_sub(pool_idle as u32);
 
         let labels = [("pool".to_string(), pool_name.to_string())];
 
@@ -109,7 +110,7 @@ impl DatabasePoolMonitor {
         gauge(
             DB_CONNECTION_POOL_ACTIVE_COUNTER,
             &labels,
-            (pool_size as i32 - pool_idle as i32) as f64,
+            pool_active as f64,
         );
         gauge(
             DB_CONNECTION_POOL_IDLE_COUNTER,
@@ -125,19 +126,19 @@ impl DatabasePoolMonitor {
         tracing::debug!(
             "{} pool metrics - active: {}, idle: {}, max: {}",
             pool_name,
-            pool_size as i32 - pool_idle as i32,
+            pool_active,
             pool_idle,
             pool_max
         );
 
         // Warn if pool utilization is high
-        let pool_utilization = (pool_size as i32 - pool_idle as i32) as f64 / pool_max as f64;
+        let pool_utilization = pool_active as f64 / pool_max as f64;
         if pool_utilization > self.warn_utilization_threshold {
             tracing::warn!(
                 "High {} pool utilization: {:.1}% ({}/{})",
                 pool_name,
                 pool_utilization * 100.0,
-                pool_size as i32 - pool_idle as i32,
+                pool_active,
                 pool_max
             );
         }

--- a/rust/feature-flags/src/db_monitor.rs
+++ b/rust/feature-flags/src/db_monitor.rs
@@ -9,7 +9,7 @@ use tracing::error;
 
 use crate::metrics::consts::{
     DB_CONNECTION_POOL_ACTIVE_COUNTER, DB_CONNECTION_POOL_IDLE_COUNTER,
-    DB_CONNECTION_POOL_MAX_COUNTER,
+    DB_CONNECTION_POOL_MAX_COUNTER, DB_CONNECTION_POOL_SIZE_GAUGE,
 };
 
 pub struct DatabasePoolMonitor {
@@ -99,19 +99,26 @@ impl DatabasePoolMonitor {
         let pool_idle = pool.num_idle();
         let pool_max = pool.options().get_max_connections();
 
+        let labels = [("pool".to_string(), pool_name.to_string())];
+
+        gauge(
+            DB_CONNECTION_POOL_SIZE_GAUGE,
+            &labels,
+            pool_size as f64,
+        );
         gauge(
             DB_CONNECTION_POOL_ACTIVE_COUNTER,
-            &[("pool".to_string(), pool_name.to_string())],
+            &labels,
             (pool_size as i32 - pool_idle as i32) as f64,
         );
         gauge(
             DB_CONNECTION_POOL_IDLE_COUNTER,
-            &[("pool".to_string(), pool_name.to_string())],
+            &labels,
             pool_idle as f64,
         );
         gauge(
             DB_CONNECTION_POOL_MAX_COUNTER,
-            &[("pool".to_string(), pool_name.to_string())],
+            &labels,
             pool_max as f64,
         );
 

--- a/rust/feature-flags/src/db_monitor.rs
+++ b/rust/feature-flags/src/db_monitor.rs
@@ -102,26 +102,14 @@ impl DatabasePoolMonitor {
 
         let labels = [("pool".to_string(), pool_name.to_string())];
 
-        gauge(
-            DB_CONNECTION_POOL_SIZE_GAUGE,
-            &labels,
-            pool_size as f64,
-        );
+        gauge(DB_CONNECTION_POOL_SIZE_GAUGE, &labels, pool_size as f64);
         gauge(
             DB_CONNECTION_POOL_ACTIVE_COUNTER,
             &labels,
             pool_active as f64,
         );
-        gauge(
-            DB_CONNECTION_POOL_IDLE_COUNTER,
-            &labels,
-            pool_idle as f64,
-        );
-        gauge(
-            DB_CONNECTION_POOL_MAX_COUNTER,
-            &labels,
-            pool_max as f64,
-        );
+        gauge(DB_CONNECTION_POOL_IDLE_COUNTER, &labels, pool_idle as f64);
+        gauge(DB_CONNECTION_POOL_MAX_COUNTER, &labels, pool_max as f64);
 
         tracing::debug!(
             "{} pool metrics - active: {}, idle: {}, max: {}",

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -24,6 +24,7 @@ pub const FLAG_REQUEST_FAULTS_COUNTER: &str = "flags_request_faults_total";
 pub const DB_CONNECTION_POOL_ACTIVE_COUNTER: &str = "flags_db_connection_pool_active_total";
 pub const DB_CONNECTION_POOL_IDLE_COUNTER: &str = "flags_db_connection_pool_idle_total";
 pub const DB_CONNECTION_POOL_MAX_COUNTER: &str = "flags_db_connection_pool_max_total";
+pub const DB_CONNECTION_POOL_SIZE_GAUGE: &str = "flags_db_connection_pool_size";
 
 // Flag evaluation timing
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -30,6 +30,7 @@ async fn create_storage(config: &Config) -> Arc<PostgresStorage> {
                 idle_timeout: config.idle_timeout(),
                 test_before_acquire: true,
                 statement_timeout_ms: config.statement_timeout(),
+                ..Default::default()
             };
 
             // Create primary pool


### PR DESCRIPTION
## Problem

During investigation of pool exhaustion incidents on the feature flags service, we couldn't answer the fundamental question: "How many new TLS connections are being created per second?" sqlx doesn't expose connection creation/destruction counts, so we had no visibility into connection churn per pool.

## Changes

- Add `db_connection_created_total` counter via sqlx's `after_connect` hook, firing each time a new physical TCP/TLS connection is established (not on pool reuse). Labeled by `pool` name.
- Add `flags_db_connection_pool_size` gauge to the periodic db monitor, reporting `pool.size()` directly for sanity-checking that `size == active + idle` (divergence indicates connections in a transitional state).
- Add `pool_name: Option<String>` to `PoolConfig` in `common-database` to thread pool identity into the hook. Opt-in — services that don't set it get no counter overhead.
- Use `..Default::default()` in `personhog-replica` to insulate from future `PoolConfig` field additions.

**Key queries enabled:**
```promql
# Connection creation rate per pool
rate(db_connection_created_total{pool="non_persons_reader"}[5m])

# Pool reuse rate (fraction of acquires that reused an existing connection)
1 - (rate(db_connection_created_total[5m]) / rate(flags_db_connection_time_count[5m]))
```

## How did you test this code?

- All existing `common-database` tests pass (25 tests)
- Added unit tests for `build_pool_config` verifying `pool_name` propagation and `statement_timeout_ms == 0 → None`
- `cargo clippy` clean across all affected packages (`common-database`, `feature-flags`, `personhog-replica`)
- I'm an agent and have not tested this manually in a running environment

## Publish to changelog?

No