### PR TITLE
feat(llma): add evaluation results API endpoint

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -60,6 +60,7 @@ from products.llm_analytics.backend.api import (
     DatasetItemViewSet,
     DatasetViewSet,
     EvaluationConfigViewSet,
+    EvaluationResultsViewSet,
     EvaluationRunViewSet,
     EvaluationViewSet,
     LLMAnalyticsClusteringRunViewSet,
@@ -1242,6 +1243,13 @@ environments_router.register(
     r"llm_analytics/evaluation_config",
     EvaluationConfigViewSet,
     "environment_llm_analytics_evaluation_config",
+    ["team_id"],
+)
+
+environments_router.register(
+    r"llm_analytics/evaluation_results",
+    EvaluationResultsViewSet,
+    "environment_llm_analytics_evaluation_results",
     ["team_id"],
 )
 

--- a/products/llm_analytics/backend/api/__init__.py
+++ b/products/llm_analytics/backend/api/__init__.py
@@ -3,6 +3,7 @@ from .clustering_config import ClusteringConfigViewSet
 from .clustering_job import ClusteringJobViewSet
 from .datasets import DatasetItemViewSet, DatasetViewSet
 from .evaluation_config import EvaluationConfigViewSet
+from .evaluation_results import EvaluationResultsViewSet
 from .evaluation_runs import EvaluationRunViewSet
 from .evaluation_summary import LLMEvaluationSummaryViewSet
 from .evaluations import EvaluationViewSet
@@ -28,6 +29,7 @@ __all__ = [
     "DatasetViewSet",
     "DatasetItemViewSet",
     "EvaluationViewSet",
+    "EvaluationResultsViewSet",
     "EvaluationRunViewSet",
     "EvaluationConfigViewSet",
     "LLMProviderKeyViewSet",

--- a/products/llm_analytics/backend/api/evaluation_results.py
+++ b/products/llm_analytics/backend/api/evaluation_results.py
@@ -1,0 +1,158 @@
+from rest_framework import serializers, status, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.api.monitoring import monitor
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.permissions import AccessControlPermission
+
+from products.llm_analytics.backend.api.metrics import llma_track_latency
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+
+
+class EvaluationResultSerializer(serializers.Serializer):
+    uuid = serializers.CharField(read_only=True)
+    timestamp = serializers.DateTimeField(read_only=True)
+    evaluation_id = serializers.CharField(read_only=True)
+    evaluation_name = serializers.CharField(read_only=True)
+    generation_id = serializers.CharField(read_only=True)
+    trace_id = serializers.CharField(read_only=True, allow_null=True)
+    result = serializers.BooleanField(read_only=True, allow_null=True)
+    reasoning = serializers.CharField(read_only=True, allow_null=True)
+    applicable = serializers.BooleanField(read_only=True, allow_null=True)
+
+
+class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    Query evaluation results ($ai_evaluation events).
+
+    GET /api/environments/:id/llm_analytics/evaluation_results/
+        ?evaluation_id=<uuid>       Filter by evaluation UUID
+        &generation_id=<uuid>       Filter by generation event UUID
+        &result=pass|fail|na        Filter by result status
+        &limit=50                   Max results (default 50, max 200)
+    """
+
+    scope_object = "evaluation"
+    permission_classes = [IsAuthenticated, AccessControlPermission]
+    serializer_class = EvaluationResultSerializer
+
+    @llma_track_latency("llma_evaluation_results_list")
+    @monitor(feature=None, endpoint="llma_evaluation_results_list", method="GET")
+    def list(self, request: Request, **kwargs) -> Response:
+        evaluation_id = request.query_params.get("evaluation_id")
+        generation_id = request.query_params.get("generation_id")
+        result_filter = request.query_params.get("result")
+        limit = min(int(request.query_params.get("limit", DEFAULT_LIMIT)), MAX_LIMIT)
+
+        if not evaluation_id and not generation_id:
+            return Response(
+                {"error": "At least one of evaluation_id or generation_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        where_conditions: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["event"]),
+                right=ast.Constant(value="$ai_evaluation"),
+            ),
+        ]
+
+        if evaluation_id:
+            where_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["properties", "$ai_evaluation_id"]),
+                    right=ast.Constant(value=evaluation_id),
+                )
+            )
+
+        if generation_id:
+            where_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["properties", "$ai_target_event_id"]),
+                    right=ast.Constant(value=generation_id),
+                )
+            )
+
+        if result_filter == "pass":
+            where_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["properties", "$ai_evaluation_result"]),
+                    right=ast.Constant(value=True),
+                )
+            )
+        elif result_filter == "fail":
+            where_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["properties", "$ai_evaluation_result"]),
+                    right=ast.Constant(value=False),
+                )
+            )
+        elif result_filter == "na":
+            where_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["properties", "$ai_evaluation_applicable"]),
+                    right=ast.Constant(value=False),
+                )
+            )
+
+        query = parse_select(
+            """
+            SELECT
+                uuid,
+                timestamp,
+                properties.$ai_evaluation_id as evaluation_id,
+                properties.$ai_evaluation_name as evaluation_name,
+                properties.$ai_target_event_id as generation_id,
+                properties.$ai_trace_id as trace_id,
+                properties.$ai_evaluation_result as result,
+                properties.$ai_evaluation_reasoning as reasoning,
+                properties.$ai_evaluation_applicable as applicable
+            FROM events
+            WHERE {where_clause}
+            ORDER BY timestamp DESC
+            LIMIT {limit}
+            """
+        )
+
+        with tags_context(product=Product.LLM_ANALYTICS):
+            query_result = execute_hogql_query(
+                query_type="EvaluationResultsList",
+                query=query,
+                placeholders={
+                    "where_clause": ast.And(exprs=where_conditions),
+                    "limit": ast.Constant(value=limit),
+                },
+                team=self.team,
+            )
+
+        results = [
+            {
+                "uuid": str(row[0]) if row[0] else "",
+                "timestamp": row[1],
+                "evaluation_id": str(row[2]) if row[2] else "",
+                "evaluation_name": row[3] or "",
+                "generation_id": str(row[4]) if row[4] else "",
+                "trace_id": str(row[5]) if row[5] else None,
+                "result": None if row[8] is False else row[6],
+                "reasoning": row[7] or None,
+                "applicable": row[8],
+            }
+            for row in (query_result.results or [])
+        ]
+
+        return Response({"results": results, "count": len(results)})

--- a/products/llm_analytics/backend/api/evaluation_results.py
+++ b/products/llm_analytics/backend/api/evaluation_results.py
@@ -51,7 +51,10 @@ class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         evaluation_id = request.query_params.get("evaluation_id")
         generation_id = request.query_params.get("generation_id")
         result_filter = request.query_params.get("result")
-        limit = min(int(request.query_params.get("limit", DEFAULT_LIMIT)), MAX_LIMIT)
+        try:
+            limit = min(int(request.query_params.get("limit", DEFAULT_LIMIT)), MAX_LIMIT)
+        except (ValueError, TypeError):
+            return Response({"error": "limit must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
 
         if not evaluation_id and not generation_id:
             return Response(
@@ -85,6 +88,17 @@ class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 )
             )
 
+        not_na_guard = ast.Or(
+            exprs=[
+                ast.Call(name="isNull", args=[ast.Field(chain=["properties", "$ai_evaluation_applicable"])]),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.NotEq,
+                    left=ast.Field(chain=["properties", "$ai_evaluation_applicable"]),
+                    right=ast.Constant(value=False),
+                ),
+            ]
+        )
+
         if result_filter == "pass":
             where_conditions.append(
                 ast.CompareOperation(
@@ -93,6 +107,7 @@ class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     right=ast.Constant(value=True),
                 )
             )
+            where_conditions.append(not_na_guard)
         elif result_filter == "fail":
             where_conditions.append(
                 ast.CompareOperation(
@@ -101,6 +116,7 @@ class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     right=ast.Constant(value=False),
                 )
             )
+            where_conditions.append(not_na_guard)
         elif result_filter == "na":
             where_conditions.append(
                 ast.CompareOperation(
@@ -142,7 +158,7 @@ class EvaluationResultsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         results = [
             {
-                "uuid": str(row[0]) if row[0] else "",
+                "uuid": str(row[0]),
                 "timestamp": row[1],
                 "evaluation_id": str(row[2]) if row[2] else "",
                 "evaluation_name": row[3] or "",

--- a/products/llm_analytics/backend/api/test/test_evaluation_results.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_results.py
@@ -120,3 +120,11 @@ class TestEvaluationResultsAPI(APIBaseTest):
         call_kwargs = mock_query.call_args
         placeholders = call_kwargs.kwargs.get("placeholders", {})
         assert placeholders["limit"].value == 200
+
+    def test_invalid_limit_returns_400(self):
+        response = self.client.get(
+            self.url,
+            {"evaluation_id": str(self.evaluation.id), "limit": "abc"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "limit" in response.data["error"]

--- a/products/llm_analytics/backend/api/test/test_evaluation_results.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_results.py
@@ -1,0 +1,122 @@
+import uuid
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from rest_framework import status
+
+from products.llm_analytics.backend.models.evaluations import Evaluation
+
+
+class TestEvaluationResultsAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.evaluation = Evaluation.objects.create(
+            team=self.team,
+            name="Test Evaluation",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "Is the response helpful?"},
+            output_type="boolean",
+            output_config={"allows_na": False},
+            enabled=True,
+            created_by=self.user,
+        )
+        self.url = f"/api/environments/{self.team.id}/llm_analytics/evaluation_results/"
+
+    def test_unauthenticated_user_cannot_access(self):
+        self.client.logout()
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_requires_at_least_one_filter(self):
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "evaluation_id" in response.data["error"]
+
+    @patch("products.llm_analytics.backend.api.evaluation_results.execute_hogql_query")
+    def test_filter_by_evaluation_id(self, mock_query):
+        mock_result = MagicMock()
+        mock_result.results = [
+            [
+                "event-uuid-1",
+                "2026-03-05T10:00:00Z",
+                str(self.evaluation.id),
+                "Test Evaluation",
+                "gen-uuid-1",
+                "trace-1",
+                True,
+                "Looks good",
+                None,
+            ],
+        ]
+        mock_query.return_value = mock_result
+
+        response = self.client.get(self.url, {"evaluation_id": str(self.evaluation.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["evaluation_id"] == str(self.evaluation.id)
+        assert response.data["results"][0]["result"] is True
+        assert response.data["results"][0]["reasoning"] == "Looks good"
+
+    @patch("products.llm_analytics.backend.api.evaluation_results.execute_hogql_query")
+    def test_filter_by_generation_id(self, mock_query):
+        mock_result = MagicMock()
+        mock_result.results = []
+        mock_query.return_value = mock_result
+
+        gen_id = str(uuid.uuid4())
+        response = self.client.get(self.url, {"generation_id": gen_id})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 0
+        assert response.data["results"] == []
+
+    @patch("products.llm_analytics.backend.api.evaluation_results.execute_hogql_query")
+    def test_filter_by_both_ids(self, mock_query):
+        mock_result = MagicMock()
+        mock_result.results = []
+        mock_query.return_value = mock_result
+
+        response = self.client.get(
+            self.url,
+            {"evaluation_id": str(self.evaluation.id), "generation_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.llm_analytics.backend.api.evaluation_results.execute_hogql_query")
+    def test_na_result_nullifies_result_field(self, mock_query):
+        mock_result = MagicMock()
+        mock_result.results = [
+            [
+                "event-uuid-2",
+                "2026-03-05T10:00:00Z",
+                str(self.evaluation.id),
+                "Test Evaluation",
+                "gen-uuid-2",
+                None,
+                True,
+                "Not applicable",
+                False,
+            ],
+        ]
+        mock_query.return_value = mock_result
+
+        response = self.client.get(self.url, {"evaluation_id": str(self.evaluation.id)})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["results"][0]["result"] is None
+        assert response.data["results"][0]["applicable"] is False
+
+    @patch("products.llm_analytics.backend.api.evaluation_results.execute_hogql_query")
+    def test_limit_capped_at_max(self, mock_query):
+        mock_result = MagicMock()
+        mock_result.results = []
+        mock_query.return_value = mock_result
+
+        response = self.client.get(
+            self.url,
+            {"evaluation_id": str(self.evaluation.id), "limit": "999"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        # Verify the query was called with capped limit (200)
+        call_kwargs = mock_query.call_args
+        placeholders = call_kwargs.kwargs.get("placeholders", {})
+        assert placeholders["limit"].value == 200

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -319,6 +319,31 @@ export interface ClusteringRunRequestApi {
     clustering_job_id?: string | null
 }
 
+export interface EvaluationResultApi {
+    readonly uuid: string
+    readonly timestamp: string
+    readonly evaluation_id: string
+    readonly evaluation_name: string
+    readonly generation_id: string
+    /** @nullable */
+    readonly trace_id: string | null
+    /** @nullable */
+    readonly result: boolean | null
+    /** @nullable */
+    readonly reasoning: string | null
+    /** @nullable */
+    readonly applicable: boolean | null
+}
+
+export interface PaginatedEvaluationResultListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: EvaluationResultApi[]
+}
+
 /**
  * * `all` - all
  * `pass` - pass
@@ -787,6 +812,17 @@ export type EvaluationsListParams = {
 }
 
 export type LlmAnalyticsClusteringJobsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type LlmAnalyticsEvaluationResultsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -23,11 +23,13 @@ import type {
     EvaluationsListParams,
     LLMProviderKeyApi,
     LlmAnalyticsClusteringJobsListParams,
+    LlmAnalyticsEvaluationResultsListParams,
     LlmAnalyticsProviderKeysListParams,
     PaginatedClusteringJobListApi,
     PaginatedDatasetItemListApi,
     PaginatedDatasetListApi,
     PaginatedEvaluationListApi,
+    PaginatedEvaluationResultListApi,
     PaginatedLLMProviderKeyListApi,
     PatchedClusteringJobApi,
     PatchedDatasetApi,
@@ -352,6 +354,45 @@ export const llmAnalyticsEvaluationConfigSetActiveKeyCreate = async (
     return apiMutator<void>(getLlmAnalyticsEvaluationConfigSetActiveKeyCreateUrl(projectId), {
         ...options,
         method: 'POST',
+    })
+}
+
+/**
+ * Query evaluation results ($ai_evaluation events).
+
+GET /api/environments/:id/llm_analytics/evaluation_results/
+    ?evaluation_id=<uuid>       Filter by evaluation UUID
+    &generation_id=<uuid>       Filter by generation event UUID
+    &result=pass|fail|na        Filter by result status
+    &limit=50                   Max results (default 50, max 200)
+ */
+export const getLlmAnalyticsEvaluationResultsListUrl = (
+    projectId: string,
+    params?: LlmAnalyticsEvaluationResultsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/llm_analytics/evaluation_results/?${stringifiedParams}`
+        : `/api/environments/${projectId}/llm_analytics/evaluation_results/`
+}
+
+export const llmAnalyticsEvaluationResultsList = async (
+    projectId: string,
+    params?: LlmAnalyticsEvaluationResultsListParams,
+    options?: RequestInit
+): Promise<PaginatedEvaluationResultListApi> => {
+    return apiMutator<PaginatedEvaluationResultListApi>(getLlmAnalyticsEvaluationResultsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -450,7 +450,7 @@
         }
     },
     "evaluations-get": {
-        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status. Evaluation results are stored as '$ai_evaluation' events — to query results, use the execute-sql or query-run tool with a HogQL query filtering on event = '$ai_evaluation'. Key properties: $ai_evaluation_id (evaluation UUID), $ai_evaluation_name, $ai_target_event_id (generation event UUID), $ai_trace_id, $ai_evaluation_result (boolean pass/fail), $ai_evaluation_reasoning (text), $ai_evaluation_applicable (boolean, false = N/A).",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "List LLM analytics evaluations.",
@@ -525,7 +525,7 @@
         }
     },
     "evaluation-run": {
-        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "Run an evaluation on a specific event.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -449,6 +449,96 @@
             "readOnlyHint": true
         }
     },
+    "evaluations-get": {
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "List LLM analytics evaluations.",
+        "title": "List evaluations",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-get": {
+        "description": "Get a specific LLM analytics evaluation by its UUID. Returns full details including name, type (llm_judge or hog), configuration, conditions, and enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Get a specific evaluation by ID.",
+        "title": "Get evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-create": {
+        "description": "Create a new LLM analytics evaluation. Two types are supported: 'llm_judge' uses an LLM to score generations against a prompt you define (for subjective checks like tone, helpfulness, hallucination detection), and 'hog' runs deterministic code against each generation (for rule-based checks like format validation, keyword detection, length limits). For llm_judge evaluations, provide a prompt in evaluation_config and a model_configuration. For hog evaluations, provide source code in evaluation_config.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Create a new evaluation.",
+        "title": "Create evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-update": {
+        "description": "Update an existing LLM analytics evaluation. You can change the name, description, enabled status, evaluation config (prompt or source code), and output config. Use this to enable/disable evaluations or modify their scoring logic.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Update an evaluation.",
+        "title": "Update evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-delete": {
+        "description": "Delete an LLM analytics evaluation (soft delete). The evaluation will be marked as deleted and will no longer run.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Delete an evaluation.",
+        "title": "Delete evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-run": {
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Run an evaluation on a specific event.",
+        "title": "Run evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -44,7 +44,13 @@ import getInsight from './insights/get'
 import getAllInsights from './insights/getAll'
 import queryInsight from './insights/query'
 import updateInsight from './insights/update'
-// LLM Observability
+// LLM Analytics
+import evaluationCreate from './llmAnalytics/evaluations/create'
+import evaluationDelete from './llmAnalytics/evaluations/delete'
+import evaluationGet from './llmAnalytics/evaluations/get'
+import evaluationsGet from './llmAnalytics/evaluations/getAll'
+import evaluationRun from './llmAnalytics/evaluations/run'
+import evaluationUpdate from './llmAnalytics/evaluations/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
 import logsListAttributes from './logs/listAttributes'
 import logsListAttributeValues from './logs/listAttributeValues'
@@ -146,8 +152,14 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-reorder-tiles': reorderDashboardTiles,
     'add-insight-to-dashboard': addInsightToDashboard,
 
-    // LLM Observability
+    // LLM Analytics
     'get-llm-total-costs-for-project': getLLMCosts,
+    'evaluations-get': evaluationsGet,
+    'evaluation-get': evaluationGet,
+    'evaluation-create': evaluationCreate,
+    'evaluation-update': evaluationUpdate,
+    'evaluation-delete': evaluationDelete,
+    'evaluation-run': evaluationRun,
 
     // Surveys
     'surveys-get-all': getAllSurveys,

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -3,45 +3,70 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const ModelConfigurationSchema = z.object({
-    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    provider: z.enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
     model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
     provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
 })
 
-const schema = z.object({
-    name: z.string().max(400).describe('Name of the evaluation.'),
-    description: z.string().optional().describe('Description of what this evaluation checks.'),
-    enabled: z
-        .boolean()
-        .optional()
-        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
-    evaluation_type: z
-        .enum(['llm_judge', 'hog'])
-        .describe(
-            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+const schema = z
+    .object({
+        name: z.string().max(400).describe('Name of the evaluation.'),
+        description: z.string().optional().describe('Description of what this evaluation checks.'),
+        enabled: z
+            .boolean()
+            .optional()
+            .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+        evaluation_type: z
+            .enum(['llm_judge', 'hog'])
+            .describe(
+                'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+            ),
+        evaluation_config: z
+            .object({
+                prompt: z
+                    .string()
+                    .optional()
+                    .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+                source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+            })
+            .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+        output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+        output_config: z
+            .object({
+                allows_na: z
+                    .boolean()
+                    .optional()
+                    .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+            })
+            .optional(),
+        model_configuration: ModelConfigurationSchema.optional().describe(
+            'LLM model configuration (required for llm_judge evaluations).'
         ),
-    evaluation_config: z
-        .object({
-            prompt: z
-                .string()
-                .optional()
-                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
-            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
-        })
-        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
-    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
-    output_config: z
-        .object({
-            allows_na: z
-                .boolean()
-                .optional()
-                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
-        })
-        .optional(),
-    model_configuration: ModelConfigurationSchema.optional().describe(
-        'LLM model configuration (required for llm_judge evaluations).'
-    ),
-})
+    })
+    .superRefine((data, ctx) => {
+        if (data.evaluation_type === 'llm_judge') {
+            if (!data.evaluation_config.prompt) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"prompt" is required for llm_judge evaluations',
+                    path: ['evaluation_config', 'prompt'],
+                })
+            }
+            if (!data.model_configuration) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"model_configuration" is required for llm_judge evaluations',
+                    path: ['model_configuration'],
+                })
+            }
+        } else if (data.evaluation_type === 'hog' && !data.evaluation_config.source) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: '"source" is required for hog evaluations',
+                path: ['evaluation_config', 'source'],
+            })
+        }
+    })
 
 type Params = z.infer<typeof schema>
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const ModelConfigurationSchema = z.object({
+    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
+    provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
+})
+
+const schema = z.object({
+    name: z.string().max(400).describe('Name of the evaluation.'),
+    description: z.string().optional().describe('Description of what this evaluation checks.'),
+    enabled: z
+        .boolean()
+        .optional()
+        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+    evaluation_type: z
+        .enum(['llm_judge', 'hog'])
+        .describe(
+            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+        ),
+    evaluation_config: z
+        .object({
+            prompt: z
+                .string()
+                .optional()
+                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+        })
+        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+    output_config: z
+        .object({
+            allows_na: z
+                .boolean()
+                .optional()
+                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+        })
+        .optional(),
+    model_configuration: ModelConfigurationSchema.optional().describe(
+        'LLM model configuration (required for llm_judge evaluations).'
+    ),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluations/`,
+        body: params as unknown as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-create',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to delete.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+        body: { deleted: true },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-delete',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to retrieve.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    search: z.string().optional().describe('Search evaluations by name or description.'),
+    enabled: z.boolean().optional().describe('Filter by enabled status.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/`,
+        query: {
+            search: params.search,
+            enabled: params.enabled !== undefined ? String(params.enabled) : undefined,
+        },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluations-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to run.'),
     target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
@@ -15,8 +15,10 @@ type Params = z.infer<typeof schema>
 export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
     const projectId = await context.stateManager.getProjectId()
 
+    const { evaluationId, ...rest } = params
     const body = {
-        ...params,
+        ...rest,
+        evaluation_id: evaluationId,
         event: params.event ?? '$ai_generation',
     }
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
+    timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
+    event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
+    distinct_id: z.string().optional().describe('Distinct ID of the event (optional, improves lookup performance).'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const body = {
+        ...params,
+        event: params.event ?? '$ai_generation',
+    }
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluation_runs/`,
+        body,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-run',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to update.'),
+    name: z.string().max(400).optional().describe('Updated name.'),
+    description: z.string().optional().describe('Updated description.'),
+    enabled: z.boolean().optional().describe('Enable or disable the evaluation.'),
+    evaluation_config: z
+        .object({
+            prompt: z.string().optional(),
+            source: z.string().optional(),
+        })
+        .optional()
+        .describe('Updated evaluation configuration.'),
+    output_config: z
+        .object({
+            allows_na: z.boolean().optional(),
+        })
+        .optional()
+        .describe('Updated output configuration.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+    const { evaluationId, ...body } = params
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${evaluationId}/`,
+        body: body as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-update',
+    schema,
+    handler,
+})
+
+export default tool


### PR DESCRIPTION
## Problem

Evaluation results (`$ai_evaluation` events) are stored in ClickHouse but there's no REST API endpoint to query them. The frontend uses inline HogQL queries, and the MCP server would need to embed raw HogQL too. This is fragile — if the event schema changes, every consumer breaks.

## Changes

Add `GET /api/environments/:id/llm_analytics/evaluation_results/` endpoint that queries `$ai_evaluation` events from ClickHouse using HogQL AST (safe parameterization).

**Query params:**
- `evaluation_id` — filter by evaluation UUID
- `generation_id` — filter by generation event UUID
- `result` — filter by status: `pass`, `fail`, or `na`
- `limit` — max results (default 50, max 200)

At least one of `evaluation_id` or `generation_id` is required.

**Returns:** `{ results: [...], count: N }` with each result containing:
- `uuid`, `timestamp`, `evaluation_id`, `evaluation_name`
- `generation_id`, `trace_id`
- `result` (bool/null), `reasoning`, `applicable`

Includes unit tests with mocked ClickHouse queries.

**Part 2 of a 3-PR stack** — depends on PR #50004, MCP tool follows in PR #50011.

## How did you test this code?

- Unit tests in `test_evaluation_results.py` (mocked ClickHouse)
- Follows existing patterns from `evaluation_summary.py`
- Uses HogQL AST for safe query construction (no f-strings with user data)

Closes #50025 (tracked)