### PR TITLE
fix: Don't duplicate tags for OpenAPI schema

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -386,7 +386,9 @@ def custom_postprocessing_hook(result, generator, request, public):
                 path,
             )
             if match:
-                definition["tags"].append(match.group("one"))
+                tag = match.group("one")
+                if tag not in definition["tags"]:
+                    definition["tags"].append(tag)
             for tag in definition["tags"]:
                 all_tags.append(tag)
 


### PR DESCRIPTION
## Problem

Endpoints like `PersonViewSet` set `tags=["persons"]` via `@extend_schema`, but `custom_postprocessing_hook` in `documentation.py` also extracts "persons" from the URL path and appends it unconditionally — resulting in `["persons", "persons"]`. The docs site's OpenAPI parser interprets that as two separate groups, creating a "Persons-2" [page](https://posthog.com/docs/api/persons-2#post-api-environments-environment_id-persons-bulk_delete).

## Changes

Check if tag not in `definition["tags"]` before appending.