### PR TITLE
feat(ph-ai): use sonnet for research agent plan mode, opus for research mode

### DIFF
--- a/ee/hogai/research_agent/executables.py
+++ b/ee/hogai/research_agent/executables.py
@@ -23,8 +23,11 @@ class ResearchAgentExecutable(PlanModeExecutable):
     MAX_TOKENS = 16_384
 
     def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
+        is_research_mode = state.supermode == AgentMode.RESEARCH
+        model_name = "claude-opus-4-6" if is_research_mode else "claude-sonnet-4-6"
+
         base_model = MaxChatAnthropic(
-            model="claude-opus-4-5-20251101",
+            model=model_name,
             streaming=True,
             stream_usage=True,
             user=self._user,

--- a/ee/hogai/research_agent/prompts/research.py
+++ b/ee/hogai/research_agent/prompts/research.py
@@ -46,6 +46,8 @@ Guidelines:
 - Each tool call should target a specific uncertainty in your current draft
 - Decompose complex investigations using the `task` tool for parallel verification
 - Tool results and user messages may include <system_reminder> tags. These contain useful information and reminders, NOT part of the user's input or tool result.
+- **Do as many iterations as necessary** to revise the draft notebook - do not settle for a draft with remaining [UNVERIFIED] or [TODO] markers when more research could resolve them, and always ask yourself if one more round of revision/research would bring more value to the user
+- **If in doubt, stop** - it is better to publish a report that honestly marks remaining uncertainties than to fabricate or speculate beyond what the data supports, or to iterate just for the sake of it
 </goal>
 """.strip()
 

--- a/ee/hogai/research_agent/test/test_executables.py
+++ b/ee/hogai/research_agent/test/test_executables.py
@@ -144,8 +144,8 @@ class TestResearchAgentExecutable(ClickhouseTestMixin, BaseTest):
             assert captured_state is not None  # for mypy
             self.assertEqual(captured_state.supermode, AgentMode.RESEARCH)
 
-    async def test_get_model_uses_claude_opus_with_thinking(self):
-        state = AssistantState(messages=[HumanMessage(content="Test")])
+    async def test_get_model_uses_opus_in_research_mode(self):
+        state = AssistantState(messages=[HumanMessage(content="Test")], supermode=AgentMode.RESEARCH)
         node = _create_research_agent_node(self.team, self.user, state=state)
 
         mock_model = MagicMock()
@@ -156,15 +156,29 @@ class TestResearchAgentExecutable(ClickhouseTestMixin, BaseTest):
 
             mock_anthropic.assert_called_once()
             call_kwargs = mock_anthropic.call_args.kwargs
-            self.assertEqual(call_kwargs["model"], "claude-opus-4-5-20251101")
+            self.assertEqual(call_kwargs["model"], "claude-opus-4-6")
             self.assertEqual(call_kwargs["max_tokens"], 16_384)
             self.assertEqual(call_kwargs["thinking"], {"type": "enabled", "budget_tokens": 4096})
             self.assertTrue(call_kwargs["streaming"])
             self.assertTrue(call_kwargs["billable"])
             self.assertIn("interleaved-thinking-2025-05-14", call_kwargs["betas"])
 
+    async def test_get_model_uses_sonnet_in_plan_mode(self):
+        state = AssistantState(messages=[HumanMessage(content="Test")], supermode=AgentMode.PLAN)
+        node = _create_research_agent_node(self.team, self.user, state=state)
+
+        mock_model = MagicMock()
+        mock_model.bind_tools = MagicMock(return_value=mock_model)
+
+        with patch("ee.hogai.research_agent.executables.MaxChatAnthropic", return_value=mock_model) as mock_anthropic:
+            node._get_model(state, [])
+
+            mock_anthropic.assert_called_once()
+            call_kwargs = mock_anthropic.call_args.kwargs
+            self.assertEqual(call_kwargs["model"], "claude-sonnet-4-6")
+
     async def test_get_model_binds_tools_with_parallel_calls(self):
-        state = AssistantState(messages=[HumanMessage(content="Test")])
+        state = AssistantState(messages=[HumanMessage(content="Test")], supermode=AgentMode.RESEARCH)
         node = _create_research_agent_node(self.team, self.user, state=state)
 
         mock_model = MagicMock()


### PR DESCRIPTION
## Problem

The research agent uses the same expensive model (Opus) for both planning and actual research phases. Planning is less demanding and can use a lighter model, while research mode benefits from the most capable model and clearer iteration guidance.

## Changes

- Research agent now uses Sonnet 4.6 during plan mode and Opus 4.6 during research mode, selected dynamically based on `state.supermode`
- Added prompt guidelines encouraging thorough draft iteration ("do as many iterations as necessary") while also advising to stop when in doubt rather than fabricate
- Updated tests to cover both model selection paths

## How did you test this code?

Automated tests — split the existing model test into two cases verifying Opus is used in research mode and Sonnet in plan mode. All 20 tests in `test_executables.py` pass.

## Publish to changelog?

No