### PR TITLE
chore(autonomy): remove bot prs from codeowners auto assignment

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
     assign-reviewers:
         runs-on: 'ubuntu-22.04'
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'posthog[bot]'
 
         steps:
             # GitHub app token is required because GITHUB_TOKEN can't assign team members as reviewers (requires org-level permission)


### PR DESCRIPTION
Removes the PRs created by the product autonomy bot from auto assignment based on CODEOWNERS-soft.

Alternatively we could keep the PRs as draft until they are vetted by a human.

More context: https://posthog.slack.com/archives/C0113360FFV/p1772715694060699