### PR TITLE
feat: Add action list and detail UI apps for MCP

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -68,7 +68,8 @@
         {
             "files": [
                 "products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx",
-                "frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx"
+                "frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx",
+                "services/mcp/src/resources/ui-apps.ts"
             ],
             "options": {
                 "experimentalSortImports": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
         "@posthog/hogql-parser": "1.3.26",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "^0.36.6",
+        "@posthog/mosaic": "workspace:*",
         "@posthog/products-actions": "workspace:*",
         "@posthog/products-cohorts": "workspace:*",
         "@posthog/products-conversations": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
       '@posthog/icons':
         specifier: ^0.36.6
         version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@posthog/mosaic':
+        specifier: workspace:*
+        version: link:../common/mosaic
       '@posthog/products-actions':
         specifier: workspace:*
         version: link:../products/actions

--- a/products/actions/frontend/mcp-apps/ActionListView.tsx
+++ b/products/actions/frontend/mcp-apps/ActionListView.tsx
@@ -24,8 +24,13 @@ export function ActionListView({ data, onActionClick }: ActionListViewProps): Re
             if (!onActionClick) {
                 return
             }
+
             setViewState({ view: 'loading', name: action.name })
-            const detail = await onActionClick(action)
+            const detail = await onActionClick(action).catch((error) => {
+                console.error('Error loading action detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', action: detail })
             } else {
@@ -58,8 +63,6 @@ export function ActionListView({ data, onActionClick }: ActionListViewProps): Re
             </div>
         )
     }
-
-    const items = Array.isArray(data.results) ? data.results : Array.isArray(data) ? data : []
 
     const columns: DataTableColumn<ActionData>[] = [
         {
@@ -117,12 +120,12 @@ export function ActionListView({ data, onActionClick }: ActionListViewProps): Re
             <Stack gap="sm">
                 <div className="flex items-center justify-between">
                     <span className="text-sm text-text-secondary">
-                        {items.length} action{items.length === 1 ? '' : 's'}
+                        {data.results.length} action{data.results.length === 1 ? '' : 's'}
                     </span>
                 </div>
                 <DataTable<ActionData>
                     columns={columns}
-                    data={items}
+                    data={data.results}
                     pageSize={10}
                     defaultSort={{ key: 'name', direction: 'asc' }}
                     emptyMessage="No actions found"

--- a/products/actions/frontend/mcp-apps/ActionListView.tsx
+++ b/products/actions/frontend/mcp-apps/ActionListView.tsx
@@ -1,0 +1,133 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { ActionView, type ActionData } from './ActionView'
+
+export interface ActionListData {
+    results: ActionData[]
+    _posthogUrl?: string
+}
+
+export interface ActionListViewProps {
+    data: ActionListData
+    onActionClick?: (action: ActionData) => Promise<ActionData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; action: ActionData }
+
+export function ActionListView({ data, onActionClick }: ActionListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (action: ActionData) => {
+            if (!onActionClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: action.name })
+            const detail = await onActionClick(action)
+            if (detail) {
+                setViewState({ view: 'detail', action: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onActionClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All actions" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All actions" />
+                    <ActionView action={viewState.action} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const items = Array.isArray(data.results) ? data.results : Array.isArray(data) ? data : []
+
+    const columns: DataTableColumn<ActionData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onActionClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    row.name
+                ),
+        },
+        {
+            key: 'tags',
+            header: 'Tags',
+            render: (row): ReactNode =>
+                row.tags?.length ? (
+                    <div className="flex gap-1 flex-wrap">
+                        {row.tags.map((tag) => (
+                            <Badge key={tag} variant="neutral" size="sm">
+                                {tag}
+                            </Badge>
+                        ))}
+                    </div>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+        {
+            key: 'steps' as keyof ActionData,
+            header: 'Steps',
+            render: (row): ReactNode => <span className="text-text-secondary">{row.steps?.length ?? 0}</span>,
+        },
+        {
+            key: 'created_at',
+            header: 'Created',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.created_at ? (
+                    <span className="text-text-secondary">{formatDate(row.created_at)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {items.length} action{items.length === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<ActionData>
+                    columns={columns}
+                    data={items}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No actions found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/actions/frontend/mcp-apps/ActionView.tsx
+++ b/products/actions/frontend/mcp-apps/ActionView.tsx
@@ -1,0 +1,123 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
+
+export interface ActionStepData {
+    event?: string | null
+    tag_name?: string | null
+    text?: string | null
+    text_matching?: string | null
+    href?: string | null
+    href_matching?: string | null
+    selector?: string | null
+    url?: string | null
+    url_matching?: string | null
+    properties?: Array<{ key: string; value: unknown; operator?: string; type?: string }>
+}
+
+export interface ActionData {
+    id: number
+    name: string
+    description?: string | null
+    steps?: ActionStepData[]
+    tags?: string[]
+    pinned_at?: string | null
+    created_at?: string
+    created_by?: { first_name?: string; email?: string } | null
+    _posthogUrl?: string
+}
+
+export interface ActionViewProps {
+    action: ActionData
+}
+
+function ActionStep({ step, index }: { step: ActionStepData; index: number }): ReactElement {
+    const conditions: Array<{ label: string; value: string }> = []
+    if (step.event) {
+        conditions.push({ label: 'Event', value: step.event })
+    }
+    if (step.url) {
+        conditions.push({ label: `URL ${step.url_matching ?? 'contains'}`, value: step.url })
+    }
+    if (step.selector) {
+        conditions.push({ label: 'Selector', value: step.selector })
+    }
+    if (step.text) {
+        conditions.push({ label: `Text ${step.text_matching ?? 'contains'}`, value: step.text })
+    }
+    if (step.href) {
+        conditions.push({ label: `Link ${step.href_matching ?? 'contains'}`, value: step.href })
+    }
+
+    return (
+        <Stack gap="xs">
+            <span className="text-xs font-medium text-text-secondary uppercase tracking-wide">Step {index + 1}</span>
+            {conditions.length > 0 ? (
+                <DescriptionList items={conditions.map((c) => ({ label: c.label, value: c.value }))} />
+            ) : (
+                <span className="text-xs text-text-secondary">No conditions</span>
+            )}
+        </Stack>
+    )
+}
+
+export function ActionView({ action }: ActionViewProps): ReactElement {
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary">{action.name}</span>
+                        {action.pinned_at && (
+                            <Badge variant="info" size="sm">
+                                Pinned
+                            </Badge>
+                        )}
+                    </div>
+                    {action.description && <span className="text-sm text-text-secondary">{action.description}</span>}
+                    {action.tags && action.tags.length > 0 && (
+                        <div className="flex gap-1 flex-wrap">
+                            {action.tags.map((tag) => (
+                                <Badge key={tag} variant="neutral" size="sm">
+                                    {tag}
+                                </Badge>
+                            ))}
+                        </div>
+                    )}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        items={[
+                            ...(action.created_at ? [{ label: 'Created', value: formatDate(action.created_at) }] : []),
+                            ...(action.created_by
+                                ? [
+                                      {
+                                          label: 'Created by',
+                                          value: action.created_by.first_name || action.created_by.email || 'Unknown',
+                                      },
+                                  ]
+                                : []),
+                        ]}
+                    />
+                </Card>
+
+                {action.steps && action.steps.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="md">
+                            <span className="text-sm font-semibold text-text-primary">
+                                Steps ({action.steps.length})
+                            </span>
+                            {action.steps.map((step, i) => (
+                                <div key={i}>
+                                    {i > 0 && <div className="border-t border-border-primary -mx-4 mb-3" />}
+                                    <ActionStep step={step} index={i} />
+                                </div>
+                            ))}
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/actions/frontend/mcp-apps/index.ts
+++ b/products/actions/frontend/mcp-apps/index.ts
@@ -1,0 +1,2 @@
+export { ActionView, type ActionData, type ActionViewProps } from './ActionView'
+export { ActionListView, type ActionListData, type ActionListViewProps } from './ActionListView'

--- a/services/mcp/definitions/actions.yaml
+++ b/services/mcp/definitions/actions.yaml
@@ -26,6 +26,7 @@ tools:
             funnels. Supports pagination with limit and offset parameters. Note: Search/filtering by name is not
             supported on this endpoint.
         mcp_version: 1
+        ui_resource_uri: ui://posthog/action-list.html
     action-create:
         operation: actions_create
         enabled: true
@@ -51,6 +52,7 @@ tools:
         param_overrides:
             name:
                 description: Name of the action (must be unique within the project)
+        ui_resource_uri: ui://posthog/action.html
     action-get:
         operation: actions_retrieve
         enabled: true
@@ -66,6 +68,7 @@ tools:
             Get a specific action by ID. Returns the action configuration including all steps and their trigger
             conditions.
         mcp_version: 1
+        ui_resource_uri: ui://posthog/action.html
     actions-update:
         operation: actions_update
         enabled: false
@@ -88,6 +91,7 @@ tools:
             - bytecode_error
             - creation_context
             - last_calculated_at
+        ui_resource_uri: ui://posthog/action.html
     action-delete:
         operation: actions_destroy
         enabled: true

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -65,17 +65,30 @@ function getRegionFromRequest(request: Request): CloudRegion | null {
 }
 
 // Detect error codes and return appropriate responses
-const errorHandler = async (response: Response): Promise<Response> => {
+const onThenErrorHandler = async (response: Response): Promise<Response> => {
     if (!response.ok) {
         const body = await response.clone().text()
-        if (body.includes(ErrorCode.INACTIVE_OAUTH_TOKEN)) {
-            return new Response('OAuth token is inactive', { status: 401 })
-        } else if (body.includes(ErrorCode.INVALID_API_KEY)) {
-            return new Response('Invalid API key', { status: 401 })
+        const errorResponse = generateErrorResponse(body)
+        if (errorResponse) {
+            return errorResponse
         }
     }
 
     return response
+}
+
+const onCatchErrorHandler = async (error: Error): Promise<Response> => {
+    return generateErrorResponse(error.message) || new Response('Internal server error', { status: 500 })
+}
+
+const generateErrorResponse = (message: string): Response | null => {
+    if (message.includes(ErrorCode.INACTIVE_OAUTH_TOKEN)) {
+        return new Response('OAuth token is inactive', { status: 401 })
+    } else if (message.includes(ErrorCode.INVALID_API_KEY)) {
+        return new Response('Invalid API key', { status: 401 })
+    }
+
+    return null
 }
 
 const handleRequest = async (
@@ -232,15 +245,19 @@ const handleRequest = async (
     const readOnlyRaw = request.headers.get('x-posthog-readonly') || url.searchParams.get('readonly')
     const readOnly = readOnlyRaw === 'true' || readOnlyRaw === '1' || undefined
 
-    Object.assign(ctx.props, { features, region: regionParam, version, readOnly })
-    log.extend({ features, version })
+    const extraContextProps = { features, region: regionParam, version, readOnly }
+    Object.assign(ctx.props, extraContextProps)
+    log.extend(extraContextProps)
 
+    let server: Promise<Response> | null = null
     if (url.pathname.startsWith('/mcp')) {
-        return MCP.serve('/mcp').fetch(request, env, ctx).then(errorHandler)
+        server = MCP.serve('/mcp').fetch(request, env, ctx)
+    } else if (url.pathname.startsWith('/sse')) {
+        server = MCP.serveSSE('/sse').fetch(request, env, ctx)
     }
 
-    if (url.pathname.startsWith('/sse')) {
-        return MCP.serveSSE('/sse').fetch(request, env, ctx).then(errorHandler)
+    if (server !== null) {
+        return server.then(onThenErrorHandler).catch(onCatchErrorHandler)
     }
 
     log.extend({ error: 'route_not_found' })

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -25,3 +25,16 @@ export const QUERY_RESULTS_RESOURCE_URI = 'ui://posthog/query-results.html'
  * Displays SDK events, tool result data, and Mosaic component showcase.
  */
 export const DEBUG_RESOURCE_URI = 'ui://posthog/debug.html'
+
+/**
+
+ * Action detail visualization.
+ * Used by: action-get, action-create, action-update
+ */
+export const ACTION_RESOURCE_URI = 'ui://posthog/action.html'
+
+/**
+ * Action list visualization.
+ * Used by: actions-get-all
+ */
+export const ACTION_LIST_RESOURCE_URI = 'ui://posthog/action-list.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -4,11 +4,38 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 import type { Context } from '@/tools/types'
 
+import {
+    ACTION_LIST_RESOURCE_URI,
+    ACTION_RESOURCE_URI,
+    DEBUG_RESOURCE_URI,
+    QUERY_RESULTS_RESOURCE_URI,
+} from './ui-apps-constants'
+
 // Import bundled HTML at build time (wrangler Text rule)
 // Each UI app has its own HTML file in ui-apps-dist/src/ui-apps/apps/<name>/
+import actionListHtml from '../../ui-apps-dist/src/ui-apps/apps/action-list/index.html'
+import actionHtml from '../../ui-apps-dist/src/ui-apps/apps/action/index.html'
 import debugHtml from '../../ui-apps-dist/src/ui-apps/apps/debug/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
-import { DEBUG_RESOURCE_URI, QUERY_RESULTS_RESOURCE_URI } from './ui-apps-constants'
+
+const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
+    // Core
+    {
+        name: 'MCP Apps Debug',
+        uri: DEBUG_RESOURCE_URI,
+        description: 'Debug app for testing MCP Apps SDK integration',
+        html: debugHtml,
+    },
+    {
+        name: 'Query Results',
+        uri: QUERY_RESULTS_RESOURCE_URI,
+        description: 'Interactive visualization for PostHog query results',
+        html: queryResultsHtml,
+    },
+    // Actions
+    { name: 'Action', uri: ACTION_RESOURCE_URI, description: 'Action detail view', html: actionHtml },
+    { name: 'Action list', uri: ACTION_LIST_RESOURCE_URI, description: 'Action list view', html: actionListHtml },
+]
 
 /**
  * Registers UI app resources with the MCP server.
@@ -18,26 +45,9 @@ import { DEBUG_RESOURCE_URI, QUERY_RESULTS_RESOURCE_URI } from './ui-apps-consta
  * Each tool type can have its own visualization registered here.
  */
 export async function registerUiAppResources(server: McpServer, context: Context): Promise<void> {
-    registerDemoApp(server, context) // Demo app - used by demo-mcp-ui-apps tool for testing
-    registerQueryResultsApp(server, context) // Query Results - used by query-run and insight-query tools
-}
-
-function registerDemoApp(server: McpServer, context: Context): void {
-    registerApp(server, context, {
-        name: 'MCP Apps Demo',
-        uri: DEBUG_RESOURCE_URI,
-        description: 'Demo app for testing MCP Apps SDK integration - displays SDK events and tool data',
-        html: debugHtml,
-    })
-}
-
-function registerQueryResultsApp(server: McpServer, context: Context): void {
-    registerApp(server, context, {
-        name: 'Query Results',
-        uri: QUERY_RESULTS_RESOURCE_URI,
-        description: 'Interactive visualization for PostHog query results (trends, funnels, tables)',
-        html: queryResultsHtml,
-    })
+    for (const app of UI_APPS) {
+        registerApp(server, context, app)
+    }
 }
 
 interface RegisterAppParams {
@@ -70,6 +80,3 @@ function registerApp(server: McpServer, context: Context, { name, uri, descripti
         }
     })
 }
-
-// Re-export for tools to import
-export { QUERY_RESULTS_RESOURCE_URI, DEBUG_RESOURCE_URI }

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -37,6 +37,11 @@ const actionsGetAll = (): ToolBase<typeof ActionsGetAllSchema, unknown> => ({
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions`,
         }
     },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/action-list.html',
+        },
+    },
 })
 
 const ActionCreateSchema = ActionsCreateBody.omit({ deleted: true, last_calculated_at: true, _create_in_folder: true })
@@ -78,6 +83,11 @@ const actionCreate = (): ToolBase<typeof ActionCreateSchema, Schemas.Action & { 
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${(result as any).id}`,
         }
     },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/action.html',
+        },
+    },
 })
 
 const ActionGetSchema = ActionsRetrieveParams.omit({ project_id: true })
@@ -95,6 +105,11 @@ const actionGet = (): ToolBase<typeof ActionGetSchema, Schemas.Action & { _posth
             ...(result as any),
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${(result as any).id}`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/action.html',
+        },
     },
 })
 
@@ -138,6 +153,11 @@ const actionUpdate = (): ToolBase<typeof ActionUpdateSchema, Schemas.Action & { 
             ...(result as any),
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${(result as any).id}`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/action.html',
+        },
     },
 })
 

--- a/services/mcp/src/ui-apps/apps/action-list/index.html
+++ b/services/mcp/src/ui-apps/apps/action-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Actions</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/action-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/action-list/main.tsx
@@ -1,0 +1,60 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { type ActionData, type ActionListData, ActionListView } from 'products/actions/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ActionListApp(): JSX.Element {
+    return (
+        <AppWrapper<ActionListData> appName="PostHog Actions">
+            {({ data, app }) => <ActionListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function ActionListContent({ data, app }: { data: ActionListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for action "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (action: ActionData): Promise<ActionData | null> => {
+            if (!app) {
+                fallbackToChat(action.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'action-get',
+                    arguments: { actionId: action.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(action.name)
+                    return null
+                }
+                return result.structuredContent as unknown as ActionData
+            } catch {
+                fallbackToChat(action.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <ActionListView data={data} onActionClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ActionListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/action-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/action-list/main.tsx
@@ -36,7 +36,7 @@ function ActionListContent({ data, app }: { data: ActionListData; app: App | nul
             try {
                 const result = await app.callServerTool({
                     name: 'action-get',
-                    arguments: { actionId: action.id },
+                    arguments: { id: action.id },
                 })
                 if (result.isError || !result.structuredContent) {
                     fallbackToChat(action.name)

--- a/services/mcp/src/ui-apps/apps/action/index.html
+++ b/services/mcp/src/ui-apps/apps/action/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Action</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/action/main.tsx
+++ b/services/mcp/src/ui-apps/apps/action/main.tsx
@@ -1,0 +1,16 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type ActionData, ActionView } from 'products/actions/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ActionApp(): JSX.Element {
+    return <AppWrapper<ActionData> appName="PostHog Action">{({ data }) => <ActionView action={data!} />}</AppWrapper>
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ActionApp />)
+}


### PR DESCRIPTION
## Problem

This adds UI components and MCP apps for displaying PostHog actions in a user-friendly interface. Users need a way to view and interact with actions data through dedicated UI components rather than just raw API responses.

## Changes

- Created `ActionView` component for displaying individual action details including steps, tags, creation info, and metadata
- Created `ActionListView` component for displaying a table of actions with sorting, pagination, and click-to-detail functionality
- Added two MCP apps: `action-list` for browsing all actions and `action` for viewing individual action details
- Updated action tool handlers to include `_posthogUrl` metadata and UI resource URIs for proper app integration
- Modified `actions-get-all` response format to return structured data with results array
- Removed auto-generated actions tools file in favor of custom implementations

The UI components feature:
- Sortable data table with name, tags, steps count, and creation date columns
- Detailed action view showing steps with conditions, properties, and metadata
- Navigation between list and detail views with loading states
- Badge displays for tags and pinned status
- Fallback to chat interface when direct tool calls fail


## Publish to changelog?

No - not yet.