### PR TITLE
chore(e2e): use Docker healthchecks and containerized plugins for ingestion

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -40,6 +40,10 @@ env:
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
     CLICKHOUSE_DATABASE: posthog_test
+    # Database names passed to the plugins Docker service via env var substitution
+    POSTHOG_DB_NAME: posthog_e2e_test
+    POSTHOG_PERSONS_DB_NAME: posthog_persons_e2e_test
+    PLUGIN_SERVER_MODE: ingestion-v2
     PGHOST: localhost
     PGUSER: posthog
     PGPASSWORD: posthog
@@ -198,8 +202,8 @@ jobs:
                     while [ $attempt -le $max_attempts ]; do
                         echo "Attempt $attempt of $max_attempts to start stack..."
 
-                        if docker compose -f docker-compose.dev.yml --profile capture down && \
-                          docker compose -f docker-compose.dev.yml --profile capture up -d; then
+                        if docker compose -f docker-compose.dev.yml --profile capture --profile ingestion down && \
+                          docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d; then
                             echo "Stack started successfully"
                             exit 0
                         fi
@@ -320,10 +324,10 @@ jobs:
                   bin/turbo --filter=@posthog/frontend prepare
 
             - name: Start Docker services
-              run: docker compose -f docker-compose.dev.yml --profile capture up -d
+              run: docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              run: bin/wait-for-docker capture
 
             - name: Build frontend
               run: |
@@ -372,19 +376,11 @@ jobs:
                   source ./bin/celery-queues.env
                   echo "CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES" >> $GITHUB_ENV
 
-            - name: Install Node.js ingestion dependencies
-              run: |
-                  pnpm --filter=@posthog/nodejs... install --frozen-lockfile
-                  pnpm --filter=@posthog/cyclotron package
-
-            - name: Start PostHog web, Celery worker & Node.js ingestion
+            - name: Start PostHog web & Celery worker
               run: |
                   python manage.py run_autoreload_celery --type=worker &> /tmp/celery.log &
                   # WARNING: Worker count is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
                   python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 2 &> /tmp/server.log &
-                  # Node.js ingestion pipeline — processes $set/$unset events from Kafka into person properties.
-                  # PERSONS_DATABASE_URL is needed because the Node.js config key differs from PERSONS_DB_WRITER_URL.
-                  cd nodejs && PLUGIN_SERVER_MODE=ingestion-v2 NODE_ENV=dev PERSONS_DATABASE_URL="$PERSONS_DB_WRITER_URL" npx tsx src/index.ts &> /tmp/ingestion.log &
 
             # Install Playwright browsers while we wait for PostHog to be ready
             - name: Install Playwright browsers
@@ -398,33 +394,8 @@ jobs:
                   interval: 2000
                   verbose: true
 
-            - name: Wait for capture service to be ready
-              run: |
-                  echo "Waiting for capture service on port 3307..."
-                  for i in $(seq 1 60); do
-                    if curl -sf http://localhost:3307/_liveness > /dev/null 2>&1; then
-                      echo "Capture service ready after ${i}s"
-                      exit 0
-                    fi
-                    sleep 1
-                  done
-                  echo "Capture service not ready after 60s"
-                  docker logs posthog-capture-1 2>&1 | tail -20
-                  exit 1
-
-            - name: Wait for Node.js ingestion service to be ready
-              run: |
-                  echo "Waiting for ingestion service on port 6738..."
-                  for i in $(seq 1 60); do
-                    if curl -sf http://localhost:6738/_ready > /dev/null 2>&1; then
-                      echo "Ingestion service ready after ${i}s"
-                      exit 0
-                    fi
-                    sleep 1
-                  done
-                  echo "Ingestion service not ready after 60s"
-                  tail -50 /tmp/ingestion.log 2>&1
-                  exit 1
+            - name: Wait for ingestion service to be ready
+              run: bin/wait-for-docker plugins
 
             - name: Run Playwright tests
               id: playwright-tests
@@ -519,6 +490,7 @@ jobs:
               run: |
                   docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
                   docker logs posthog-capture-1 > playwright/test-results/docker-capture.log 2>&1 || echo "No capture container" > playwright/test-results/docker-capture.log
+                  docker logs posthog-plugins-1 > playwright/test-results/docker-plugins.log 2>&1 || echo "No plugins container" > playwright/test-results/docker-plugins.log
 
             - name: Archive test artifacts
               if: always()
@@ -532,7 +504,6 @@ jobs:
                       playwright/test-results-attempt-*/
                       /tmp/celery.log
                       /tmp/server.log
-                      /tmp/ingestion.log
                       /tmp/playwright-output-attempt-*.log
                   retention-days: 30
                   if-no-files-found: ignore

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -203,7 +203,7 @@ jobs:
                         echo "Attempt $attempt of $max_attempts to start stack..."
 
                         if docker compose -f docker-compose.dev.yml --profile capture --profile ingestion down && \
-                          docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d; then
+                          docker compose -f docker-compose.dev.yml --profile capture up -d; then
                             echo "Stack started successfully"
                             exit 0
                         fi
@@ -324,7 +324,7 @@ jobs:
                   bin/turbo --filter=@posthog/frontend prepare
 
             - name: Start Docker services
-              run: docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d
+              run: docker compose -f docker-compose.dev.yml --profile capture up -d
 
             - name: Wait for Docker services
               run: bin/wait-for-docker capture
@@ -376,11 +376,13 @@ jobs:
                   source ./bin/celery-queues.env
                   echo "CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES" >> $GITHUB_ENV
 
-            - name: Start PostHog web & Celery worker
+            - name: Start PostHog web, Celery worker & ingestion
               run: |
                   python manage.py run_autoreload_celery --type=worker &> /tmp/celery.log &
                   # WARNING: Worker count is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
                   python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 2 &> /tmp/server.log &
+                  # Start the Node.js ingestion container now that the database exists and migrations have run.
+                  docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d plugins
 
             # Install Playwright browsers while we wait for PostHog to be ready
             - name: Install Playwright browsers

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -328,6 +328,8 @@ jobs:
 
             - name: Wait for Docker services
               run: bin/wait-for-docker capture
+              env:
+                  COMPOSE_PROFILES: capture
 
             - name: Build frontend
               run: |
@@ -398,6 +400,8 @@ jobs:
 
             - name: Wait for ingestion service to be ready
               run: bin/wait-for-docker plugins
+              env:
+                  COMPOSE_PROFILES: capture,ingestion
 
             - name: Run Playwright tests
               id: playwright-tests

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,8 +100,41 @@ services:
                 condition: service_started
             redis7:
                 condition: service_healthy
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://localhost:3000/_liveness']
+            interval: 5s
+            timeout: 5s
+            retries: 12
         profiles:
             - capture
+
+    plugins:
+        extends:
+            file: docker-compose.base.yml
+            service: plugins
+        image: ghcr.io/posthog/posthog-node:master
+        ports:
+            - '6738:6738'
+        environment:
+            DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_DB_NAME:-posthog}
+            PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
+            CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-posthog}
+            PLUGIN_SERVER_MODE: ${PLUGIN_SERVER_MODE:-}
+        depends_on:
+            kafka:
+                condition: service_started
+            redis7:
+                condition: service_healthy
+            db:
+                condition: service_healthy
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://localhost:6738/_ready']
+            interval: 5s
+            timeout: 5s
+            retries: 30
+            start_period: 15s
+        profiles:
+            - ingestion
 
     db:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -120,6 +120,10 @@ services:
             PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
             CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-posthog}
             PLUGIN_SERVER_MODE: ${PLUGIN_SERVER_MODE:-}
+            # CDP Redis defaults to 127.0.0.1 — must point to the Docker service
+            CDP_REDIS_HOST: redis7
+            # Encryption keys default is only set when NODE_ENV=dev, but the image uses production
+            ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
         depends_on:
             kafka:
                 condition: service_started


### PR DESCRIPTION
**Why**

The original PR runs Node.js ingestion from source on the host — installing pnpm deps, building cyclotron FFI bindings, and polling readiness with hand-rolled curl loops. All of this is unnecessary since the `posthog-node:master` Docker image already exists and can run `ingestion-v2` mode out of the box.

**Changes**

- Add `capture` service healthcheck (`_liveness` endpoint) so `bin/wait-for-docker` can gate on it
- Add `plugins` service to `docker-compose.dev.yml` under the `ingestion` profile, using the pre-built `posthog-node:master` image with Docker healthcheck on `_ready`
- Database names are passed via env var substitution (`POSTHOG_DB_NAME`, `POSTHOG_PERSONS_DB_NAME`) so the container connects to the e2e test databases
- Replace two ~15-line curl polling loops with `bin/wait-for-docker capture` and `bin/wait-for-docker plugins`
- Remove the "Install Node.js ingestion dependencies" step (no more host-side `pnpm install` + `cyclotron package`)
- Collect docker logs from the plugins container on failure

**Notes**

The plugins container will crash-loop briefly on startup because the e2e test database doesn't exist yet — it's created mid-workflow after frontend build. `restart: on-failure` (from base) handles this, and `bin/wait-for-docker plugins` runs after migrations, giving it plenty of time to stabilize.