### PR TITLE
feat: Add LLM costs UI app with model breakdown table

### DIFF
--- a/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
+++ b/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
@@ -22,7 +22,7 @@ export interface LLMCostsViewProps {
 }
 
 function formatCurrency(value: number): string {
-    return `$${value.toFixed(4)}`
+    return `$${value.toFixed(2)}`
 }
 
 interface ModelRow {
@@ -32,7 +32,7 @@ interface ModelRow {
 }
 
 export function LLMCostsView({ data }: LLMCostsViewProps): ReactElement {
-    const series = Array.isArray(data) ? data : (data.results ?? [])
+    const series = data.results
 
     if (series.length === 0) {
         return (

--- a/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
+++ b/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
@@ -1,0 +1,98 @@
+import type { ReactElement } from 'react'
+
+import { Card, DataTable, type DataTableColumn, EmptyState, Stack } from '@posthog/mosaic'
+
+export interface LLMCostSeries {
+    label: string
+    count: number
+    data: number[]
+    labels: string[]
+    days: string[]
+    aggregated_value: number
+    breakdown_value?: string
+}
+
+export interface LLMCostsData {
+    results: LLMCostSeries[]
+    _posthogUrl?: string
+}
+
+export interface LLMCostsViewProps {
+    data: LLMCostsData
+}
+
+function formatCurrency(value: number): string {
+    return `$${value.toFixed(4)}`
+}
+
+interface ModelRow {
+    model: string
+    totalCost: number
+    latestDayCost: number
+}
+
+export function LLMCostsView({ data }: LLMCostsViewProps): ReactElement {
+    const series = Array.isArray(data) ? data : (data.results ?? [])
+
+    if (series.length === 0) {
+        return (
+            <div className="p-4">
+                <EmptyState title="No LLM cost data" description="No AI generation events found for this period" />
+            </div>
+        )
+    }
+
+    const totalCost = series.reduce((sum, s) => sum + (s.aggregated_value ?? 0), 0)
+
+    const rows: ModelRow[] = series.map((s) => ({
+        model: s.breakdown_value || s.label || 'Unknown',
+        totalCost: s.aggregated_value ?? 0,
+        latestDayCost: s.data?.length ? s.data[s.data.length - 1] : 0,
+    }))
+
+    const columns: DataTableColumn<ModelRow>[] = [
+        { key: 'model', header: 'Model', sortable: true },
+        {
+            key: 'totalCost',
+            header: 'Total cost',
+            align: 'right',
+            sortable: true,
+            render: (row) => <span className="tabular-nums">{formatCurrency(row.totalCost)}</span>,
+        },
+        {
+            key: 'latestDayCost',
+            header: 'Latest day',
+            align: 'right',
+            sortable: true,
+            render: (row) => (
+                <span className="tabular-nums text-text-secondary">{formatCurrency(row.latestDayCost)}</span>
+            ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <span className="text-lg font-semibold text-text-primary">LLM costs</span>
+                    <span className="text-2xl font-bold text-text-primary tabular-nums">
+                        {formatCurrency(totalCost)}
+                    </span>
+                    <span className="text-xs text-text-secondary">Total across all models</span>
+                </Stack>
+
+                <Card padding="md">
+                    <Stack gap="sm">
+                        <span className="text-sm font-semibold text-text-primary">Breakdown by model</span>
+                        <DataTable<ModelRow>
+                            columns={columns}
+                            data={rows}
+                            defaultSort={{ key: 'totalCost', direction: 'desc' }}
+                            emptyMessage="No model data"
+                        />
+                    </Stack>
+                </Card>
+            </Stack>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
+++ b/products/llm_analytics/frontend/mcp-apps/LLMCostsView.tsx
@@ -47,7 +47,7 @@ export function LLMCostsView({ data }: LLMCostsViewProps): ReactElement {
     const rows: ModelRow[] = series.map((s) => ({
         model: s.breakdown_value || s.label || 'Unknown',
         totalCost: s.aggregated_value ?? 0,
-        latestDayCost: s.data?.length ? s.data[s.data.length - 1] : 0,
+        latestDayCost: s.data?.length ? s.data[s.data.length - 1]! : 0,
     }))
 
     const columns: DataTableColumn<ModelRow>[] = [

--- a/products/llm_analytics/frontend/mcp-apps/index.ts
+++ b/products/llm_analytics/frontend/mcp-apps/index.ts
@@ -1,0 +1,1 @@
+export { LLMCostsView, type LLMCostsData, type LLMCostsViewProps } from './LLMCostsView'

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -96,3 +96,10 @@ export const FEATURE_FLAG_RESOURCE_URI = 'ui://posthog/feature-flag.html'
  * Shows a data table of all feature flags with status, tags, and dates.
  */
 export const FEATURE_FLAG_LIST_RESOURCE_URI = 'ui://posthog/feature-flag-list.html'
+
+/**
+
+ * LLM costs visualization.
+ * Used by: get-llm-total-costs-for-project
+ */
+export const LLM_COSTS_RESOURCE_URI = 'ui://posthog/llm-costs.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -18,6 +18,7 @@ import {
     EXPERIMENT_RESULTS_RESOURCE_URI,
     FEATURE_FLAG_LIST_RESOURCE_URI,
     FEATURE_FLAG_RESOURCE_URI,
+    LLM_COSTS_RESOURCE_URI,
     QUERY_RESULTS_RESOURCE_URI,
 } from './ui-apps-constants'
 
@@ -36,6 +37,7 @@ import experimentResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/experimen
 import experimentHtml from '../../ui-apps-dist/src/ui-apps/apps/experiment/index.html'
 import featureFlagListHtml from '../../ui-apps-dist/src/ui-apps/apps/feature-flag-list/index.html'
 import featureFlagHtml from '../../ui-apps-dist/src/ui-apps/apps/feature-flag/index.html'
+import llmCostsHtml from '../../ui-apps-dist/src/ui-apps/apps/llm-costs/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
 
 const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
@@ -108,6 +110,13 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
         uri: FEATURE_FLAG_LIST_RESOURCE_URI,
         description: 'Feature flag list view',
         html: featureFlagListHtml,
+    },
+    // LLM analytics
+    {
+        name: 'LLM costs',
+        uri: LLM_COSTS_RESOURCE_URI,
+        description: 'LLM costs breakdown by model',
+        html: llmCostsHtml,
     },
 ]
 

--- a/services/mcp/src/tools/llmAnalytics/getLLMCosts.ts
+++ b/services/mcp/src/tools/llmAnalytics/getLLMCosts.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { LLM_COSTS_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { LLMAnalyticsGetCostsSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -39,13 +40,21 @@ export const getLLMCostsHandler: ToolBase<typeof schema, unknown>['handler'] = a
     if (!costsResult.success) {
         throw new Error(`Failed to get LLM costs: ${costsResult.error.message}`)
     }
-    return costsResult.data.results
+    return {
+        results: costsResult.data.results,
+        _posthogUrl: `${context.api.getProjectBaseUrl(String(projectId))}/llm-observability`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'get-llm-total-costs-for-project',
     schema,
     handler: getLLMCostsHandler,
+    _meta: {
+        ui: {
+            resourceUri: LLM_COSTS_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/ui-apps/apps/llm-costs/index.html
+++ b/services/mcp/src/ui-apps/apps/llm-costs/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog LLM Costs</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/llm-costs/main.tsx
+++ b/services/mcp/src/ui-apps/apps/llm-costs/main.tsx
@@ -1,0 +1,18 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type LLMCostsData, LLMCostsView } from 'products/llm_analytics/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function LLMCostsApp(): JSX.Element {
+    return (
+        <AppWrapper<LLMCostsData> appName="PostHog LLM Costs">{({ data }) => <LLMCostsView data={data!} />}</AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<LLMCostsApp />)
+}

--- a/services/mcp/tests/tools/llmAnalytics.integration.test.ts
+++ b/services/mcp/tests/tools/llmAnalytics.integration.test.ts
@@ -43,9 +43,9 @@ describe('LLM Analytics', { concurrent: false }, () => {
             const result = await costsTool.handler(context, {
                 projectId: Number(TEST_PROJECT_ID),
             })
-            const costsData = parseToolResponse(result)
 
-            expect(Array.isArray(costsData)).toBe(true)
+            const costsData = parseToolResponse(result)
+            expect(Array.isArray(costsData.results)).toBe(true)
         })
 
         it('should get LLM costs for custom time period', async () => {
@@ -53,9 +53,9 @@ describe('LLM Analytics', { concurrent: false }, () => {
                 projectId: Number(TEST_PROJECT_ID),
                 days: 30,
             })
-            const costsData = parseToolResponse(result)
 
-            expect(Array.isArray(costsData)).toBe(true)
+            const costsData = parseToolResponse(result)
+            expect(Array.isArray(costsData.results)).toBe(true)
         })
 
         it('should get LLM costs for single day', async () => {
@@ -63,9 +63,9 @@ describe('LLM Analytics', { concurrent: false }, () => {
                 projectId: Number(TEST_PROJECT_ID),
                 days: 1,
             })
-            const costsData = parseToolResponse(result)
 
-            expect(Array.isArray(costsData)).toBe(true)
+            const costsData = parseToolResponse(result)
+            expect(Array.isArray(costsData.results)).toBe(true)
         })
     })
 
@@ -77,15 +77,17 @@ describe('LLM Analytics', { concurrent: false }, () => {
                 projectId: Number(TEST_PROJECT_ID),
                 days: 7,
             })
+
             const weekData = parseToolResponse(weekResult)
-            expect(Array.isArray(weekData)).toBe(true)
+            expect(Array.isArray(weekData.results)).toBe(true)
 
             const monthResult = await costsTool.handler(context, {
                 projectId: Number(TEST_PROJECT_ID),
                 days: 30,
             })
+
             const monthData = parseToolResponse(monthResult)
-            expect(Array.isArray(monthData)).toBe(true)
+            expect(Array.isArray(monthData.results)).toBe(true)
         })
     })
 })


### PR DESCRIPTION
## Problem

Users need a way to visualize and analyze LLM costs across different models in their PostHog projects. This provides visibility into AI generation expenses and helps teams understand their LLM usage patterns and costs.

## Changes

- Added `LLMCostsView` React component that displays LLM costs in a table format with model breakdown
- Created a new UI app for rendering LLM costs with total cost display and per-model breakdown
- Enhanced the `get-llm-total-costs-for-project` MCP tool to return structured data with PostHog URL reference
- Added currency formatting utility and sortable data table with total costs and latest day costs
- Implemented empty state handling for when no LLM cost data is available

The view shows:
- Total cost across all models at the top
- Breakdown table by model showing total cost and latest day cost
- Sortable columns with currency formatting
- Empty state when no data is available


## Publish to changelog?

No - not yet.