### PR TITLE
fix(dwh): show pretty error on code 636

### DIFF
--- a/products/data_warehouse/backend/models/table.py
+++ b/products/data_warehouse/backend/models/table.py
@@ -472,6 +472,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         {
             27,  # CANNOT_PARSE_INPUT ("expected ',' at end of stream")
             117,  # INCORRECT_DATA ("Expected end of line")
+            636,  # CANNOT_EXTRACT_TABLE_STRUCTURE (wraps inner parse errors like 117)
         }
     )
 

--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -369,7 +369,8 @@ class TestTable(BaseTest):
         )
         assert table.csv_allow_double_quotes is None
 
-    def test_validate_csv_double_quotes_raises_on_parse_failure(self):
+    @pytest.mark.parametrize("code", [27, 117, 636])
+    def test_validate_csv_double_quotes_raises_on_parse_failure(self, code):
         from clickhouse_driver.errors import ServerException
 
         credential = DataWarehouseCredential.objects.create(access_key="key", access_secret="secret", team=self.team)
@@ -384,7 +385,7 @@ class TestTable(BaseTest):
 
         with patch(
             "products.data_warehouse.backend.models.table.sync_execute",
-            side_effect=ServerException("Expected end of line", code=117),
+            side_effect=ServerException("Expected end of line", code=code),
         ):
             with pytest.raises(Exception, match="CSV parsing failed"):
                 table._validate_csv_double_quotes_setting()

--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -2,6 +2,8 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from posthog.hogql.database.models import DateTimeDatabaseField, IntegerDatabaseField, StringDatabaseField
 
 from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
@@ -369,7 +371,7 @@ class TestTable(BaseTest):
         )
         assert table.csv_allow_double_quotes is None
 
-    @pytest.mark.parametrize("code", [27, 117, 636])
+    @parameterized.expand([27, 117, 636])
     def test_validate_csv_double_quotes_raises_on_parse_failure(self, code):
         from clickhouse_driver.errors import ServerException
 


### PR DESCRIPTION
## Changes

We want to show a pretty error when importing a CSV fails with code 636, as it might be related to the wrong CSV quote handling option.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no