### PR TITLE
feat(mcp): add chartSettings/tableSettings to DataVisualizationNode

### DIFF
--- a/services/mcp/src/schema/insights.ts
+++ b/services/mcp/src/schema/insights.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { DataVizChartSettings, DataVizTableSettings } from './query'
 
 export const InsightSchema = z.object({
     id: z.number(),
@@ -51,6 +52,12 @@ export const CreateInsightInputSchema = z.object({
             .describe(
                 'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused.'
             ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
+        chartSettings: DataVizChartSettings.optional().describe(
+            'Chart settings for DataVisualizationNode (HogQL) insights. Use xAxis to set X-axis column, yAxis to set Y-axis columns with display type (line/bar/auto).'
+        ),
+        tableSettings: DataVizTableSettings.optional().describe(
+            'Table settings for DataVisualizationNode (HogQL) insights.'
+        ),
     }),
     description: z.string().optional(),
     favorited: z.boolean(),
@@ -68,6 +75,12 @@ export const UpdateInsightInputSchema = z.object({
             .describe(
                 'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused'
             ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, and to allow the LLM to make a change to an existing insight whose schema we do not support in our simplified subset of the full insight schema.
+        chartSettings: DataVizChartSettings.optional().describe(
+            'Chart settings for DataVisualizationNode (HogQL) insights. Use xAxis to set X-axis column, yAxis to set Y-axis columns with display type (line/bar/auto).'
+        ),
+        tableSettings: DataVizTableSettings.optional().describe(
+            'Table settings for DataVisualizationNode (HogQL) insights.'
+        ),
     }),
     favorited: z.boolean().optional(),
     dashboard: z.number().optional(),

--- a/services/mcp/src/schema/query.ts
+++ b/services/mcp/src/schema/query.ts
@@ -163,6 +163,81 @@ const HogQLQuerySchema = z.object({
     filters: HogQLFilters.optional(),
 })
 
+// Chart settings for DataVisualizationNode
+const DataVizDisplayType = z.enum(['auto', 'line', 'bar'])
+
+const YAxisPosition = z.enum(['left', 'right'])
+
+const ChartSettingsDisplay = z.object({
+    color: z.string().nullable().optional(),
+    displayType: DataVizDisplayType.nullable().optional(),
+    label: z.string().nullable().optional(),
+    trendLine: z.boolean().nullable().optional(),
+    yAxisPosition: YAxisPosition.nullable().optional(),
+})
+
+const FormattingStyle = z.enum(['none', 'number', 'percent'])
+
+const ChartSettingsFormatting = z.object({
+    decimalPlaces: z.number().nullable().optional(),
+    prefix: z.string().nullable().optional(),
+    style: FormattingStyle.nullable().optional(),
+    suffix: z.string().nullable().optional(),
+})
+
+const ChartAxisSettings = z.object({
+    display: ChartSettingsDisplay.nullable().optional(),
+    formatting: ChartSettingsFormatting.nullable().optional(),
+})
+
+const ChartAxis = z.object({
+    column: z.string(),
+    settings: ChartAxisSettings.nullable().optional(),
+})
+
+const AxisScale = z.enum(['linear', 'logarithmic'])
+
+const YAxisSettings = z.object({
+    scale: AxisScale.nullable().optional(),
+    showGridLines: z.boolean().nullable().optional(),
+    showTicks: z.boolean().nullable().optional(),
+    startAtZero: z.boolean().nullable().optional(),
+})
+
+const GoalLine = z.object({
+    label: z.string().optional(),
+    value: z.number().optional(),
+})
+
+const DataVizChartSettings = z.object({
+    goalLines: z.array(GoalLine).nullable().optional(),
+    leftYAxisSettings: YAxisSettings.nullable().optional(),
+    rightYAxisSettings: YAxisSettings.nullable().optional(),
+    seriesBreakdownColumn: z.string().nullable().optional(),
+    showLegend: z.boolean().nullable().optional(),
+    showTotalRow: z.boolean().nullable().optional(),
+    showXAxisBorder: z.boolean().nullable().optional(),
+    showXAxisTicks: z.boolean().nullable().optional(),
+    showYAxisBorder: z.boolean().nullable().optional(),
+    stackBars100: z.boolean().nullable().optional(),
+    xAxis: ChartAxis.nullable().optional(),
+    yAxis: z.array(ChartAxis).nullable().optional(),
+    yAxisAtZero: z.boolean().nullable().optional(),
+})
+
+const ConditionalFormattingRule = z.object({
+    bytecode: z.array(z.any()).optional(),
+    color: z.string().optional(),
+    colorMode: z.enum(['single', 'range']).optional(),
+    columnName: z.string().optional(),
+    input: z.string().optional(),
+})
+
+const DataVizTableSettings = z.object({
+    columns: z.array(ChartAxis).nullable().optional(),
+    conditionalFormatting: z.array(ConditionalFormattingRule).nullable().optional(),
+})
+
 // Funnels filter
 const FunnelsFilter = z.object({
     layout: FunnelLayout.optional(),
@@ -195,6 +270,12 @@ const InsightVizNodeSchema = z.object({
 const DataVisualizationNodeSchema = z.object({
     kind: z.literal('DataVisualizationNode'),
     source: HogQLQuerySchema,
+    chartSettings: DataVizChartSettings.optional().describe(
+        'Chart visualization settings including axis configuration. Use xAxis to set X-axis column, yAxis array to set Y-axis columns with optional display type (line/bar/auto).'
+    ),
+    tableSettings: DataVizTableSettings.optional().describe(
+        'Table display settings including column configuration and conditional formatting.'
+    ),
 })
 
 // Any insight query
@@ -233,6 +314,10 @@ export {
     // HogQL types
     HogQLVariable,
     HogQLFilters,
+    // Chart settings for DataVisualizationNode
+    DataVizChartSettings,
+    DataVizTableSettings,
+    ChartAxis,
     // Queries
     TrendsQuerySchema,
     FunnelsQuerySchema,

--- a/services/mcp/src/schema/query.ts
+++ b/services/mcp/src/schema/query.ts
@@ -205,8 +205,12 @@ const YAxisSettings = z.object({
 })
 
 const GoalLine = z.object({
-    label: z.string().optional(),
-    value: z.number().optional(),
+    label: z.string(),
+    value: z.number(),
+    borderColor: z.string().optional(),
+    displayLabel: z.boolean().optional(),
+    displayIfCrossed: z.boolean().optional(),
+    position: z.enum(['start', 'end']).optional(),
 })
 
 const DataVizChartSettings = z.object({
@@ -223,19 +227,26 @@ const DataVizChartSettings = z.object({
     xAxis: ChartAxis.nullable().optional(),
     yAxis: z.array(ChartAxis).nullable().optional(),
     yAxisAtZero: z.boolean().nullable().optional(),
+    heatmap: z.object({
+        colorPalette: z.string().optional(),
+        showValues: z.boolean().optional(),
+    }).nullable().optional(),
 })
 
 const ConditionalFormattingRule = z.object({
-    bytecode: z.array(z.any()).optional(),
-    color: z.string().optional(),
-    colorMode: z.enum(['single', 'range']).optional(),
-    columnName: z.string().optional(),
-    input: z.string().optional(),
+    id: z.string(),
+    templateId: z.string(),
+    columnName: z.string(),
+    bytecode: z.array(z.any()),
+    input: z.string(),
+    color: z.string(),
+    colorMode: z.enum(['light', 'dark']).optional(),
 })
 
 const DataVizTableSettings = z.object({
     columns: z.array(ChartAxis).nullable().optional(),
     conditionalFormatting: z.array(ConditionalFormattingRule).nullable().optional(),
+    pinnedColumns: z.array(z.string()).nullable().optional(),
 })
 
 // Funnels filter


### PR DESCRIPTION
## Problem

When creating HogQL (`DataVisualizationNode`) insights via the MCP API, there's no way to configure chart visualization — users have to open each insight in the PostHog UI and manually set X axis, Y axis, display type, etc. This is tedious for automated workflows that create multiple insights.

## Changes

Added `chartSettings` and `tableSettings` fields to `DataVisualizationNode` schema, matching PostHog's own API types (`generated.ts`). This surfaces in both `QueryRunInputSchema` and `CreateInsightInputSchema`/`UpdateInsightInputSchema`.

New schema types added to `query.ts`:
- `ChartAxis`, `ChartSettingsDisplay`, `ChartSettingsFormatting` — per-axis config
- `DataVizChartSettings` — xAxis, yAxis, goalLines, heatmap, legend, stacking, etc.
- `DataVizTableSettings` — columns, conditionalFormatting, pinnedColumns
- `GoalLine`, `YAxisSettings`, `ConditionalFormattingRule` — supporting types

All fields are optional so existing usage is unaffected.

## How did you test this code?

TypeScript type checking passes (`pnpm typecheck`). Schema types are derived from PostHog's `generated.ts` API types to ensure compatibility.

## Publish to changelog?

no