### PR TITLE
chore: Mark claude git worktrees ignored

### DIFF
--- a/.idea/posthog.iml
+++ b/.idea/posthog.iml
@@ -49,6 +49,7 @@
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/rest_framework" />
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/services" />
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/transformations" />
+      <excludeFolder url="file://$MODULE_DIR$/.claude/worktrees" />
       <excludePattern pattern="*node_modules*" />
     </content>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION
## Problem

Claude creates git worktrees in the .claude folder, this can slow down pycharm a lot while working on stuff

## Changes

Mark this as `excluded`

## How did you test this code?

n/a 

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
