### PR TITLE
feat(logs): support initialFilters in LogsViewer and LogsViewerModal

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
@@ -129,6 +129,79 @@ describe('logsViewerFiltersLogic', () => {
         })
     })
 
+    describe('initialFilters', () => {
+        it('applies initialFilters on mount', async () => {
+            const initialLogic = logsViewerFiltersLogic({
+                id: 'with-initial',
+                initialFilters: { searchTerm: 'session_id:abc', severityLevels: ['error'] },
+            })
+            initialLogic.mount()
+            await expectLogic(initialLogic).toFinishAllListeners()
+
+            expect(initialLogic.values.filters.searchTerm).toBe('session_id:abc')
+            expect(initialLogic.values.filters.severityLevels).toEqual(['error'])
+            // other filters remain at defaults
+            expect(initialLogic.values.filters.dateRange).toEqual({ date_from: '-1h', date_to: null })
+
+            initialLogic.unmount()
+        })
+
+        it('does not call setFilters when no initialFilters provided', async () => {
+            const plainLogic = logsViewerFiltersLogic({ id: 'no-initial' })
+            plainLogic.mount()
+            await expectLogic(plainLogic).toFinishAllListeners()
+
+            expect(plainLogic.values.filters.searchTerm).toBe('')
+            expect(plainLogic.values.filters.severityLevels).toEqual([])
+
+            plainLogic.unmount()
+        })
+
+        it('applies new initialFilters when props change', async () => {
+            const initialProps = {
+                id: 'props-changed',
+                initialFilters: { searchTerm: 'first' },
+            }
+            const builtLogic = logsViewerFiltersLogic.build(initialProps)
+            builtLogic.mount()
+            await expectLogic(builtLogic).toFinishAllListeners()
+
+            expect(builtLogic.values.filters.searchTerm).toBe('first')
+
+            // Simulate props change (as BindLogic would do when parent re-renders with new props)
+            logsViewerFiltersLogic.build({
+                id: 'props-changed',
+                initialFilters: { searchTerm: 'second', severityLevels: ['warn'] },
+            })
+            await expectLogic(builtLogic).toFinishAllListeners()
+
+            expect(builtLogic.values.filters.searchTerm).toBe('second')
+            expect(builtLogic.values.filters.severityLevels).toEqual(['warn'])
+
+            builtLogic.unmount()
+        })
+
+        it('resets filters when initialFilters is removed', async () => {
+            const builtLogic = logsViewerFiltersLogic.build({
+                id: 'props-cleared',
+                initialFilters: { searchTerm: 'session_id:abc' },
+            })
+            builtLogic.mount()
+            await expectLogic(builtLogic).toFinishAllListeners()
+            expect(builtLogic.values.filters.searchTerm).toBe('session_id:abc')
+
+            // Simulate reopening without initialFilters
+            logsViewerFiltersLogic.build({ id: 'props-cleared', initialFilters: undefined })
+            await expectLogic(builtLogic).toFinishAllListeners()
+
+            expect(builtLogic.values.filters.searchTerm).toBe('')
+            expect(builtLogic.values.filters.severityLevels).toEqual([])
+            expect(builtLogic.values.filters.serviceNames).toEqual([])
+
+            builtLogic.unmount()
+        })
+    })
+
     describe('keyed instances', () => {
         it('maintains separate state for different keys', async () => {
             const logic1 = logsViewerFiltersLogic({ id: 'tab-1' })

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, propsChanged, props, reducers, selectors } from 'kea'
 import posthog from 'posthog-js'
 
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
@@ -23,6 +23,7 @@ export const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
 
 export interface LogsViewerFiltersLogicProps {
     id: string
+    initialFilters?: Partial<LogsViewerFilters>
 }
 
 export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
@@ -162,4 +163,25 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
             actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)
         },
     })),
+
+    propsChanged(({ actions, props: logicProps }, oldProps) => {
+        if (logicProps.initialFilters && logicProps.initialFilters !== oldProps.initialFilters) {
+            actions.setFilters(logicProps.initialFilters, false)
+        } else if (!logicProps.initialFilters && oldProps.initialFilters) {
+            actions.setFilters(
+                {
+                    searchTerm: '',
+                    severityLevels: DEFAULT_SEVERITY_LEVELS,
+                    serviceNames: DEFAULT_SERVICE_NAMES,
+                },
+                false
+            )
+        }
+    }),
+
+    afterMount(({ actions, props: logicProps }) => {
+        if (logicProps.initialFilters) {
+            actions.setFilters(logicProps.initialFilters, false)
+        }
+    }),
 ])

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -7,6 +7,7 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
 import { logsFilterHistoryLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterHistoryLogic'
@@ -28,11 +29,12 @@ const SCROLL_AMOUNT_PX = 8
 export interface LogsViewerProps {
     id: string
     showFullScreenButton?: boolean
+    initialFilters?: Partial<LogsViewerFilters>
 }
 
-export function LogsViewer({ id, showFullScreenButton = true }: LogsViewerProps): JSX.Element {
+export function LogsViewer({ id, showFullScreenButton = true, initialFilters }: LogsViewerProps): JSX.Element {
     return (
-        <BindLogic logic={logsViewerFiltersLogic} props={{ id }}>
+        <BindLogic logic={logsViewerFiltersLogic} props={{ id, initialFilters }}>
             <BindLogic logic={logsViewerConfigLogic} props={{ id }}>
                 <BindLogic logic={logsViewerDataLogic} props={{ id }}>
                     <BindLogic logic={logDetailsModalLogic} props={{ id }}>

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/LogsViewerModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/LogsViewerModal.tsx
@@ -11,7 +11,7 @@ import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { logsViewerModalLogic } from './logsViewerModalLogic'
 
 export function LogsViewerModal(): JSX.Element | null {
-    const { isOpen, viewerId, fullScreen } = useValues(logsViewerModalLogic)
+    const { isOpen, viewerId, fullScreen, initialFilters } = useValues(logsViewerModalLogic)
     const { closeLogsViewerModal } = useActions(logsViewerModalLogic)
     const [floatingContainer, setFloatingContainer] = useState<HTMLDivElement | null>(null)
     const floatingContainerRef = useCallback((el: HTMLDivElement | null) => setFloatingContainer(el), [])
@@ -35,7 +35,11 @@ export function LogsViewerModal(): JSX.Element | null {
                 </div>
                 <LemonModal.Content embedded className="flex flex-col flex-1 min-h-0 overflow-x-hidden">
                     <div className="flex-1 min-h-0 overflow-hidden p-2">
-                        <LogsViewer id={viewerId} showFullScreenButton={false} />
+                        <LogsViewer
+                            id={viewerId}
+                            showFullScreenButton={false}
+                            initialFilters={initialFilters ?? undefined}
+                        />
                     </div>
                 </LemonModal.Content>
                 <div ref={floatingContainerRef} />

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
@@ -86,6 +86,34 @@ describe('logsViewerModalLogic', () => {
         })
     })
 
+    describe('initialFilters', () => {
+        it('defaults to null', () => {
+            expect(logic.values.initialFilters).toBeNull()
+        })
+
+        it('stores provided initialFilters', async () => {
+            const filters = { searchTerm: 'session_id:abc' }
+            await expectLogic(logic, () => {
+                logic.actions.openLogsViewerModal({ initialFilters: filters })
+            }).toMatchValues({ initialFilters: filters })
+        })
+
+        it('defaults to null when not provided in options', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openLogsViewerModal({ id: 'some-id' })
+            }).toMatchValues({ initialFilters: null })
+        })
+
+        it('clears initialFilters on close', async () => {
+            logic.actions.openLogsViewerModal({ initialFilters: { searchTerm: 'test' } })
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.closeLogsViewerModal()
+            }).toMatchValues({ initialFilters: null })
+        })
+    })
+
     describe('open/close cycle', () => {
         it('restores all state on reopen with different options', async () => {
             logic.actions.openLogsViewerModal({ id: 'first', fullScreen: false })

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.ts
@@ -1,13 +1,22 @@
 import { actions, kea, path, reducers } from 'kea'
 
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
 import type { logsViewerModalLogicType } from './logsViewerModalLogicType'
+
+export interface OpenLogsViewerModalOptions {
+    id?: string
+    fullScreen?: boolean
+    initialFilters?: Partial<LogsViewerFilters>
+}
 
 export const logsViewerModalLogic = kea<logsViewerModalLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogsViewerModal', 'logsViewerModalLogic']),
     actions({
-        openLogsViewerModal: (options?: { id?: string; fullScreen?: boolean }) => ({
+        openLogsViewerModal: (options?: OpenLogsViewerModalOptions) => ({
             id: options?.id ?? 'modal',
             fullScreen: options?.fullScreen ?? true,
+            initialFilters: options?.initialFilters ?? null,
         }),
         closeLogsViewerModal: true,
     }),
@@ -29,6 +38,13 @@ export const logsViewerModalLogic = kea<logsViewerModalLogicType>([
             true,
             {
                 openLogsViewerModal: (_, { fullScreen }) => fullScreen,
+            },
+        ],
+        initialFilters: [
+            null as Partial<LogsViewerFilters> | null,
+            {
+                openLogsViewerModal: (_, { initialFilters }) => initialFilters,
+                closeLogsViewerModal: () => null,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

When opening the logs viewer modal from context (e.g. a session recording or error tracking), there's no way to pre-populate filters like session ID or service name. Users have to manually re-enter context they already had.

## Changes

- `openLogsViewerModal` now accepts `initialFilters?: Partial<LogsViewerFilters>` in its options
- Filters flow through: `logsViewerModalLogic` → `LogsViewerModal` → `LogsViewer` → `logsViewerFiltersLogic`
- `logsViewerFiltersLogic` applies initial filters via `afterMount` (first open) and `propsChanged` (subsequent opens with different filters)
- Filters are cleared when the modal closes

Usage:
```ts
openLogsViewerModal({
    initialFilters: { searchTerm: 'session_id:abc123', severityLevels: ['error'] },
})
```

## How did you test this code?

Unit tests added for both logsViewerModalLogic and logsViewerFiltersLogic covering:

- Storing and clearing initialFilters
- Applying filters on mount
- Applying new filters on props change
- No-op when no initial filters provided

## Publish to changelog?
No