### PR TITLE
feat: Add survey UI apps for MCP with list, detail, and stats views

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2690,6 +2690,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
 
   products/tasks:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2693,7 +2693,7 @@ importers:
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'
-        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
 
   products/tasks:
     dependencies:

--- a/products/surveys/frontend/mcp-apps/SurveyListView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyListView.tsx
@@ -1,0 +1,146 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { SurveyView, type SurveyData } from './SurveyView'
+
+export interface SurveyListData {
+    results: SurveyData[]
+    _posthogUrl?: string
+}
+
+export interface SurveyListViewProps {
+    data: SurveyListData
+    onSurveyClick?: (survey: SurveyData) => Promise<SurveyData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; survey: SurveyData }
+
+const statusVariants: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    completed: 'info',
+    archived: 'neutral',
+}
+
+export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (survey: SurveyData) => {
+            if (!onSurveyClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: survey.name })
+            const detail = await onSurveyClick(survey)
+            if (detail) {
+                setViewState({ view: 'detail', survey: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onSurveyClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All surveys" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All surveys" />
+                    <SurveyView survey={viewState.survey} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const columns: DataTableColumn<SurveyData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onSurveyClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    row.name
+                ),
+        },
+        {
+            key: 'type',
+            header: 'Type',
+            render: (row): ReactNode =>
+                row.type ? (
+                    <Badge variant="neutral" size="sm">
+                        {row.type}
+                    </Badge>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+        {
+            key: 'status',
+            header: 'Status',
+            render: (row): ReactNode => {
+                const status = row.status ?? 'draft'
+                return (
+                    <Badge variant={statusVariants[status] ?? 'neutral'} size="sm">
+                        {status.charAt(0).toUpperCase() + status.slice(1)}
+                    </Badge>
+                )
+            },
+        },
+        {
+            key: 'questions' as keyof SurveyData,
+            header: 'Questions',
+            render: (row): ReactNode => <span className="text-text-secondary">{row.questions?.length ?? 0}</span>,
+        },
+        {
+            key: 'created_at',
+            header: 'Created',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.created_at ? (
+                    <span className="text-text-secondary">{formatDate(row.created_at)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {data.results.length} survey{data.results.length === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<SurveyData>
+                    columns={columns}
+                    data={data.results}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No surveys found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/surveys/frontend/mcp-apps/SurveyListView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyListView.tsx
@@ -3,6 +3,7 @@ import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
 import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
 
 import { SurveyView, type SurveyData } from './SurveyView'
+import { STATUS_VARIANTS } from './utils'
 
 export interface SurveyListData {
     results: SurveyData[]
@@ -16,13 +17,6 @@ export interface SurveyListViewProps {
 
 type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; survey: SurveyData }
 
-const statusVariants: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
-    active: 'success',
-    draft: 'neutral',
-    completed: 'info',
-    archived: 'neutral',
-}
-
 export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): ReactElement {
     const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
 
@@ -31,8 +25,13 @@ export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): Re
             if (!onSurveyClick) {
                 return
             }
+
             setViewState({ view: 'loading', name: survey.name })
-            const detail = await onSurveyClick(survey)
+            const detail = await onSurveyClick(survey).catch((error) => {
+                console.error('Error loading survey detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', survey: detail })
             } else {
@@ -101,7 +100,7 @@ export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): Re
             render: (row): ReactNode => {
                 const status = row.status ?? 'draft'
                 return (
-                    <Badge variant={statusVariants[status] ?? 'neutral'} size="sm">
+                    <Badge variant={STATUS_VARIANTS[status] ?? 'neutral'} size="sm">
                         {status.charAt(0).toUpperCase() + status.slice(1)}
                     </Badge>
                 )

--- a/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Stack } from '@posthog/mosaic'
+
+export interface SurveyQuestionData {
+    type: string
+    question: string
+    description?: string | null
+    choices?: string[] | null
+    scale?: number | null
+    lowerBoundLabel?: string | null
+    upperBoundLabel?: string | null
+    branching?: Record<string, unknown> | null
+}
+
+export interface SurveyQuestionProps {
+    question: SurveyQuestionData
+    index: number
+}
+
+const typeLabels: Record<string, string> = {
+    open: 'Open text',
+    multiple_choice: 'Multiple choice',
+    single_choice: 'Single choice',
+    rating: 'Rating',
+    link: 'Link',
+    nps: 'NPS',
+}
+
+export function SurveyQuestion({ question, index }: SurveyQuestionProps): ReactElement {
+    return (
+        <Stack gap="xs">
+            <div className="flex items-center gap-2">
+                <span className="text-xs text-text-secondary">Q{index + 1}</span>
+                <Badge variant="neutral" size="sm">
+                    {typeLabels[question.type] ?? question.type}
+                </Badge>
+            </div>
+            <span className="text-sm text-text-primary">{question.question}</span>
+            {question.description && <span className="text-xs text-text-secondary">{question.description}</span>}
+            {question.choices && question.choices.length > 0 && (
+                <ul className="list-disc list-inside text-xs text-text-secondary pl-2">
+                    {question.choices.map((choice, i) => (
+                        <li key={i}>{choice}</li>
+                    ))}
+                </ul>
+            )}
+            {question.type === 'rating' && question.scale && (
+                <span className="text-xs text-text-secondary">
+                    Scale: 1&ndash;{question.scale}
+                    {question.lowerBoundLabel && ` (${question.lowerBoundLabel}`}
+                    {question.upperBoundLabel && ` to ${question.upperBoundLabel})`}
+                </span>
+            )}
+        </Stack>
+    )
+}

--- a/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
@@ -2,6 +2,8 @@ import type { ReactElement } from 'react'
 
 import { Badge, Stack } from '@posthog/mosaic'
 
+import { TYPE_LABELS } from './utils'
+
 export interface SurveyQuestionData {
     type: string
     question: string
@@ -18,22 +20,18 @@ export interface SurveyQuestionProps {
     index: number
 }
 
-const typeLabels: Record<string, string> = {
-    open: 'Open text',
-    multiple_choice: 'Multiple choice',
-    single_choice: 'Single choice',
-    rating: 'Rating',
-    link: 'Link',
-    nps: 'NPS',
-}
-
 export function SurveyQuestion({ question, index }: SurveyQuestionProps): ReactElement {
+    const bounds =
+        question.lowerBoundLabel || question.upperBoundLabel
+            ? `(${question.lowerBoundLabel ?? ''}${question.lowerBoundLabel && question.upperBoundLabel ? ' to ' : ''}${question.upperBoundLabel ?? ''})`
+            : ''
+
     return (
         <Stack gap="xs">
             <div className="flex items-center gap-2">
                 <span className="text-xs text-text-secondary">Q{index + 1}</span>
                 <Badge variant="neutral" size="sm">
-                    {typeLabels[question.type] ?? question.type}
+                    {TYPE_LABELS[question.type] ?? question.type}
                 </Badge>
             </div>
             <span className="text-sm text-text-primary">{question.question}</span>
@@ -47,9 +45,7 @@ export function SurveyQuestion({ question, index }: SurveyQuestionProps): ReactE
             )}
             {question.type === 'rating' && question.scale && (
                 <span className="text-xs text-text-secondary">
-                    Scale: 1&ndash;{question.scale}
-                    {question.lowerBoundLabel && ` (${question.lowerBoundLabel}`}
-                    {question.upperBoundLabel && ` to ${question.upperBoundLabel})`}
+                    Scale: 1&ndash;{question.scale}&nbsp;{bounds}
                 </span>
             )}
         </Stack>

--- a/products/surveys/frontend/mcp-apps/SurveyStatsView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyStatsView.tsx
@@ -1,0 +1,86 @@
+import type { ReactElement } from 'react'
+
+import { Card, DataTable, type DataTableColumn, ProgressBar, Stack } from '@posthog/mosaic'
+
+export interface SurveyStatEntry {
+    name: string
+    total_count: number
+    unique_persons: number
+}
+
+export interface SurveyStatsData {
+    survey_id?: string
+    stats?: Record<string, { total_count: number; unique_persons: number }>
+    rates?: { response_rate?: number; dismissal_rate?: number }
+    _posthogUrl?: string
+}
+
+export interface SurveyStatsViewProps {
+    data: SurveyStatsData
+}
+
+export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
+    const entries: SurveyStatEntry[] = data.stats
+        ? Object.entries(data.stats).map(([name, val]) => ({
+              name,
+              total_count: val.total_count,
+              unique_persons: val.unique_persons,
+          }))
+        : []
+
+    const columns: DataTableColumn<SurveyStatEntry>[] = [
+        { key: 'name', header: 'Event', sortable: true },
+        { key: 'total_count', header: 'Total', align: 'right', sortable: true },
+        { key: 'unique_persons', header: 'Unique persons', align: 'right', sortable: true },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <span className="text-lg font-semibold text-text-primary">Survey stats</span>
+
+                {data.rates && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            {data.rates.response_rate != null && (
+                                <div>
+                                    <div className="flex justify-between text-sm mb-1">
+                                        <span className="text-text-secondary">Response rate</span>
+                                        <span className="text-text-primary tabular-nums">
+                                            {(data.rates.response_rate * 100).toFixed(1)}%
+                                        </span>
+                                    </div>
+                                    <ProgressBar value={data.rates.response_rate * 100} variant="success" size="md" />
+                                </div>
+                            )}
+                            {data.rates.dismissal_rate != null && (
+                                <div>
+                                    <div className="flex justify-between text-sm mb-1">
+                                        <span className="text-text-secondary">Dismissal rate</span>
+                                        <span className="text-text-primary tabular-nums">
+                                            {(data.rates.dismissal_rate * 100).toFixed(1)}%
+                                        </span>
+                                    </div>
+                                    <ProgressBar value={data.rates.dismissal_rate * 100} variant="warning" size="md" />
+                                </div>
+                            )}
+                        </Stack>
+                    </Card>
+                )}
+
+                {entries.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="sm">
+                            <span className="text-sm font-semibold text-text-primary">Events</span>
+                            <DataTable<SurveyStatEntry>
+                                columns={columns}
+                                data={entries}
+                                emptyMessage="No stats available"
+                            />
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/surveys/frontend/mcp-apps/SurveyView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyView.tsx
@@ -1,0 +1,96 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
+
+import { SurveyQuestion, type SurveyQuestionData } from './SurveyQuestion'
+
+export interface SurveyData {
+    id: string
+    name: string
+    description?: string | null
+    type?: string
+    status?: string
+    questions?: SurveyQuestionData[]
+    conditions?: Record<string, unknown> | null
+    start_date?: string | null
+    end_date?: string | null
+    created_at?: string
+    responses_limit?: number | null
+    archived?: boolean
+    _posthogUrl?: string
+}
+
+export interface SurveyViewProps {
+    survey: SurveyData
+}
+
+const statusVariants: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    completed: 'info',
+    archived: 'neutral',
+}
+
+const typeLabels: Record<string, string> = {
+    popover: 'Popover',
+    api: 'API',
+    widget: 'Widget',
+    button: 'Button',
+    full_screen: 'Full screen',
+    email: 'Email',
+}
+
+export function SurveyView({ survey }: SurveyViewProps): ReactElement {
+    const status = survey.status ?? 'draft'
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary">{survey.name}</span>
+                        <Badge variant={statusVariants[status] ?? 'neutral'} size="md">
+                            {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </Badge>
+                        {survey.type && (
+                            <Badge variant="neutral" size="sm">
+                                {typeLabels[survey.type] ?? survey.type}
+                            </Badge>
+                        )}
+                    </div>
+                    {survey.description && <span className="text-sm text-text-secondary">{survey.description}</span>}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        columns={2}
+                        items={[
+                            ...(survey.start_date ? [{ label: 'Started', value: formatDate(survey.start_date) }] : []),
+                            ...(survey.end_date ? [{ label: 'Ended', value: formatDate(survey.end_date) }] : []),
+                            ...(survey.responses_limit != null
+                                ? [{ label: 'Response limit', value: String(survey.responses_limit) }]
+                                : []),
+                            ...(survey.created_at ? [{ label: 'Created', value: formatDate(survey.created_at) }] : []),
+                        ]}
+                    />
+                </Card>
+
+                {survey.questions && survey.questions.length > 0 && (
+                    <Card padding="md">
+                        <Stack gap="md">
+                            <span className="text-sm font-semibold text-text-primary">
+                                Questions ({survey.questions.length})
+                            </span>
+                            {survey.questions.map((q, i) => (
+                                <div key={i}>
+                                    {i > 0 && <div className="border-t border-border-primary -mx-4 mb-3" />}
+                                    <SurveyQuestion question={q} index={i} />
+                                </div>
+                            ))}
+                        </Stack>
+                    </Card>
+                )}
+            </Stack>
+        </div>
+    )
+}

--- a/products/surveys/frontend/mcp-apps/SurveyView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyView.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
 
 import { SurveyQuestion, type SurveyQuestionData } from './SurveyQuestion'
+import { STATUS_VARIANTS, TYPE_LABELS } from './utils'
 
 export interface SurveyData {
     id: string
@@ -24,22 +25,6 @@ export interface SurveyViewProps {
     survey: SurveyData
 }
 
-const statusVariants: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
-    active: 'success',
-    draft: 'neutral',
-    completed: 'info',
-    archived: 'neutral',
-}
-
-const typeLabels: Record<string, string> = {
-    popover: 'Popover',
-    api: 'API',
-    widget: 'Widget',
-    button: 'Button',
-    full_screen: 'Full screen',
-    email: 'Email',
-}
-
 export function SurveyView({ survey }: SurveyViewProps): ReactElement {
     const status = survey.status ?? 'draft'
 
@@ -49,12 +34,12 @@ export function SurveyView({ survey }: SurveyViewProps): ReactElement {
                 <Stack gap="xs">
                     <div className="flex items-center gap-2 flex-wrap">
                         <span className="text-lg font-semibold text-text-primary">{survey.name}</span>
-                        <Badge variant={statusVariants[status] ?? 'neutral'} size="md">
+                        <Badge variant={STATUS_VARIANTS[status] ?? 'neutral'} size="md">
                             {status.charAt(0).toUpperCase() + status.slice(1)}
                         </Badge>
                         {survey.type && (
                             <Badge variant="neutral" size="sm">
-                                {typeLabels[survey.type] ?? survey.type}
+                                {TYPE_LABELS[survey.type] ?? survey.type}
                             </Badge>
                         )}
                     </div>

--- a/products/surveys/frontend/mcp-apps/index.ts
+++ b/products/surveys/frontend/mcp-apps/index.ts
@@ -1,0 +1,4 @@
+export { SurveyView, type SurveyData, type SurveyViewProps } from './SurveyView'
+export { SurveyListView, type SurveyListData, type SurveyListViewProps } from './SurveyListView'
+export { SurveyStatsView, type SurveyStatsData, type SurveyStatsViewProps } from './SurveyStatsView'
+export { SurveyQuestion, type SurveyQuestionData, type SurveyQuestionProps } from './SurveyQuestion'

--- a/products/surveys/frontend/mcp-apps/utils.ts
+++ b/products/surveys/frontend/mcp-apps/utils.ts
@@ -1,0 +1,15 @@
+export const STATUS_VARIANTS: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    completed: 'info',
+    archived: 'neutral',
+}
+
+export const TYPE_LABELS: Record<string, string> = {
+    open: 'Open text',
+    multiple_choice: 'Multiple choice',
+    single_choice: 'Single choice',
+    rating: 'Rating',
+    link: 'Link',
+    nps: 'NPS',
+}

--- a/products/surveys/package.json
+++ b/products/surveys/package.json
@@ -8,6 +8,9 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "@storybook/react": "catalog:"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@types/react": "*",

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -13,13 +13,6 @@
  */
 
 /**
- * Query results visualization.
- * Used by: query-run, insight-query
- * Shows trends, funnels, tables, and other query result types.
- */
-export const QUERY_RESULTS_RESOURCE_URI = 'ui://posthog/query-results.html'
-
-/**
 
  * Action detail visualization.
  * Used by: action-get, action-create, action-update
@@ -103,3 +96,34 @@ export const FEATURE_FLAG_LIST_RESOURCE_URI = 'ui://posthog/feature-flag-list.ht
  * Used by: get-llm-total-costs-for-project
  */
 export const LLM_COSTS_RESOURCE_URI = 'ui://posthog/llm-costs.html'
+
+/**
+ * Query results visualization.
+ * Used by: query-run, insight-query
+ * Shows trends, funnels, tables, and other query result types.
+ */
+export const QUERY_RESULTS_RESOURCE_URI = 'ui://posthog/query-results.html'
+
+/**
+ * Survey detail visualization.
+ * Used by: survey-get, survey-create, survey-update
+ */
+export const SURVEY_RESOURCE_URI = 'ui://posthog/survey.html'
+
+/**
+ * Survey list visualization.
+ * Used by: surveys-get-all
+ */
+export const SURVEY_LIST_RESOURCE_URI = 'ui://posthog/survey-list.html'
+
+/**
+ * Survey stats visualization.
+ * Used by: survey-stats
+ */
+export const SURVEY_STATS_RESOURCE_URI = 'ui://posthog/survey-stats.html'
+
+/**
+ * Survey global stats visualization.
+ * Used by: surveys-global-stats
+ */
+export const SURVEY_GLOBAL_STATS_RESOURCE_URI = 'ui://posthog/survey-global-stats.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -20,6 +20,10 @@ import {
     FEATURE_FLAG_RESOURCE_URI,
     LLM_COSTS_RESOURCE_URI,
     QUERY_RESULTS_RESOURCE_URI,
+    SURVEY_GLOBAL_STATS_RESOURCE_URI,
+    SURVEY_LIST_RESOURCE_URI,
+    SURVEY_RESOURCE_URI,
+    SURVEY_STATS_RESOURCE_URI,
 } from './ui-apps-constants'
 
 // Import bundled HTML at build time (wrangler Text rule)
@@ -39,6 +43,10 @@ import featureFlagListHtml from '../../ui-apps-dist/src/ui-apps/apps/feature-fla
 import featureFlagHtml from '../../ui-apps-dist/src/ui-apps/apps/feature-flag/index.html'
 import llmCostsHtml from '../../ui-apps-dist/src/ui-apps/apps/llm-costs/index.html'
 import queryResultsHtml from '../../ui-apps-dist/src/ui-apps/apps/query-results/index.html'
+import surveyGlobalStatsHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-global-stats/index.html'
+import surveyListHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-list/index.html'
+import surveyStatsHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-stats/index.html'
+import surveyHtml from '../../ui-apps-dist/src/ui-apps/apps/survey/index.html'
 
 const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
     // Core
@@ -117,6 +125,21 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
         uri: LLM_COSTS_RESOURCE_URI,
         description: 'LLM costs breakdown by model',
         html: llmCostsHtml,
+    },
+    // Surveys
+    { name: 'Survey', uri: SURVEY_RESOURCE_URI, description: 'Survey detail view', html: surveyHtml },
+    { name: 'Survey list', uri: SURVEY_LIST_RESOURCE_URI, description: 'Survey list view', html: surveyListHtml },
+    {
+        name: 'Survey stats',
+        uri: SURVEY_STATS_RESOURCE_URI,
+        description: 'Survey statistics view',
+        html: surveyStatsHtml,
+    },
+    {
+        name: 'Survey global stats',
+        uri: SURVEY_GLOBAL_STATS_RESOURCE_URI,
+        description: 'Survey global statistics view',
+        html: surveyGlobalStatsHtml,
     },
 ]
 

--- a/services/mcp/src/tools/surveys/create.ts
+++ b/services/mcp/src/tools/surveys/create.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyCreateSchema } from '@/schema/tool-inputs'
 import { formatSurvey, type FormattedSurvey } from '@/tools/surveys/utils/survey-utils'
 import type { Context, ToolBase } from '@/tools/types'
@@ -49,6 +50,11 @@ const tool = (): ToolBase<typeof schema, FormattedSurvey> => ({
     name: 'survey-create',
     schema,
     handler: createHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/get.ts
+++ b/services/mcp/src/tools/surveys/get.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyGetSchema } from '@/schema/tool-inputs'
 import { formatSurvey, type FormattedSurvey } from '@/tools/surveys/utils/survey-utils'
 import type { Context, ToolBase } from '@/tools/types'
@@ -31,6 +32,11 @@ const tool = (): ToolBase<typeof schema, FormattedSurvey> => ({
     name: 'survey-get',
     schema,
     handler: getHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/getAll.ts
+++ b/services/mcp/src/tools/surveys/getAll.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_LIST_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyGetAllSchema } from '@/schema/tool-inputs'
 import { formatSurveys, type FormattedSurvey } from '@/tools/surveys/utils/survey-utils'
 import type { Context, ToolBase } from '@/tools/types'
@@ -20,17 +21,21 @@ export const getAllHandler: ToolBase<typeof schema, Result>['handler'] = async (
 
     const formattedSurveys = formatSurveys(surveysResult.data, context, projectId)
 
-    const response = {
+    return {
         results: formattedSurveys,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/surveys`,
     }
-
-    return response
 }
 
 const tool = (): ToolBase<typeof schema, Result> => ({
     name: 'surveys-get-all',
     schema,
     handler: getAllHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_LIST_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/global-stats.ts
+++ b/services/mcp/src/tools/surveys/global-stats.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_GLOBAL_STATS_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyGlobalStatsSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -18,13 +19,21 @@ export const globalStatsHandler: ToolBase<typeof schema, unknown>['handler'] = a
         throw new Error(`Failed to get survey global stats: ${result.error.message}`)
     }
 
-    return result.data
+    return {
+        ...result.data,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/surveys`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'surveys-global-stats',
     schema,
     handler: globalStatsHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_GLOBAL_STATS_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/stats.ts
+++ b/services/mcp/src/tools/surveys/stats.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_STATS_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyStatsSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase } from '@/tools/types'
 
@@ -19,13 +20,21 @@ export const statsHandler: ToolBase<typeof schema, unknown>['handler'] = async (
         throw new Error(`Failed to get survey stats: ${result.error.message}`)
     }
 
-    return result.data
+    return {
+        ...result.data,
+        _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/surveys/${params.survey_id}`,
+    }
 }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'survey-stats',
     schema,
     handler: statsHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_STATS_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/update.ts
+++ b/services/mcp/src/tools/surveys/update.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { SURVEY_RESOURCE_URI } from '@/resources/ui-apps-constants'
 import { SurveyUpdateSchema } from '@/schema/tool-inputs'
 import { formatSurvey, type FormattedSurvey } from '@/tools/surveys/utils/survey-utils'
 import type { Context, ToolBase } from '@/tools/types'
@@ -51,6 +52,11 @@ const tool = (): ToolBase<typeof schema, FormattedSurvey> => ({
     name: 'survey-update',
     schema,
     handler: updateHandler,
+    _meta: {
+        ui: {
+            resourceUri: SURVEY_RESOURCE_URI,
+        },
+    },
 })
 
 export default tool

--- a/services/mcp/src/tools/surveys/utils/survey-utils.ts
+++ b/services/mcp/src/tools/surveys/utils/survey-utils.ts
@@ -6,7 +6,7 @@ type SurveyData = Schemas.Survey
 export interface FormattedSurvey extends Omit<SurveyData, 'end_date'> {
     status: 'draft' | 'active' | 'completed' | 'archived'
     end_date?: string | undefined
-    url?: string
+    _posthogUrl?: string
 }
 
 /**
@@ -30,7 +30,7 @@ export function formatSurvey(survey: SurveyData, context: Context, projectId: st
     // Add URL if we have context and survey ID
     if (context && survey.id && projectId) {
         const baseUrl = context.api.getProjectBaseUrl(projectId)
-        formatted.url = `${baseUrl}/surveys/${survey.id}`
+        formatted._posthogUrl = `${baseUrl}/surveys/${survey.id}`
     }
 
     return formatted

--- a/services/mcp/src/ui-apps/apps/survey-global-stats/index.html
+++ b/services/mcp/src/ui-apps/apps/survey-global-stats/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Survey Global Stats</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/survey-global-stats/main.tsx
+++ b/services/mcp/src/ui-apps/apps/survey-global-stats/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type SurveyStatsData, SurveyStatsView } from 'products/surveys/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function SurveyGlobalStatsApp(): JSX.Element {
+    return (
+        <AppWrapper<SurveyStatsData> appName="PostHog Survey Global Stats">
+            {({ data }) => <SurveyStatsView data={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<SurveyGlobalStatsApp />)
+}

--- a/services/mcp/src/ui-apps/apps/survey-list/index.html
+++ b/services/mcp/src/ui-apps/apps/survey-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Surveys</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/survey-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/survey-list/main.tsx
@@ -1,0 +1,60 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { type SurveyData, type SurveyListData, SurveyListView } from 'products/surveys/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function SurveyListApp(): JSX.Element {
+    return (
+        <AppWrapper<SurveyListData> appName="PostHog Surveys">
+            {({ data, app }) => <SurveyListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function SurveyListContent({ data, app }: { data: SurveyListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for survey "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (survey: SurveyData): Promise<SurveyData | null> => {
+            if (!app) {
+                fallbackToChat(survey.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'survey-get',
+                    arguments: { surveyId: survey.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(survey.name)
+                    return null
+                }
+                return result.structuredContent as unknown as SurveyData
+            } catch {
+                fallbackToChat(survey.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <SurveyListView data={data} onSurveyClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<SurveyListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/survey-stats/index.html
+++ b/services/mcp/src/ui-apps/apps/survey-stats/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Survey Stats</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/survey-stats/main.tsx
+++ b/services/mcp/src/ui-apps/apps/survey-stats/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type SurveyStatsData, SurveyStatsView } from 'products/surveys/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function SurveyStatsApp(): JSX.Element {
+    return (
+        <AppWrapper<SurveyStatsData> appName="PostHog Survey Stats">
+            {({ data }) => <SurveyStatsView data={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<SurveyStatsApp />)
+}

--- a/services/mcp/src/ui-apps/apps/survey/index.html
+++ b/services/mcp/src/ui-apps/apps/survey/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Survey</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/survey/main.tsx
+++ b/services/mcp/src/ui-apps/apps/survey/main.tsx
@@ -1,0 +1,16 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type SurveyData, SurveyView } from 'products/surveys/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function SurveyApp(): JSX.Element {
+    return <AppWrapper<SurveyData> appName="PostHog Survey">{({ data }) => <SurveyView survey={data!} />}</AppWrapper>
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<SurveyApp />)
+}


### PR DESCRIPTION
## Problem

This adds comprehensive UI components and applications for displaying PostHog survey data in MCP (Model Context Protocol) applications. The components provide rich visual interfaces for viewing survey lists, individual survey details, and survey statistics, enhancing the user experience when working with survey data through MCP tools.

## Changes

- **Survey UI Components**: Created reusable React components for displaying survey data:
  - `SurveyListView`: Displays surveys in a sortable data table with status badges and question counts
  - `SurveyView`: Shows detailed survey information including questions, metadata, and configuration
  - `SurveyQuestion`: Renders individual survey questions with type-specific formatting
  - `SurveyStatsView`: Displays survey statistics with progress bars for response/dismissal rates

- **MCP UI Applications**: Built four standalone applications that consume survey data:
  - Survey list browser with drill-down capability to individual surveys
  - Individual survey detail viewer
  - Survey statistics dashboard
  - Global survey statistics overview

- **Enhanced Survey Tools**: Added UI metadata to survey MCP tools linking them to their corresponding UI applications, and included PostHog URLs in tool responses for better integration

- **Survey Utilities**: Updated survey formatting utilities to include `_posthogUrl` field for linking back to PostHog interface

## Publish to changelog?

No - not yet.