### PR TITLE
feat: Add error tracking UI components for MCP apps

### DIFF
--- a/products/error_tracking/frontend/mcp-apps/ErrorDetailsView.tsx
+++ b/products/error_tracking/frontend/mcp-apps/ErrorDetailsView.tsx
@@ -1,0 +1,117 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, EmptyState, formatDate, Stack } from '@posthog/mosaic'
+
+import { type ExceptionData, StackTraceView } from './StackTraceView'
+
+export interface ErrorDetailsEventData {
+    uuid?: string
+    distinct_id?: string
+    timestamp?: string
+    properties?: Record<string, unknown>
+}
+
+export interface ErrorDetailsData {
+    results?: ErrorDetailsEventData[]
+    _posthogUrl?: string
+}
+
+function extractExceptions(properties: Record<string, unknown>): ExceptionData[] {
+    // Primary source: $exception_list (structured exception data)
+    if (Array.isArray(properties.$exception_list) && properties.$exception_list.length > 0) {
+        return properties.$exception_list as ExceptionData[]
+    }
+
+    // Fallback: construct from individual properties
+    const type = properties.$exception_type as string | undefined
+    const value = (properties.$exception_message ?? properties.$exception_value) as string | undefined
+    if (type || value) {
+        return [{ type: type ?? 'Error', value: value ?? '' }]
+    }
+
+    return []
+}
+
+export function ErrorDetailsView({ data }: { data: ErrorDetailsData }): ReactElement {
+    const events = data.results ?? (Array.isArray(data) ? data : [])
+
+    if (events.length === 0) {
+        return (
+            <div className="p-4">
+                <EmptyState
+                    title="No error events"
+                    description="No error events found for this issue in the selected time range"
+                />
+            </div>
+        )
+    }
+
+    // Show the first (most recent) event
+    const event = events[0]
+    const properties = event.properties ?? {}
+    const exceptions = extractExceptions(properties)
+
+    const exceptionType = (properties.$exception_type as string) ?? exceptions[0]?.type ?? 'Error'
+    const exceptionMessage = (properties.$exception_message as string) ?? exceptions[0]?.value ?? ''
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant="danger" size="md">
+                            {exceptionType}
+                        </Badge>
+                        {properties.$exception_synthetic && (
+                            <Badge variant="neutral" size="sm">
+                                Synthetic
+                            </Badge>
+                        )}
+                    </div>
+                    <span className="text-sm text-text-primary">{exceptionMessage}</span>
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        columns={2}
+                        items={[
+                            ...(event.timestamp
+                                ? [{ label: 'Timestamp', value: formatDate(event.timestamp, true) }]
+                                : []),
+                            ...(event.distinct_id ? [{ label: 'Distinct ID', value: event.distinct_id }] : []),
+                            ...(properties.$browser
+                                ? [
+                                      {
+                                          label: 'Browser',
+                                          value: `${properties.$browser}${properties.$browser_version ? ` ${properties.$browser_version}` : ''}`,
+                                      },
+                                  ]
+                                : []),
+                            ...(properties.$os
+                                ? [
+                                      {
+                                          label: 'OS',
+                                          value: `${properties.$os}${properties.$os_version ? ` ${properties.$os_version}` : ''}`,
+                                      },
+                                  ]
+                                : []),
+                            ...(properties.$lib ? [{ label: 'Library', value: properties.$lib as string }] : []),
+                            ...(properties.$current_url
+                                ? [{ label: 'URL', value: properties.$current_url as string }]
+                                : []),
+                        ]}
+                    />
+                </Card>
+
+                {exceptions.length > 0 && <StackTraceView exceptions={exceptions} />}
+
+                {events.length > 1 && (
+                    <span className="text-xs text-text-secondary">
+                        Showing most recent event. {events.length - 1} more event{events.length - 1 === 1 ? '' : 's'} in
+                        this issue.
+                    </span>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/mcp-apps/ErrorIssueListView.tsx
+++ b/products/error_tracking/frontend/mcp-apps/ErrorIssueListView.tsx
@@ -1,0 +1,134 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { ErrorIssueView, type ErrorIssueData } from './ErrorIssueView'
+
+export interface ErrorIssueListData {
+    count?: number
+    results: ErrorIssueData[]
+    _posthogUrl?: string
+}
+
+export interface ErrorIssueListViewProps {
+    data: ErrorIssueListData
+    onIssueClick?: (issue: ErrorIssueData) => Promise<ErrorIssueData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; issue: ErrorIssueData }
+
+const statusConfig: Record<string, { label: string; variant: 'success' | 'danger' | 'warning' | 'neutral' }> = {
+    active: { label: 'Active', variant: 'danger' },
+    resolved: { label: 'Resolved', variant: 'success' },
+    archived: { label: 'Archived', variant: 'neutral' },
+    pending_release: { label: 'Pending release', variant: 'warning' },
+    suppressed: { label: 'Suppressed', variant: 'neutral' },
+}
+
+export function ErrorIssueListView({ data, onIssueClick }: ErrorIssueListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (issue: ErrorIssueData) => {
+            if (!onIssueClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: issue.name })
+            const detail = await onIssueClick(issue)
+            if (detail) {
+                setViewState({ view: 'detail', issue: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onIssueClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All issues" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All issues" />
+                    <ErrorIssueView issue={viewState.issue} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const columns: DataTableColumn<ErrorIssueData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onIssueClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors max-w-xs truncate block"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    <span className="max-w-xs truncate block">{row.name}</span>
+                ),
+        },
+        {
+            key: 'status',
+            header: 'Status',
+            render: (row): ReactNode => {
+                const cfg = statusConfig[row.status ?? 'active'] ?? {
+                    label: row.status ?? 'Unknown',
+                    variant: 'neutral' as const,
+                }
+                return (
+                    <Badge variant={cfg.variant} size="sm">
+                        {cfg.label}
+                    </Badge>
+                )
+            },
+        },
+        {
+            key: 'first_seen',
+            header: 'First seen',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.first_seen ? (
+                    <span className="text-text-secondary">{formatDate(row.first_seen)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {data.count ?? data.results.length} issue{(data.count ?? data.results.length) === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<ErrorIssueData>
+                    columns={columns}
+                    data={data.results}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No error tracking issues found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/mcp-apps/ErrorIssueListView.tsx
+++ b/products/error_tracking/frontend/mcp-apps/ErrorIssueListView.tsx
@@ -33,8 +33,13 @@ export function ErrorIssueListView({ data, onIssueClick }: ErrorIssueListViewPro
             if (!onIssueClick) {
                 return
             }
+
             setViewState({ view: 'loading', name: issue.name })
-            const detail = await onIssueClick(issue)
+            const detail = await onIssueClick(issue).catch((error) => {
+                console.error('Error loading issue detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', issue: detail })
             } else {

--- a/products/error_tracking/frontend/mcp-apps/ErrorIssueView.tsx
+++ b/products/error_tracking/frontend/mcp-apps/ErrorIssueView.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, formatDate, Link, Stack } from '@posthog/mosaic'
+
+export interface ExternalIssue {
+    external_url: string
+    integration?: { display_name?: string }
+}
+
+export interface ErrorIssueData {
+    id: string
+    name: string
+    description?: string | null
+    status?: string
+    first_seen?: string
+    assignee?: { id: string; type: string } | null
+    external_issues?: ExternalIssue[]
+    _posthogUrl?: string
+}
+
+export interface ErrorIssueViewProps {
+    issue: ErrorIssueData
+}
+
+const statusConfig: Record<string, { label: string; variant: 'success' | 'danger' | 'warning' | 'neutral' }> = {
+    active: { label: 'Active', variant: 'danger' },
+    resolved: { label: 'Resolved', variant: 'success' },
+    archived: { label: 'Archived', variant: 'neutral' },
+    pending_release: { label: 'Pending release', variant: 'warning' },
+    suppressed: { label: 'Suppressed', variant: 'neutral' },
+}
+
+export function ErrorIssueView({ issue }: ErrorIssueViewProps): ReactElement {
+    const cfg = statusConfig[issue.status ?? 'active'] ?? {
+        label: issue.status ?? 'Unknown',
+        variant: 'neutral' as const,
+    }
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary break-all">{issue.name}</span>
+                        <Badge variant={cfg.variant} size="md">
+                            {cfg.label}
+                        </Badge>
+                    </div>
+                    {issue.description && <span className="text-sm text-text-secondary">{issue.description}</span>}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        items={[
+                            ...(issue.first_seen
+                                ? [{ label: 'First seen', value: formatDate(issue.first_seen, true) }]
+                                : []),
+                            ...(issue.assignee
+                                ? [{ label: 'Assignee', value: `${issue.assignee.type} (${issue.assignee.id})` }]
+                                : []),
+                        ]}
+                    />
+                </Card>
+
+                {issue.external_issues && issue.external_issues.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">External issues</span>
+                            {issue.external_issues.map((ext, i) => (
+                                <div key={i} className="flex items-center gap-2">
+                                    {ext.integration?.display_name && (
+                                        <Badge variant="neutral" size="sm">
+                                            {ext.integration.display_name}
+                                        </Badge>
+                                    )}
+                                    <Link href={ext.external_url} external className="text-sm">
+                                        {ext.external_url}
+                                    </Link>
+                                </div>
+                            ))}
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/mcp-apps/StackTraceView.tsx
+++ b/products/error_tracking/frontend/mcp-apps/StackTraceView.tsx
@@ -1,0 +1,194 @@
+import type { ReactElement } from 'react'
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge, Card, Stack } from '@posthog/mosaic'
+
+export interface StackFrame {
+    raw_id?: string
+    mangled_name?: string
+    resolved_name?: string | null
+    source?: string | null
+    line?: number | null
+    column?: number | null
+    in_app?: boolean
+    lang?: string
+    resolved?: boolean
+    context?: {
+        before?: Array<{ number: number; line: string }>
+        line?: { number: number; line: string }
+        after?: Array<{ number: number; line: string }>
+    } | null
+}
+
+export interface ExceptionData {
+    type: string
+    value: string
+    module?: string
+    mechanism?: { handled?: boolean; type?: string }
+    stacktrace?: {
+        type?: string
+        frames?: StackFrame[]
+    }
+}
+
+export interface StackTraceViewProps {
+    exceptions: ExceptionData[]
+}
+
+function formatFrameLocation(frame: StackFrame): string {
+    const parts: string[] = []
+    if (frame.source) {
+        parts.push(frame.source)
+    }
+    if (frame.line != null) {
+        parts.push(`:${frame.line}`)
+        if (frame.column != null) {
+            parts.push(`:${frame.column}`)
+        }
+    }
+    return parts.join('')
+}
+
+function FrameContextLines({ context }: { context: NonNullable<StackFrame['context']> }): ReactElement {
+    const allLines = [
+        ...(context.before ?? []).map((l) => ({ ...l, type: 'context' as const })),
+        ...(context.line ? [{ ...context.line, type: 'error' as const }] : []),
+        ...(context.after ?? []).map((l) => ({ ...l, type: 'context' as const })),
+    ]
+
+    return (
+        <pre className="text-xs overflow-x-auto bg-bg-secondary rounded p-2 font-mono leading-relaxed">
+            {allLines.map((l, i) => (
+                <div key={i} className={l.type === 'error' ? 'bg-danger/10 -mx-2 px-2' : ''}>
+                    <span className="inline-block w-10 text-right text-text-secondary select-none pr-3 tabular-nums">
+                        {l.number}
+                    </span>
+                    <span className={l.type === 'error' ? 'text-text-danger font-medium' : 'text-text-primary'}>
+                        {l.line}
+                    </span>
+                </div>
+            ))}
+        </pre>
+    )
+}
+
+function FrameRow({ frame, index }: { frame: StackFrame; index: number }): ReactElement {
+    const funcName = frame.resolved_name || frame.mangled_name || '<anonymous>'
+    const location = formatFrameLocation(frame)
+    const hasContext =
+        frame.context && (frame.context.before?.length || frame.context.line || frame.context.after?.length)
+
+    if (!hasContext) {
+        return (
+            <div className="flex items-start gap-2 py-1.5 px-2 text-xs font-mono">
+                <span className={frame.in_app ? 'text-text-primary font-medium' : 'text-text-secondary'}>
+                    {funcName}
+                </span>
+                {location && <span className="text-text-secondary truncate ml-auto shrink-0">{location}</span>}
+                {frame.in_app === false && (
+                    <Badge variant="neutral" size="sm" className="ml-1 shrink-0">
+                        vendor
+                    </Badge>
+                )}
+            </div>
+        )
+    }
+
+    return (
+        <AccordionItem value={`frame-${index}`}>
+            <AccordionTrigger className="px-2">
+                <div className="flex items-center gap-2 min-w-0">
+                    <span
+                        className={
+                            frame.in_app
+                                ? 'text-text-primary font-medium font-mono text-xs'
+                                : 'text-text-secondary font-mono text-xs'
+                        }
+                    >
+                        {funcName}
+                    </span>
+                    {location && (
+                        <span className="text-text-secondary text-xs truncate ml-auto shrink-0">{location}</span>
+                    )}
+                    {frame.in_app === false && (
+                        <Badge variant="neutral" size="sm" className="shrink-0">
+                            vendor
+                        </Badge>
+                    )}
+                </div>
+            </AccordionTrigger>
+            <AccordionContent className="pl-6 pr-2">
+                <FrameContextLines context={frame.context!} />
+            </AccordionContent>
+        </AccordionItem>
+    )
+}
+
+function ExceptionSection({ exception, index }: { exception: ExceptionData; index: number }): ReactElement {
+    const frames = exception.stacktrace?.frames ?? []
+    // Reverse frames so most recent call is at the top (Python/JS convention)
+    const displayFrames = [...frames].reverse()
+    const inAppCount = frames.filter((f) => f.in_app).length
+
+    return (
+        <Card padding="md">
+            <Stack gap="sm">
+                <div className="flex items-center gap-2 flex-wrap">
+                    {index > 0 && (
+                        <span className="text-xs text-text-secondary uppercase tracking-wide">Caused by</span>
+                    )}
+                    <Badge variant="danger" size="md">
+                        {exception.type}
+                    </Badge>
+                    {exception.mechanism?.handled === false && (
+                        <Badge variant="warning" size="sm">
+                            Unhandled
+                        </Badge>
+                    )}
+                </div>
+                <span className="text-sm text-text-primary">{exception.value}</span>
+
+                {displayFrames.length > 0 && (
+                    <div className="mt-1">
+                        <div className="flex items-center gap-2 mb-1">
+                            <span className="text-xs text-text-secondary">
+                                {displayFrames.length} frame{displayFrames.length === 1 ? '' : 's'}
+                            </span>
+                            {inAppCount > 0 && (
+                                <span className="text-xs text-text-secondary">({inAppCount} in-app)</span>
+                            )}
+                        </div>
+                        <div className="rounded border border-border-primary overflow-hidden">
+                            <Accordion multiple defaultExpanded={getDefaultExpanded(displayFrames)}>
+                                {displayFrames.map((frame, i) => (
+                                    <FrameRow key={frame.raw_id ?? i} frame={frame} index={i} />
+                                ))}
+                            </Accordion>
+                        </div>
+                    </div>
+                )}
+            </Stack>
+        </Card>
+    )
+}
+
+/** Auto-expand the first in-app frame that has context */
+function getDefaultExpanded(frames: StackFrame[]): string[] {
+    const idx = frames.findIndex(
+        (f) => f.in_app && f.context && (f.context.before?.length || f.context.line || f.context.after?.length)
+    )
+    return idx >= 0 ? [`frame-${idx}`] : []
+}
+
+export function StackTraceView({ exceptions }: StackTraceViewProps): ReactElement {
+    if (exceptions.length === 0) {
+        return <div className="text-sm text-text-secondary p-4">No exception data available</div>
+    }
+
+    return (
+        <Stack gap="md">
+            {exceptions.map((exception, i) => (
+                <ExceptionSection key={i} exception={exception} index={i} />
+            ))}
+        </Stack>
+    )
+}

--- a/products/error_tracking/frontend/mcp-apps/index.ts
+++ b/products/error_tracking/frontend/mcp-apps/index.ts
@@ -1,0 +1,4 @@
+export { ErrorIssueView, type ErrorIssueData, type ErrorIssueViewProps } from './ErrorIssueView'
+export { ErrorIssueListView, type ErrorIssueListData, type ErrorIssueListViewProps } from './ErrorIssueListView'
+export { ErrorDetailsView, type ErrorDetailsData, type ErrorDetailsEventData } from './ErrorDetailsView'
+export { StackTraceView, type StackTraceViewProps, type ExceptionData, type StackFrame } from './StackTraceView'

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -92,12 +92,14 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: '{id}'
         list: true
         title: List error tracking issues
         description: >
             List all error tracking issues in the project. Returns issues with status, volume, first/last seen
             timestamps, and assignee info.
         mcp_version: 1
+        ui_resource_uri: ui://posthog/error-issue-list.html
     error-tracking-issues-create:
         operation: error_tracking_issues_create
         enabled: false
@@ -110,11 +112,13 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: '{id}'
         title: Get error tracking issue
         description: >
             Get a specific error tracking issue by ID. Returns full issue details including status, description, volume,
             and metadata.
         mcp_version: 1
+        ui_resource_uri: ui://posthog/error-issue.html
     error-tracking-issues-update:
         operation: error_tracking_issues_update
         enabled: false
@@ -127,10 +131,12 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
+        enrich_url: '{id}'
         title: Update error tracking issue
         description: >
             Update an error tracking issue. Can change status (active, resolved, suppressed), assign to a user, or
             update description.
+        ui_resource_uri: ui://posthog/error-issue.html
     error-tracking-issues-destroy:
         operation: error_tracking_issues_destroy
         enabled: false

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -50,3 +50,19 @@ export const COHORT_RESOURCE_URI = 'ui://posthog/cohort.html'
  * Used by: cohorts-list
  */
 export const COHORT_LIST_RESOURCE_URI = 'ui://posthog/cohort-list.html'
+
+/**
+ * Error details visualization with stack traces.
+ * Used by: error-details
+ */
+export const ERROR_DETAILS_RESOURCE_URI = 'ui://posthog/error-details.html'
+/**
+ * Error tracking issue detail visualization.
+ * Used by: error-tracking-issues-retrieve, error-tracking-issues-partial-update
+ */
+export const ERROR_ISSUE_RESOURCE_URI = 'ui://posthog/error-issue.html'
+/**
+ * Error tracking issue list visualization.
+ * Used by: error-tracking-issues-list
+ */
+export const ERROR_ISSUE_LIST_RESOURCE_URI = 'ui://posthog/error-issue-list.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -10,6 +10,9 @@ import {
     COHORT_LIST_RESOURCE_URI,
     COHORT_RESOURCE_URI,
     DEBUG_RESOURCE_URI,
+    ERROR_DETAILS_RESOURCE_URI,
+    ERROR_ISSUE_LIST_RESOURCE_URI,
+    ERROR_ISSUE_RESOURCE_URI,
     QUERY_RESULTS_RESOURCE_URI,
 } from './ui-apps-constants'
 
@@ -20,6 +23,9 @@ import actionHtml from '../../ui-apps-dist/src/ui-apps/apps/action/index.html'
 import cohortListHtml from '../../ui-apps-dist/src/ui-apps/apps/cohort-list/index.html'
 import cohortHtml from '../../ui-apps-dist/src/ui-apps/apps/cohort/index.html'
 import debugHtml from '../../ui-apps-dist/src/ui-apps/apps/debug/index.html'
+import errorDetailsHtml from '../../ui-apps-dist/src/ui-apps/apps/error-details/index.html'
+import errorIssueListHtml from '../../ui-apps-dist/src/ui-apps/apps/error-issue-list/index.html'
+import errorIssueHtml from '../../ui-apps-dist/src/ui-apps/apps/error-issue/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
 
 const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
@@ -42,6 +48,25 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
     // Cohorts
     { name: 'Cohort', uri: COHORT_RESOURCE_URI, description: 'Cohort detail view', html: cohortHtml },
     { name: 'Cohort list', uri: COHORT_LIST_RESOURCE_URI, description: 'Cohort list view', html: cohortListHtml },
+    // Error tracking
+    {
+        name: 'Error details',
+        uri: ERROR_DETAILS_RESOURCE_URI,
+        description: 'Error details with stack traces',
+        html: errorDetailsHtml,
+    },
+    {
+        name: 'Error issue',
+        uri: ERROR_ISSUE_RESOURCE_URI,
+        description: 'Error tracking issue detail view',
+        html: errorIssueHtml,
+    },
+    {
+        name: 'Error issue list',
+        uri: ERROR_ISSUE_LIST_RESOURCE_URI,
+        description: 'Error tracking issue list view',
+        html: errorIssueListHtml,
+    },
 ]
 
 /**

--- a/services/mcp/src/tools/errorTracking/errorDetails.ts
+++ b/services/mcp/src/tools/errorTracking/errorDetails.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { ERROR_DETAILS_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { ErrorTrackingDetailsSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -30,13 +31,21 @@ export const errorDetailsHandler: ToolBase<typeof schema, unknown>['handler'] = 
         throw new Error(`Failed to get error details: ${errorsResult.error.message}`)
     }
 
-    return errorsResult.data.results
+    return {
+        results: errorsResult.data.results,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking/${issueId}`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'error-details',
     schema,
     handler: errorDetailsHandler,
+    _meta: {
+        ui: {
+            resourceUri: ERROR_DETAILS_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/errorTracking/listErrors.ts
+++ b/services/mcp/src/tools/errorTracking/listErrors.ts
@@ -1,13 +1,14 @@
 import type { z } from 'zod'
 
+import { ERROR_ISSUE_LIST_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { ErrorTrackingListSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = ErrorTrackingListSchema
-
 type Params = z.infer<typeof schema>
+type Result = any & { __posthogUrl: string }
 
-export const listErrorsHandler: ToolBase<typeof schema, unknown>['handler'] = async (
+export const listErrorsHandler: ToolBase<typeof schema, Result>['handler'] = async (
     context: Context,
     params: Params
 ) => {
@@ -32,13 +33,21 @@ export const listErrorsHandler: ToolBase<typeof schema, unknown>['handler'] = as
         throw new Error(`Failed to list errors: ${errorsResult.error.message}`)
     }
 
-    return errorsResult.data.results
+    return {
+        results: errorsResult.data.results,
+        __posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'list-errors',
     schema,
     handler: listErrorsHandler,
+    _meta: {
+        ui: {
+            resourceUri: ERROR_ISSUE_LIST_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/errorTracking/listErrors.ts
+++ b/services/mcp/src/tools/errorTracking/listErrors.ts
@@ -6,7 +6,7 @@ import type { Context, ToolBase } from '@/tools/types'
 
 const schema = ErrorTrackingListSchema
 type Params = z.infer<typeof schema>
-type Result = any & { __posthogUrl: string }
+type Result = any & { _posthogUrl: string }
 
 export const listErrorsHandler: ToolBase<typeof schema, Result>['handler'] = async (
     context: Context,
@@ -35,7 +35,7 @@ export const listErrorsHandler: ToolBase<typeof schema, Result>['handler'] = asy
 
     return {
         results: errorsResult.data.results,
-        __posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking`,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking`,
     }
 }
 

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -28,10 +28,20 @@ const errorTrackingIssuesList = (): ToolBase<
                 offset: params.offset,
             },
         })
+        const items = (result as any).results ?? result
         return {
             ...(result as any),
+            results: (items as any[]).map((item: any) => ({
+                ...item,
+                _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking/${item.id}`,
+            })),
             _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/error-issue-list.html',
+        },
     },
 })
 
@@ -49,7 +59,15 @@ const errorTrackingIssuesRetrieve = (): ToolBase<
             method: 'GET',
             path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/`,
         })
-        return result
+        return {
+            ...(result as any),
+            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking/${(result as any).id}`,
+        }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/error-issue.html',
+        },
     },
 })
 
@@ -89,7 +107,15 @@ const errorTrackingIssuesPartialUpdate = (): ToolBase<
             path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/`,
             body,
         })
-        return result
+        return {
+            ...(result as any),
+            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/error_tracking/${(result as any).id}`,
+        }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/error-issue.html',
+        },
     },
 })
 

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -12,10 +12,7 @@ import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingIssuesListSchema = ErrorTrackingIssuesListQueryParams
 
-const errorTrackingIssuesList = (): ToolBase<
-    typeof ErrorTrackingIssuesListSchema,
-    Schemas.PaginatedErrorTrackingIssueFullList & { _posthogUrl: string }
-> => ({
+const errorTrackingIssuesList = (): ToolBase<typeof ErrorTrackingIssuesListSchema, unknown> => ({
     name: 'error-tracking-issues-list',
     schema: ErrorTrackingIssuesListSchema,
     handler: async (context: Context, params: z.infer<typeof ErrorTrackingIssuesListSchema>) => {
@@ -49,7 +46,7 @@ const ErrorTrackingIssuesRetrieveSchema = ErrorTrackingIssuesRetrieveParams.omit
 
 const errorTrackingIssuesRetrieve = (): ToolBase<
     typeof ErrorTrackingIssuesRetrieveSchema,
-    Schemas.ErrorTrackingIssueFull
+    Schemas.ErrorTrackingIssueFull & { _posthogUrl: string }
 > => ({
     name: 'error-tracking-issues-retrieve',
     schema: ErrorTrackingIssuesRetrieveSchema,
@@ -77,7 +74,7 @@ const ErrorTrackingIssuesPartialUpdateSchema = ErrorTrackingIssuesPartialUpdateP
 
 const errorTrackingIssuesPartialUpdate = (): ToolBase<
     typeof ErrorTrackingIssuesPartialUpdateSchema,
-    Schemas.ErrorTrackingIssueFull
+    Schemas.ErrorTrackingIssueFull & { _posthogUrl: string }
 > => ({
     name: 'error-tracking-issues-partial-update',
     schema: ErrorTrackingIssuesPartialUpdateSchema,

--- a/services/mcp/src/ui-apps/apps/error-details/index.html
+++ b/services/mcp/src/ui-apps/apps/error-details/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Error Details</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/error-details/main.tsx
+++ b/services/mcp/src/ui-apps/apps/error-details/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type ErrorDetailsData, ErrorDetailsView } from 'products/error_tracking/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ErrorDetailsApp(): JSX.Element {
+    return (
+        <AppWrapper<ErrorDetailsData> appName="PostHog Error Details">
+            {({ data }) => <ErrorDetailsView data={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ErrorDetailsApp />)
+}

--- a/services/mcp/src/ui-apps/apps/error-issue-list/index.html
+++ b/services/mcp/src/ui-apps/apps/error-issue-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Error Issues</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/error-issue-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/error-issue-list/main.tsx
@@ -1,0 +1,64 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import {
+    type ErrorIssueData,
+    type ErrorIssueListData,
+    ErrorIssueListView,
+} from 'products/error_tracking/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ErrorIssueListApp(): JSX.Element {
+    return (
+        <AppWrapper<ErrorIssueListData> appName="PostHog Error Issues">
+            {({ data, app }) => <ErrorIssueListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function ErrorIssueListContent({ data, app }: { data: ErrorIssueListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for error issue "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (issue: ErrorIssueData): Promise<ErrorIssueData | null> => {
+            if (!app) {
+                fallbackToChat(issue.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'error-tracking-issues-retrieve',
+                    arguments: { id: issue.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(issue.name)
+                    return null
+                }
+                return result.structuredContent as unknown as ErrorIssueData
+            } catch {
+                fallbackToChat(issue.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <ErrorIssueListView data={data} onIssueClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ErrorIssueListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/error-issue/index.html
+++ b/services/mcp/src/ui-apps/apps/error-issue/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Error Issue</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/error-issue/main.tsx
+++ b/services/mcp/src/ui-apps/apps/error-issue/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type ErrorIssueData, ErrorIssueView } from 'products/error_tracking/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ErrorIssueApp(): JSX.Element {
+    return (
+        <AppWrapper<ErrorIssueData> appName="PostHog Error Issue">
+            {({ data }) => <ErrorIssueView issue={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ErrorIssueApp />)
+}

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -46,7 +46,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             const result = await listTool.handler(context, {})
             const errorData = parseToolResponse(result)
 
-            expect(Array.isArray(errorData)).toBe(true)
+            expect(Array.isArray(errorData.results)).toBe(true)
         })
 
         it('should list errors with custom date range', async () => {
@@ -61,7 +61,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             })
             const errorData = parseToolResponse(result)
 
-            expect(Array.isArray(errorData)).toBe(true)
+            expect(Array.isArray(errorData.results)).toBe(true)
         })
 
         it('should filter by status', async () => {
@@ -70,7 +70,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             })
             const errorData = parseToolResponse(result)
 
-            expect(Array.isArray(errorData)).toBe(true)
+            expect(Array.isArray(errorData.results)).toBe(true)
         })
 
         it('should handle empty results', async () => {
@@ -80,7 +80,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             })
             const errorData = parseToolResponse(result)
 
-            expect(Array.isArray(errorData)).toBe(true)
+            expect(Array.isArray(errorData.results)).toBe(true)
         })
     })
 
@@ -163,7 +163,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             const listResult = await listTool.handler(context, {})
             const errorList = parseToolResponse(listResult)
 
-            expect(Array.isArray(errorList)).toBe(true)
+            expect(Array.isArray(errorList.results)).toBe(true)
 
             if (errorList.length > 0 && errorList[0].issueId) {
                 const firstError = errorList[0]
@@ -192,17 +192,17 @@ describe('Error Tracking', { concurrent: false }, () => {
             const listResult = await listTool.handler(context, { status: StatusErrors.All })
             const errorList = parseToolResponse(listResult)
 
-            expect(Array.isArray(errorList)).toBe(true)
+            expect(Array.isArray(errorList.results)).toBe(true)
 
-            if (errorList.length === 0 || !errorList[0].id) {
+            if (errorList.results.length === 0 || !errorList.results[0].id) {
                 return
             }
 
-            const issueId = errorList[0].id
+            const issueId = errorList.results[0].id
 
             const detailsResult = await detailsTool.handler(context, { issueId })
             const errorDetails = parseToolResponse(detailsResult)
-            expect(Array.isArray(errorDetails)).toBe(true)
+            expect(Array.isArray(errorDetails.results)).toBe(true)
 
             const updateResult = (await updateTool.handler(context, {
                 issueId,

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -95,7 +95,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             })
             const errorDetails = parseToolResponse(result)
 
-            expect(Array.isArray(errorDetails)).toBe(true)
+            expect(Array.isArray(errorDetails.results)).toBe(true)
         })
 
         it('should get error details with custom date range', async () => {
@@ -110,7 +110,7 @@ describe('Error Tracking', { concurrent: false }, () => {
             })
             const errorDetails = parseToolResponse(result)
 
-            expect(Array.isArray(errorDetails)).toBe(true)
+            expect(Array.isArray(errorDetails.results)).toBe(true)
         })
     })
 
@@ -172,7 +172,7 @@ describe('Error Tracking', { concurrent: false }, () => {
                 })
                 const errorDetails = parseToolResponse(detailsResult)
 
-                expect(Array.isArray(errorDetails)).toBe(true)
+                expect(Array.isArray(errorDetails.results)).toBe(true)
             } else {
                 const testIssueId = '00000000-0000-0000-0000-000000000000'
                 const detailsResult = await detailsTool.handler(context, {
@@ -180,7 +180,7 @@ describe('Error Tracking', { concurrent: false }, () => {
                 })
                 const errorDetails = parseToolResponse(detailsResult)
 
-                expect(Array.isArray(errorDetails)).toBe(true)
+                expect(Array.isArray(errorDetails.results)).toBe(true)
             }
         })
 


### PR DESCRIPTION
## Problem

Error tracking tools in the MCP server lack visual interfaces, making it difficult for users to browse error issues, view stack traces, and understand error details in a user-friendly format. Users need rich UI components to effectively navigate error tracking data.

## Changes

Added comprehensive React UI components for error tracking functionality:

- **ErrorIssueListView**: Displays a paginated table of error issues with status badges, clickable navigation, and issue counts
- **ErrorIssueView**: Shows detailed error issue information including status, assignee, external integrations, and metadata
- **ErrorDetailsView**: Renders error event details with exception information, browser/OS data, and contextual metadata  
- **StackTraceView**: Interactive stack trace display with expandable frames, syntax highlighting, code context, and in-app/vendor frame distinction

Enhanced MCP tools configuration:
- Added UI resource URIs to error tracking tools for seamless integration
- Enriched API responses with PostHog URLs for deep linking
- Created three dedicated UI apps (error-issue-list, error-issue, error-details) with proper routing

Key features:
- Responsive design with proper loading states and empty states
- Interactive accordion-style stack trace frames with code context
- Status badges and external issue integration display
- Automatic expansion of relevant stack frames
- Fallback to chat interface when tool calls fail


## Publish to changelog?

No - not yet.