### PR TITLE
fix(llma): increase ClickHouse query timeout for clustering data queries

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import structlog
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
@@ -26,6 +27,12 @@ from posthog.temporal.llm_analytics.trace_clustering.models import (
 )
 
 logger = structlog.get_logger(__name__)
+
+# ClickHouse max_execution_time for clustering queries (seconds).
+# Default HogQL timeout is 60s which is too tight for generation-level
+# queries with filters on high-volume teams (nested subqueries on events table).
+# These run in background Temporal activities with their own 120s timeout.
+CLUSTERING_QUERY_MAX_EXECUTION_TIME = 120
 
 # AI event types to query for trace filtering (same as TracesQueryRunner)
 AI_EVENT_TYPES = ("$ai_span", "$ai_generation", "$ai_embedding", "$ai_metric", "$ai_feedback", "$ai_trace")
@@ -194,6 +201,7 @@ def fetch_item_embeddings_for_clustering(
             query=query,
             placeholders=placeholders,
             team=team,
+            settings=HogQLGlobalSettings(max_execution_time=CLUSTERING_QUERY_MAX_EXECUTION_TIME),
         )
 
     rows = result.results or []
@@ -303,6 +311,7 @@ def fetch_item_summaries(
                 "max_rows": ast.Constant(value=max_rows),
             },
             team=team,
+            settings=HogQLGlobalSettings(max_execution_time=CLUSTERING_QUERY_MAX_EXECUTION_TIME),
         )
 
     rows = result.results or []


### PR DESCRIPTION
## Problem

Generation-level clustering with event filters is failing on high-volume teams with ClickHouse query timeouts. The nested subqueries scan millions of events table rows to resolve property filters before joining to the small embeddings table (~6K rows), pushing execution past the default 60s `max_execution_time`.

## Changes

- Set `max_execution_time=120` for both clustering data queries (`fetch_item_embeddings_for_clustering` and `fetch_item_summaries`)
- This aligns with the existing Temporal `COMPUTE_ACTIVITY_TIMEOUT` of 120s
- Added `CLUSTERING_QUERY_MAX_EXECUTION_TIME` constant with rationale

The default HogQL `max_execution_time` is 60s (set in `HogQLGlobalSettings`). The failing query took 69s — barely over the limit. 120s gives comfortable headroom for background Temporal workflows.

## How did you test this code?

I'm an agent and haven't tested this manually. The change is a configuration-only tweak (passing a `settings` kwarg to `execute_hogql_query`). The existing test suite mocks `execute_hogql_query` so the setting doesn't affect test behavior.

Validated via PostHog MCP that the affected team has ~5.6M AI events but only ~6K embeddings in the 7-day clustering window, confirming the events table scan is the bottleneck.

## Publish to changelog?

no