### PR TITLE
feat(flags): add group key columns to posthog_person table

### DIFF
--- a/rust/persons_migrations/20260304000001_add_group_keys_to_person.sql
+++ b/rust/persons_migrations/20260304000001_add_group_keys_to_person.sql
@@ -1,0 +1,13 @@
+-- Add group key columns to person table
+-- These columns store the group keys (e.g. company name) that a person belongs to,
+-- enabling JOINs from persons to groups for mixed user+group flag targeting.
+--
+-- SAFE: Adding columns with defaults is instant in Postgres 11+ (metadata-only)
+-- No table rewrite required regardless of table size
+-- For partitioned tables, ALTER TABLE propagates to all partitions automatically
+
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_0_key VARCHAR(400) DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_1_key VARCHAR(400) DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_2_key VARCHAR(400) DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_3_key VARCHAR(400) DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_4_key VARCHAR(400) DEFAULT '';

--- a/rust/persons_migrations/20260304000001_add_group_keys_to_person.sql
+++ b/rust/persons_migrations/20260304000001_add_group_keys_to_person.sql
@@ -6,8 +6,8 @@
 -- No table rewrite required regardless of table size
 -- For partitioned tables, ALTER TABLE propagates to all partitions automatically
 
-ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_0_key VARCHAR(400) DEFAULT '';
-ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_1_key VARCHAR(400) DEFAULT '';
-ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_2_key VARCHAR(400) DEFAULT '';
-ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_3_key VARCHAR(400) DEFAULT '';
-ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_4_key VARCHAR(400) DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_0_key VARCHAR(400) NOT NULL DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_1_key VARCHAR(400) NOT NULL DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_2_key VARCHAR(400) NOT NULL DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_3_key VARCHAR(400) NOT NULL DEFAULT '';
+ALTER TABLE posthog_person ADD COLUMN IF NOT EXISTS group_4_key VARCHAR(400) NOT NULL DEFAULT '';


### PR DESCRIPTION
## Problem

The feature flags team needs to support mixed user+group flag targeting for blast radius calculations. This requires JOINing persons to groups, but the Rust-managed `posthog_person` table doesn't have group key columns yet.

This is PR 1 of 2. The service code that populates these columns will follow in a separate PR after this migration is deployed.

Closes #46294

## Changes

Adds `group_0_key` through `group_4_key` VARCHAR(400) columns to `posthog_person` with `DEFAULT ''`.

Safe: `ADD COLUMN ... DEFAULT` is metadata-only in Postgres 11+ — no table rewrite, no locks, instant. Propagates automatically to partitions.

## How did you test this code?

Migration-only change. Verified the SQL syntax is correct and uses `IF NOT EXISTS` for idempotency.

## Publish to changelog?

No