### PR TITLE
feat(flags): add cross-request person cache behind feature flag

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -505,6 +505,18 @@ pub struct Config {
 
     #[envconfig(from = "TEAM_NEGATIVE_CACHE_TTL_SECONDS", default = "300")]
     pub team_negative_cache_ttl_seconds: u64,
+
+    // Cross-request person cache to reduce PostgreSQL load.
+    // When enabled, caches (team_id, distinct_id) → Person results in-memory
+    // so repeated lookups within the TTL window skip the DB query.
+    #[envconfig(from = "PERSON_CACHE_ENABLED", default = "false")]
+    pub person_cache_enabled: FlexBool,
+
+    #[envconfig(from = "PERSON_CACHE_TTL_SECONDS", default = "5")]
+    pub person_cache_ttl_seconds: u64,
+
+    #[envconfig(from = "PERSON_CACHE_MAX_CAPACITY", default = "100000")]
+    pub person_cache_max_capacity: u64,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -699,6 +711,9 @@ impl Config {
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,
             team_negative_cache_ttl_seconds: 300,
+            person_cache_enabled: FlexBool(false),
+            person_cache_ttl_seconds: 5,
+            person_cache_max_capacity: 100_000,
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -16,6 +16,7 @@ use crate::flags::flag_models::{
     FeatureFlag, FeatureFlagId, FeatureFlagList, FlagFilters, FlagPropertyGroup,
 };
 use crate::flags::flag_operations::flags_require_db_preparation;
+use crate::flags::person_cache::PersonCache;
 use crate::handler::canonical_log::{install_rayon_canonical_log, take_rayon_canonical_log};
 use crate::handler::with_canonical_log;
 use crate::metrics::consts::{
@@ -245,6 +246,8 @@ pub struct FeatureFlagMatcher {
     rayon_dispatcher: Option<RayonDispatcher>,
     /// When true, skip all writes to PostgreSQL and Redis.
     skip_writes: bool,
+    /// Cross-request person cache for deduplicating person DB queries
+    person_cache: Option<PersonCache>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -292,6 +295,7 @@ impl FeatureFlagMatcher {
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
             skip_writes: false,
+            person_cache: None,
         }
     }
 
@@ -307,6 +311,11 @@ impl FeatureFlagMatcher {
 
     pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
         self.skip_writes = skip_writes;
+        self
+    }
+
+    pub fn with_person_cache(mut self, person_cache: PersonCache) -> Self {
+        self.person_cache = Some(person_cache);
         self
     }
 
@@ -1850,6 +1859,7 @@ impl FeatureFlagMatcher {
             &group_data.type_indexes,
             &group_data.keys,
             static_cohort_ids,
+            self.person_cache.as_ref(),
         )
         .await
         {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -26,12 +26,13 @@ use crate::{
     api::{errors::FlagError, types::FlagValue},
     cohorts::cohort_models::CohortId,
     flags::flag_models::FeatureFlagId,
+    flags::person_cache::PersonCache,
     handler::with_canonical_log,
     metrics::consts::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
         FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
-        FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME,
+        FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_CACHE_HIT_COUNTER,
+        FLAG_PERSON_CACHE_MISS_COUNTER, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -155,6 +156,7 @@ pub fn populate_missing_initial_properties(properties: &mut HashMap<String, Valu
 ///
 /// This function fetches both person and group properties for a specified distinct ID and team ID.
 /// It updates the properties cache with the fetched properties and returns void if it succeeds.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(
     team_id = %team_id,
     distinct_id = %distinct_id,
@@ -170,6 +172,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     group_type_indexes: &HashSet<GroupTypeIndex>,
     group_keys: &HashSet<String>,
     static_cohort_ids: Vec<CohortId>,
+    person_cache: Option<&PersonCache>,
 ) -> Result<(), FlagError> {
     // Add the test-specific counter increment
     #[cfg(test)]
@@ -231,44 +234,67 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         ("team_id".to_string(), team_id.to_string()),
     ];
 
-    // First query: Get person data from the distinct_id (person_id and person_properties)
+    // First query: Get person data from the distinct_id (person_id and person_properties).
+    // The person cache sits in front of this query to avoid repeated DB lookups for the
+    // same (team_id, distinct_id) pair across concurrent requests.
+    //
     // TRICKY: sometimes we don't have a person_id ingested by the time we get a `/flags` request for a given
     // distinct_id. There's two cases for that:
     // 1. there's a race condition between person ingestion and flag evaluation.  In that case, only the first flag request
-    // be missing a person id, and all subsequent requests will have a person id.  That means the first flag evaluation could be wrong, but all subsequent ones will be correct.  Not a huge problem.
+    // will be missing a person id, and all subsequent requests will have a person id.  That means the first flag evaluation could be wrong, but all subsequent ones will be correct.  Not a huge problem.
     // 2. the distinct_id is associated with an anonymous or cookieless user.  In that case, it's fine to not return a person ID and to never return person properties.  This is handled by just
     // returning an empty HashMap for person properties whenever I actually need them, and then obviously any condition that depends on person properties will return false.
     // That's fine though, we shouldn't error out just because we can't find a person ID.
-    let person_query_start = Instant::now();
-    let person_query_timer = common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &query_labels);
-    let person = Person::from_distinct_id(&mut conn, team_id, &distinct_id).await?;
-    let (person_id, person_props) = person
-        .map(|p| (Some(p.id), Some(p.properties)))
-        .unwrap_or((None, None));
-    person_query_timer.fin();
-    let person_query_duration = person_query_start.elapsed();
-    with_canonical_log(|log| {
-        log.person_queries += 1;
-        log.person_query_time_ms += person_query_duration.as_millis() as u64;
-    });
-
-    if person_query_duration.as_millis() > 500 {
-        warn!(
-            duration_ms = person_query_duration.as_millis(),
-            distinct_id = distinct_id,
-            team_id = team_id,
-            sql_summary =
-                "SELECT person_id, properties with INNER JOIN from persondistinctid to person",
-            "Slow person query detected"
-        );
+    let (person_id, person_props) = if let Some(cached) = match person_cache {
+        Some(cache) => cache.get(team_id, &distinct_id).await,
+        None => None,
+    } {
+        common_metrics::inc(FLAG_PERSON_CACHE_HIT_COUNTER, &query_labels, 1);
+        cached
+            .map(|p| (Some(p.id), Some(p.properties)))
+            .unwrap_or((None, None))
     } else {
-        info!(
-            duration_ms = person_query_duration.as_millis(),
-            distinct_id = distinct_id,
-            team_id = team_id,
-            "Person query completed"
-        );
-    }
+        common_metrics::inc(FLAG_PERSON_CACHE_MISS_COUNTER, &query_labels, 1);
+        let person_query_start = Instant::now();
+        let person_query_timer =
+            common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &query_labels);
+        let person = Person::from_distinct_id(&mut conn, team_id, &distinct_id).await?;
+
+        if let Some(cache) = person_cache {
+            cache
+                .insert(team_id, distinct_id.clone(), person.clone())
+                .await;
+        }
+
+        let (person_id, person_props) = person
+            .map(|p| (Some(p.id), Some(p.properties)))
+            .unwrap_or((None, None));
+        person_query_timer.fin();
+        let person_query_duration = person_query_start.elapsed();
+        with_canonical_log(|log| {
+            log.person_queries += 1;
+            log.person_query_time_ms += person_query_duration.as_millis() as u64;
+        });
+
+        if person_query_duration.as_millis() > 500 {
+            warn!(
+                duration_ms = person_query_duration.as_millis(),
+                distinct_id = distinct_id,
+                team_id = team_id,
+                sql_summary =
+                    "SELECT person_id, properties with INNER JOIN from persondistinctid to person",
+                "Slow person query detected"
+            );
+        } else {
+            info!(
+                duration_ms = person_query_duration.as_millis(),
+                distinct_id = distinct_id,
+                team_id = team_id,
+                "Person query completed"
+            );
+        }
+        (person_id, person_props)
+    };
     let person_processing_timer = common_metrics::timing_guard(FLAG_PERSON_PROCESSING_TIME, &[]);
     if let Some(person_id) = person_id {
         // NB: this is where we actually set our person ID in the flag evaluation state.

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -10,6 +10,7 @@ pub mod flag_operations;
 pub mod flag_property_group;
 pub mod flag_request;
 pub mod flag_service;
+pub mod person_cache;
 pub mod property_filter;
 
 #[cfg(test)]

--- a/rust/feature-flags/src/flags/person_cache.rs
+++ b/rust/feature-flags/src/flags/person_cache.rs
@@ -1,0 +1,162 @@
+//! Cross-request person cache to reduce PostgreSQL load.
+//!
+//! Caches `(team_id, distinct_id) → Option<Person>` results for a short TTL,
+//! avoiding repeated DB queries when the same person is looked up across
+//! multiple `/flags` requests within seconds.
+
+use common_types::Person;
+use moka::future::Cache;
+use std::time::Duration;
+
+/// In-memory cross-request cache for person lookups, keyed by `(team_id, distinct_id)`.
+///
+/// Caches both found persons (`Some(Person)`) and not-found results (`None`)
+/// to avoid repeated DB queries for anonymous or cookieless users.
+#[derive(Clone)]
+pub struct PersonCache {
+    cache: Cache<(i32, String), Option<Person>>,
+    enabled: bool,
+}
+
+impl PersonCache {
+    pub fn new(max_capacity: u64, ttl_seconds: u64, enabled: bool) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_capacity)
+            .time_to_live(Duration::from_secs(ttl_seconds))
+            .build();
+
+        Self { cache, enabled }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Look up a cached person result. Returns `Some(Option<Person>)` on cache hit
+    /// (where the inner `Option` distinguishes found vs not-found persons),
+    /// or `None` on cache miss.
+    pub async fn get(&self, team_id: i32, distinct_id: &str) -> Option<Option<Person>> {
+        if !self.enabled {
+            return None;
+        }
+        self.cache.get(&(team_id, distinct_id.to_string())).await
+    }
+
+    /// Insert a person lookup result into the cache.
+    pub async fn insert(&self, team_id: i32, distinct_id: String, person: Option<Person>) {
+        if !self.enabled {
+            return;
+        }
+        self.cache.insert((team_id, distinct_id), person).await;
+    }
+
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn make_person(team_id: i32) -> Person {
+        Person {
+            id: 42,
+            created_at: Utc::now(),
+            team_id,
+            uuid: Uuid::new_v4(),
+            properties: json!({"email": "test@example.com"}),
+            is_identified: true,
+            is_user_id: None,
+            version: Some(1),
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_miss_returns_none() {
+        let cache = PersonCache::new(100, 60, true);
+        assert!(cache.get(1, "missing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_round_trip() {
+        let cache = PersonCache::new(100, 60, true);
+        let person = make_person(1);
+
+        cache
+            .insert(1, "user-1".to_string(), Some(person.clone()))
+            .await;
+
+        let result = cache.get(1, "user-1").await;
+        assert!(result.is_some());
+        let cached_person = result.unwrap();
+        assert!(cached_person.is_some());
+        assert_eq!(cached_person.unwrap().id, person.id);
+    }
+
+    #[tokio::test]
+    async fn negative_caching_stores_none_person() {
+        let cache = PersonCache::new(100, 60, true);
+
+        cache.insert(1, "anonymous".to_string(), None).await;
+
+        let result = cache.get(1, "anonymous").await;
+        // Cache hit (Some) with a not-found person (None)
+        assert!(result.is_some());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn different_team_ids_are_separate_entries() {
+        let cache = PersonCache::new(100, 60, true);
+        let person = make_person(1);
+
+        cache.insert(1, "user-1".to_string(), Some(person)).await;
+
+        // Same distinct_id, different team
+        assert!(cache.get(2, "user-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ttl_expiration() {
+        let cache = PersonCache::new(100, 1, true);
+        let person = make_person(1);
+
+        cache.insert(1, "user-1".to_string(), Some(person)).await;
+        assert!(cache.get(1, "user-1").await.is_some());
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert!(cache.get(1, "user-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn disabled_cache_always_misses() {
+        let cache = PersonCache::new(100, 60, false);
+        let person = make_person(1);
+
+        cache.insert(1, "user-1".to_string(), Some(person)).await;
+
+        assert!(cache.get(1, "user-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn multiple_entries_are_independent() {
+        let cache = PersonCache::new(100, 60, true);
+
+        cache.insert(1, "a".to_string(), None).await;
+        cache.insert(1, "b".to_string(), Some(make_person(1))).await;
+
+        // Both entries are independently retrievable
+        let a = cache.get(1, "a").await;
+        assert!(a.is_some());
+        assert!(a.unwrap().is_none()); // "a" was stored as not-found
+
+        let b = cache.get(1, "b").await;
+        assert!(b.is_some());
+        assert!(b.unwrap().is_some()); // "b" was stored as found
+    }
+}

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -33,7 +33,8 @@ pub async fn evaluate_feature_flags(
     )
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
     .with_rayon_dispatcher(context.rayon_dispatcher)
-    .with_skip_writes(context.skip_writes);
+    .with_skip_writes(context.skip_writes)
+    .with_person_cache(context.person_cache);
 
     matcher
         .evaluate_all_feature_flags(

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -264,6 +264,7 @@ pub async fn evaluate_for_request(
         parallel_eval_threshold: state.config.parallel_eval_threshold,
         rayon_dispatcher: state.rayon_dispatcher.clone(),
         skip_writes: *state.config.skip_writes,
+        person_cache: state.person_cache.clone(),
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -195,6 +195,7 @@ async fn test_evaluate_feature_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -289,6 +290,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -697,6 +699,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -804,6 +807,7 @@ async fn test_evaluate_feature_flags_details() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -963,6 +967,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -1057,6 +1062,7 @@ async fn test_long_distinct_id() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
 
     let request_id = Uuid::new_v4();
@@ -1577,6 +1583,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
     let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4()).await;
 
@@ -1600,6 +1607,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 1,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2),
         skip_writes: false,
+        person_cache: crate::flags::person_cache::PersonCache::new(100, 5, false),
     };
     let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4()).await;
 

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 
 use crate::{
     api::types::FlagsQueryParams, cohorts::cohort_cache_manager::CohortCacheManager,
-    flags::flag_models::FeatureFlagList, rayon_dispatcher::RayonDispatcher, router,
-    utils::user_agent::UserAgentInfo,
+    flags::flag_models::FeatureFlagList, flags::person_cache::PersonCache,
+    rayon_dispatcher::RayonDispatcher, router, utils::user_agent::UserAgentInfo,
 };
 
 pub struct RequestContext {
@@ -67,6 +67,8 @@ pub struct FeatureFlagEvaluationContext {
     pub rayon_dispatcher: RayonDispatcher,
     /// When true, skip all writes to PostgreSQL and Redis.
     pub skip_writes: bool,
+    /// Cross-request person cache for deduplicating person DB queries
+    pub person_cache: PersonCache,
 }
 
 /// SDK type classification based on user-agent parsing.

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -26,6 +26,10 @@ pub const DB_CONNECTION_POOL_IDLE_COUNTER: &str = "flags_db_connection_pool_idle
 pub const DB_CONNECTION_POOL_MAX_COUNTER: &str = "flags_db_connection_pool_max_total";
 pub const DB_CONNECTION_POOL_SIZE_GAUGE: &str = "flags_db_connection_pool_size";
 
+// Person cache (cross-request dedup)
+pub const FLAG_PERSON_CACHE_HIT_COUNTER: &str = "flags_person_cache_hit_total";
+pub const FLAG_PERSON_CACHE_MISS_COUNTER: &str = "flags_person_cache_miss_total";
+
 // Flag evaluation timing
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
 pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -39,6 +39,7 @@ use crate::{
     },
     cohorts::cohort_cache_manager::CohortCacheManager,
     config::{Config, TeamIdCollection},
+    flags::person_cache::PersonCache,
     metrics::{
         consts::{
             FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER,
@@ -87,6 +88,8 @@ pub struct State {
     /// In-memory negative cache for invalid API tokens, preventing repeated
     /// Redis/S3/PG lookups for tokens that don't correspond to any team
     pub team_negative_cache: NegativeCache,
+    /// Cross-request person cache to reduce PostgreSQL person query load
+    pub person_cache: PersonCache,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -106,6 +109,7 @@ pub fn router(
     config_hypercache_reader: Arc<HyperCacheReader>,
     rayon_dispatcher: RayonDispatcher,
     team_negative_cache: NegativeCache,
+    person_cache: PersonCache,
     config: Config,
 ) -> Router {
     // Initialize flag definitions rate limiter with default and custom team rates
@@ -172,6 +176,7 @@ pub fn router(
         config_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
+        person_cache,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -8,6 +8,7 @@ use crate::cohorts::cohort_cache_manager::CohortCacheManager;
 use crate::config::Config;
 use crate::database_pools::DatabasePools;
 use crate::db_monitor::DatabasePoolMonitor;
+use crate::flags::person_cache::PersonCache;
 use crate::rayon_dispatcher::RayonDispatcher;
 use crate::router;
 use crate::tokio_monitor::TokioRuntimeMonitor;
@@ -324,6 +325,18 @@ pub async fn serve<F>(
         "Created team negative cache for invalid API tokens"
     );
 
+    let person_cache = PersonCache::new(
+        config.person_cache_max_capacity,
+        config.person_cache_ttl_seconds,
+        *config.person_cache_enabled,
+    );
+    tracing::info!(
+        enabled = *config.person_cache_enabled,
+        capacity = config.person_cache_max_capacity,
+        ttl_seconds = config.person_cache_ttl_seconds,
+        "Created person cache"
+    );
+
     if *config.skip_writes {
         tracing::warn!(
             "SKIP_WRITES is enabled: all writes to PostgreSQL and Redis are disabled. \
@@ -361,6 +374,7 @@ pub async fn serve<F>(
         config_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
+        person_cache,
         config,
     );
 

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -330,6 +330,7 @@ impl ServerHandle {
                 config_hypercache_reader,
                 RayonDispatcher::new(2),
                 NegativeCache::new(10_000, 300),
+                feature_flags::flags::person_cache::PersonCache::new(100_000, 5, false),
                 config,
             );
 


### PR DESCRIPTION
## Problem

The feature flags service makes a person query (`posthog_person` JOIN `posthog_persondistinctid`) for every `/flags` request that needs person properties (~62% of traffic, ~5,400 req/s). When the same `(team_id, distinct_id)` is looked up across multiple concurrent requests within seconds, the DB receives redundant identical queries. At production scale, person query p50 is 580ms and p99 is 8.9s due to contention on the shared Persons PostgreSQL database.

This also provides instrumentation toward understanding the working-set size for the [dedicated FF read store RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1014) — specifically, the cache hit/miss metrics (labeled by `team_id`) will reveal how many distinct `(team_id, distinct_id)` pairs the flags service actually queries, and how concentrated the traffic is.

## Changes

Adds an in-memory cross-request person cache to the Rust feature flags service, gated behind the `PERSON_CACHE_ENABLED` env var (default: `false`).

- **`person_cache.rs`** — New `PersonCache` struct backed by [moka](https://docs.rs/moka) with configurable max capacity and TTL. Caches `(team_id, distinct_id) → Option<Person>`, including negative results (anonymous/cookieless users that have no person row).
- **`flag_matching_utils.rs`** — `fetch_and_locally_cache_all_relevant_properties` now checks the person cache before querying PostgreSQL, and populates it on miss.
- **`config.rs`** — Three new env vars: `PERSON_CACHE_ENABLED` (default `false`), `PERSON_CACHE_TTL_SECONDS` (default `5`), `PERSON_CACHE_MAX_CAPACITY` (default `100000`).
- **`metrics/consts.rs`** — Two new counters: `flags_person_cache_hit_total` and `flags_person_cache_miss_total`, both labeled with `team_id` for per-team working-set analysis.
- **Wiring** (`server.rs`, `router.rs`, `handler/flags.rs`, `handler/evaluation.rs`, `handler/types.rs`) — The cache is created at startup and threaded through to the flag matcher via `FeatureFlagEvaluationContext`.

## How did you test this code?

- 7 unit tests in `person_cache.rs` covering: cache miss, insert/get round-trip, negative caching, team isolation, TTL expiration, disabled cache behavior, and independent entries.
- All existing handler tests updated to pass a disabled `PersonCache` — no behavioral change when cache is off.
- Integration tests in `tests/common/mod.rs` updated.

## Publish to changelog?

No
