### PR TITLE
fix(kafka-assigner): handle dead consumer assignments and batch handoff relay events

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'jose-sequeira/kafka-assigner-metadata-fetch-logs'
 
 jobs:
     build:

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,6 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'jose-sequeira/kafka-assigner-metadata-fetch-logs'
 
 jobs:
     build:

--- a/rust/kafka-assigner/src/assigner.rs
+++ b/rust/kafka-assigner/src/assigner.rs
@@ -327,6 +327,7 @@ impl Assigner {
         let mut all_assignments: Vec<PartitionAssignment> = Vec::new();
         let mut all_handoffs: Vec<HandoffState> = Vec::new();
         let now = util::now_seconds();
+        let active_set: HashSet<&str> = active_consumers.iter().map(|s| s.as_str()).collect();
 
         for config in &topic_configs {
             let current_assignments = store.list_assignments_for_topic(&config.topic).await?;
@@ -340,13 +341,42 @@ impl Assigner {
                 &active_consumers,
                 config.partition_count,
             );
-            let handoffs = util::compute_required_handoffs(&current_map, &desired);
+            let moves = util::compute_required_handoffs(&current_map, &desired);
 
-            let handoff_partitions: HashSet<u32> = handoffs.iter().map(|(p, _, _)| *p).collect();
+            // Separate moves into direct assignments (old owner is dead) and
+            // handoffs (old owner is alive and needs the handoff protocol).
+            let mut moving_partitions: HashSet<u32> = HashSet::new();
+            for (partition, old_owner, new_owner) in moves {
+                moving_partitions.insert(partition);
+                if active_set.contains(old_owner.as_str()) {
+                    all_handoffs.push(HandoffState {
+                        topic: config.topic.clone(),
+                        partition,
+                        old_owner,
+                        new_owner,
+                        phase: HandoffPhase::Warming,
+                        started_at: now,
+                    });
+                } else {
+                    tracing::info!(
+                        topic = %config.topic,
+                        partition,
+                        old_owner = %old_owner,
+                        new_owner = %new_owner,
+                        "old owner is dead, assigning directly without handoff"
+                    );
+                    all_assignments.push(PartitionAssignment {
+                        topic: config.topic.clone(),
+                        partition,
+                        owner: new_owner,
+                        status: AssignmentStatus::Active,
+                    });
+                }
+            }
 
-            // Stable assignments: partitions not being handed off
+            // Stable assignments: partitions not moving
             for (&partition, owner) in &desired {
-                if !handoff_partitions.contains(&partition) {
+                if !moving_partitions.contains(&partition) {
                     all_assignments.push(PartitionAssignment {
                         topic: config.topic.clone(),
                         partition,
@@ -354,17 +384,6 @@ impl Assigner {
                         status: AssignmentStatus::Active,
                     });
                 }
-            }
-
-            for (partition, old_owner, new_owner) in handoffs {
-                all_handoffs.push(HandoffState {
-                    topic: config.topic.clone(),
-                    partition,
-                    old_owner,
-                    new_owner,
-                    phase: HandoffPhase::Warming,
-                    started_at: now,
-                });
             }
         }
 

--- a/rust/kafka-assigner/src/assigner.rs
+++ b/rust/kafka-assigner/src/assigner.rs
@@ -140,6 +140,19 @@ impl Assigner {
             });
         }
 
+        // Periodic cleanup loop: catches timed-out handoffs that the
+        // event-driven watch loops miss (e.g. when the system is quiescent
+        // and no consumer/handoff events are firing).
+        {
+            let store = Arc::clone(&self.store);
+            let strategy = Arc::clone(&self.strategy);
+            let handoff_timeout = self.config.handoff_timeout;
+            let token = cancel.child_token();
+            tasks.spawn(async move {
+                Self::periodic_cleanup_loop(store, strategy, handoff_timeout, token).await
+            });
+        }
+
         let result = tokio::select! {
             _ = cancel.cancelled() => Ok(()),
             Some(result) = tasks.join_next() => {
@@ -235,6 +248,38 @@ impl Assigner {
                     // After processing all events, check if all handoffs have
                     // completed. If so, re-trigger rebalancing to pick up any
                     // consumer changes that were deferred.
+                    if store.list_handoffs().await?.is_empty() {
+                        Self::handle_consumer_change_static(&store, strategy.as_ref(), handoff_timeout).await?;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Periodically clean up timed-out handoffs and re-trigger rebalancing.
+    ///
+    /// The watch-based loops only run cleanup when events arrive. If the
+    /// system is quiescent (no consumer changes, no handoff updates), stale
+    /// handoffs can block rebalancing indefinitely. This loop runs every
+    /// `handoff_timeout / 2` to catch those cases.
+    async fn periodic_cleanup_loop(
+        store: Arc<KafkaAssignerStore>,
+        strategy: Arc<dyn AssignmentStrategy>,
+        handoff_timeout: Duration,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        // Check at half the timeout interval so we catch stale handoffs
+        // reasonably soon after they expire.
+        let interval = handoff_timeout / 2;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(interval) => {
+                    let consumers = store.list_consumers().await?;
+                    let active = active_consumer_names(&consumers);
+                    Self::cleanup_stale_handoffs(&store, &active, handoff_timeout).await?;
+
                     if store.list_handoffs().await?.is_empty() {
                         Self::handle_consumer_change_static(&store, strategy.as_ref(), handoff_timeout).await?;
                     }

--- a/rust/kafka-assigner/src/assigner.rs
+++ b/rust/kafka-assigner/src/assigner.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use etcd_client::EventType;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use assignment_coordination::leader_election::{self, LeaderElectionConfig};
@@ -109,12 +110,17 @@ impl Assigner {
         self.handle_consumer_change(self.config.handoff_timeout)
             .await?;
 
+        // Serialize rebalance execution across all loops to prevent
+        // concurrent read-then-write races on assignments and handoffs.
+        let rebalance_guard: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+
         // Watch consumers and handoffs concurrently
         let mut tasks = tokio::task::JoinSet::new();
 
         {
             let store = Arc::clone(&self.store);
             let strategy = Arc::clone(&self.strategy);
+            let guard = Arc::clone(&rebalance_guard);
             let debounce_interval = self.config.rebalance_debounce_interval;
             let handoff_timeout = self.config.handoff_timeout;
             let token = cancel.child_token();
@@ -122,6 +128,7 @@ impl Assigner {
                 Self::watch_consumers_loop(
                     store,
                     strategy,
+                    guard,
                     debounce_interval,
                     handoff_timeout,
                     token,
@@ -133,10 +140,11 @@ impl Assigner {
         {
             let store = Arc::clone(&self.store);
             let strategy = Arc::clone(&self.strategy);
+            let guard = Arc::clone(&rebalance_guard);
             let handoff_timeout = self.config.handoff_timeout;
             let token = cancel.child_token();
             tasks.spawn(async move {
-                Self::watch_handoffs_loop(store, strategy, handoff_timeout, token).await
+                Self::watch_handoffs_loop(store, strategy, guard, handoff_timeout, token).await
             });
         }
 
@@ -146,10 +154,11 @@ impl Assigner {
         {
             let store = Arc::clone(&self.store);
             let strategy = Arc::clone(&self.strategy);
+            let guard = Arc::clone(&rebalance_guard);
             let handoff_timeout = self.config.handoff_timeout;
             let token = cancel.child_token();
             tasks.spawn(async move {
-                Self::periodic_cleanup_loop(store, strategy, handoff_timeout, token).await
+                Self::periodic_cleanup_loop(store, strategy, guard, handoff_timeout, token).await
             });
         }
 
@@ -170,6 +179,7 @@ impl Assigner {
     async fn watch_consumers_loop(
         store: Arc<KafkaAssignerStore>,
         strategy: Arc<dyn AssignmentStrategy>,
+        rebalance_guard: Arc<Mutex<()>>,
         debounce_interval: Duration,
         handoff_timeout: Duration,
         cancel: CancellationToken,
@@ -199,6 +209,7 @@ impl Assigner {
                 }
             }
 
+            let _lock = rebalance_guard.lock().await;
             Self::handle_consumer_change_static(&store, strategy.as_ref(), handoff_timeout).await?;
         }
     }
@@ -215,6 +226,7 @@ impl Assigner {
     async fn watch_handoffs_loop(
         store: Arc<KafkaAssignerStore>,
         strategy: Arc<dyn AssignmentStrategy>,
+        rebalance_guard: Arc<Mutex<()>>,
         handoff_timeout: Duration,
         cancel: CancellationToken,
     ) -> Result<()> {
@@ -237,6 +249,8 @@ impl Assigner {
                             }
                         }
                     }
+
+                    let _lock = rebalance_guard.lock().await;
 
                     // Clean up handoffs that can no longer make progress
                     // (e.g. old_owner died at Complete phase — nobody will
@@ -265,6 +279,7 @@ impl Assigner {
     async fn periodic_cleanup_loop(
         store: Arc<KafkaAssignerStore>,
         strategy: Arc<dyn AssignmentStrategy>,
+        rebalance_guard: Arc<Mutex<()>>,
         handoff_timeout: Duration,
         cancel: CancellationToken,
     ) -> Result<()> {
@@ -276,6 +291,8 @@ impl Assigner {
             tokio::select! {
                 _ = cancel.cancelled() => return Ok(()),
                 _ = tokio::time::sleep(interval) => {
+                    let _lock = rebalance_guard.lock().await;
+
                     let consumers = store.list_consumers().await?;
                     let active = active_consumer_names(&consumers);
                     Self::cleanup_stale_handoffs(&store, &active, handoff_timeout).await?;
@@ -346,14 +363,15 @@ impl Assigner {
         handoff_timeout: Duration,
     ) -> Result<()> {
         let consumers = store.list_consumers().await?;
-        let active_consumers = active_consumer_names(&consumers);
+        let ready_consumers = active_consumer_names(&consumers);
+        let registered = registered_consumer_names(&consumers);
 
         // Clean up handoffs targeting consumers that are no longer active.
-        Self::cleanup_stale_handoffs(store, &active_consumers, handoff_timeout).await?;
+        Self::cleanup_stale_handoffs(store, &ready_consumers, handoff_timeout).await?;
 
-        // No consumers: delete all assignments so stale keys don't linger.
-        if active_consumers.is_empty() {
-            tracing::info!("no active consumers, clearing all assignments");
+        // No registered consumers at all: delete all assignments so stale keys don't linger.
+        if registered.is_empty() {
+            tracing::info!("no registered consumers, clearing all assignments");
             store.delete_all_assignments().await?;
             return Ok(());
         }
@@ -370,6 +388,12 @@ impl Assigner {
             return Ok(());
         }
 
+        // No Ready consumers to assign to (but some are still registered/draining).
+        if ready_consumers.is_empty() {
+            tracing::debug!("no ready consumers, skipping assignment");
+            return Ok(());
+        }
+
         let topic_configs = store.list_topic_configs().await?;
         if topic_configs.is_empty() {
             tracing::debug!("no topic configs, skipping assignment");
@@ -378,8 +402,11 @@ impl Assigner {
 
         let mut all_assignments: Vec<PartitionAssignment> = Vec::new();
         let mut all_handoffs: Vec<HandoffState> = Vec::new();
+        let mut has_changes = false;
         let now = util::now_seconds();
-        let active_set: HashSet<&str> = active_consumers.iter().map(|s| s.as_str()).collect();
+        // Use registered set for liveness: a Draining consumer is alive and
+        // needs the handoff protocol, not a direct reassignment.
+        let registered_set: HashSet<&str> = registered.iter().map(|s| s.as_str()).collect();
 
         for config in &topic_configs {
             let current_assignments = store.list_assignments_for_topic(&config.topic).await?;
@@ -390,17 +417,21 @@ impl Assigner {
 
             let desired = strategy.compute_assignments(
                 &current_map,
-                &active_consumers,
+                &ready_consumers,
                 config.partition_count,
             );
             let moves = util::compute_required_handoffs(&current_map, &desired);
+
+            if !moves.is_empty() || current_map.len() != desired.len() {
+                has_changes = true;
+            }
 
             // Separate moves into direct assignments (old owner is dead) and
             // handoffs (old owner is alive and needs the handoff protocol).
             let mut moving_partitions: HashSet<u32> = HashSet::new();
             for (partition, old_owner, new_owner) in moves {
                 moving_partitions.insert(partition);
-                if active_set.contains(old_owner.as_str()) {
+                if registered_set.contains(old_owner.as_str()) {
                     all_handoffs.push(HandoffState {
                         topic: config.topic.clone(),
                         partition,
@@ -437,6 +468,12 @@ impl Assigner {
                     });
                 }
             }
+        }
+
+        // No-op fast path: desired matches current for all topics.
+        if !has_changes {
+            tracing::debug!("assignments unchanged, skipping write");
+            return Ok(());
         }
 
         if all_assignments.is_empty() && all_handoffs.is_empty() {
@@ -508,7 +545,8 @@ impl Assigner {
 
 // ── Pure functions ──────────────────────────────────────────────
 
-/// Extract sorted consumer names, filtering to active statuses.
+/// Extract sorted consumer names, filtering to Ready status only.
+/// Use for assignment computation (only Ready consumers get new partitions).
 fn active_consumer_names(consumers: &[RegisteredConsumer]) -> Vec<String> {
     let mut active: Vec<&RegisteredConsumer> = consumers
         .iter()
@@ -516,6 +554,14 @@ fn active_consumer_names(consumers: &[RegisteredConsumer]) -> Vec<String> {
         .collect();
     active.sort_by(|a, b| a.consumer_name.cmp(&b.consumer_name));
     active.iter().map(|c| c.consumer_name.clone()).collect()
+}
+
+/// Extract sorted names of all registered consumers regardless of status.
+/// Use for liveness checks (a Draining consumer is still alive).
+fn registered_consumer_names(consumers: &[RegisteredConsumer]) -> Vec<String> {
+    let mut names: Vec<String> = consumers.iter().map(|c| c.consumer_name.clone()).collect();
+    names.sort();
+    names
 }
 
 #[cfg(test)]

--- a/rust/kafka-assigner/src/assigner.rs
+++ b/rust/kafka-assigner/src/assigner.rs
@@ -306,6 +306,13 @@ impl Assigner {
         // Clean up handoffs targeting consumers that are no longer active.
         Self::cleanup_stale_handoffs(store, &active_consumers, handoff_timeout).await?;
 
+        // No consumers: delete all assignments so stale keys don't linger.
+        if active_consumers.is_empty() {
+            tracing::info!("no active consumers, clearing all assignments");
+            store.delete_all_assignments().await?;
+            return Ok(());
+        }
+
         // Skip rebalancing while handoffs are in flight to prevent
         // overlapping rebalances. watch_handoffs_loop re-triggers
         // rebalancing once all handoffs complete.

--- a/rust/kafka-assigner/src/config.rs
+++ b/rust/kafka-assigner/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     #[envconfig(from = "BIND_PORT", default = "50051")]
     pub port: u16,
 
-    #[envconfig(default = "64")]
+    #[envconfig(default = "1024")]
     pub stream_channel_size: usize,
 
     #[envconfig(default = "30")]

--- a/rust/kafka-assigner/src/config.rs
+++ b/rust/kafka-assigner/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     #[envconfig(default = "1024")]
     pub stream_channel_size: usize,
 
-    #[envconfig(default = "30")]
+    #[envconfig(default = "15")]
     pub consumer_lease_ttl_secs: i64,
 
     #[envconfig(default = "10")]
@@ -121,7 +121,7 @@ mod tests {
     fn default_config_parses() {
         let config = Config::init_with_defaults().expect("default config should parse");
         assert_eq!(config.stream_channel_size, 1024);
-        assert_eq!(config.consumer_lease_ttl_secs, 30);
+        assert_eq!(config.consumer_lease_ttl_secs, 15);
         assert_eq!(config.leader_lease_ttl_secs, 15);
         assert_eq!(config.handoff_timeout_secs, 300);
     }

--- a/rust/kafka-assigner/src/config.rs
+++ b/rust/kafka-assigner/src/config.rs
@@ -24,10 +24,10 @@ pub struct Config {
     #[envconfig(default = "1024")]
     pub stream_channel_size: usize,
 
-    #[envconfig(default = "15")]
+    #[envconfig(default = "30")]
     pub consumer_lease_ttl_secs: i64,
 
-    #[envconfig(default = "10")]
+    #[envconfig(default = "5")]
     pub consumer_keepalive_interval_secs: u64,
 
     // ── Assigner / leader election ──────────────────────────────────
@@ -105,6 +105,19 @@ impl Config {
         Duration::from_secs(self.kafka_metadata_timeout_secs)
     }
 
+    pub fn validate(&self) -> Result<(), String> {
+        if self.consumer_keepalive_interval_secs as i64 >= self.consumer_lease_ttl_secs {
+            return Err(format!(
+                "consumer_keepalive_interval_secs ({}) must be less than consumer_lease_ttl_secs ({})",
+                self.consumer_keepalive_interval_secs, self.consumer_lease_ttl_secs
+            ));
+        }
+        if self.handoff_timeout_secs == 0 {
+            return Err("handoff_timeout_secs must be greater than 0".to_string());
+        }
+        Ok(())
+    }
+
     pub fn build_strategy(&self) -> Result<Arc<dyn AssignmentStrategy>, String> {
         match self.assignment_strategy.as_str() {
             "sticky-balanced" => Ok(Arc::new(StickyBalancedStrategy)),
@@ -121,7 +134,7 @@ mod tests {
     fn default_config_parses() {
         let config = Config::init_with_defaults().expect("default config should parse");
         assert_eq!(config.stream_channel_size, 1024);
-        assert_eq!(config.consumer_lease_ttl_secs, 15);
+        assert_eq!(config.consumer_lease_ttl_secs, 30);
         assert_eq!(config.leader_lease_ttl_secs, 15);
         assert_eq!(config.handoff_timeout_secs, 300);
     }

--- a/rust/kafka-assigner/src/config.rs
+++ b/rust/kafka-assigner/src/config.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn default_config_parses() {
         let config = Config::init_with_defaults().expect("default config should parse");
-        assert_eq!(config.stream_channel_size, 64);
+        assert_eq!(config.stream_channel_size, 1024);
         assert_eq!(config.consumer_lease_ttl_secs, 30);
         assert_eq!(config.leader_lease_ttl_secs, 15);
         assert_eq!(config.handoff_timeout_secs, 300);

--- a/rust/kafka-assigner/src/grpc/convert.rs
+++ b/rust/kafka-assigner/src/grpc/convert.rs
@@ -1,6 +1,6 @@
 use kafka_assigner_proto::kafka_assigner::v1 as proto;
 
-use crate::types::{AssignmentEvent, PartitionAssignment, TopicPartition};
+use crate::types::{AssignmentEvent, HandoffState, PartitionAssignment, TopicPartition};
 
 use proto::assignment_command::Command;
 
@@ -15,28 +15,45 @@ impl From<&TopicPartition> for proto::TopicPartition {
     }
 }
 
-impl From<&AssignmentEvent> for proto::AssignmentCommand {
-    fn from(event: &AssignmentEvent) -> Self {
-        let command = match event {
-            AssignmentEvent::Assignment {
-                assigned,
-                unassigned,
-            } => Command::Assignment(proto::AssignmentUpdate {
-                assigned: assigned.iter().map(proto::TopicPartition::from).collect(),
-                unassigned: unassigned.iter().map(proto::TopicPartition::from).collect(),
-            }),
-            AssignmentEvent::Warm(handoff) => Command::Warm(proto::WarmPartition {
-                partition: Some(proto::TopicPartition::from(&handoff.topic_partition())),
-                current_owner: handoff.old_owner.clone(),
-            }),
-            AssignmentEvent::Release(handoff) => Command::Release(proto::ReleasePartition {
-                partition: Some(proto::TopicPartition::from(&handoff.topic_partition())),
-                new_owner: handoff.new_owner.clone(),
-            }),
-        };
-        Self {
-            command: Some(command),
+/// Convert a domain event into one or more proto commands.
+///
+/// `Assignment` produces a single command with all partitions.
+/// `Warm` and `Release` are batched per-consumer at the domain level but
+/// expand to one proto command per partition (the proto schema uses a single
+/// partition per warm/release message).
+pub fn to_proto_commands(event: &AssignmentEvent) -> Vec<proto::AssignmentCommand> {
+    match event {
+        AssignmentEvent::Assignment {
+            assigned,
+            unassigned,
+        } => {
+            vec![proto::AssignmentCommand {
+                command: Some(Command::Assignment(proto::AssignmentUpdate {
+                    assigned: assigned.iter().map(proto::TopicPartition::from).collect(),
+                    unassigned: unassigned.iter().map(proto::TopicPartition::from).collect(),
+                })),
+            }]
         }
+        AssignmentEvent::Warm(handoffs) => handoffs.iter().map(warm_command).collect(),
+        AssignmentEvent::Release(handoffs) => handoffs.iter().map(release_command).collect(),
+    }
+}
+
+fn warm_command(handoff: &HandoffState) -> proto::AssignmentCommand {
+    proto::AssignmentCommand {
+        command: Some(Command::Warm(proto::WarmPartition {
+            partition: Some(proto::TopicPartition::from(&handoff.topic_partition())),
+            current_owner: handoff.old_owner.clone(),
+        })),
+    }
+}
+
+fn release_command(handoff: &HandoffState) -> proto::AssignmentCommand {
+    proto::AssignmentCommand {
+        command: Some(Command::Release(proto::ReleasePartition {
+            partition: Some(proto::TopicPartition::from(&handoff.topic_partition())),
+            new_owner: handoff.new_owner.clone(),
+        })),
     }
 }
 
@@ -107,9 +124,10 @@ mod tests {
                 partition: 3,
             }],
         };
-        let cmd = proto::AssignmentCommand::from(&event);
-        match cmd.command {
-            Some(Command::Assignment(update)) => {
+        let cmds = to_proto_commands(&event);
+        assert_eq!(cmds.len(), 1);
+        match cmds[0].command {
+            Some(Command::Assignment(ref update)) => {
                 assert_eq!(update.assigned.len(), 2);
                 assert_eq!(update.assigned[0].topic, "events");
                 assert_eq!(update.assigned[0].partition, 0);
@@ -123,21 +141,40 @@ mod tests {
     }
 
     #[test]
-    fn warm_event_includes_current_owner() {
-        let event = AssignmentEvent::Warm(HandoffState {
-            topic: "events".to_string(),
-            partition: 5,
-            old_owner: "c-0".to_string(),
-            new_owner: "c-1".to_string(),
-            phase: HandoffPhase::Warming,
-            started_at: 0,
-        });
-        let cmd = proto::AssignmentCommand::from(&event);
-        match cmd.command {
-            Some(Command::Warm(warm)) => {
-                let tp = warm.partition.unwrap();
-                assert_eq!(tp.topic, "events");
+    fn warm_batch_expands_to_individual_commands() {
+        let event = AssignmentEvent::Warm(vec![
+            HandoffState {
+                topic: "events".to_string(),
+                partition: 5,
+                old_owner: "c-0".to_string(),
+                new_owner: "c-1".to_string(),
+                phase: HandoffPhase::Warming,
+                started_at: 0,
+            },
+            HandoffState {
+                topic: "events".to_string(),
+                partition: 7,
+                old_owner: "c-0".to_string(),
+                new_owner: "c-1".to_string(),
+                phase: HandoffPhase::Warming,
+                started_at: 0,
+            },
+        ]);
+        let cmds = to_proto_commands(&event);
+        assert_eq!(cmds.len(), 2);
+
+        match cmds[0].command {
+            Some(Command::Warm(ref warm)) => {
+                let tp = warm.partition.as_ref().unwrap();
                 assert_eq!(tp.partition, 5);
+                assert_eq!(warm.current_owner, "c-0");
+            }
+            _ => panic!("expected warm command"),
+        }
+        match cmds[1].command {
+            Some(Command::Warm(ref warm)) => {
+                let tp = warm.partition.as_ref().unwrap();
+                assert_eq!(tp.partition, 7);
                 assert_eq!(warm.current_owner, "c-0");
             }
             _ => panic!("expected warm command"),
@@ -145,19 +182,20 @@ mod tests {
     }
 
     #[test]
-    fn release_event_includes_new_owner() {
-        let event = AssignmentEvent::Release(HandoffState {
+    fn release_batch_expands_to_individual_commands() {
+        let event = AssignmentEvent::Release(vec![HandoffState {
             topic: "events".to_string(),
             partition: 3,
             old_owner: "c-0".to_string(),
             new_owner: "c-1".to_string(),
             phase: HandoffPhase::Complete,
             started_at: 0,
-        });
-        let cmd = proto::AssignmentCommand::from(&event);
-        match cmd.command {
-            Some(Command::Release(rel)) => {
-                let tp = rel.partition.unwrap();
+        }]);
+        let cmds = to_proto_commands(&event);
+        assert_eq!(cmds.len(), 1);
+        match cmds[0].command {
+            Some(Command::Release(ref rel)) => {
+                let tp = rel.partition.as_ref().unwrap();
                 assert_eq!(tp.topic, "events");
                 assert_eq!(tp.partition, 3);
                 assert_eq!(rel.new_owner, "c-1");

--- a/rust/kafka-assigner/src/grpc/relay.rs
+++ b/rust/kafka-assigner/src/grpc/relay.rs
@@ -60,13 +60,7 @@ async fn relay_with_reconnect<F>(
     let mut backoff = INITIAL_BACKOFF;
 
     loop {
-        match relay_fn(
-            Arc::clone(store),
-            Arc::clone(registry),
-            cancel.clone(),
-        )
-        .await
-        {
+        match relay_fn(Arc::clone(store), Arc::clone(registry), cancel.clone()).await {
             Ok(()) => return, // Clean shutdown via cancellation
             Err(e) => {
                 if cancel.is_cancelled() {

--- a/rust/kafka-assigner/src/grpc/relay.rs
+++ b/rust/kafka-assigner/src/grpc/relay.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use etcd_client::EventType;
 use tokio::sync::mpsc::error::TrySendError;
@@ -11,6 +12,9 @@ use crate::store::{self, KafkaAssignerStore};
 use crate::types::{
     AssignmentEvent, HandoffPhase, HandoffState, PartitionAssignment, TopicPartition,
 };
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 /// Watches etcd for assignment and handoff changes, relaying commands
 /// to consumers connected to this instance.
@@ -27,11 +31,61 @@ pub async fn run_relay(
     registry: Arc<ConsumerRegistry>,
     cancel: CancellationToken,
 ) -> Result<()> {
-    tokio::try_join!(
-        relay_assignments(store.clone(), registry.clone(), cancel.clone()),
-        relay_handoffs(store.clone(), registry.clone(), cancel.clone()),
-    )?;
+    // Run both watch loops independently so one failing doesn't stop the other.
+    // Each loop self-heals on transient etcd errors with exponential backoff.
+    tokio::join!(
+        relay_with_reconnect("assignments", &store, &registry, &cancel, |s, r, c| {
+            Box::pin(relay_assignments(s, r, c))
+        }),
+        relay_with_reconnect("handoffs", &store, &registry, &cancel, |s, r, c| {
+            Box::pin(relay_handoffs(s, r, c))
+        }),
+    );
     Ok(())
+}
+
+async fn relay_with_reconnect<F>(
+    name: &str,
+    store: &Arc<KafkaAssignerStore>,
+    registry: &Arc<ConsumerRegistry>,
+    cancel: &CancellationToken,
+    relay_fn: F,
+) where
+    F: Fn(
+        Arc<KafkaAssignerStore>,
+        Arc<ConsumerRegistry>,
+        CancellationToken,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>>,
+{
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        match relay_fn(
+            Arc::clone(store),
+            Arc::clone(registry),
+            cancel.clone(),
+        )
+        .await
+        {
+            Ok(()) => return, // Clean shutdown via cancellation
+            Err(e) => {
+                if cancel.is_cancelled() {
+                    return;
+                }
+                tracing::error!(
+                    relay = name,
+                    error = %e,
+                    backoff_secs = backoff.as_secs(),
+                    "relay watch failed, reconnecting"
+                );
+                tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+        }
+    }
 }
 
 /// Watch assignment changes and push `Assignment` events to affected consumers.

--- a/rust/kafka-assigner/src/grpc/relay.rs
+++ b/rust/kafka-assigner/src/grpc/relay.rs
@@ -29,7 +29,7 @@ pub async fn run_relay(
 ) -> Result<()> {
     tokio::try_join!(
         relay_assignments(store.clone(), registry.clone(), cancel.clone()),
-        relay_handoffs(store, registry, cancel),
+        relay_handoffs(store.clone(), registry.clone(), cancel.clone()),
     )?;
     Ok(())
 }
@@ -92,7 +92,11 @@ async fn relay_assignments(
     }
 }
 
-/// Watch handoff changes and push `Warm`/`Release` events to affected consumers.
+/// Watch handoff changes and push batched `Warm`/`Release` events to affected consumers.
+///
+/// Like `relay_assignments`, this batches events per-consumer from each watch
+/// response. Without batching, a rebalance moving hundreds of partitions would
+/// send one event per partition, overflowing the consumer channel.
 async fn relay_handoffs(
     store: Arc<KafkaAssignerStore>,
     registry: Arc<ConsumerRegistry>,
@@ -106,53 +110,63 @@ async fn relay_handoffs(
             msg = stream.message() => {
                 let resp = msg?.ok_or_else(|| Error::invalid_state("handoff watch stream ended"))?;
 
+                let mut warms: HashMap<String, Vec<HandoffState>> = HashMap::new();
+                let mut releases: HashMap<String, Vec<HandoffState>> = HashMap::new();
+
                 for event in resp.events() {
                     if event.event_type() == EventType::Put {
                         match store::parse_watch_value::<HandoffState>(event) {
-                            Ok(handoff) => {
-                                relay_handoff_event(&registry, &handoff);
-                            }
+                            Ok(handoff) => match handoff.phase {
+                                HandoffPhase::Warming => {
+                                    warms
+                                        .entry(handoff.new_owner.clone())
+                                        .or_default()
+                                        .push(handoff);
+                                }
+                                HandoffPhase::Complete => {
+                                    releases
+                                        .entry(handoff.old_owner.clone())
+                                        .or_default()
+                                        .push(handoff);
+                                }
+                                // Ready is a consumer → leader signal, not relayed.
+                                HandoffPhase::Ready => {}
+                            },
                             Err(e) => {
                                 tracing::error!(error = %e, "failed to parse handoff event");
                             }
                         }
                     }
                 }
-            }
-        }
-    }
-}
 
-/// Route a single handoff event to the appropriate consumer.
-fn relay_handoff_event(registry: &ConsumerRegistry, handoff: &HandoffState) {
-    match handoff.phase {
-        HandoffPhase::Warming => {
-            if let Some(sender) = registry.get_sender(&handoff.new_owner) {
-                match sender.try_send(AssignmentEvent::Warm(handoff.clone())) {
-                    Ok(()) => {}
-                    Err(TrySendError::Full(_)) => {
-                        tracing::warn!(consumer = %handoff.new_owner, "consumer channel full, dropping warm");
+                for (consumer, handoffs) in warms {
+                    if let Some(sender) = registry.get_sender(&consumer) {
+                        match sender.try_send(AssignmentEvent::Warm(handoffs)) {
+                            Ok(()) => {}
+                            Err(TrySendError::Full(_)) => {
+                                tracing::warn!(consumer = %consumer, "consumer channel full, dropping warm batch");
+                            }
+                            Err(TrySendError::Closed(_)) => {
+                                tracing::debug!(consumer = %consumer, "consumer channel closed, skipping warm batch");
+                            }
+                        }
                     }
-                    Err(TrySendError::Closed(_)) => {
-                        tracing::debug!(consumer = %handoff.new_owner, "consumer channel closed, skipping warm");
+                }
+
+                for (consumer, handoffs) in releases {
+                    if let Some(sender) = registry.get_sender(&consumer) {
+                        match sender.try_send(AssignmentEvent::Release(handoffs)) {
+                            Ok(()) => {}
+                            Err(TrySendError::Full(_)) => {
+                                tracing::warn!(consumer = %consumer, "consumer channel full, dropping release batch");
+                            }
+                            Err(TrySendError::Closed(_)) => {
+                                tracing::debug!(consumer = %consumer, "consumer channel closed, skipping release batch");
+                            }
+                        }
                     }
                 }
             }
         }
-        HandoffPhase::Complete => {
-            if let Some(sender) = registry.get_sender(&handoff.old_owner) {
-                match sender.try_send(AssignmentEvent::Release(handoff.clone())) {
-                    Ok(()) => {}
-                    Err(TrySendError::Full(_)) => {
-                        tracing::warn!(consumer = %handoff.old_owner, "consumer channel full, dropping release");
-                    }
-                    Err(TrySendError::Closed(_)) => {
-                        tracing::debug!(consumer = %handoff.old_owner, "consumer channel closed, skipping release");
-                    }
-                }
-            }
-        }
-        // Ready is a consumer → leader signal, not relayed to consumers.
-        HandoffPhase::Ready => {}
     }
 }

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -271,13 +271,19 @@ impl KafkaAssigner for KafkaAssignerService {
                 );
             }
 
-            // Cleanup: unregister from local registry and revoke the etcd lease.
+            // Unregister from the local in-memory registry so the server stops
+            // trying to send commands on the dead channel.
+            //
+            // We intentionally do NOT revoke the etcd lease here. Letting it
+            // expire naturally (after consumer_lease_ttl) gives the consumer a
+            // grace period to reconnect — e.g. during a rolling deployment —
+            // without triggering a rebalance. If the consumer reconnects before
+            // the TTL elapses, it overwrites the key with a fresh lease and no
+            // partition movement occurs. If it doesn't come back, the lease
+            // expires and the assigner reassigns its partitions.
             registry.unregister(&name);
-            if let Err(e) = store.revoke_lease(lease_id).await {
-                tracing::warn!(consumer = %name, error = %e, "failed to revoke lease on cleanup");
-            }
 
-            tracing::info!(consumer = %name, "consumer disconnected, cleaned up");
+            tracing::info!(consumer = %name, lease_id, "consumer disconnected, lease will expire via TTL");
         });
 
         Ok(Response::new(ReceiverStream::new(proto_rx)))

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -45,7 +45,7 @@ impl KafkaAssignerService {
             store,
             registry,
             kafka_config,
-            64,
+            1024,
             30,
             Duration::from_secs(10),
         )
@@ -239,8 +239,14 @@ impl KafkaAssigner for KafkaAssignerService {
             async move {
                 let mut event_rx = event_rx;
                 while let Some(event) = event_rx.recv().await {
-                    let cmd = proto::AssignmentCommand::from(&event);
-                    if proto_tx.send(Ok(cmd)).await.is_err() {
+                    let mut failed = false;
+                    for cmd in convert::to_proto_commands(&event) {
+                        if proto_tx.send(Ok(cmd)).await.is_err() {
+                            failed = true;
+                            break;
+                        }
+                    }
+                    if failed {
                         break;
                     }
                 }

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -131,7 +131,7 @@ impl KafkaAssignerService {
                 })?
                 .map_err(|e| {
                     tracing::error!(topic, error = %e, "failed to fetch partition count");
-                    Status::internal(format!("failed to fetch partition count: {e}"))
+                    Status::internal("failed to fetch Kafka metadata")
                 })?;
 
                 let config = TopicConfig {
@@ -195,24 +195,34 @@ impl KafkaAssigner for KafkaAssignerService {
         // Create the channel that bridges the registry to the gRPC stream.
         let (event_tx, event_rx) = mpsc::channel::<AssignmentEvent>(self.stream_channel_size);
 
-        // If the consumer already owns partitions (e.g. reconnecting), send them
-        // as the first message. New consumers get an empty set — skip the no-op.
+        // Always send an Assignment snapshot as the first message to satisfy
+        // the stream contract (service.proto). Consumers rely on receiving a
+        // snapshot before any Warm/Release commands.
         let assignments = self
             .store
             .list_assignments()
             .await
             .map_err(|e| Status::internal(format!("failed to list assignments: {e}")))?;
         let owned = convert::consumer_partitions(&consumer_name, &assignments);
-        if !owned.is_empty() {
-            let initial = AssignmentEvent::Assignment {
-                assigned: owned,
-                unassigned: vec![],
-            };
-            event_tx
-                .send(initial)
-                .await
-                .map_err(|_| Status::internal("failed to send initial assignment"))?;
-        }
+        let initial = AssignmentEvent::Assignment {
+            assigned: owned,
+            unassigned: vec![],
+        };
+        event_tx
+            .send(initial)
+            .await
+            .map_err(|_| Status::internal("failed to send initial assignment"))?;
+
+        // Register in the local consumer registry BEFORE replaying
+        // handoffs. This ensures there is no window where a live handoff
+        // PUT from the relay is dropped (no sender) AND is also absent
+        // from the replay snapshot. Duplicates are safe since warm/release
+        // handling is idempotent.
+        self.registry.register(ConsumerConnection {
+            consumer_name: consumer_name.clone(),
+            command_tx: event_tx.clone(),
+            lease_id,
+        });
 
         // Replay pending handoffs that involve this consumer.
         // The relay only forwards etcd watch events, so if a handoff was
@@ -255,13 +265,6 @@ impl KafkaAssigner for KafkaAssignerService {
                 .await
                 .map_err(|_| Status::internal("failed to send pending releases"))?;
         }
-
-        // Register in the local consumer registry.
-        self.registry.register(ConsumerConnection {
-            consumer_name: consumer_name.clone(),
-            command_tx: event_tx,
-            lease_id,
-        });
 
         tracing::info!(consumer = %consumer_name, "consumer registered via gRPC");
 

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -12,7 +12,9 @@ use tonic::{Request, Response, Status};
 use crate::consumer_registry::{ConsumerConnection, ConsumerRegistry};
 use crate::grpc::convert;
 use crate::store::KafkaAssignerStore;
-use crate::types::{AssignmentEvent, ConsumerStatus, RegisteredConsumer, TopicConfig};
+use crate::types::{
+    AssignmentEvent, ConsumerStatus, HandoffPhase, RegisteredConsumer, TopicConfig,
+};
 
 /// Kafka connection settings for admin metadata lookups.
 #[derive(Clone)]
@@ -210,6 +212,48 @@ impl KafkaAssigner for KafkaAssignerService {
                 .send(initial)
                 .await
                 .map_err(|_| Status::internal("failed to send initial assignment"))?;
+        }
+
+        // Replay pending handoffs that involve this consumer.
+        // The relay only forwards etcd watch events, so if a handoff was
+        // created or advanced while this consumer was disconnected (e.g.
+        // during a rolling restart), the command was never delivered.
+        let handoffs = self
+            .store
+            .list_handoffs()
+            .await
+            .map_err(|e| Status::internal(format!("failed to list handoffs: {e}")))?;
+        let pending_warms: Vec<_> = handoffs
+            .iter()
+            .filter(|h| h.phase == HandoffPhase::Warming && h.new_owner == consumer_name)
+            .cloned()
+            .collect();
+        let pending_releases: Vec<_> = handoffs
+            .iter()
+            .filter(|h| h.phase == HandoffPhase::Complete && h.old_owner == consumer_name)
+            .cloned()
+            .collect();
+        if !pending_warms.is_empty() {
+            tracing::info!(
+                consumer = %consumer_name,
+                count = pending_warms.len(),
+                "replaying pending Warming handoffs on reconnect"
+            );
+            event_tx
+                .send(AssignmentEvent::Warm(pending_warms))
+                .await
+                .map_err(|_| Status::internal("failed to send pending warms"))?;
+        }
+        if !pending_releases.is_empty() {
+            tracing::info!(
+                consumer = %consumer_name,
+                count = pending_releases.len(),
+                "replaying pending Complete handoffs (releases) on reconnect"
+            );
+            event_tx
+                .send(AssignmentEvent::Release(pending_releases))
+                .await
+                .map_err(|_| Status::internal("failed to send pending releases"))?;
         }
 
         // Register in the local consumer registry.

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -123,8 +123,14 @@ impl KafkaAssignerService {
                     )
                 })
                 .await
-                .map_err(|e| Status::internal(format!("metadata fetch task panicked: {e}")))?
-                .map_err(|e| Status::internal(format!("failed to fetch partition count: {e}")))?;
+                .map_err(|e| {
+                    tracing::error!(topic, error = %e, "metadata fetch task panicked");
+                    Status::internal(format!("metadata fetch task panicked: {e}"))
+                })?
+                .map_err(|e| {
+                    tracing::error!(topic, error = %e, "failed to fetch partition count");
+                    Status::internal(format!("failed to fetch partition count: {e}"))
+                })?;
 
                 let config = TopicConfig {
                     topic: topic.to_string(),

--- a/rust/kafka-assigner/src/kafka_admin.rs
+++ b/rust/kafka-assigner/src/kafka_admin.rs
@@ -13,6 +13,14 @@ pub fn fetch_partition_count(
     topic: &str,
     timeout: Duration,
 ) -> Result<u32, String> {
+    tracing::info!(
+        kafka_hosts,
+        tls,
+        topic,
+        timeout_secs = timeout.as_secs(),
+        "fetching partition count from Kafka"
+    );
+
     let mut config = ClientConfig::new();
     config.set("bootstrap.servers", kafka_hosts);
 
@@ -22,13 +30,13 @@ pub fn fetch_partition_count(
             .set("enable.ssl.certificate.verification", "false");
     }
 
-    let consumer: BaseConsumer = config
-        .create()
-        .map_err(|e| format!("failed to create Kafka client: {e}"))?;
+    let consumer: BaseConsumer = config.create().map_err(|e| {
+        format!("failed to create Kafka client (hosts={kafka_hosts}, tls={tls}): {e}")
+    })?;
 
-    let metadata = consumer
-        .fetch_metadata(Some(topic), timeout)
-        .map_err(|e| format!("failed to fetch metadata for topic '{topic}': {e}"))?;
+    let metadata = consumer.fetch_metadata(Some(topic), timeout).map_err(|e| {
+        format!("failed to fetch metadata for topic '{topic}' (hosts={kafka_hosts}, tls={tls}): {e}")
+    })?;
 
     let topic_metadata = metadata
         .topics()

--- a/rust/kafka-assigner/src/kafka_admin.rs
+++ b/rust/kafka-assigner/src/kafka_admin.rs
@@ -35,7 +35,9 @@ pub fn fetch_partition_count(
     })?;
 
     let metadata = consumer.fetch_metadata(Some(topic), timeout).map_err(|e| {
-        format!("failed to fetch metadata for topic '{topic}' (hosts={kafka_hosts}, tls={tls}): {e}")
+        format!(
+            "failed to fetch metadata for topic '{topic}' (hosts={kafka_hosts}, tls={tls}): {e}"
+        )
     })?;
 
     let topic_metadata = metadata

--- a/rust/kafka-assigner/src/main.rs
+++ b/rust/kafka-assigner/src/main.rs
@@ -24,6 +24,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let config = Config::init_with_defaults()?;
+    config
+        .validate()
+        .map_err(|e| format!("invalid config: {e}"))?;
     tracing::info!(?config, "loaded configuration");
 
     let etcd_store = EtcdStore::connect(StoreConfig {

--- a/rust/kafka-assigner/src/store.rs
+++ b/rust/kafka-assigner/src/store.rs
@@ -170,6 +170,11 @@ impl KafkaAssignerStore {
         Ok(())
     }
 
+    pub async fn delete_all_assignments(&self) -> Result<()> {
+        let key = self.key(StoreKey::AssignmentsPrefix);
+        Ok(self.inner.delete_prefix(&key).await?)
+    }
+
     pub async fn watch_assignments(&self) -> Result<WatchStream> {
         let key = self.key(StoreKey::AssignmentsPrefix);
         Ok(self.inner.watch(&key).await?)

--- a/rust/kafka-assigner/src/types.rs
+++ b/rust/kafka-assigner/src/types.rs
@@ -99,8 +99,12 @@ pub enum HandoffPhase {
 
 /// A command the assigner sends to a consumer via gRPC.
 ///
-/// This is the domain-level representation. It gets converted to the proto
-/// `AssignmentCommand` at the gRPC boundary.
+/// This is the domain-level representation. It gets converted to one or more
+/// proto `AssignmentCommand` messages at the gRPC boundary.
+///
+/// `Warm` and `Release` carry batched handoffs per-consumer so the relay can
+/// send a single event per consumer per watch response, avoiding channel
+/// overflow when many partitions are handed off simultaneously.
 #[derive(Debug, Clone)]
 pub enum AssignmentEvent {
     /// Batch assignment update: partitions added and/or removed.
@@ -109,10 +113,10 @@ pub enum AssignmentEvent {
         assigned: Vec<TopicPartition>,
         unassigned: Vec<TopicPartition>,
     },
-    /// Start warming a partition for handoff.
-    Warm(HandoffState),
-    /// Release a partition after handoff completion.
-    Release(HandoffState),
+    /// Start warming one or more partitions for handoff.
+    Warm(Vec<HandoffState>),
+    /// Release one or more partitions after handoff completion.
+    Release(Vec<HandoffState>),
 }
 
 impl PartitionAssignment {

--- a/rust/kafka-assigner/tests/common/mod.rs
+++ b/rust/kafka-assigner/tests/common/mod.rs
@@ -230,7 +230,11 @@ pub async fn start_grpc_server(
     cancel: CancellationToken,
 ) -> GrpcTestServer {
     let registry = Arc::new(ConsumerRegistry::new());
-    let config = Config::init_with_defaults().expect("default config should parse");
+    let mut config = Config::init_with_defaults().expect("default config should parse");
+    // Use short lease TTL in tests so crash recovery doesn't take 30s.
+    // Keepalive must be shorter than TTL to avoid expiring healthy consumers.
+    config.consumer_lease_ttl_secs = 5;
+    config.consumer_keepalive_interval_secs = 1;
     let service =
         KafkaAssignerService::from_config(Arc::clone(&store), Arc::clone(&registry), &config);
 

--- a/rust/kafka-assigner/tests/grpc_integration.rs
+++ b/rust/kafka-assigner/tests/grpc_integration.rs
@@ -395,12 +395,12 @@ async fn grpc_crash_during_warming() {
     .await;
 
     // Crash c-1 — drops the gRPC stream. The server detects the closed
-    // channel, revokes the etcd lease, and the consumer disappears.
+    // channel and the etcd lease expires via TTL, removing the consumer.
     c1.crash();
 
-    // Stale handoffs targeting dead c-1 should be cleaned up.
+    // Stale handoffs targeting dead c-1 should be cleaned up after lease expiry.
     let check_store = Arc::clone(&store);
-    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+    wait_for_condition(Duration::from_secs(30), POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         async move { store.list_handoffs().await.unwrap_or_default().is_empty() }
     })
@@ -456,8 +456,9 @@ async fn grpc_consumer_crashes_mid_operation() {
     // Wait for c-1 to disappear and all partitions to converge to c-0.
     // The c-0 driver handles WarmPartition commands for incoming partitions.
     // Complete-phase handoffs with dead old_owner (c-1) are auto-cleaned.
+    // The lease expires via TTL (not eagerly revoked), so we need extra time.
     let check_store = Arc::clone(&store);
-    wait_for_condition(Duration::from_secs(15), POLL_INTERVAL, || {
+    wait_for_condition(Duration::from_secs(30), POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         async move {
             let handoffs = store.list_handoffs().await.unwrap_or_default();
@@ -505,9 +506,10 @@ async fn grpc_rapid_reconnect() {
     let _c0_new_driver = spawn_consumer_driver(c0_new, Duration::ZERO);
 
     // Wait for the consumer to be registered and all partitions assigned.
-    // There may be a brief window where the old lease is revoked and the
-    // new one isn't yet seen by the assigner, so partitions may briefly
-    // be unassigned. The system should converge.
+    // The old lease is NOT eagerly revoked — it expires naturally via TTL.
+    // If the reconnect happens before the TTL elapses, the new registration
+    // overwrites the key without a Delete event, avoiding unnecessary
+    // rebalancing. The system should converge.
     let check_store = Arc::clone(&store);
     wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
@@ -563,9 +565,9 @@ async fn grpc_sequential_crashes_converge() {
     // Crash c-2.
     c2_driver.abort();
 
-    // Wait for convergence to c-0 + c-1.
+    // Wait for convergence to c-0 + c-1 (lease expires via TTL).
     let check_store = Arc::clone(&store);
-    wait_for_condition(Duration::from_secs(20), POLL_INTERVAL, || {
+    wait_for_condition(Duration::from_secs(30), POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         async move {
             let handoffs = store.list_handoffs().await.unwrap_or_default();
@@ -582,9 +584,9 @@ async fn grpc_sequential_crashes_converge() {
     // Crash c-1.
     c1_driver.abort();
 
-    // Wait for convergence to c-0 only.
+    // Wait for convergence to c-0 only (lease expires via TTL).
     let check_store = Arc::clone(&store);
-    wait_for_condition(Duration::from_secs(20), POLL_INTERVAL, || {
+    wait_for_condition(Duration::from_secs(30), POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         async move {
             let handoffs = store.list_handoffs().await.unwrap_or_default();

--- a/rust/kafka-assigner/tests/integration.rs
+++ b/rust/kafka-assigner/tests/integration.rs
@@ -383,32 +383,25 @@ async fn consumer_crash_reassigns_partitions() {
     })
     .await;
 
-    // Wait for all partitions to move to c-1, driving handoffs as they appear.
-    // The assigner creates handoffs from dead c-0 to c-1. At the Complete
-    // phase, cleanup_stale_handoffs auto-deletes them (old_owner is dead).
+    // Dead consumer's partitions should be directly reassigned (no handoffs).
     let check_store = Arc::clone(&store);
     wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         async move {
-            let handoffs = store.list_handoffs().await.unwrap_or_default();
-            for h in &handoffs {
-                match h.phase {
-                    HandoffPhase::Warming => {
-                        signal_ready(&store, &h.topic_partition()).await;
-                    }
-                    HandoffPhase::Complete => {
-                        signal_released(&store, &h.topic_partition()).await;
-                    }
-                    HandoffPhase::Ready => {}
-                }
-            }
-
             let assignments = store.list_assignments().await.unwrap_or_default();
             assignments.len() == NUM_PARTITIONS as usize
                 && assignments.iter().all(|a| a.owner == "c-1")
         }
     })
     .await;
+
+    // No handoffs should have been created — dead owner bypasses handoff protocol.
+    let handoffs = store.list_handoffs().await.unwrap();
+    assert!(
+        handoffs.is_empty(),
+        "expected no handoffs for dead consumer, got {}",
+        handoffs.len()
+    );
 
     cancel.cancel();
 }
@@ -484,6 +477,148 @@ async fn consumer_crash_during_warming_cleans_up() {
         !final_assignments.values().any(|v| v == "c-1"),
         "dead consumer should not own any partitions"
     );
+
+    cancel.cancel();
+}
+
+#[tokio::test]
+async fn dead_consumer_partitions_assigned_directly_without_handoffs() {
+    let store = test_store("dead-direct-assign").await;
+    let cancel = CancellationToken::new();
+
+    set_topic_config(&store, "events", NUM_PARTITIONS).await;
+    let _assigner = start_assigner(Arc::clone(&store), cancel.clone());
+
+    // Register c-0 with a short lease so we can kill it.
+    let c0 = register_consumer(&store, "c-0", 2).await;
+
+    // Wait for c-0 to own all partitions.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "c-0")
+        }
+    })
+    .await;
+
+    // Kill c-0 and register c-1 as the replacement.
+    kill_consumer(&store, c0).await;
+    let _c1 = register_consumer(&store, "c-1", 10).await;
+
+    // c-1 should get all partitions via direct assignment (no handoffs).
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "c-1")
+        }
+    })
+    .await;
+
+    // No handoffs should exist — dead old_owner means no handoff protocol.
+    let handoffs = store.list_handoffs().await.unwrap();
+    assert!(
+        handoffs.is_empty(),
+        "expected no handoffs when old owner is dead, got {}",
+        handoffs.len()
+    );
+
+    cancel.cancel();
+}
+
+#[tokio::test]
+async fn mixed_dead_and_alive_owners_during_rebalance() {
+    let store = test_store("mixed-dead-alive").await;
+    let cancel = CancellationToken::new();
+
+    set_topic_config(&store, "events", NUM_PARTITIONS).await;
+    let _assigner = start_assigner(Arc::clone(&store), cancel.clone());
+
+    // Start with 3 consumers. c-0 has a short lease.
+    let c0 = register_consumer(&store, "c-0", 2).await;
+    let _c1 = register_consumer(&store, "c-1", 10).await;
+    let _c2 = register_consumer(&store, "c-2", 10).await;
+
+    // Wait for balanced 3-way assignment.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+
+            // Drive any handoffs from initial assignment.
+            for h in &handoffs {
+                match h.phase {
+                    HandoffPhase::Warming => {
+                        signal_ready(&store, &h.topic_partition()).await;
+                    }
+                    HandoffPhase::Complete => {
+                        signal_released(&store, &h.topic_partition()).await;
+                    }
+                    HandoffPhase::Ready => {}
+                }
+            }
+
+            assignments.len() == NUM_PARTITIONS as usize
+                && handoffs.is_empty()
+                && assignments.iter().any(|a| a.owner == "c-0")
+                && assignments.iter().any(|a| a.owner == "c-1")
+                && assignments.iter().any(|a| a.owner == "c-2")
+        }
+    })
+    .await;
+
+    // Record how many partitions c-0 owns before dying.
+    let pre_crash = store.list_assignments().await.unwrap();
+    let c0_count = pre_crash.iter().filter(|a| a.owner == "c-0").count();
+    assert!(c0_count > 0, "c-0 should own partitions before crash");
+
+    // Kill c-0. Now c-1 and c-2 need to absorb its partitions.
+    kill_consumer(&store, c0).await;
+
+    // Wait for c-0's partitions to be redistributed. Since c-1/c-2 are alive,
+    // their partitions that need to move use handoffs, but c-0's partitions
+    // should be directly assigned.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            // Drive handoffs between live consumers.
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            for h in &handoffs {
+                match h.phase {
+                    HandoffPhase::Warming => {
+                        signal_ready(&store, &h.topic_partition()).await;
+                    }
+                    HandoffPhase::Complete => {
+                        signal_released(&store, &h.topic_partition()).await;
+                    }
+                    HandoffPhase::Ready => {}
+                }
+            }
+
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            let no_c0 = !assignments.iter().any(|a| a.owner == "c-0");
+            let all_assigned = assignments.len() == NUM_PARTITIONS as usize;
+            let no_pending = store.list_handoffs().await.unwrap_or_default().is_empty();
+            no_c0 && all_assigned && no_pending
+        }
+    })
+    .await;
+
+    // Verify even split between c-1 and c-2.
+    let assignments = store.list_assignments().await.unwrap();
+    let c1_count = assignments.iter().filter(|a| a.owner == "c-1").count();
+    let c2_count = assignments.iter().filter(|a| a.owner == "c-2").count();
+    assert_eq!(c1_count + c2_count, NUM_PARTITIONS as usize);
+    assert_eq!(c1_count, NUM_PARTITIONS as usize / 2);
+    assert_eq!(c2_count, NUM_PARTITIONS as usize / 2);
 
     cancel.cancel();
 }


### PR DESCRIPTION
## Problem

The kafka-assigner had several issues causing stuck partitions and failed handoffs during rebalances: dead consumers' assignments lingered in etcd forever, warm/release events were sent individually per partition overflowing the 64-slot consumer channel, and handoff state wasn't replayed on consumer reconnect.

## Changes

- Skip handoff protocol when the old owner is dead, assigning partitions directly to the new owner instead of creating handoffs that can never complete
- Batch warm/release events per-consumer in the relay, matching the existing assignment batching pattern, to prevent channel overflow during large rebalances
- Delete all assignments from etcd when no active consumers remain so stale keys don't linger
- Replay pending handoff state (warms and releases) when a consumer reconnects, so commands missed during disconnection are delivered
- Add periodic cleanup loop to catch timed-out handoffs when the system is quiescent
- Remove auto lease revocation on disconnect, letting the TTL expire to give consumers a reconnect grace window during rolling restarts
- Increase default channel size from 64 to 1024
- Reduce consumer lease TTL from 30s to 15s

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
