### PR TITLE
fix(devex): fixing wait for docker compose

### DIFF
--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -20,10 +20,25 @@ SERVICES+=("$@")
 # instead of actual service startup.  Wait for any running compose
 # process to finish first so the timeout only measures health-check time.
 COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
-if pgrep -f "docker compose.*up" >/dev/null 2>&1; then
+# Match only actual `docker` processes running `compose up`, not shell wrappers.
+# mprocs spawns `/bin/sh -c "... docker compose up -d && docker compose logs ..."`,
+# whose command string matches "docker compose.*up" even after `up` has finished.
+_docker_compose_up_running() {
+    local pids pid comm
+    pids=$(pgrep -f "docker compose.*up" 2>/dev/null) || return 1
+    for pid in $pids; do
+        comm=$(ps -p "$pid" -o comm= 2>/dev/null) || continue
+        case "${comm##*/}" in
+            sh|bash|zsh|fish) ;;
+            *) return 0 ;;
+        esac
+    done
+    return 1
+}
+if _docker_compose_up_running; then
     echo "docker compose is still running (likely pulling images) — waiting for it to finish…"
     compose_wait_start=$SECONDS
-    while pgrep -f "docker compose.*up" >/dev/null 2>&1; do
+    while _docker_compose_up_running; do
         if [ $(( SECONDS - compose_wait_start )) -ge "$COMPOSE_WAIT_TIMEOUT" ]; then
             echo "Timed out after ${COMPOSE_WAIT_TIMEOUT}s waiting for docker compose to finish. Proceeding anyway."
             break

--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -19,26 +19,15 @@ SERVICES+=("$@")
 # start checking health, the 300 s timeout burns on image downloads
 # instead of actual service startup.  Wait for any running compose
 # process to finish first so the timeout only measures health-check time.
-COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
-# Match only actual `docker` processes running `compose up`, not shell wrappers.
-# mprocs spawns `/bin/sh -c "... docker compose up -d && docker compose logs ..."`,
-# whose command string matches "docker compose.*up" even after `up` has finished.
-_docker_compose_up_running() {
-    local pids pid comm
-    pids=$(pgrep -f "docker compose.*up" 2>/dev/null) || return 1
-    for pid in $pids; do
-        comm=$(ps -p "$pid" -o comm= 2>/dev/null) || continue
-        case "${comm##*/}" in
-            sh|bash|zsh|fish) ;;
-            *) return 0 ;;
-        esac
-    done
-    return 1
-}
-if _docker_compose_up_running; then
+#
+# Only in CI — locally mprocs keeps a shell wrapper alive whose command
+# string matches "docker compose.*up" long after `up -d` has finished,
+# causing a permanent false positive.
+if [ -n "${CI:-}" ] && pgrep -f "docker compose.*up" >/dev/null 2>&1; then
+    COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
     echo "docker compose is still running (likely pulling images) — waiting for it to finish…"
     compose_wait_start=$SECONDS
-    while _docker_compose_up_running; do
+    while pgrep -f "docker compose.*up" >/dev/null 2>&1; do
         if [ $(( SECONDS - compose_wait_start )) -ge "$COMPOSE_WAIT_TIMEOUT" ]; then
             echo "Timed out after ${COMPOSE_WAIT_TIMEOUT}s waiting for docker compose to finish. Proceeding anyway."
             break


### PR DESCRIPTION
## Problem

it's causing waiting forever even when docker compose is up and not letting backend services to spin up

```
 backend: always required (configure via: hogli dev:setup)
Resolved 564 packages in 6ms
Audited 526 packages in 10ms
docker compose is still running (likely pulling images) — waiting for it to finish…
```

## Changes

improve the docker compose pgrep

## How did you test this code?

local works again 💥 

## Publish to changelog?

no