### PR TITLE
fix(flags): add approvals and RBAC gates to v2 enable toggle

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -32,6 +32,7 @@ import {
     Tooltip,
 } from '@posthog/lemon-ui'
 
+import { approvalsGateLogic } from 'lib/approvals/approvalsGateLogic'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -40,6 +41,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import 'lib/lemon-ui/Lettermark'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { alphabet } from 'lib/utils'
+import { ApprovalActionKey } from 'scenes/approvals/utils'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 import { urls } from 'scenes/urls'
 
@@ -84,6 +86,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
     } = useActions(featureFlagLogic)
     const { tags: availableTags } = useValues(tagsModel)
     const { featureFlags } = useValues(enabledFeaturesLogic)
+    const { isApprovalRequired } = useValues(approvalsGateLogic)
     const hasEvaluationTags = useFeatureFlag('FLAG_EVALUATION_TAGS')
     const featureFlagsV2Enabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAGS_V2]
     const showBucketingIdentifierUI = !!featureFlags[FEATURE_FLAGS.FLAG_BUCKETING_IDENTIFIER]
@@ -260,23 +263,38 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                 <LemonDivider />
 
                                 <LemonField name="active">
-                                    {({ value, onChange }) => (
-                                        <LemonSwitch
-                                            checked={value}
-                                            onChange={onChange}
-                                            label={
-                                                <span className="flex items-center gap-1">
-                                                    <span>Enabled</span>
-                                                    <Tooltip title="When disabled, all SDKs return false without checking release conditions.">
-                                                        <IconInfo className="text-secondary text-base" />
-                                                    </Tooltip>
-                                                </span>
-                                            }
-                                            bordered
-                                            fullWidth
-                                            data-attr="feature-flag-enabled"
-                                        />
-                                    )}
+                                    {({ value, onChange }) => {
+                                        const requiresApprovalToEnable =
+                                            isNewFeatureFlag &&
+                                            isApprovalRequired(ApprovalActionKey.FEATURE_FLAG_ENABLE)
+
+                                        if (requiresApprovalToEnable && value) {
+                                            queueMicrotask(() => onChange(false))
+                                        }
+
+                                        return (
+                                            <LemonSwitch
+                                                checked={value}
+                                                onChange={onChange}
+                                                disabledReason={
+                                                    requiresApprovalToEnable
+                                                        ? 'Enabling feature flags requires approval. Create the flag first, then enable it.'
+                                                        : undefined
+                                                }
+                                                label={
+                                                    <span className="flex items-center gap-1">
+                                                        <span>Enabled</span>
+                                                        <Tooltip title="When disabled, all SDKs return false without checking release conditions.">
+                                                            <IconInfo className="text-secondary text-base" />
+                                                        </Tooltip>
+                                                    </span>
+                                                }
+                                                bordered
+                                                fullWidth
+                                                data-attr="feature-flag-enabled"
+                                            />
+                                        )
+                                    }}
                                 </LemonField>
                             </div>
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
@@ -6,6 +6,7 @@ import posthog from 'posthog-js'
 import { IconCode, IconFlag, IconGlobe, IconLaptop, IconList, IconMessage, IconServer } from '@posthog/icons'
 import { LemonButton, LemonCollapse, LemonDialog, LemonDivider, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
+import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -13,7 +14,7 @@ import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagL
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { FeatureFlagEvaluationRuntime, FeatureFlagType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, FeatureFlagEvaluationRuntime, FeatureFlagType } from '~/types'
 
 import { EditableOverviewSection } from './EditableOverviewSection'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
@@ -64,7 +65,7 @@ function TagsDisplay({ tags, evaluationTags, flagId, hasEvaluationTags }: TagsDi
  */
 export function FeatureFlagOverviewV2({ featureFlag, onGetFeedback }: FeatureFlagOverviewV2Props): JSX.Element {
     const { featureFlags } = useValues(enabledFeaturesLogic)
-    const { recordingFilterForFlag } = useValues(featureFlagLogic)
+    const { recordingFilterForFlag, featureFlagActiveUpdateLoading } = useValues(featureFlagLogic)
     const { toggleFeatureFlagActive } = useActions(featureFlagLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
@@ -173,13 +174,25 @@ export function FeatureFlagOverviewV2({ featureFlag, onGetFeedback }: FeatureFla
                                 </LemonTag>
                             </div>
                         ) : (
-                            <LemonSwitch
-                                checked={featureFlag.active}
-                                onChange={handleToggleClick}
-                                label="Enable feature flag"
-                                bordered
-                                fullWidth
-                            />
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.FeatureFlag}
+                                minAccessLevel={AccessControlLevel.Editor}
+                                userAccessLevel={featureFlag.user_access_level}
+                            >
+                                <LemonSwitch
+                                    checked={featureFlag.active}
+                                    onChange={handleToggleClick}
+                                    loading={featureFlagActiveUpdateLoading}
+                                    disabledReason={
+                                        !featureFlag.can_edit
+                                            ? "You only have view access to this feature flag. To make changes, contact the flag's creator."
+                                            : null
+                                    }
+                                    label="Enable feature flag"
+                                    bordered
+                                    fullWidth
+                                />
+                            </AccessControlAction>
                         )}
                     </div>
 


### PR DESCRIPTION
## Summary

- Wrap the v2 overview enable toggle in `AccessControlAction` for RBAC enforcement (parity with v1)
- Add approval requirement check on enable toggle for new flags in the v2 form UI (disables toggle with message when approval policy is active)

## Context

The v2 feature flag UI (behind `feature-flags-v2` flag) was missing two gates that v1 has:
1. **RBAC**: The overview toggle had no `AccessControlAction` wrapper, so users without editor access could attempt to toggle
2. **Approvals**: The form UI's enable toggle had no `isApprovalRequired` check, allowing new flags to be created as enabled even when an approval policy requires it

<img width="1350" height="430" alt="image" src="https://github.com/user-attachments/assets/ddabbbc2-19e8-44f2-bf26-82874406068c" />
