### PR TITLE
fix(filters): property definitions crash with non-array values

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -411,4 +411,35 @@ describe('the property definitions model', () => {
             expect(logic.values.formatPropertyValueForDisplay('$timestamp', undefined)).toEqual(null)
         })
     })
+
+    describe('loading property values', () => {
+        it.each([
+            [
+                'valid array results',
+                { results: [{ name: 'chrome' }, { name: 'firefox' }], refreshing: false },
+                [{ name: 'chrome' }, { name: 'firefox' }],
+            ],
+            ['non-array object in results', { results: { some: 'object' }, refreshing: false }, []],
+            ['null results', { results: null, refreshing: false }, []],
+            ['missing results key', { refreshing: false }, []],
+        ])('handles %s without crashing and stores correct values', async (_label, apiResponse, expectedValues) => {
+            useMocks({
+                get: {
+                    '/api/event/values/': () => [200, apiResponse],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.Event,
+                    propertyKey: 'browser',
+                    eventNames: [],
+                    newInput: undefined,
+                })
+            }).toFinishAllListeners()
+
+            expect(logic.values.options['browser'].values).toEqual(expectedValues)
+        })
+    })
 })

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -243,7 +243,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             {} as Record<string, Option>,
             {
                 setOptionsLoading: (state, { key }) => ({ ...state, [key]: { ...state[key], status: 'loading' } }),
-                setOptions: (state, { key, values, allowCustomValues, refreshing }) => {
+                setOptions: (state, { key, values: rawValues, allowCustomValues, refreshing }) => {
+                    const values = Array.isArray(rawValues) ? rawValues : []
                     const current = state[key]
                     const valueNames = values.map((v) => toString(v.name))
 
@@ -444,7 +445,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             )
             breakpoint()
 
-            const propValues = responseData.results
+            const propValues = Array.isArray(responseData.results) ? responseData.results : []
             const refreshing = responseData.refreshing
 
             actions.setOptions(propertyKey, propValues, type !== PropertyDefinitionType.FlagValue, refreshing)


### PR DESCRIPTION
## TL;DR
Guard against non-array values in the property definitions `setOptions` reducer to prevent crashes when unexpected data types are encountered.


## Problem
The `setOptions` reducer in the property definitions model was not validating that incoming values were arrays before processing them, causing crashes when the API returned or the state contained non-array values.

Started happening 1st of march. Looks like the cache properties changes
<img width="1279" height="592" alt="Screenshot 2026-03-05 at 08 43 03" src="https://github.com/user-attachments/assets/aa702eca-b7da-41cf-94ac-b71739b2d0e9" />


## Changes
- Added type checking in `propertyDefinitionsModel.ts` to guard against non-array values in the `setOptions` reducer
- Ensures the reducer safely handles edge cases where malformed or unexpected data types are passed

## How did you test this code?
As an agent, I have reviewed the code changes for correctness. The fix adds defensive programming by validating input types before array operations, which prevents runtime errors without requiring specific test scenarios to be manually executed.

## Publish to changelog?
no