### PR TITLE
fix: add PostgreSQL connectivity check before migrations

### DIFF
--- a/bin/wait-for-postgres
+++ b/bin/wait-for-postgres
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Wait for PostgreSQL to accept connections on a given host:port.
+#
+# Unlike Docker health checks (which verify the container is healthy),
+# this script verifies that the HOST PORT BINDING is actually accepting
+# connections. This is important when:
+#   - Docker is recreating containers (due to --pull always)
+#   - Orbstack/Docker Desktop has stale network assignments
+#   - There's a brief gap between container "healthy" and port binding ready
+#
+# Usage:
+#   bin/wait-for-postgres [host:port] [timeout_seconds]
+#
+# Examples:
+#   bin/wait-for-postgres                    # localhost:5432, 60s timeout
+#   bin/wait-for-postgres localhost:5432 30  # custom timeout
+#   bin/wait-for-postgres db:5432            # Docker network host
+#
+set -euo pipefail
+
+HOST_PORT="${1:-localhost:5432}"
+TIMEOUT="${2:-60}"
+
+# Parse host and port
+HOST="${HOST_PORT%:*}"
+PORT="${HOST_PORT#*:}"
+if [ "$HOST" = "$PORT" ]; then
+    PORT=5432
+fi
+
+echo "Waiting for PostgreSQL at $HOST:$PORT (timeout: ${TIMEOUT}s)..."
+
+SECONDS=0
+while [ "$SECONDS" -lt "$TIMEOUT" ]; do
+    # Try to connect using pg_isready if available (most reliable)
+    if command -v pg_isready &>/dev/null; then
+        if pg_isready -h "$HOST" -p "$PORT" -q 2>/dev/null; then
+            echo "PostgreSQL at $HOST:$PORT is ready (${SECONDS}s)"
+            exit 0
+        fi
+    # Fall back to netcat/nc for TCP check
+    elif command -v nc &>/dev/null; then
+        if nc -z "$HOST" "$PORT" 2>/dev/null; then
+            echo "PostgreSQL at $HOST:$PORT is accepting connections (${SECONDS}s)"
+            exit 0
+        fi
+    # Fall back to bash /dev/tcp (works on most systems)
+    elif (echo >/dev/tcp/"$HOST"/"$PORT") 2>/dev/null; then
+        echo "PostgreSQL at $HOST:$PORT is accepting connections (${SECONDS}s)"
+        exit 0
+    else
+        echo "Error: No suitable tool found (pg_isready, nc, or bash /dev/tcp)" >&2
+        exit 1
+    fi
+
+    if [ "$((SECONDS % 10))" -eq 0 ] && [ "$SECONDS" -gt 0 ]; then
+        echo "  Still waiting for $HOST:$PORT... (${SECONDS}s)"
+    fi
+    sleep 1
+done
+
+echo ""
+echo "=========================================="
+echo "TIMEOUT: ${TIMEOUT}s waiting for PostgreSQL at $HOST:$PORT"
+echo "=========================================="
+echo ""
+echo "This can happen when:"
+echo "  1. Docker is still pulling images or recreating containers"
+echo "  2. Docker/Orbstack has stale network assignments"
+echo ""
+echo "Quick fix:"
+echo "  docker compose -f docker-compose.dev.yml down"
+echo "  docker network prune -f"
+echo "  docker compose -f docker-compose.dev.yml up -d"
+echo ""
+echo "Or use hogli to reset:"
+echo "  hogli docker:services:down && hogli start"
+echo "=========================================="
+exit 1

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -322,6 +322,32 @@ docker:
         description: Stop Docker infrastructure services
         services:
             - docker
+    docker:network:fix:
+        cmd: 'echo "Stopping all containers..."
+
+            docker stop $(docker ps -aq) 2>/dev/null || true
+
+            echo "Removing containers..."
+
+            docker rm $(docker ps -aq) 2>/dev/null || true
+
+            echo "Pruning Docker networks..."
+
+            docker network prune -f
+
+            echo "Restarting Docker services..."
+
+            docker compose -f docker-compose.dev.yml up -d
+
+            echo ""
+
+            echo "Network reset complete. Run ''hogli start'' to continue."
+
+            '
+        description: Fix stale Docker network assignments (helps with 'Connection refused'
+            errors after pulling)
+        services:
+            - docker
     docker:services:remove:
         cmd: docker compose -f docker-compose.dev.yml down -v
         description: Stop Docker infrastructure services and remove all volumes (complete
@@ -619,6 +645,10 @@ tools:
     generate_personhog_proto:
         bin_script: generate_personhog_proto.sh
         description: 'TODO: add description for generate_personhog_proto.sh'
+        hidden: true
+    wait:for:postgres:
+        bin_script: wait-for-postgres
+        description: 'TODO: add description for wait-for-postgres'
         hidden: true
 utilities:
     nuke:

--- a/rust/bin/migrate-cyclotron
+++ b/rust/bin/migrate-cyclotron
@@ -1,10 +1,24 @@
 #!/bin/sh
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+REPO_ROOT=$(dirname "$(dirname "$SCRIPT_DIR")")
 
 CYCLOTRON_DATABASE_NAME=${CYCLOTRON_DATABASE_NAME:-cyclotron}
 CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_DATABASE_NAME}
 
+# Extract host:port from database URL for connectivity check
+# URL format: postgres://user:pass@host:port/dbname
+PG_HOST_PORT=$(echo "$CYCLOTRON_DATABASE_URL" | sed -n 's|.*@\([^/]*\)/.*|\1|p')
+if [ -z "$PG_HOST_PORT" ]; then
+    PG_HOST_PORT="localhost:5432"
+fi
+
 echo "Performing cyclotron migrations for $CYCLOTRON_DATABASE_URL (DATABASE_NAME=$CYCLOTRON_DATABASE_NAME)"
+
+# Wait for PostgreSQL to accept connections on the host port
+# This is important because Docker health checks don't guarantee host port binding is ready
+if [ -x "$REPO_ROOT/bin/wait-for-postgres" ]; then
+    "$REPO_ROOT/bin/wait-for-postgres" "$PG_HOST_PORT" 60
+fi
 
 cd $SCRIPT_DIR/..
 

--- a/rust/bin/migrate-cyclotron-shadow
+++ b/rust/bin/migrate-cyclotron-shadow
@@ -1,10 +1,24 @@
 #!/bin/sh
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+REPO_ROOT=$(dirname "$(dirname "$SCRIPT_DIR")")
 
 CYCLOTRON_SHADOW_DATABASE_NAME=${CYCLOTRON_SHADOW_DATABASE_NAME:-cyclotron_shadow}
 CYCLOTRON_SHADOW_DATABASE_URL=${CYCLOTRON_SHADOW_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_SHADOW_DATABASE_NAME}
 
+# Extract host:port from database URL for connectivity check
+# URL format: postgres://user:pass@host:port/dbname
+PG_HOST_PORT=$(echo "$CYCLOTRON_SHADOW_DATABASE_URL" | sed -n 's|.*@\([^/]*\)/.*|\1|p')
+if [ -z "$PG_HOST_PORT" ]; then
+    PG_HOST_PORT="localhost:5432"
+fi
+
 echo "Performing cyclotron shadow migrations for $CYCLOTRON_SHADOW_DATABASE_URL (DATABASE_NAME=$CYCLOTRON_SHADOW_DATABASE_NAME)"
+
+# Wait for PostgreSQL to accept connections on the host port
+# This is important because Docker health checks don't guarantee host port binding is ready
+if [ -x "$REPO_ROOT/bin/wait-for-postgres" ]; then
+    "$REPO_ROOT/bin/wait-for-postgres" "$PG_HOST_PORT" 60
+fi
 
 cd $SCRIPT_DIR/..
 

--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -5,6 +5,57 @@ set -eE
 MIGRATION_TYPE=""
 FRESH_MODE=false
 
+# Wait for PostgreSQL to accept connections on a given URL
+# This handles the race condition where Docker health checks pass but
+# the host port binding isn't ready (common with Orbstack/Docker Desktop)
+wait_for_postgres() {
+    local db_url="$1"
+    local timeout="${2:-60}"
+
+    # Extract host:port from database URL
+    # URL format: postgres://user:pass@host:port/dbname
+    local host_port
+    host_port=$(echo "$db_url" | sed -n 's|.*@\([^/]*\)/.*|\1|p')
+    if [ -z "$host_port" ]; then
+        host_port="localhost:5432"
+    fi
+
+    local host="${host_port%:*}"
+    local port="${host_port#*:}"
+    if [ "$host" = "$port" ]; then
+        port=5432
+    fi
+
+    log_json "info" "Waiting for PostgreSQL" "waiting" "" "\"host\":\"$host\",\"port\":$port,\"timeout\":$timeout"
+
+    local seconds=0
+    while [ "$seconds" -lt "$timeout" ]; do
+        # Try pg_isready if available
+        if command -v pg_isready &>/dev/null; then
+            if pg_isready -h "$host" -p "$port" -q 2>/dev/null; then
+                log_json "info" "PostgreSQL is ready" "ready" "" "\"elapsed_seconds\":$seconds"
+                return 0
+            fi
+        # Fall back to netcat
+        elif command -v nc &>/dev/null; then
+            if nc -z "$host" "$port" 2>/dev/null; then
+                log_json "info" "PostgreSQL is accepting connections" "ready" "" "\"elapsed_seconds\":$seconds"
+                return 0
+            fi
+        # Fall back to bash /dev/tcp
+        elif (echo >/dev/tcp/"$host"/"$port") 2>/dev/null; then
+            log_json "info" "PostgreSQL is accepting connections" "ready" "" "\"elapsed_seconds\":$seconds"
+            return 0
+        fi
+
+        sleep 1
+        seconds=$((seconds + 1))
+    done
+
+    log_json "error" "Timeout waiting for PostgreSQL" "timeout" "" "\"host\":\"$host\",\"port\":$port,\"timeout\":$timeout"
+    return 1
+}
+
 parse_args() {
     MIGRATION_TYPE="$1"
     shift || true
@@ -86,6 +137,9 @@ run_persons_migrations() {
     PERSONS_DATABASE_NAME=${PERSONS_DATABASE_NAME:-posthog_persons}
     PERSONS_DATABASE_URL=${PERSONS_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$PERSONS_DATABASE_NAME}
 
+    # Wait for PostgreSQL to be ready before starting migrations
+    wait_for_postgres "$PERSONS_DATABASE_URL" 60
+
     log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$PERSONS_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
     if [ "$FRESH_MODE" = true ]; then
@@ -105,6 +159,9 @@ run_cyclotron_migrations() {
     CYCLOTRON_DATABASE_NAME=${CYCLOTRON_DATABASE_NAME:-cyclotron}
     CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_DATABASE_NAME}
 
+    # Wait for PostgreSQL to be ready before starting migrations
+    wait_for_postgres "$CYCLOTRON_DATABASE_URL" 60
+
     log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
     if [ "$FRESH_MODE" = true ]; then
@@ -123,6 +180,9 @@ run_cyclotron_shadow_migrations() {
     local db_type="cyclotron-shadow"
     CYCLOTRON_SHADOW_DATABASE_NAME=${CYCLOTRON_SHADOW_DATABASE_NAME:-cyclotron_shadow}
     CYCLOTRON_SHADOW_DATABASE_URL=${CYCLOTRON_SHADOW_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_SHADOW_DATABASE_NAME}
+
+    # Wait for PostgreSQL to be ready before starting migrations
+    wait_for_postgres "$CYCLOTRON_SHADOW_DATABASE_URL" 60
 
     log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_SHADOW_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
@@ -148,6 +208,9 @@ run_behavioral_cohorts_migrations() {
     DB_PASS="${POSTGRES_BEHAVIORAL_COHORTS_PASSWORD:-posthog}"
 
     BEHAVIORAL_COHORTS_DATABASE_URL=${BEHAVIORAL_COHORTS_DATABASE_URL:-postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/$BEHAVIORAL_COHORTS_DATABASE_NAME}
+
+    # Wait for PostgreSQL to be ready before starting migrations
+    wait_for_postgres "$BEHAVIORAL_COHORTS_DATABASE_URL" 60
 
     log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$BEHAVIORAL_COHORTS_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 


### PR DESCRIPTION
This addresses the "Connection refused (os error 61)" errors that occur when running migrations after pulling master, particularly on Orbstack.

Root cause: Docker health checks verify container health, but not that the host port binding (localhost:5432) is ready. When `--pull always` recreates containers, there's a race condition where migrations can start before the port is accepting connections.

Changes:
- Add bin/wait-for-postgres: waits for actual TCP connectivity
- Update rust/bin/migrate-cyclotron to use wait-for-postgres
- Update rust/bin/migrate-cyclotron-shadow to use wait-for-postgres
- Update rust/bin/migrate-entry to include wait_for_postgres() helper
- Add docker:network:fix hogli command for quick network recovery

https://claude.ai/code/session_01TVME6tNs7TAdZyjTqeJu4R

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
