### PR TITLE
feat(llma): add LLM analytics evaluations MCP tools

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -450,7 +450,7 @@
         }
     },
     "evaluations-get": {
-        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status. Evaluation results are stored as '$ai_evaluation' events — to query results, use the execute-sql or query-run tool with a HogQL query filtering on event = '$ai_evaluation'. Key properties: $ai_evaluation_id (evaluation UUID), $ai_evaluation_name, $ai_target_event_id (generation event UUID), $ai_trace_id, $ai_evaluation_result (boolean pass/fail), $ai_evaluation_reasoning (text), $ai_evaluation_applicable (boolean, false = N/A).",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "List LLM analytics evaluations.",
@@ -525,7 +525,7 @@
         }
     },
     "evaluation-run": {
-        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "Run an evaluation on a specific event.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -449,6 +449,96 @@
             "readOnlyHint": true
         }
     },
+    "evaluations-get": {
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "List LLM analytics evaluations.",
+        "title": "List evaluations",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-get": {
+        "description": "Get a specific LLM analytics evaluation by its UUID. Returns full details including name, type (llm_judge or hog), configuration, conditions, and enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Get a specific evaluation by ID.",
+        "title": "Get evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-create": {
+        "description": "Create a new LLM analytics evaluation. Two types are supported: 'llm_judge' uses an LLM to score generations against a prompt you define (for subjective checks like tone, helpfulness, hallucination detection), and 'hog' runs deterministic code against each generation (for rule-based checks like format validation, keyword detection, length limits). For llm_judge evaluations, provide a prompt in evaluation_config and a model_configuration. For hog evaluations, provide source code in evaluation_config.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Create a new evaluation.",
+        "title": "Create evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-update": {
+        "description": "Update an existing LLM analytics evaluation. You can change the name, description, enabled status, evaluation config (prompt or source code), and output config. Use this to enable/disable evaluations or modify their scoring logic.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Update an evaluation.",
+        "title": "Update evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-delete": {
+        "description": "Delete an LLM analytics evaluation (soft delete). The evaluation will be marked as deleted and will no longer run.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Delete an evaluation.",
+        "title": "Delete evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-run": {
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Run an evaluation on a specific event.",
+        "title": "Run evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -79,6 +79,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'error_tracking:write',
     'event_definition:read',
     'event_definition:write',
+    'evaluation:read',
+    'evaluation:write',
     'experiment:read',
     'experiment:write',
     'feature_flag:read',

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -38,7 +38,13 @@ import getInsight from './insights/get'
 import getAllInsights from './insights/getAll'
 import queryInsight from './insights/query'
 import updateInsight from './insights/update'
-// LLM Observability
+// LLM Analytics
+import evaluationCreate from './llmAnalytics/evaluations/create'
+import evaluationDelete from './llmAnalytics/evaluations/delete'
+import evaluationGet from './llmAnalytics/evaluations/get'
+import evaluationsGet from './llmAnalytics/evaluations/getAll'
+import evaluationRun from './llmAnalytics/evaluations/run'
+import evaluationUpdate from './llmAnalytics/evaluations/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
 import logsListAttributes from './logs/listAttributes'
 import logsListAttributeValues from './logs/listAttributeValues'
@@ -145,8 +151,14 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-reorder-tiles': reorderDashboardTiles,
     'add-insight-to-dashboard': addInsightToDashboard,
 
-    // LLM Observability
+    // LLM Analytics
     'get-llm-total-costs-for-project': getLLMCosts,
+    'evaluations-get': evaluationsGet,
+    'evaluation-get': evaluationGet,
+    'evaluation-create': evaluationCreate,
+    'evaluation-update': evaluationUpdate,
+    'evaluation-delete': evaluationDelete,
+    'evaluation-run': evaluationRun,
 
     // Surveys
     'surveys-get-all': getAllSurveys,

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -3,45 +3,70 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const ModelConfigurationSchema = z.object({
-    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    provider: z.enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
     model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
     provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
 })
 
-const schema = z.object({
-    name: z.string().max(400).describe('Name of the evaluation.'),
-    description: z.string().optional().describe('Description of what this evaluation checks.'),
-    enabled: z
-        .boolean()
-        .optional()
-        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
-    evaluation_type: z
-        .enum(['llm_judge', 'hog'])
-        .describe(
-            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+const schema = z
+    .object({
+        name: z.string().max(400).describe('Name of the evaluation.'),
+        description: z.string().optional().describe('Description of what this evaluation checks.'),
+        enabled: z
+            .boolean()
+            .optional()
+            .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+        evaluation_type: z
+            .enum(['llm_judge', 'hog'])
+            .describe(
+                'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+            ),
+        evaluation_config: z
+            .object({
+                prompt: z
+                    .string()
+                    .optional()
+                    .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+                source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+            })
+            .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+        output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+        output_config: z
+            .object({
+                allows_na: z
+                    .boolean()
+                    .optional()
+                    .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+            })
+            .optional(),
+        model_configuration: ModelConfigurationSchema.optional().describe(
+            'LLM model configuration (required for llm_judge evaluations).'
         ),
-    evaluation_config: z
-        .object({
-            prompt: z
-                .string()
-                .optional()
-                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
-            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
-        })
-        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
-    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
-    output_config: z
-        .object({
-            allows_na: z
-                .boolean()
-                .optional()
-                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
-        })
-        .optional(),
-    model_configuration: ModelConfigurationSchema.optional().describe(
-        'LLM model configuration (required for llm_judge evaluations).'
-    ),
-})
+    })
+    .superRefine((data, ctx) => {
+        if (data.evaluation_type === 'llm_judge') {
+            if (!data.evaluation_config.prompt) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"prompt" is required for llm_judge evaluations',
+                    path: ['evaluation_config', 'prompt'],
+                })
+            }
+            if (!data.model_configuration) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"model_configuration" is required for llm_judge evaluations',
+                    path: ['model_configuration'],
+                })
+            }
+        } else if (data.evaluation_type === 'hog' && !data.evaluation_config.source) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: '"source" is required for hog evaluations',
+                path: ['evaluation_config', 'source'],
+            })
+        }
+    })
 
 type Params = z.infer<typeof schema>
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const ModelConfigurationSchema = z.object({
+    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
+    provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
+})
+
+const schema = z.object({
+    name: z.string().max(400).describe('Name of the evaluation.'),
+    description: z.string().optional().describe('Description of what this evaluation checks.'),
+    enabled: z
+        .boolean()
+        .optional()
+        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+    evaluation_type: z
+        .enum(['llm_judge', 'hog'])
+        .describe(
+            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+        ),
+    evaluation_config: z
+        .object({
+            prompt: z
+                .string()
+                .optional()
+                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+        })
+        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+    output_config: z
+        .object({
+            allows_na: z
+                .boolean()
+                .optional()
+                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+        })
+        .optional(),
+    model_configuration: ModelConfigurationSchema.optional().describe(
+        'LLM model configuration (required for llm_judge evaluations).'
+    ),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluations/`,
+        body: params as unknown as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-create',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to delete.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+        body: { deleted: true },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-delete',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to retrieve.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    search: z.string().optional().describe('Search evaluations by name or description.'),
+    enabled: z.boolean().optional().describe('Filter by enabled status.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/`,
+        query: {
+            search: params.search,
+            enabled: params.enabled !== undefined ? String(params.enabled) : undefined,
+        },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluations-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to run.'),
     target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
@@ -15,8 +15,10 @@ type Params = z.infer<typeof schema>
 export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
     const projectId = await context.stateManager.getProjectId()
 
+    const { evaluationId, ...rest } = params
     const body = {
-        ...params,
+        ...rest,
+        evaluation_id: evaluationId,
         event: params.event ?? '$ai_generation',
     }
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
+    timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
+    event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
+    distinct_id: z.string().optional().describe('Distinct ID of the event (optional, improves lookup performance).'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const body = {
+        ...params,
+        event: params.event ?? '$ai_generation',
+    }
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluation_runs/`,
+        body,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-run',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to update.'),
+    name: z.string().max(400).optional().describe('Updated name.'),
+    description: z.string().optional().describe('Updated description.'),
+    enabled: z.boolean().optional().describe('Enable or disable the evaluation.'),
+    evaluation_config: z
+        .object({
+            prompt: z.string().optional(),
+            source: z.string().optional(),
+        })
+        .optional()
+        .describe('Updated evaluation configuration.'),
+    output_config: z
+        .object({
+            allows_na: z.boolean().optional(),
+        })
+        .optional()
+        .describe('Updated output configuration.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+    const { evaluationId, ...body } = params
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${evaluationId}/`,
+        body: body as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-update',
+    schema,
+    handler,
+})
+
+export default tool


### PR DESCRIPTION
## Problem

Users of the PostHog MCP server have no way to manage LLM Analytics evaluations. Evaluations are a key feature for scoring AI generations for quality, relevance, safety, and other criteria — but the MCP only exposes a single LLM costs tool today.

## Changes

Add 6 new MCP tools for LLM Analytics evaluations:

- **`evaluations-get`** — List evaluations with optional search and enabled filter
- **`evaluation-get`** — Get a specific evaluation by UUID
- **`evaluation-create`** — Create LLM judge or Hog code evaluations
- **`evaluation-update`** — Partial update of evaluation config, name, enabled status
- **`evaluation-delete`** — Soft delete an evaluation
- **`evaluation-run`** — Trigger an async evaluation run on a specific generation event

Also renames the `// LLM Observability` comment to `// LLM Analytics` for consistency.

**Part 1 of a 3-PR stack** — evaluation results endpoint and MCP tool follow.

## How did you test this code?

- TypeScript compiles cleanly (`tsc --noEmit`)
- Follows existing tool patterns (experiments, error tracking)
- Tools use `context.api.request()` to call existing backend endpoints

Closes #50025 (tracked)