### PR TITLE
chore(gateway): send rate limit events to posthog

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -8,7 +8,9 @@ from uuid import uuid4
 import structlog
 from posthoganalytics import Posthog
 
+from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.callbacks.base import InstrumentedCallback
+from llm_gateway.config import get_settings
 from llm_gateway.request_context import (
     get_auth_user,
     get_posthog_flags,
@@ -18,6 +20,51 @@ from llm_gateway.request_context import (
 )
 
 logger = structlog.get_logger(__name__)
+
+SCOPE_TO_EVENT: dict[str, str] = {
+    "user_cost_burst": "ai burst rate limited",
+    "user_cost_sustained": "ai sustained rate limited",
+    "product_cost": "ai product rate limited",
+}
+
+
+def capture_rate_limit_event(
+    scope: str, product: str, auth_user: AuthenticatedUser | None, end_user_id: str | None
+) -> None:
+    settings = get_settings()
+    if not settings.posthog_project_token:
+        return
+    event = SCOPE_TO_EVENT.get(scope)
+    if not event:
+        return
+    distinct_id = (auth_user.distinct_id if auth_user else None) or end_user_id
+    if not distinct_id:
+        return
+    team_id = auth_user.team_id if auth_user and auth_user.team_id else None
+    properties: dict[str, Any] = {"ai_product": product, "scope": scope}
+    if team_id:
+        properties["team_id"] = team_id
+    capture_kwargs: dict[str, Any] = {
+        "distinct_id": distinct_id,
+        "event": event,
+        "properties": properties,
+    }
+    if team_id:
+        capture_kwargs["groups"] = {"project": team_id}
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(
+        None, partial(_capture_rate_limit_sync, settings.posthog_project_token, settings.posthog_host, capture_kwargs)
+    )
+
+
+def _capture_rate_limit_sync(api_key: str, host: str, capture_kwargs: dict[str, Any]) -> None:
+    client = Posthog(api_key, host=host, sync_mode=True, enable_local_evaluation=False)
+    try:
+        client.capture(**capture_kwargs)
+    except Exception as e:
+        logger.exception("posthog_rate_limit_capture_failed", error=str(e))
+    finally:
+        client.shutdown()
 
 
 def _replace_binary_content(data: Any) -> Any:

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
@@ -29,6 +29,9 @@ class ThrottleRunner:
                     scope=scope,
                     status_code=result.status_code,
                 )
+                from llm_gateway.callbacks.posthog import capture_rate_limit_event
+
+                capture_rate_limit_event(scope, context.product, context.user, context.end_user_id)
                 return result
         return ThrottleResult.allow()
 

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.callbacks.posthog import PostHogCallback, _replace_binary_content, _truncate_for_capture
+from llm_gateway.callbacks.posthog import (
+    PostHogCallback,
+    _replace_binary_content,
+    _truncate_for_capture,
+    capture_rate_limit_event,
+)
 
 
 def _run_sync(executor, fn, *args):
@@ -522,3 +527,141 @@ class TestTruncateForCapture:
             assert props["$ai_total_cost_usd"] == 1.23
             assert props["$ai_latency"] == 2.5
             assert len(json.dumps(props)) < _MAX_SIZE
+
+
+def _run_rate_limit_sync(executor, fn, *args):
+    fn(*args)
+
+
+class TestCaptureRateLimitEvent:
+    @pytest.fixture
+    def auth_user(self):
+        return AuthenticatedUser(
+            user_id=1,
+            team_id=99,
+            auth_method="personal_api_key",
+            distinct_id="user-abc",
+        )
+
+    @pytest.fixture
+    def auth_user_no_team(self):
+        return AuthenticatedUser(
+            user_id=2,
+            team_id=None,
+            auth_method="personal_api_key",
+            distinct_id="user-no-team",
+        )
+
+    @pytest.fixture
+    def mock_settings(self):
+        settings = MagicMock()
+        settings.posthog_project_token = "phc_test"
+        settings.posthog_host = "https://us.i.posthog.com"
+        return settings
+
+    @pytest.fixture
+    def mock_loop(self):
+        loop = MagicMock()
+        loop.run_in_executor.side_effect = _run_rate_limit_sync
+        with patch("llm_gateway.callbacks.posthog.asyncio") as mock_asyncio:
+            mock_asyncio.get_running_loop.return_value = loop
+            yield loop
+
+    @pytest.mark.parametrize(
+        "scope,expected_event",
+        [
+            ("user_cost_burst", "ai burst rate limited"),
+            ("user_cost_sustained", "ai sustained rate limited"),
+            ("product_cost", "ai product rate limited"),
+        ],
+    )
+    def test_each_scope_fires_correct_event(
+        self, scope: str, expected_event: str, auth_user: AuthenticatedUser, mock_settings: MagicMock, mock_loop
+    ) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event(scope, "twig", auth_user, None)
+
+            mock_client.capture.assert_called_once()
+            kw = mock_client.capture.call_args.kwargs
+            assert kw["event"] == expected_event
+            assert kw["distinct_id"] == "user-abc"
+            assert kw["properties"]["ai_product"] == "twig"
+            assert kw["properties"]["scope"] == scope
+            assert kw["properties"]["team_id"] == 99
+            assert kw["groups"] == {"project": 99}
+            mock_client.shutdown.assert_called_once()
+
+    def test_unknown_scope_fires_nothing(
+        self, auth_user: AuthenticatedUser, mock_settings: MagicMock, mock_loop
+    ) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("unknown_scope", "twig", auth_user, None)
+            mock_client.capture.assert_not_called()
+
+    def test_no_posthog_token_fires_nothing(self, auth_user: AuthenticatedUser, mock_loop) -> None:
+        settings = MagicMock()
+        settings.posthog_project_token = None
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("user_cost_burst", "twig", auth_user, None)
+            mock_client.capture.assert_not_called()
+
+    def test_no_distinct_id_and_no_end_user_id_fires_nothing(self, mock_settings: MagicMock, mock_loop) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("user_cost_burst", "twig", None, None)
+            mock_client.capture.assert_not_called()
+
+    def test_team_id_present_includes_groups(
+        self, auth_user: AuthenticatedUser, mock_settings: MagicMock, mock_loop
+    ) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("user_cost_burst", "twig", auth_user, None)
+
+            kw = mock_client.capture.call_args.kwargs
+            assert kw["groups"] == {"project": 99}
+            assert kw["properties"]["team_id"] == 99
+
+    def test_team_id_absent_no_groups(
+        self, auth_user_no_team: AuthenticatedUser, mock_settings: MagicMock, mock_loop
+    ) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("user_cost_burst", "twig", auth_user_no_team, None)
+
+            kw = mock_client.capture.call_args.kwargs
+            assert "groups" not in kw
+            assert "team_id" not in kw["properties"]
+
+    def test_falls_back_to_end_user_id(self, mock_settings: MagicMock, mock_loop) -> None:
+        mock_client = MagicMock()
+        with (
+            patch("llm_gateway.callbacks.posthog.get_settings", return_value=mock_settings),
+            patch("llm_gateway.callbacks.posthog.Posthog", return_value=mock_client),
+        ):
+            capture_rate_limit_event("user_cost_burst", "twig", None, "end-user-xyz")
+
+            kw = mock_client.capture.call_args.kwargs
+            assert kw["distinct_id"] == "end-user-xyz"
+            assert "groups" not in kw


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Currently, when the LLM gateway enforces cost-based rate limits and a request is denied, only Prometheus counters and structured logs are emitted. This means rate-limited requests are invisible in PostHog analytics.

This PR aims to provide visibility into these events by firing PostHog events, mirroring the existing "ai burst rate limited" and "ai sustained rate limited" events already present in the Django app.

## Changes

1.  **`services/llm-gateway/src/llm_gateway/callbacks/posthog.py`**:
    *   Added `SCOPE_TO_EVENT` mapping for rate limit scopes to PostHog event names.
    *   Implemented `capture_rate_limit_event()` to construct and asynchronously fire PostHog events when a rate limit is exceeded, including `ai_product`, `scope`, and optionally `team_id`/`groups`.
    *   Added `_capture_rate_limit_sync()` as a helper for synchronous PostHog capture in a separate thread.
2.  **`services/llm-gateway/src/llm_gateway/rate_limiting/runner.py`**:
    *   Modified `ThrottleRunner.check()` to call `capture_rate_limit_event()` after a rate limit is exceeded. The import is inline to prevent circular dependencies.
3.  **`services/llm-gateway/tests/callbacks/test_posthog.py`**:
    *   Added `TestCaptureRateLimitEvent` with parameterized tests covering:
        *   Correct event names for each scope.
        *   No event fired for unknown scopes, missing `posthog_project_token`, or missing `distinct_id`/`end_user_id`.
        *   Correct handling of `team_id` for `groups` and properties.
        *   Fallback to `end_user_id` when `auth_user` is absent.

## How did you test this code?

Automated tests were added in `services/llm-gateway/tests/callbacks/test_posthog.py` covering various scenarios for event capture.

The following tests were run:
```bash
cd services/llm-gateway
pytest tests/callbacks/test_posthog.py tests/test_cost_throttles.py
```
All 119 tests passed (47 callback tests + 72 throttle tests).
Lint checks were also run and passed.

## Publish to changelog?

Yes

---
<p><a href="https://cursor.com/agents/bc-1d531314-0fc9-4033-8304-c448ed7ee7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d531314-0fc9-4033-8304-c448ed7ee7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->