### PR TITLE
feat: Add workflow UI components for MCP apps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2886,7 +2886,7 @@ importers:
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'
-        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2884,6 +2884,9 @@ importers:
         specifier: '*'
         version: 3.25.76
     devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 7.6.4(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))

--- a/products/surveys/frontend/mcp-apps/SurveyListView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyListView.tsx
@@ -3,7 +3,7 @@ import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
 import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
 
 import { SurveyView, type SurveyData } from './SurveyView'
-import { STATUS_VARIANTS } from './utils'
+import { STATUS_VARIANTS, SURVEY_TYPE_LABELS } from './utils'
 
 export interface SurveyListData {
     results: SurveyData[]
@@ -88,7 +88,7 @@ export function SurveyListView({ data, onSurveyClick }: SurveyListViewProps): Re
             render: (row): ReactNode =>
                 row.type ? (
                     <Badge variant="neutral" size="sm">
-                        {row.type}
+                        {SURVEY_TYPE_LABELS[row.type] ?? row.type}
                     </Badge>
                 ) : (
                     <span className="text-text-secondary">&mdash;</span>

--- a/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyQuestion.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react'
 
 import { Badge, Stack } from '@posthog/mosaic'
 
-import { TYPE_LABELS } from './utils'
+import { SURVEY_QUESTION_TYPE_LABELS } from './utils'
 
 export interface SurveyQuestionData {
     type: string
@@ -31,7 +31,7 @@ export function SurveyQuestion({ question, index }: SurveyQuestionProps): ReactE
             <div className="flex items-center gap-2">
                 <span className="text-xs text-text-secondary">Q{index + 1}</span>
                 <Badge variant="neutral" size="sm">
-                    {TYPE_LABELS[question.type] ?? question.type}
+                    {SURVEY_QUESTION_TYPE_LABELS[question.type] ?? question.type}
                 </Badge>
             </div>
             <span className="text-sm text-text-primary">{question.question}</span>

--- a/products/surveys/frontend/mcp-apps/SurveyView.tsx
+++ b/products/surveys/frontend/mcp-apps/SurveyView.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react'
 import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
 
 import { SurveyQuestion, type SurveyQuestionData } from './SurveyQuestion'
-import { STATUS_VARIANTS, TYPE_LABELS } from './utils'
+import { STATUS_VARIANTS, SURVEY_TYPE_LABELS } from './utils'
 
 export interface SurveyData {
     id: string
@@ -39,7 +39,7 @@ export function SurveyView({ survey }: SurveyViewProps): ReactElement {
                         </Badge>
                         {survey.type && (
                             <Badge variant="neutral" size="sm">
-                                {TYPE_LABELS[survey.type] ?? survey.type}
+                                {SURVEY_TYPE_LABELS[survey.type] ?? survey.type}
                             </Badge>
                         )}
                     </div>

--- a/products/surveys/frontend/mcp-apps/utils.ts
+++ b/products/surveys/frontend/mcp-apps/utils.ts
@@ -5,7 +5,14 @@ export const STATUS_VARIANTS: Record<string, 'success' | 'warning' | 'neutral' |
     archived: 'neutral',
 }
 
-export const TYPE_LABELS: Record<string, string> = {
+export const SURVEY_TYPE_LABELS: Record<string, string> = {
+    popover: 'Popover',
+    api: 'API',
+    widget: 'Widget',
+    external_survey: 'External survey',
+}
+
+export const SURVEY_QUESTION_TYPE_LABELS: Record<string, string> = {
     open: 'Open text',
     multiple_choice: 'Multiple choice',
     single_choice: 'Single choice',

--- a/products/workflows/frontend/mcp-apps/WorkflowListView.tsx
+++ b/products/workflows/frontend/mcp-apps/WorkflowListView.tsx
@@ -2,6 +2,7 @@ import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
 
 import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
 
+import { STATUS_VARIANTS } from './utils'
 import { WorkflowView, type WorkflowData } from './WorkflowView'
 
 export interface WorkflowListData {
@@ -17,13 +18,6 @@ export interface WorkflowListViewProps {
 
 type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; workflow: WorkflowData }
 
-const statusVariants: Record<string, 'success' | 'neutral' | 'info'> = {
-    active: 'success',
-    draft: 'neutral',
-    archived: 'neutral',
-    paused: 'info',
-}
-
 export function WorkflowListView({ data, onWorkflowClick }: WorkflowListViewProps): ReactElement {
     const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
 
@@ -32,8 +26,13 @@ export function WorkflowListView({ data, onWorkflowClick }: WorkflowListViewProp
             if (!onWorkflowClick) {
                 return
             }
+
             setViewState({ view: 'loading', name: workflow.name })
-            const detail = await onWorkflowClick(workflow)
+            const detail = await onWorkflowClick(workflow).catch((error) => {
+                console.error('Error loading workflow detail:', error)
+                return null
+            })
+
             if (detail) {
                 setViewState({ view: 'detail', workflow: detail })
             } else {
@@ -88,10 +87,10 @@ export function WorkflowListView({ data, onWorkflowClick }: WorkflowListViewProp
             key: 'status',
             header: 'Status',
             render: (row): ReactNode => {
-                const s = row.status ?? 'draft'
+                const status = row.status ?? 'draft'
                 return (
-                    <Badge variant={statusVariants[s] ?? 'neutral'} size="sm">
-                        {s.charAt(0).toUpperCase() + s.slice(1)}
+                    <Badge variant={STATUS_VARIANTS[status] ?? 'neutral'} size="sm">
+                        {status.charAt(0).toUpperCase() + status.slice(1)}
                     </Badge>
                 )
             },

--- a/products/workflows/frontend/mcp-apps/WorkflowListView.tsx
+++ b/products/workflows/frontend/mcp-apps/WorkflowListView.tsx
@@ -1,0 +1,139 @@
+import { type ReactElement, type ReactNode, useCallback, useState } from 'react'
+
+import { BackButton, Badge, DataTable, type DataTableColumn, formatDate, LoadingState, Stack } from '@posthog/mosaic'
+
+import { WorkflowView, type WorkflowData } from './WorkflowView'
+
+export interface WorkflowListData {
+    count?: number
+    results: WorkflowData[]
+    _posthogUrl?: string
+}
+
+export interface WorkflowListViewProps {
+    data: WorkflowListData
+    onWorkflowClick?: (workflow: WorkflowData) => Promise<WorkflowData | null>
+}
+
+type ViewState = { view: 'list' } | { view: 'loading'; name: string } | { view: 'detail'; workflow: WorkflowData }
+
+const statusVariants: Record<string, 'success' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    archived: 'neutral',
+    paused: 'info',
+}
+
+export function WorkflowListView({ data, onWorkflowClick }: WorkflowListViewProps): ReactElement {
+    const [viewState, setViewState] = useState<ViewState>({ view: 'list' })
+
+    const handleClick = useCallback(
+        async (workflow: WorkflowData) => {
+            if (!onWorkflowClick) {
+                return
+            }
+            setViewState({ view: 'loading', name: workflow.name })
+            const detail = await onWorkflowClick(workflow)
+            if (detail) {
+                setViewState({ view: 'detail', workflow: detail })
+            } else {
+                setViewState({ view: 'list' })
+            }
+        },
+        [onWorkflowClick]
+    )
+
+    const handleBack = useCallback(() => setViewState({ view: 'list' }), [])
+
+    if (viewState.view === 'loading') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All workflows" />
+                    <LoadingState label={viewState.name} />
+                </Stack>
+            </div>
+        )
+    }
+
+    if (viewState.view === 'detail') {
+        return (
+            <div className="p-4">
+                <Stack gap="sm">
+                    <BackButton onClick={handleBack} label="All workflows" />
+                    <WorkflowView workflow={viewState.workflow} />
+                </Stack>
+            </div>
+        )
+    }
+
+    const columns: DataTableColumn<WorkflowData>[] = [
+        {
+            key: 'name',
+            header: 'Name',
+            sortable: true,
+            render: (row): ReactNode =>
+                onWorkflowClick ? (
+                    <button
+                        onClick={() => handleClick(row)}
+                        className="text-link underline decoration-border-primary hover:decoration-link cursor-pointer text-left transition-colors"
+                    >
+                        {row.name}
+                    </button>
+                ) : (
+                    row.name
+                ),
+        },
+        {
+            key: 'status',
+            header: 'Status',
+            render: (row): ReactNode => {
+                const s = row.status ?? 'draft'
+                return (
+                    <Badge variant={statusVariants[s] ?? 'neutral'} size="sm">
+                        {s.charAt(0).toUpperCase() + s.slice(1)}
+                    </Badge>
+                )
+            },
+        },
+        {
+            key: 'version',
+            header: 'Version',
+            align: 'right',
+            render: (row): ReactNode => (
+                <span className="text-text-secondary">{row.version != null ? `v${row.version}` : '\u2014'}</span>
+            ),
+        },
+        {
+            key: 'updated_at',
+            header: 'Updated',
+            sortable: true,
+            render: (row): ReactNode =>
+                row.updated_at ? (
+                    <span className="text-text-secondary">{formatDate(row.updated_at)}</span>
+                ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                ),
+        },
+    ]
+
+    return (
+        <div className="p-4">
+            <Stack gap="sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-text-secondary">
+                        {data.count ?? data.results.length} workflow
+                        {(data.count ?? data.results.length) === 1 ? '' : 's'}
+                    </span>
+                </div>
+                <DataTable<WorkflowData>
+                    columns={columns}
+                    data={data.results}
+                    pageSize={10}
+                    defaultSort={{ key: 'name', direction: 'asc' }}
+                    emptyMessage="No workflows found"
+                />
+            </Stack>
+        </div>
+    )
+}

--- a/products/workflows/frontend/mcp-apps/WorkflowView.tsx
+++ b/products/workflows/frontend/mcp-apps/WorkflowView.tsx
@@ -2,6 +2,8 @@ import type { ReactElement } from 'react'
 
 import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
 
+import { STATUS_VARIANTS } from './utils'
+
 export interface WorkflowData {
     id: string
     name: string
@@ -20,13 +22,6 @@ export interface WorkflowViewProps {
     workflow: WorkflowData
 }
 
-const statusVariants: Record<string, 'success' | 'neutral' | 'info'> = {
-    active: 'success',
-    draft: 'neutral',
-    archived: 'neutral',
-    paused: 'info',
-}
-
 export function WorkflowView({ workflow }: WorkflowViewProps): ReactElement {
     const status = workflow.status ?? 'draft'
 
@@ -36,7 +31,7 @@ export function WorkflowView({ workflow }: WorkflowViewProps): ReactElement {
                 <Stack gap="xs">
                     <div className="flex items-center gap-2 flex-wrap">
                         <span className="text-lg font-semibold text-text-primary">{workflow.name}</span>
-                        <Badge variant={statusVariants[status] ?? 'neutral'} size="md">
+                        <Badge variant={STATUS_VARIANTS[status] ?? 'neutral'} size="md">
                             {status.charAt(0).toUpperCase() + status.slice(1)}
                         </Badge>
                         {workflow.version != null && (

--- a/products/workflows/frontend/mcp-apps/WorkflowView.tsx
+++ b/products/workflows/frontend/mcp-apps/WorkflowView.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react'
+
+import { Badge, Card, DescriptionList, formatDate, Stack } from '@posthog/mosaic'
+
+export interface WorkflowData {
+    id: string
+    name: string
+    description?: string | null
+    status?: string
+    version?: number
+    trigger?: Record<string, unknown> | null
+    exit_condition?: string | null
+    created_at?: string
+    updated_at?: string
+    created_by?: { first_name?: string; email?: string } | null
+    _posthogUrl?: string
+}
+
+export interface WorkflowViewProps {
+    workflow: WorkflowData
+}
+
+const statusVariants: Record<string, 'success' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    archived: 'neutral',
+    paused: 'info',
+}
+
+export function WorkflowView({ workflow }: WorkflowViewProps): ReactElement {
+    const status = workflow.status ?? 'draft'
+
+    return (
+        <div className="p-4">
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-lg font-semibold text-text-primary">{workflow.name}</span>
+                        <Badge variant={statusVariants[status] ?? 'neutral'} size="md">
+                            {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </Badge>
+                        {workflow.version != null && (
+                            <Badge variant="neutral" size="sm">
+                                v{workflow.version}
+                            </Badge>
+                        )}
+                    </div>
+                    {workflow.description && (
+                        <span className="text-sm text-text-secondary">{workflow.description}</span>
+                    )}
+                </Stack>
+
+                <Card padding="md">
+                    <DescriptionList
+                        columns={2}
+                        items={[
+                            ...(workflow.exit_condition
+                                ? [{ label: 'Exit condition', value: workflow.exit_condition }]
+                                : []),
+                            ...(workflow.created_at
+                                ? [{ label: 'Created', value: formatDate(workflow.created_at) }]
+                                : []),
+                            ...(workflow.updated_at
+                                ? [{ label: 'Updated', value: formatDate(workflow.updated_at) }]
+                                : []),
+                            ...(workflow.created_by
+                                ? [
+                                      {
+                                          label: 'Created by',
+                                          value:
+                                              workflow.created_by.first_name || workflow.created_by.email || 'Unknown',
+                                      },
+                                  ]
+                                : []),
+                        ]}
+                    />
+                </Card>
+
+                <div className="rounded border border-border-primary bg-[var(--color-background-info)] px-3 py-2">
+                    <span className="text-xs text-text-secondary">
+                        View in PostHog for the full visual workflow editor
+                    </span>
+                </div>
+            </Stack>
+        </div>
+    )
+}

--- a/products/workflows/frontend/mcp-apps/index.ts
+++ b/products/workflows/frontend/mcp-apps/index.ts
@@ -1,0 +1,2 @@
+export { WorkflowView, type WorkflowData, type WorkflowViewProps } from './WorkflowView'
+export { WorkflowListView, type WorkflowListData, type WorkflowListViewProps } from './WorkflowListView'

--- a/products/workflows/frontend/mcp-apps/utils.ts
+++ b/products/workflows/frontend/mcp-apps/utils.ts
@@ -1,0 +1,6 @@
+export const STATUS_VARIANTS: Record<string, 'success' | 'neutral' | 'info'> = {
+    active: 'success',
+    draft: 'neutral',
+    archived: 'neutral',
+    paused: 'info',
+}

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -6,7 +6,7 @@
 # All other fields (title, description, enrich_url, etc.) are yours to configure.
 category: Workflows
 feature: hog_flows
-url_prefix: /workflows
+url_prefix: /pipeline/destinations
 tools:
     workflows-list:
         operation: hog_flows_list
@@ -24,6 +24,7 @@ tools:
             description, status (draft/active/archived), version, trigger configuration,
             and timestamps.
         mcp_version: 1
+        ui_resource_uri: 'ui://posthog/workflow-list.html'
     workflows-get:
         operation: hog_flows_retrieve
         enabled: true
@@ -33,8 +34,10 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: 'hog-{id}'
         title: Get workflow
         description: >
             Get a specific workflow by ID. Returns the full workflow definition
             including trigger, edges, actions, exit condition, and variables.
         mcp_version: 1
+        ui_resource_uri: 'ui://posthog/workflow.html'

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -13,6 +13,7 @@
         "use-debounce": "catalog:"
     },
     "devDependencies": {
+        "@storybook/react": "catalog:",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {

--- a/services/mcp/scripts/build-ui-apps.ts
+++ b/services/mcp/scripts/build-ui-apps.ts
@@ -16,11 +16,12 @@ import { config as dotenvConfig } from 'dotenv'
 import { existsSync, readdirSync, rmSync, statSync } from 'fs'
 import { join, resolve } from 'path'
 
-const ROOT_DIR = resolve(__dirname, '..')
-const APPS_DIR = resolve(ROOT_DIR, 'src/ui-apps/apps')
+const MCP_ROOT_DIR = resolve(__dirname, '..')
+const ROOT_DIR = resolve(MCP_ROOT_DIR, '..', '..')
+const APPS_DIR = resolve(MCP_ROOT_DIR, 'src/ui-apps/apps')
 
 // Load environment variables from .dev.vars (Cloudflare convention)
-const devVarsPath = resolve(ROOT_DIR, '.dev.vars')
+const devVarsPath = resolve(MCP_ROOT_DIR, '.dev.vars')
 if (existsSync(devVarsPath)) {
     const output = dotenvConfig({ path: devVarsPath })
     const loadedKeys = Object.keys(output.parsed || {})
@@ -51,7 +52,7 @@ function buildAppAsync(appName: string): Promise<void> {
     return new Promise((resolve, reject) => {
         // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
         const child = exec('vite build --config vite.ui-apps.config.ts', {
-            cwd: ROOT_DIR,
+            cwd: MCP_ROOT_DIR,
             env: {
                 ...process.env,
                 UI_APP: appName,
@@ -84,7 +85,7 @@ function buildAppSync(appName: string): void {
 
     // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
     execSync(`UI_APP=${appName} vite build --config vite.ui-apps.config.ts`, {
-        cwd: ROOT_DIR,
+        cwd: MCP_ROOT_DIR,
         stdio: 'inherit',
         env: {
             ...process.env,
@@ -140,8 +141,9 @@ function watchApps(apps: string[]): void {
 
         const watcher = chokidar.watch(
             [
-                join(ROOT_DIR, 'src/ui-apps/**/*.{ts,tsx,css,html}'),
-                resolve(ROOT_DIR, '../../common/mosaic/src/**/*.{ts,tsx,css}'),
+                join(MCP_ROOT_DIR, 'src/ui-apps/**/*.{ts,tsx,css,html}'),
+                join(ROOT_DIR, 'products/**/mcp-apps/**/*.{ts,tsx,css}'),
+                join(ROOT_DIR, 'common/mosaic/src/**/*.{ts,tsx,css}'),
             ],
             {
                 ignoreInitial: true,

--- a/services/mcp/src/resources/ui-apps-constants.ts
+++ b/services/mcp/src/resources/ui-apps-constants.ts
@@ -31,6 +31,7 @@ export const ACTION_LIST_RESOURCE_URI = 'ui://posthog/action-list.html'
  * Used by: cohorts-retrieve, cohorts-create, cohorts-partial-update
  */
 export const COHORT_RESOURCE_URI = 'ui://posthog/cohort.html'
+
 /**
  * Cohort list visualization.
  * Used by: cohorts-list
@@ -49,11 +50,13 @@ export const DEBUG_RESOURCE_URI = 'ui://posthog/debug.html'
  * Used by: error-details
  */
 export const ERROR_DETAILS_RESOURCE_URI = 'ui://posthog/error-details.html'
+
 /**
  * Error tracking issue detail visualization.
  * Used by: error-tracking-issues-retrieve, error-tracking-issues-partial-update
  */
 export const ERROR_ISSUE_RESOURCE_URI = 'ui://posthog/error-issue.html'
+
 /**
  * Error tracking issue list visualization.
  * Used by: error-tracking-issues-list
@@ -65,11 +68,13 @@ export const ERROR_ISSUE_LIST_RESOURCE_URI = 'ui://posthog/error-issue-list.html
  * Used by: experiment-get, experiment-create, experiment-update
  */
 export const EXPERIMENT_RESOURCE_URI = 'ui://posthog/experiment.html'
+
 /**
  * Experiment list visualization.
  * Used by: experiment-get-all
  */
 export const EXPERIMENT_LIST_RESOURCE_URI = 'ui://posthog/experiment-list.html'
+
 /**
  * Experiment results visualization.
  * Used by: experiment-results-get
@@ -83,6 +88,7 @@ export const EXPERIMENT_RESULTS_RESOURCE_URI = 'ui://posthog/experiment-results.
  * Shows flag status, release conditions, variants, and property filters.
  */
 export const FEATURE_FLAG_RESOURCE_URI = 'ui://posthog/feature-flag.html'
+
 /**
  * Feature flag list visualization.
  * Used by: feature-flag-get-all
@@ -127,3 +133,16 @@ export const SURVEY_STATS_RESOURCE_URI = 'ui://posthog/survey-stats.html'
  * Used by: surveys-global-stats
  */
 export const SURVEY_GLOBAL_STATS_RESOURCE_URI = 'ui://posthog/survey-global-stats.html'
+
+/**
+
+ * Workflow detail visualization.
+ * Used by: workflows-get
+ */
+export const WORKFLOW_RESOURCE_URI = 'ui://posthog/workflow.html'
+
+/**
+ * Workflow list visualization.
+ * Used by: workflows-list
+ */
+export const WORKFLOW_LIST_RESOURCE_URI = 'ui://posthog/workflow-list.html'

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -24,6 +24,8 @@ import {
     SURVEY_LIST_RESOURCE_URI,
     SURVEY_RESOURCE_URI,
     SURVEY_STATS_RESOURCE_URI,
+    WORKFLOW_LIST_RESOURCE_URI,
+    WORKFLOW_RESOURCE_URI,
 } from './ui-apps-constants'
 
 // Import bundled HTML at build time (wrangler Text rule)
@@ -47,6 +49,8 @@ import surveyGlobalStatsHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-gl
 import surveyListHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-list/index.html'
 import surveyStatsHtml from '../../ui-apps-dist/src/ui-apps/apps/survey-stats/index.html'
 import surveyHtml from '../../ui-apps-dist/src/ui-apps/apps/survey/index.html'
+import workflowListHtml from '../../ui-apps-dist/src/ui-apps/apps/workflow-list/index.html'
+import workflowHtml from '../../ui-apps-dist/src/ui-apps/apps/workflow/index.html'
 
 const UI_APPS: Array<{ name: string; uri: string; description: string; html: string }> = [
     // Core
@@ -140,6 +144,14 @@ const UI_APPS: Array<{ name: string; uri: string; description: string; html: str
         uri: SURVEY_GLOBAL_STATS_RESOURCE_URI,
         description: 'Survey global statistics view',
         html: surveyGlobalStatsHtml,
+    },
+    // Workflows
+    { name: 'Workflow', uri: WORKFLOW_RESOURCE_URI, description: 'Workflow detail view', html: workflowHtml },
+    {
+        name: 'Workflow list',
+        uri: WORKFLOW_LIST_RESOURCE_URI,
+        description: 'Workflow list view',
+        html: workflowListHtml,
     },
 ]
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -41,7 +41,7 @@ const workflowsList = (): ToolBase<
 
 const WorkflowsGetSchema = HogFlowsRetrieveParams.omit({ project_id: true })
 
-const workflowsGet = (): ToolBase<typeof WorkflowsGetSchema, Schemas.HogFlow> => ({
+const workflowsGet = (): ToolBase<typeof WorkflowsGetSchema, Schemas.HogFlow & { _posthogUrl: string }> => ({
     name: 'workflows-get',
     schema: WorkflowsGetSchema,
     handler: async (context: Context, params: z.infer<typeof WorkflowsGetSchema>) => {

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -29,8 +29,13 @@ const workflowsList = (): ToolBase<
         })
         return {
             ...(result as any),
-            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/workflows`,
+            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/pipeline/destinations`,
         }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/workflow-list.html',
+        },
     },
 })
 
@@ -45,7 +50,15 @@ const workflowsGet = (): ToolBase<typeof WorkflowsGetSchema, Schemas.HogFlow> =>
             method: 'GET',
             path: `/api/projects/${projectId}/hog_flows/${params.id}/`,
         })
-        return result
+        return {
+            ...(result as any),
+            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/pipeline/destinations/hog-${(result as any).id}`,
+        }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/workflow.html',
+        },
     },
 })
 

--- a/services/mcp/src/ui-apps/apps/workflow-list/index.html
+++ b/services/mcp/src/ui-apps/apps/workflow-list/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Workflows</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/workflow-list/main.tsx
+++ b/services/mcp/src/ui-apps/apps/workflow-list/main.tsx
@@ -1,0 +1,60 @@
+import '../../styles/tailwind.css'
+
+import type { App } from '@modelcontextprotocol/ext-apps'
+import { useCallback } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { type WorkflowData, type WorkflowListData, WorkflowListView } from 'products/workflows/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function WorkflowListApp(): JSX.Element {
+    return (
+        <AppWrapper<WorkflowListData> appName="PostHog Workflows">
+            {({ data, app }) => <WorkflowListContent data={data!} app={app} />}
+        </AppWrapper>
+    )
+}
+
+function WorkflowListContent({ data, app }: { data: WorkflowListData; app: App | null }): JSX.Element {
+    const fallbackToChat = useCallback(
+        (name: string) => {
+            app?.sendMessage({
+                role: 'user',
+                content: [{ type: 'text', text: `Show me the details for workflow "${name}"` }],
+            })
+        },
+        [app]
+    )
+
+    const handleClick = useCallback(
+        async (workflow: WorkflowData): Promise<WorkflowData | null> => {
+            if (!app) {
+                fallbackToChat(workflow.name)
+                return null
+            }
+            try {
+                const result = await app.callServerTool({
+                    name: 'workflows-get',
+                    arguments: { id: workflow.id },
+                })
+                if (result.isError || !result.structuredContent) {
+                    fallbackToChat(workflow.name)
+                    return null
+                }
+                return result.structuredContent as unknown as WorkflowData
+            } catch {
+                fallbackToChat(workflow.name)
+                return null
+            }
+        },
+        [app, fallbackToChat]
+    )
+
+    return <WorkflowListView data={data} onWorkflowClick={handleClick} />
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<WorkflowListApp />)
+}

--- a/services/mcp/src/ui-apps/apps/workflow/index.html
+++ b/services/mcp/src/ui-apps/apps/workflow/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PostHog Workflow</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+
+</html>

--- a/services/mcp/src/ui-apps/apps/workflow/main.tsx
+++ b/services/mcp/src/ui-apps/apps/workflow/main.tsx
@@ -1,0 +1,20 @@
+import '../../styles/tailwind.css'
+
+import { createRoot } from 'react-dom/client'
+
+import { type WorkflowData, WorkflowView } from 'products/workflows/frontend/mcp-apps'
+
+import { AppWrapper } from '../../components/AppWrapper'
+
+function WorkflowApp(): JSX.Element {
+    return (
+        <AppWrapper<WorkflowData> appName="PostHog Workflow">
+            {({ data }) => <WorkflowView workflow={data!} />}
+        </AppWrapper>
+    )
+}
+
+const container = document.getElementById('root')
+if (container) {
+    createRoot(container).render(<WorkflowApp />)
+}


### PR DESCRIPTION
## Problem

Users need a visual interface to view and interact with PostHog workflows through the MCP (Model Context Protocol) system. Currently, workflow data can only be accessed through API calls without a user-friendly interface for browsing workflow lists or viewing individual workflow details.

## Changes

- Added React components `WorkflowListView` and `WorkflowView` for displaying workflow data with interactive features
- Created MCP UI applications for workflow list and individual workflow views with HTML entry points
- Updated MCP tool configuration to include UI resource URIs and proper URL routing
- Enhanced workflow API responses to include PostHog URLs for navigation
- Added Storybook React dependency for component development
- Implemented status badges, data tables, and detailed workflow information display
- Added navigation between list and detail views with loading states

## Publish to changelog?

No - not yet.