### PR TITLE
feat(flags): add timeout to rayon semaphore

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -125,6 +125,8 @@ pub enum FlagError {
     DataParsingError,
     #[error("Parallel batch evaluation task panicked")]
     BatchEvaluationPanicked,
+    #[error("Rayon semaphore acquisition timed out after {0}ms")]
+    RayonSemaphoreTimeout(u64),
     #[error(transparent)]
     CookielessError(#[from] CookielessManagerError),
 }
@@ -174,6 +176,7 @@ impl FlagError {
             FlagError::DataParsingError => ("data_parsing_error", 500),
             FlagError::BatchEvaluationPanicked => ("batch_evaluation_panicked", 500),
             FlagError::HashKeyOverrideError => ("hash_key_override_error", 500),
+            FlagError::RayonSemaphoreTimeout(_) => ("rayon_semaphore_timeout", 504),
 
             // Data parsing errors (500) - internal errors, not service unavailability
             FlagError::DataParsingErrorWithContext(_) => ("flag_data_parsing_error", 500),
@@ -316,6 +319,8 @@ impl FlagError {
             | FlagError::BatchEvaluationPanicked
             | FlagError::DataParsingErrorWithContext(_)
             | FlagError::HashKeyOverrideError => StatusCode::INTERNAL_SERVER_ERROR,
+
+            FlagError::RayonSemaphoreTimeout(_) => StatusCode::GATEWAY_TIMEOUT,
 
             FlagError::RedisUnavailable
             | FlagError::DatabaseUnavailable
@@ -509,6 +514,10 @@ impl IntoResponse for FlagError {
                 tracing::error!("Parallel batch evaluation task panicked");
                 (StatusCode::INTERNAL_SERVER_ERROR, "An internal error occurred during flag evaluation. Please try again later.".to_string())
             }
+            FlagError::RayonSemaphoreTimeout(ms) => {
+                tracing::warn!("Rayon semaphore acquisition timed out after {}ms", ms);
+                (StatusCode::GATEWAY_TIMEOUT, format!("Evaluation pool busy, timed out after {ms}ms. Please retry."))
+            }
             FlagError::CookielessError(err) => {
                 match err {
                     // 400 Bad Request errors - client-side issues
@@ -622,6 +631,7 @@ mod tests {
         assert!(FlagError::RedisUnavailable.is_5xx());
         assert!(FlagError::TimeoutError(None).is_5xx());
         assert!(FlagError::BatchEvaluationPanicked.is_5xx());
+        assert!(FlagError::RayonSemaphoreTimeout(800).is_5xx());
         assert!(FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).is_5xx());
 
         // Test 4XX errors
@@ -740,6 +750,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::RayonSemaphoreTimeout(800),
             CookielessManagerError::MissingProperty("test".to_string()).into(), // CookielessError
         ];
 
@@ -793,6 +804,8 @@ mod tests {
         assert_eq!(FlagError::PersonNotFound.status_code(), 503);
         assert_eq!(FlagError::PropertiesNotInCache.status_code(), 503);
         assert_eq!(FlagError::StaticCohortMatchesNotCached.status_code(), 503);
+        // Semaphore timeout is 504 (gateway timeout for ingress retry)
+        assert_eq!(FlagError::RayonSemaphoreTimeout(800).status_code(), 504);
     }
 
     #[test]
@@ -841,6 +854,7 @@ mod tests {
             FlagError::DependencyCycle(DependencyType::Cohort, 2),
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::RayonSemaphoreTimeout(800),
             FlagError::DataParsingErrorWithContext("test".to_string()),
             FlagError::RedisUnavailable,
             FlagError::DatabaseUnavailable,
@@ -954,6 +968,7 @@ mod tests {
             FlagError::CacheMiss,
             FlagError::DataParsingError,
             FlagError::BatchEvaluationPanicked,
+            FlagError::RayonSemaphoreTimeout(800),
             CookielessManagerError::MissingProperty("test".to_string()).into(),
         ];
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -486,6 +486,13 @@ pub struct Config {
     #[envconfig(from = "MAX_CONCURRENT_BATCH_EVALS", default = "0")]
     pub max_concurrent_batch_evals: usize,
 
+    // Maximum time (ms) to wait for a Rayon semaphore permit before failing fast.
+    // When the wait exceeds this threshold, the request returns 504 so that
+    // ingress can retry it on a less-loaded pod.
+    // 0 = no timeout (await indefinitely, backwards-compatible).
+    #[envconfig(from = "RAYON_SEMAPHORE_TIMEOUT_MS", default = "0")]
+    pub rayon_semaphore_timeout_ms: u64,
+
     // When true, skip all writes to PostgreSQL and Redis.
     // Used to safely deploy and test the personhog migration path
     // without risking any data mutations.
@@ -695,6 +702,7 @@ impl Config {
             optimize_experience_continuity_lookups: FlexBool(true),
             parallel_eval_threshold: 100,
             max_concurrent_batch_evals: 0,
+            rayon_semaphore_timeout_ms: 0,
             skip_writes: FlexBool(false),
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -334,7 +334,7 @@ impl FeatureFlagMatcher {
         request_id: Uuid,
         flag_keys: Option<Vec<String>>,
         optimize_experience_continuity_lookups: bool,
-    ) -> FlagsResponse {
+    ) -> Result<FlagsResponse, FlagError> {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
 
         // Build dependency graph once - reused for both optimization check and evaluation
@@ -344,7 +344,7 @@ impl FeatureFlagMatcher {
             flags_with_missing_deps: global_flags_with_missing_deps,
         } = match build_dependency_graph(&feature_flags, self.team_id) {
             Some(result) => result,
-            None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
+            None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
         };
 
         // Filter graph by flag_keys if specified (includes transitive dependencies)
@@ -358,7 +358,7 @@ impl FeatureFlagMatcher {
                     graph,
                     flags_with_missing_deps,
                 }) => (graph, flags_with_missing_deps),
-                None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
+                None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
             }
         } else {
             (global_dependency_graph, global_flags_with_missing_deps)
@@ -451,7 +451,7 @@ impl FeatureFlagMatcher {
                 dependency_graph,
                 flags_with_missing_deps,
             )
-            .await;
+            .await?;
 
         let has_cycle_errors = graph_errors.iter().any(|e| e.is_cycle());
         let has_errors = flag_hash_key_override_error
@@ -462,7 +462,12 @@ impl FeatureFlagMatcher {
             .label("outcome", if has_errors { "error" } else { "success" })
             .fin();
 
-        FlagsResponse::new(has_errors, flags_response.flags, None, request_id)
+        Ok(FlagsResponse::new(
+            has_errors,
+            flags_response.flags,
+            None,
+            request_id,
+        ))
     }
 
     /// Processes hash key overrides for feature flags with experience continuity enabled.
@@ -632,7 +637,7 @@ impl FeatureFlagMatcher {
         request_id: Uuid,
         dependency_graph: DependencyGraph<FeatureFlag>,
         flags_with_missing_deps: HashSet<i32>,
-    ) -> FlagsResponse {
+    ) -> Result<FlagsResponse, FlagError> {
         let mut errors_while_computing_flags = overrides.hash_key_override_error;
         let mut evaluated_flags_map = HashMap::new();
 
@@ -677,15 +682,15 @@ impl FeatureFlagMatcher {
                 &mut evaluated_flags_map,
                 &flags_with_missing_deps,
             )
-            .await;
+            .await?;
         errors_while_computing_flags |= graph_evaluation_errors;
 
-        FlagsResponse::new(
+        Ok(FlagsResponse::new(
             errors_while_computing_flags,
             evaluated_flags_map,
             None,
             request_id,
-        )
+        ))
     }
 
     /// Evaluates flags using the provided dependency graph.
@@ -700,13 +705,13 @@ impl FeatureFlagMatcher {
         request_hash_key_override: &Option<String>,
         evaluated_flags_map: &mut HashMap<String, FlagDetails>,
         flags_with_missing_deps: &HashSet<i32>,
-    ) -> bool {
+    ) -> Result<bool, FlagError> {
         // Consume the graph to get owned flags in evaluation order
         let evaluation_stages = match flag_dependency_graph.into_evaluation_stages() {
             Ok(stages) => stages,
             Err(e) => {
                 log_dependency_graph_operation_error("get evaluation stages", &e, self.team_id);
-                return true;
+                return Ok(true);
             }
         };
 
@@ -723,12 +728,12 @@ impl FeatureFlagMatcher {
                     request_hash_key_override,
                     flags_with_missing_deps,
                 )
-                .await;
+                .await?;
             errors_while_computing_flags |= level_errors;
             evaluated_flags_map.extend(level_evaluated_flags_map);
         }
 
-        errors_while_computing_flags
+        Ok(errors_while_computing_flags)
     }
 
     /// Prepares evaluation state for flags that require database properties.
@@ -813,7 +818,7 @@ impl FeatureFlagMatcher {
         hash_key_overrides: &Option<HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
         flags_with_missing_deps: &HashSet<i32>,
-    ) -> (HashMap<String, FlagDetails>, bool) {
+    ) -> Result<(HashMap<String, FlagDetails>, bool), FlagError> {
         let mut errors_while_computing_flags = false;
         let mut level_evaluated_flags_map = HashMap::new();
 
@@ -877,7 +882,7 @@ impl FeatureFlagMatcher {
                         hash_key_overrides,
                         request_hash_key_override,
                     )
-                    .await;
+                    .await?;
 
                 for (flag, result) in &results {
                     self.process_flag_result(
@@ -901,7 +906,7 @@ impl FeatureFlagMatcher {
             )
             .fin();
 
-        (level_evaluated_flags_map, errors_while_computing_flags)
+        Ok((level_evaluated_flags_map, errors_while_computing_flags))
     }
 
     /// Pre-compute property overrides for all flags upfront.
@@ -1024,7 +1029,7 @@ impl FeatureFlagMatcher {
         flags_with_missing_deps: &HashSet<i32>,
         hash_key_overrides: &Option<HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
-    ) -> Vec<(FeatureFlag, Result<FeatureFlagMatch, FlagError>)> {
+    ) -> Result<Vec<(FeatureFlag, Result<FeatureFlagMatch, FlagError>)>, FlagError> {
         let matcher = self.clone();
         let missing_deps = flags_with_missing_deps.clone();
         let hash_overrides = hash_key_overrides.clone();
@@ -1062,7 +1067,10 @@ impl FeatureFlagMatcher {
         };
 
         let result = match &self.rayon_dispatcher {
-            Some(dispatcher) => dispatcher.spawn(work).await,
+            Some(dispatcher) => dispatcher
+                .try_spawn(work)
+                .await
+                .map_err(|t| FlagError::RayonSemaphoreTimeout(t.waited.as_millis() as u64))?,
             None => {
                 // Fallback for tests: unbounded dispatch (no semaphore).
                 let (tx, rx) = tokio::sync::oneshot::channel();
@@ -1084,7 +1092,7 @@ impl FeatureFlagMatcher {
                 .collect()
         });
 
-        results_with_deltas
+        Ok(results_with_deltas
             .into_iter()
             .map(|(flag, result, delta)| {
                 if let Some(delta) = delta {
@@ -1092,7 +1100,7 @@ impl FeatureFlagMatcher {
                 }
                 (flag, result)
             })
-            .collect()
+            .collect())
     }
 
     /// Constructs per-flag error results from lightweight snapshots when the

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -214,7 +214,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
         assert!(!result.errors_while_computing_flags);
         assert_eq!(
             result.flags.get("test_flag").unwrap().to_value(),
@@ -304,7 +305,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
         assert!(!legacy_response.errors_while_computing_flags);
@@ -395,7 +397,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("independent_flag").unwrap().to_value(),
@@ -426,7 +429,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("independent_flag").unwrap().to_value(),
@@ -557,7 +561,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -580,7 +585,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -603,7 +609,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -722,7 +729,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
         // Add this assertion to check the call count
         let fetch_calls = get_fetch_calls_count();
         assert_eq!(fetch_calls, 1, "Expected fetch_and_locally_cache_all_relevant_properties to be called exactly 1 time, but it was called {fetch_calls} times");
@@ -858,7 +866,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             // Cycle errors still cause errors_while_computing_flags to be true
             assert!(result.errors_while_computing_flags);
             assert_eq!(
@@ -894,7 +903,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             // Cycle errors still cause errors_while_computing_flags to be true
             assert!(result.errors_while_computing_flags);
             assert_eq!(
@@ -1021,7 +1031,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -1045,7 +1056,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -1068,7 +1080,8 @@ mod tests {
                     None,
                     false,
                 )
-                .await;
+                .await
+                .unwrap();
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
                 result.flags.get("leaf_flag").unwrap().to_value(),
@@ -1374,7 +1387,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         let fetch_calls = get_fetch_calls_count();
         assert_eq!(
@@ -3561,7 +3575,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .unwrap();
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
         assert!(
@@ -3646,7 +3661,8 @@ mod tests {
             None,
         )
         .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None, false)
-        .await;
+        .await
+        .unwrap();
 
         assert!(result.flags.get("flag_continuity_missing").unwrap().enabled);
 
@@ -3782,7 +3798,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .unwrap();
 
         let legacy_response = LegacyFlagsResponse::from_response(result);
         assert!(
@@ -4471,7 +4488,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         // Should succeed because we have overrides
         assert!(!result.errors_while_computing_flags);
@@ -5217,7 +5235,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         let fetch_calls = get_fetch_calls_count();
         assert_eq!(
@@ -5258,7 +5277,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result2.errors_while_computing_flags);
         let flag_result2 = result2.flags.get(&flag.key).unwrap();
@@ -5293,7 +5313,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result3.errors_while_computing_flags);
         let flag_result3 = result3.flags.get(&flag.key).unwrap();
@@ -5330,7 +5351,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result4.errors_while_computing_flags);
         let flag_result4 = result4.flags.get(&flag.key).unwrap();
@@ -5488,7 +5510,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result.errors_while_computing_flags);
         // The flag should evaluate using DB properties for condition 1 (which has feature_access="full")
@@ -5529,7 +5552,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result2.errors_while_computing_flags);
         let flag_result2 = result2.flags.get(&flag.key).unwrap();
@@ -5570,7 +5594,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result3.errors_while_computing_flags);
         let flag_result3 = result3.flags.get(&flag.key).unwrap();
@@ -5607,7 +5632,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result4.errors_while_computing_flags);
         let flag_result4 = result4.flags.get(&flag.key).unwrap();
@@ -5648,7 +5674,8 @@ mod tests {
                 None,
                 false,
             )
-            .await;
+            .await
+            .unwrap();
 
         assert!(!result5.errors_while_computing_flags);
         let flag_result5 = result5.flags.get(&flag.key).unwrap();
@@ -5866,7 +5893,8 @@ mod tests {
                 graph_result.graph,
                 graph_result.flags_with_missing_deps,
             )
-            .await;
+            .await
+            .unwrap();
 
         // Should have errors_while_computing_flags set to true
         assert!(
@@ -6031,7 +6059,8 @@ mod tests {
                 graph_result.graph,
                 graph_result.flags_with_missing_deps,
             )
-            .await;
+            .await
+            .unwrap();
 
         // Disabled base flag should NOT be in the response (only active flags are returned)
         assert!(
@@ -6132,7 +6161,8 @@ mod tests {
                 graph_result.graph,
                 graph_result.flags_with_missing_deps,
             )
-            .await;
+            .await
+            .unwrap();
 
         // Disabled standalone flag should NOT be in the response
         assert!(
@@ -6217,7 +6247,8 @@ mod tests {
             None,
             true, // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the optimization actually skipped the hash key override lookup
         let lookup_count = get_hash_key_override_lookup_count();
@@ -6307,7 +6338,8 @@ mod tests {
             None,
             true, // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the lookup DID happen for partial rollout (optimization doesn't skip it)
         let lookup_count = get_hash_key_override_lookup_count();
@@ -6410,7 +6442,8 @@ mod tests {
             None,
             true, // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the lookup DID happen for multivariate (optimization doesn't skip it)
         let lookup_count = get_hash_key_override_lookup_count();
@@ -6518,7 +6551,8 @@ mod tests {
             None,
             true, // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the optimization skipped the lookup (100% variant = no hashing needed)
         let lookup_count = get_hash_key_override_lookup_count();
@@ -6610,7 +6644,8 @@ mod tests {
             None,
             false, // optimization disabled (legacy behavior)
         )
-        .await;
+        .await
+        .unwrap();
 
         // Flag should still evaluate correctly in legacy mode
         assert!(
@@ -6742,7 +6777,8 @@ mod tests {
             None,
             true, // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the lookup DID happen because flag_needs_lookup requires it.
         // Even though flag_optimizable could be optimized, the presence of
@@ -6878,7 +6914,8 @@ mod tests {
             Some(vec!["flag_optimizable".to_string()]), // Only request the optimizable flag
             true,                                       // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify the lookup was SKIPPED because we only requested flag_optimizable,
         // which is 100% rollout and doesn't need the hash key override lookup.
@@ -7020,7 +7057,8 @@ mod tests {
             Some(vec!["flag_depends_on_b".to_string()]), // Only request the dependent flag
             true,                                        // optimization enabled
         )
-        .await;
+        .await
+        .unwrap();
 
         // The lookup SHOULD happen because flag_needs_lookup (a dependency) requires it,
         // even though flag_depends_on_b itself wouldn't need it (100% rollout).
@@ -7120,7 +7158,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .unwrap();
 
         // Verify no DB fetch was needed since all required properties are in overrides
         let fetch_calls = get_fetch_calls_count();
@@ -7229,7 +7268,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(
             !result.errors_while_computing_flags,
@@ -7331,7 +7371,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(
             !result.errors_while_computing_flags,

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::types::FlagsResponse,
+    api::{errors::FlagError, types::FlagsResponse},
     database::PostgresRouter,
     flags::{flag_group_type_mapping::GroupTypeMappingCache, flag_matching::FeatureFlagMatcher},
 };
@@ -11,7 +11,7 @@ use super::types::FeatureFlagEvaluationContext;
 pub async fn evaluate_feature_flags(
     context: FeatureFlagEvaluationContext,
     request_id: Uuid,
-) -> FlagsResponse {
+) -> Result<FlagsResponse, FlagError> {
     let group_type_mapping_cache = GroupTypeMappingCache::new(context.team_id);
 
     // Create router from the context

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -232,14 +232,14 @@ pub async fn evaluate_for_request(
     request_id: Uuid,
     disable_flags: bool,
     flag_keys: Option<Vec<String>>,
-) -> FlagsResponse {
+) -> Result<FlagsResponse, FlagError> {
     // If flags are disabled, return empty FlagsResponse
     if disable_flags {
-        return FlagsResponse::new(false, HashMap::new(), None, request_id);
+        return Ok(FlagsResponse::new(false, HashMap::new(), None, request_id));
     }
 
     if filtered_flags.flags.is_empty() {
-        return FlagsResponse::new(false, HashMap::new(), None, request_id);
+        return Ok(FlagsResponse::new(false, HashMap::new(), None, request_id));
     }
 
     let ctx = FeatureFlagEvaluationContext {

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -211,7 +211,7 @@ async fn process_request_inner(
                 request.is_flags_disabled(),
                 request.flag_keys.clone(),
             )
-            .await;
+            .await?;
 
             // Only record billing if flags are not disabled
             if !request.is_flags_disabled() {

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -193,13 +193,15 @@ async fn test_evaluate_feature_flags() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
 
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
 
     assert!(!result.errors_while_computing_flags);
     assert!(result.flags.contains_key("test_flag"));
@@ -287,13 +289,15 @@ async fn test_evaluate_feature_flags_with_errors() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
 
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
     let error_flag = result.flags.get("error-flag");
     assert!(error_flag.is_some());
     assert_eq!(
@@ -695,12 +699,14 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
 
     assert!(!result.errors_while_computing_flags);
     assert!(result.flags["flag_1"].enabled);
@@ -802,12 +808,14 @@ async fn test_evaluate_feature_flags_details() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
 
     assert!(!result.errors_while_computing_flags);
 
@@ -961,12 +969,14 @@ async fn test_evaluate_feature_flags_with_overrides() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
 
     assert!(
         result.flags.contains_key("test_flag"),
@@ -1055,12 +1065,14 @@ async fn test_long_distinct_id() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
 
     let request_id = Uuid::new_v4();
-    let result = evaluate_feature_flags(evaluation_context, request_id).await;
+    let result = evaluate_feature_flags(evaluation_context, request_id)
+        .await
+        .unwrap();
 
     let legacy_response = LegacyFlagsResponse::from_response(result);
 
@@ -1575,10 +1587,12 @@ async fn test_parallel_path_matches_sequential_results() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 100,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
-    let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4()).await;
+    let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4())
+        .await
+        .unwrap();
 
     // Run parallel (threshold = 1, forces rayon+oneshot for any batch >= 1)
     let parallel_context = FeatureFlagEvaluationContext {
@@ -1598,10 +1612,12 @@ async fn test_parallel_path_matches_sequential_results() {
         flag_keys: None,
         optimize_experience_continuity_lookups: false,
         parallel_eval_threshold: 1,
-        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
+        rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
     };
-    let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4()).await;
+    let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4())
+        .await
+        .unwrap();
 
     // Both paths should produce identical flag results
     assert_eq!(

--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -171,11 +171,18 @@ fn main() {
     } else {
         config.max_concurrent_batch_evals
     };
-    let rayon_dispatcher = RayonDispatcher::new(max_concurrent_batch_evals);
+    let semaphore_timeout = if config.rayon_semaphore_timeout_ms == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_millis(
+            config.rayon_semaphore_timeout_ms,
+        ))
+    };
+    let rayon_dispatcher = RayonDispatcher::new(max_concurrent_batch_evals, semaphore_timeout);
 
     eprintln!(
-        "Initialized thread pools: tokio_workers={}, rayon_threads={}, max_concurrent_batch_evals={}",
-        threads.tokio_workers, threads.rayon_threads, max_concurrent_batch_evals,
+        "Initialized thread pools: tokio_workers={}, rayon_threads={}, max_concurrent_batch_evals={}, semaphore_timeout_ms={}",
+        threads.tokio_workers, threads.rayon_threads, max_concurrent_batch_evals, config.rayon_semaphore_timeout_ms,
     );
 
     tokio_runtime.block_on(async_main(config, rayon_dispatcher))

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -126,6 +126,12 @@ pub const RAYON_DISPATCHER_TOTAL_ACQUIRES: &str = "flags_rayon_dispatcher_acquir
 // means the pool is saturated and the semaphore is the bottleneck.
 pub const RAYON_DISPATCHER_INFLIGHT_TASKS: &str = "flags_rayon_dispatcher_inflight_tasks";
 
+// Counter of semaphore acquisitions that timed out (request failed fast with 504).
+// Non-zero means the configured timeout is being hit and requests are being
+// redistributed to other pods via ingress retry.
+pub const RAYON_DISPATCHER_SEMAPHORE_TIMEOUTS: &str =
+    "flags_rayon_dispatcher_semaphore_timeouts_total";
+
 // Flag batch evaluation metrics
 // These track the performance difference between sequential and parallel evaluation strategies.
 // Used for A/B testing and tuning the PARALLEL_EVAL_THRESHOLD.

--- a/rust/feature-flags/src/rayon_dispatcher.rs
+++ b/rust/feature-flags/src/rayon_dispatcher.rs
@@ -63,32 +63,17 @@ impl RayonDispatcher {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let available_before = self.available_permits();
-        gauge(
-            RAYON_DISPATCHER_AVAILABLE_PERMITS,
-            &[],
-            available_before as f64,
-        );
-
-        inc(RAYON_DISPATCHER_TOTAL_ACQUIRES, &[], 1);
-        if available_before == 0 {
-            inc(RAYON_DISPATCHER_CONTENDED_ACQUIRES, &[], 1);
-        }
-
-        let wait_start = std::time::Instant::now();
-        let permit = self.acquire().await;
-        histogram(
-            RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
-            &[],
-            wait_start.elapsed().as_secs_f64() * 1000.0,
-        );
-
+        // try_acquire(None) is infallible — no timeout means unbounded wait
+        let permit = self
+            .try_acquire(None)
+            .await
+            .expect("try_acquire(None) is infallible");
         Self::dispatch(permit, work).await
     }
 
     /// Like [`spawn`](Self::spawn), but respects the configured semaphore timeout.
     ///
-    /// - When `self.timeout` is `None`: delegates to `spawn`, wraps in `Ok`.
+    /// - When `self.timeout` is `None`: acquires without timeout, wraps in `Ok`.
     /// - When `self.timeout` is `Some(d)`: if the semaphore wait exceeds `d`,
     ///   returns `Err(SemaphoreTimeout)` so the caller can fail fast (HTTP 504).
     pub async fn try_spawn<F, R>(&self, work: F) -> Result<Option<R>, SemaphoreTimeout>
@@ -96,11 +81,23 @@ impl RayonDispatcher {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let deadline = match self.timeout {
-            None => return Ok(self.spawn(work).await),
-            Some(d) => d,
-        };
+        let permit = self.try_acquire(self.timeout).await?;
+        Ok(Self::dispatch(permit, work).await)
+    }
 
+    /// Number of permits not currently held. Useful for saturation metrics.
+    pub fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    /// Acquires a semaphore permit, recording all acquire-time metrics.
+    ///
+    /// When `timeout` is `None`, waits without limit. When `Some(d)`, fails
+    /// with `SemaphoreTimeout` if the permit isn't acquired within `d`.
+    async fn try_acquire(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<OwnedSemaphorePermit, SemaphoreTimeout> {
         let available_before = self.available_permits();
         gauge(
             RAYON_DISPATCHER_AVAILABLE_PERMITS,
@@ -114,33 +111,26 @@ impl RayonDispatcher {
         }
 
         let wait_start = std::time::Instant::now();
-        let permit = match tokio::time::timeout(deadline, self.acquire()).await {
-            Ok(permit) => {
-                histogram(
-                    RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
-                    &[],
-                    wait_start.elapsed().as_secs_f64() * 1000.0,
-                );
-                permit
-            }
-            Err(_) => {
-                let waited = wait_start.elapsed();
-                histogram(
-                    RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
-                    &[],
-                    waited.as_secs_f64() * 1000.0,
-                );
-                inc(RAYON_DISPATCHER_SEMAPHORE_TIMEOUTS, &[], 1);
-                return Err(SemaphoreTimeout { waited });
-            }
+        let result = match timeout {
+            None => Ok(self.acquire().await),
+            Some(deadline) => tokio::time::timeout(deadline, self.acquire())
+                .await
+                .map_err(|_| wait_start.elapsed()),
         };
 
-        Ok(Self::dispatch(permit, work).await)
-    }
+        histogram(
+            RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
+            &[],
+            wait_start.elapsed().as_secs_f64() * 1000.0,
+        );
 
-    /// Number of permits not currently held. Useful for saturation metrics.
-    pub fn available_permits(&self) -> usize {
-        self.semaphore.available_permits()
+        match result {
+            Ok(permit) => Ok(permit),
+            Err(waited) => {
+                inc(RAYON_DISPATCHER_SEMAPHORE_TIMEOUTS, &[], 1);
+                Err(SemaphoreTimeout { waited })
+            }
+        }
     }
 
     async fn acquire(&self) -> OwnedSemaphorePermit {
@@ -268,21 +258,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn try_spawn_returns_ok_none_on_panic() {
+        let dispatcher = RayonDispatcher::new(2, Some(Duration::from_secs(5)));
+        let result = dispatcher
+            .try_spawn(|| {
+                panic!("intentional test panic");
+            })
+            .await;
+        assert_eq!(result.unwrap(), None::<()>);
+    }
+
+    #[tokio::test]
     async fn try_spawn_returns_err_on_timeout() {
         // 1 permit, block it with a long-running task
         let dispatcher = RayonDispatcher::new(1, Some(Duration::from_millis(10)));
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel::<()>();
         let d = dispatcher.clone();
         let _blocker = tokio::spawn(async move {
             d.spawn(move || {
+                let _ = acquired_tx.send(());
                 let _ = rx.blocking_recv();
             })
             .await
         });
 
-        // Wait for the blocker to acquire the permit
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        // Wait for the blocker to actually acquire the permit
+        acquired_rx.await.unwrap();
 
         // This should timeout because the permit is held
         let result = dispatcher.try_spawn(|| 99).await;

--- a/rust/feature-flags/src/rayon_dispatcher.rs
+++ b/rust/feature-flags/src/rayon_dispatcher.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_metrics::{gauge, histogram, inc};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -7,10 +8,19 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use crate::metrics::consts::{
     RAYON_DISPATCHER_AVAILABLE_PERMITS, RAYON_DISPATCHER_CONTENDED_ACQUIRES,
     RAYON_DISPATCHER_EXECUTION_TIME, RAYON_DISPATCHER_INFLIGHT_TASKS,
-    RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME, RAYON_DISPATCHER_TOTAL_ACQUIRES,
+    RAYON_DISPATCHER_SEMAPHORE_TIMEOUTS, RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
+    RAYON_DISPATCHER_TOTAL_ACQUIRES,
 };
 
 static INFLIGHT_TASKS: AtomicUsize = AtomicUsize::new(0);
+
+/// Returned by [`RayonDispatcher::try_spawn`] when the semaphore wait exceeds the
+/// configured timeout. The caller can convert this into an HTTP 504 to trigger
+/// ingress retry on a less-loaded pod.
+#[derive(Debug)]
+pub struct SemaphoreTimeout {
+    pub waited: Duration,
+}
 
 /// Bounds concurrent batch dispatches to the Rayon thread pool.
 ///
@@ -27,12 +37,14 @@ static INFLIGHT_TASKS: AtomicUsize = AtomicUsize::new(0);
 #[derive(Clone)]
 pub struct RayonDispatcher {
     semaphore: Arc<Semaphore>,
+    timeout: Option<Duration>,
 }
 
 impl RayonDispatcher {
-    pub fn new(max_concurrent_batches: usize) -> Self {
+    pub fn new(max_concurrent_batches: usize, timeout: Option<Duration>) -> Self {
         Self {
             semaphore: Arc::new(Semaphore::new(max_concurrent_batches)),
+            timeout,
         }
     }
 
@@ -71,6 +83,82 @@ impl RayonDispatcher {
             wait_start.elapsed().as_secs_f64() * 1000.0,
         );
 
+        Self::dispatch(permit, work).await
+    }
+
+    /// Like [`spawn`](Self::spawn), but respects the configured semaphore timeout.
+    ///
+    /// - When `self.timeout` is `None`: delegates to `spawn`, wraps in `Ok`.
+    /// - When `self.timeout` is `Some(d)`: if the semaphore wait exceeds `d`,
+    ///   returns `Err(SemaphoreTimeout)` so the caller can fail fast (HTTP 504).
+    pub async fn try_spawn<F, R>(&self, work: F) -> Result<Option<R>, SemaphoreTimeout>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let deadline = match self.timeout {
+            None => return Ok(self.spawn(work).await),
+            Some(d) => d,
+        };
+
+        let available_before = self.available_permits();
+        gauge(
+            RAYON_DISPATCHER_AVAILABLE_PERMITS,
+            &[],
+            available_before as f64,
+        );
+
+        inc(RAYON_DISPATCHER_TOTAL_ACQUIRES, &[], 1);
+        if available_before == 0 {
+            inc(RAYON_DISPATCHER_CONTENDED_ACQUIRES, &[], 1);
+        }
+
+        let wait_start = std::time::Instant::now();
+        let permit = match tokio::time::timeout(deadline, self.acquire()).await {
+            Ok(permit) => {
+                histogram(
+                    RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
+                    &[],
+                    wait_start.elapsed().as_secs_f64() * 1000.0,
+                );
+                permit
+            }
+            Err(_) => {
+                let waited = wait_start.elapsed();
+                histogram(
+                    RAYON_DISPATCHER_SEMAPHORE_WAIT_TIME,
+                    &[],
+                    waited.as_secs_f64() * 1000.0,
+                );
+                inc(RAYON_DISPATCHER_SEMAPHORE_TIMEOUTS, &[], 1);
+                return Err(SemaphoreTimeout { waited });
+            }
+        };
+
+        Ok(Self::dispatch(permit, work).await)
+    }
+
+    /// Number of permits not currently held. Useful for saturation metrics.
+    pub fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    async fn acquire(&self) -> OwnedSemaphorePermit {
+        self.semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("rayon dispatcher semaphore closed — this is a bug")
+    }
+
+    /// Dispatches `work` onto the Rayon pool, returning the result via oneshot.
+    /// The permit is released before sending the result so that `rx.await` is a
+    /// reliable synchronization point for permit availability.
+    async fn dispatch<F, R>(permit: OwnedSemaphorePermit, work: F) -> Option<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         rayon::spawn(move || {
@@ -86,10 +174,6 @@ impl RayonDispatcher {
             );
 
             INFLIGHT_TASKS.fetch_sub(1, Ordering::Relaxed);
-
-            // Release the permit before sending the result so that
-            // `rx.await` is a reliable synchronization point for permit
-            // availability
             drop(permit);
 
             if let Ok(value) = result {
@@ -100,19 +184,6 @@ impl RayonDispatcher {
 
         rx.await.ok()
     }
-
-    /// Number of permits not currently held. Useful for saturation metrics.
-    pub fn available_permits(&self) -> usize {
-        self.semaphore.available_permits()
-    }
-
-    async fn acquire(&self) -> OwnedSemaphorePermit {
-        self.semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("rayon dispatcher semaphore closed — this is a bug")
-    }
 }
 
 #[cfg(test)]
@@ -121,14 +192,14 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_returns_result() {
-        let dispatcher = RayonDispatcher::new(2);
+        let dispatcher = RayonDispatcher::new(2, None);
         let result = dispatcher.spawn(|| 42).await;
         assert_eq!(result, Some(42));
     }
 
     #[tokio::test]
     async fn spawn_returns_none_on_panic() {
-        let dispatcher = RayonDispatcher::new(2);
+        let dispatcher = RayonDispatcher::new(2, None);
         let result = dispatcher
             .spawn(|| {
                 panic!("intentional test panic");
@@ -139,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn permits_bound_concurrency() {
-        let dispatcher = RayonDispatcher::new(1);
+        let dispatcher = RayonDispatcher::new(1, None);
         let peak = Arc::new(AtomicUsize::new(0));
         let active = Arc::new(AtomicUsize::new(0));
 
@@ -168,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn available_permits_reflects_state() {
-        let dispatcher = RayonDispatcher::new(2);
+        let dispatcher = RayonDispatcher::new(2, None);
         assert_eq!(dispatcher.available_permits(), 2);
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
@@ -187,5 +258,46 @@ mod tests {
         tx.send(()).unwrap();
         handle.await.unwrap();
         assert_eq!(dispatcher.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn try_spawn_returns_ok_on_success() {
+        let dispatcher = RayonDispatcher::new(2, Some(Duration::from_secs(5)));
+        let result = dispatcher.try_spawn(|| 42).await;
+        assert_eq!(result.unwrap(), Some(42));
+    }
+
+    #[tokio::test]
+    async fn try_spawn_returns_err_on_timeout() {
+        // 1 permit, block it with a long-running task
+        let dispatcher = RayonDispatcher::new(1, Some(Duration::from_millis(10)));
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let d = dispatcher.clone();
+        let _blocker = tokio::spawn(async move {
+            d.spawn(move || {
+                let _ = rx.blocking_recv();
+            })
+            .await
+        });
+
+        // Wait for the blocker to acquire the permit
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // This should timeout because the permit is held
+        let result = dispatcher.try_spawn(|| 99).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.waited >= Duration::from_millis(10));
+
+        // Clean up
+        let _ = tx.send(());
+    }
+
+    #[tokio::test]
+    async fn try_spawn_delegates_to_spawn_when_no_timeout() {
+        let dispatcher = RayonDispatcher::new(2, None);
+        let result = dispatcher.try_spawn(|| "hello").await;
+        assert_eq!(result.unwrap(), Some("hello"));
     }
 }

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -29,7 +29,7 @@ impl ServerHandle {
         let notify = Arc::new(Notify::new());
         let shutdown = notify.clone();
 
-        let rayon_dispatcher = RayonDispatcher::new(2);
+        let rayon_dispatcher = RayonDispatcher::new(2, None);
         tokio::spawn(async move {
             serve(config, listener, rayon_dispatcher, async move {
                 notify.notified().await
@@ -328,7 +328,7 @@ impl ServerHandle {
                 flags_with_cohorts_hypercache_reader,
                 team_hypercache_reader,
                 config_hypercache_reader,
-                RayonDispatcher::new(2),
+                RayonDispatcher::new(2, None),
                 NegativeCache::new(10_000, 300),
                 config,
             );


### PR DESCRIPTION
## Problem

Under load spikes, requests queue on the Rayon semaphore (up to 3s per metrics) waiting for a batch evaluation slot.
The p99 spikes while p95 stays stable at ~80ms, classic head-of-line blocking where a few unlucky requests wait behind a saturated pool.

There is no mechanism to shed these queued requests.
They sit until they either get a permit or Tower's request timeout kills them (503), wasting capacity on work that will never complete in time.

## Solution

When the semaphore wait exceeds a configurable threshold, fail the request fast with **HTTP 504** so that ingress (Contour/Envoy) retries it on a different, less-loaded pod.

504 is used instead of 503 because multiple existing error variants already return 503 (`DatabaseUnavailable`, `RedisUnavailable`, `TimeoutError`, Tower `TimeoutLayer`).
Retrying on 503 would amplify traffic during DB/Redis outages.
No existing error uses 504, so `retriableStatusCodes: [504]` is surgically scoped to semaphore contention only.

| Scenario | Status | Retried? | Amplification risk |
|---|---|---|---|
| Semaphore contention | 504 | Yes (2x) | Intentional — redistributes load |
| DB outage | 503 | No | None |
| Redis outage | 503 | No | None |
| Tower timeout | 503 | No | None |

## Changes

**Config** (`config.rs`)
- Add `RAYON_SEMAPHORE_TIMEOUT_MS` (default `0` = disabled, production target TBD).

**Metrics** (`metrics/consts.rs`)
- Add `flags_rayon_dispatcher_semaphore_timeouts_total` counter.

**Rayon dispatcher** (`rayon_dispatcher.rs`)
- Add `SemaphoreTimeout` error struct and `try_spawn()` method.
  When timeout is `None`, delegates to `spawn`. When `Some(d)`, wraps semaphore acquire in `tokio::time::timeout`.
- Extract shared rayon dispatch closure into `dispatch()` helper.

**Error variant** (`api/errors.rs`)
- Add `FlagError::RayonSemaphoreTimeout(u64)` mapped to HTTP 504.
- Update `error_metadata`, `is_5xx`, `IntoResponse`, and all test vectors.

**Result propagation** (`flag_matching.rs`, `handler/evaluation.rs`, `handler/flags.rs`, `handler/mod.rs`)
- Change return types of `evaluate_all_feature_flags` → `evaluate_flags_with_overrides` → `evaluate_flags_with_dependency_graph` → `evaluate_flags_in_level` → `evaluate_batch_parallel` from direct values to `Result<..., FlagError>`.
- The semaphore timeout propagates up via `?` and becomes an HTTP 504 through the existing `IntoResponse` implementation.

**Startup** (`main.rs`)
- Pass configured timeout to `RayonDispatcher::new()`.

**Ingress** (`charts/argocd/contour-ingress/values/`)
- Add `retriable-status-codes` + `retriableStatusCodes: [504]` to `/decide`, `/flags`, `/flags/definitions` routes across dev, prod-us, and prod-eu.

## Deployment

1. Ship Rust changes with `RAYON_SEMAPHORE_TIMEOUT_MS=0` (disabled). Code deploys, does nothing.
2. Ship ingress changes. `retriableStatusCodes: [504]` is inert when no 504s are generated.
3. Enable `RAYON_SEMAPHORE_TIMEOUT_MS=800` and monitor `flags_rayon_dispatcher_semaphore_timeouts_total`.
5. Rollback: set `RAYON_SEMAPHORE_TIMEOUT_MS=0`: instant disable, no redeploy.

## How did you test this code?

- New unit tests on `RayonDispatcher::try_spawn` (success, timeout, no-timeout delegation).
- Updated all test call sites for the new `Result` return types.
- `cargo check` passes cleanly.
- Existing tests use `dispatcher: None` (test fallback path), so unaffected by `try_spawn`.

## Publish to changelog?

No
