### PR TITLE
chore(mcp): add AI trace and span tracking for tool executions

### DIFF
--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -1,10 +1,11 @@
+import { env } from 'cloudflare:workers'
 import { PostHog } from 'posthog-node'
 
 const POSTHOG_API_KEY = 'sTMFPsFhdP1Ssg'
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 
-const DEV_POSTHOG_API_KEY = 'phc_C6h5hqm0bvKtlL5npVRSB62g5QWW3jtN31RQTQ8nBmE'
-const DEV_POSTHOG_HOST = 'http://localhost:8010'
+const DEV_POSTHOG_API_KEY = env.POSTHOG_ANALYTICS_API_KEY ?? POSTHOG_API_KEY
+const DEV_POSTHOG_HOST = env.POSTHOG_ANALYTICS_HOST ?? POSTHOG_HOST
 
 let _client: PostHog | undefined
 

--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -1,16 +1,30 @@
 import { PostHog } from 'posthog-node'
 
+const POSTHOG_API_KEY = 'sTMFPsFhdP1Ssg'
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+
+const DEV_POSTHOG_API_KEY = 'phc_C6h5hqm0bvKtlL5npVRSB62g5QWW3jtN31RQTQ8nBmE'
+const DEV_POSTHOG_HOST = 'http://localhost:8010'
+
 let _client: PostHog | undefined
 
 export enum AnalyticsEvent {
     MCP_TOOL_CALL = 'mcp tool call',
     MCP_TOOL_RESPONSE = 'mcp tool response',
+    AI_TRACE = '$ai_trace',
+    AI_SPAN = '$ai_span',
 }
 
-export const getPostHogClient = (): PostHog => {
+export function generateId(): string {
+    return crypto.randomUUID()
+}
+
+export const getPostHogClient = (devMode?: boolean): PostHog => {
     if (!_client) {
-        _client = new PostHog('sTMFPsFhdP1Ssg', {
-            host: 'https://us.i.posthog.com',
+        const apiKey = devMode ? DEV_POSTHOG_API_KEY : POSTHOG_API_KEY
+        const host = devMode ? DEV_POSTHOG_HOST : POSTHOG_HOST
+        _client = new PostHog(apiKey, {
+            host,
             flushAt: 1,
             flushInterval: 0,
         })

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { getPostHogClient } from '@/lib/analytics'
+import { CUSTOM_API_BASE_URL } from '@/lib/constants'
 
 export enum ErrorCode {
     INVALID_API_KEY = 'INVALID_API_KEY',
@@ -52,7 +53,7 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
         properties.$session_id = sessionUuid
     }
 
-    getPostHogClient().captureException(mcpError, distinctId, properties)
+    getPostHogClient(!!CUSTOM_API_BASE_URL).captureException(mcpError, distinctId, properties)
 
     return {
         content: [

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -5,7 +5,7 @@ import { McpAgent } from 'agents/mcp'
 import type { z } from 'zod'
 
 import { ApiClient } from '@/api/client'
-import { AnalyticsEvent, getPostHogClient } from '@/lib/analytics'
+import { AnalyticsEvent, generateId, getPostHogClient } from '@/lib/analytics'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import {
     CUSTOM_API_BASE_URL,
@@ -205,7 +205,7 @@ export class MCP extends McpAgent<Env> {
         try {
             const distinctId = await this.getDistinctId()
 
-            const client = getPostHogClient()
+            const client = getPostHogClient(!!CUSTOM_API_BASE_URL)
 
             await this.resolveClientInfo()
 
@@ -234,6 +234,11 @@ export class MCP extends McpAgent<Env> {
         handler: (params: z.infer<TSchema>) => Promise<any>
     ): void {
         const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
+            const traceId = generateId()
+            const spanId = generateId()
+            const spanName = `mcp/${tool.name}`
+            const startTime = performance.now()
+            const inputState = JSON.stringify(params)
             const validation = tool.schema.safeParse(params)
 
             if (!validation.success) {
@@ -242,10 +247,29 @@ export class MCP extends McpAgent<Env> {
                     valid_input: false,
                     input: params,
                 })
+                const latency = (performance.now() - startTime) / 1000
+                const errorOutput = `Invalid input: ${validation.error.message}`
+                const outputState = JSON.stringify(errorOutput)
+                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                    $ai_trace_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_latency: latency,
+                    $ai_is_error: true,
+                })
+                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
+                    $ai_trace_id: traceId,
+                    $ai_span_id: spanId,
+                    $ai_parent_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_input_state: inputState,
+                    $ai_output_state: outputState,
+                    $ai_latency: latency,
+                    $ai_is_error: true,
+                })
                 return [
                     {
                         type: 'text',
-                        text: `Invalid input: ${validation.error.message}`,
+                        text: errorOutput,
                     },
                 ]
             }
@@ -257,8 +281,25 @@ export class MCP extends McpAgent<Env> {
 
             try {
                 const result = await handler(params)
+                const latency = (performance.now() - startTime) / 1000
+                const outputState = JSON.stringify(result)
+
                 await this.trackEvent(AnalyticsEvent.MCP_TOOL_RESPONSE, {
                     tool: tool.name,
+                })
+                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                    $ai_trace_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_latency: latency,
+                })
+                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
+                    $ai_trace_id: traceId,
+                    $ai_span_id: spanId,
+                    $ai_parent_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_input_state: inputState,
+                    $ai_output_state: outputState,
+                    $ai_latency: latency,
                 })
 
                 // For tools with UI resources, include structuredContent for better UI rendering
@@ -291,6 +332,25 @@ export class MCP extends McpAgent<Env> {
                     ...(hasUiResource ? { structuredContent } : {}),
                 }
             } catch (error: any) {
+                const latency = (performance.now() - startTime) / 1000
+                const errorMessage = error instanceof Error ? error.message : String(error)
+                const outputState = JSON.stringify({ error: errorMessage })
+                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                    $ai_trace_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_latency: latency,
+                    $ai_is_error: true,
+                })
+                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
+                    $ai_trace_id: traceId,
+                    $ai_span_id: spanId,
+                    $ai_parent_id: traceId,
+                    $ai_span_name: spanName,
+                    $ai_input_state: inputState,
+                    $ai_output_state: outputState,
+                    $ai_latency: latency,
+                    $ai_is_error: true,
+                })
                 const distinctId = await this.getDistinctId()
                 return handleToolError(
                     error,

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -45,6 +45,16 @@ export type Env = {
      * PostHog API token for MCP Apps analytics (used for CSP and analytics ingestion).
      */
     POSTHOG_UI_APPS_TOKEN: string | undefined
+    /**
+     * PostHog API key for dev/self-hosted analytics.
+     * Falls back to the production US key if not set.
+     */
+    POSTHOG_ANALYTICS_API_KEY: string | undefined
+    /**
+     * PostHog host for dev/self-hosted analytics.
+     * Falls back to the production US host if not set.
+     */
+    POSTHOG_ANALYTICS_HOST: string | undefined
 }
 
 export type Context = {

--- a/services/mcp/tests/integration/feature-routing.test.ts
+++ b/services/mcp/tests/integration/feature-routing.test.ts
@@ -9,6 +9,8 @@ const createMockContext = (): Context => ({
     cache: {} as any,
     env: {
         INKEEP_API_KEY: undefined,
+        POSTHOG_ANALYTICS_API_KEY: undefined,
+        POSTHOG_ANALYTICS_HOST: undefined,
         POSTHOG_API_BASE_URL: undefined,
         POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: undefined,
         POSTHOG_UI_APPS_TOKEN: undefined,

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -99,6 +99,8 @@ const createMockContext = (scopes: string[]): Context => ({
     cache: {} as any,
     env: {
         INKEEP_API_KEY: undefined,
+        POSTHOG_ANALYTICS_API_KEY: undefined,
+        POSTHOG_ANALYTICS_HOST: undefined,
         POSTHOG_API_BASE_URL: undefined,
         POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: undefined,
         POSTHOG_UI_APPS_TOKEN: undefined,

--- a/services/mcp/worker-configuration.d.ts
+++ b/services/mcp/worker-configuration.d.ts
@@ -11,6 +11,8 @@ declare namespace Cloudflare {
 		POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: string;
 		POSTHOG_UI_APPS_TOKEN: string;
 		INKEEP_API_KEY: string;
+		POSTHOG_ANALYTICS_API_KEY: string;
+		POSTHOG_ANALYTICS_HOST: string;
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").MCP>;
 	}
 }


### PR DESCRIPTION
## Problem

MCP server tool executions aren't being tracked with PostHog's AI observability events (`$ai_trace` and `$ai_generation`), making it hard to monitor tool performance, latency, and errors.

## Changes

- Added `$ai_trace` and `$ai_generation` event tracking to all tool execution paths (success, validation error, runtime error)
- Made the PostHog analytics client configurable for dev/self-hosted environments via `POSTHOG_ANALYTICS_API_KEY` and `POSTHOG_ANALYTICS_HOST` env vars
- Each tool execution now generates a unique trace ID and span ID, records latency, input/output state, and error status

## How did you test this code?

Tested locally with the MCP server running against a dev PostHog instance, verified trace events are captured correctly for successful tool calls, validation errors, and runtime errors.

## Publish to changelog?

No