### PR TITLE
feat: Add cohort UI components for MCP apps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,6 +1801,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
 
   products/conversations:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1804,7 +1804,7 @@ importers:
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'
-        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
 
   products/conversations:
     dependencies:
@@ -17820,10 +17820,6 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-
-  object-inspect@1.13.3:
-    resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
-    engines: {node: '>= 0.4'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -36799,7 +36795,7 @@ snapshots:
       is-string: 1.1.1
       is-typed-array: 1.1.15
       is-weakref: 1.0.2
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
       object-keys: 1.1.1
       object.assign: 4.1.7
       regexp.prototype.flags: 1.5.4
@@ -42057,8 +42053,6 @@ snapshots:
 
   object-hash@3.0.0: {}
 
-  object-inspect@1.13.3: {}
-
   object-inspect@1.13.4: {}
 
   object-is@1.1.5:
@@ -45214,27 +45208,27 @@ snapshots:
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
 
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2

--- a/products/cohorts/frontend/mcp-apps/CohortListView.tsx
+++ b/products/cohorts/frontend/mcp-apps/CohortListView.tsx
@@ -1,0 +1,132 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { CohortView, type CohortData } from './CohortView'
+
+export interface CohortListData {
+    results: CohortData[]
+    _posthogUrl?: string
+}
+
+export interface CohortListViewProps {
+    data: CohortListData
+    onCohortClick?: (cohort: CohortData) => Promise<CohortData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; cohort: CohortData }
+
+export function CohortListView({ data, onCohortClick }: CohortListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (cohort: CohortData) => {
+            if (!onCohortClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: cohort.name })
+            const detail = await onCohortClick(cohort)
+            if (detail) {
+                setViewState({ view: 'detail', cohort: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onCohortClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All cohorts" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All cohorts" />
+                    <CohortView cohort={viewState.cohort} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const items = Array.isArray(data.results) ? data.results : Array.isArray(data) ? data : []
+
+    const columns: DataTableColumn<CohortData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onCohortClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    row.name
+                ),
+        },
+        {
+            key: 'is_static',
+            header: 'Type',
+            render: (row): ReactNode => (
+                <Badge variant={row.is_static ? 'neutral' : 'info'} size="sm">
+                    {row.is_static ? 'Static' : 'Dynamic'}
+                </Badge>
+            ),
+        },
+        {
+            key: 'count',
+            header: 'Persons',
+            align: 'right',
+            sortable: true,
+            render: (row): ReactNode => (
+                <span className="text-text-secondary tabular-nums">
+                    {row.count != null ? row.count.toLocaleString() : '\u2014'}
+                </span>
+            ),
+        },
+        {
+            key: 'created_at',
+            header: 'Created',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.created_at ? (
+                    <span className="text-text-secondary">{formatDate(row.created_at)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {items.length} cohort{items.length === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<CohortData>
+                    columns={columns}
+                    data={items}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No cohorts found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/cohorts/frontend/mcp-apps/CohortListView.tsx
+++ b/products/cohorts/frontend/mcp-apps/CohortListView.tsx
@@ -25,7 +25,11 @@ export function CohortListView({ data, onCohortClick }: CohortListViewProps): Re
                 return
             }
             setViewState({ view: 'loading', name: cohort.name })
-            const detail = await onCohortClick(cohort)
+            const detail = await onCohortClick(cohort).catch((error) => {
+                console.error('Error loading cohort detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', cohort: detail })
             } else {
@@ -58,8 +62,6 @@ export function CohortListView({ data, onCohortClick }: CohortListViewProps): Re
             </div>
         )
     }
-
-    const items = Array.isArray(data.results) ? data.results : Array.isArray(data) ? data : []
 
     const columns: DataTableColumn<CohortData>[] = [
         {
@@ -116,12 +118,12 @@ export function CohortListView({ data, onCohortClick }: CohortListViewProps): Re
             <Stack gap="sm">
                 <div className="flex items-center justify-between">
                     <span className="text-sm text-text-secondary">
-                        {items.length} cohort{items.length === 1 ? '' : 's'}
+                        {data.results.length} cohort{data.results.length === 1 ? '' : 's'}
                     </span>
                 </div>
                 <DataTable<CohortData>
                     columns={columns}
-                    data={items}
+                    data={data.results}
                     pageSize={10}
                     defaultSort={{ key: 'name', direction: 'asc' }}
                     emptyMessage="No cohorts found"

--- a/products/cohorts/frontend/mcp-apps/CohortView.tsx
+++ b/products/cohorts/frontend/mcp-apps/CohortView.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
+
+export interface CohortData {
+    id: number
+    name: string
+    description?: string | null
+    is_static?: boolean
+    is_calculating?: boolean
+    count?: number | null
+    created_at?: string
+    created_by?: { first_name?: string; email?: string } | null
+    filters?: Record<string, unknown>
+    _posthogUrl?: string
+}
+
+export interface CohortViewProps {
+    cohort: CohortData
+}
+
+export function CohortView({ cohort }: CohortViewProps): ReactElement {
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary">{cohort.name}</span>
+                        <Badge variant={cohort.is_static ? 'neutral' : 'info'} size="md">
+                            {cohort.is_static ? 'Static' : 'Dynamic'}
+                        </Badge>
+                        {cohort.is_calculating && (
+                            <Badge variant="warning" size="sm">
+                                Calculating...
+                            </Badge>
+                        )}
+                    </div>
+                    {cohort.description && <span className="text-sm text-text-secondary">{cohort.description}</span>}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        columns={2}
+                        items={[
+                            ...(cohort.count != null
+                                ? [{ label: 'Persons', value: cohort.count.toLocaleString() }]
+                                : []),
+                            ...(cohort.created_at ? [{ label: 'Created', value: formatDate(cohort.created_at) }] : []),
+                            ...(cohort.created_by
+                                ? [
+                                      {
+                                          label: 'Created by',
+                                          value: cohort.created_by.first_name || cohort.created_by.email || 'Unknown',
+                                      },
+                                  ]
+                                : []),
+                        ]}
+                    />
+                </Card>
+            </Stack>
+        </div>
+    )
+}

--- a/products/cohorts/frontend/mcp-apps/index.ts
+++ b/products/cohorts/frontend/mcp-apps/index.ts
@@ -1,0 +1,2 @@
+export { CohortView, type CohortData, type CohortViewProps } from './CohortView'
+export { CohortListView, type CohortListData, type CohortListViewProps } from './CohortListView'

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -8,6 +8,9 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "@storybook/react": "catalog:"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@types/react": "*",

--- a/services/mcp/definitions/cohorts.yaml
+++ b/services/mcp/definitions/cohorts.yaml
@@ -27,6 +27,7 @@ tools:
             List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic
             cohorts (automatically updated based on property filters).
         mcp_version: 1
+        ui_resource_uri: ui://posthog/cohort-list.html
     cohorts-create:
         operation: cohorts_create
         enabled: true
@@ -56,6 +57,7 @@ tools:
             - count
             - experiment_set
         mcp_version: 1
+        ui_resource_uri: ui://posthog/cohort.html
     cohorts-retrieve:
         operation: cohorts_retrieve
         enabled: true
@@ -71,6 +73,7 @@ tools:
             Get a specific cohort by ID. Returns the cohort name, description, filters (for dynamic cohorts), count of
             matching users, and calculation status.
         mcp_version: 1
+        ui_resource_uri: ui://posthog/cohort.html
     cohorts-update:
         operation: cohorts_update
         enabled: false
@@ -101,6 +104,7 @@ tools:
             - count
             - experiment_set
         mcp_version: 1
+        ui_resource_uri: ui://posthog/cohort.html
     cohorts-destroy:
         operation: cohorts_destroy
         enabled: false

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -38,3 +38,15 @@ export const ACTION_RESOURCE_URI = 'ui://posthog/action.html'
  * Used by: actions-get-all
  */
 export const ACTION_LIST_RESOURCE_URI = 'ui://posthog/action-list.html'
+
+/**
+
+ * Cohort detail visualization.
+ * Used by: cohorts-retrieve, cohorts-create, cohorts-partial-update
+ */
+export const COHORT_RESOURCE_URI = 'ui://posthog/cohort.html'
+/**
+ * Cohort list visualization.
+ * Used by: cohorts-list
+ */
+export const COHORT_LIST_RESOURCE_URI = 'ui://posthog/cohort-list.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -7,6 +7,8 @@ import type { Context } from '@/tools/types'
 import {
     ACTION_LIST_RESOURCE_URI,
     ACTION_RESOURCE_URI,
+    COHORT_LIST_RESOURCE_URI,
+    COHORT_RESOURCE_URI,
     DEBUG_RESOURCE_URI,
     QUERY_RESULTS_RESOURCE_URI,
 } from './ui-apps-constants'
@@ -15,6 +17,8 @@ import {
 // Each UI app has its own HTML file in ui-apps-dist/src/ui-apps/apps/<name>/
 import actionListHtml from '../../ui-apps-dist/src/ui-apps/apps/action-list/index.html'
 import actionHtml from '../../ui-apps-dist/src/ui-apps/apps/action/index.html'
+import cohortListHtml from '../../ui-apps-dist/src/ui-apps/apps/cohort-list/index.html'
+import cohortHtml from '../../ui-apps-dist/src/ui-apps/apps/cohort/index.html'
 import debugHtml from '../../ui-apps-dist/src/ui-apps/apps/debug/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
 
@@ -35,6 +39,9 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
     // Actions
     { name: 'Action', uri: ACTION_RESOURCE_URI, description: 'Action detail view', html: actionHtml },
     { name: 'Action list', uri: ACTION_LIST_RESOURCE_URI, description: 'Action list view', html: actionListHtml },
+    // Cohorts
+    { name: 'Cohort', uri: COHORT_RESOURCE_URI, description: 'Cohort detail view', html: cohortHtml },
+    { name: 'Cohort list', uri: COHORT_LIST_RESOURCE_URI, description: 'Cohort list view', html: cohortListHtml },
 ]
 
 /**

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -40,6 +40,11 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, unknown> => ({
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/cohorts`,
         }
     },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/cohort-list.html',
+        },
+    },
 })
 
 const CohortsCreateSchema = CohortsCreateBody.omit({
@@ -83,6 +88,11 @@ const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, Schemas.Cohort & 
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/cohorts/${(result as any).id}`,
         }
     },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/cohort.html',
+        },
+    },
 })
 
 const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true })
@@ -100,6 +110,11 @@ const cohortsRetrieve = (): ToolBase<typeof CohortsRetrieveSchema, Schemas.Cohor
             ...(result as any),
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/cohorts/${(result as any).id}`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/cohort.html',
+        },
     },
 })
 
@@ -146,6 +161,11 @@ const cohortsPartialUpdate = (): ToolBase<
             ...(result as any),
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/cohorts/${(result as any).id}`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/cohort.html',
+        },
     },
 })
 

--- a/services/mcp/src/ui-apps/apps/cohort-list/index.html
+++ b/services/mcp/src/ui-apps/apps/cohort-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Cohorts</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/cohort-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/cohort-list/main.tsx
@@ -1,0 +1,60 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { type CohortData, type CohortListData, CohortListView } from 'products/cohorts/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function CohortListApp(): JSX.Element {
+    return (
+        <AppWrapper<CohortListData> appName="PostHog Cohorts">
+            {({ data, app }) => <CohortListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function CohortListContent({ data, app }: { data: CohortListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for cohort "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (cohort: CohortData): Promise<CohortData | null> => {
+            if (!app) {
+                fallbackToChat(cohort.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'cohorts-retrieve',
+                    arguments: { id: cohort.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(cohort.name)
+                    return null
+                }
+                return result.structuredContent as unknown as CohortData
+            } catch {
+                fallbackToChat(cohort.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <CohortListView data={data} onCohortClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<CohortListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/cohort/index.html
+++ b/services/mcp/src/ui-apps/apps/cohort/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Cohort</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/cohort/main.tsx
+++ b/services/mcp/src/ui-apps/apps/cohort/main.tsx
@@ -1,0 +1,16 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type CohortData, CohortView } from 'products/cohorts/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function CohortApp(): JSX.Element {
+    return <AppWrapper<CohortData> appName="PostHog Cohort">{({ data }) => <CohortView cohort={data!} />}</AppWrapper>
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<CohortApp />)
+}


### PR DESCRIPTION
## Problem

Users need a visual interface to browse and view cohorts in PostHog through MCP (Model Context Protocol) applications. Currently, cohort data can only be accessed through API calls without a user-friendly interface for exploring cohort lists and individual cohort details.

## Changes

- Added React components for cohort visualization:
  - `CohortListView`: Displays cohorts in a sortable data table with filtering and navigation
  - `CohortView`: Shows detailed information for individual cohorts including metadata and statistics
- Created MCP UI applications:
  - Cohort list app (`cohort-list`) for browsing all cohorts
  - Individual cohort app (`cohort`) for viewing cohort details
- Updated MCP cohorts service to include UI resource URIs and return structured data with PostHog URLs
- Added Storybook development dependency for component development

The cohort list view includes interactive features like clicking to view details, loading states, and fallback to chat when API calls fail. Both views display cohort type badges (Static/Dynamic), person counts, creation dates, and other relevant metadata.


## Publish to changelog?

No - not yet.