### PR TITLE
chore(django): include service name in personhog client metadata

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -37,7 +37,7 @@ from posthog.models.group_type_mapping import (
 )
 from posthog.models.user import User
 from posthog.personhog_client.converters import GroupTypeMappingResult
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
 from products.event_definitions.backend.models.property_definition import PropertyType
@@ -229,14 +229,19 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
             try:
                 result = fetch_group_type_mapping_result(self.team.project_id, group_type_index)
                 if result is not None:
-                    PERSONHOG_ROUTING_TOTAL.labels(operation="get_group_type_mapping_or_404", source="personhog").inc()
+                    PERSONHOG_ROUTING_TOTAL.labels(
+                        operation="get_group_type_mapping_or_404", source="personhog", client_name=get_client_name()
+                    ).inc()
                     return result
                 raise NotFound()
             except NotFound:
                 raise
             except Exception:
                 PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                    operation="get_group_type_mapping_or_404", source="personhog", error_type="grpc_error"
+                    operation="get_group_type_mapping_or_404",
+                    source="personhog",
+                    error_type="grpc_error",
+                    client_name=get_client_name(),
                 ).inc()
                 logger.warning(
                     "personhog_group_type_mapping_failure",
@@ -247,7 +252,9 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
 
         try:
             obj = GroupTypeMapping.objects.get(project_id=self.team.project_id, group_type_index=group_type_index)
-            PERSONHOG_ROUTING_TOTAL.labels(operation="get_group_type_mapping_or_404", source="django_orm").inc()
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="get_group_type_mapping_or_404", source="django_orm", client_name=get_client_name()
+            ).inc()
             return GroupTypeMappingResult(group_type=obj.group_type, group_type_index=obj.group_type_index)
         except GroupTypeMapping.DoesNotExist:
             raise NotFound()

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2931,7 +2931,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 63}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 import structlog
 
 from posthog.models.utils import RootTeamMixin
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.rbac.decorators import field_access_control
 from posthog.utils import get_safe_cache, safe_cache_delete, safe_cache_set
 
@@ -127,13 +127,18 @@ def get_group_types_for_project(project_id: int) -> list[dict[str, Any]]:
     if use_personhog():
         try:
             result = _fetch_group_types_via_personhog(project_id)
-            PERSONHOG_ROUTING_TOTAL.labels(operation="get_group_types_for_project", source="personhog").inc()
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="get_group_types_for_project", source="personhog", client_name=get_client_name()
+            ).inc()
             safe_cache_set(cache_key, result, GROUP_TYPES_CACHE_TTL)
             safe_cache_set(stale_cache_key, result, GROUP_TYPES_STALE_CACHE_TTL)
             return result
         except Exception:
             PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                operation="get_group_types_for_project", source="personhog", error_type="grpc_error"
+                operation="get_group_types_for_project",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
             ).inc()
             logger.warning("personhog_group_types_failure", project_id=project_id, exc_info=True)
 
@@ -143,7 +148,9 @@ def get_group_types_for_project(project_id: int) -> list[dict[str, Any]]:
             .order_by("group_type_index")
             .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
         )
-        PERSONHOG_ROUTING_TOTAL.labels(operation="get_group_types_for_project", source="django_orm").inc()
+        PERSONHOG_ROUTING_TOTAL.labels(
+            operation="get_group_types_for_project", source="django_orm", client_name=get_client_name()
+        ).inc()
         safe_cache_set(cache_key, result, GROUP_TYPES_CACHE_TTL)
         safe_cache_set(stale_cache_key, result, GROUP_TYPES_STALE_CACHE_TTL)
         return result

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -125,7 +125,9 @@ class TestGetGroupTypesForProjectRouting(SimpleTestCase):
         else:
             assert result == ORM_DATA
 
-        mock_routing_counter.labels.assert_called_with(operation="get_group_types_for_project", source=expected_source)
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_group_types_for_project", source=expected_source, client_name="posthog-django"
+        )
 
         if grpc_exception is not None and gate_on:
             mock_errors_counter.labels.assert_called_once()

--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -69,7 +69,9 @@ class PersonHogClient:
             ("grpc.enable_retries", 1),
         ]
         channel = grpc.insecure_channel(addr, options=options)
-        self._channel = grpc.intercept_channel(channel, ClientNameInterceptor(client_name), MetricsInterceptor())
+        self._channel = grpc.intercept_channel(
+            channel, ClientNameInterceptor(client_name), MetricsInterceptor(client_name)
+        )
         self._stub = PersonHogServiceStub(self._channel)
         self._timeout = timeout_ms / 1000.0
 

--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -8,7 +8,7 @@ from django.conf import settings
 import grpc
 import structlog
 
-from posthog.personhog_client.interceptor import MetricsInterceptor
+from posthog.personhog_client.interceptor import ClientNameInterceptor, MetricsInterceptor
 from posthog.personhog_client.proto import (
     CheckCohortMembershipRequest,
     CohortMembershipResponse,
@@ -47,6 +47,7 @@ class PersonHogClient:
     def __init__(
         self,
         addr: str,
+        client_name: str = "posthog-django",
         timeout_ms: int = 5000,
         keepalive_time_ms: int = 30_000,
         keepalive_timeout_ms: int = 5_000,
@@ -68,7 +69,7 @@ class PersonHogClient:
             ("grpc.enable_retries", 1),
         ]
         channel = grpc.insecure_channel(addr, options=options)
-        self._channel = grpc.intercept_channel(channel, MetricsInterceptor())
+        self._channel = grpc.intercept_channel(channel, ClientNameInterceptor(client_name), MetricsInterceptor())
         self._stub = PersonHogServiceStub(self._channel)
         self._timeout = timeout_ms / 1000.0
 
@@ -163,8 +164,10 @@ def get_personhog_client() -> Optional[PersonHogClient]:
                     return None
 
                 timeout_ms = getattr(settings, "PERSONHOG_TIMEOUT_MS", 5000)
+                client_name = getattr(settings, "OTEL_SERVICE_NAME", None) or "posthog-django"
                 _client = PersonHogClient(
                     addr=addr,
+                    client_name=client_name,
                     timeout_ms=timeout_ms,
                     keepalive_time_ms=getattr(settings, "PERSONHOG_KEEPALIVE_TIME_MS", 30_000),
                     keepalive_timeout_ms=getattr(settings, "PERSONHOG_KEEPALIVE_TIMEOUT_MS", 5_000),

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import time
+from collections import namedtuple
 from collections.abc import Sequence
 from typing import Any
 
 import grpc
 from prometheus_client import Counter, Histogram
+
+_ClientCallDetails = namedtuple(
+    "_ClientCallDetails",
+    ["method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"],
+)
+
+
+class _MutableClientCallDetails(_ClientCallDetails, grpc.ClientCallDetails):
+    pass
+
 
 PERSONHOG_REQUEST_DURATION = Histogram(
     "personhog_grpc_request_duration_seconds",
@@ -31,12 +42,11 @@ def _with_metadata(
     client_call_details: grpc.ClientCallDetails,
     extra: Sequence[tuple[str, str]],
 ) -> grpc.ClientCallDetails:
-    existing = list(client_call_details.metadata) if client_call_details.metadata else []
-    existing.extend(extra)
-    return grpc.ClientCallDetails(
+    metadata = list(client_call_details.metadata or []) + list(extra)
+    return _MutableClientCallDetails(
         method=client_call_details.method,
         timeout=client_call_details.timeout,
-        metadata=existing,
+        metadata=metadata,
         credentials=client_call_details.credentials,
         wait_for_ready=client_call_details.wait_for_ready,
         compression=client_call_details.compression,

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -18,17 +18,17 @@ class _MutableClientCallDetails(_ClientCallDetails, grpc.ClientCallDetails):
     pass
 
 
-PERSONHOG_REQUEST_DURATION = Histogram(
-    "personhog_grpc_request_duration_seconds",
-    "gRPC request duration from the Django client to personhog",
-    labelnames=["method"],
+PERSONHOG_DJANGO_REQUEST_DURATION = Histogram(
+    "personhog_django_grpc_request_duration_seconds",
+    "gRPC request duration from a Django personhog client to the personhog service",
+    labelnames=["method", "client_name"],
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
 )
 
-PERSONHOG_REQUEST_COUNT = Counter(
-    "personhog_grpc_requests_total",
-    "Total gRPC requests from the Django client to personhog",
-    labelnames=["method", "status"],
+PERSONHOG_DJANGO_REQUEST_COUNT = Counter(
+    "personhog_django_grpc_requests_total",
+    "Total gRPC requests from a Django personhog client to the personhog service",
+    labelnames=["method", "status", "client_name"],
 )
 
 
@@ -68,6 +68,9 @@ class ClientNameInterceptor(grpc.UnaryUnaryClientInterceptor):
 
 
 class MetricsInterceptor(grpc.UnaryUnaryClientInterceptor):
+    def __init__(self, client_name: str) -> None:
+        self._client_name = client_name
+
     def intercept_unary_unary(
         self,
         continuation: Any,
@@ -81,11 +84,13 @@ class MetricsInterceptor(grpc.UnaryUnaryClientInterceptor):
             # grpc-python returns a future-like object; .code() is None on success
             code = response.code()
             status = code.name if code else "OK"
-            PERSONHOG_REQUEST_COUNT.labels(method=method, status=status).inc()
+            PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
             return response
         except grpc.RpcError as exc:
             status = exc.code().name if exc.code() else "UNKNOWN"
-            PERSONHOG_REQUEST_COUNT.labels(method=method, status=status).inc()
+            PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
             raise
         finally:
-            PERSONHOG_REQUEST_DURATION.labels(method=method).observe(time.monotonic() - start)
+            PERSONHOG_DJANGO_REQUEST_DURATION.labels(method=method, client_name=self._client_name).observe(
+                time.monotonic() - start
+            )

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
 from typing import Any
 
 import grpc
@@ -24,6 +25,36 @@ def _method_name(client_call_details: grpc.ClientCallDetails) -> str:
     # client_call_details.method is like "/personhog.service.v1.PersonHogService/GetPerson"
     method: str = client_call_details.method or "unknown"
     return method.rsplit("/", 1)[-1]
+
+
+def _with_metadata(
+    client_call_details: grpc.ClientCallDetails,
+    extra: Sequence[tuple[str, str]],
+) -> grpc.ClientCallDetails:
+    existing = list(client_call_details.metadata) if client_call_details.metadata else []
+    existing.extend(extra)
+    return grpc.ClientCallDetails(
+        method=client_call_details.method,
+        timeout=client_call_details.timeout,
+        metadata=existing,
+        credentials=client_call_details.credentials,
+        wait_for_ready=client_call_details.wait_for_ready,
+        compression=client_call_details.compression,
+    )
+
+
+class ClientNameInterceptor(grpc.UnaryUnaryClientInterceptor):
+    def __init__(self, client_name: str) -> None:
+        self._client_name = client_name
+
+    def intercept_unary_unary(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        new_details = _with_metadata(client_call_details, [("x-client-name", self._client_name)])
+        return continuation(new_details, request)
 
 
 class MetricsInterceptor(grpc.UnaryUnaryClientInterceptor):

--- a/posthog/personhog_client/metrics.py
+++ b/posthog/personhog_client/metrics.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import os
+
 from prometheus_client import Counter
+
+
+def get_client_name() -> str:
+    return os.environ.get("OTEL_SERVICE_NAME") or "posthog-django"
+
 
 PERSONHOG_ROUTING_TOTAL = Counter(
     "personhog_routing_total",
     "Tracks which data source was used for each personhog-eligible operation",
-    labelnames=["operation", "source"],
+    labelnames=["operation", "source", "client_name"],
 )
 
 PERSONHOG_ROUTING_ERRORS_TOTAL = Counter(
     "personhog_routing_errors_total",
     "Errors encountered during personhog routing (triggers fallback to ORM)",
-    labelnames=["operation", "source", "error_type"],
+    labelnames=["operation", "source", "error_type", "client_name"],
 )

--- a/posthog/personhog_client/metrics.py
+++ b/posthog/personhog_client/metrics.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import os
+from django.conf import settings
 
 from prometheus_client import Counter
 
 
 def get_client_name() -> str:
-    return os.environ.get("OTEL_SERVICE_NAME") or "posthog-django"
+    return getattr(settings, "OTEL_SERVICE_NAME", None) or "posthog-django"
 
 
 PERSONHOG_ROUTING_TOTAL = Counter(

--- a/posthog/personhog_client/test_interceptor.py
+++ b/posthog/personhog_client/test_interceptor.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from posthog.test.base import BaseTest
+
+import grpc
+from parameterized import parameterized
+
+from posthog.personhog_client.interceptor import ClientNameInterceptor, _MutableClientCallDetails, _with_metadata
+
+
+def _make_call_details(
+    method: str = "/test/Method",
+    metadata: list[tuple[str, str]] | None = None,
+) -> grpc.ClientCallDetails:
+    return _MutableClientCallDetails(
+        method=method,
+        timeout=5.0,
+        metadata=metadata,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    )
+
+
+class TestWithMetadata(BaseTest):
+    @parameterized.expand(
+        [
+            ("no_existing_metadata", None, [("x-key", "val")], [("x-key", "val")]),
+            ("empty_existing_metadata", [], [("x-key", "val")], [("x-key", "val")]),
+            (
+                "preserves_existing_metadata",
+                [("existing", "header")],
+                [("x-key", "val")],
+                [("existing", "header"), ("x-key", "val")],
+            ),
+            (
+                "multiple_extra_entries",
+                None,
+                [("a", "1"), ("b", "2")],
+                [("a", "1"), ("b", "2")],
+            ),
+        ]
+    )
+    def test_with_metadata(
+        self,
+        _name: str,
+        existing_metadata: list[tuple[str, str]] | None,
+        extra: list[tuple[str, str]],
+        expected: list[tuple[str, str]],
+    ) -> None:
+        details = _make_call_details(metadata=existing_metadata)
+        result = _with_metadata(details, extra)
+
+        self.assertEqual(list(result.metadata), expected)
+        self.assertEqual(result.method, details.method)
+        self.assertEqual(result.timeout, details.timeout)
+
+
+class TestClientNameInterceptor(BaseTest):
+    @parameterized.expand(
+        [
+            ("default_name", "posthog-django"),
+            ("web_deploy", "posthog-django-web"),
+            ("worker_deploy", "posthog-django-worker"),
+        ]
+    )
+    def test_injects_client_name(self, _name: str, client_name: str) -> None:
+        interceptor = ClientNameInterceptor(client_name)
+        original_details = _make_call_details()
+        captured_details: list[grpc.ClientCallDetails] = []
+
+        def mock_continuation(details: grpc.ClientCallDetails, request: object) -> str:
+            captured_details.append(details)
+            return "ok"
+
+        result = interceptor.intercept_unary_unary(mock_continuation, original_details, request=b"")
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(captured_details), 1)
+        metadata = dict(captured_details[0].metadata)
+        self.assertEqual(metadata["x-client-name"], client_name)


### PR DESCRIPTION
## Problem

The personhog router/replica services have no way to attribute incoming gRPC requests to specific Django deploys (e.g., `django-web` vs `django-worker` vs `django-query`). This makes it impossible to build dashboards that break down personhog traffic by caller, which is critical for monitoring the rollout.

## Changes

- Added a `ClientNameInterceptor` gRPC client interceptor that injects an `x-client-name` metadata header on every outgoing request — the server side can read this to attribute traffic
- `PersonHogClient` accepts a `client_name` parameter (default `"posthog-django"`)
- `get_personhog_client()` reads `settings.OTEL_SERVICE_NAME` to automatically identify the deploy (e.g., `posthog-django-web`, `posthog-django-worker`)
- Used the standard gRPC Python `namedtuple` subclass pattern for constructing `ClientCallDetails` with additional metadata
- Renamed gRPC client-side metrics from `personhog_grpc_*` to `personhog_django_grpc_*` to clearly distinguish them from metrics emitted by other personhog clients
- Added `client_name` label to all personhog metrics:
  - `personhog_django_grpc_request_duration_seconds` (interceptor)
  - `personhog_django_grpc_requests_total` (interceptor)
  - `personhog_routing_total` (routing decisions)
  - `personhog_routing_errors_total` (routing errors)
- Added `get_client_name()` helper in `metrics.py` that reads `OTEL_SERVICE_NAME` for call sites


## How did you test this code?

- Unit tests for the interceptor: `_with_metadata` correctly appends metadata to both empty and existing metadata, and `ClientNameInterceptor` passes the expected `x-client-name` header through to the continuation — see `posthog/personhog_client/test_interceptor.py`
- Updated existing routing tests in `posthog/models/test/test_group_type_mapping.py` to assert the new `client_name` label is included in metric calls
