### PR TITLE
fix: Isolate hog transformer/tophog producer

### DIFF
--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -103,7 +103,7 @@ describe('IngestionConsumer', () => {
     ) => {
         const ingester = new IngestionConsumer(
             hub,
-            { ...hub, hogTransformer: createHogTransformerService(hub, hub) },
+            { ...hub, kafkaMetricsProducer: hub.kafkaProducer, hogTransformer: createHogTransformerService(hub, hub) },
             overrides
         )
         // NOTE: We don't actually use kafka so we skip instantiation for faster tests

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -54,6 +54,7 @@ export interface IngestionConsumerDeps {
     postgres: PostgresRouter
     redisPool: RedisPool
     kafkaProducer: KafkaProducerWrapper
+    kafkaMetricsProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository
@@ -91,7 +92,7 @@ export class IngestionConsumer {
     private eventIngestionRestrictionManager: EventIngestionRestrictionManager
     private eventSchemaEnforcementManager: EventSchemaEnforcementManager
     public readonly promiseScheduler = new PromiseScheduler()
-    private topHog: TopHog
+    private topHog!: TopHog
 
     private joinedPipeline!: BatchPipeline<
         JoinedIngestionPipelineInput,
@@ -190,7 +191,7 @@ export class IngestionConsumer {
         this.kafkaProducer = this.deps.kafkaProducer
 
         this.topHog = new TopHog({
-            kafkaProducer: this.kafkaProducer!,
+            kafkaProducer: this.deps.kafkaMetricsProducer,
             topic: KAFKA_CLICKHOUSE_TOPHOG,
             pipeline: this.config.INGESTION_PIPELINE ?? 'unknown',
             lane: this.config.INGESTION_LANE ?? 'unknown',
@@ -213,6 +214,7 @@ export class IngestionConsumer {
                 this.kafkaOverflowProducer = producer
             }),
         ])
+
         this.topHog.start()
 
         // Initialize pipeline

--- a/nodejs/src/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/src/ingestion/ingestion-e2e.test.ts
@@ -247,6 +247,7 @@ const createTestWithTeamIngester = (baseConfig: Partial<PluginsServerConfig> = {
 
             const ingester = new IngestionConsumer(hub, {
                 ...hub,
+                kafkaMetricsProducer: hub.kafkaProducer,
                 hogTransformer: createHogTransformerService(hub, hub),
             })
             // NOTE: We don't actually use kafka so we skip instantiation for faster tests

--- a/nodejs/src/ingestion/person-properties-metadata.e2e.test.ts
+++ b/nodejs/src/ingestion/person-properties-metadata.e2e.test.ts
@@ -174,6 +174,7 @@ const createTestWithTeamIngester = (baseConfig: Partial<PluginsServerConfig> = {
 
             const ingester = new IngestionConsumer(hub, {
                 ...hub,
+                kafkaMetricsProducer: hub.kafkaProducer,
                 hogTransformer: createHogTransformerService(hub, hub),
             })
             ingester['kafkaConsumer'] = {

--- a/nodejs/src/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/src/ingestion/person-updates-e2e.test.ts
@@ -220,7 +220,11 @@ describe.each(FLAG_COMBINATIONS)('Person Updates E2E ($#)', (config) => {
         team = fetchedTeam
         currentToken = team.api_token
 
-        ingester = new IngestionConsumer(hub, { ...hub, hogTransformer: createHogTransformerService(hub, hub) })
+        ingester = new IngestionConsumer(hub, {
+            ...hub,
+            kafkaMetricsProducer: hub.kafkaProducer,
+            hogTransformer: createHogTransformerService(hub, hub),
+        })
         ingester['kafkaConsumer'] = {
             connect: jest.fn(),
             disconnect: jest.fn(),

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -76,6 +76,7 @@ export class PluginServer {
 
     // Infrastructure resources (tracked for shutdown cleanup)
     private kafkaProducer?: KafkaProducerWrapper
+    private kafkaMetricsProducer?: KafkaProducerWrapper
     private postgres?: PostgresRouter
     private redisPool?: RedisPool
     private posthogRedisPool?: RedisPool
@@ -186,7 +187,7 @@ export class PluginServer {
                       pubSub: this.pubsub!,
                       encryptedFields: ingestionCdpServices!.encryptedFields,
                       integrationManager: ingestionCdpServices!.integrationManager,
-                      kafkaProducer: this.kafkaProducer!,
+                      kafkaProducer: this.kafkaMetricsProducer!,
                       teamManager,
                       internalCaptureService: ingestionCdpServices!.internalCaptureService,
                   }
@@ -201,6 +202,7 @@ export class PluginServer {
                     postgres: this.postgres!,
                     redisPool: this.redisPool!,
                     kafkaProducer: this.kafkaProducer!,
+                    kafkaMetricsProducer: this.kafkaMetricsProducer!,
                     teamManager,
                     groupTypeManager: ingestionServices!.groupTypeManager,
                     groupRepository: ingestionCdpServices!.groupRepository,
@@ -239,6 +241,7 @@ export class PluginServer {
                     postgres: this.postgres!,
                     redisPool: this.redisPool!,
                     kafkaProducer: this.kafkaProducer!,
+                    kafkaMetricsProducer: this.kafkaMetricsProducer!,
                     teamManager,
                     groupTypeManager: ingestionServices!.groupTypeManager,
                     groupRepository: ingestionCdpServices!.groupRepository,
@@ -479,6 +482,7 @@ export class PluginServer {
 
         logger.info('🤔', 'Connecting to Kafka...')
         this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
+        this.kafkaMetricsProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
         logger.info('👍', 'Kafka ready')
 
         logger.info('🤔', 'Connecting to ingestion Redis...')
@@ -663,6 +667,7 @@ export class PluginServer {
         logger.info('💤', ' Shutting down infrastructure...')
         await Promise.allSettled([
             this.kafkaProducer?.disconnect(),
+            this.kafkaMetricsProducer?.disconnect(),
             this.redisPool?.drain(),
             this.posthogRedisPool?.drain(),
             this.cookielessRedisPool?.drain(),


### PR DESCRIPTION
## Problem

In order to make sure there's no contention between secondary kafka producers and our main producer (who generate side effects that need to be awaited sometimes), this PR isolates hogtransformer and tophog to use a separate producer

## Changes

- Add a secondary `kafkaMetricsProducer` in `server.ts` to isolate non-critical Kafka traffic from the primary producer
- Pass `kafkaMetricsProducer` to `IngestionConsumer` deps and use it for TopHog instead of the primary producer
- Pass `kafkaMetricsProducer` as the `kafkaProducer` for hog transformer deps (monitoring service)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
