### PR TITLE
chore(alerts): Alerts copy update

### DIFF
--- a/frontend/src/lib/components/Alerts/views/Alerts.tsx
+++ b/frontend/src/lib/components/Alerts/views/Alerts.tsx
@@ -119,7 +119,7 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
                     productName="Alerts"
                     productKey={ProductKey.ALERTS}
                     thingName="alert"
-                    description="Alerts enable you to monitor your insight and notify you when certain conditions are met. Please note that alerts are in alpha and may not be fully reliable."
+                    description="Alerts enable you to monitor your insight and notify you when certain conditions are met."
                     // TODO: update docs link when ready
                     // docsURL="https://posthog.com/docs/data/annotations"
                     isEmpty={alertsSortedByState.length === 0 && !alertsLoading}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The existing UI copy for alerts incorrectly stated that the feature was in alpha and might not be fully reliable. This update removes that outdated disclaimer, aligning the text with the current stability of the alerts feature.

## Changes

Updated the introductory text for alerts in `frontend/src/lib/components/Alerts/views/Alerts.tsx` to remove the "in alpha and may not be fully reliable" disclaimer.

## How did you test this code?

The agent performed a codebase search (`ripgrep`) to confirm the specific text was updated and that no other instances of the outdated copy remained.
As an agent, I have not manually tested this change in the UI.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1772725086492659?thread_ts=1772725086.492659&cid=C09BDQLM8KA)

<p><a href="https://cursor.com/agents/bc-069ef2bc-654b-54c5-a302-94f162d2269c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-069ef2bc-654b-54c5-a302-94f162d2269c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->