### PR TITLE
fix(signals): Add title to the summary.

### DIFF
--- a/posthog/temporal/data_imports/signals/github_issues.py
+++ b/posthog/temporal/data_imports/signals/github_issues.py
@@ -8,10 +8,13 @@ logger = get_logger(__name__)
 
 GITHUB_IGNORED_STATES = ("closed",)
 
-GITHUB_SUMMARIZATION_PROMPT = """Summarize this GitHub issue into a concise description for semantic search.
-Capture the core problem or request, the product area affected, and key context like error messages or what the user was doing when the issue occurred.
+GITHUB_SUMMARIZATION_PROMPT = """Summarize this GitHub issue for semantic search.
+Output exactly two parts separated by a newline:
+1. A short title (under 100 characters) that captures the core issue
+2. A concise summary capturing the problem or request, the product area affected, and key context like error messages or what the user was doing when the issue occurred
+
 Strip raw logs, full stack traces, and large code blocks — but keep specific error messages and high-level reproduction context if they clarify the issue.
-Keep the summary under {max_length} characters. Respond with only the summary text.
+Keep the total output under {max_length} characters. Respond with only the title and summary, nothing else.
 
 <issue>
 {description}

--- a/posthog/temporal/data_imports/signals/linear_issues.py
+++ b/posthog/temporal/data_imports/signals/linear_issues.py
@@ -8,10 +8,13 @@ logger = get_logger(__name__)
 
 LINEAR_IGNORED_STATE_TYPES = ("completed", "canceled")
 
-LINEAR_SUMMARIZATION_PROMPT = """Summarize this Linear issue into a concise description for semantic search.
-Capture the core problem or request, the product area affected, and key context like error messages or what the user was doing when the issue occurred.
+LINEAR_SUMMARIZATION_PROMPT = """Summarize this Linear issue for semantic search.
+Output exactly two parts separated by a newline:
+1. A short title (under 100 characters) that captures the core issue
+2. A concise summary capturing the problem or request, the product area affected, and key context like error messages or what the user was doing when the issue occurred
+
 Strip raw logs, full stack traces, and large code blocks — but keep specific error messages and high-level reproduction context if they clarify the issue.
-Keep the summary under {max_length} characters. Respond with only the summary text.
+Keep the total output under {max_length} characters. Respond with only the title and summary, nothing else.
 
 <issue>
 {description}

--- a/posthog/temporal/data_imports/signals/zendesk_tickets.py
+++ b/posthog/temporal/data_imports/signals/zendesk_tickets.py
@@ -9,10 +9,13 @@ logger = get_logger(__name__)
 # We don't want to analyze tickets that were already solved
 ZENDESK_IGNORED_STATUSES = ("closed", "solved")
 
-ZENDESK_SUMMARIZATION_PROMPT = """Summarize this support ticket into a concise description for semantic search.
-Capture the core problem or request, the product area affected, and any relevant context like error messages or what the customer already tried.
+ZENDESK_SUMMARIZATION_PROMPT = """Summarize this support ticket for semantic search.
+Output exactly two parts separated by a newline:
+1. A short title (under 100 characters) that captures the core issue
+2. A concise summary capturing the problem or request, the product area affected, and any relevant context like error messages or what the customer already tried
+
 Strip email signatures, legal disclaimers, and system-generated footers — but keep quoted replies or conversation fragments if they add context about the issue.
-Keep the summary under {max_length} characters. Respond with only the summary text.
+Keep the total output under {max_length} characters. Respond with only the title and summary, nothing else.
 
 <ticket>
 {description}


### PR DESCRIPTION
## Problem
- When summarizing, we generate a large chunk of text in a single-ish line, while down the line we split by "\n" (temporary solution)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Generate title

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
