### PR TITLE
feat: use egress proxy in batch exports

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -923,7 +923,9 @@ class SlackIntegration:
 
     @property
     def client(self) -> WebClient:
-        return WebClient(self.integration.sensitive_config["access_token"])
+        from posthog.security.outbound_proxy import get_proxy_url
+
+        return WebClient(self.integration.sensitive_config["access_token"], proxy=get_proxy_url())
 
     def async_client(self, session: Optional["aiohttp.ClientSession"] = None) -> AsyncWebClient:
         return AsyncWebClient(self.integration.sensitive_config["access_token"], session=session)
@@ -1065,7 +1067,9 @@ class GoogleAdsIntegration:
 
     @property
     def client(self) -> WebClient:
-        return WebClient(self.integration.sensitive_config["access_token"])
+        from posthog.security.outbound_proxy import get_proxy_url
+
+        return WebClient(self.integration.sensitive_config["access_token"], proxy=get_proxy_url())
 
     def list_google_ads_conversion_actions(self, customer_id, parent_id=None) -> list[dict]:
         response = external_requests.request(
@@ -1349,7 +1353,9 @@ class LinkedInAdsIntegration:
 
     @property
     def client(self) -> WebClient:
-        return WebClient(self.integration.sensitive_config["access_token"])
+        from posthog.security.outbound_proxy import get_proxy_url
+
+        return WebClient(self.integration.sensitive_config["access_token"], proxy=get_proxy_url())
 
     def list_linkedin_ads_conversion_rules(self, account_id):
         response = external_requests.request(

--- a/posthog/security/outbound_proxy.py
+++ b/posthog/security/outbound_proxy.py
@@ -48,8 +48,7 @@ def get_proxy_url() -> str | None:
     return None
 
 
-def get_proxy_host_port() -> tuple[str, int] | None:
-    """Return ``(host, port)`` for SDKs that need them separately (e.g. Snowflake)."""
+def _get_proxy_host_port() -> tuple[str, int] | None:
     url = get_proxy_url()
     if not url:
         return None
@@ -57,6 +56,18 @@ def get_proxy_host_port() -> tuple[str, int] | None:
 
     parsed = urlparse(url)
     return (parsed.hostname or "", parsed.port or 8080)
+
+
+def get_proxy_host_port_dict() -> dict[str, str]:
+    """Return ``{"proxy_host": ..., "proxy_port": ...}`` or ``{}`` when proxy is disabled.
+
+    Suitable for spreading into SDKs that accept separate host/port params
+    (e.g. Snowflake's ``connect(proxy_host=, proxy_port=)``).
+    """
+    hp = _get_proxy_host_port()
+    if not hp:
+        return {}
+    return {"proxy_host": hp[0], "proxy_port": str(hp[1])}
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/security/outbound_proxy.py
+++ b/posthog/security/outbound_proxy.py
@@ -48,6 +48,17 @@ def get_proxy_url() -> str | None:
     return None
 
 
+def get_proxy_host_port() -> tuple[str, int] | None:
+    """Return ``(host, port)`` for SDKs that need them separately (e.g. Snowflake)."""
+    url = get_proxy_url()
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    return (parsed.hostname or "", parsed.port or 8080)
+
+
 # ---------------------------------------------------------------------------
 # requests — pre-configured Session instance
 # ---------------------------------------------------------------------------

--- a/products/batch_exports/backend/api/destination_tests/azure_blob.py
+++ b/products/batch_exports/backend/api/destination_tests/azure_blob.py
@@ -40,8 +40,19 @@ class AzureBlobContainerTestStep(DestinationTestStep):
         assert self.connection_string is not None
         assert self.container_name is not None
 
+        from posthog.security.outbound_proxy import get_proxy_url
+
+        proxy_url = get_proxy_url()
+        proxy_kwargs: dict = {}
+        if proxy_url:
+            from azure.core.pipeline.policies import ProxyPolicy
+
+            proxy_kwargs["proxy_policy"] = ProxyPolicy(proxies={"https": proxy_url, "http": proxy_url})
+
         try:
-            async with BlobServiceClient.from_connection_string(self.connection_string) as blob_service_client:
+            async with BlobServiceClient.from_connection_string(
+                self.connection_string, **proxy_kwargs
+            ) as blob_service_client:
                 container_client = blob_service_client.get_container_client(self.container_name)
                 await container_client.get_container_properties()
 

--- a/products/batch_exports/backend/api/destination_tests/s3.py
+++ b/products/batch_exports/backend/api/destination_tests/s3.py
@@ -49,7 +49,13 @@ class S3EnsureBucketTestStep(DestinationTestStep):
     async def _run_step(self) -> DestinationTestStepResult:
         """Run this test step."""
         import aioboto3
+        from aiobotocore.config import AioConfig
         from botocore.exceptions import ClientError
+
+        from posthog.security.outbound_proxy import get_proxy_config
+
+        proxy_cfg = get_proxy_config()
+        boto_config = AioConfig(proxies=proxy_cfg) if proxy_cfg else None
 
         session = aioboto3.Session()
         async with session.client(
@@ -58,6 +64,7 @@ class S3EnsureBucketTestStep(DestinationTestStep):
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             endpoint_url=self.endpoint_url,
+            config=boto_config,
         ) as client:
             assert self.bucket_name is not None
             try:

--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -81,6 +81,11 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
         if result is not None:
             return result
 
+        from posthog.security.outbound_proxy import get_proxy_host_port
+
+        proxy = get_proxy_host_port()
+        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+
         try:
             connection = await asyncio.to_thread(
                 snowflake.connector.connect,
@@ -90,6 +95,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
                 private_key=private_key,
                 # wrap role in quotes in case it contains lowercase or special characters
                 role=f'"{self.role}"' if self.role is not None else None,
+                **proxy_kwargs,
             )
         except (OperationalError, InterfaceError, DatabaseError) as err:
             if err.msg is not None and "404 Not Found" in err.msg:
@@ -165,6 +171,11 @@ class SnowflakeWarehouseTestStep(DestinationTestStep):
         if result is not None:
             return result
 
+        from posthog.security.outbound_proxy import get_proxy_host_port
+
+        proxy = get_proxy_host_port()
+        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+
         connection = await asyncio.to_thread(
             snowflake.connector.connect,
             user=self.user,
@@ -172,6 +183,7 @@ class SnowflakeWarehouseTestStep(DestinationTestStep):
             account=self.account,
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
+            **proxy_kwargs,
         )
 
         with connection.cursor() as cursor:
@@ -253,6 +265,11 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
         if result is not None:
             return result
 
+        from posthog.security.outbound_proxy import get_proxy_host_port
+
+        proxy = get_proxy_host_port()
+        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+
         connection = await asyncio.to_thread(
             snowflake.connector.connect,
             user=self.user,
@@ -261,6 +278,7 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
             warehouse=self.warehouse,
+            **proxy_kwargs,
         )
 
         with connection:
@@ -347,6 +365,11 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
         if result is not None:
             return result
 
+        from posthog.security.outbound_proxy import get_proxy_host_port
+
+        proxy = get_proxy_host_port()
+        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+
         connection = await asyncio.to_thread(
             snowflake.connector.connect,
             user=self.user,
@@ -355,6 +378,7 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
             private_key=private_key,
             role=f'"{self.role}"' if self.role is not None else None,
             warehouse=self.warehouse,
+            **proxy_kwargs,
         )
 
         with connection:

--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -81,10 +81,9 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
         if result is not None:
             return result
 
-        from posthog.security.outbound_proxy import get_proxy_host_port
+        from posthog.security.outbound_proxy import get_proxy_host_port_dict
 
-        proxy = get_proxy_host_port()
-        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+        proxy_kwargs = get_proxy_host_port_dict()
 
         try:
             connection = await asyncio.to_thread(
@@ -171,10 +170,9 @@ class SnowflakeWarehouseTestStep(DestinationTestStep):
         if result is not None:
             return result
 
-        from posthog.security.outbound_proxy import get_proxy_host_port
+        from posthog.security.outbound_proxy import get_proxy_host_port_dict
 
-        proxy = get_proxy_host_port()
-        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+        proxy_kwargs = get_proxy_host_port_dict()
 
         connection = await asyncio.to_thread(
             snowflake.connector.connect,
@@ -265,10 +263,9 @@ class SnowflakeDatabaseTestStep(DestinationTestStep):
         if result is not None:
             return result
 
-        from posthog.security.outbound_proxy import get_proxy_host_port
+        from posthog.security.outbound_proxy import get_proxy_host_port_dict
 
-        proxy = get_proxy_host_port()
-        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+        proxy_kwargs = get_proxy_host_port_dict()
 
         connection = await asyncio.to_thread(
             snowflake.connector.connect,
@@ -365,10 +362,9 @@ class SnowflakeSchemaTestStep(DestinationTestStep):
         if result is not None:
             return result
 
-        from posthog.security.outbound_proxy import get_proxy_host_port
+        from posthog.security.outbound_proxy import get_proxy_host_port_dict
 
-        proxy = get_proxy_host_port()
-        proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+        proxy_kwargs = get_proxy_host_port_dict()
 
         connection = await asyncio.to_thread(
             snowflake.connector.connect,

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -154,10 +154,20 @@ class AzureBlobConsumer(Consumer):
         # Blobs larger than `max_single_put_size` are uploaded in blocks of `max_block_size`.
         # These are Azure SDK defaults but we set them explicitly for visibility.
         # See: https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient
+        from posthog.security.outbound_proxy import get_proxy_url
+
+        proxy_url = get_proxy_url()
+        proxy_kwargs: dict = {}
+        if proxy_url:
+            from azure.core.pipeline.policies import ProxyPolicy
+
+            proxy_kwargs["proxy_policy"] = ProxyPolicy(proxies={"https": proxy_url, "http": proxy_url})
+
         blob_service_client = BlobServiceClient.from_connection_string(
             conn_str=connection_string,
             max_single_put_size=64 * 1024 * 1024,  # 64 MiB
             max_block_size=4 * 1024 * 1024,  # 4 MiB
+            **proxy_kwargs,
         )
         container_client = blob_service_client.get_container_client(inputs.container_name)
 

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -342,10 +342,17 @@ class BigQueryClient:
             },
             scopes=["https://www.googleapis.com/auth/cloud-platform"],
         )
-        client = bigquery.Client(
-            project=project_id,
-            credentials=credentials,
-        )
+        from posthog.security.outbound_proxy import get_proxy_config
+
+        proxy_cfg = get_proxy_config()
+        if proxy_cfg:
+            from google.auth.transport.requests import AuthorizedSession
+
+            authed_session = AuthorizedSession(credentials)
+            authed_session.proxies = proxy_cfg
+            client = bigquery.Client(project=project_id, credentials=credentials, _http=authed_session)
+        else:
+            client = bigquery.Client(project=project_id, credentials=credentials)
         return cls(client)
 
     async def create_table(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -991,6 +991,13 @@ async def upload_manifest_file(
     requirement when using Parquet. Since we don't track exactly the size of bytes of
     each Parquet file produced, this function gets it from S3 instead.
     """
+    from aiobotocore.config import AioConfig
+
+    from posthog.security.outbound_proxy import get_proxy_config
+
+    proxy_cfg = get_proxy_config()
+    boto_config = AioConfig(proxies=proxy_cfg) if proxy_cfg else None
+
     session = aioboto3.Session()
     async with session.client(
         "s3",
@@ -998,6 +1005,7 @@ async def upload_manifest_file(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         endpoint_url=endpoint_url,
+        config=boto_config,
     ) as client:
         entries = []
 
@@ -1084,12 +1092,20 @@ async def delete_uploaded_files(
     The delete itself is a "best-effort" as we don't want to fail the batch export if
     this fails.
     """
+    from aiobotocore.config import AioConfig
+
+    from posthog.security.outbound_proxy import get_proxy_config
+
+    proxy_cfg = get_proxy_config()
+    boto_config = AioConfig(proxies=proxy_cfg) if proxy_cfg else None
+
     session = aioboto3.Session()
     async with session.client(
         "s3",
         region_name=region_name,
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
+        config=boto_config,
     ) as client:
 
         async def delete_key(f: str):

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -520,6 +520,13 @@ class ConcurrentS3Consumer(Consumer):
             }
             if self.use_virtual_style_addressing:
                 config["s3"] = {"addressing_style": "virtual"}
+
+            from posthog.security.outbound_proxy import get_proxy_config
+
+            proxy_cfg = get_proxy_config()
+            if proxy_cfg:
+                config["proxies"] = proxy_cfg
+
             boto_config = AioConfig(**config)
 
             try:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -573,6 +573,11 @@ class SnowflakeClient:
 
         try:
             async with CONNECTION_SEMAPHORE:
+                from posthog.security.outbound_proxy import get_proxy_host_port
+
+                proxy = get_proxy_host_port()
+                proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+
                 connection = await asyncio.to_thread(
                     snowflake.connector.connect,
                     user=self.user,
@@ -585,6 +590,7 @@ class SnowflakeClient:
                     role=f'"{self.role}"' if self.role is not None else None,
                     private_key=self.private_key,
                     login_timeout=5,
+                    **proxy_kwargs,
                 )
             connection.telemetry_enabled = False
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -573,10 +573,9 @@ class SnowflakeClient:
 
         try:
             async with CONNECTION_SEMAPHORE:
-                from posthog.security.outbound_proxy import get_proxy_host_port
+                from posthog.security.outbound_proxy import get_proxy_host_port_dict
 
-                proxy = get_proxy_host_port()
-                proxy_kwargs = {"proxy_host": proxy[0], "proxy_port": str(proxy[1])} if proxy else {}
+                proxy_kwargs = get_proxy_host_port_dict()
 
                 connection = await asyncio.to_thread(
                     snowflake.connector.connect,


### PR DESCRIPTION
This ensures requests flow through the egress proxy, significantly limiting the ability to perform SSRF. 