### PR TITLE
chore(devex): document lightweight husky bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - Auto-detect flox environment before running terminal commands
   - If flox is available, and you run into trouble executing commands, try with `flox activate -- bash -c "<command>"` pattern
     - Never use `flox activate` in interactive sessions (it hangs if you try)
+  - If local hooks fail with missing Husky bootstrap files (for example `.husky/_/husky.sh`) or missing `lint-staged`, run `pnpm install --frozen-lockfile --filter=.` once in the repo root
 - Tests:
   - All tests: `pytest`
   - Single test: `pytest path/to/test.py::TestClass::test_method`


### PR DESCRIPTION
## Summary
- add AGENTS guidance for fresh worktrees where Husky bootstrap files or lint-staged are missing
- document lightweight fix: pnpm install --frozen-lockfile --filter=.

## Testing
- docs-only change