### PR TITLE
fix(surveys): track and display "No response" for optional choice questions

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -28,8 +28,9 @@ function QuestionTitle({
     question,
     questionIndex,
     totalResponses = 0,
+    noResponseCount = 0,
     displayedResponsesCount,
-}: Props & { totalResponses?: number; displayedResponsesCount?: number }): JSX.Element {
+}: Props & { totalResponses?: number; noResponseCount?: number; displayedResponsesCount?: number }): JSX.Element {
     const shouldShowAnalyzeButton =
         question.type === SurveyQuestionType.Open ||
         (question.type === SurveyQuestionType.SingleChoice && question.hasOpenChoice) ||
@@ -47,6 +48,12 @@ function QuestionTitle({
         metaParts.push({
             text: `${humanFriendlyNumber(totalResponses)} ${pluralize(totalResponses, 'response', 'responses', false)}`,
             className: 'text-text-secondary',
+        })
+    }
+    if (noResponseCount > 0) {
+        metaParts.push({
+            text: `${humanFriendlyNumber(noResponseCount)} skipped`,
+            className: 'text-muted',
         })
     }
     if (question.type === SurveyQuestionType.Open && displayedResponsesCount !== undefined && totalResponses > 0) {
@@ -231,9 +238,10 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
     }
 
     if (processedData.totalResponses === 0 || processedData.data.length === 0) {
+        const skipCount = 'noResponseCount' in processedData ? processedData.noResponseCount : 0
         return (
             <div className="flex flex-col gap-2">
-                <QuestionTitle question={question} questionIndex={questionIndex} />
+                <QuestionTitle question={question} questionIndex={questionIndex} noResponseCount={skipCount} />
 
                 <SurveyNoResponsesBanner type="question" />
             </div>
@@ -246,6 +254,7 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                 question={question}
                 questionIndex={questionIndex}
                 totalResponses={processedData.totalResponses}
+                noResponseCount={'noResponseCount' in processedData ? processedData.noResponseCount : 0}
                 displayedResponsesCount={
                     processedData.type === SurveyQuestionType.Open ? processedData.data.length : undefined
                 }

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -2078,6 +2078,7 @@ describe('mergeResponsesByQuestion', () => {
                 type: SurveyQuestionType.SingleChoice,
                 data: [{ label: 'Yes', value: 5, isPredefined: true }],
                 totalResponses: 6,
+                noResponseCount: 0,
             },
         }
         const openEnded: ResponsesByQuestion = {
@@ -2085,6 +2086,7 @@ describe('mergeResponsesByQuestion', () => {
                 type: SurveyQuestionType.SingleChoice,
                 data: [{ label: 'Custom answer', value: 1, isPredefined: false, distinctId: 'u1', timestamp: 'ts' }],
                 totalResponses: 0,
+                noResponseCount: 0,
             },
         }
 
@@ -2101,6 +2103,7 @@ describe('mergeResponsesByQuestion', () => {
                 type: SurveyQuestionType.Rating,
                 data: [{ label: '5', value: 10, isPredefined: true }],
                 totalResponses: 10,
+                noResponseCount: 0,
             },
         }
 

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -213,7 +213,11 @@ function processChoiceQuestion(
     const predefined = new Set(question.choices ?? [])
 
     let total = 0
-    const data: ChoiceQuestionResponseData[] = dataEntries
+    const noResponseEntry = entries.find(([l]) => l === '__no_response__')
+    const noResponseCount = noResponseEntry ? noResponseEntry[1] : 0
+    const filteredEntries = dataEntries.filter(([l]) => l !== '__no_response__')
+
+    const data: ChoiceQuestionResponseData[] = filteredEntries
         .map(([label, count]) => {
             if (questionType === SurveyQuestionType.SingleChoice) {
                 total += count
@@ -238,6 +242,7 @@ function processChoiceQuestion(
         type: questionType,
         data,
         totalResponses: total,
+        noResponseCount,
     }
 }
 
@@ -292,6 +297,7 @@ function processRatingQuestion(
         type: SurveyQuestionType.Rating,
         data,
         totalResponses: total,
+        noResponseCount: 0,
     }
 }
 

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -425,7 +425,7 @@ export function processOpenEndedResults(
             }
             const otherData = collectOpenChoiceResponses(question, type, rows, columnIndex, distinctIdIdx, timestampIdx)
             if (otherData.length > 0) {
-                result[questionId] = { type, data: otherData, totalResponses: 0 }
+                result[questionId] = { type, data: otherData, totalResponses: 0, noResponseCount: 0 }
             }
         }
     }

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -543,6 +543,14 @@ export function buildAggregateQuery(
             FROM events
             WHERE ${baseWhere} AND ${responseExpr} != ''
             GROUP BY label`)
+
+            if (question.type === SurveyQuestionType.SingleChoice && question.optional) {
+                branches.push(`SELECT '${question.id}' AS question_id,
+                    '__no_response__' AS label,
+                    count() AS cnt
+                FROM events
+                WHERE ${baseWhere} AND ${responseExpr} = ''`)
+            }
         } else if (question.type === SurveyQuestionType.MultipleChoice) {
             branches.push(`SELECT '${question.id}' AS question_id,
                 trim(BOTH '"\\'' FROM arrayJoin(${responseExpr})) AS label,
@@ -556,6 +564,14 @@ export function buildAggregateQuery(
                 count() AS cnt
             FROM events
             WHERE ${baseWhere} AND length(${responseExpr}) > 0`)
+
+            if (question.optional) {
+                branches.push(`SELECT '${question.id}' AS question_id,
+                    '__no_response__' AS label,
+                    count() AS cnt
+                FROM events
+                WHERE ${baseWhere} AND length(${responseExpr}) = 0`)
+            }
         } else if (question.type === SurveyQuestionType.Open) {
             branches.push(`SELECT '${question.id}' AS question_id,
                 '__total__' AS label,

--- a/frontend/src/scenes/surveys/utils/demoDataGenerator.ts
+++ b/frontend/src/scenes/surveys/utils/demoDataGenerator.ts
@@ -427,6 +427,7 @@ function processDemoResults(questions: SurveyQuestion[], rawResults: SurveyRawRe
                 type: question.type,
                 data,
                 totalResponses: total,
+                noResponseCount: 0,
             } as ChoiceQuestionProcessedResponses | OpenQuestionProcessedResponses
         }
     })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3316,6 +3316,7 @@ export interface ChoiceQuestionProcessedResponses {
     type: SurveyQuestionType.SingleChoice | SurveyQuestionType.Rating | SurveyQuestionType.MultipleChoice
     data: ChoiceQuestionResponseData[]
     totalResponses: number
+    noResponseCount: number
 }
 
 export interface OpenQuestionProcessedResponses {

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -739,10 +739,21 @@ class Command(BaseCommand):
             "response_sampling_daily_limits": None,
         }
 
-    def generate_response_for_question(self, question: dict[str, Any]) -> str | list[str] | None:
-        """Generate a realistic response for a given question type."""
+    def generate_response_for_question(
+        self, question: dict[str, Any], allow_skip: bool = True
+    ) -> str | list[str] | None:
+        """Generate a realistic response for a given question type.
+
+        If the question is optional and allow_skip is True, there's a chance
+        of returning None to simulate a skipped response.
+        """
+        is_optional = question.get("optional", False)
         question_type = question.get("type")
         question_text = question.get("question", "").lower()
+
+        # ~15% chance of skipping optional questions
+        if allow_skip and is_optional and random.random() < 0.15:
+            return None
 
         if question_type == "open":
             # Check for LLM feedback survey question


### PR DESCRIPTION
## Summary

Optional single/multiple choice questions silently dropped null responses. Skip rates were invisible.

Now tracks skip count and displays it as "X skipped" in the question header metadata (e.g., "Multiple choice · 76 responses · 12 skipped"). Chart and percentages stay clean. Denominator is still "people who answered."

![CleanShot 2026-03-05 at 14 40 32@2x](https://github.com/user-attachments/assets/f7f905c7-7d5a-4342-9f3b-17138b11cc6b)


Also updated the management command to generate ~15% null responses for optional questions.


## Test plan

- [ ] `python manage.py generate_random_surveys --wipe --responses 200 --question-types single_choice multiple_choice`
- [ ] Verify "X skipped" shows in question header for choice questions with skips
- [ ] Verify chart percentages still add up to ~100% for single choice
- [ ] Verify rating and open questions are unaffected