### PR TITLE
feat(ph-ai): convert deep research conversations to assistant on follow-up

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -353,7 +353,12 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         has_message = serializer.validated_data.get("message") is not None
         has_resume_payload = serializer.validated_data.get("resume_payload") is not None
         if conversation.type == Conversation.Type.DEEP_RESEARCH:
-            is_research = True
+            if not is_new_conversation and is_idle and has_message and not has_resume_payload:
+                conversation.type = Conversation.Type.ASSISTANT
+                conversation.save(update_fields=["type", "updated_at"])
+                is_research = False
+            else:
+                is_research = True
 
         if has_message and not is_idle:
             raise Conflict("Cannot resume streaming with a new message")

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -666,7 +666,7 @@ class TestConversation(APIBaseTest):
                 self.assertIn("beta", response_data["detail"])
 
     @override_settings(DEBUG=False)
-    def test_research_rate_limit_applies_to_existing_research_conversations(self):
+    def test_research_rate_limit_applies_to_new_research_conversations(self):
         """Test that research rate limits apply to new DEEP_RESEARCH conversations (before conversion)."""
         with patch(
             "ee.hogai.core.executor.AgentExecutor.astream",

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -667,25 +667,21 @@ class TestConversation(APIBaseTest):
 
     @override_settings(DEBUG=False)
     def test_research_rate_limit_applies_to_existing_research_conversations(self):
-        """Test that research rate limits apply to existing deep research conversations."""
-        # Create an existing DEEP_RESEARCH conversation
-        conversation = Conversation.objects.create(
-            user=self.user, team=self.team, type=Conversation.Type.DEEP_RESEARCH, status=Conversation.Status.IDLE
-        )
-
+        """Test that research rate limits apply to new DEEP_RESEARCH conversations (before conversion)."""
         with patch(
             "ee.hogai.core.executor.AgentExecutor.astream",
             return_value=_async_generator(),
         ):
             with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
-                # First 3 requests should succeed
+                # First 3 new research conversations should succeed (3/minute limit)
                 for i in range(3):
                     response = self.client.post(
                         f"/api/environments/{self.team.id}/conversations/",
                         {
                             "content": f"test query {i}",
                             "trace_id": str(uuid.uuid4()),
-                            "conversation": str(conversation.id),
+                            "conversation": str(uuid.uuid4()),
+                            "agent_mode": AgentMode.RESEARCH.value,
                         },
                     )
                     self.assertEqual(response.status_code, status.HTTP_200_OK, f"Request {i} should succeed")
@@ -696,11 +692,11 @@ class TestConversation(APIBaseTest):
                     {
                         "content": "test query 4",
                         "trace_id": str(uuid.uuid4()),
-                        "conversation": str(conversation.id),
+                        "conversation": str(uuid.uuid4()),
+                        "agent_mode": AgentMode.RESEARCH.value,
                     },
                 )
                 self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
-                # Check that the response contains the research-specific message
                 response_data = response.json()
                 self.assertIn("Research mode", response_data["detail"])
 
@@ -924,6 +920,138 @@ class TestConversation(APIBaseTest):
                 self.assertIsInstance(workflow_inputs, ResearchAgentWorkflowInputs)
                 # Even without impersonation, research mode is non-billable
                 self.assertEqual(workflow_inputs.is_agent_billable, False)
+
+    def test_deep_research_converts_to_assistant_on_followup_message(self):
+        """Test that an idle DEEP_RESEARCH conversation converts to ASSISTANT when user sends a follow-up."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            type=Conversation.Type.DEEP_RESEARCH,
+            status=Conversation.Status.IDLE,
+        )
+
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ) as mock_astream:
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": "follow-up question",
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(conversation.id),
+                    },
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                conversation.refresh_from_db()
+                self.assertEqual(conversation.type, Conversation.Type.ASSISTANT)
+
+                call_args = mock_astream.call_args
+                workflow_class = call_args[0][0]
+                self.assertEqual(workflow_class, ChatAgentWorkflow)
+
+                workflow_inputs = call_args[0][1]
+                self.assertIsInstance(workflow_inputs, ChatAgentWorkflowInputs)
+
+    def test_deep_research_stays_research_when_not_idle(self):
+        """Test that an in-progress DEEP_RESEARCH conversation stays as research."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            type=Conversation.Type.DEEP_RESEARCH,
+            status=Conversation.Status.IN_PROGRESS,
+        )
+
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ) as mock_astream:
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": None,
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(conversation.id),
+                    },
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                conversation.refresh_from_db()
+                self.assertEqual(conversation.type, Conversation.Type.DEEP_RESEARCH)
+
+                workflow_class = mock_astream.call_args[0][0]
+                self.assertEqual(workflow_class, ResearchAgentWorkflow)
+
+    def test_deep_research_stays_research_when_resume_payload_present(self):
+        """Test that an idle DEEP_RESEARCH conversation stays as research when resume_payload is present (auto-rejecting approval)."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            type=Conversation.Type.DEEP_RESEARCH,
+            status=Conversation.Status.IDLE,
+        )
+
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ) as mock_astream:
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": "new question",
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(conversation.id),
+                        "resume_payload": {"action": "reject"},
+                    },
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                conversation.refresh_from_db()
+                self.assertEqual(conversation.type, Conversation.Type.DEEP_RESEARCH)
+
+                workflow_class = mock_astream.call_args[0][0]
+                self.assertEqual(workflow_class, ResearchAgentWorkflow)
+
+    @override_settings(DEBUG=False)
+    def test_converted_conversation_rate_limits_as_regular(self):
+        """Test that after conversion from DEEP_RESEARCH to ASSISTANT, _is_research_request returns False."""
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            type=Conversation.Type.DEEP_RESEARCH,
+            status=Conversation.Status.IDLE,
+        )
+
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ):
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                # First message converts DEEP_RESEARCH → ASSISTANT
+                self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": "follow-up",
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(conversation.id),
+                    },
+                )
+
+                conversation.refresh_from_db()
+                self.assertEqual(conversation.type, Conversation.Type.ASSISTANT)
+
+                # Subsequent messages should not be rate-limited as research
+                viewset = ConversationViewSet()
+                viewset.team = self.team
+                mock_request = type("Request", (), {"data": {"conversation": str(conversation.id)}})()
+                self.assertFalse(viewset._is_research_request(mock_request))
 
     def test_chat_mode_uses_chat_agent_workflow(self):
         """Test that non-research modes use ChatAgentWorkflow."""


### PR DESCRIPTION
## Problem

When a user sends a follow-up message in a completed deep research conversation, it continues running as a research workflow. Follow-up questions in an idle research conversation should be handled by the regular chat agent instead, since the research task is done.

## Changes

- When a user sends a new message to an idle `DEEP_RESEARCH` conversation (no resume payload), the conversation type is converted to `ASSISTANT` and handled by the chat agent workflow
- Research mode is preserved when the conversation is still in progress, or when a resume payload is present (e.g. plan approval/rejection)
- Updated rate limit test to use new conversations instead of reusing an existing one, since follow-ups now convert to assistant mode

## How did you test this code?

Added tests covering:
- Idle deep research + follow-up message → converts to assistant
- In-progress deep research → stays as research
- Idle deep research + resume payload → stays as research
- Converted conversation is no longer rate-limited as research

## Publish to changelog?

No