### PR TITLE
feat: use report_user_action for insight analytics events

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -55,7 +55,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.constants import INSIGHT, INSIGHT_FUNNELS, INSIGHT_STICKINESS, TRENDS_STICKINESS, FunnelVizType
 from posthog.decorators import cached_by_filters
 from posthog.errors import ExposedCHQueryError
-from posthog.event_usage import get_request_analytics_properties, groups
+from posthog.event_usage import report_user_action
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
 from posthog.hogql_queries.apply_dashboard_filters import (
     WRAPPER_NODE_KINDS,
@@ -140,6 +140,7 @@ def log_and_report_insight_activity(
     team_id: int,
     user: User,
     was_impersonated: bool,
+    request: Request | None = None,
     changes: list[Change] | None = None,
     properties: dict[str, Any] | None = None,
 ) -> None:
@@ -164,12 +165,14 @@ def log_and_report_insight_activity(
             properties = {}
         organization = Organization.objects.get(id=organization_id)
         team = Team.objects.get(id=team_id)
-        if not was_impersonated and user.distinct_id:
-            posthoganalytics.capture(
+        if not was_impersonated:
+            report_user_action(
+                user,
                 f"insight {activity}",
-                distinct_id=user.distinct_id,
-                properties={"insight_id": insight_short_id, **properties},
-                groups=(groups(organization, team) if team_id else groups(organization)),
+                {"insight_id": insight_short_id, **properties},
+                team=team,
+                organization=organization,
+                request=request,
             )
 
 
@@ -198,8 +201,6 @@ def capture_legacy_api_call(request: request.Request, team: Team) -> None:
         raise PermissionDenied("Legacy insight endpoints are not available for this user.")
 
     try:
-        event = "legacy insight endpoint called"
-        distinct_id: str = request.user.distinct_id  # type: ignore
         properties = {
             "path": request._request.path,
             "method": request._request.method,
@@ -209,8 +210,13 @@ def capture_legacy_api_call(request: request.Request, team: Team) -> None:
             "user_agent": request.headers.get("user-agent"),
         }
 
-        posthoganalytics.capture(
-            event, distinct_id=distinct_id, properties=properties, groups=(groups(team.organization, team))
+        report_user_action(
+            request.user,
+            "legacy insight endpoint called",
+            properties,
+            team=team,
+            organization=team.organization,
+            request=request,
         )
     except Exception as e:
         logging.exception(f"Error in capture_legacy_api_call: {e}")
@@ -489,7 +495,7 @@ class InsightSerializer(InsightBasicSerializer):
             team_id=team_id,
             user=self.context["request"].user,
             was_impersonated=is_impersonated_session(self.context["request"]),
-            properties=get_request_analytics_properties(request),
+            request=self.context["request"],
         )
 
         return insight
@@ -573,8 +579,8 @@ class InsightSerializer(InsightBasicSerializer):
             team_id=self.context["team_id"],
             user=self.context["request"].user,
             was_impersonated=is_impersonated_session(self.context["request"]),
+            request=self.context["request"],
             changes=changes,
-            properties=get_request_analytics_properties(self.context["request"]),
         )
 
     def _synthetic_dashboard_changes(self, dashboards_before_change: list[dict]) -> list[Change]:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -207,7 +207,7 @@ def capture_legacy_api_call(request: request.Request, team: Team) -> None:
         }
 
         report_user_action(
-            request.user,
+            cast(User, request.user),
             "legacy insight endpoint called",
             properties,
             team=team,

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -142,7 +142,6 @@ def log_and_report_insight_activity(
     was_impersonated: bool,
     request: Request | None = None,
     changes: list[Change] | None = None,
-    properties: dict[str, Any] | None = None,
 ) -> None:
     """
     Insight id and short_id are passed separately as some activities (like delete) alter the Insight instance
@@ -161,15 +160,13 @@ def log_and_report_insight_activity(
             activity=activity,
             detail=Detail(name=insight_name, changes=changes, short_id=insight_short_id),
         )
-        if properties is None:
-            properties = {}
         organization = Organization.objects.get(id=organization_id)
         team = Team.objects.get(id=team_id)
         if not was_impersonated:
             report_user_action(
                 user,
                 f"insight {activity}",
-                {"insight_id": insight_short_id, **properties},
+                {"insight_id": insight_short_id},
                 team=team,
                 organization=organization,
                 request=request,
@@ -206,7 +203,6 @@ def capture_legacy_api_call(request: request.Request, team: Team) -> None:
             "method": request._request.method,
             "query_method": get_query_method(request=request, team=team),
             "filter": get_filter(request=request, team=team),
-            "was_impersonated": is_impersonated_session(request),
             "user_agent": request.headers.get("user-agent"),
         }
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -196,10 +196,9 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 response_1.json().items(),
             )
             mock_capture.assert_any_call(
-                "insight created",
                 distinct_id=self.user.distinct_id,
+                event="insight created",
                 properties={
-                    "insight_id": response_1.json()["short_id"],
                     "$current_url": "https://posthog.com/my-referer",
                     "$session_id": "my-session-id",
                     "source": "web",
@@ -208,6 +207,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     "mcp_client_name": None,
                     "mcp_client_version": None,
                     "mcp_protocol_version": None,
+                    "insight_id": response_1.json()["short_id"],
                 },
                 groups=ANY,
             )
@@ -237,10 +237,9 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             insight_short_id = response_2.json()["short_id"]
             # Check that "insight updated" event was called among all capture calls
             mock_capture.assert_any_call(
-                "insight updated",
                 distinct_id=self.user.distinct_id,
+                event="insight updated",
                 properties={
-                    "insight_id": insight_short_id,
                     "$current_url": "https://posthog.com/my-referer",
                     "$session_id": "my-session-id",
                     "source": "web",
@@ -249,6 +248,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     "mcp_client_name": None,
                     "mcp_client_version": None,
                     "mcp_protocol_version": None,
+                    "insight_id": insight_short_id,
                 },
                 groups=ANY,
             )


### PR DESCRIPTION
## Problem

Insight analytics events (`insight created`, `insight updated`, `insight deleted`, `insight restored`, `legacy insight endpoint called`) use raw `posthoganalytics.capture()` instead of `report_user_action()`. This means they miss out on consistent request analytics properties and group context that `report_user_action` provides.

Dashboard events already use `report_user_action` — this brings insight events in line.

## Changes

- Refactored `log_and_report_insight_activity()` to use `report_user_action()` instead of direct `posthoganalytics.capture()`
  - Added `request` parameter so `report_user_action` can extract request analytics properties
  - Callers now pass `request=` instead of `properties=get_request_analytics_properties(request)` (handled internally by `report_user_action`)
- Refactored `capture_legacy_api_call()` to use `report_user_action()` instead of direct `posthoganalytics.capture()`
- Updated test assertions to match `report_user_action`'s keyword-arg call signature

## How did you test this code?

Ran the full insight API test suite (`pytest posthog/api/test/test_insight.py`) — 107 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Publish to changelog?

No