### PR TITLE
feat(approvals): restyle promo banner to match ProductIntroduction

### DIFF
--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -35,18 +35,20 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
     }
 
     return (
-        <LemonBanner type="info" hideIcon>
-            <div className="flex flex-row gap-8 px-8 py-3 items-center justify-evenly">
-                <div>
-                    <h3 className="mb-1 text-lg font-semibold">Stop yolo-shipping flag changes</h3>
-                    <p className="mb-3">
+        <LemonBanner type="info" hideIcon className="bg-transparent border-dashed border-2">
+            <div className="flex items-center gap-8 w-full justify-center p-4">
+                <div className="w-40 shrink-0 hidden md:block">
+                    <JudgeHog className="w-full h-full" />
+                </div>
+                <div className="flex-shrink max-w-140">
+                    <h2>Stop yolo-shipping flag changes</h2>
+                    <p>
                         Require a second pair of eyes before feature flags go live. Because "I swear I only changed one
                         condition" is not a rollback strategy.
                     </p>
-                    <div className="flex flex-row gap-2">
+                    <div className="flex items-center gap-x-4 gap-y-2 mt-6 flex-wrap">
                         <LemonButton
                             type="primary"
-                            className="w-fit"
                             to={urls.approvals()}
                             onClick={() => posthog.capture('feature flags approvals promo cta clicked')}
                         >
@@ -59,11 +61,10 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
                                 dismiss()
                             }}
                         >
-                            I'm not interested
+                            Not interested
                         </LemonButton>
                     </div>
                 </div>
-                <JudgeHog className="h-30 w-fit shrink-0" alt="Judge hedgehog illustration" />
             </div>
         </LemonBanner>
     )

--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -37,7 +37,7 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
     return (
         <LemonBanner type="info" hideIcon className="bg-transparent border-dashed border-2">
             <div className="flex items-center gap-8 w-full justify-center p-4">
-                <div className="w-40 shrink-0 hidden md:block">
+                <div className="w-30 shrink-0 hidden md:block">
                     <JudgeHog className="w-full h-full" />
                 </div>
                 <div className="flex-shrink max-w-140">

--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -41,7 +41,7 @@ export function ApprovalsPromoBanner(): JSX.Element | null {
                     <JudgeHog className="w-full h-full" />
                 </div>
                 <div className="flex-shrink max-w-140">
-                    <h2>Stop yolo-shipping flag changes</h2>
+                    <h2>Stop YOLO-shipping flag changes</h2>
                     <p>
                         Require a second pair of eyes before feature flags go live. Because "I swear I only changed one
                         condition" is not a rollback strategy.


### PR DESCRIPTION
## Problem

The approvals promo banner on the feature flags page looked out of place compared to other product introduction banners.

## Changes

- Restyled the `ApprovalsPromoBanner` to match the `ProductIntroduction` component layout
- Intentionally didnt use the ProductIntroduction as this would have reset the local state for banner dismisses and a bunch of users would have seen it for a second time, despite that they dismissed it before.

<img width="1350" height="430" alt="image" src="https://github.com/user-attachments/assets/092ea94b-a12d-462c-a0fb-52447c47c2ad" />

## How did you test this code?

Visual inspection only — no behavioral changes, just layout/styling.

## Publish to changelog?

No