### PR TITLE
chore(dashboard): make Edit Layout text explicit

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -190,18 +190,20 @@ export function DashboardHeader(): JSX.Element | null {
                         dashboardId={dashboard.id}
                         userAccessLevel={dashboard.user_access_level}
                     />
-                    {canEditDashboard && (
-                        <TextCardModal
-                            isOpen={showTextTileModal}
-                            onClose={() => push(urls.dashboard(dashboard.id))}
-                            dashboard={dashboard}
-                            textTileId={textTileId}
-                        />
-                    )}
-                    {canEditDashboard && <DeleteDashboardModal />}
-                    {canEditDashboard && <DuplicateDashboardModal />}
+                    {canEditDashboard ? (
+                        <>
+                            <TextCardModal
+                                isOpen={showTextTileModal}
+                                onClose={() => push(urls.dashboard(dashboard.id))}
+                                dashboard={dashboard}
+                                textTileId={textTileId}
+                            />
+                            <DeleteDashboardModal />
+                            <DuplicateDashboardModal />
+                            <DashboardInsightColorsModal />
+                        </>
+                    ) : null}
 
-                    {canEditDashboard && <DashboardInsightColorsModal />}
                     {user?.is_staff && <DashboardTemplateEditor />}
                     <TerraformExportModal
                         isOpen={terraformModalOpen}
@@ -535,7 +537,7 @@ export function DashboardHeader(): JSX.Element | null {
                             </LemonButton>
                         ) : (
                             <>
-                                {dashboard && (
+                                {dashboard ? (
                                     <>
                                         <LemonButton
                                             type="secondary"
@@ -546,26 +548,6 @@ export function DashboardHeader(): JSX.Element | null {
                                             tooltip="Share"
                                             tooltipPlacement="top"
                                         />
-                                        {canEditDashboard && hasTileRedesign && (
-                                            <LemonButton
-                                                type="secondary"
-                                                data-attr="dashboard-edit-mode-button"
-                                                onClick={() =>
-                                                    setDashboardMode(
-                                                        DashboardMode.Edit,
-                                                        DashboardEventSource.SceneCommonButtons
-                                                    )
-                                                }
-                                                size="small"
-                                                icon={<IconPencil fontSize="16" />}
-                                                tooltip="Edit layout"
-                                                tooltipPlacement="top"
-                                            />
-                                        )}
-                                    </>
-                                )}
-                                {dashboard ? (
-                                    <>
                                         <AccessControlAction
                                             resourceType={AccessControlResourceType.Dashboard}
                                             minAccessLevel={AccessControlLevel.Editor}
@@ -593,6 +575,22 @@ export function DashboardHeader(): JSX.Element | null {
                                                 </LemonButton>
                                             </AppShortcut>
                                         </AccessControlAction>
+                                        {canEditDashboard && hasTileRedesign && (
+                                            <LemonButton
+                                                type="secondary"
+                                                data-attr="dashboard-edit-mode-button"
+                                                onClick={() =>
+                                                    setDashboardMode(
+                                                        DashboardMode.Edit,
+                                                        DashboardEventSource.SceneCommonButtons
+                                                    )
+                                                }
+                                                size="small"
+                                                icon={<IconPencil fontSize="16" />}
+                                            >
+                                                Edit layout
+                                            </LemonButton>
+                                        )}
                                         <MaxTool
                                             identifier="upsert_dashboard"
                                             context={{


### PR DESCRIPTION
## Problem

In a recent dashboard survey, there were a number of complaints that it was hard to find the edit layout button since we moved to a icon only button, and edit layout with text is only found in the sidebar.

## Changes

Moved edit layout button next to add insight, as the most popular items, and added explicit text.

Before:
<img width="551" height="126" alt="image" src="https://github.com/user-attachments/assets/aae28153-e690-4c40-bf1c-13e5053c18d1" />

After:
<img width="548" height="167" alt="image" src="https://github.com/user-attachments/assets/acbf46d8-69b6-45f8-b904-b0301d3ca090" />


## How did you test this code?
Local

## Publish to changelog?

No
