### PR TITLE
feat(tasks): Add title_manually_set field to Task model

### DIFF
--- a/products/tasks/backend/migrations/0024_task_title_manually_set.py
+++ b/products/tasks/backend/migrations/0024_task_title_manually_set.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tasks", "0023_alter_codeinvite_id_alter_codeinviteredemption_id"),
     ]

--- a/products/tasks/backend/migrations/0024_task_title_manually_set.py
+++ b/products/tasks/backend/migrations/0024_task_title_manually_set.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tasks", "0023_alter_codeinvite_id_alter_codeinviteredemption_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="task",
+            name="title_manually_set",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0023_alter_codeinvite_id_alter_codeinviteredemption_id
+0024_task_title_manually_set

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -45,6 +45,7 @@ class Task(DeletedMetaFields, models.Model):
     created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, db_index=False)
     task_number = models.IntegerField(null=True, blank=True)
     title = models.CharField(max_length=255)
+    title_manually_set = models.BooleanField(default=False)
     description = models.TextField()
     origin_product = models.CharField(max_length=20, choices=OriginProduct.choices)
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -29,6 +29,7 @@ class TaskSerializer(serializers.ModelSerializer):
             "task_number",
             "slug",
             "title",
+            "title_manually_set",
             "description",
             "origin_product",
             "repository",

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -85,12 +85,19 @@ class TaskSerializer(serializers.ModelSerializer):
             if default_integration:
                 validated_data["github_integration"] = default_integration
 
-        # Auto-generate title from description if not provided or empty
         title = validated_data.get("title", "").strip()
         if not title and validated_data.get("description"):
             validated_data["title"] = generate_task_title(validated_data["description"])
+            validated_data.setdefault("title_manually_set", False)
+        elif title:
+            validated_data.setdefault("title_manually_set", True)
 
         return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if "title" in validated_data and "title_manually_set" not in validated_data:
+            validated_data["title_manually_set"] = True
+        return super().update(instance, validated_data)
 
 
 class AgentDefinitionSerializer(serializers.Serializer):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -121,6 +121,7 @@ export interface PatchedTaskApi {
     readonly slug?: string
     /** @maxLength 255 */
     title?: string
+    title_manually_set?: boolean
     description?: string
     origin_product?: OriginProductEnumApi
     /**


### PR DESCRIPTION
## Problem

We need a way to tell when the title has been manually set by the user and not LLM generated, so we don't overwrite it with the auto title feature in Code.

## Changes

  1. Add title_manually_set boolean field (default False) to the Task model
  2. Create migration 0024_task_title_manually_set
  3. Expose title_manually_set in the Task serializer

## How did you test this code?

Manually
