### PR TITLE
chore: add org to delayed usage reports EU list

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -81,6 +81,7 @@ TWENTY_FOUR_HOURS = 24 * 60 * 60
 # Organizations with delayed data ingestion that need delayed usage report re-runs
 # This is a temporary solution until we switch event usage queries from timestamp to created_at
 DELAYED_ORGS_EU: list[str] = [
+    "018beddd-5eb1-0000-7953-5a5b982e80bf",
     "01975ab3-7ec5-0000-9751-a89cbc971419",
 ]
 DELAYED_ORGS_US: list[str] = []


### PR DESCRIPTION
## Changes

Add org 018beddd-5eb1-0000-7953-5a5b982e80bf to DELAYED_ORGS_EU to ensure their bulk imported events are captured in delayed usage reports.

Slack thread: https://posthog.slack.com/archives/C08ERRQT41E/p1772720324260299?thread_ts=1772715682.920249&cid=C08ERRQT41E

## How did you test this code?

n/a

## Publish to changelog?

no