### PR TITLE
feat(llma): add evaluations MCP tools via code generation pipeline

### DIFF
--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -6,6 +6,7 @@ from typing import cast
 from django.conf import settings
 
 import structlog
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -29,17 +30,24 @@ logger = structlog.get_logger(__name__)
 
 
 class EvaluationRunRequestSerializer(serializers.Serializer):
-    evaluation_id = serializers.UUIDField(required=True)
-    target_event_id = serializers.UUIDField(required=True)
-    timestamp = serializers.DateTimeField(required=True)
-    event = serializers.CharField(required=True)
-    distinct_id = serializers.CharField(required=False, allow_null=True)
+    evaluation_id = serializers.UUIDField(required=True, help_text="UUID of the evaluation to run.")
+    target_event_id = serializers.UUIDField(required=True, help_text="UUID of the $ai_generation event to evaluate.")
+    timestamp = serializers.DateTimeField(
+        required=True, help_text="ISO 8601 timestamp of the target event (needed for efficient ClickHouse lookup)."
+    )
+    event = serializers.CharField(
+        required=True, help_text='Event name. Use "$ai_generation" for LLM generation events.'
+    )
+    distinct_id = serializers.CharField(
+        required=False, allow_null=True, help_text="Distinct ID of the event (optional, improves lookup performance)."
+    )
 
 
 class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "evaluation"
     permission_classes = [IsAuthenticated, AccessControlPermission]
 
+    @extend_schema(request=EvaluationRunRequestSerializer)
     @llma_track_latency("llma_evaluation_runs_create")
     @monitor(feature=None, endpoint="llma_evaluation_runs_create", method="POST")
     def create(self, request: Request, **kwargs) -> Response:

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -7,6 +7,22 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+export interface EvaluationRunRequestApi {
+    /** UUID of the evaluation to run. */
+    evaluation_id: string
+    /** UUID of the $ai_generation event to evaluate. */
+    target_event_id: string
+    /** ISO 8601 timestamp of the target event (needed for efficient ClickHouse lookup). */
+    timestamp: string
+    /** Event name. Use "$ai_generation" for LLM generation events. */
+    event: string
+    /**
+     * Distinct ID of the event (optional, improves lookup performance).
+     * @nullable
+     */
+    distinct_id?: string | null
+}
+
 /**
  * * `llm_judge` - LLM as a judge
  * `hog` - Hog

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -18,6 +18,7 @@ import type {
     DatasetItemsListParams,
     DatasetsListParams,
     EvaluationApi,
+    EvaluationRunRequestApi,
     EvaluationSummaryRequestApi,
     EvaluationSummaryResponseApi,
     EvaluationsListParams,
@@ -68,10 +69,16 @@ export const getEvaluationRunsCreateUrl = (projectId: string) => {
     return `/api/environments/${projectId}/evaluation_runs/`
 }
 
-export const evaluationRunsCreate = async (projectId: string, options?: RequestInit): Promise<void> => {
+export const evaluationRunsCreate = async (
+    projectId: string,
+    evaluationRunRequestApi: EvaluationRunRequestApi,
+    options?: RequestInit
+): Promise<void> => {
     return apiMutator<void>(getEvaluationRunsCreateUrl(projectId), {
         ...options,
         method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(evaluationRunRequestApi),
     })
 }
 

--- a/products/llm_analytics/mcp/evaluations.yaml
+++ b/products/llm_analytics/mcp/evaluations.yaml
@@ -18,20 +18,20 @@ tools:
             destructive: false
             idempotent: true
         list: true
+        title: List evaluations
+        description: >
+            List all LLM Analytics evaluations in the project. Evaluations automatically score AI generations for
+            quality, safety, relevance, and other criteria. Two types exist: "llm_judge" (sends each generation to an
+            LLM with a scoring prompt) and "hog" (runs deterministic Hog code).
+
+            Results are stored as $ai_evaluation events with properties: $ai_evaluation_id, $ai_evaluation_name,
+            $ai_evaluation_type ("online" or "offline"), $ai_evaluation_runtime ("llm_judge" or "hog"),
+            $ai_evaluation_result (boolean), $ai_evaluation_reasoning, $ai_evaluation_applicable, $ai_target_event_id,
+            $ai_trace_id.
         include_params:
             - search
             - limit
             - offset
-        title: List evaluations
-        description: >
-            List all LLM Analytics evaluations in the project. Evaluations automatically score AI generations
-            for quality, safety, relevance, and other criteria. Two types exist: "llm_judge" (sends each generation
-            to an LLM with a scoring prompt) and "hog" (runs deterministic Hog code).
-
-            Results are stored as $ai_evaluation events with properties: $ai_evaluation_id, $ai_evaluation_name,
-            $ai_evaluation_type ("online" or "offline"), $ai_evaluation_runtime ("llm_judge" or "hog"),
-            $ai_evaluation_result (boolean), $ai_evaluation_reasoning, $ai_evaluation_applicable,
-            $ai_target_event_id, $ai_trace_id.
         mcp_version: 1
     evaluations-create:
         operation: evaluations_create
@@ -45,16 +45,16 @@ tools:
         enrich_url: '{id}'
         title: Create evaluation
         description: >
-            Create a new LLM Analytics evaluation. For "llm_judge" type, provide a prompt in evaluation_config
-            and a model_configuration. For "hog" type, provide Hog source code in evaluation_config.source.
-            Evaluations are disabled by default — use evaluations-partial-update to enable.
+            Create a new LLM Analytics evaluation. For "llm_judge" type, provide a prompt in evaluation_config and a
+            model_configuration. For "hog" type, provide Hog source code in evaluation_config.source. Evaluations are
+            disabled by default — use evaluations-partial-update to enable.
         param_overrides:
             name:
                 description: Name of the evaluation (must be unique within the project, max 400 chars)
             evaluation_type:
                 description: >
-                    Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt.
-                    "hog" runs deterministic Hog code against each generation.
+                    Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt. "hog" runs
+                    deterministic Hog code against each generation.
     evaluations-retrieve:
         operation: evaluations_retrieve
         enabled: true
@@ -66,8 +66,8 @@ tools:
             idempotent: true
         title: Get evaluation
         description: >
-            Get a specific evaluation by ID. Returns the full evaluation configuration including type,
-            config, output settings, and model configuration.
+            Get a specific evaluation by ID. Returns the full evaluation configuration including type, config, output
+            settings, and model configuration.
         mcp_version: 1
     evaluations-update:
         operation: evaluations_update
@@ -83,24 +83,12 @@ tools:
             idempotent: true
         title: Update evaluation
         description: >
-            Update an evaluation. Can change name, description, enabled status, evaluation config,
-            output config, or model configuration. Use {"enabled": true} to start scoring new generations.
-            Use {"deleted": true} to soft-delete an evaluation.
+            Update an evaluation. Can change name, description, enabled status, evaluation config, output config, or
+            model configuration. Use {"enabled": true} to start scoring new generations. Use {"deleted": true} to
+            soft-delete an evaluation.
     evaluations-destroy:
         operation: evaluations_destroy
         enabled: false
-    evaluation-run:
-        operation: evaluation_runs_create
-        enabled: true
-        scopes:
-            - evaluation:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Run evaluation on a generation
-        description: >
-            Trigger an async evaluation run on a specific generation event. Starts a Temporal workflow
-            and returns immediately with a workflow ID. Requires evaluation_id, target_event_id, and
-            timestamp (ISO 8601, needed for ClickHouse index lookup). The event field defaults to
-            "$ai_generation".
+    evaluations-test-hog-create:
+        operation: evaluations_test_hog_create
+        enabled: false

--- a/products/llm_analytics/mcp/evaluations.yaml
+++ b/products/llm_analytics/mcp/evaluations.yaml
@@ -1,0 +1,106 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: LLM Analytics Evaluations
+feature: llm_analytics
+url_prefix: /evaluations
+tools:
+    evaluations-list:
+        operation: evaluations_list
+        enabled: true
+        scopes:
+            - evaluation:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        include_params:
+            - search
+            - limit
+            - offset
+        title: List evaluations
+        description: >
+            List all LLM Analytics evaluations in the project. Evaluations automatically score AI generations
+            for quality, safety, relevance, and other criteria. Two types exist: "llm_judge" (sends each generation
+            to an LLM with a scoring prompt) and "hog" (runs deterministic Hog code).
+
+            Results are stored as $ai_evaluation events with properties: $ai_evaluation_id, $ai_evaluation_name,
+            $ai_evaluation_type ("online" or "offline"), $ai_evaluation_runtime ("llm_judge" or "hog"),
+            $ai_evaluation_result (boolean), $ai_evaluation_reasoning, $ai_evaluation_applicable,
+            $ai_target_event_id, $ai_trace_id.
+        mcp_version: 1
+    evaluations-create:
+        operation: evaluations_create
+        enabled: true
+        scopes:
+            - evaluation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{id}'
+        title: Create evaluation
+        description: >
+            Create a new LLM Analytics evaluation. For "llm_judge" type, provide a prompt in evaluation_config
+            and a model_configuration. For "hog" type, provide Hog source code in evaluation_config.source.
+            Evaluations are disabled by default — use evaluations-partial-update to enable.
+        param_overrides:
+            name:
+                description: Name of the evaluation (must be unique within the project, max 400 chars)
+            evaluation_type:
+                description: >
+                    Type of evaluation. "llm_judge" uses an LLM to score generations against a prompt.
+                    "hog" runs deterministic Hog code against each generation.
+    evaluations-retrieve:
+        operation: evaluations_retrieve
+        enabled: true
+        scopes:
+            - evaluation:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get evaluation
+        description: >
+            Get a specific evaluation by ID. Returns the full evaluation configuration including type,
+            config, output settings, and model configuration.
+        mcp_version: 1
+    evaluations-update:
+        operation: evaluations_update
+        enabled: false
+    evaluations-partial-update:
+        operation: evaluations_partial_update
+        enabled: true
+        scopes:
+            - evaluation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update evaluation
+        description: >
+            Update an evaluation. Can change name, description, enabled status, evaluation config,
+            output config, or model configuration. Use {"enabled": true} to start scoring new generations.
+            Use {"deleted": true} to soft-delete an evaluation.
+    evaluations-destroy:
+        operation: evaluations_destroy
+        enabled: false
+    evaluation-run:
+        operation: evaluation_runs_create
+        enabled: true
+        scopes:
+            - evaluation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run evaluation on a generation
+        description: >
+            Trigger an async evaluation run on a specific generation event. Starts a Temporal workflow
+            and returns immediately with a workflow ID. Requires evaluation_id, target_event_id, and
+            timestamp (ISO 8601, needed for ClickHouse index lookup). The event field defaults to
+            "$ai_generation".

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -134,6 +134,81 @@
             "readOnlyHint": false
         }
     },
+    "evaluations-list": {
+        "description": "List all LLM Analytics evaluations in the project. Evaluations automatically score AI generations for quality, safety, relevance, and other criteria. Two types exist: \"llm_judge\" (sends each generation to an LLM with a scoring prompt) and \"hog\" (runs deterministic Hog code).\nResults are stored as $ai_evaluation events with properties: $ai_evaluation_id, $ai_evaluation_name, $ai_evaluation_type (\"online\" or \"offline\"), $ai_evaluation_runtime (\"llm_judge\" or \"hog\"), $ai_evaluation_result (boolean), $ai_evaluation_reasoning, $ai_evaluation_applicable, $ai_target_event_id, $ai_trace_id.",
+        "category": "LLM Analytics Evaluations",
+        "feature": "llm_analytics",
+        "summary": "List evaluations",
+        "title": "List evaluations",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluations-create": {
+        "description": "Create a new LLM Analytics evaluation. For \"llm_judge\" type, provide a prompt in evaluation_config and a model_configuration. For \"hog\" type, provide Hog source code in evaluation_config.source. Evaluations are disabled by default — use evaluations-partial-update to enable.",
+        "category": "LLM Analytics Evaluations",
+        "feature": "llm_analytics",
+        "summary": "Create evaluation",
+        "title": "Create evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluations-retrieve": {
+        "description": "Get a specific evaluation by ID. Returns the full evaluation configuration including type, config, output settings, and model configuration.",
+        "category": "LLM Analytics Evaluations",
+        "feature": "llm_analytics",
+        "summary": "Get evaluation",
+        "title": "Get evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "evaluations-partial-update": {
+        "description": "Update an evaluation. Can change name, description, enabled status, evaluation config, output config, or model configuration. Use {\"enabled\": true} to start scoring new generations. Use {\"deleted\": true} to soft-delete an evaluation.",
+        "category": "LLM Analytics Evaluations",
+        "feature": "llm_analytics",
+        "summary": "Update evaluation",
+        "title": "Update evaluation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "evaluation-run": {
+        "description": "Trigger an async evaluation run on a specific generation event. Starts a Temporal workflow and returns immediately with a workflow ID. Requires evaluation_id, target_event_id, and timestamp (ISO 8601, needed for ClickHouse index lookup). The event field defaults to \"$ai_generation\".",
+        "category": "LLM Analytics Evaluations",
+        "feature": "llm_analytics",
+        "summary": "Run evaluation on a generation",
+        "title": "Run evaluation on a generation",
+        "required_scopes": ["evaluation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "workflows-list": {
         "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",

--- a/services/mcp/src/generated/evaluations/api.ts
+++ b/services/mcp/src/generated/evaluations/api.ts
@@ -1,0 +1,453 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 7 ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Create a new evaluation run.
+
+This endpoint validates the request and enqueues a Temporal workflow
+to asynchronously execute the evaluation.
+ */
+export const EvaluationRunsCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const EvaluationRunsCreateBody = zod.object({
+    evaluation_id: zod.string().describe('UUID of the evaluation to run.'),
+    target_event_id: zod.string().describe('UUID of the $ai_generation event to evaluate.'),
+    timestamp: zod
+        .string()
+        .datetime({})
+        .describe('ISO 8601 timestamp of the target event (needed for efficient ClickHouse lookup).'),
+    event: zod.string().describe('Event name. Use "$ai_generation" for LLM generation events.'),
+    distinct_id: zod.string().nullish().describe('Distinct ID of the event (optional, improves lookup performance).'),
+})
+
+export const EvaluationsListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const EvaluationsListQueryParams = zod.object({
+    enabled: zod.boolean().optional().describe('Filter by enabled status'),
+    id__in: zod.array(zod.string()).optional().describe('Multiple values may be separated by commas.'),
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .array(zod.enum(['-created_at', '-name', '-updated_at', 'created_at', 'name', 'updated_at']))
+        .optional()
+        .describe(
+            'Ordering\n\n* `created_at` - Created At\n* `-created_at` - Created At (descending)\n* `updated_at` - Updated At\n* `-updated_at` - Updated At (descending)\n* `name` - Name\n* `-name` - Name (descending)'
+        ),
+    search: zod.string().optional().describe('Search in name or description'),
+})
+
+export const evaluationsListResponseResultsItemNameMax = 400
+
+export const evaluationsListResponseResultsItemModelConfigurationOneModelMax = 100
+
+export const evaluationsListResponseResultsItemCreatedByOneDistinctIdMax = 200
+
+export const evaluationsListResponseResultsItemCreatedByOneFirstNameMax = 150
+
+export const evaluationsListResponseResultsItemCreatedByOneLastNameMax = 150
+
+export const evaluationsListResponseResultsItemCreatedByOneEmailMax = 254
+
+export const EvaluationsListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(evaluationsListResponseResultsItemNameMax),
+            description: zod.string().optional(),
+            enabled: zod.boolean().optional(),
+            evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+            evaluation_config: zod.unknown().optional(),
+            output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+            output_config: zod.unknown().optional(),
+            conditions: zod.unknown().optional(),
+            model_configuration: zod
+                .object({
+                    provider: zod
+                        .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                        .describe(
+                            '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                        ),
+                    model: zod.string().max(evaluationsListResponseResultsItemModelConfigurationOneModelMax),
+                    provider_key_id: zod.string().nullish(),
+                    provider_key_name: zod.string().nullable(),
+                })
+                .describe('Nested serializer for model configuration.')
+                .nullish(),
+            created_at: zod.string().datetime({}),
+            updated_at: zod.string().datetime({}),
+            created_by: zod.object({
+                id: zod.number(),
+                uuid: zod.string(),
+                distinct_id: zod.string().max(evaluationsListResponseResultsItemCreatedByOneDistinctIdMax).nullish(),
+                first_name: zod.string().max(evaluationsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
+                last_name: zod.string().max(evaluationsListResponseResultsItemCreatedByOneLastNameMax).optional(),
+                email: zod.string().email().max(evaluationsListResponseResultsItemCreatedByOneEmailMax),
+                is_email_verified: zod.boolean().nullish(),
+                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+                role_at_organization: zod
+                    .union([
+                        zod
+                            .enum([
+                                'engineering',
+                                'data',
+                                'product',
+                                'founder',
+                                'leadership',
+                                'marketing',
+                                'sales',
+                                'other',
+                            ])
+                            .describe(
+                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                            ),
+                        zod.enum(['']),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+            }),
+            deleted: zod.boolean().optional(),
+        })
+    ),
+})
+
+export const EvaluationsCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const evaluationsCreateBodyNameMax = 400
+
+export const evaluationsCreateBodyModelConfigurationOneModelMax = 100
+
+export const EvaluationsCreateBody = zod.object({
+    name: zod.string().max(evaluationsCreateBodyNameMax),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsCreateBodyModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    deleted: zod.boolean().optional(),
+})
+
+export const EvaluationsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this evaluation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const evaluationsRetrieveResponseNameMax = 400
+
+export const evaluationsRetrieveResponseModelConfigurationOneModelMax = 100
+
+export const evaluationsRetrieveResponseCreatedByOneDistinctIdMax = 200
+
+export const evaluationsRetrieveResponseCreatedByOneFirstNameMax = 150
+
+export const evaluationsRetrieveResponseCreatedByOneLastNameMax = 150
+
+export const evaluationsRetrieveResponseCreatedByOneEmailMax = 254
+
+export const EvaluationsRetrieveResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(evaluationsRetrieveResponseNameMax),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsRetrieveResponseModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    created_at: zod.string().datetime({}),
+    updated_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(evaluationsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(evaluationsRetrieveResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(evaluationsRetrieveResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(evaluationsRetrieveResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    deleted: zod.boolean().optional(),
+})
+
+export const EvaluationsUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this evaluation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const evaluationsUpdateBodyNameMax = 400
+
+export const evaluationsUpdateBodyModelConfigurationOneModelMax = 100
+
+export const EvaluationsUpdateBody = zod.object({
+    name: zod.string().max(evaluationsUpdateBodyNameMax),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsUpdateBodyModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    deleted: zod.boolean().optional(),
+})
+
+export const evaluationsUpdateResponseNameMax = 400
+
+export const evaluationsUpdateResponseModelConfigurationOneModelMax = 100
+
+export const evaluationsUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const evaluationsUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const evaluationsUpdateResponseCreatedByOneLastNameMax = 150
+
+export const evaluationsUpdateResponseCreatedByOneEmailMax = 254
+
+export const EvaluationsUpdateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(evaluationsUpdateResponseNameMax),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsUpdateResponseModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    created_at: zod.string().datetime({}),
+    updated_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(evaluationsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(evaluationsUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(evaluationsUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(evaluationsUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    deleted: zod.boolean().optional(),
+})
+
+export const EvaluationsPartialUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this evaluation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const evaluationsPartialUpdateBodyNameMax = 400
+
+export const evaluationsPartialUpdateBodyModelConfigurationOneModelMax = 100
+
+export const EvaluationsPartialUpdateBody = zod.object({
+    name: zod.string().max(evaluationsPartialUpdateBodyNameMax).optional(),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod
+        .enum(['llm_judge', 'hog'])
+        .optional()
+        .describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).optional().describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsPartialUpdateBodyModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    deleted: zod.boolean().optional(),
+})
+
+export const evaluationsPartialUpdateResponseNameMax = 400
+
+export const evaluationsPartialUpdateResponseModelConfigurationOneModelMax = 100
+
+export const evaluationsPartialUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const evaluationsPartialUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const evaluationsPartialUpdateResponseCreatedByOneLastNameMax = 150
+
+export const evaluationsPartialUpdateResponseCreatedByOneEmailMax = 254
+
+export const EvaluationsPartialUpdateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(evaluationsPartialUpdateResponseNameMax),
+    description: zod.string().optional(),
+    enabled: zod.boolean().optional(),
+    evaluation_type: zod.enum(['llm_judge', 'hog']).describe('* `llm_judge` - LLM as a judge\n* `hog` - Hog'),
+    evaluation_config: zod.unknown().optional(),
+    output_type: zod.enum(['boolean']).describe('* `boolean` - Boolean (Pass/Fail)'),
+    output_config: zod.unknown().optional(),
+    conditions: zod.unknown().optional(),
+    model_configuration: zod
+        .object({
+            provider: zod
+                .enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks'])
+                .describe(
+                    '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks'
+                ),
+            model: zod.string().max(evaluationsPartialUpdateResponseModelConfigurationOneModelMax),
+            provider_key_id: zod.string().nullish(),
+            provider_key_name: zod.string().nullable(),
+        })
+        .describe('Nested serializer for model configuration.')
+        .nullish(),
+    created_at: zod.string().datetime({}),
+    updated_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(evaluationsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(evaluationsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(evaluationsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(evaluationsPartialUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    deleted: zod.boolean().optional(),
+})
+
+/**
+ * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
+ */
+export const EvaluationsDestroyParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this evaluation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})

--- a/services/mcp/src/tools/generated/evaluations.ts
+++ b/services/mcp/src/tools/generated/evaluations.ts
@@ -1,0 +1,186 @@
+// AUTO-GENERATED from products/llm_analytics/mcp/evaluations.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import {
+    EvaluationRunsCreateBody,
+    EvaluationsCreateBody,
+    EvaluationsListQueryParams,
+    EvaluationsPartialUpdateBody,
+    EvaluationsPartialUpdateParams,
+    EvaluationsRetrieveParams,
+} from '@/generated/evaluations/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const EvaluationsListSchema = EvaluationsListQueryParams.omit({ enabled: true, id__in: true, order_by: true })
+
+const evaluationsList = (): ToolBase<typeof EvaluationsListSchema> => ({
+    name: 'evaluations-list',
+    schema: EvaluationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof EvaluationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request({
+            method: 'GET',
+            path: `/api/environments/${projectId}/evaluations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                search: params.search,
+            },
+        })
+        return result
+    },
+})
+
+const EvaluationsCreateSchema = EvaluationsCreateBody
+
+const evaluationsCreate = (): ToolBase<typeof EvaluationsCreateSchema> => ({
+    name: 'evaluations-create',
+    schema: EvaluationsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof EvaluationsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.evaluation_type !== undefined) {
+            body['evaluation_type'] = params.evaluation_type
+        }
+        if (params.evaluation_config !== undefined) {
+            body['evaluation_config'] = params.evaluation_config
+        }
+        if (params.output_type !== undefined) {
+            body['output_type'] = params.output_type
+        }
+        if (params.output_config !== undefined) {
+            body['output_config'] = params.output_config
+        }
+        if (params.conditions !== undefined) {
+            body['conditions'] = params.conditions
+        }
+        if (params.model_configuration !== undefined) {
+            body['model_configuration'] = params.model_configuration
+        }
+        if (params.deleted !== undefined) {
+            body['deleted'] = params.deleted
+        }
+        const result = await context.api.request({
+            method: 'POST',
+            path: `/api/environments/${projectId}/evaluations/`,
+            body,
+        })
+        return {
+            ...(result as any),
+            url: `${context.api.getProjectBaseUrl(projectId)}/evaluations/${(result as any).id}`,
+        }
+    },
+})
+
+const EvaluationsRetrieveSchema = EvaluationsRetrieveParams.omit({ project_id: true })
+
+const evaluationsRetrieve = (): ToolBase<typeof EvaluationsRetrieveSchema> => ({
+    name: 'evaluations-retrieve',
+    schema: EvaluationsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof EvaluationsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request({
+            method: 'GET',
+            path: `/api/environments/${projectId}/evaluations/${params.id}/`,
+        })
+        return result
+    },
+})
+
+const EvaluationsPartialUpdateSchema = EvaluationsPartialUpdateParams.omit({ project_id: true }).extend(
+    EvaluationsPartialUpdateBody.shape
+)
+
+const evaluationsPartialUpdate = (): ToolBase<typeof EvaluationsPartialUpdateSchema> => ({
+    name: 'evaluations-partial-update',
+    schema: EvaluationsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof EvaluationsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.evaluation_type !== undefined) {
+            body['evaluation_type'] = params.evaluation_type
+        }
+        if (params.evaluation_config !== undefined) {
+            body['evaluation_config'] = params.evaluation_config
+        }
+        if (params.output_type !== undefined) {
+            body['output_type'] = params.output_type
+        }
+        if (params.output_config !== undefined) {
+            body['output_config'] = params.output_config
+        }
+        if (params.conditions !== undefined) {
+            body['conditions'] = params.conditions
+        }
+        if (params.model_configuration !== undefined) {
+            body['model_configuration'] = params.model_configuration
+        }
+        if (params.deleted !== undefined) {
+            body['deleted'] = params.deleted
+        }
+        const result = await context.api.request({
+            method: 'PATCH',
+            path: `/api/environments/${projectId}/evaluations/${params.id}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const EvaluationRunSchema = EvaluationRunsCreateBody
+
+const evaluationRun = (): ToolBase<typeof EvaluationRunSchema> => ({
+    name: 'evaluation-run',
+    schema: EvaluationRunSchema,
+    handler: async (context: Context, params: z.infer<typeof EvaluationRunSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.evaluation_id !== undefined) {
+            body['evaluation_id'] = params.evaluation_id
+        }
+        if (params.target_event_id !== undefined) {
+            body['target_event_id'] = params.target_event_id
+        }
+        if (params.timestamp !== undefined) {
+            body['timestamp'] = params.timestamp
+        }
+        if (params.event !== undefined) {
+            body['event'] = params.event
+        }
+        if (params.distinct_id !== undefined) {
+            body['distinct_id'] = params.distinct_id
+        }
+        const result = await context.api.request({
+            method: 'POST',
+            path: `/api/environments/${projectId}/evaluation_runs/`,
+            body,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'evaluations-list': evaluationsList,
+    'evaluations-create': evaluationsCreate,
+    'evaluations-retrieve': evaluationsRetrieve,
+    'evaluations-partial-update': evaluationsPartialUpdate,
+    'evaluation-run': evaluationRun,
+}

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -3,10 +3,12 @@ import type { ToolBase, ZodObjectAny } from '@/tools/types'
 // AUTO-GENERATED — do not edit
 import { GENERATED_TOOLS as cohorts } from './cohorts'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
+import { GENERATED_TOOLS as evaluations } from './evaluations'
 import { GENERATED_TOOLS as workflows } from './workflows'
 
 export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     ...cohorts,
     ...error_tracking,
+    ...evaluations,
     ...workflows,
 }


### PR DESCRIPTION
## Summary

- Adds 5 evaluation MCP tools using the code generation pipeline (replacing hand-written tools from #50004)
- YAML definitions in `products/llm_analytics/mcp/evaluations.yaml` — the source of truth
- Adds `@extend_schema(request=...)` + `help_text` to `EvaluationRunViewSet` so drf-spectacular discovers the request body

### Tools generated

| Tool | Operation | Notes |
|------|-----------|-------|
| `evaluations-list` | `evaluations_list` | Excludes `enabled`/`id__in`/`order_by` params (type mismatch workaround) |
| `evaluations-create` | `evaluations_create` | Enriches response with project URL |
| `evaluations-retrieve` | `evaluations_retrieve` | — |
| `evaluations-partial-update` | `evaluations_partial_update` | Covers update + soft delete (`{deleted: true}`) |
| `evaluation-run` | `evaluation_runs_create` | Needed `@extend_schema` fix for body discovery |

### Pipeline feedback

Documented in detail in the skill file, but key issues:
1. `--product` scaffold matches by URL path — `evaluation_runs` at `/evaluation_runs/` wasn't discovered with `--product evaluations`
2. Plain `ViewSet` (not `ModelViewSet`) needs explicit `@extend_schema` for body discovery
3. Boolean/array query params don't fit `Record<string, string | number | undefined>` — workaround: `include_params` to exclude them

Part of #50025

## Test plan

- [x] `pnpm --filter=@posthog/mcp run typecheck` passes
- [ ] Manual test: list/create/get/update evaluations via MCP client
- [ ] Verify generated tool definitions appear in `generated-tool-definitions.json`