### PR TITLE
feat(flags): update person SQL definitions for group keys

### DIFF
--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -445,7 +445,7 @@ DELETE_PERSON_FROM_STATIC_COHORT = f"DELETE FROM {PERSON_STATIC_COHORT_TABLE} WH
 
 COPY_PERSONS_BETWEEN_TEAMS = COPY_ROWS_BETWEEN_TEAMS_BASE_SQL.format(
     table_name=PERSONS_TABLE,
-    columns_except_team_id="""id, created_at, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at""",
+    columns_except_team_id="""id, created_at, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at, group_0_key, group_1_key, group_2_key, group_3_key, group_4_key""",
 )
 
 COPY_PERSON_DISTINCT_ID2S_BETWEEN_TEAMS = COPY_ROWS_BETWEEN_TEAMS_BASE_SQL.format(
@@ -454,7 +454,7 @@ COPY_PERSON_DISTINCT_ID2S_BETWEEN_TEAMS = COPY_ROWS_BETWEEN_TEAMS_BASE_SQL.forma
 )
 
 SELECT_PERSONS_OF_TEAM = """
-SELECT id, created_at, properties, is_identified, version, last_seen_at
+SELECT id, created_at, properties, is_identified, version, last_seen_at, group_0_key, group_1_key, group_2_key, group_3_key, group_4_key
 FROM {table_name}
 WHERE team_id = %(source_team_id)s
 """.format(table_name=PERSONS_TABLE)
@@ -494,11 +494,11 @@ WHERE team_id = %(team_id)s
 )
 
 INSERT_PERSON_SQL = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, %(is_deleted)s, %(version)s, %(last_seen_at)s
+INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at, group_0_key, group_1_key, group_2_key, group_3_key, group_4_key) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, %(is_deleted)s, %(version)s, %(last_seen_at)s, %(group_0_key)s, %(group_1_key)s, %(group_2_key)s, %(group_3_key)s, %(group_4_key)s
 """
 
 INSERT_PERSON_BULK_SQL = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at) VALUES
+INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version, last_seen_at, group_0_key, group_1_key, group_2_key, group_3_key, group_4_key) VALUES
 """
 
 INSERT_PERSON_DISTINCT_ID2 = """

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -109,7 +109,7 @@ if TEST:
             # Round to the hour for last_seen_at
             last_seen_at = dt.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S.%f")
             person_inserts.append(
-                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, 0, '{last_seen_at}')"
+                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, 0, '{last_seen_at}', '', '', '', '', '')"
             )
 
         PersonDistinctId.objects.bulk_create(distinct_ids)
@@ -134,6 +134,11 @@ def create_person(
     timestamp: Optional[Union[datetime.datetime, str]] = None,
     created_at: Optional[datetime.datetime] = None,
     last_seen_at: Optional[datetime.datetime] = None,
+    group_0_key: str = "",
+    group_1_key: str = "",
+    group_2_key: str = "",
+    group_3_key: str = "",
+    group_4_key: str = "",
 ) -> str:
     if properties is None:
         properties = {}
@@ -172,6 +177,11 @@ def create_person(
         "version": version,
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
         "last_seen_at": last_seen_at_formatted,
+        "group_0_key": group_0_key,
+        "group_1_key": group_1_key,
+        "group_2_key": group_2_key,
+        "group_3_key": group_3_key,
+        "group_4_key": group_4_key,
     }
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_PERSON, sql=INSERT_PERSON_SQL, data=data, sync=sync)


### PR DESCRIPTION
## Problem

Part 2 of mixed user + group targeting for feature flags. The migration in #46214 added `group_0_key` through `group_4_key` columns to the ClickHouse person table to enable joins from persons to groups for blast radius calculations and analytics.

Closes #46293

## Changes

Updated SQL definitions and utility functions to include the new group key columns:

- `COPY_PERSONS_BETWEEN_TEAMS` - preserves group keys when copying demo data between teams
- `SELECT_PERSONS_OF_TEAM` - includes group keys in person reads for Postgres sync
- `INSERT_PERSON_SQL` - supports group keys in single-person inserts
- `INSERT_PERSON_BULK_SQL` - supports group keys in bulk inserts
- `create_person()` - accepts optional group key parameters (default to empty string)
- `bulk_create_persons()` - includes empty group key values in test inserts

## How did you test this code?

Ran person model tests (`test_person_model.py`, `test_person_schema.py`) and schema consistency tests (`test_schema.py`). All 210+ tests pass. The group keys default to empty strings, maintaining backward compatibility.

I am an agent and have tested this via automated unit and integration tests only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no