### PR TITLE
fix(mcp): Add --output flag to scaffold-yaml command documentation

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -10,7 +10,11 @@ Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-
 ## Quick workflow
 
 ```sh
-# 1. Scaffold a starter YAML with all operations disabled
+# 1. Scaffold a starter YAML with all operations disabled.
+#    --product is a substring match on URL paths: it selects every endpoint
+#    whose path contains /<name>/ (hyphens normalized to underscores).
+#    The value can be a product name or any path-segment needle
+#    (e.g. --product actions matches /api/projects/{project_id}/actions/).
 pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product \
     --output ../../products/your_product/mcp/tools.yaml
 

--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -11,7 +11,8 @@ Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-
 
 ```sh
 # 1. Scaffold a starter YAML with all operations disabled
-pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product \
+    --output ../../products/your_product/mcp/tools.yaml
 
 # 2. Configure the YAML — enable tools, add scopes, annotations, descriptions
 #    Place in products/<product>/mcp/*.yaml (preferred) or services/mcp/definitions/*.yaml

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -167,8 +167,12 @@ Product teams own their definitions and control which operations are exposed as 
 **Workflow: scaffold, configure, generate.**
 
 1. **Scaffold** a starter YAML with all operations disabled.
-   Operations are discovered by matching URL paths against product names
-   (e.g., `error_tracking` matches all paths containing `/error_tracking/`).
+   `--product` is a **substring match** on URL paths —
+   it selects every endpoint whose path contains `/<name>/`
+   (hyphens are normalized to underscores before matching).
+   The value doesn't have to be an exact product name;
+   any string that appears as a path segment will work
+   (e.g., `--product actions` matches `/api/projects/{project_id}/actions/`).
 
    ```sh
    pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -15,7 +15,8 @@ see [Writing skills](/handbook/engineering/ai/writing-skills).
 
 ```sh
 # 1. Scaffold a starter YAML with all operations disabled
-pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product
+pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product \
+    --output ../../products/your_product/mcp/tools.yaml
 
 # 2. Configure the YAML – enable tools, add scopes, annotations, descriptions
 #    Place in products/<product>/mcp/*.yaml (preferred) or services/mcp/definitions/*.yaml

--- a/services/mcp/definitions/README.md
+++ b/services/mcp/definitions/README.md
@@ -39,6 +39,13 @@ Run the full pipeline: `hogli build:openapi`
        --output ../../products/your_product/mcp/tools.yaml
    ```
 
+   `--product` is a **substring match** on URL paths:
+   it selects every endpoint whose path contains `/<name>/`
+   (hyphens are normalized to underscores before matching).
+   The value doesn't have to be an exact product name —
+   any string that appears as a path segment will work
+   (e.g. `--product actions` matches `/api/projects/{project_id}/actions/`).
+
 2. **Configure** — edit the YAML to enable the tools you want. Each enabled tool needs
    `scopes`, `annotations`, and ideally a `description`:
 

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -370,7 +370,8 @@ function main(): void {
         console.error('       scaffold-yaml --path <prefix> [--output <file>]')
         console.error('       scaffold-yaml --sync-all')
         console.error('')
-        console.error('Products are matched by URL path containing /<name>/.')
+        console.error('--product is a substring match: selects endpoints whose path contains /<name>/')
+        console.error('(hyphens normalized to underscores). Can be a product name or any path segment.')
         process.exit(1)
     }
 


### PR DESCRIPTION
## Problem

The documentation for the MCP tools scaffolding process was incomplete. It didn't show users where to specify the output location for the generated YAML file, which could lead to confusion about where the scaffolded configuration should be placed.

## Changes

Updated the `scaffold-yaml` command examples in both the skill guide and handbook documentation to include the `--output` flag, explicitly showing users to place the generated `tools.yaml` file in the correct location: `products/your_product/mcp/tools.yaml`.

This makes the scaffolding workflow clearer and aligns with the documented best practice of placing MCP tool definitions in the product-specific directory.

## How did you test this code?

Documentation-only changes. No testing needed.

## Publish to changelog?

No

https://claude.ai/code/session_01FX2Du64oJxHJQfnZyZwKW5