### PR TITLE
chore(ds): Add last 50 job runs to schema view on admin

### DIFF
--- a/posthog/admin/admins/external_data_schema_admin.py
+++ b/posthog/admin/admins/external_data_schema_admin.py
@@ -34,7 +34,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         obj = self.get_object(request, object_id)
         if obj:
             extra_context["jobs"] = (
-                ExternalDataJob.objects.filter(schema=obj).order_by("-created_at").select_related("schema")[:50]
+                ExternalDataJob.objects.filter(schema=obj).order_by("-created_at")[:50]
             )
             extra_context["temporal_ui_host"] = settings.TEMPORAL_UI_HOST
             extra_context["temporal_namespace"] = settings.TEMPORAL_NAMESPACE

--- a/posthog/admin/admins/external_data_schema_admin.py
+++ b/posthog/admin/admins/external_data_schema_admin.py
@@ -33,9 +33,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         extra_context = extra_context or {}
         obj = self.get_object(request, object_id)
         if obj:
-            extra_context["jobs"] = (
-                ExternalDataJob.objects.filter(schema=obj).order_by("-created_at")[:50]
-            )
+            extra_context["jobs"] = ExternalDataJob.objects.filter(schema=obj).order_by("-created_at")[:50]
             extra_context["temporal_ui_host"] = settings.TEMPORAL_UI_HOST
             extra_context["temporal_namespace"] = settings.TEMPORAL_NAMESPACE
             extra_context["site_url"] = settings.SITE_URL

--- a/posthog/admin/admins/external_data_schema_admin.py
+++ b/posthog/admin/admins/external_data_schema_admin.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
+from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema
 
 
@@ -24,6 +26,21 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
     autocomplete_fields = ("team",)
     readonly_fields = ("table", "source")
     ordering = ("-created_at",)
+
+    change_form_template = "admin/data_warehouse/externaldataschema/change_form.html"
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        obj = self.get_object(request, object_id)
+        if obj:
+            extra_context["jobs"] = (
+                ExternalDataJob.objects.filter(schema=obj).order_by("-created_at").select_related("schema")[:50]
+            )
+            extra_context["temporal_ui_host"] = settings.TEMPORAL_UI_HOST
+            extra_context["temporal_namespace"] = settings.TEMPORAL_NAMESPACE
+            extra_context["site_url"] = settings.SITE_URL
+            extra_context["team_id"] = obj.team_id
+        return super().change_view(request, object_id, form_url, extra_context=extra_context)
 
     @admin.display(description="Team")
     def team_link(self, schema: ExternalDataSchema):

--- a/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
+++ b/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
@@ -1,0 +1,89 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block after_field_sets %}
+    {{ block.super }}
+
+    <fieldset class="module aligned">
+        <h2>Temporal schedule</h2>
+        <div class="form-row" style="padding: 10px;">
+            <a href="{{ temporal_ui_host }}/namespaces/{{ temporal_namespace }}/schedules/{{ original.id }}"
+               target="_blank">View schedule in Temporal</a>
+        </div>
+    </fieldset>
+
+    <fieldset class="module aligned">
+        <h2>Jobs (recent 50)</h2>
+        {% if jobs %}
+        <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+                <tr style="background: #f5f5f5;">
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Job ID</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Status</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Created at</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Finished at</th>
+                    <th style="padding: 8px; text-align: right; border-bottom: 2px solid #ddd;">Rows synced</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Temporal workflow</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Logs</th>
+                    <th style="padding: 8px; text-align: left; border-bottom: 2px solid #ddd;">Error</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr style="border-bottom: 1px solid #eee;">
+                    <td style="padding: 8px; font-family: monospace; font-size: 12px;">{{ job.id }}</td>
+                    <td style="padding: 8px;">
+                        {% if job.status == "Running" %}
+                            <span class="status-badge status-running" style="color: blue;">Running</span>
+                        {% elif job.status == "Completed" %}
+                            <span class="status-badge status-completed" style="color: green;">Completed</span>
+                        {% elif job.status == "Failed" %}
+                            <span class="status-badge status-failed" style="color: red;">Failed</span>
+                        {% elif job.status == "BillingLimitReached" %}
+                            <span style="color: orange;">Billing limit reached</span>
+                        {% elif job.status == "BillingLimitTooLow" %}
+                            <span style="color: orange;">Billing limit too low</span>
+                        {% else %}
+                            <span>{{ job.status }}</span>
+                        {% endif %}
+                    </td>
+                    <td style="padding: 8px;">{{ job.created_at|date:"Y-m-d H:i:s" }}</td>
+                    <td style="padding: 8px;">{% if job.finished_at %}{{ job.finished_at|date:"Y-m-d H:i:s" }}{% else %}&mdash;{% endif %}</td>
+                    <td style="padding: 8px; text-align: right;">{% if job.rows_synced is not None %}{{ job.rows_synced }}{% else %}&mdash;{% endif %}</td>
+                    <td style="padding: 8px;">
+                        {% if job.workflow_id %}
+                            <a href="{{ temporal_ui_host }}/namespaces/{{ temporal_namespace }}/workflows/{{ job.workflow_id }}/{{ job.workflow_run_id }}"
+                               target="_blank">View workflow</a>
+                        {% else %}
+                            &mdash;
+                        {% endif %}
+                    </td>
+                    <td style="padding: 8px;">
+                        {% if job.workflow_id %}
+                            <a href="{{ site_url }}/project/{{ team_id }}/logs?searchTerm={{ job.workflow_id }}"
+                               target="_blank">View logs</a>
+                        {% else %}
+                            &mdash;
+                        {% endif %}
+                    </td>
+                    <td style="padding: 8px;">
+                        {% if job.latest_error %}
+                            <span style="color: red; font-size: 12px;" title="{{ job.latest_error }}">
+                                {{ job.latest_error|truncatechars:80 }}
+                            </span>
+                            <br>
+                            <a href="{{ site_url }}/project/{{ team_id }}/error_tracking?searchQuery={{ job.latest_error|truncatechars:200|urlencode }}"
+                               target="_blank" style="font-size: 11px;">View in error tracking</a>
+                        {% else %}
+                            &mdash;
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+            <div class="form-row" style="padding: 10px; color: #666;">No jobs found for this schema.</div>
+        {% endif %}
+    </fieldset>
+{% endblock %}

--- a/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
+++ b/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
@@ -51,12 +51,14 @@
                     <td style="padding: 8px;">{% if job.finished_at %}{{ job.finished_at|date:"Y-m-d H:i:s" }}{% else %}&mdash;{% endif %}</td>
                     <td style="padding: 8px; text-align: right;">{% if job.rows_synced is not None %}{{ job.rows_synced }}{% else %}&mdash;{% endif %}</td>
                     <td style="padding: 8px;">
-                        {% if job.workflow_id %}
+                    <td style="padding: 8px;">
+                        {% if job.workflow_id and job.workflow_run_id %}
                             <a href="{{ temporal_ui_host }}/namespaces/{{ temporal_namespace }}/workflows/{{ job.workflow_id }}/{{ job.workflow_run_id }}"
                                target="_blank">View workflow</a>
                         {% else %}
                             &mdash;
                         {% endif %}
+                    </td>
                     </td>
                     <td style="padding: 8px;">
                         {% if job.workflow_id %}


### PR DESCRIPTION
## Problem

Add more tools for support in django admin

## Changes

  * Added job history table to ExternalDataSchema Django admin detail page
  * Added Temporal schedule link to ExternalDataSchema admin
  * Added links to PostHog Logs product filtered by workflow ID
  * Added links to PostHog Error Tracking searched by error message

## How did you test this code?

local test

## Publish to changelog?
NO
