### PR TITLE
feat: Add experiment UI apps for MCP

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2121,6 +2121,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
 
   products/feature_flags:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2124,7 +2124,7 @@ importers:
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'
-        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
 
   products/feature_flags:
     dependencies:
@@ -14630,11 +14630,6 @@ packages:
   hammerjs@2.0.8:
     resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
     engines: {node: '>=0.8.0'}
-
-  handlebars@4.7.7:
-    resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -30949,7 +30944,7 @@ snapshots:
       es-module-lexer: 1.7.0
       express: 4.18.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.4)(webpack@5.88.2)
-      fs-extra: 11.1.1
+      fs-extra: 11.3.2
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
       magic-string: 0.30.21
       path-browserify: 1.0.1
@@ -30990,7 +30985,7 @@ snapshots:
       '@storybook/client-logger': 7.6.4
       '@storybook/core-events': 7.6.4
       '@storybook/global': 5.0.0
-      qs: 6.14.0
+      qs: 6.14.1
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
@@ -31019,7 +31014,7 @@ snapshots:
       execa: 5.1.1
       express: 4.18.2
       find-up: 5.0.0
-      fs-extra: 11.1.1
+      fs-extra: 11.3.2
       get-npm-tarball-url: 2.0.3
       get-port: 5.1.1
       giget: 1.1.2
@@ -31108,9 +31103,9 @@ snapshots:
       file-system-cache: 2.3.0
       find-cache-dir: 3.3.2
       find-up: 5.0.0
-      fs-extra: 11.1.1
+      fs-extra: 11.3.2
       glob: 10.4.5
-      handlebars: 4.7.7
+      handlebars: 4.7.8
       lazy-universal-dotenv: 4.0.0
       node-fetch: 2.7.0(encoding@0.1.13)
       picomatch: 2.3.1
@@ -31205,7 +31200,7 @@ snapshots:
       '@babel/types': 7.28.1
       '@storybook/csf': 0.1.13
       '@storybook/types': 7.6.4
-      fs-extra: 11.1.1
+      fs-extra: 11.3.2
       recast: 0.23.4
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -31294,7 +31289,7 @@ snapshots:
       '@types/node': 18.19.130
       '@types/semver': 7.5.5
       babel-plugin-add-react-displayname: 0.0.5
-      fs-extra: 11.1.1
+      fs-extra: 11.3.2
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 7.0.1
@@ -31331,7 +31326,7 @@ snapshots:
       dequal: 2.0.3
       lodash: 4.17.23
       memoizerific: 1.11.3
-      qs: 6.14.0
+      qs: 6.14.1
       synchronous-promise: 2.0.17
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -37525,15 +37520,6 @@ snapshots:
       through2: 2.0.5
 
   hammerjs@2.0.8: {}
-
-  handlebars@4.7.7:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
 
   handlebars@4.7.8:
     dependencies:

--- a/products/experiments/frontend/mcp-apps/ExperimentListView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentListView.tsx
@@ -2,7 +2,8 @@ import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
 
 import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
 
-import { ExperimentView, type ExperimentData } from './ExperimentView'
+import { ExperimentView } from './ExperimentView'
+import { ExperimentData, getStatus } from './utils'
 
 export interface ExperimentListData {
     count?: number
@@ -17,19 +18,6 @@ export interface ExperimentListViewProps {
 
 type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; experiment: ExperimentData }
 
-function getStatus(exp: ExperimentData): { label: string; variant: 'success' | 'warning' | 'neutral' | 'info' } {
-    if (exp.archived) {
-        return { label: 'Archived', variant: 'neutral' }
-    }
-    if (!exp.start_date) {
-        return { label: 'Draft', variant: 'neutral' }
-    }
-    if (exp.end_date) {
-        return { label: 'Complete', variant: 'success' }
-    }
-    return { label: 'Running', variant: 'info' }
-}
-
 export function ExperimentListView({ data, onExperimentClick }: ExperimentListViewProps): ReactElement {
     const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
 
@@ -38,8 +26,13 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
             if (!onExperimentClick) {
                 return
             }
+
             setViewState({ view: 'loading', name: experiment.name })
-            const detail = await onExperimentClick(experiment)
+            const detail = await onExperimentClick(experiment).catch((error) => {
+                console.error('Error loading experiment detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', experiment: detail })
             } else {
@@ -73,7 +66,6 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
         )
     }
 
-    const results = data.results ?? data
     const columns: DataTableColumn<ExperimentData>[] = [
         {
             key: 'name',
@@ -152,13 +144,13 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
             <Stack gap="sm">
                 <div className="flex items-center justify-between">
                     <span className="text-sm text-text-secondary">
-                        {(Array.isArray(results) ? results.length : data.count) ?? 0} experiment
-                        {(Array.isArray(results) ? results.length : data.count) === 1 ? '' : 's'}
+                        {data.results.length} experiment
+                        {data.results.length === 1 ? '' : 's'}
                     </span>
                 </div>
                 <DataTable<ExperimentData>
                     columns={columns}
-                    data={Array.isArray(results) ? results : []}
+                    data={data.results}
                     pageSize={10}
                     defaultSort={{ key: 'name', direction: 'asc' }}
                     emptyMessage="No experiments found"

--- a/products/experiments/frontend/mcp-apps/ExperimentListView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentListView.tsx
@@ -1,0 +1,169 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { ExperimentView, type ExperimentData } from './ExperimentView'
+
+export interface ExperimentListData {
+    count?: number
+    results: ExperimentData[]
+    _posthogUrl?: string
+}
+
+export interface ExperimentListViewProps {
+    data: ExperimentListData
+    onExperimentClick?: (experiment: ExperimentData) => Promise<ExperimentData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; experiment: ExperimentData }
+
+function getStatus(exp: ExperimentData): { label: string; variant: 'success' | 'warning' | 'neutral' | 'info' } {
+    if (exp.archived) {
+        return { label: 'Archived', variant: 'neutral' }
+    }
+    if (!exp.start_date) {
+        return { label: 'Draft', variant: 'neutral' }
+    }
+    if (exp.end_date) {
+        return { label: 'Complete', variant: 'success' }
+    }
+    return { label: 'Running', variant: 'info' }
+}
+
+export function ExperimentListView({ data, onExperimentClick }: ExperimentListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (experiment: ExperimentData) => {
+            if (!onExperimentClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: experiment.name })
+            const detail = await onExperimentClick(experiment)
+            if (detail) {
+                setViewState({ view: 'detail', experiment: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onExperimentClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All experiments" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All experiments" />
+                    <ExperimentView experiment={viewState.experiment} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const results = data.results ?? data
+    const columns: DataTableColumn<ExperimentData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onExperimentClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    row.name
+                ),
+        },
+        {
+            key: 'status' as keyof ExperimentData,
+            header: 'Status',
+            render: (row): ReactNode => {
+                const s = getStatus(row)
+                return (
+                    <Badge variant={s.variant} size="sm">
+                        {s.label}
+                    </Badge>
+                )
+            },
+        },
+        {
+            key: 'feature_flag_key',
+            header: 'Flag key',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.feature_flag_key ? (
+                    <span className="text-text-secondary">{row.feature_flag_key}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+        {
+            key: 'parameters' as keyof ExperimentData,
+            header: 'Variants',
+            render: (row): ReactNode => {
+                const variants = row.parameters?.feature_flag_variants
+                if (!variants || variants.length === 0) {
+                    return <span className="text-text-secondary">&mdash;</span>
+                }
+                return (
+                    <div className="flex gap-1 flex-wrap">
+                        {variants.map((v) => (
+                            <Badge key={v.key} variant={v.key === 'control' ? 'neutral' : 'info'} size="sm">
+                                {v.key}
+                                {v.rollout_percentage != null ? `: ${v.rollout_percentage}%` : ''}
+                            </Badge>
+                        ))}
+                    </div>
+                )
+            },
+        },
+        {
+            key: 'start_date',
+            header: 'Started',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.start_date ? (
+                    <span className="text-text-secondary">{formatDate(row.start_date)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {(Array.isArray(results) ? results.length : data.count) ?? 0} experiment
+                        {(Array.isArray(results) ? results.length : data.count) === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<ExperimentData>
+                    columns={columns}
+                    data={Array.isArray(results) ? results : []}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No experiments found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/experiments/frontend/mcp-apps/ExperimentResultsView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentResultsView.tsx
@@ -1,0 +1,129 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DataTable, type DataTableColumn, ProgressBar, Stack } from '@posthog/mosaic'
+
+export interface ExperimentExposure {
+    variant: string
+    count: number
+}
+
+export interface MetricResult {
+    name?: string
+    variant: string
+    count?: number
+    exposure?: number
+    absolute_exposure?: number
+    probability?: number
+    significant?: boolean
+}
+
+export interface ExperimentResultsData {
+    experiment?: { id: number; name?: string }
+    primaryMetricsResults?: MetricResult[][]
+    secondaryMetricsResults?: MetricResult[][]
+    exposures?: Record<string, number>
+    _posthogUrl?: string
+}
+
+export interface ExperimentResultsViewProps {
+    data: ExperimentResultsData
+}
+
+export function ExperimentResultsView({ data }: ExperimentResultsViewProps): ReactElement {
+    const exposureEntries = data.exposures
+        ? Object.entries(data.exposures).map(([variant, count]) => ({ variant, count: count as number }))
+        : []
+
+    const exposureColumns: DataTableColumn<ExperimentExposure>[] = [
+        { key: 'variant', header: 'Variant', sortable: true },
+        { key: 'count', header: 'Exposures', align: 'right', sortable: true },
+    ]
+
+    const allPrimary = (data.primaryMetricsResults ?? []).flat()
+    const allSecondary = (data.secondaryMetricsResults ?? []).flat()
+
+    const metricColumns: DataTableColumn<MetricResult>[] = [
+        { key: 'variant', header: 'Variant', sortable: true },
+        { key: 'count', header: 'Count', align: 'right' },
+        {
+            key: 'probability',
+            header: 'Probability',
+            align: 'right',
+            render: (row) =>
+                row.probability != null ? (
+                    <div className="flex items-center gap-2 justify-end">
+                        <ProgressBar
+                            value={row.probability * 100}
+                            variant={row.probability > 0.95 ? 'success' : row.probability > 0.5 ? 'info' : 'warning'}
+                            size="sm"
+                            className="w-16"
+                        />
+                        <span className="tabular-nums">{(row.probability * 100).toFixed(1)}%</span>
+                    </div>
+                ) : (
+                    '\u2014'
+                ),
+        },
+        {
+            key: 'significant',
+            header: 'Significant',
+            render: (row) =>
+                row.significant != null ? (
+                    <Badge variant={row.significant ? 'success' : 'neutral'} size="sm">
+                        {row.significant ? 'Yes' : 'No'}
+                    </Badge>
+                ) : (
+                    '\u2014'
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                {data.experiment?.name && (
+                    <span className="text-lg font-semibold text-text-primary">{data.experiment.name}</span>
+                )}
+
+                {exposureEntries.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">Exposures</span>
+                            <DataTable<ExperimentExposure>
+                                columns={exposureColumns}
+                                data={exposureEntries}
+                                emptyMessage="No exposure data"
+                            />
+                        </Stack>
+                    </Card>
+                )}
+
+                {allPrimary.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">Primary metrics</span>
+                            <DataTable<MetricResult>
+                                columns={metricColumns}
+                                data={allPrimary}
+                                emptyMessage="No primary metric results"
+                            />
+                        </Stack>
+                    </Card>
+                )}
+
+                {allSecondary.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">Secondary metrics</span>
+                            <DataTable<MetricResult>
+                                columns={metricColumns}
+                                data={allSecondary}
+                                emptyMessage="No secondary metric results"
+                            />
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/experiments/frontend/mcp-apps/ExperimentView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentView.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react'
 
 import { Badge, Card, DataTable, type DataTableColumn, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
 
-import { ExperimentData, ExperimentVariant, getStatus } from './utils'
+import { ExperimentData, ExperimentVariant, getConclusion, getStatus } from './utils'
 
 export interface ExperimentViewProps {
     experiment: ExperimentData
@@ -81,8 +81,8 @@ export function ExperimentView({ experiment }: ExperimentViewProps): ReactElemen
                         <Stack gap="sm">
                             <div className="flex items-center gap-2">
                                 <span className="text-sm font-semibold text-text-primary">Conclusion</span>
-                                <Badge variant="success" size="sm">
-                                    {experiment.conclusion}
+                                <Badge variant={getConclusion(experiment).variant} size="sm">
+                                    {getConclusion(experiment).label}
                                 </Badge>
                             </div>
                             {experiment.conclusion_comment && (

--- a/products/experiments/frontend/mcp-apps/ExperimentView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentView.tsx
@@ -2,57 +2,10 @@ import type { ReactElement } from 'react'
 
 import { Badge, Card, DataTable, type DataTableColumn, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
 
-export interface ExperimentVariant {
-    key: string
-    name?: string
-    rollout_percentage?: number
-}
-
-export interface ExperimentMetric {
-    kind: string
-    event?: string
-    property?: string
-    math?: string
-}
-
-export interface ExperimentData {
-    id: number
-    name: string
-    type?: string
-    description?: string | null
-    feature_flag_key?: string
-    start_date?: string | null
-    end_date?: string | null
-    archived?: boolean
-    created_at?: string
-    updated_at?: string
-    parameters?: {
-        feature_flag_variants?: ExperimentVariant[]
-        [key: string]: unknown
-    }
-    metrics?: ExperimentMetric[]
-    metrics_secondary?: ExperimentMetric[]
-    filters?: Record<string, unknown>
-    conclusion?: string | null
-    conclusion_comment?: string | null
-    _posthogUrl?: string
-}
+import { ExperimentData, ExperimentVariant, getStatus } from './utils'
 
 export interface ExperimentViewProps {
     experiment: ExperimentData
-}
-
-function getStatus(exp: ExperimentData): { label: string; variant: 'success' | 'warning' | 'neutral' | 'info' } {
-    if (exp.archived) {
-        return { label: 'Archived', variant: 'neutral' }
-    }
-    if (!exp.start_date) {
-        return { label: 'Draft', variant: 'neutral' }
-    }
-    if (exp.end_date) {
-        return { label: 'Complete', variant: 'success' }
-    }
-    return { label: 'Running', variant: 'info' }
 }
 
 export function ExperimentView({ experiment }: ExperimentViewProps): ReactElement {

--- a/products/experiments/frontend/mcp-apps/ExperimentView.tsx
+++ b/products/experiments/frontend/mcp-apps/ExperimentView.tsx
@@ -1,0 +1,144 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DataTable, type DataTableColumn, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
+
+export interface ExperimentVariant {
+    key: string
+    name?: string
+    rollout_percentage?: number
+}
+
+export interface ExperimentMetric {
+    kind: string
+    event?: string
+    property?: string
+    math?: string
+}
+
+export interface ExperimentData {
+    id: number
+    name: string
+    type?: string
+    description?: string | null
+    feature_flag_key?: string
+    start_date?: string | null
+    end_date?: string | null
+    archived?: boolean
+    created_at?: string
+    updated_at?: string
+    parameters?: {
+        feature_flag_variants?: ExperimentVariant[]
+        [key: string]: unknown
+    }
+    metrics?: ExperimentMetric[]
+    metrics_secondary?: ExperimentMetric[]
+    filters?: Record<string, unknown>
+    conclusion?: string | null
+    conclusion_comment?: string | null
+    _posthogUrl?: string
+}
+
+export interface ExperimentViewProps {
+    experiment: ExperimentData
+}
+
+function getStatus(exp: ExperimentData): { label: string; variant: 'success' | 'warning' | 'neutral' | 'info' } {
+    if (exp.archived) {
+        return { label: 'Archived', variant: 'neutral' }
+    }
+    if (!exp.start_date) {
+        return { label: 'Draft', variant: 'neutral' }
+    }
+    if (exp.end_date) {
+        return { label: 'Complete', variant: 'success' }
+    }
+    return { label: 'Running', variant: 'info' }
+}
+
+export function ExperimentView({ experiment }: ExperimentViewProps): ReactElement {
+    const status = getStatus(experiment)
+    const variants = experiment.parameters?.feature_flag_variants ?? []
+
+    const variantColumns: DataTableColumn<ExperimentVariant>[] = [
+        { key: 'key', header: 'Key', sortable: true },
+        { key: 'name', header: 'Name' },
+        {
+            key: 'rollout_percentage',
+            header: 'Rollout %',
+            align: 'right',
+            render: (row) => (row.rollout_percentage != null ? `${row.rollout_percentage}%` : '\u2014'),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary">{experiment.name}</span>
+                        <Badge variant={status.variant} size="md">
+                            {status.label}
+                        </Badge>
+                        {experiment.type && (
+                            <Badge variant="neutral" size="sm">
+                                {experiment.type}
+                            </Badge>
+                        )}
+                    </div>
+                    {experiment.description && (
+                        <span className="text-sm text-text-secondary">{experiment.description}</span>
+                    )}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        columns={2}
+                        items={[
+                            ...(experiment.feature_flag_key
+                                ? [{ label: 'Feature flag', value: experiment.feature_flag_key }]
+                                : []),
+                            ...(experiment.start_date
+                                ? [{ label: 'Started', value: formatDate(experiment.start_date) }]
+                                : []),
+                            ...(experiment.end_date
+                                ? [{ label: 'Ended', value: formatDate(experiment.end_date) }]
+                                : []),
+                            ...(experiment.created_at
+                                ? [{ label: 'Created', value: formatDate(experiment.created_at) }]
+                                : []),
+                        ]}
+                    />
+                </Card>
+
+                {variants.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">Variants</span>
+                            <DataTable<ExperimentVariant>
+                                columns={variantColumns}
+                                data={variants}
+                                emptyMessage="No variants"
+                            />
+                        </Stack>
+                    </Card>
+                )}
+
+                {experiment.conclusion && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <div className="flex items-center gap-2">
+                                <span className="text-sm font-semibold text-text-primary">Conclusion</span>
+                                <Badge variant="success" size="sm">
+                                    {experiment.conclusion}
+                                </Badge>
+                            </div>
+                            {experiment.conclusion_comment && (
+                                <span className="text-sm text-text-secondary">{experiment.conclusion_comment}</span>
+                            )}
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/experiments/frontend/mcp-apps/index.ts
+++ b/products/experiments/frontend/mcp-apps/index.ts
@@ -1,7 +1,8 @@
-export { ExperimentView, type ExperimentData, type ExperimentViewProps } from './ExperimentView'
+export { ExperimentView, type ExperimentViewProps } from './ExperimentView'
 export { ExperimentListView, type ExperimentListData, type ExperimentListViewProps } from './ExperimentListView'
 export {
     ExperimentResultsView,
     type ExperimentResultsData,
     type ExperimentResultsViewProps,
 } from './ExperimentResultsView'
+export { type ExperimentData } from './utils'

--- a/products/experiments/frontend/mcp-apps/index.ts
+++ b/products/experiments/frontend/mcp-apps/index.ts
@@ -1,0 +1,7 @@
+export { ExperimentView, type ExperimentData, type ExperimentViewProps } from './ExperimentView'
+export { ExperimentListView, type ExperimentListData, type ExperimentListViewProps } from './ExperimentListView'
+export {
+    ExperimentResultsView,
+    type ExperimentResultsData,
+    type ExperimentResultsViewProps,
+} from './ExperimentResultsView'

--- a/products/experiments/frontend/mcp-apps/utils.ts
+++ b/products/experiments/frontend/mcp-apps/utils.ts
@@ -46,3 +46,17 @@ export function getStatus(exp: ExperimentData): { label: string; variant: 'succe
     }
     return { label: 'Running', variant: 'info' }
 }
+
+export function getConclusion(exp: ExperimentData): { label: string; variant: 'success' | 'danger' | 'neutral' } {
+    if (exp.conclusion === 'won') {
+        return { label: 'Won', variant: 'success' }
+    }
+    if (exp.conclusion === 'lost') {
+        return { label: 'Lost', variant: 'danger' }
+    }
+
+    return {
+        label: exp.conclusion ? exp.conclusion.charAt(0).toUpperCase() + exp.conclusion.slice(1) : 'Inconclusive',
+        variant: 'neutral',
+    }
+}

--- a/products/experiments/frontend/mcp-apps/utils.ts
+++ b/products/experiments/frontend/mcp-apps/utils.ts
@@ -1,0 +1,48 @@
+export interface ExperimentVariant {
+    key: string
+    name?: string
+    rollout_percentage?: number
+}
+
+export interface ExperimentMetric {
+    kind: string
+    event?: string
+    property?: string
+    math?: string
+}
+
+export interface ExperimentData {
+    id: number
+    name: string
+    type?: string
+    description?: string | null
+    feature_flag_key?: string
+    start_date?: string | null
+    end_date?: string | null
+    archived?: boolean
+    created_at?: string
+    updated_at?: string
+    parameters?: {
+        feature_flag_variants?: ExperimentVariant[]
+        [key: string]: unknown
+    }
+    metrics?: ExperimentMetric[]
+    metrics_secondary?: ExperimentMetric[]
+    filters?: Record<string, unknown>
+    conclusion?: string | null
+    conclusion_comment?: string | null
+    _posthogUrl?: string
+}
+
+export function getStatus(exp: ExperimentData): { label: string; variant: 'success' | 'warning' | 'neutral' | 'info' } {
+    if (exp.archived) {
+        return { label: 'Archived', variant: 'neutral' }
+    }
+    if (!exp.start_date) {
+        return { label: 'Draft', variant: 'neutral' }
+    }
+    if (exp.end_date) {
+        return { label: 'Complete', variant: 'success' }
+    }
+    return { label: 'Running', variant: 'info' }
+}

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -8,6 +8,9 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "@storybook/react": "catalog:"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@types/react": "*",

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -20,13 +20,6 @@
 export const QUERY_RESULTS_RESOURCE_URI = 'ui://posthog/query-results.html'
 
 /**
- * Debug app for testing MCP Apps SDK integration.
- * Used by: debug-mcp-ui-apps
- * Displays SDK events, tool result data, and Mosaic component showcase.
- */
-export const DEBUG_RESOURCE_URI = 'ui://posthog/debug.html'
-
-/**
 
  * Action detail visualization.
  * Used by: action-get, action-create, action-update
@@ -52,6 +45,13 @@ export const COHORT_RESOURCE_URI = 'ui://posthog/cohort.html'
 export const COHORT_LIST_RESOURCE_URI = 'ui://posthog/cohort-list.html'
 
 /**
+ * Debug app for testing MCP Apps SDK integration.
+ * Used by: debug-mcp-ui-apps
+ * Displays SDK events, tool result data, and Mosaic component showcase.
+ */
+export const DEBUG_RESOURCE_URI = 'ui://posthog/debug.html'
+
+/**
  * Error details visualization with stack traces.
  * Used by: error-details
  */
@@ -66,3 +66,19 @@ export const ERROR_ISSUE_RESOURCE_URI = 'ui://posthog/error-issue.html'
  * Used by: error-tracking-issues-list
  */
 export const ERROR_ISSUE_LIST_RESOURCE_URI = 'ui://posthog/error-issue-list.html'
+
+/**
+ * Experiment detail visualization.
+ * Used by: experiment-get, experiment-create, experiment-update
+ */
+export const EXPERIMENT_RESOURCE_URI = 'ui://posthog/experiment.html'
+/**
+ * Experiment list visualization.
+ * Used by: experiment-get-all
+ */
+export const EXPERIMENT_LIST_RESOURCE_URI = 'ui://posthog/experiment-list.html'
+/**
+ * Experiment results visualization.
+ * Used by: experiment-results-get
+ */
+export const EXPERIMENT_RESULTS_RESOURCE_URI = 'ui://posthog/experiment-results.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -13,6 +13,9 @@ import {
     ERROR_DETAILS_RESOURCE_URI,
     ERROR_ISSUE_LIST_RESOURCE_URI,
     ERROR_ISSUE_RESOURCE_URI,
+    EXPERIMENT_LIST_RESOURCE_URI,
+    EXPERIMENT_RESOURCE_URI,
+    EXPERIMENT_RESULTS_RESOURCE_URI,
     QUERY_RESULTS_RESOURCE_URI,
 } from './ui-apps-constants'
 
@@ -26,6 +29,9 @@ import debugHtml from '../../ui-apps-dist/src/ui-apps/apps/debug/index.html'
 import errorDetailsHtml from '../../ui-apps-dist/src/ui-apps/apps/error-details/index.html'
 import errorIssueListHtml from '../../ui-apps-dist/src/ui-apps/apps/error-issue-list/index.html'
 import errorIssueHtml from '../../ui-apps-dist/src/ui-apps/apps/error-issue/index.html'
+import experimentListHtml from '../../ui-apps-dist/src/ui-apps/apps/experiment-list/index.html'
+import experimentResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/experiment-results/index.html'
+import experimentHtml from '../../ui-apps-dist/src/ui-apps/apps/experiment/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
 
 const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
@@ -66,6 +72,25 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
         uri: ERROR_ISSUE_LIST_RESOURCE_URI,
         description: 'Error tracking issue list view',
         html: errorIssueListHtml,
+    },
+    // Experiments
+    {
+        name: 'Experiment',
+        uri: EXPERIMENT_RESOURCE_URI,
+        description: 'Experiment detail view',
+        html: experimentHtml,
+    },
+    {
+        name: 'Experiment list',
+        uri: EXPERIMENT_LIST_RESOURCE_URI,
+        description: 'Experiment list view',
+        html: experimentListHtml,
+    },
+    {
+        name: 'Experiment results',
+        uri: EXPERIMENT_RESULTS_RESOURCE_URI,
+        description: 'Experiment results visualization',
+        html: experimentResultsHtml,
     },
 ]
 

--- a/services/mcp/src/tools/experiments/create.ts
+++ b/services/mcp/src/tools/experiments/create.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { EXPERIMENT_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import type { Experiment } from '@/schema/experiments'
 import { ExperimentCreateSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
@@ -7,7 +8,7 @@ import type { Context, ToolBase } from '@/tools/types'
 const schema = ExperimentCreateSchema
 
 type Params = z.infer<typeof schema>
-type Result = Experiment & { url: string }
+type Result = Experiment & { __posthogUrl: string }
 
 /**
  * Create a comprehensive A/B test experiment with guided setup
@@ -26,18 +27,21 @@ export const createExperimentHandler: ToolBase<typeof schema, Result>['handler']
     }
 
     const experiment = result.data
-    const experimentWithUrl = {
+    return {
         ...experiment,
-        url: `${context.api.getProjectBaseUrl(projectId)}/experiments/${experiment.id}`,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/experiments/${experiment.id}`,
     }
-
-    return experimentWithUrl
 }
 
 const tool = (): ToolBase<typeof schema, Result> => ({
     name: 'experiment-create',
     schema,
     handler: createExperimentHandler,
+    _meta: {
+        ui: {
+            resourceUri: EXPERIMENT_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/experiments/get.ts
+++ b/services/mcp/src/tools/experiments/get.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { EXPERIMENT_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import type { Experiment } from '@/schema/experiments'
 import { ExperimentGetSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
@@ -7,7 +8,7 @@ import type { Context, ToolBase } from '@/tools/types'
 const schema = ExperimentGetSchema
 
 type Params = z.infer<typeof schema>
-type Result = Experiment
+type Result = Experiment & { __posthogUrl: string }
 
 export const getHandler: ToolBase<typeof schema, Result>['handler'] = async (
     context: Context,
@@ -23,13 +24,21 @@ export const getHandler: ToolBase<typeof schema, Result>['handler'] = async (
         throw new Error(`Failed to get experiment: ${result.error.message}`)
     }
 
-    return result.data
+    return {
+        ...result.data,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/experiments/${result.data.id}`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema, Result> => ({
     name: 'experiment-get',
     schema,
     handler: getHandler,
+    _meta: {
+        ui: {
+            resourceUri: EXPERIMENT_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/experiments/getAll.ts
+++ b/services/mcp/src/tools/experiments/getAll.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { EXPERIMENT_LIST_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import type { Experiment } from '@/schema/experiments'
 import { ExperimentGetAllSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
@@ -7,7 +8,7 @@ import type { Context, ToolBase } from '@/tools/types'
 const schema = ExperimentGetAllSchema
 
 type Params = z.infer<typeof schema>
-type Result = Experiment[]
+type Result = { results: Experiment[]; _posthogUrl: string }
 
 export const getAllHandler: ToolBase<typeof schema, Result>['handler'] = async (context: Context, params: Params) => {
     const projectId = await context.stateManager.getProjectId()
@@ -23,13 +24,21 @@ export const getAllHandler: ToolBase<typeof schema, Result>['handler'] = async (
         throw new Error(`Failed to get experiments: ${results.error.message}`)
     }
 
-    return results.data
+    return {
+        results: results.data,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/experiments`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema, Result> => ({
     name: 'experiment-get-all',
     schema,
     handler: getAllHandler,
+    _meta: {
+        ui: {
+            resourceUri: EXPERIMENT_LIST_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/experiments/getResults.ts
+++ b/services/mcp/src/tools/experiments/getResults.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { EXPERIMENT_RESULTS_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import type { ExperimentResultsSummary } from '@/schema/experiments'
 import { transformExperimentResults } from '@/schema/experiments'
 import { ExperimentResultsGetSchema } from '@/schema/tool-inputs'
@@ -8,7 +9,7 @@ import type { Context, ToolBase } from '@/tools/types'
 const schema = ExperimentResultsGetSchema
 
 type Params = z.infer<typeof schema>
-type Result = ExperimentResultsSummary
+type Result = ExperimentResultsSummary & { _posthogUrl: string }
 
 /**
  * Get experiment results including metrics and exposures data
@@ -32,18 +33,26 @@ export const getResultsHandler: ToolBase<typeof schema, Result>['handler'] = asy
 
     const { experiment, primaryMetricsResults, secondaryMetricsResults, exposures } = result.data
 
-    return transformExperimentResults({
-        experiment,
-        primaryMetricsResults,
-        secondaryMetricsResults,
-        exposures,
-    })
+    return {
+        ...transformExperimentResults({
+            experiment,
+            primaryMetricsResults,
+            secondaryMetricsResults,
+            exposures,
+        }),
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/experiments/${params.experimentId}`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema, Result> => ({
     name: 'experiment-results-get',
     schema,
     handler: getResultsHandler,
+    _meta: {
+        ui: {
+            resourceUri: EXPERIMENT_RESULTS_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/experiments/update.ts
+++ b/services/mcp/src/tools/experiments/update.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { EXPERIMENT_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import type { Experiment } from '@/schema/experiments'
 import { ExperimentUpdateTransformSchema } from '@/schema/experiments'
 import { ExperimentUpdateSchema } from '@/schema/tool-inputs'
@@ -9,7 +10,7 @@ import type { Context, Tool, ToolBase } from '@/tools/types'
 const schema = ExperimentUpdateSchema
 
 type Params = z.infer<typeof schema>
-type Result = Experiment & { url: string }
+type Result = Experiment & { __posthogUrl: string }
 
 export const updateHandler: ToolBase<typeof schema, Result>['handler'] = async (context: Context, params: Params) => {
     const { experimentId, data } = params
@@ -27,12 +28,10 @@ export const updateHandler: ToolBase<typeof schema, Result>['handler'] = async (
         throw new Error(`Failed to update experiment: ${updateResult.error.message}`)
     }
 
-    const experimentWithUrl = {
+    return {
         ...updateResult.data,
-        url: `${context.api.getProjectBaseUrl(projectId)}/experiments/${updateResult.data.id}`,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/experiments/${updateResult.data.id}`,
     }
-
-    return experimentWithUrl
 }
 
 const definition = getToolDefinition('experiment-update')
@@ -49,6 +48,11 @@ const tool = (): Tool<typeof schema, Result> => ({
         idempotentHint: true,
         openWorldHint: true,
         readOnlyHint: false,
+    },
+    _meta: {
+        ui: {
+            resourceUri: EXPERIMENT_RESOURCE_URI,
+        },
     },
 })
 

--- a/services/mcp/src/ui-apps/apps/experiment-list/index.html
+++ b/services/mcp/src/ui-apps/apps/experiment-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Experiments</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/experiment-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/experiment-list/main.tsx
@@ -1,0 +1,64 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import {
+    type ExperimentData,
+    type ExperimentListData,
+    ExperimentListView,
+} from 'products/experiments/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ExperimentListApp(): JSX.Element {
+    return (
+        <AppWrapper<ExperimentListData> appName="PostHog Experiments">
+            {({ data, app }) => <ExperimentListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function ExperimentListContent({ data, app }: { data: ExperimentListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for experiment "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (experiment: ExperimentData): Promise<ExperimentData | null> => {
+            if (!app) {
+                fallbackToChat(experiment.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'experiment-get',
+                    arguments: { experimentId: experiment.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(experiment.name)
+                    return null
+                }
+                return result.structuredContent as unknown as ExperimentData
+            } catch {
+                fallbackToChat(experiment.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <ExperimentListView data={data} onExperimentClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ExperimentListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/experiment-results/index.html
+++ b/services/mcp/src/ui-apps/apps/experiment-results/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Experiment Results</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/experiment-results/main.tsx
+++ b/services/mcp/src/ui-apps/apps/experiment-results/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type ExperimentResultsData, ExperimentResultsView } from 'products/experiments/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ExperimentResultsApp(): JSX.Element {
+    return (
+        <AppWrapper<ExperimentResultsData> appName="PostHog Experiment Results">
+            {({ data }) => <ExperimentResultsView data={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ExperimentResultsApp />)
+}

--- a/services/mcp/src/ui-apps/apps/experiment/index.html
+++ b/services/mcp/src/ui-apps/apps/experiment/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Experiment</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/experiment/main.tsx
+++ b/services/mcp/src/ui-apps/apps/experiment/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type ExperimentData, ExperimentView } from 'products/experiments/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function ExperimentApp(): JSX.Element {
+    return (
+        <AppWrapper<ExperimentData> appName="PostHog Experiment">
+            {({ data }) => <ExperimentView experiment={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<ExperimentApp />)
+}

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -365,7 +365,7 @@ describe('Experiments', { concurrent: false }, () => {
                 const offsetResult = await getAllTool.handler(context, { data: { limit: 10, offset: 1 } })
                 const offsetExperiments = parseToolResponse(offsetResult)
                 // Verify offset is working by checking first result is different from original first result
-                expect(offsetExperiments.results[0].id).not.toBe(allExperiments[0].id)
+                expect(offsetExperiments.results[0].id).not.toBe(allExperiments.results[0].id)
             }
         })
 

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -365,7 +365,7 @@ describe('Experiments', { concurrent: false }, () => {
                 const offsetResult = await getAllTool.handler(context, { data: { limit: 10, offset: 1 } })
                 const offsetExperiments = parseToolResponse(offsetResult)
                 // Verify offset is working by checking first result is different from original first result
-                expect(offsetExperiments[0].id).not.toBe(allExperiments[0].id)
+                expect(offsetExperiments.results[0].id).not.toBe(allExperiments[0].id)
             }
         })
 

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -88,7 +88,7 @@ describe('Experiments', { concurrent: false }, () => {
             expect(experiment.name).toBe(params.name)
             expect(experiment.feature_flag_key).toBe(params.feature_flag_key)
             expect(experiment.start_date).toBeNull() // Draft experiments have no start date
-            expect(experiment.url).toContain('/experiments/')
+            expect(experiment._posthogUrl).toContain('/experiments/')
         })
 
         it('should create an experiment with description and type', async () => {
@@ -330,13 +330,11 @@ describe('Experiments', { concurrent: false }, () => {
             // Get all experiments
             const result = await getAllTool.handler(context, {})
             const allExperiments = parseToolResponse(result)
-
-            expect(Array.isArray(allExperiments)).toBe(true)
-            expect(allExperiments.length).toBeGreaterThanOrEqual(3)
+            expect(allExperiments.results.length).toBeGreaterThanOrEqual(3)
 
             // Verify our test experiments are in the list
             for (const testExp of testExperiments) {
-                const found = allExperiments.find((e: any) => e.id === testExp.id)
+                const found = allExperiments.results.find((e: any) => e.id === testExp.id)
                 expect(found).toBeTruthy()
             }
         })
@@ -345,8 +343,8 @@ describe('Experiments', { concurrent: false }, () => {
             const result = await getAllTool.handler(context, {})
             const experiments = parseToolResponse(result)
 
-            if (experiments.length > 0) {
-                const experiment = experiments[0]
+            if (experiments.results.length > 0) {
+                const experiment = experiments.results[0]
                 expect(experiment).toHaveProperty('id')
                 expect(experiment).toHaveProperty('name')
                 expect(experiment).toHaveProperty('feature_flag_key')
@@ -356,14 +354,14 @@ describe('Experiments', { concurrent: false }, () => {
         it('should respect limit parameter', async () => {
             const result = await getAllTool.handler(context, { data: { limit: 2 } })
             const experiments = parseToolResponse(result)
-            expect(experiments.length).toBeLessThanOrEqual(2)
+            expect(experiments.results.length).toBeLessThanOrEqual(2)
         })
 
         it('should respect offset parameter', async () => {
             const allResult = await getAllTool.handler(context, { data: { limit: 10 } })
             const allExperiments = parseToolResponse(allResult)
 
-            if (allExperiments.length > 1) {
+            if (allExperiments.results.length > 1) {
                 const offsetResult = await getAllTool.handler(context, { data: { limit: 10, offset: 1 } })
                 const offsetExperiments = parseToolResponse(offsetResult)
                 // Verify offset is working by checking first result is different from original first result
@@ -374,7 +372,7 @@ describe('Experiments', { concurrent: false }, () => {
         it('should use default limit when not specified', async () => {
             const result = await getAllTool.handler(context, {})
             const experiments = parseToolResponse(result)
-            expect(experiments.length).toBeLessThanOrEqual(50)
+            expect(experiments.results.length).toBeLessThanOrEqual(50)
         })
     })
 
@@ -553,7 +551,7 @@ describe('Experiments', { concurrent: false }, () => {
             // Verify it appears in list
             const listResult = await getAllTool.handler(context, {})
             const allExperiments = parseToolResponse(listResult)
-            const found = allExperiments.find((e: any) => e.id === createdExperiment.id)
+            const found = allExperiments.results.find((e: any) => e.id === createdExperiment.id)
             expect(found).toBeTruthy()
         })
 
@@ -917,7 +915,7 @@ describe('Experiments', { concurrent: false }, () => {
 
             expect(updatedExperiment.name).toBe('Updated Name')
             expect(updatedExperiment.description).toBe('Updated description with new hypothesis')
-            expect(updatedExperiment.url).toContain('/experiments/')
+            expect(updatedExperiment._posthogUrl).toContain('/experiments/')
             expect(updatedExperiment.start_date).toBeNull() // Draft experiments have no start date
         })
 


### PR DESCRIPTION
## Problem

This adds comprehensive UI components and MCP apps for displaying PostHog experiments data in a structured, interactive format. The components provide list views, detail views, and results visualization for experiments, making it easier for users to browse and analyze experiment data through the MCP interface.

## Changes

- Added three new React components in `products/experiments/frontend/mcp-apps/`:
  - `ExperimentListView` - displays experiments in a sortable table with status badges, variant information, and clickable experiment names
  - `ExperimentView` - shows detailed experiment information including metadata, variants table, and conclusion
  - `ExperimentResultsView` - visualizes experiment results with exposure data, primary/secondary metrics, and probability indicators with progress bars

- Created three corresponding MCP UI apps:
  - `experiment-list` - interactive list that allows drilling down into experiment details
  - `experiment` - detailed view of a single experiment
  - `experiment-results` - results visualization with metrics and statistical data

- Updated experiment tool handlers to include `_posthogUrl` fields and UI resource URIs for proper MCP integration

- Added Storybook React as a dev dependency for the experiments package

The UI components use PostHog's Mosaic design system with features like:
- Sortable data tables with custom column rendering
- Status badges with appropriate color variants
- Progress bars for probability visualization
- Responsive card layouts
- Loading states and navigation between views


## Publish to changelog?

No - not yet.