### PR TITLE
fix(batch_exports): use get-or-create for backfill to handle Temporal retries

### DIFF
--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -962,7 +962,10 @@ async def acreate_batch_export_backfill(
     status: str = BatchExportRun.Status.RUNNING,
     backfill_id: str | None = None,
 ) -> BatchExportBackfill:
-    """Create a BatchExportBackfill.
+    """Create a BatchExportBackfill, or return an existing one if a backfill_id is provided and already exists.
+
+    We use `aget_or_create` to handle the rare case (which we have seen in production) where the Temporal activity
+    retries due to a timeout, but the previous attempt has committed the row to Postgres.
 
     Args:
         batch_export_id: The UUID of the BatchExport the BatchExportBackfill to create belongs to.
@@ -972,17 +975,23 @@ async def acreate_batch_export_backfill(
         status: The initial status for the created BatchExportBackfill.
         backfill_id: Pre-generated UUID for the backfill. If provided, will be used as the model's primary key.
     """
-    kwargs: dict = {
-        "batch_export_id": batch_export_id,
+
+    defaults: dict = {
         "status": status,
         "start_at": dt.datetime.fromisoformat(start_at) if start_at else None,
         "end_at": dt.datetime.fromisoformat(end_at) if end_at else None,
-        "team_id": team_id,
     }
+
     if backfill_id is not None:
-        kwargs["id"] = backfill_id
-    backfill = BatchExportBackfill(**kwargs)
-    await backfill.asave()
+        backfill, _created = await BatchExportBackfill.objects.aget_or_create(
+            id=backfill_id,
+            team_id=team_id,
+            batch_export_id=batch_export_id,
+            defaults=defaults,
+        )
+    else:
+        backfill = BatchExportBackfill(**defaults, team_id=team_id, batch_export_id=batch_export_id)
+        await backfill.asave()
 
     return backfill
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -954,7 +954,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
     return batch_export
 
 
-async def acreate_batch_export_backfill(
+async def aget_or_create_batch_export_backfill(
     batch_export_id: UUID,
     team_id: int,
     start_at: str | None,

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -32,7 +32,7 @@ from posthog.temporal.common.logger import get_write_only_logger
 from products.batch_exports.backend.service import (
     BackfillBatchExportInputs,
     BackfillDetails,
-    acreate_batch_export_backfill,
+    aget_or_create_batch_export_backfill,
     unpause_batch_export,
     update_batch_export_backfill,
 )
@@ -89,7 +89,7 @@ async def create_batch_export_backfill_model(inputs: CreateBatchExportBackfillIn
     model instance to represent them in our database.
     """
 
-    backfill = await acreate_batch_export_backfill(
+    backfill = await aget_or_create_batch_export_backfill(
         batch_export_id=uuid.UUID(inputs.batch_export_id),
         start_at=inputs.start_at,
         end_at=inputs.end_at,

--- a/products/batch_exports/backend/tests/conftest.py
+++ b/products/batch_exports/backend/tests/conftest.py
@@ -1,0 +1,28 @@
+import random
+
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+
+from posthog.models import Organization, Team
+from posthog.models.team.util import delete_batch_exports
+
+
+@pytest_asyncio.fixture
+async def aorganization(db):
+    name = f"BatchExportsTestOrg-{random.randint(1, 99999)}"
+    org = await sync_to_async(Organization.objects.create)(name=name, is_ai_data_processing_approved=True)
+
+    yield org
+
+    await sync_to_async(org.delete)()
+
+
+@pytest_asyncio.fixture
+async def ateam(aorganization):
+    name = f"BatchExportsTestTeam-{random.randint(1, 99999)}"
+    # need to use create here rather than acreate because TeamManager.create() has some custom logic
+    team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
+
+    yield team
+    await sync_to_async(delete_batch_exports)(team_ids=[team.pk])
+    await sync_to_async(team.delete)()

--- a/products/batch_exports/backend/tests/test_service.py
+++ b/products/batch_exports/backend/tests/test_service.py
@@ -1,4 +1,8 @@
+import uuid
+
 import pytest
+
+from posthog.batch_exports.models import BatchExport, BatchExportBackfill, BatchExportDestination, BatchExportRun
 
 from products.batch_exports.backend.service import (
     AzureBlobBatchExportInputs,
@@ -7,6 +11,7 @@ from products.batch_exports.backend.service import (
     PostgresBatchExportInputs,
     RedshiftBatchExportInputs,
     S3BatchExportInputs,
+    acreate_batch_export_backfill,
 )
 
 DESTINATION_INPUTS = {
@@ -124,3 +129,84 @@ class TestTypeCoercionInBatchExportInputs:
             max_file_size_mb=None,
         )
         assert inputs.max_file_size_mb is None
+
+
+@pytest.fixture
+async def batch_export(ateam):
+    destination = await BatchExportDestination.objects.acreate(
+        type="S3",
+        config={
+            "bucket_name": "test",
+            "region": "us-east-1",
+            "prefix": "test",
+            "aws_access_key_id": "test",
+            "aws_secret_access_key": "test",
+        },
+    )
+    batch_export = await BatchExport.objects.acreate(
+        team=ateam,
+        destination=destination,
+        interval="hour",
+        name="Test Export",
+    )
+    yield batch_export
+    await batch_export.adelete()
+    await destination.adelete()
+
+
+async def test_creates_new_backfill(ateam, batch_export):
+    backfill = await acreate_batch_export_backfill(
+        batch_export_id=batch_export.id,
+        team_id=ateam.id,
+        start_at="2024-01-01T00:00:00+00:00",
+        end_at="2024-01-02T00:00:00+00:00",
+    )
+
+    assert backfill.batch_export_id == batch_export.id
+    assert backfill.team_id == ateam.id
+    assert backfill.status == BatchExportRun.Status.RUNNING
+    assert await BatchExportBackfill.objects.filter(id=backfill.id).aexists()
+
+
+async def test_creates_new_backfill_with_preset_id(ateam, batch_export):
+    backfill_id = str(uuid.uuid4())
+    backfill = await acreate_batch_export_backfill(
+        batch_export_id=batch_export.id,
+        team_id=ateam.id,
+        start_at="2024-01-01T00:00:00+00:00",
+        end_at="2024-01-02T00:00:00+00:00",
+        backfill_id=backfill_id,
+    )
+
+    assert str(backfill.id) == backfill_id
+
+
+async def test_returns_existing_backfill_on_retry_with_same_id(ateam, batch_export):
+    backfill_id = str(uuid.uuid4())
+    kwargs = {
+        "batch_export_id": batch_export.id,
+        "team_id": ateam.id,
+        "start_at": "2024-01-01T00:00:00+00:00",
+        "end_at": "2024-01-02T00:00:00+00:00",
+        "backfill_id": backfill_id,
+    }
+
+    first = await acreate_batch_export_backfill(**kwargs)
+    second = await acreate_batch_export_backfill(**kwargs)
+
+    assert str(first.id) == str(second.id)
+    assert await BatchExportBackfill.objects.filter(id=backfill_id).acount() == 1
+
+
+async def test_creates_backfill_without_id_does_not_deduplicate(ateam, batch_export):
+    kwargs = {
+        "batch_export_id": batch_export.id,
+        "team_id": ateam.id,
+        "start_at": "2024-01-01T00:00:00+00:00",
+        "end_at": "2024-01-02T00:00:00+00:00",
+    }
+
+    first = await acreate_batch_export_backfill(**kwargs)
+    second = await acreate_batch_export_backfill(**kwargs)
+
+    assert first.id != second.id

--- a/products/batch_exports/backend/tests/test_service.py
+++ b/products/batch_exports/backend/tests/test_service.py
@@ -11,7 +11,7 @@ from products.batch_exports.backend.service import (
     PostgresBatchExportInputs,
     RedshiftBatchExportInputs,
     S3BatchExportInputs,
-    acreate_batch_export_backfill,
+    aget_or_create_batch_export_backfill,
 )
 
 DESTINATION_INPUTS = {
@@ -155,7 +155,7 @@ async def batch_export(ateam):
 
 
 async def test_creates_new_backfill(ateam, batch_export):
-    backfill = await acreate_batch_export_backfill(
+    backfill = await aget_or_create_batch_export_backfill(
         batch_export_id=batch_export.id,
         team_id=ateam.id,
         start_at="2024-01-01T00:00:00+00:00",
@@ -170,7 +170,7 @@ async def test_creates_new_backfill(ateam, batch_export):
 
 async def test_creates_new_backfill_with_preset_id(ateam, batch_export):
     backfill_id = str(uuid.uuid4())
-    backfill = await acreate_batch_export_backfill(
+    backfill = await aget_or_create_batch_export_backfill(
         batch_export_id=batch_export.id,
         team_id=ateam.id,
         start_at="2024-01-01T00:00:00+00:00",
@@ -191,8 +191,8 @@ async def test_returns_existing_backfill_on_retry_with_same_id(ateam, batch_expo
         "backfill_id": backfill_id,
     }
 
-    first = await acreate_batch_export_backfill(**kwargs)
-    second = await acreate_batch_export_backfill(**kwargs)
+    first = await aget_or_create_batch_export_backfill(**kwargs)
+    second = await aget_or_create_batch_export_backfill(**kwargs)
 
     assert str(first.id) == str(second.id)
     assert await BatchExportBackfill.objects.filter(id=backfill_id).acount() == 1
@@ -206,7 +206,7 @@ async def test_creates_backfill_without_id_does_not_deduplicate(ateam, batch_exp
         "end_at": "2024-01-02T00:00:00+00:00",
     }
 
-    first = await acreate_batch_export_backfill(**kwargs)
-    second = await acreate_batch_export_backfill(**kwargs)
+    first = await aget_or_create_batch_export_backfill(**kwargs)
+    second = await aget_or_create_batch_export_backfill(**kwargs)
 
     assert first.id != second.id


### PR DESCRIPTION
## Problem

In production, we've seen cases where the Temporal activity that creates the backfill row in Postgres timeout for whatever reason, however the row was eventally created. On an activity retry we fail to create the backfill again due to an `IntegrityError`.

## Changes

- Changed `acreate_batch_export_backfill` in `posthog/batch_exports/service.py` to use Django's `aget_or_create` when a `backfill_id` is provided, so retries return the existing row instead of raising `IntegrityError`
- The lookup includes `team_id` and `batch_export_id` alongside the `id` to ensure we never return a backfill belonging to a different team or export
- When no `backfill_id` is provided, behavior is unchanged (a new row is created each time)

## How did you test this code?

Added tests in `posthog/batch_exports/tests/test_service.py`

## Publish to changelog?

No