### PR TITLE
chore(capture): fix reversed defaults in GRL test thresholds

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -91,7 +91,7 @@ pub struct Config {
     // --- Token+DistinctId limiter config ---
     /// Per-(token, distinct_id) rate limit threshold per window interval
     /// Note: default is too high to trigger limiting in production
-    #[envconfig(default = "5000000")]
+    #[envconfig(default = "300000")]
     pub global_rate_limit_token_distinctid_threshold: u64,
 
     /// CSV list of key=value pairs for custom per-(token, distinct_id) thresholds
@@ -104,7 +104,7 @@ pub struct Config {
     // --- Token-only limiter config ---
     /// Per-token rate limit threshold per window interval
     /// Note: default is too high to trigger limiting in production
-    #[envconfig(default = "100000")]
+    #[envconfig(default = "5000000")]
     pub global_rate_limit_token_threshold: u64,
 
     /// CSV list of key=value pairs for custom per-token thresholds

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -98,7 +98,7 @@ pub struct Config {
     pub global_rate_limit_token_distinctid_overrides_csv: Option<String>,
 
     /// Max local cache entries for the per-(token, distinct_id) limiter
-    #[envconfig(default = "10000000")]
+    #[envconfig(default = "5000000")]
     pub global_rate_limit_token_distinctid_local_cache_max_entries: u64,
 
     // --- Token-only limiter config ---


### PR DESCRIPTION
## Problem
Defaults for initial global rate limiter test in prod `capture` should be too high to trigger. Let's apply the right one to the right limiter
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* flip flop token vs token + distinct ID limiter threshold defaults in capture
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Mirror smoke test helped sus this out - already sanity checked new values in this PR on 100% of prod US traffic in mirror ✅ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
