### PR TITLE
chore: add LLM context section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@
 
 <!-- ## 🤖 LLM context -->
 
-<!-- If an LLM agent authored or co-authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
+<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,7 @@
 <!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
 
 <!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
+
+<!-- ## 🤖 LLM context -->
+
+<!-- If an LLM agent authored or co-authored this PR, uncomment this section and leave any relevant context about the session, tools used, or anything else that may help reviewers. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@
 
 <!-- ## 🤖 LLM context -->
 
-<!-- If an LLM agent authored or co-authored this PR, uncomment this section and leave any relevant context about the session, tools used, or anything else that may help reviewers. -->
+<!-- If an LLM agent authored or co-authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->


### PR DESCRIPTION
## Problem

When LLM agents open PRs, there's no standard place for them to leave context about the session, tools used, or other metadata that might help reviewers.

## Changes

Adds a commented-out "LLM context" section at the end of the PR template. It's invisible by default but gives agents a place to uncomment and add relevant info when they author or co-author a PR.

## How did you test this code?

Verified the template renders correctly with the new section commented out.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Claude Opus 4.6).