### PR TITLE
fix: apply aggregation axis formatting to box plot charts

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -154,9 +154,7 @@ export function InsightDisplayConfig(): JSX.Element {
                   },
               ]
             : []),
-        ...(!showPercentStackView &&
-        isTrends &&
-        display !== ChartDisplayType.CalendarHeatmap
+        ...(!showPercentStackView && isTrends && display !== ChartDisplayType.CalendarHeatmap
             ? [
                   {
                       title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
@@ -249,9 +247,7 @@ export function InsightDisplayConfig(): JSX.Element {
                         ]),
               ]
             : []),
-        ...(mightContainFractionalNumbers &&
-        isTrends &&
-        display !== ChartDisplayType.CalendarHeatmap
+        ...(mightContainFractionalNumbers && isTrends && display !== ChartDisplayType.CalendarHeatmap
             ? [
                   {
                       title: 'Decimal places',

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -156,8 +156,7 @@ export function InsightDisplayConfig(): JSX.Element {
             : []),
         ...(!showPercentStackView &&
         isTrends &&
-        display !== ChartDisplayType.CalendarHeatmap &&
-        display !== ChartDisplayType.BoxPlot
+        display !== ChartDisplayType.CalendarHeatmap
             ? [
                   {
                       title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
@@ -252,8 +251,7 @@ export function InsightDisplayConfig(): JSX.Element {
             : []),
         ...(mightContainFractionalNumbers &&
         isTrends &&
-        display !== ChartDisplayType.CalendarHeatmap &&
-        display !== ChartDisplayType.BoxPlot
+        display !== ChartDisplayType.CalendarHeatmap
             ? [
                   {
                       title: 'Decimal places',

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -6,6 +6,7 @@ import { Chart, ChartConfiguration, ChartEvent } from 'lib/Chart'
 import { getGraphColors, getSeriesColor } from 'lib/colors'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { useChart } from 'lib/hooks/useChart'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -58,9 +59,8 @@ function getNearestDataIndex(chart: Chart, event: ChartEvent | { x: number; y: n
 
 export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { boxplotData, chartData, labels, yAxisScaleType, querySource, interval, insightData } = useValues(
-        boxPlotChartLogic(insightProps)
-    )
+    const { boxplotData, chartData, labels, yAxisScaleType, querySource, interval, insightData, trendsFilter } =
+        useValues(boxPlotChartLogic(insightProps))
     const { timezone, weekStartDay } = useValues(teamLogic)
 
     const colors = getGraphColors()
@@ -91,7 +91,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                     dateRange={insightData?.resolved_date_range}
                     hideColorCol
                     renderSeries={(value) => <div className="datum-label-column">{value}</div>}
-                    renderCount={(value: number) => value.toLocaleString()}
+                    renderCount={(value: number) => formatAggregationAxisValue(trendsFilter, value)}
                     hideInspectActorsSection={!showPersonsModal}
                     groupTypeLabel="people"
                 />
@@ -100,7 +100,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
             const bounds = chart.canvas.getBoundingClientRect()
             positionTooltip(tooltipEl, bounds, caretX, caretY, true)
         },
-        [boxplotData, getTooltip, positionTooltip, timezone, interval, insightData, showPersonsModal]
+        [boxplotData, getTooltip, positionTooltip, timezone, interval, insightData, showPersonsModal, trendsFilter]
     )
 
     const handleClick = useCallback(
@@ -221,6 +221,9 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                             ticks: {
                                 color: colors.axisLabel as string,
                                 font: { size: 12 },
+                                callback: (value) => {
+                                    return formatAggregationAxisValue(trendsFilter, value)
+                                },
                             },
                             grid: {
                                 color: colors.axisLine as string,
@@ -242,6 +245,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
             yAxisScaleType,
             handleClick,
             showPersonsModal,
+            trendsFilter,
         ],
     })
 
@@ -256,7 +260,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
         }
         canvas.addEventListener('mouseleave', onMouseLeave)
         return () => canvas.removeEventListener('mouseleave', onMouseLeave)
-    }, [hideTooltip])
+    }, [hideTooltip, canvasRef.current])
 
     if (!boxplotData || boxplotData.length === 0) {
         return <div className="flex items-center justify-center h-full text-muted">No data for this time range</div>

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotResultsTable.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotResultsTable.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { BoxPlotDatum } from '~/queries/schema/schema-general'
@@ -9,11 +10,13 @@ import { boxPlotChartLogic } from './boxPlotChartLogic'
 
 export function BoxPlotResultsTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { boxplotData } = useValues(boxPlotChartLogic(insightProps))
+    const { boxplotData, trendsFilter } = useValues(boxPlotChartLogic(insightProps))
 
     if (!boxplotData || boxplotData.length === 0) {
         return null
     }
+
+    const formatValue = (value: number): string => formatAggregationAxisValue(trendsFilter, value)
 
     return (
         <LemonTable
@@ -28,37 +31,37 @@ export function BoxPlotResultsTable(): JSX.Element | null {
                     title: 'Min',
                     key: 'min',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.min.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.min),
                 },
                 {
                     title: '25th percentile',
                     key: 'p25',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.p25.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.p25),
                 },
                 {
                     title: 'Median',
                     key: 'median',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.median.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.median),
                 },
                 {
                     title: 'Mean',
                     key: 'mean',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.mean.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.mean),
                 },
                 {
                     title: '75th percentile',
                     key: 'p75',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.p75.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.p75),
                 },
                 {
                     title: 'Max',
                     key: 'max',
                     align: 'right',
-                    render: (_, datum: BoxPlotDatum) => datum.max.toLocaleString(),
+                    render: (_, datum: BoxPlotDatum) => formatValue(datum.max),
                 },
             ]}
             rowKey="day"

--- a/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
@@ -24,7 +24,10 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'BoxPlot', 'boxPlotChartLogic', key]),
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['insightData', 'yAxisScaleType', 'querySource', 'interval']],
+        values: [
+            insightVizDataLogic(props),
+            ['insightData', 'yAxisScaleType', 'querySource', 'interval', 'trendsFilter'],
+        ],
     })),
     selectors({
         boxplotData: [


### PR DESCRIPTION
## Problem

Box plot charts were not applying the same aggregation axis value formatting (e.g., decimal places, percentage formatting) that other chart types use. This is silly when e.g. timing is a great usecase for boxplots

## Changes

support them
<img width="2914" height="852" alt="CleanShot 2026-03-07 at 13 27 24@2x" src="https://github.com/user-attachments/assets/1f05cf42-c21e-4a8d-9898-f644122f29aa" />

## How did you test this code?

tested locally

https://claude.ai/code/session_01AgdczWyddMn8eULP4dXMcH