### PR TITLE
feat: Add Page Leave Health Check to Dagster

### DIFF
--- a/frontend/src/scenes/health/healthCategories.tsx
+++ b/frontend/src/scenes/health/healthCategories.tsx
@@ -43,6 +43,7 @@ export const HEALTH_CATEGORY_CONFIG: Record<HealthIssueCategory, CategoryConfig>
 const KIND_TO_CATEGORY: Record<string, HealthIssueCategory> = {
     // Ingestion
     no_live_events: 'ingestion',
+    no_pageleave_events: 'ingestion',
     ingestion_lag: 'ingestion',
 
     // SDKs
@@ -51,6 +52,7 @@ const KIND_TO_CATEGORY: Record<string, HealthIssueCategory> = {
 
 export const KIND_LABELS: Record<string, string> = {
     no_live_events: 'No live events',
+    no_pageleave_events: 'No pageleave events',
     ingestion_lag: 'Ingestion lag',
     sdk_outdated: 'SDK outdated',
 }

--- a/posthog/dags/locations/shared.py
+++ b/posthog/dags/locations/shared.py
@@ -5,6 +5,7 @@ from posthog.clickhouse.custom_metrics import MetricsClient
 from posthog.dags import slack_alerts
 
 from products.web_analytics.dags.no_live_events import no_live_events_check
+from products.web_analytics.dags.no_pageleave_events import no_pageleave_events_check
 
 from . import resources
 
@@ -26,8 +27,9 @@ def report_job_status_metric(
 defs = dagster.Definitions(
     jobs=[
         # Health Checks
-        # Web Analytics
+        # Ingestion
         no_live_events_check.job,
+        no_pageleave_events_check.job,
     ],
     sensors=[
         slack_alerts.notify_slack_on_failure,

--- a/products/web_analytics/backend/test/test_no_pageleave_events.py
+++ b/products/web_analytics/backend/test/test_no_pageleave_events.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.models.health_issue import HealthIssue
+
+from products.web_analytics.dags.no_pageleave_events import detect_no_pageleave_events
+
+
+@pytest.mark.parametrize(
+    "mock_rows, expected_teams",
+    [
+        ([], set()),
+        ([(42,)], {42}),
+        ([(1,), (3,)], {1, 3}),
+    ],
+    ids=["all_healthy", "single_team_missing_pageleave", "multiple_teams_mixed"],
+)
+@patch("products.web_analytics.dags.no_pageleave_events.execute_clickhouse_health_team_query")
+def test_detect_no_pageleave_events(mock_query: MagicMock, mock_rows: list, expected_teams: set) -> None:
+    mock_query.return_value = mock_rows
+    context = MagicMock()
+
+    result = detect_no_pageleave_events([1, 2, 3, 42], context)
+
+    assert set(result.keys()) == expected_teams
+    for team_id in expected_teams:
+        issues = result[team_id]
+        assert len(issues) == 1
+        assert issues[0].severity == HealthIssue.Severity.WARNING
+        assert "$pageleave" in issues[0].payload["reason"]

--- a/products/web_analytics/dags/no_pageleave_events.py
+++ b/products/web_analytics/dags/no_pageleave_events.py
@@ -1,0 +1,53 @@
+import dagster
+
+from posthog.dags.common import JobOwners
+from posthog.dags.common.health.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY, batch_detector
+from posthog.dags.common.health.framework import create_health_check
+from posthog.dags.common.health.query import execute_clickhouse_health_team_query
+from posthog.dags.common.health.types import HealthCheckResult
+from posthog.models.health_issue import HealthIssue
+
+NO_PAGELEAVE_LOOKBACK_DAYS = 30
+NO_PAGELEAVE_SQL = """
+SELECT team_id
+FROM events
+WHERE team_id IN %(team_ids)s
+  AND event IN ('$pageview', '$pageleave')
+  AND timestamp >= now() - INTERVAL %(lookback_days)s DAY
+GROUP BY team_id
+HAVING countIf(event = '$pageview') > 0
+   AND countIf(event = '$pageleave') = 0
+"""
+
+
+def detect_no_pageleave_events(
+    team_ids: list[int], context: dagster.OpExecutionContext
+) -> dict[int, list[HealthCheckResult]]:
+    rows = execute_clickhouse_health_team_query(
+        NO_PAGELEAVE_SQL,
+        team_ids=team_ids,
+        lookback_days=NO_PAGELEAVE_LOOKBACK_DAYS,
+        context=context,
+    )
+
+    issues: dict[int, list[HealthCheckResult]] = {}
+    for (team_id,) in rows:
+        issues[team_id] = [
+            HealthCheckResult(
+                severity=HealthIssue.Severity.WARNING,
+                payload={
+                    "reason": f"Team has $pageview events but no $pageleave events in last {NO_PAGELEAVE_LOOKBACK_DAYS} days"
+                },
+                hash_keys=[],
+            )
+        ]
+
+    return issues
+
+
+no_pageleave_events_check = create_health_check(
+    name="no_pageleave_events",
+    kind="no_pageleave_events",
+    detector=batch_detector(detect_no_pageleave_events, **CLICKHOUSE_BATCH_EXECUTION_POLICY),
+    owner=JobOwners.TEAM_WEB_ANALYTICS,
+)


### PR DESCRIPTION
## Problem
The page leave event health check needs to be migrated over to Dagster

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new health check job

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, small smoke test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
