### PR TITLE
feat(llma): add evaluation-results MCP tool

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -524,6 +524,21 @@
             "readOnlyHint": false
         }
     },
+    "evaluation-results": {
+        "description": "Query evaluation results for a specific generation or evaluation. Returns the verdict (pass/fail), reasoning, and whether the evaluation was applicable. Filter by evaluationId to see all results for one evaluation, or by generationId to see all evaluation results for a specific AI generation. Optionally filter by result status (pass/fail/na).",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Get evaluation results for a generation or evaluation.",
+        "title": "Get evaluation results",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "evaluation-run": {
         "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -49,6 +49,7 @@ import evaluationCreate from './llmAnalytics/evaluations/create'
 import evaluationDelete from './llmAnalytics/evaluations/delete'
 import evaluationGet from './llmAnalytics/evaluations/get'
 import evaluationsGet from './llmAnalytics/evaluations/getAll'
+import evaluationResultsGet from './llmAnalytics/evaluations/getResults'
 import evaluationRun from './llmAnalytics/evaluations/run'
 import evaluationUpdate from './llmAnalytics/evaluations/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
@@ -159,6 +160,7 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'evaluation-create': evaluationCreate,
     'evaluation-update': evaluationUpdate,
     'evaluation-delete': evaluationDelete,
+    'evaluation-results': evaluationResultsGet,
     'evaluation-run': evaluationRun,
 
     // Surveys

--- a/services/mcp/src/tools/llmAnalytics/evaluations/getResults.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/getResults.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z
+        .string()
+        .uuid()
+        .optional()
+        .describe('Filter results by evaluation UUID. Provide this or generationId (or both).'),
+    generationId: z
+        .string()
+        .optional()
+        .describe('Filter results by generation event UUID. Provide this or evaluationId (or both).'),
+    result: z.enum(['pass', 'fail', 'na']).optional().describe('Filter by result status: "pass", "fail", or "na".'),
+    limit: z
+        .number()
+        .int()
+        .positive()
+        .max(200)
+        .optional()
+        .describe('Maximum number of results. Defaults to 50, max 200.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { evaluationId, generationId, result, limit } = params
+
+    if (!evaluationId && !generationId) {
+        throw new Error('Either evaluationId or generationId must be provided.')
+    }
+
+    const projectId = await context.stateManager.getProjectId()
+
+    const queryParams: Record<string, string | number | undefined> = {
+        evaluation_id: evaluationId,
+        generation_id: generationId,
+        result,
+        limit,
+    }
+
+    const response = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/llm_analytics/evaluation_results/`,
+        query: queryParams,
+    })
+
+    return response
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-results',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/getResults.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/getResults.ts
@@ -10,6 +10,7 @@ const schema = z.object({
         .describe('Filter results by evaluation UUID. Provide this or generationId (or both).'),
     generationId: z
         .string()
+        .uuid()
         .optional()
         .describe('Filter results by generation event UUID. Provide this or evaluationId (or both).'),
     result: z.enum(['pass', 'fail', 'na']).optional().describe('Filter by result status: "pass", "fail", or "na".'),


### PR DESCRIPTION
## Problem

After adding the evaluation results backend endpoint (PR #50010), MCP users need a tool to query evaluation results for their AI generations.

## Changes

Add `evaluation-results` MCP tool that calls `GET /llm_analytics/evaluation_results/`.

**Params:**
- `evaluationId` — filter by evaluation UUID
- `generationId` — filter by generation event UUID  
- `result` — filter by status: `pass`, `fail`, or `na`
- `limit` — max results (default 50, max 200)

Supports single result lookups (both IDs) and batch queries (one ID).

**Part 3 of a 3-PR stack** — depends on PRs #50004 and #50010.

## How did you test this code?

- TypeScript compiles cleanly (`tsc --noEmit`)
- Follows same pattern as other evaluation MCP tools in the stack

Closes #50025 (tracked)