### PR TITLE
fix(ducklake): client prefer ssl

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -36,9 +36,7 @@ def _make_duckgres_conninfo(team_id: int) -> str:
         dbname=config["DUCKGRES_DATABASE"],
         user=config["DUCKGRES_USERNAME"],
         password=config["DUCKGRES_PASSWORD"],
-        sslmode="require",
-        sslcert="",
-        sslkey="",
+        sslmode="prefer",
     )
 
 


### PR DESCRIPTION
## Problem
OperationalError: connection failed: connection to server at "10.52.1.243", port 5432 failed: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- sslmode="prefer"
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
i didn't
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
