### PR TITLE
fix(flags): scope HyperCache verification to teams with flags

### DIFF
--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -250,6 +250,27 @@ class BaseHyperCacheCommand(BaseCommand):
 
         return total_processed
 
+    # Team scoping
+
+    def get_teams_queryset(self):
+        """Return the base queryset of teams to process.
+
+        Uses the config's ``get_teams_queryset_fn`` when set, falling back to
+        all teams.
+        """
+        config = self.get_hypercache_config()
+        if config.get_teams_queryset_fn is not None:
+            return config.get_teams_queryset_fn().select_related("organization", "project")
+        return Team.objects.select_related("organization", "project")
+
+    def _print_scope_info(self, scoped_count: int, total_count: int):
+        """Print a message when team scoping reduces the verification set."""
+        if scoped_count < total_count:
+            skipped = total_count - scoped_count
+            self.stdout.write(
+                f"Scope: {scoped_count:,} of {total_count:,} teams ({skipped:,} teams skipped — no relevant data)\n"
+            )
+
     # Verification framework
 
     def run_verification(
@@ -303,13 +324,19 @@ class BaseHyperCacheCommand(BaseCommand):
                 self.stdout.write(f"Verifying {teams_queryset.count()} specific teams...\n")
                 self._verify_teams_batch(list(teams_queryset), stats, mismatches, verbose, fix)
             elif sample_size:
-                teams_queryset = Team.objects.select_related("organization", "project").order_by("?")[:sample_size]
-                self.stdout.write(f"Verifying random sample of {teams_queryset.count()} teams...\n")
-                self._verify_teams_batch(list(teams_queryset), stats, mismatches, verbose, fix)
+                total_teams = Team.objects.count()
+                scoped_queryset = self.get_teams_queryset()
+                scoped_count = scoped_queryset.count()
+                self._print_scope_info(scoped_count, total_teams)
+                teams = list(scoped_queryset.order_by("?")[:sample_size])
+                self.stdout.write(f"Verifying random sample of {len(teams)} teams...\n")
+                self._verify_teams_batch(teams, stats, mismatches, verbose, fix)
             else:
                 # For all teams, use chunked iteration to avoid memory exhaustion
-                teams_queryset = Team.objects.select_related("organization", "project")
+                total_teams = Team.objects.count()
+                teams_queryset = self.get_teams_queryset()
                 total = teams_queryset.count()
+                self._print_scope_info(total, total_teams)
                 self.stdout.write(f"Verifying all {total} teams...\n")
 
                 # Process teams in chunks using the helper method

--- a/posthog/management/commands/test/test_base_hypercache_command.py
+++ b/posthog/management/commands/test/test_base_hypercache_command.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
+from posthog.models.team.team import Team
 from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 
 
@@ -115,6 +116,7 @@ def create_mock_config():
     mock_config.hypercache.batch_load_fn = None
     mock_config.hypercache.expiry_sorted_set_key = None  # Disable expiry tracking by default
     mock_config.cache_display_name = "test cache"
+    mock_config.get_teams_queryset_fn = None  # Match real config default
     return mock_config
 
 
@@ -843,3 +845,172 @@ class TestGracePeriodSkipping(BaseTest):
 
         output = command.stdout.getvalue()
         assert "Skipped (grace period)" not in output
+
+
+def create_scoped_mock_config(scoped_team_ids: list[int] | None = None):
+    """Create a mock config with optional get_teams_queryset_fn scoping."""
+    mock_config = create_mock_config()
+    if scoped_team_ids is not None:
+        mock_config.get_teams_queryset_fn = lambda: Team.objects.filter(id__in=scoped_team_ids)
+    else:
+        mock_config.get_teams_queryset_fn = None
+    return mock_config
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test", TEST=True)
+class TestGetTeamsQueryset(BaseTest):
+    """Test the get_teams_queryset() behavior driven by config."""
+
+    def test_default_returns_all_teams_when_no_queryset_fn(self):
+        """When config has no get_teams_queryset_fn, returns all teams."""
+        mock_config = create_mock_config()
+        mock_config.get_teams_queryset_fn = None
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        qs = command.get_teams_queryset()
+        assert self.team in list(qs)
+
+    def test_config_queryset_fn_scopes_all_teams_path(self):
+        """Config's get_teams_queryset_fn restricts which teams are verified."""
+        from posthog.models import Team as TeamModel
+
+        team2 = TeamModel.objects.create(organization=self.organization, name="Team 2")
+
+        mock_config = create_scoped_mock_config(scoped_team_ids=[team2.id])
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.management.commands._base_hypercache_command.get_cache_stats"):
+            command.run_verification(team_ids=None, sample_size=None, verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        assert "Verifying all 1 teams" in output
+
+    def test_config_queryset_fn_scopes_sample_path(self):
+        """Config's get_teams_queryset_fn restricts the sample pool."""
+        from posthog.models import Team as TeamModel
+
+        team2 = TeamModel.objects.create(organization=self.organization, name="Team 2")
+
+        mock_config = create_scoped_mock_config(scoped_team_ids=[team2.id])
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.management.commands._base_hypercache_command.get_cache_stats"):
+            command.run_verification(team_ids=None, sample_size=10, verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        # Sample draws from scoped queryset (only 1 team), so at most 1 verified
+        assert "Verifying random sample of 1 teams" in output
+
+    def test_sample_path_scope_info_shows_scoped_count_not_sample_count(self):
+        """_print_scope_info reports the full scoped count, not the post-sample count."""
+        from posthog.models import Team as TeamModel
+
+        team2 = TeamModel.objects.create(organization=self.organization, name="Team 2")
+        TeamModel.objects.create(organization=self.organization, name="Team 3")
+
+        # Scope to 2 of 3 teams, then sample 1
+        mock_config = create_scoped_mock_config(scoped_team_ids=[self.team.id, team2.id])
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.management.commands._base_hypercache_command.get_cache_stats"):
+            command.run_verification(team_ids=None, sample_size=1, verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        # Scope info should show the full scoped count (2), not the sample count (1)
+        assert "Scope: 2 of" in output
+        assert "Verifying random sample of 1 teams" in output
+
+    def test_team_ids_ignores_config_scoping(self):
+        """Explicit --team-ids bypasses config's get_teams_queryset_fn."""
+        mock_config = create_scoped_mock_config(scoped_team_ids=[])
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.management.commands._base_hypercache_command.get_cache_stats"):
+            command.run_verification(team_ids=[self.team.id], sample_size=None, verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        assert "Verifying 1 specific teams" in output
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test", TEST=True)
+class TestPrintScopeInfo(BaseTest):
+    """Test _print_scope_info() output."""
+
+    def test_prints_message_when_scoped(self):
+        """Scope info message printed when scoped count < total count."""
+        command = ConcreteHyperCacheCommand(mock_config=create_mock_config())
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        command._print_scope_info(1, 10)
+
+        output = command.stdout.getvalue()
+        assert "Scope:" in output
+        assert "teams skipped" in output
+
+    def test_omits_message_when_not_scoped(self):
+        """Scope info message omitted when scoped count equals total count."""
+        command = ConcreteHyperCacheCommand(mock_config=create_mock_config())
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        command._print_scope_info(5, 5)
+
+        output = command.stdout.getvalue()
+        assert "Scope:" not in output
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test", TEST=True)
+class TestFlagVerifyCommandScoping(BaseTest):
+    """Test that the flag verify commands scope to teams with flags."""
+
+    def test_includes_teams_with_only_soft_deleted_flags(self):
+        """Teams where all flags are soft-deleted are still included in scope."""
+        from posthog.management.commands.verify_flags_cache import Command as VerifyFlagsCommand
+        from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="deleted-flag",
+            name="Deleted Flag",
+            created_by=self.user,
+            deleted=True,
+        )
+
+        command = VerifyFlagsCommand()
+        qs = command.get_teams_queryset()
+        assert self.team in list(qs)
+
+    def test_excludes_teams_with_no_flags(self):
+        """Teams that have never had any flags are excluded from scope."""
+        from posthog.management.commands.verify_flags_cache import Command as VerifyFlagsCommand
+        from posthog.models import Team as TeamModel
+
+        team_no_flags = TeamModel.objects.create(organization=self.organization, name="No Flags Team")
+
+        command = VerifyFlagsCommand()
+        qs = command.get_teams_queryset()
+        team_ids = list(qs.values_list("id", flat=True))
+        assert team_no_flags.id not in team_ids
+
+    def test_flag_definitions_command_scopes_same_way(self):
+        """verify_flag_definitions_cache uses identical scoping logic."""
+        from posthog.management.commands.verify_flag_definitions_cache import Command as VerifyFlagDefinitionsCommand
+        from posthog.models import Team as TeamModel
+        from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+        team_with_flag = TeamModel.objects.create(organization=self.organization, name="Has Flag")
+        team_no_flags = TeamModel.objects.create(organization=self.organization, name="No Flags")
+        FeatureFlag.objects.create(
+            team=team_with_flag,
+            key="test-flag",
+            name="Test",
+            created_by=self.user,
+        )
+
+        command = VerifyFlagDefinitionsCommand()
+        qs = command.get_teams_queryset()
+        team_ids = list(qs.values_list("id", flat=True))
+        assert team_with_flag.id in team_ids
+        assert team_no_flags.id not in team_ids

--- a/posthog/management/commands/verify_flag_definitions_cache.py
+++ b/posthog/management/commands/verify_flag_definitions_cache.py
@@ -2,10 +2,8 @@
 Management command to verify flag definitions cache consistency.
 
 Compares cached flag definitions data against database to detect discrepancies.
-By default verifies only the with-cohorts variant, which serves the vast majority of
-traffic (the without-cohorts variant is deprecated). Both variants derive from the same
-source data and share the same Celery update path, so checking one is a reliable
-indicator of overall cache health. Use --variant both to verify both explicitly.
+Verifies both cache variants (with-cohorts and without-cohorts). When --fix is
+used, each variant's cache is updated independently.
 
 Usage:
     # Verify all teams
@@ -16,10 +14,6 @@ Usage:
 
     # Sample random teams
     python manage.py verify_flag_definitions_cache --sample 100
-
-    # Verify a specific variant (default: with-cohorts)
-    python manage.py verify_flag_definitions_cache --variant without-cohorts
-    python manage.py verify_flag_definitions_cache --variant both
 
     # Verbose output (show full diffs)
     python manage.py verify_flag_definitions_cache --verbose
@@ -45,13 +39,6 @@ class Command(BaseHyperCacheCommand):
     def add_arguments(self, parser):
         self.add_common_team_arguments(parser)
         self.add_verify_arguments(parser)
-        parser.add_argument(
-            "--variant",
-            type=str,
-            default="with-cohorts",
-            choices=["with-cohorts", "without-cohorts", "both"],
-            help="Which variant(s) to verify (default: with-cohorts)",
-        )
 
     @override
     def format_verbose_diff(self, diff: dict):
@@ -89,25 +76,17 @@ class Command(BaseHyperCacheCommand):
         sample_size = options.get("sample")
         verbose = options.get("verbose", False)
         fix = options.get("fix", False)
-        variant = options.get("variant")
 
         # Validate input arguments to prevent resource exhaustion
         if sample_size is not None:
             if not self.validate_sample_size(sample_size):
                 return
 
-        # Determine which configs to verify
-        if variant == "with-cohorts":
-            configs_to_verify = [(FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts", True)]
-        elif variant == "without-cohorts":
-            configs_to_verify = [(FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts", False)]
-        else:  # "both"
-            configs_to_verify = [
-                (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts", True),
-                (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts", False),
-            ]
+        configs_to_verify = [
+            (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, "with cohorts", True),
+            (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, "without cohorts", False),
+        ]
 
-        # Verify each variant
         for config, variant_name, include_cohorts in configs_to_verify:
             self.stdout.write(f"\n{'=' * 70}")
             self.stdout.write(self.style.SUCCESS(f"Verifying flag definitions cache ({variant_name})"))

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -25,15 +25,17 @@ Manual operations:
     clear_flags_cache(team_id)
 """
 
-import time
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
 
 from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -374,25 +376,19 @@ def _compare_flag_fields(db_flag: dict, cached_flag: dict) -> list[dict]:
     return field_diffs
 
 
-def _get_team_ids_with_flags() -> set[int]:
+def get_teams_with_flags_queryset() -> "QuerySet[Team]":
     """
-    Get the set of team IDs that have at least one active, non-deleted flag.
+    Return a queryset of teams that have ever had a feature flag.
 
-    Used by verification to skip expensive DB loads for the ~90% of teams
-    that have zero flags. For those teams, we just verify the cache contains
-    {"flags": []}.
+    Queries via ``objects_including_soft_deleted`` so that teams whose flags
+    were all soft-deleted still get their cache verified (the cache should
+    contain ``{"flags": []}``, not be absent).
+
+    Used as the single source of truth for scoping both Celery verification
+    tasks and management commands to the ~10% of teams that have flags.
     """
-    start_time = time.time()
-    result = set(FeatureFlag.objects.filter(active=True).values_list("team_id", flat=True).distinct())
-    duration_ms = (time.time() - start_time) * 1000
-
-    logger.info(
-        "Loaded team IDs with flags",
-        count=len(result),
-        duration_ms=round(duration_ms, 2),
-    )
-
-    return result
+    has_flags = FeatureFlag.objects_including_soft_deleted.filter(team_id=OuterRef("pk"))
+    return Team.objects.filter(Exists(has_flags))
 
 
 def _get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
@@ -431,8 +427,7 @@ FLAGS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     hypercache=flags_hypercache,
     update_fn=update_flags_cache,
     cache_name="flags",
-    get_team_ids_needing_full_verification_fn=_get_team_ids_with_flags,
-    empty_cache_value={"flags": []},
+    get_teams_queryset_fn=get_teams_with_flags_queryset,
     get_team_ids_to_skip_fix_fn=_get_team_ids_with_recently_updated_flags,
 )
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -40,7 +40,7 @@ from posthog.models.cohort.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.util import get_nested_cohort_ids
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
-from posthog.models.feature_flag.flags_cache import _compare_flag_fields
+from posthog.models.feature_flag.flags_cache import _compare_flag_fields, get_teams_with_flags_queryset
 from posthog.models.feature_flag.types import FlagFilters, FlagProperty, PropertyFilterType
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.surveys.survey import Survey
@@ -689,16 +689,23 @@ def _update_flag_definitions_without_cohorts(team: Team | int, ttl: int | None =
 
 # HyperCache management configs for warming/verification.
 # Two separate configs, one for each cache variant.
+# Both share the same team-scoping queryset from flags_cache, giving flag
+# definitions the same ~89% team reduction that the flags cache already has.
+# Each config uses a per-variant update_fn so that callers iterating both
+# configs (e.g., warm_caches, refresh) don't double-write a variant.
+# Verification runs both configs independently to keep each variant correct.
 FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     hypercache=flag_definitions_hypercache,
     update_fn=_update_flag_definitions_with_cohorts,
     cache_name="flag_definitions",
+    get_teams_queryset_fn=get_teams_with_flags_queryset,
 )
 
 FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     hypercache=flag_definitions_without_cohorts_hypercache,
     update_fn=_update_flag_definitions_without_cohorts,
     cache_name="flag_definitions_no_cohorts",
+    get_teams_queryset_fn=get_teams_with_flags_queryset,
 )
 
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -25,6 +25,7 @@ from posthog.models.feature_flag.flags_cache import (
     clear_flags_cache,
     flags_hypercache,
     get_flags_from_cache,
+    get_teams_with_flags_queryset,
     update_flags_cache,
 )
 
@@ -2189,3 +2190,25 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
 
         result = _get_team_ids_with_recently_updated_flags([self.team.id])
         assert result == set()
+
+
+class TestGetTeamsWithFlagsQueryset(BaseTest):
+    def test_includes_team_with_active_flag(self):
+        FeatureFlag.objects.create(team=self.team, key="active-flag", created_by=self.user)
+        qs = get_teams_with_flags_queryset()
+        assert self.team.id in qs.values_list("id", flat=True)
+
+    def test_includes_team_with_soft_deleted_flag(self):
+        FeatureFlag.objects.create(team=self.team, key="del", created_by=self.user, deleted=True)
+        qs = get_teams_with_flags_queryset()
+        assert self.team.id in qs.values_list("id", flat=True)
+
+    def test_includes_team_with_inactive_flag(self):
+        FeatureFlag.objects.create(team=self.team, key="off", created_by=self.user, active=False)
+        qs = get_teams_with_flags_queryset()
+        assert self.team.id in qs.values_list("id", flat=True)
+
+    def test_excludes_team_with_no_flags(self):
+        team_no_flags = Team.objects.create(organization=self.organization, name="No Flags")
+        qs = get_teams_with_flags_queryset()
+        assert team_no_flags.id not in qs.values_list("id", flat=True)

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -15,7 +15,10 @@ import random
 import statistics
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
 
 from django.conf import settings
 from django.db import connection
@@ -185,12 +188,10 @@ class HyperCacheManagementConfig:
     update_fn: UpdateFn  # Function to update cache for a team
     cache_name: str  # Canonical cache name (e.g., "flags", "team_metadata")
 
-    # Optional properties for verification optimization
-    # If set, only teams in this set will have full DB data loaded during verification.
-    # Teams not in this set will use a fast-path check against empty_cache_value.
-    get_team_ids_needing_full_verification_fn: Callable[[], set[int]] | None = None
-    # The expected cache value for teams that don't need full verification (e.g., {"flags": []})
-    empty_cache_value: dict | None = None
+    # Optional queryset function to scope which teams are processed during
+    # verification and management commands. When set, only teams returned by
+    # this queryset are iterated. Teams outside the queryset are skipped entirely.
+    get_teams_queryset_fn: Callable[[], "QuerySet"] | None = None
 
     # Optional batch function to determine which teams should skip fixes.
     # Used to implement grace periods for recently updated data, avoiding race
@@ -198,17 +199,6 @@ class HyperCacheManagementConfig:
     # Takes a list of team IDs, returns a set of team IDs that should skip fixes.
     # Called once per batch for efficiency (avoids N+1 queries).
     get_team_ids_to_skip_fix_fn: Callable[[list[int]], set[int]] | None = None
-
-    def __post_init__(self) -> None:
-        """Validate that optimization fields are set together."""
-        has_team_ids_fn = self.get_team_ids_needing_full_verification_fn is not None
-        has_empty_value = self.empty_cache_value is not None
-
-        if has_team_ids_fn != has_empty_value:
-            raise ValueError(
-                "Verification optimization requires both get_team_ids_needing_full_verification_fn "
-                "and empty_cache_value to be set together (either both set or both None)"
-            )
 
     # Derived properties (computed from required properties using conventions)
     @property
@@ -349,7 +339,9 @@ def warm_caches(
                 invalidated = invalidate_all_caches(config)
                 logger.info("Invalidated caches", count=invalidated)
 
-        # Filter to specific teams if requested
+        # Warm all teams (not just scoped ones) so every team has a cache entry.
+        # This prevents cache misses at read time for teams without flags, which
+        # would otherwise fall through to a database lookup on every request.
         teams_queryset = Team.objects.select_related("organization", "project")
         if team_ids:
             teams_queryset = teams_queryset.filter(id__in=team_ids)

--- a/posthog/storage/hypercache_verifier.py
+++ b/posthog/storage/hypercache_verifier.py
@@ -82,11 +82,13 @@ def verify_and_fix_all_teams(
     chunk_size: int | None = None,
 ) -> VerificationResult:
     """
-    Verify all teams' caches and auto-fix any issues.
+    Verify caches for teams in the configured scope and auto-fix any issues.
 
-    Processes teams in chunks using seek-based pagination for memory efficiency.
-    For each team, calls verify_team_fn to check cache consistency. If issues
-    are found, automatically fixes them using config.update_fn.
+    When ``config.get_teams_queryset_fn`` is set, only teams returned by that
+    queryset are processed; otherwise all teams are verified. Processes teams
+    in chunks using seek-based pagination for memory efficiency. For each team,
+    calls verify_team_fn to check cache consistency. If issues are found,
+    automatically fixes them using config.update_fn.
 
     Args:
         config: HyperCache management configuration with update_fn
@@ -111,29 +113,12 @@ def verify_and_fix_all_teams(
     result = VerificationResult()
     last_id = 0
 
-    # Pre-compute team IDs needing full verification if optimization is configured.
-    # For flags cache, this is ~20K teams with flags vs 238K total teams.
-    # This allows skipping expensive DB loads for teams with empty caches.
-    team_ids_needing_full_verification: set[int] | None = None
-    if config.get_team_ids_needing_full_verification_fn is not None:
-        try:
-            team_ids_needing_full_verification = config.get_team_ids_needing_full_verification_fn()
-            logger.info(
-                "Loaded team IDs needing full verification",
-                cache_type=cache_type,
-                count=len(team_ids_needing_full_verification),
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to load team IDs for optimization, falling back to full verification",
-                cache_type=cache_type,
-                error=str(e),
-            )
+    base_qs = config.get_teams_queryset_fn() if config.get_teams_queryset_fn else Team.objects.all()
 
     batch_number = 0
     while True:
         teams = list(
-            Team.objects.filter(id__gt=last_id).select_related("organization", "project").order_by("id")[:chunk_size]
+            base_qs.filter(id__gt=last_id).select_related("organization", "project").order_by("id")[:chunk_size]
         )
 
         if not teams:
@@ -143,7 +128,7 @@ def verify_and_fix_all_teams(
         batch_start = result.total
         batch_fixes_start = result.total_fixed
 
-        _verify_and_fix_batch(teams, config, verify_team_fn, cache_type, result, team_ids_needing_full_verification)
+        _verify_and_fix_batch(teams, config, verify_team_fn, cache_type, result)
 
         batch_verified = result.total - batch_start
         batch_fixed = result.total_fixed - batch_fixes_start
@@ -181,40 +166,12 @@ def verify_and_fix_all_teams(
     return result
 
 
-def _partition_teams_for_verification(
-    teams: list[Team],
-    team_ids_needing_full_verification: set[int] | None,
-    config: HyperCacheManagementConfig,
-) -> tuple[list[Team], list[Team]]:
-    """
-    Split teams into those needing full DB verification vs fast-path empty check.
-
-    Args:
-        teams: List of Team objects to partition
-        team_ids_needing_full_verification: Set of team IDs that have data requiring full verification.
-            If None, all teams use full verification.
-        config: HyperCache management configuration
-
-    Returns:
-        Tuple of (teams_for_full_check, teams_for_empty_check)
-    """
-    if team_ids_needing_full_verification is not None and config.empty_cache_value is not None:
-        teams_for_full_check = [t for t in teams if t.id in team_ids_needing_full_verification]
-        teams_for_empty_check = [t for t in teams if t.id not in team_ids_needing_full_verification]
-    else:
-        teams_for_full_check = teams
-        teams_for_empty_check = []
-
-    return teams_for_full_check, teams_for_empty_check
-
-
 def _verify_and_fix_batch(
     teams: list[Team],
     config: HyperCacheManagementConfig,
     verify_team_fn: Callable[[Team, dict | None, dict | None], dict],
     cache_type: str,
     result: VerificationResult,
-    team_ids_needing_full_verification: set[int] | None = None,
 ) -> None:
     """
     Verify and fix a batch of teams.
@@ -225,8 +182,6 @@ def _verify_and_fix_batch(
         verify_team_fn: Function to verify a single team (team, db_batch_data, cache_batch_data)
         cache_type: Name for metrics/logging
         result: VerificationResult to accumulate stats
-        team_ids_needing_full_verification: If provided, only load DB data for teams in this set.
-            Teams not in this set use fast-path verification against empty_cache_value.
     """
     # Batch-read cached values using MGET (single Redis round trip)
     try:
@@ -247,32 +202,15 @@ def _verify_and_fix_batch(
         except Exception as e:
             logger.warning("Batch skip-fix check failed, proceeding without skips", error=str(e))
 
-    # Partition teams into full verification vs fast-path empty check
-    teams_for_full_check, teams_for_empty_check = _partition_teams_for_verification(
-        teams, team_ids_needing_full_verification, config
-    )
-
-    # Batch-load DB data only for teams that need full verification
+    # Batch-load DB data for all teams in the batch
     db_batch_data = None
-    if teams_for_full_check and config.hypercache.batch_load_fn:
+    if config.hypercache.batch_load_fn:
         try:
-            db_batch_data = config.hypercache.batch_load_fn(teams_for_full_check)
+            db_batch_data = config.hypercache.batch_load_fn(teams)
         except Exception as e:
             logger.warning("Batch load failed, falling back to individual loads", error=str(e))
 
-    # Fast-path: verify teams that should have empty caches
-    for team in teams_for_empty_check:
-        result.total += 1
-        try:
-            _verify_empty_cache_team(
-                team, config, cache_batch_data, expiry_status, cache_type, result, team_ids_to_skip_fix
-            )
-        except Exception as e:
-            result.errors += 1
-            logger.exception("Error verifying team (empty check)", team_id=team.id, error=str(e))
-
-    # Full verification for teams that have data
-    for team in teams_for_full_check:
+    for team in teams:
         result.total += 1
 
         try:
@@ -326,72 +264,6 @@ def _verify_and_fix_batch(
                 result=result,
                 verification=verification,
             )
-
-
-def _verify_empty_cache_team(
-    team: Team,
-    config: HyperCacheManagementConfig,
-    cache_batch_data: dict,
-    expiry_status: dict | None,
-    cache_type: str,
-    result: VerificationResult,
-    team_ids_to_skip_fix: set[int],
-) -> None:
-    """
-    Fast-path verification for teams expected to have empty cache values.
-
-    This avoids loading DB data for teams that should have empty caches (e.g., teams with no flags).
-    Just checks that the cached value matches empty_cache_value.
-    """
-    empty_value = config.empty_cache_value
-    if empty_value is None:
-        raise ValueError(
-            f"empty_cache_value must be configured to verify team {team.id} as empty, "
-            "but config.empty_cache_value is None"
-        )
-
-    # Get cached data from batch
-    cached_entry = cache_batch_data.get(team.id)
-    if cached_entry:
-        cached_data, source = cached_entry
-    else:
-        cached_data, source = None, "miss"
-
-    # Determine issue type (if any)
-    # Note: batch_get_from_cache only returns "redis" or "miss" sources (never "db")
-    issue_type: str | None = None
-    if source == "miss" or cached_data is None:
-        issue_type = "cache_miss"
-    elif cached_data != empty_value:
-        issue_type = "cache_mismatch"
-    else:
-        # Cache matches - check expiry tracking
-        identifier = config.hypercache.get_cache_identifier(team)
-        if expiry_status and not expiry_status.get(identifier, True):
-            issue_type = "expiry_missing"
-
-    if issue_type:
-        # Check if we should skip fixing (e.g., grace period for recently updated flags)
-        if team.id in team_ids_to_skip_fix:
-            result.skipped_for_grace_period += 1
-            if len(result.skipped_team_ids) < MAX_FIXED_TEAM_IDS_TO_LOG:
-                result.skipped_team_ids.append(team.id)
-            logger.debug(
-                "Skipping fix due to grace period",
-                team_id=team.id,
-                issue_type=issue_type,
-                cache_type=cache_type,
-            )
-            return
-
-        _fix_and_record(
-            team=team,
-            config=config,
-            issue_type=issue_type,
-            cache_type=cache_type,
-            result=result,
-            verification={"db_data": empty_value},
-        )
 
 
 def _fix_and_record(

--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -501,72 +501,26 @@ class TestPushHypercacheStatsMetrics(BaseTest):
         assert "Failed to push hypercache stats" in str(mock_logger.warning.call_args)
 
 
-class TestConfigValidation(BaseTest):
-    """Test HyperCacheManagementConfig validation."""
+class TestConfigGetTeamsQuerysetFn(BaseTest):
+    """Test HyperCacheManagementConfig.get_teams_queryset_fn."""
 
-    def test_both_optimization_fields_none_is_valid(self):
-        """Config with both optimization fields None is valid."""
-        # Should not raise
+    def test_default_is_none(self):
         config = create_test_config()
-        assert config.get_team_ids_needing_full_verification_fn is None
-        assert config.empty_cache_value is None
+        assert config.get_teams_queryset_fn is None
 
-    def test_both_optimization_fields_set_is_valid(self):
-        """Config with both optimization fields set is valid."""
+    def test_can_be_set_to_callable(self):
+        from posthog.models.team.team import Team
+
         hypercache = create_test_hypercache()
 
         def update_fn(team, ttl=None):
             return True
 
-        def get_team_ids():
-            return {1, 2, 3}
-
-        # Should not raise
         config = HyperCacheManagementConfig(
             hypercache=hypercache,
             update_fn=update_fn,
             cache_name="test_cache",
-            get_team_ids_needing_full_verification_fn=get_team_ids,
-            empty_cache_value={"flags": []},
+            get_teams_queryset_fn=lambda: Team.objects.all(),
         )
-        assert config.get_team_ids_needing_full_verification_fn is not None
-        assert config.empty_cache_value is not None
-
-    def test_only_team_ids_fn_set_raises_error(self):
-        """Config with only get_team_ids_needing_full_verification_fn raises ValueError."""
-        hypercache = create_test_hypercache()
-
-        def update_fn(team, ttl=None):
-            return True
-
-        def get_team_ids():
-            return {1, 2, 3}
-
-        with self.assertRaises(ValueError) as context:
-            HyperCacheManagementConfig(
-                hypercache=hypercache,
-                update_fn=update_fn,
-                cache_name="test_cache",
-                get_team_ids_needing_full_verification_fn=get_team_ids,
-                empty_cache_value=None,  # Missing!
-            )
-
-        assert "both get_team_ids_needing_full_verification_fn and empty_cache_value" in str(context.exception)
-
-    def test_only_empty_cache_value_set_raises_error(self):
-        """Config with only empty_cache_value raises ValueError."""
-        hypercache = create_test_hypercache()
-
-        def update_fn(team, ttl=None):
-            return True
-
-        with self.assertRaises(ValueError) as context:
-            HyperCacheManagementConfig(
-                hypercache=hypercache,
-                update_fn=update_fn,
-                cache_name="test_cache",
-                get_team_ids_needing_full_verification_fn=None,  # Missing!
-                empty_cache_value={"flags": []},
-            )
-
-        assert "both get_team_ids_needing_full_verification_fn and empty_cache_value" in str(context.exception)
+        assert config.get_teams_queryset_fn is not None
+        assert config.get_teams_queryset_fn().count() >= 0

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -19,9 +19,7 @@ from posthog.storage.hypercache_verifier import (
     MAX_FIXED_TEAM_IDS_TO_LOG,
     VerificationResult,
     _fix_and_record,
-    _partition_teams_for_verification,
     _verify_and_fix_batch,
-    _verify_empty_cache_team,
     verify_and_fix_all_teams,
 )
 
@@ -658,6 +656,7 @@ class TestVerifyAndFixAllTeams(BaseTest):
     def test_processes_all_teams_in_chunks(self):
         """Test that all teams are processed in chunks."""
         mock_config = MagicMock()
+        mock_config.get_teams_queryset_fn = None
         mock_config.hypercache.batch_load_fn = None
         mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.side_effect = lambda t: str(t.id)
@@ -679,6 +678,7 @@ class TestVerifyAndFixAllTeams(BaseTest):
     def test_returns_aggregated_results(self):
         """Test that results are aggregated across all chunks."""
         mock_config = MagicMock()
+        mock_config.get_teams_queryset_fn = None
         mock_config.hypercache.batch_load_fn = None
         mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.update_fn.return_value = True
@@ -701,369 +701,28 @@ class TestVerifyAndFixAllTeams(BaseTest):
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
-class TestPartitionTeamsForVerification(BaseTest):
-    """Test _partition_teams_for_verification helper function."""
+class TestVerifyAndFixAllTeamsQuerysetScoping(BaseTest):
+    """Test that verify_and_fix_all_teams uses get_teams_queryset_fn for team scoping."""
 
-    def test_all_teams_full_check_when_optimization_disabled(self):
-        """When team_ids_needing_full_verification is None, all teams go to full check."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = None
-
-        teams = [self.team]
-        full_check, empty_check = _partition_teams_for_verification(teams, None, mock_config)
-
-        assert full_check == teams
-        assert empty_check == []
-
-    def test_all_teams_full_check_when_empty_cache_value_is_none(self):
-        """When empty_cache_value is None, all teams go to full check even with team_ids set."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = None
-
-        teams = [self.team]
-        team_ids = {self.team.id}
-        full_check, empty_check = _partition_teams_for_verification(teams, team_ids, mock_config)
-
-        assert full_check == teams
-        assert empty_check == []
-
-    def test_teams_with_flags_go_to_full_check(self):
-        """Teams in team_ids_needing_full_verification go to full check."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        teams = [self.team]
-        team_ids_with_flags = {self.team.id}
-        full_check, empty_check = _partition_teams_for_verification(teams, team_ids_with_flags, mock_config)
-
-        assert full_check == [self.team]
-        assert empty_check == []
-
-    def test_teams_without_flags_go_to_empty_check(self):
-        """Teams NOT in team_ids_needing_full_verification go to empty check."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        teams = [self.team]
-        team_ids_with_flags: set[int] = set()  # Empty - no teams have flags
-        full_check, empty_check = _partition_teams_for_verification(teams, team_ids_with_flags, mock_config)
-
-        assert full_check == []
-        assert empty_check == [self.team]
-
-    def test_mixed_teams_split_correctly(self):
-        """Batch with mix of teams with/without flags splits correctly."""
+    def test_scopes_to_queryset_when_configured(self):
+        """Only teams returned by get_teams_queryset_fn are verified."""
         from posthog.models import Team
 
         team2 = Team.objects.create(organization=self.organization, name="Team 2")
 
         mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        teams = [self.team, team2]
-        # Only self.team has flags
-        team_ids_with_flags = {self.team.id}
-        full_check, empty_check = _partition_teams_for_verification(teams, team_ids_with_flags, mock_config)
-
-        assert full_check == [self.team]
-        assert empty_check == [team2]
-
-
-@override_settings(FLAGS_REDIS_URL="redis://test")
-class TestVerifyEmptyCacheTeam(BaseTest):
-    """Test _verify_empty_cache_team fast-path verification."""
-
-    def test_cache_miss_triggers_fix(self):
-        """Teams with no cache entry should be fixed via set_cache_value with empty data."""
-        mock_config = MagicMock()
-        empty_value: dict = {"flags": []}
-        mock_config.empty_cache_value = empty_value
-        mock_config.update_fn.return_value = True
-
-        result = VerificationResult()
-        # Cache batch data has no entry for this team (cache miss)
-        cache_batch_data: dict = {}
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=None,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=set(),
-        )
-
-        assert result.cache_miss_fixed == 1
-        # Empty cache value is passed as db_data, so set_cache_value is used directly
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, empty_value)
-        mock_config.update_fn.assert_not_called()
-
-    def test_cached_data_none_triggers_fix(self):
-        """Teams with cached_data=None should be fixed."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        result = VerificationResult()
-        # Cache entry exists but data is None
-        cache_batch_data = {self.team.id: (None, "redis")}
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=None,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=set(),
-        )
-
-        assert result.cache_miss_fixed == 1
-
-    def test_cache_mismatch_triggers_fix(self):
-        """Teams with cached flags but expected empty should be fixed via set_cache_value with empty data."""
-        mock_config = MagicMock()
-        empty_value: dict = {"flags": []}
-        mock_config.empty_cache_value = empty_value
-        mock_config.update_fn.return_value = True
-
-        result = VerificationResult()
-        # Cache has stale data (team used to have flags)
-        cache_batch_data = {self.team.id: ({"flags": [{"id": 1, "key": "old-flag"}]}, "redis")}
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=None,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=set(),
-        )
-
-        assert result.cache_mismatch_fixed == 1
-        # Empty cache value is passed as db_data, so set_cache_value is used directly
-        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, empty_value)
-        mock_config.update_fn.assert_not_called()
-
-    def test_cache_match_no_fix(self):
-        """Teams with correct empty cache should not trigger fix."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
-
-        result = VerificationResult()
-        # Cache correctly has empty value
-        cache_batch_data: dict = {self.team.id: ({"flags": []}, "redis")}
-        expiry_status = {str(self.team.id): True}  # Tracked
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=expiry_status,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=set(),
-        )
-
-        # No fixes should be triggered
-        assert result.total_fixed == 0
-        mock_config.hypercache.set_cache_value.assert_not_called()
-
-    def test_expiry_missing_triggers_fix(self):
-        """Empty cache match but missing expiry tracking should trigger fix."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
-
-        result = VerificationResult()
-        # Cache matches but expiry tracking missing
-        cache_batch_data: dict = {self.team.id: ({"flags": []}, "redis")}
-        expiry_status = {str(self.team.id): False}  # NOT tracked
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=expiry_status,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=set(),
-        )
-
-        # Should fix expiry tracking
-        assert result.expiry_missing_fixed == 1
-
-    def test_raises_value_error_if_empty_cache_value_not_set(self):
-        """Should raise ValueError if empty_cache_value is None."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = None  # Misconfiguration
-
-        result = VerificationResult()
-        cache_batch_data: dict = {}
-
-        with self.assertRaises(ValueError) as context:
-            _verify_empty_cache_team(
-                team=self.team,
-                config=mock_config,
-                cache_batch_data=cache_batch_data,
-                expiry_status=None,
-                cache_type="flags",
-                result=result,
-                team_ids_to_skip_fix=set(),
-            )
-
-        assert "empty_cache_value must be configured" in str(context.exception)
-        assert str(self.team.id) in str(context.exception)
-
-    def test_team_ids_to_skip_fix_skips_fix_for_empty_cache_team(self):
-        """Test that team_ids_to_skip_fix can skip fixes in empty cache path."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        result = VerificationResult()
-        # Cache miss - would normally trigger fix
-        cache_batch_data: dict = {}
-        # Team is in the skip set
-        team_ids_to_skip_fix = {self.team.id}
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=None,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=team_ids_to_skip_fix,
-        )
-
-        # Fix should be skipped
-        assert result.total_fixed == 0
-        assert result.skipped_for_grace_period == 1
-        assert self.team.id in result.skipped_team_ids
-        mock_config.hypercache.set_cache_value.assert_not_called()
-
-    def test_empty_team_ids_to_skip_fix_does_not_skip_for_empty_cache_team(self):
-        """Test that empty team_ids_to_skip_fix allows empty cache fixes to proceed."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-
-        result = VerificationResult()
-        # Cache miss - should trigger fix
-        cache_batch_data: dict = {}
-        # Empty skip set - should proceed with fix
-        team_ids_to_skip_fix: set[int] = set()
-
-        _verify_empty_cache_team(
-            team=self.team,
-            config=mock_config,
-            cache_batch_data=cache_batch_data,
-            expiry_status=None,
-            cache_type="flags",
-            result=result,
-            team_ids_to_skip_fix=team_ids_to_skip_fix,
-        )
-
-        # Fix should proceed
-        assert result.cache_miss_fixed == 1
-        assert result.skipped_for_grace_period == 0
-
-
-@override_settings(FLAGS_REDIS_URL="redis://test")
-class TestVerifyAndFixBatchOptimization(BaseTest):
-    """Test _verify_and_fix_batch optimization path selection."""
-
-    def test_teams_with_flags_use_full_verification_path(self):
-        """Teams in team_ids_needing_full_verification should use full DB load."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-        mock_config.hypercache.batch_load_fn.return_value = {self.team.id: {"flags": []}}
+        mock_config.get_teams_queryset_fn = lambda: Team.objects.filter(id=team2.id)
+        mock_config.hypercache.batch_load_fn = None
         mock_config.hypercache.batch_get_from_cache.return_value = {}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
+        mock_config.hypercache.get_cache_identifier.side_effect = lambda t: str(t.id)
 
-        result = VerificationResult()
-        verify_fn_calls = []
-
-        def verify_fn(team, db_batch_data, cache_batch_data):
-            verify_fn_calls.append(team.id)
-            return {"status": "match", "issue": None}
-
-        # Team with flags should be in the full check list
-        team_ids_with_flags = {self.team.id}
-
-        with patch(
-            "posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={str(self.team.id): True}
-        ):
-            _verify_and_fix_batch(
-                teams=[self.team],
-                config=mock_config,
-                verify_team_fn=verify_fn,
-                cache_type="flags",
-                result=result,
-                team_ids_needing_full_verification=team_ids_with_flags,
-            )
-
-        # Should have called batch_load_fn for teams with flags
-        mock_config.hypercache.batch_load_fn.assert_called_once_with([self.team])
-        # verify_fn should have been called (not _verify_empty_cache_team)
-        assert len(verify_fn_calls) == 1
-        assert verify_fn_calls[0] == self.team.id
-
-    def test_teams_without_flags_use_empty_check_fast_path(self):
-        """Teams NOT in team_ids_needing_full_verification should use fast-path."""
-        mock_config = MagicMock()
-        mock_config.empty_cache_value = {"flags": []}
-        mock_config.hypercache.batch_load_fn = MagicMock(return_value={})
-        mock_config.hypercache.batch_get_from_cache.return_value = {self.team.id: ({"flags": []}, "redis")}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
-
-        result = VerificationResult()
-        verify_fn_calls = []
+        verified_team_ids: list[int] = []
 
         def verify_fn(team, db_batch_data, cache_batch_data):
-            verify_fn_calls.append(team.id)
+            verified_team_ids.append(team.id)
             return {"status": "match", "issue": None}
 
-        # Team WITHOUT flags - empty optimization set means no teams have flags
-        team_ids_with_flags: set[int] = set()
-
-        with patch(
-            "posthog.storage.hypercache_verifier.batch_check_expiry_tracking",
-            return_value={str(self.team.id): True},
-        ):
-            _verify_and_fix_batch(
-                teams=[self.team],
-                config=mock_config,
-                verify_team_fn=verify_fn,
-                cache_type="flags",
-                result=result,
-                team_ids_needing_full_verification=team_ids_with_flags,
-            )
-
-        # Should NOT have called batch_load_fn (no teams need full verification)
-        mock_config.hypercache.batch_load_fn.assert_not_called()
-        # verify_fn should NOT have been called (_verify_empty_cache_team was used instead)
-        assert len(verify_fn_calls) == 0
-        # But total should still count the team
-        assert result.total == 1
-
-    def test_optimization_fallback_when_function_fails(self):
-        """When get_team_ids_needing_full_verification_fn fails, fall back to full verification."""
-        mock_config = MagicMock()
-        mock_config.get_team_ids_needing_full_verification_fn = MagicMock(
-            side_effect=Exception("Database connection failed")
-        )
-        mock_config.hypercache.batch_load_fn = MagicMock(return_value={})
-        mock_config.hypercache.batch_get_from_cache.return_value = {}
-        mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
-
-        def verify_fn(team, db_batch_data, cache_batch_data):
-            return {"status": "match", "issue": None}
-
-        with patch(
-            "posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={str(self.team.id): True}
-        ):
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
             result = verify_and_fix_all_teams(
                 config=mock_config,
                 verify_team_fn=verify_fn,
@@ -1071,8 +730,50 @@ class TestVerifyAndFixBatchOptimization(BaseTest):
                 chunk_size=100,
             )
 
-        # Should still complete successfully with full verification fallback
+        assert result.total == 1
+        assert team2.id in verified_team_ids
+        assert self.team.id not in verified_team_ids
+
+    def test_empty_queryset_processes_zero_teams(self):
+        """When get_teams_queryset_fn returns empty queryset, no teams are verified."""
+        from posthog.models import Team
+
+        mock_config = MagicMock()
+        mock_config.get_teams_queryset_fn = lambda: Team.objects.none()
+        mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            raise AssertionError("Should never be called")
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
+            result = verify_and_fix_all_teams(
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                chunk_size=100,
+            )
+
+        assert result.total == 0
+
+    def test_iterates_all_teams_when_queryset_fn_is_none(self):
+        """When get_teams_queryset_fn is None, all teams are verified."""
+        mock_config = MagicMock()
+        mock_config.get_teams_queryset_fn = None
+        mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+        mock_config.hypercache.get_cache_identifier.side_effect = lambda t: str(t.id)
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            return {"status": "match", "issue": None}
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
+            result = verify_and_fix_all_teams(
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                chunk_size=100,
+            )
+
+        # Should have verified at least self.team
         assert result.total >= 1
-        assert result.errors == 0
-        # Should have used full verification path (batch_load_fn called)
-        mock_config.hypercache.batch_load_fn.assert_called()

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -21,9 +21,11 @@ from celery import shared_task
 from posthog.exceptions_capture import capture_exception
 from posthog.models.feature_flag.local_evaluation import (
     FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
+    FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
     verify_team_flag_definitions,
 )
 from posthog.models.team.team import Team
+from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 from posthog.storage.hypercache_verifier import _run_verification_for_cache
 from posthog.tasks.utils import CeleryQueue, PushGatewayTask
 
@@ -70,36 +72,57 @@ def _run_flag_definitions_verification() -> None:
 
         start_time = time.time()
 
-        # Only verify the with-cohorts variant. Both variants are always updated together
-        # by update_flag_definitions_cache(), so if one is stale, both are. Fixing one
-        # fixes both, so verifying both would just duplicate work.
-        def verify_fn(
-            team: Team,
-            db_batch_data: dict | None = None,
-            cache_batch_data: dict | None = None,
-            verbose: bool = False,
-        ) -> dict:
-            return verify_team_flag_definitions(
-                team,
-                db_batch_data=db_batch_data,
-                cache_batch_data=cache_batch_data,
-                include_cohorts=True,
-                verbose=verbose,
-            )
+        variants: list[tuple[HyperCacheManagementConfig, bool, str]] = [
+            (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, True, "with-cohorts"),
+            (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, False, "without-cohorts"),
+        ]
 
-        try:
-            _run_verification_for_cache(
-                config=FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
-                verify_team_fn=verify_fn,
-                cache_type=cache_type,
-                chunk_size=settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE,
-            )
-        except Exception as e:
-            logger.exception("Failed cache verification", cache_type=cache_type, error=str(e))
-            capture_exception(e)
-            raise
+        errors: list[Exception] = []
+
+        for config, include_cohorts, variant_name in variants:
+
+            def verify_fn(
+                team: Team,
+                db_batch_data: dict | None = None,
+                cache_batch_data: dict | None = None,
+                verbose: bool = False,
+                _include_cohorts: bool = include_cohorts,
+            ) -> dict:
+                return verify_team_flag_definitions(
+                    team,
+                    db_batch_data=db_batch_data,
+                    cache_batch_data=cache_batch_data,
+                    include_cohorts=_include_cohorts,
+                    verbose=verbose,
+                )
+
+            try:
+                _run_verification_for_cache(
+                    config=config,
+                    verify_team_fn=verify_fn,
+                    cache_type=f"{cache_type}_{variant_name}",
+                    chunk_size=settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE,
+                )
+            except Exception as e:
+                logger.exception(
+                    "Failed cache verification",
+                    cache_type=cache_type,
+                    variant=variant_name,
+                    error=str(e),
+                )
+                capture_exception(e)
+                errors.append(e)
 
         duration = time.time() - start_time
+        if errors:
+            logger.warning(
+                "Cache verification finished with errors",
+                cache_type=cache_type,
+                duration_seconds=duration,
+                failed_variants=len(errors),
+            )
+            raise errors[0]
+
         logger.info("Completed cache verification", cache_type=cache_type, duration_seconds=duration)
     finally:
         django_cache.delete(lock_key)
@@ -217,12 +240,12 @@ def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
     """
     Periodic task to verify the flag definitions HyperCache and fix issues.
 
-    Runs hourly at minute 50. Verifies the with-cohorts variant (fixing it
-    automatically fixes both variants since update_flag_definitions_cache
-    updates both). Fixes cache misses, mismatches, or expiry tracking issues.
+    Runs hourly at minute 50. Verifies both cache variants (with-cohorts and
+    without-cohorts) independently, fixing cache misses, mismatches, or expiry
+    tracking issues for each. Errors on one variant don't block the other.
 
     Uses a distributed lock to skip execution if a previous run is still in progress.
 
-    Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions", issue_type="..."}
+    Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_<variant>", issue_type="..."}
     """
     _run_flag_definitions_verification()

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -133,26 +133,29 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     """Tests for the flag definitions cache verification task."""
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verifies_flag_definitions_cache(self, mock_run_verification: MagicMock) -> None:
+    def test_verifies_both_flag_definitions_variants(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
         verify_and_fix_flag_definitions_cache_task()
 
-        # Only verifies with-cohorts variant (fixing it fixes both variants)
-        mock_run_verification.assert_called_once()
-        assert mock_run_verification.call_args[1]["cache_type"] == "flag_definitions"
+        assert mock_run_verification.call_count == 2
+        cache_types = [call[1]["cache_type"] for call in mock_run_verification.call_args_list]
+        assert cache_types == ["flag_definitions_with-cohorts", "flag_definitions_without-cohorts"]
 
     @patch("posthog.tasks.hypercache_verification.capture_exception")
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
+    def test_captures_error_continues_to_next_variant_then_reraises(
+        self, mock_run_verification: MagicMock, mock_capture: MagicMock
+    ) -> None:
         error = Exception("flag_definitions verification failed")
-        mock_run_verification.side_effect = error
+        mock_run_verification.side_effect = [error, MagicMock()]
 
         with self.assertRaises(Exception) as context:
             verify_and_fix_flag_definitions_cache_task()
 
-        mock_capture.assert_called_once_with(error)
         assert context.exception is error
+        mock_capture.assert_called_once_with(error)
+        assert mock_run_verification.call_count == 2
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:


### PR DESCRIPTION
## Problem

Two issues with the HyperCache verification system for feature flags:

1. **Verification checked all ~238K teams** instead of only the ~24K teams that have (or ever had) feature flags. This wasted resources on the ~89% of teams with zero flags.

2. **Only the with-cohorts flag definition cache variant was verified.** The without-cohorts variant could remain stale, causing the local evaluation endpoint to serve incorrect flag data.

Since flags are soft-deleted (`deleted=True`), we use `objects_including_soft_deleted` to find teams that have *ever* had a flag — so teams that deleted their last flag still get verified.

## Changes

- Add `get_teams_queryset_fn` to `HyperCacheManagementConfig` for pluggable team-scoping on both management commands and Celery tasks
- Replace the partition-based optimization (`get_team_ids_needing_full_verification_fn` + `empty_cache_value`) with queryset-level scoping that skips irrelevant teams entirely
- Verify both flag definition cache variants (with-cohorts and without-cohorts) independently in the Celery task, with per-variant error isolation
- Remove `--variant` CLI argument from `verify_flag_definitions_cache` (always verifies both now)
- Warm path intentionally still warms all teams to prevent cache misses falling through to database lookups

## How did you test this code?

- `pytest posthog/models/feature_flag/test/test_flags_cache.py` (all pass)
- `pytest posthog/tasks/test/test_hypercache_verification.py` (all pass)
- `pytest posthog/management/commands/test/test_base_hypercache_command.py` (all pass)
- `pytest posthog/storage/test/test_hypercache_verifier.py` (all pass)
- `pytest posthog/storage/test/test_hypercache_manager.py` (all pass)

## Publish to changelog?

no

## Follow-up

I think we might want to remove the `warm_*` management commands or simply have them call these `verify_*` functions. There's a lot of duplication and I need to make this change to them.