### PR TITLE
fix: fixes a small spacing issue with scene titles next to edit/collapse

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -339,7 +339,7 @@ export function SceneTitleSection({
                                         hasDescription ? (
                                             <ButtonPrimitive
                                                 className={cn(
-                                                    'size-[var(--button-height-sm)] shrink-0 -ml-2',
+                                                    'size-[var(--button-height-sm)] shrink-0',
                                                     isScrolled
                                                         ? 'animate-fade-out-subtle pointer-events-none'
                                                         : 'animate-fade-in-subtle group-hover/scene-title-section:opacity-100 opacity-30 transition-opacity duration-200 motion-reduce:transition-none'


### PR DESCRIPTION
## Problem

On scene titles, there's some overlap with the collapse buttons/edit button

## Changes

Removes the negative margin on the collapse button.

Before:
<img width="105" height="78" alt="image" src="https://github.com/user-attachments/assets/a200297b-7f74-4911-811a-e0156a3f3a09" />


After:
<img width="467" height="112" alt="image" src="https://github.com/user-attachments/assets/2c193401-dbae-43f3-b2b8-f441db2fed31" />


## How did you test this code?

Locally

## Publish to changelog?

No