### PR TITLE
fix(mcp): turn off self capture

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -125,6 +125,7 @@ jobs:
         timeout-minutes: 30
         if: needs.changes.outputs.mcp == 'true'
         env:
+            OPT_OUT_CAPTURE: 1
             SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
             PERSONS_DB_WRITER_URL: 'postgres://posthog:posthog@localhost:5432/posthog_persons'


### PR DESCRIPTION
these tests have self capture on the django instance, should be off