### PR TITLE
fix(actions): fixes issue with opening sidebar on new actions

### DIFF
--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -2,6 +2,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { beforeUnload, router, urlToAction } from 'kea-router'
+import { CombinedLocation } from 'kea-router/lib/utils'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
@@ -234,7 +235,18 @@ export const actionEditLogic = kea<actionEditLogicType>([
     })),
 
     beforeUnload((logic) => ({
-        enabled: () => (logic.isMounted() ? logic.values.actionChanged : false),
+        enabled: (newLocation?: CombinedLocation) => {
+            if (!logic.isMounted() || !logic.values.actionChanged) {
+                return false
+            }
+
+            // Ignore in-page URL updates such as opening the side panel
+            if (newLocation && newLocation.pathname === router.values.location.pathname) {
+                return false
+            }
+
+            return true
+        },
         message: 'Leave action?\nChanges you made will be discarded.',
         onConfirm: () => {
             logic.actions.resetAction()


### PR DESCRIPTION
## Problem

Opening the sidebar on a new actions page causes a prompt to appear asking if they want to save changes.
<img width="557" height="324" alt="image" src="https://github.com/user-attachments/assets/a560b526-dcb1-4768-8f0e-435aeba4666a" />

They have to then click cancel/okay to open the sidebar.

## Changes

Makes it such that the opening the sidebar doesnt prompt the change

Leaving to another link from inside the sidebar still prompts the popup.

## How did you test this code?

Locally
## Publish to changelog?
No