### PR TITLE
feat(llma): add managing-llm-evaluations agent skill

### DIFF
--- a/products/llm_analytics/skills/managing-llm-evaluations/SKILL.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/SKILL.md
@@ -88,9 +88,9 @@ Quick pass rate check:
 
 ```sql
 SELECT
-    countIf(properties.$ai_evaluation_result = true) as pass_count,
-    countIf(properties.$ai_evaluation_result = false) as fail_count,
-    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+    countIf(properties.$ai_evaluation_result = true AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as pass_count,
+    countIf(properties.$ai_evaluation_result = false AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as fail_count,
+    round(if(pass_count + fail_count = 0, null, pass_count / (pass_count + fail_count) * 100), 1) as pass_rate
 FROM events
 WHERE event = '$ai_evaluation'
     AND properties.$ai_evaluation_id = '<evaluation_uuid>'
@@ -111,6 +111,7 @@ FROM events
 WHERE event = '$ai_evaluation'
     AND properties.$ai_evaluation_id = '<evaluation_uuid>'
     AND properties.$ai_evaluation_result = false
+    AND timestamp > now() - interval 7 day
 ORDER BY timestamp DESC
 LIMIT 20
 ```

--- a/products/llm_analytics/skills/managing-llm-evaluations/SKILL.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: managing-llm-evaluations
+description: >
+  Guides agents through creating, running, and analyzing LLM evaluation results in PostHog.
+  Use when a user wants to set up quality checks on AI generations, understand evaluation
+  pass/fail rates, debug failing evaluations, write Hog evaluation code, or query
+  $ai_evaluation event data. Covers both LLM-as-a-judge and code-based (Hog) evaluation types.
+---
+
+# Managing LLM evaluations
+
+Evaluations automatically score AI generations for quality, safety, relevance, and other criteria.
+There are two types:
+
+- **LLM judge** — sends each generation to an LLM with a scoring prompt (subjective checks like helpfulness, hallucination, tone)
+- **Hog code** — runs deterministic code against each generation (rule-based checks like length limits, keyword detection, format validation)
+
+## Workflow
+
+### 1. Discover existing evaluations
+
+List what's already set up. Check which are enabled and what type they are.
+
+```text
+evaluations-get (optionally with search or enabled filter)
+```
+
+### 2. Choose the right evaluation type
+
+| Use case                                         | Type        | Why                                              |
+| ------------------------------------------------ | ----------- | ------------------------------------------------ |
+| Subjective quality (helpfulness, accuracy, tone) | `llm_judge` | Needs LLM reasoning                              |
+| Hallucination detection                          | `llm_judge` | Requires comparing output to input context       |
+| Format validation (JSON, markdown, length)       | `hog`       | Deterministic, free, instant                     |
+| Keyword/regex checks                             | `hog`       | No LLM needed                                    |
+| Cost/token thresholds                            | `hog`       | Simple property comparison                       |
+| Content safety                                   | Either      | LLM judge for nuance, Hog for keyword blocklists |
+
+### 3. Create an evaluation
+
+For **LLM judge**, you need a prompt and model configuration:
+
+```json
+{
+  "name": "Helpfulness check",
+  "evaluation_type": "llm_judge",
+  "evaluation_config": {
+    "prompt": "Evaluate if the AI response is helpful and addresses the user's question. Return true if helpful, false if not."
+  },
+  "output_type": "boolean",
+  "output_config": { "allows_na": true },
+  "model_configuration": {
+    "provider": "openai",
+    "model": "gpt-4o"
+  }
+}
+```
+
+For **Hog code**, provide source code (see [Hog code examples](./references/hog-code-examples.md)):
+
+```json
+{
+  "name": "Output length check",
+  "evaluation_type": "hog",
+  "evaluation_config": {
+    "source": "let len := length(output)\nif (len < 10) { return false }\nreturn true"
+  },
+  "output_type": "boolean",
+  "output_config": { "allows_na": false }
+}
+```
+
+### 4. Enable the evaluation
+
+Evaluations are disabled by default. Enable to start scoring new generations:
+
+```text
+evaluation-update with { "enabled": true }
+```
+
+### 5. Query evaluation results
+
+Results are stored as `$ai_evaluation` events.
+See [event schema](./references/event-schema.md) for the full property reference
+and [query examples](./references/query-examples.md) for ready-made HogQL patterns.
+
+Quick pass rate check:
+
+```sql
+SELECT
+    countIf(properties.$ai_evaluation_result = true) as pass_count,
+    countIf(properties.$ai_evaluation_result = false) as fail_count,
+    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND timestamp > now() - interval 7 day
+```
+
+### 6. Debug failing evaluations
+
+To understand why generations are failing:
+
+```sql
+SELECT
+    properties.$ai_target_event_id as generation_id,
+    properties.$ai_evaluation_result as result,
+    properties.$ai_evaluation_reasoning as reasoning,
+    timestamp
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND properties.$ai_evaluation_result = false
+ORDER BY timestamp DESC
+LIMIT 20
+```
+
+Then use the generation_id to look up the original generation's input/output.
+
+## References
+
+- [Event schema](./references/event-schema.md) — `$ai_evaluation` event properties
+- [Query examples](./references/query-examples.md) — HogQL patterns for evaluation analysis
+- [Hog code examples](./references/hog-code-examples.md) — common Hog evaluation patterns

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
@@ -9,7 +9,8 @@ Each event represents one evaluation run against one generation.
 | --------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `$ai_evaluation_id`         | string (UUID) | The evaluation definition UUID                                                                                        |
 | `$ai_evaluation_name`       | string        | Name of the evaluation                                                                                                |
-| `$ai_evaluation_type`       | string        | `"llm_judge"` or `"hog"`                                                                                              |
+| `$ai_evaluation_type`       | string        | `"online"` (server-side evaluation)                                                                                   |
+| `$ai_evaluation_runtime`    | string        | `"llm_judge"` or `"hog"` — the execution runtime used                                                                 |
 | `$ai_evaluation_result`     | boolean       | `true` = pass, `false` = fail                                                                                         |
 | `$ai_evaluation_reasoning`  | string        | Explanation of the verdict (LLM judge: from the LLM; Hog: captured from `print()` output)                             |
 | `$ai_evaluation_applicable` | boolean       | `false` means N/A — the evaluation wasn't applicable to this generation. When `false`, ignore `$ai_evaluation_result` |

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
@@ -1,0 +1,59 @@
+# Evaluation event schema
+
+Evaluation results are stored as `$ai_evaluation` events in PostHog.
+Each event represents one evaluation run against one generation.
+
+## Event properties
+
+| Property                    | Type          | Description                                                                                                           |
+| --------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `$ai_evaluation_id`         | string (UUID) | The evaluation definition UUID                                                                                        |
+| `$ai_evaluation_name`       | string        | Name of the evaluation                                                                                                |
+| `$ai_evaluation_type`       | string        | `"llm_judge"` or `"hog"`                                                                                              |
+| `$ai_evaluation_result`     | boolean       | `true` = pass, `false` = fail                                                                                         |
+| `$ai_evaluation_reasoning`  | string        | Explanation of the verdict (LLM judge: from the LLM; Hog: captured from `print()` output)                             |
+| `$ai_evaluation_applicable` | boolean       | `false` means N/A — the evaluation wasn't applicable to this generation. When `false`, ignore `$ai_evaluation_result` |
+| `$ai_evaluation_model`      | string        | LLM model used (only present for `llm_judge` type)                                                                    |
+| `$ai_target_event_id`       | string (UUID) | The generation event UUID that was evaluated                                                                          |
+| `$ai_trace_id`              | string (UUID) | The trace this generation belongs to                                                                                  |
+
+## Relationships
+
+```text
+$ai_generation event (uuid)
+    ↓ evaluated by
+$ai_evaluation event (properties.$ai_target_event_id → generation uuid)
+    ↑ defined by
+Evaluation definition (properties.$ai_evaluation_id → evaluation uuid)
+```
+
+## Interpreting results
+
+- `$ai_evaluation_result = true` AND `$ai_evaluation_applicable != false` → **pass**
+- `$ai_evaluation_result = false` AND `$ai_evaluation_applicable != false` → **fail**
+- `$ai_evaluation_applicable = false` → **N/A** (ignore the result field)
+- `$ai_evaluation_applicable` is NULL → evaluation doesn't support N/A, treat result as-is
+
+## Joining evaluations to generations
+
+To see the original generation input/output alongside the evaluation result:
+
+```sql
+SELECT
+    e.properties.$ai_evaluation_name as eval_name,
+    e.properties.$ai_evaluation_result as result,
+    e.properties.$ai_evaluation_reasoning as reasoning,
+    g.properties.$ai_input as generation_input,
+    g.properties.$ai_output_choices as generation_output,
+    g.properties.$ai_model as model
+FROM events e
+JOIN events g ON g.uuid = e.properties.$ai_target_event_id
+WHERE e.event = '$ai_evaluation'
+    AND e.properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND e.timestamp > now() - interval 7 day
+    AND g.event = '$ai_generation'
+ORDER BY e.timestamp DESC
+LIMIT 20
+```
+
+**Warning:** `$ai_input` and `$ai_output_choices` can be very large. Dump results to a file if needed.

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/event-schema.md
@@ -9,7 +9,7 @@ Each event represents one evaluation run against one generation.
 | --------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `$ai_evaluation_id`         | string (UUID) | The evaluation definition UUID                                                                                        |
 | `$ai_evaluation_name`       | string        | Name of the evaluation                                                                                                |
-| `$ai_evaluation_type`       | string        | `"online"` (server-side evaluation)                                                                                   |
+| `$ai_evaluation_type`       | string        | `"online"` (automatic, runs on new generations) or `"offline"` (manual/batch run)                                     |
 | `$ai_evaluation_runtime`    | string        | `"llm_judge"` or `"hog"` — the execution runtime used                                                                 |
 | `$ai_evaluation_result`     | boolean       | `true` = pass, `false` = fail                                                                                         |
 | `$ai_evaluation_reasoning`  | string        | Explanation of the verdict (LLM judge: from the LLM; Hog: captured from `print()` output)                             |

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/hog-code-examples.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/hog-code-examples.md
@@ -6,14 +6,14 @@ Use `print()` to add reasoning — printed output is captured as the evaluation 
 
 ## Available globals
 
-| Global              | Type          | Description                                        |
-| ------------------- | ------------- | -------------------------------------------------- |
-| `input`             | string/object | LLM input (prompt or messages array)               |
-| `output`            | string/object | LLM output (response or choices)                   |
-| `properties`        | object        | All event properties (access any `$ai_*` property) |
-| `event.uuid`        | string        | Event UUID                                         |
-| `event.event`       | string        | Event name                                         |
-| `event.distinct_id` | string        | Distinct ID                                        |
+| Global              | Type   | Description                                                                             |
+| ------------------- | ------ | --------------------------------------------------------------------------------------- |
+| `input`             | string | LLM input — always a string (objects are JSON-serialized; use `jsonParse()` if needed)  |
+| `output`            | string | LLM output — always a string (objects are JSON-serialized; use `jsonParse()` if needed) |
+| `properties`        | object | All event properties (access any `$ai_*` property)                                      |
+| `event.uuid`        | string | Event UUID                                                                              |
+| `event.event`       | string | Event name                                                                              |
+| `event.distinct_id` | string | Distinct ID                                                                             |
 
 ## Important Hog syntax notes
 

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/hog-code-examples.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/hog-code-examples.md
@@ -1,0 +1,105 @@
+# Hog evaluation code examples
+
+Hog evaluations run deterministic code against each generation.
+The code must return a boolean (`true` = pass, `false` = fail).
+Use `print()` to add reasoning — printed output is captured as the evaluation reasoning.
+
+## Available globals
+
+| Global              | Type          | Description                                        |
+| ------------------- | ------------- | -------------------------------------------------- |
+| `input`             | string/object | LLM input (prompt or messages array)               |
+| `output`            | string/object | LLM output (response or choices)                   |
+| `properties`        | object        | All event properties (access any `$ai_*` property) |
+| `event.uuid`        | string        | Event UUID                                         |
+| `event.event`       | string        | Event name                                         |
+| `event.distinct_id` | string        | Distinct ID                                        |
+
+## Important Hog syntax notes
+
+- Use **single quotes** for strings: `'hello'` not `"hello"`
+- Use `length()` not `len()`
+- Use `ifNull(value, default)` before comparing properties that might be null — null comparisons throw runtime errors
+- `return null` means N/A (only when `allows_na` is enabled on the evaluation)
+
+## Examples
+
+### Check output length
+
+```hog
+let len := length(output)
+if (len < 10) {
+    print('Output too short:', len, 'characters')
+    return false
+}
+if (len > 5000) {
+    print('Output too long:', len, 'characters')
+    return false
+}
+return true
+```
+
+### Check for required keywords
+
+```hog
+let out := lower(output)
+if (not like(out, '%sorry%') and not like(out, '%unfortunately%')) {
+    if (like(out, '%error%') or like(out, '%failed%')) {
+        print('Error response missing apology')
+        return false
+    }
+}
+return true
+```
+
+### Cost threshold check
+
+```hog
+let cost := ifNull(toFloat(properties.$ai_total_cost_usd), 0)
+if (cost > 0.10) {
+    print('Generation cost too high: $', cost)
+    return false
+}
+return true
+```
+
+### Token limit check
+
+```hog
+let output_tokens := ifNull(toInt(properties.$ai_output_tokens), 0)
+if (output_tokens > 2000) {
+    print('Too many output tokens:', output_tokens)
+    return false
+}
+return true
+```
+
+### Skip non-applicable generations (return N/A)
+
+Requires `allows_na: true` on the evaluation.
+
+```hog
+let model := ifNull(properties.$ai_model, '')
+if (not like(model, '%gpt%')) {
+    print('Skipping non-GPT model:', model)
+    return null
+}
+let out := lower(output)
+if (like(out, '%harmful%') or like(out, '%dangerous%')) {
+    print('Potentially harmful content detected')
+    return false
+}
+return true
+```
+
+### Check JSON output format
+
+```hog
+let out := trim(output)
+if (not like(out, '{%')) {
+    print('Output is not JSON — starts with:', left(out, 20))
+    return false
+}
+print('Output appears to be JSON')
+return true
+```

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/query-examples.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/query-examples.md
@@ -1,0 +1,100 @@
+# Evaluation query examples
+
+All queries use HogQL and filter on `event = '$ai_evaluation'`.
+Always include a time range to keep queries efficient.
+
+## Pass rate for an evaluation
+
+```sql
+SELECT
+    countIf(properties.$ai_evaluation_result = true AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as pass_count,
+    countIf(properties.$ai_evaluation_result = false AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as fail_count,
+    countIf(properties.$ai_evaluation_applicable = false) as na_count,
+    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND timestamp > now() - interval 7 day
+```
+
+## Pass rate by model
+
+```sql
+SELECT
+    g.properties.$ai_model as model,
+    countIf(e.properties.$ai_evaluation_result = true) as pass_count,
+    countIf(e.properties.$ai_evaluation_result = false) as fail_count,
+    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+FROM events e
+JOIN events g ON g.uuid = e.properties.$ai_target_event_id
+WHERE e.event = '$ai_evaluation'
+    AND e.properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND e.timestamp > now() - interval 7 day
+    AND g.event = '$ai_generation'
+GROUP BY model
+ORDER BY fail_count DESC
+```
+
+## Pass rate over time (daily trend)
+
+```sql
+SELECT
+    toDate(timestamp) as day,
+    countIf(properties.$ai_evaluation_result = true) as pass_count,
+    countIf(properties.$ai_evaluation_result = false) as fail_count,
+    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND timestamp > now() - interval 30 day
+GROUP BY day
+ORDER BY day
+```
+
+## Recent failing generations with reasoning
+
+```sql
+SELECT
+    properties.$ai_target_event_id as generation_id,
+    properties.$ai_evaluation_reasoning as reasoning,
+    timestamp
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_evaluation_id = '<evaluation_uuid>'
+    AND properties.$ai_evaluation_result = false
+    AND timestamp > now() - interval 7 day
+ORDER BY timestamp DESC
+LIMIT 20
+```
+
+## All evaluation results for a specific generation
+
+```sql
+SELECT
+    properties.$ai_evaluation_id as evaluation_id,
+    properties.$ai_evaluation_name as evaluation_name,
+    properties.$ai_evaluation_result as result,
+    properties.$ai_evaluation_reasoning as reasoning,
+    properties.$ai_evaluation_applicable as applicable
+FROM events
+WHERE event = '$ai_evaluation'
+    AND properties.$ai_target_event_id = '<generation_event_uuid>'
+ORDER BY timestamp DESC
+```
+
+## Evaluations summary across all evaluations
+
+```sql
+SELECT
+    properties.$ai_evaluation_name as evaluation_name,
+    properties.$ai_evaluation_id as evaluation_id,
+    count() as total_runs,
+    countIf(properties.$ai_evaluation_result = true) as pass_count,
+    countIf(properties.$ai_evaluation_result = false) as fail_count,
+    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+FROM events
+WHERE event = '$ai_evaluation'
+    AND timestamp > now() - interval 7 day
+GROUP BY evaluation_name, evaluation_id
+ORDER BY total_runs DESC
+```

--- a/products/llm_analytics/skills/managing-llm-evaluations/references/query-examples.md
+++ b/products/llm_analytics/skills/managing-llm-evaluations/references/query-examples.md
@@ -10,7 +10,7 @@ SELECT
     countIf(properties.$ai_evaluation_result = true AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as pass_count,
     countIf(properties.$ai_evaluation_result = false AND (isNull(properties.$ai_evaluation_applicable) OR properties.$ai_evaluation_applicable != false)) as fail_count,
     countIf(properties.$ai_evaluation_applicable = false) as na_count,
-    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+    round(if(pass_count + fail_count = 0, null, pass_count / (pass_count + fail_count) * 100), 1) as pass_rate
 FROM events
 WHERE event = '$ai_evaluation'
     AND properties.$ai_evaluation_id = '<evaluation_uuid>'
@@ -24,7 +24,7 @@ SELECT
     g.properties.$ai_model as model,
     countIf(e.properties.$ai_evaluation_result = true) as pass_count,
     countIf(e.properties.$ai_evaluation_result = false) as fail_count,
-    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+    round(if(pass_count + fail_count = 0, null, pass_count / (pass_count + fail_count) * 100), 1) as pass_rate
 FROM events e
 JOIN events g ON g.uuid = e.properties.$ai_target_event_id
 WHERE e.event = '$ai_evaluation'
@@ -42,7 +42,7 @@ SELECT
     toDate(timestamp) as day,
     countIf(properties.$ai_evaluation_result = true) as pass_count,
     countIf(properties.$ai_evaluation_result = false) as fail_count,
-    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+    round(if(pass_count + fail_count = 0, null, pass_count / (pass_count + fail_count) * 100), 1) as pass_rate
 FROM events
 WHERE event = '$ai_evaluation'
     AND properties.$ai_evaluation_id = '<evaluation_uuid>'
@@ -91,7 +91,7 @@ SELECT
     count() as total_runs,
     countIf(properties.$ai_evaluation_result = true) as pass_count,
     countIf(properties.$ai_evaluation_result = false) as fail_count,
-    round(pass_count / (pass_count + fail_count) * 100, 1) as pass_rate
+    round(if(pass_count + fail_count = 0, null, pass_count / (pass_count + fail_count) * 100), 1) as pass_rate
 FROM events
 WHERE event = '$ai_evaluation'
     AND timestamp > now() - interval 7 day

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -450,7 +450,7 @@
         }
     },
     "evaluations-get": {
-        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status. Evaluation results are stored as '$ai_evaluation' events — to query results, use the execute-sql or query-run tool with a HogQL query filtering on event = '$ai_evaluation'. Key properties: $ai_evaluation_id (evaluation UUID), $ai_evaluation_name, $ai_target_event_id (generation event UUID), $ai_trace_id, $ai_evaluation_result (boolean pass/fail), $ai_evaluation_reasoning (text), $ai_evaluation_applicable (boolean, false = N/A).",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "List LLM analytics evaluations.",
@@ -525,7 +525,7 @@
         }
     },
     "evaluation-run": {
-        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",
         "feature": "llm-analytics",
         "summary": "Run an evaluation on a specific event.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -449,6 +449,96 @@
             "readOnlyHint": true
         }
     },
+    "evaluations-get": {
+        "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "List LLM analytics evaluations.",
+        "title": "List evaluations",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-get": {
+        "description": "Get a specific LLM analytics evaluation by its UUID. Returns full details including name, type (llm_judge or hog), configuration, conditions, and enabled status.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Get a specific evaluation by ID.",
+        "title": "Get evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluation-create": {
+        "description": "Create a new LLM analytics evaluation. Two types are supported: 'llm_judge' uses an LLM to score generations against a prompt you define (for subjective checks like tone, helpfulness, hallucination detection), and 'hog' runs deterministic code against each generation (for rule-based checks like format validation, keyword detection, length limits). For llm_judge evaluations, provide a prompt in evaluation_config and a model_configuration. For hog evaluations, provide source code in evaluation_config.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Create a new evaluation.",
+        "title": "Create evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-update": {
+        "description": "Update an existing LLM analytics evaluation. You can change the name, description, enabled status, evaluation config (prompt or source code), and output config. Use this to enable/disable evaluations or modify their scoring logic.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Update an evaluation.",
+        "title": "Update evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-delete": {
+        "description": "Delete an LLM analytics evaluation (soft delete). The evaluation will be marked as deleted and will no longer run.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Delete an evaluation.",
+        "title": "Delete evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-run": {
+        "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event and returns the result. Use this to test evaluations on specific generations or to manually run evaluations.",
+        "category": "LLM analytics",
+        "feature": "llm-analytics",
+        "summary": "Run an evaluation on a specific event.",
+        "title": "Run evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -44,7 +44,13 @@ import getInsight from './insights/get'
 import getAllInsights from './insights/getAll'
 import queryInsight from './insights/query'
 import updateInsight from './insights/update'
-// LLM Observability
+// LLM Analytics
+import evaluationCreate from './llmAnalytics/evaluations/create'
+import evaluationDelete from './llmAnalytics/evaluations/delete'
+import evaluationGet from './llmAnalytics/evaluations/get'
+import evaluationsGet from './llmAnalytics/evaluations/getAll'
+import evaluationRun from './llmAnalytics/evaluations/run'
+import evaluationUpdate from './llmAnalytics/evaluations/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
 import logsListAttributes from './logs/listAttributes'
 import logsListAttributeValues from './logs/listAttributeValues'
@@ -146,8 +152,14 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-reorder-tiles': reorderDashboardTiles,
     'add-insight-to-dashboard': addInsightToDashboard,
 
-    // LLM Observability
+    // LLM Analytics
     'get-llm-total-costs-for-project': getLLMCosts,
+    'evaluations-get': evaluationsGet,
+    'evaluation-get': evaluationGet,
+    'evaluation-create': evaluationCreate,
+    'evaluation-update': evaluationUpdate,
+    'evaluation-delete': evaluationDelete,
+    'evaluation-run': evaluationRun,
 
     // Surveys
     'surveys-get-all': getAllSurveys,

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -3,45 +3,70 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const ModelConfigurationSchema = z.object({
-    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    provider: z.enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
     model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
     provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
 })
 
-const schema = z.object({
-    name: z.string().max(400).describe('Name of the evaluation.'),
-    description: z.string().optional().describe('Description of what this evaluation checks.'),
-    enabled: z
-        .boolean()
-        .optional()
-        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
-    evaluation_type: z
-        .enum(['llm_judge', 'hog'])
-        .describe(
-            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+const schema = z
+    .object({
+        name: z.string().max(400).describe('Name of the evaluation.'),
+        description: z.string().optional().describe('Description of what this evaluation checks.'),
+        enabled: z
+            .boolean()
+            .optional()
+            .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+        evaluation_type: z
+            .enum(['llm_judge', 'hog'])
+            .describe(
+                'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+            ),
+        evaluation_config: z
+            .object({
+                prompt: z
+                    .string()
+                    .optional()
+                    .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+                source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+            })
+            .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+        output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+        output_config: z
+            .object({
+                allows_na: z
+                    .boolean()
+                    .optional()
+                    .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+            })
+            .optional(),
+        model_configuration: ModelConfigurationSchema.optional().describe(
+            'LLM model configuration (required for llm_judge evaluations).'
         ),
-    evaluation_config: z
-        .object({
-            prompt: z
-                .string()
-                .optional()
-                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
-            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
-        })
-        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
-    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
-    output_config: z
-        .object({
-            allows_na: z
-                .boolean()
-                .optional()
-                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
-        })
-        .optional(),
-    model_configuration: ModelConfigurationSchema.optional().describe(
-        'LLM model configuration (required for llm_judge evaluations).'
-    ),
-})
+    })
+    .superRefine((data, ctx) => {
+        if (data.evaluation_type === 'llm_judge') {
+            if (!data.evaluation_config.prompt) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"prompt" is required for llm_judge evaluations',
+                    path: ['evaluation_config', 'prompt'],
+                })
+            }
+            if (!data.model_configuration) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: '"model_configuration" is required for llm_judge evaluations',
+                    path: ['model_configuration'],
+                })
+            }
+        } else if (data.evaluation_type === 'hog' && !data.evaluation_config.source) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: '"source" is required for hog evaluations',
+                path: ['evaluation_config', 'source'],
+            })
+        }
+    })
 
 type Params = z.infer<typeof schema>
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const ModelConfigurationSchema = z.object({
+    provider: z.enum(['openai', 'anthropic', 'google', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
+    model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
+    provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
+})
+
+const schema = z.object({
+    name: z.string().max(400).describe('Name of the evaluation.'),
+    description: z.string().optional().describe('Description of what this evaluation checks.'),
+    enabled: z
+        .boolean()
+        .optional()
+        .describe('Whether the evaluation runs automatically on new generations. Defaults to false.'),
+    evaluation_type: z
+        .enum(['llm_judge', 'hog'])
+        .describe(
+            'Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs deterministic Hog code.'
+        ),
+    evaluation_config: z
+        .object({
+            prompt: z
+                .string()
+                .optional()
+                .describe('The prompt for the LLM judge (required when evaluation_type is "llm_judge").'),
+            source: z.string().optional().describe('Hog source code (required when evaluation_type is "hog").'),
+        })
+        .describe('Configuration for the evaluation. Provide "prompt" for llm_judge or "source" for hog type.'),
+    output_type: z.literal('boolean').optional().describe('Output type. Currently only "boolean" is supported.'),
+    output_config: z
+        .object({
+            allows_na: z
+                .boolean()
+                .optional()
+                .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+        })
+        .optional(),
+    model_configuration: ModelConfigurationSchema.optional().describe(
+        'LLM model configuration (required for llm_judge evaluations).'
+    ),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluations/`,
+        body: params as unknown as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-create',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to delete.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+        body: { deleted: true },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-delete',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to retrieve.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/${params.evaluationId}/`,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/getAll.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    search: z.string().optional().describe('Search evaluations by name or description.'),
+    enabled: z.boolean().optional().describe('Filter by enabled status.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'GET',
+        path: `/api/environments/${projectId}/evaluations/`,
+        query: {
+            search: params.search,
+            enabled: params.enabled !== undefined ? String(params.enabled) : undefined,
+        },
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluations-get',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to run.'),
     target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
@@ -15,8 +15,10 @@ type Params = z.infer<typeof schema>
 export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
     const projectId = await context.stateManager.getProjectId()
 
+    const { evaluationId, ...rest } = params
     const body = {
-        ...params,
+        ...rest,
+        evaluation_id: evaluationId,
         event: params.event ?? '$ai_generation',
     }
 

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluation_id: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
+    timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
+    event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
+    distinct_id: z.string().optional().describe('Distinct ID of the event (optional, improves lookup performance).'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const body = {
+        ...params,
+        event: params.event ?? '$ai_generation',
+    }
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluation_runs/`,
+        body,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-run',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    evaluationId: z.string().uuid().describe('The UUID of the evaluation to update.'),
+    name: z.string().max(400).optional().describe('Updated name.'),
+    description: z.string().optional().describe('Updated description.'),
+    enabled: z.boolean().optional().describe('Enable or disable the evaluation.'),
+    evaluation_config: z
+        .object({
+            prompt: z.string().optional(),
+            source: z.string().optional(),
+        })
+        .optional()
+        .describe('Updated evaluation configuration.'),
+    output_config: z
+        .object({
+            allows_na: z.boolean().optional(),
+        })
+        .optional()
+        .describe('Updated output configuration.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+    const { evaluationId, ...body } = params
+
+    const result = await context.api.request({
+        method: 'PATCH',
+        path: `/api/environments/${projectId}/evaluations/${evaluationId}/`,
+        body: body as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-update',
+    schema,
+    handler,
+})
+
+export default tool


### PR DESCRIPTION
## Problem

Agents using PostHog MCP tools can manage evaluations (CRUD, run) but don't know the domain-specific workflows — which evaluation type to choose, how to query results, how to debug failures, or how to write Hog evaluation code.

## Changes

Add `managing-llm-evaluations` product skill in `products/llm_analytics/skills/` (first skill for this product).

**Entry point (`SKILL.md`):**
- Step-by-step workflow: discover → choose type → create → enable → query results → debug
- Decision table for LLM judge vs Hog type selection
- Example create payloads for both types
- Inline HogQL queries for pass rates and debugging

**References:**
- `event-schema.md` — `$ai_evaluation` event properties, relationships, result interpretation, join examples
- `query-examples.md` — 7 HogQL query patterns (pass rate, by model, over time, failing generations, per-generation, summary)
- `hog-code-examples.md` — 6 Hog code patterns (length, keywords, cost, tokens, N/A, JSON format) + globals reference + syntax notes

**Depends on PR #50004** (MCP tools this skill references).

## How did you test this code?

- `hogli lint:skills` passes (2 skills discovered)
- Markdown lint passes
- Follows patterns from existing `query-examples` skill

Closes #50025 (tracked)