### PR TITLE
feat(llma): encode job_id in batch_run_id for efficient clustering queries

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/activities.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/activities.py
@@ -77,7 +77,7 @@ def _perform_clustering_compute(inputs: ClusteringActivityInputs) -> ClusteringC
         window_end=window_end,
         max_samples=inputs.max_samples,
         analysis_level=inputs.analysis_level,
-        event_filters=inputs.event_filters if inputs.event_filters else None,
+        job_id=inputs.job_id if inputs.job_id else None,
     )
 
     logger.info(

--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -12,7 +12,6 @@ import structlog
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
-from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
@@ -29,22 +28,9 @@ from posthog.temporal.llm_analytics.trace_clustering.models import (
 logger = structlog.get_logger(__name__)
 
 # ClickHouse max_execution_time for clustering queries (seconds).
-# Default HogQL timeout is 60s which is too tight for generation-level
-# queries with filters on high-volume teams (nested subqueries on events table).
-# These run in background Temporal activities with their own 120s timeout.
+# Default HogQL timeout is 60s which is too tight for the legacy unfiltered
+# query path on high-volume teams. These run in background Temporal activities.
 CLUSTERING_QUERY_MAX_EXECUTION_TIME = 120
-
-# AI event types to query for trace filtering (same as TracesQueryRunner)
-AI_EVENT_TYPES = ("$ai_span", "$ai_generation", "$ai_embedding", "$ai_metric", "$ai_feedback", "$ai_trace")
-
-
-def _build_property_filter_expr(event_filters: list[dict], team: Team) -> ast.Expr:
-    """Build an AND-combined property filter AST expression from a list of filter dicts."""
-    property_exprs: list[ast.Expr] = []
-    for prop in event_filters:
-        property_exprs.append(property_to_expr(prop, team))
-
-    return ast.And(exprs=property_exprs) if len(property_exprs) > 1 else property_exprs[0]
 
 
 def fetch_item_embeddings_for_clustering(
@@ -53,47 +39,21 @@ def fetch_item_embeddings_for_clustering(
     window_end: datetime,
     max_samples: int,
     analysis_level: AnalysisLevel = "trace",
-    event_filters: list[dict] | None = None,
+    job_id: str | None = None,
 ) -> tuple[list[ItemId], ItemEmbeddings, ItemBatchRunIds]:
-    """Query item IDs and embeddings from document_embeddings table using HogQL.
+    """Query item IDs and embeddings from document_embeddings table.
 
-    When event_filters are provided, uses ClickHouse subqueries to push the
-    trace→generation→embedding join into the database rather than materializing
-    intermediate ID lists in Python.
-
-    Args:
-        team: Team object to query embeddings for
-        window_start: Start of time window
-        window_end: End of time window
-        max_samples: Maximum number of items to sample
-        analysis_level: "trace" or "generation" - determines which document_type to query
-        event_filters: Optional property filters to scope which traces are included
-
-    Returns:
-        Tuple of (list of item IDs, dict mapping item_id -> embedding vector,
-                  dict mapping item_id -> batch_run_id for linking to summaries)
+    Two paths:
+    - job_id present: filter by rendering suffix (batch_run_id = {team}_{ts}_{job_id})
+    - no job_id: return all embeddings for the document type (legacy/unfiltered)
     """
-    # Select document_type based on analysis_level
-    document_type_new = (
+    document_type = (
         constants.LLMA_GENERATION_DOCUMENT_TYPE
         if analysis_level == "generation"
         else constants.LLMA_TRACE_DOCUMENT_TYPE
     )
 
-    has_filters = bool(event_filters)
-
-    # Build the appropriate query based on (has_filters, analysis_level)
-    # Backwards compatibility: support both old and new document type formats
-    # - New format: document_type = "llm-trace-summary-detailed" (mode in document_type, batch_run_id in rendering)
-    # - Old format: document_type = "llm-trace-summary" AND rendering = "llma_trace_detailed"
-    if has_filters and analysis_level == "generation":
-        # Generation-level with filters: 2-level nested subquery
-        # embeddings WHERE document_id IN (SELECT generation UUIDs matching filters
-        #   WHERE trace_id IN (SELECT filtered trace_ids))
-        # The property_filters are applied at BOTH levels:
-        # - Inner: scopes to traces where any event matches the filter
-        # - Outer: ensures only generation events matching the filter are included
-        #   (e.g. a trace with both openai and anthropic generations only gets the openai ones)
+    if job_id:
         query = parse_select(
             """
             SELECT document_id, embedding, rendering
@@ -101,64 +61,14 @@ def fetch_item_embeddings_for_clustering(
             WHERE timestamp >= {start_dt}
                 AND timestamp < {end_dt}
                 AND product = {product}
-                AND (
-                    document_type = {document_type_new}
-                    OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
-                )
+                AND document_type = {document_type}
                 AND length(embedding) > 0
-                AND document_id IN (
-                    SELECT DISTINCT toString(uuid)
-                    FROM events
-                    WHERE event = {generation_event}
-                        AND timestamp >= {start_dt}
-                        AND timestamp < {end_dt}
-                        AND {property_filters}
-                        AND properties.$ai_trace_id IN (
-                            SELECT DISTINCT properties.$ai_trace_id
-                            FROM events
-                            WHERE event IN {event_types}
-                                AND timestamp >= {start_dt}
-                                AND timestamp < {end_dt}
-                                AND isNotNull(properties.$ai_trace_id)
-                                AND properties.$ai_trace_id != ''
-                                AND {property_filters}
-                        )
-                )
-            ORDER BY rand()
-            LIMIT {max_samples}
-            """
-        )
-    elif has_filters:
-        # Trace-level with filters: 1-level subquery
-        # embeddings WHERE document_id IN (SELECT filtered trace_ids)
-        query = parse_select(
-            """
-            SELECT document_id, embedding, rendering
-            FROM raw_document_embeddings
-            WHERE timestamp >= {start_dt}
-                AND timestamp < {end_dt}
-                AND product = {product}
-                AND (
-                    document_type = {document_type_new}
-                    OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
-                )
-                AND length(embedding) > 0
-                AND document_id IN (
-                    SELECT DISTINCT properties.$ai_trace_id
-                    FROM events
-                    WHERE event IN {event_types}
-                        AND timestamp >= {start_dt}
-                        AND timestamp < {end_dt}
-                        AND isNotNull(properties.$ai_trace_id)
-                        AND properties.$ai_trace_id != ''
-                        AND {property_filters}
-                )
+                AND endsWith(rendering, {job_id_suffix})
             ORDER BY rand()
             LIMIT {max_samples}
             """
         )
     else:
-        # No filters: simple query on embeddings table
         query = parse_select(
             """
             SELECT document_id, embedding, rendering
@@ -167,7 +77,7 @@ def fetch_item_embeddings_for_clustering(
                 AND timestamp < {end_dt}
                 AND product = {product}
                 AND (
-                    document_type = {document_type_new}
+                    document_type = {document_type}
                     OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
                 )
                 AND length(embedding) > 0
@@ -180,20 +90,15 @@ def fetch_item_embeddings_for_clustering(
         "start_dt": ast.Constant(value=window_start),
         "end_dt": ast.Constant(value=window_end),
         "product": ast.Constant(value=constants.LLMA_TRACE_PRODUCT),
-        "document_type_new": ast.Constant(value=document_type_new),
-        "document_type_legacy": ast.Constant(value=constants.LLMA_TRACE_DOCUMENT_TYPE_LEGACY),
-        "rendering_legacy": ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY),
+        "document_type": ast.Constant(value=document_type),
         "max_samples": ast.Constant(value=max_samples),
     }
 
-    if has_filters:
-        assert event_filters is not None
-        event_types_tuple = ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES])
-        placeholders["event_types"] = event_types_tuple
-        placeholders["property_filters"] = _build_property_filter_expr(event_filters, team)
-
-        if analysis_level == "generation":
-            placeholders["generation_event"] = ast.Constant(value="$ai_generation")
+    if job_id:
+        placeholders["job_id_suffix"] = ast.Constant(value=f"_{job_id}")
+    else:
+        placeholders["document_type_legacy"] = ast.Constant(value=constants.LLMA_TRACE_DOCUMENT_TYPE_LEGACY)
+        placeholders["rendering_legacy"] = ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY)
 
     with tags_context(product=Product.LLM_ANALYTICS):
         result = execute_hogql_query(
@@ -210,7 +115,7 @@ def fetch_item_embeddings_for_clustering(
         "fetch_item_embeddings_for_clustering_result",
         num_rows=len(rows),
         analysis_level=analysis_level,
-        has_filters=has_filters,
+        job_id=job_id,
     )
 
     # Build all maps in single loop to ensure item_ids, embeddings_map, and batch_run_ids are aligned

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_data.py
@@ -5,11 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from unittest.mock import MagicMock, patch
 
-from parameterized import parameterized
-
 from posthog.temporal.llm_analytics.trace_clustering.data import (
-    AI_EVENT_TYPES,
-    _build_property_filter_expr,
     fetch_item_embeddings_for_clustering,
     fetch_item_summaries,
 )
@@ -27,30 +23,6 @@ def mock_team(db):
         name="Test Team",
     )
     return team
-
-
-class TestBuildPropertyFilterExpr:
-    def test_single_filter_returns_expr_directly(self, mock_team):
-        from posthog.hogql import ast
-
-        result = _build_property_filter_expr(
-            [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}],
-            mock_team,
-        )
-        assert not isinstance(result, ast.And)
-
-    def test_multiple_filters_returns_and_expr(self, mock_team):
-        from posthog.hogql import ast
-
-        result = _build_property_filter_expr(
-            [
-                {"key": "$ai_model", "value": "gpt-4", "operator": "exact"},
-                {"key": "environment", "value": "production", "operator": "exact"},
-            ],
-            mock_team,
-        )
-        assert isinstance(result, ast.And)
-        assert len(result.exprs) == 2
 
 
 class TestFetchItemEmbeddingsForClustering:
@@ -101,7 +73,7 @@ class TestFetchItemEmbeddingsForClustering:
         assert trace_ids == ["trace_1", "trace_2"]
 
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_no_filters_uses_simple_query(self, mock_execute, mock_team):
+    def test_no_job_id_uses_legacy_query_with_document_type_fallback(self, mock_execute, mock_team):
         mock_result = MagicMock()
         mock_result.results = [("trace_1", [0.1, 0.2], "batch_123")]
         mock_execute.return_value = mock_result
@@ -114,77 +86,44 @@ class TestFetchItemEmbeddingsForClustering:
         )
 
         call_kwargs = mock_execute.call_args.kwargs
-        # No filters: placeholders should not contain event_types or property_filters
-        assert "event_types" not in call_kwargs["placeholders"]
-        assert "property_filters" not in call_kwargs["placeholders"]
+        assert "document_type_legacy" in call_kwargs["placeholders"]
+        assert "rendering_legacy" in call_kwargs["placeholders"]
+        assert "job_id_suffix" not in call_kwargs["placeholders"]
 
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_trace_level_with_filters_uses_subquery(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = [("trace_1", [0.1, 0.2], "batch_123")]
-        mock_execute.return_value = mock_result
-
-        event_filters = [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}]
-
-        trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
-            team=mock_team,
-            window_start=datetime(2025, 1, 1, tzinfo=UTC),
-            window_end=datetime(2025, 1, 8, tzinfo=UTC),
-            max_samples=100,
-            event_filters=event_filters,
-        )
-
-        assert trace_ids == ["trace_1"]
-        mock_execute.assert_called_once()
-        call_kwargs = mock_execute.call_args.kwargs
-        # With filters: placeholders should contain event_types and property_filters
-        assert "event_types" in call_kwargs["placeholders"]
-        assert "property_filters" in call_kwargs["placeholders"]
-        # Trace-level should not have generation_event placeholder
-        assert "generation_event" not in call_kwargs["placeholders"]
-
-    @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_generation_level_with_filters_uses_nested_subquery(self, mock_execute, mock_team):
+    def test_job_id_filters_by_rendering_suffix(self, mock_execute, mock_team):
         mock_result = MagicMock()
         mock_result.results = [
-            ("gen_1", [0.1, 0.2], "batch_123"),
-            ("gen_2", [0.3, 0.4], "batch_123"),
+            ("trace_1", [0.1, 0.2], "2_2025-01-01T00:00:00_abc-123"),
         ]
         mock_execute.return_value = mock_result
 
-        event_filters = [{"key": "ai_product", "value": "posthog_ai", "operator": "exact"}]
-
-        item_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
+        fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
             max_samples=100,
-            analysis_level="generation",
-            event_filters=event_filters,
+            job_id="abc-123",
         )
 
-        assert item_ids == ["gen_1", "gen_2"]
-        mock_execute.assert_called_once()
         call_kwargs = mock_execute.call_args.kwargs
-        # Generation-level with filters should have generation_event placeholder
-        assert "generation_event" in call_kwargs["placeholders"]
-        assert "event_types" in call_kwargs["placeholders"]
-        assert "property_filters" in call_kwargs["placeholders"]
+        assert call_kwargs["placeholders"]["job_id_suffix"].value == "_abc-123"
+        # job_id path should not include legacy fallback placeholders
+        assert "document_type_legacy" not in call_kwargs["placeholders"]
+        assert "rendering_legacy" not in call_kwargs["placeholders"]
 
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
-    def test_with_filters_returns_empty_when_no_results(self, mock_execute, mock_team):
+    def test_returns_empty_when_no_results(self, mock_execute, mock_team):
         mock_result = MagicMock()
         mock_result.results = []
         mock_execute.return_value = mock_result
 
-        event_filters = [{"key": "$ai_model", "value": "nonexistent", "operator": "exact"}]
-
         trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
             max_samples=100,
-            event_filters=event_filters,
+            job_id="some-job",
         )
 
         assert trace_ids == []
@@ -193,23 +132,20 @@ class TestFetchItemEmbeddingsForClustering:
 
     @patch("posthog.temporal.llm_analytics.trace_clustering.data.execute_hogql_query")
     def test_single_query_for_all_cases(self, mock_execute, mock_team):
-        """All cases (no filters, trace+filters, generation+filters) use a single execute_hogql_query call."""
+        """Both job_id and no-job_id paths use a single execute_hogql_query call."""
         mock_result = MagicMock()
         mock_result.results = [("id_1", [0.1], "batch_1")]
         mock_execute.return_value = mock_result
 
-        # Generation-level with filters — previously required 3 separate queries
-        event_filters = [{"key": "$ai_model", "value": "gpt-4", "operator": "exact"}]
         fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
             max_samples=100,
             analysis_level="generation",
-            event_filters=event_filters,
+            job_id="test-job",
         )
 
-        # Should be exactly 1 query, not 3
         assert mock_execute.call_count == 1
 
 
@@ -345,18 +281,3 @@ class TestFetchItemSummaries:
         )
 
         assert summaries["trace_1"]["trace_timestamp"] == test_timestamp.isoformat()
-
-
-class TestAIEventTypes:
-    @parameterized.expand(
-        [
-            ("$ai_span",),
-            ("$ai_generation",),
-            ("$ai_embedding",),
-            ("$ai_metric",),
-            ("$ai_feedback",),
-            ("$ai_trace",),
-        ]
-    )
-    def test_ai_event_type_is_defined(self, event_type):
-        assert event_type in AI_EVENT_TYPES

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -178,6 +178,8 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
         """
         start_time = temporalio.workflow.now()
         batch_run_id = f"{inputs.team_id}_{start_time.isoformat()}"
+        if inputs.job_id:
+            batch_run_id = f"{batch_run_id}_{inputs.job_id}"
         metrics = BatchSummarizationMetrics()
 
         increment_workflow_started(inputs.analysis_level)


### PR DESCRIPTION
## Problem

Generation-level clustering with event filters was failing on high-volume teams with ClickHouse query timeouts (69s vs 60s limit). The root cause: the embeddings query used nested subqueries scanning millions of events table rows (5.6M AI events) just to filter ~6K embeddings by property filters. This happened because the embeddings table lacked the event properties needed for filtering directly.

## Changes

Instead of filtering embeddings by joining back to the events table, encode the clustering `job_id` into the `batch_run_id` that's already stored on each embedding's `rendering` field.

**Summarization workflow** (`workflow.py`):
- Appends job_id to batch_run_id: `{team_id}_{timestamp}_{job_id}`

**Clustering query** (`data.py`):
- When job_id is present: `WHERE endsWith(rendering, '_{job_id}')` — queries only the embeddings table, no events table scan
- When no job_id (legacy): unfiltered embeddings query

**Removed**:
- All event_filters-based subquery paths (the 1-level and 2-level nested subqueries)
- `_build_property_filter_expr` helper and `AI_EVENT_TYPES` constant
- `property_to_expr` import

Net -171 lines.

This works for both trace and generation level clustering identically — the `document_type` placeholder selects the right type, and the `endsWith` filter is level-agnostic.

## How did you test this code?

I'm an agent and haven't tested this manually. Updated unit tests in `test_data.py` to cover:
- job_id path sets `job_id_suffix` placeholder and excludes legacy placeholders
- No job_id path uses legacy document_type fallback
- Empty results handling
- Single query call assertion

Validated via PostHog MCP that the affected team has ~5.6M AI events but only ~6K embeddings, confirming the events table scan was the bottleneck.

Note: new embeddings won't have job_id in rendering until the next summarization cycle runs after deploy. Existing embeddings without job_id suffix will use the legacy unfiltered path.

## Publish to changelog?

no