### PR TITLE
feat(flags): add name-based search for group key values

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
@@ -1,0 +1,199 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { PropertyOperator } from '~/types'
+
+import { GroupKeySelect } from './GroupKeySelect'
+
+const MOCK_GROUPS = [
+    {
+        group_type_index: 0,
+        group_key: 'uuid-001',
+        group_properties: { name: 'Fjellride AB' },
+        created_at: '2024-01-01',
+    },
+    {
+        group_type_index: 0,
+        group_key: 'uuid-002',
+        group_properties: { name: 'Bitfusion PR LLC' },
+        created_at: '2024-01-02',
+    },
+    {
+        group_type_index: 0,
+        group_key: 'uuid-003',
+        group_properties: { name: 'NexusHub' },
+        created_at: '2024-01-03',
+    },
+]
+
+describe('GroupKeySelect', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team/groups/': {
+                    results: MOCK_GROUPS,
+                    next: null,
+                },
+                '/api/environments/:team/groups/find': (req: any) => {
+                    const groupKey = req.url.searchParams.get('group_key')
+                    const group = MOCK_GROUPS.find((g) => g.group_key === groupKey)
+                    return group ? [200, group] : [404, { detail: 'Not found' }]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders group names in the dropdown, not UUIDs', async () => {
+        const onChange = jest.fn()
+        render(
+            <Provider>
+                <GroupKeySelect value={null} groupTypeIndex={0} operator={PropertyOperator.Exact} onChange={onChange} />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.click(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
+            expect(screen.getByText('Bitfusion PR LLC')).toBeInTheDocument()
+            expect(screen.getByText('NexusHub')).toBeInTheDocument()
+        })
+
+        // UUIDs should not be visible as labels
+        expect(screen.queryByText('uuid-001')).not.toBeInTheDocument()
+    })
+
+    it('stores group_key (UUID) as the value when selecting a group', async () => {
+        const onChange = jest.fn()
+        render(
+            <Provider>
+                <GroupKeySelect value={null} groupTypeIndex={0} operator={PropertyOperator.Exact} onChange={onChange} />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.click(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByText('Fjellride AB'))
+
+        expect(onChange).toHaveBeenCalledWith('uuid-001')
+    })
+
+    it('resolves existing UUID values to display names', async () => {
+        const onChange = jest.fn()
+        render(
+            <Provider>
+                <GroupKeySelect
+                    value="uuid-002"
+                    groupTypeIndex={0}
+                    operator={PropertyOperator.Exact}
+                    onChange={onChange}
+                />
+            </Provider>
+        )
+
+        // The component should resolve uuid-002 to "Bitfusion PR LLC"
+        await waitFor(() => {
+            expect(screen.getByText('Bitfusion PR LLC')).toBeInTheDocument()
+        })
+    })
+
+    it('renders read-only display when editable is false', async () => {
+        render(
+            <Provider>
+                <GroupKeySelect
+                    value="uuid-001"
+                    groupTypeIndex={0}
+                    operator={PropertyOperator.Exact}
+                    onChange={jest.fn()}
+                    editable={false}
+                />
+            </Provider>
+        )
+
+        // Should resolve and display the group name
+        await waitFor(() => {
+            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
+        })
+
+        // Should not render an input
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    })
+
+    it('supports multi-select with isOneOf operator', async () => {
+        const onChange = jest.fn()
+        render(
+            <Provider>
+                <GroupKeySelect
+                    value={['uuid-001']}
+                    groupTypeIndex={0}
+                    operator={PropertyOperator.IsOneOf}
+                    onChange={onChange}
+                />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.click(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('Bitfusion PR LLC')).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByText('Bitfusion PR LLC'))
+
+        // Should be called with both values
+        expect(onChange).toHaveBeenCalledWith(['uuid-001', 'uuid-002'])
+    })
+
+    it('falls back to group_key when group has no name property', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team/groups/': {
+                    results: [
+                        {
+                            group_type_index: 0,
+                            group_key: 'key-no-name',
+                            group_properties: {},
+                            created_at: '2024-01-01',
+                        },
+                    ],
+                    next: null,
+                },
+            },
+        })
+
+        render(
+            <Provider>
+                <GroupKeySelect
+                    value={null}
+                    groupTypeIndex={0}
+                    operator={PropertyOperator.Exact}
+                    onChange={jest.fn()}
+                />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.click(input)
+
+        await waitFor(() => {
+            expect(screen.getByText('key-no-name')).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
@@ -113,28 +113,6 @@ describe('GroupKeySelect', () => {
         })
     })
 
-    it('renders read-only display when editable is false', async () => {
-        render(
-            <Provider>
-                <GroupKeySelect
-                    value="uuid-001"
-                    groupTypeIndex={0}
-                    operator={PropertyOperator.Exact}
-                    onChange={jest.fn()}
-                    editable={false}
-                />
-            </Provider>
-        )
-
-        // Should resolve and display the group name
-        await waitFor(() => {
-            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
-        })
-
-        // Should not render an input
-        expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
-    })
-
     it('supports multi-select with exact operator', async () => {
         const onChange = jest.fn()
         render(

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
@@ -91,7 +91,7 @@ describe('GroupKeySelect', () => {
 
         await userEvent.click(screen.getByText('Fjellride AB'))
 
-        expect(onChange).toHaveBeenCalledWith('uuid-001')
+        expect(onChange).toHaveBeenCalledWith(['uuid-001'])
     })
 
     it('resolves existing UUID values to display names', async () => {

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
@@ -135,14 +135,14 @@ describe('GroupKeySelect', () => {
         expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
     })
 
-    it('supports multi-select with isOneOf operator', async () => {
+    it('supports multi-select with exact operator', async () => {
         const onChange = jest.fn()
         render(
             <Provider>
                 <GroupKeySelect
                     value={['uuid-001']}
                     groupTypeIndex={0}
-                    operator={PropertyOperator.IsOneOf}
+                    operator={PropertyOperator.Exact}
                     onChange={onChange}
                 />
             </Provider>

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
@@ -1,14 +1,12 @@
-import { useValues } from 'kea'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
-import api from 'lib/api'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { isOperatorMulti } from 'lib/utils'
-import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
-import { teamLogic } from 'scenes/teamLogic'
 
-import { Group } from '~/types'
 import type { GroupTypeIndex, PropertyFilterValue, PropertyOperator } from '~/types'
+
+import { groupKeySelectLogic } from './groupKeySelectLogic'
 
 export interface GroupKeySelectProps {
     value: PropertyFilterValue
@@ -21,11 +19,6 @@ export interface GroupKeySelectProps {
     forceSingleSelect?: boolean
 }
 
-interface GroupOption {
-    key: string
-    label: string
-}
-
 export function GroupKeySelect({
     value,
     groupTypeIndex,
@@ -36,143 +29,45 @@ export function GroupKeySelect({
     autoFocus = false,
     forceSingleSelect = false,
 }: GroupKeySelectProps): JSX.Element {
-    const { currentTeamId } = useValues(teamLogic)
-    const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
-
-    const [searchOptions, setSearchOptions] = useState<GroupOption[]>([])
-    const [resolvedValues, setResolvedValues] = useState<Map<string, string>>(new Map())
-    const [loading, setLoading] = useState(false)
-    const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-
     const currentValues = useMemo(
         () => (value === null || value === undefined ? [] : Array.isArray(value) ? value.map(String) : [String(value)]),
         [value]
     )
 
-    const fetchGroups = useCallback(
-        async (search?: string): Promise<Group[]> => {
-            if (!currentTeamId) {
-                return []
-            }
-            const params: Record<string, string | number> = { group_type_index: groupTypeIndex }
-            if (search) {
-                params.search = search
-            }
-            const response = await api.get(
-                `api/environments/${currentTeamId}/groups/?${new URLSearchParams(
-                    Object.entries(params).map(([k, v]) => [k, String(v)])
-                ).toString()}`
-            )
-            return response.results ?? []
-        },
-        [currentTeamId, groupTypeIndex]
-    )
+    const logic = groupKeySelectLogic({ groupTypeIndex, value: currentValues })
+    const { groupOptions, groupsLoading, resolvedNames } = useValues(logic)
+    const { setSearchQuery } = useActions(logic)
 
-    const updateOptionsFromGroups = useCallback(
-        (groups: Group[]): void => {
-            setSearchOptions(
-                groups.map((g) => ({
-                    key: g.group_key,
-                    label: groupDisplayId(g.group_key, g.group_properties),
-                }))
-            )
-            setResolvedValues((prev) => {
-                const next = new Map(prev)
-                for (const g of groups) {
-                    next.set(g.group_key, groupDisplayId(g.group_key, g.group_properties))
-                }
-                return next
-            })
-        },
-        [setSearchOptions, setResolvedValues]
-    )
-
-    useEffect(() => {
-        if (currentValues.length === 0 || !currentTeamId) {
-            return
-        }
-
-        const unresolved = currentValues.filter((v) => !resolvedValues.has(v))
-        if (unresolved.length === 0) {
-            return
-        }
-
-        void Promise.all(
-            unresolved.map(async (groupKey) => {
-                try {
-                    const response = await api.get(
-                        `api/environments/${currentTeamId}/groups/find?${new URLSearchParams({
-                            group_type_index: String(groupTypeIndex),
-                            group_key: groupKey,
-                        }).toString()}`
-                    )
-                    return [groupKey, groupDisplayId(response.group_key, response.group_properties)] as const
-                } catch {
-                    return [groupKey, groupKey] as const
-                }
-            })
-        ).then((results) => {
-            setResolvedValues((prev) => {
-                const next = new Map(prev)
-                for (const [key, label] of results) {
-                    next.set(key, label)
-                }
-                return next
-            })
-        })
-    }, [currentValues, currentTeamId, groupTypeIndex]) // eslint-disable-line react-hooks/exhaustive-deps
-
-    useEffect(() => {
-        setLoading(true)
-        void fetchGroups()
-            .then(updateOptionsFromGroups)
-            .finally(() => setLoading(false))
-    }, [fetchGroups, updateOptionsFromGroups])
-
-    const onSearchChange = useCallback(
-        (input: string): void => {
-            if (debounceTimer.current) {
-                clearTimeout(debounceTimer.current)
-            }
-            debounceTimer.current = setTimeout(() => {
-                setLoading(true)
-                void fetchGroups(input.trim() || undefined)
-                    .then(updateOptionsFromGroups)
-                    .finally(() => setLoading(false))
-            }, 300)
-        },
-        [fetchGroups, updateOptionsFromGroups]
-    )
+    const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
 
     const options = useMemo(() => {
-        const optionMap = new Map<string, GroupOption>()
-        for (const opt of searchOptions) {
+        const optionMap = new Map<string, { key: string; label: string }>()
+        for (const opt of groupOptions) {
             optionMap.set(opt.key, opt)
         }
         for (const v of currentValues) {
             if (!optionMap.has(v)) {
-                optionMap.set(v, { key: v, label: resolvedValues.get(v) ?? v })
+                optionMap.set(v, { key: v, label: resolvedNames[v] ?? v })
             }
         }
         return Array.from(optionMap.values())
-    }, [searchOptions, currentValues, resolvedValues])
-
-    const formattedValues = currentValues.map((v) => resolvedValues.get(v) ?? v)
+    }, [groupOptions, currentValues, resolvedNames])
 
     if (!editable) {
+        const formattedValues = currentValues.map((v) => resolvedNames[v] ?? v)
         return <>{formattedValues.join(' or ')}</>
     }
 
     return (
         <LemonInputSelect
             data-attr="prop-val"
-            loading={loading}
+            loading={groupsLoading}
             value={currentValues}
             mode={isMultiSelect ? 'multiple' : 'single'}
             singleValueAsSnack
             allowCustomValues
             onChange={(nextVal) => (isMultiSelect ? onChange(nextVal) : onChange(nextVal[0]))}
-            onInputChange={onSearchChange}
+            onInputChange={(input) => setSearchQuery(input.trim())}
             placeholder="Search groups by name..."
             size={size}
             autoFocus={autoFocus}

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
@@ -37,7 +37,6 @@ export function GroupKeySelect({
     const logic = groupKeySelectLogic({ groupTypeIndex, value: currentValues })
     const { groupOptions, groupsLoading, resolvedNames } = useValues(logic)
     const { setSearchQuery } = useActions(logic)
-
     const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
 
     const options = useMemo(() => {

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
@@ -1,0 +1,183 @@
+import { useValues } from 'kea'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import api from 'lib/api'
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { isOperatorMulti } from 'lib/utils'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Group } from '~/types'
+import type { GroupTypeIndex, PropertyFilterValue, PropertyOperator } from '~/types'
+
+export interface GroupKeySelectProps {
+    value: PropertyFilterValue
+    groupTypeIndex: GroupTypeIndex
+    operator: PropertyOperator
+    onChange: (value: PropertyFilterValue) => void
+    size?: 'xsmall' | 'small' | 'medium'
+    editable?: boolean
+    autoFocus?: boolean
+    forceSingleSelect?: boolean
+}
+
+interface GroupOption {
+    key: string
+    label: string
+}
+
+export function GroupKeySelect({
+    value,
+    groupTypeIndex,
+    operator,
+    onChange,
+    size,
+    editable = true,
+    autoFocus = false,
+    forceSingleSelect = false,
+}: GroupKeySelectProps): JSX.Element {
+    const { currentTeamId } = useValues(teamLogic)
+    const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
+
+    const [searchOptions, setSearchOptions] = useState<GroupOption[]>([])
+    const [resolvedValues, setResolvedValues] = useState<Map<string, string>>(new Map())
+    const [loading, setLoading] = useState(false)
+    const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const currentValues = useMemo(
+        () => (value === null || value === undefined ? [] : Array.isArray(value) ? value.map(String) : [String(value)]),
+        [value]
+    )
+
+    const fetchGroups = useCallback(
+        async (search?: string): Promise<Group[]> => {
+            if (!currentTeamId) {
+                return []
+            }
+            const params: Record<string, string | number> = { group_type_index: groupTypeIndex }
+            if (search) {
+                params.search = search
+            }
+            const response = await api.get(
+                `api/environments/${currentTeamId}/groups/?${new URLSearchParams(
+                    Object.entries(params).map(([k, v]) => [k, String(v)])
+                ).toString()}`
+            )
+            return response.results ?? []
+        },
+        [currentTeamId, groupTypeIndex]
+    )
+
+    const updateOptionsFromGroups = useCallback(
+        (groups: Group[]): void => {
+            setSearchOptions(
+                groups.map((g) => ({
+                    key: g.group_key,
+                    label: groupDisplayId(g.group_key, g.group_properties),
+                }))
+            )
+            setResolvedValues((prev) => {
+                const next = new Map(prev)
+                for (const g of groups) {
+                    next.set(g.group_key, groupDisplayId(g.group_key, g.group_properties))
+                }
+                return next
+            })
+        },
+        [setSearchOptions, setResolvedValues]
+    )
+
+    useEffect(() => {
+        if (currentValues.length === 0 || !currentTeamId) {
+            return
+        }
+
+        const unresolved = currentValues.filter((v) => !resolvedValues.has(v))
+        if (unresolved.length === 0) {
+            return
+        }
+
+        void Promise.all(
+            unresolved.map(async (groupKey) => {
+                try {
+                    const response = await api.get(
+                        `api/environments/${currentTeamId}/groups/find?${new URLSearchParams({
+                            group_type_index: String(groupTypeIndex),
+                            group_key: groupKey,
+                        }).toString()}`
+                    )
+                    return [groupKey, groupDisplayId(response.group_key, response.group_properties)] as const
+                } catch {
+                    return [groupKey, groupKey] as const
+                }
+            })
+        ).then((results) => {
+            setResolvedValues((prev) => {
+                const next = new Map(prev)
+                for (const [key, label] of results) {
+                    next.set(key, label)
+                }
+                return next
+            })
+        })
+    }, [currentValues, currentTeamId, groupTypeIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        setLoading(true)
+        void fetchGroups()
+            .then(updateOptionsFromGroups)
+            .finally(() => setLoading(false))
+    }, [fetchGroups, updateOptionsFromGroups])
+
+    const onSearchChange = useCallback(
+        (input: string): void => {
+            if (debounceTimer.current) {
+                clearTimeout(debounceTimer.current)
+            }
+            debounceTimer.current = setTimeout(() => {
+                setLoading(true)
+                void fetchGroups(input.trim() || undefined)
+                    .then(updateOptionsFromGroups)
+                    .finally(() => setLoading(false))
+            }, 300)
+        },
+        [fetchGroups, updateOptionsFromGroups]
+    )
+
+    const options = useMemo(() => {
+        const optionMap = new Map<string, GroupOption>()
+        for (const opt of searchOptions) {
+            optionMap.set(opt.key, opt)
+        }
+        for (const v of currentValues) {
+            if (!optionMap.has(v)) {
+                optionMap.set(v, { key: v, label: resolvedValues.get(v) ?? v })
+            }
+        }
+        return Array.from(optionMap.values())
+    }, [searchOptions, currentValues, resolvedValues])
+
+    const formattedValues = currentValues.map((v) => resolvedValues.get(v) ?? v)
+
+    if (!editable) {
+        return <>{formattedValues.join(' or ')}</>
+    }
+
+    return (
+        <LemonInputSelect
+            data-attr="prop-val"
+            loading={loading}
+            value={currentValues}
+            mode={isMultiSelect ? 'multiple' : 'single'}
+            singleValueAsSnack
+            allowCustomValues
+            onChange={(nextVal) => (isMultiSelect ? onChange(nextVal) : onChange(nextVal[0]))}
+            onInputChange={onSearchChange}
+            placeholder="Search groups by name..."
+            size={size}
+            autoFocus={autoFocus}
+            disableFiltering
+            options={options}
+        />
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
@@ -14,7 +14,6 @@ export interface GroupKeySelectProps {
     operator: PropertyOperator
     onChange: (value: PropertyFilterValue) => void
     size?: 'xsmall' | 'small' | 'medium'
-    editable?: boolean
     autoFocus?: boolean
     forceSingleSelect?: boolean
 }
@@ -25,7 +24,6 @@ export function GroupKeySelect({
     operator,
     onChange,
     size,
-    editable = true,
     autoFocus = false,
     forceSingleSelect = false,
 }: GroupKeySelectProps): JSX.Element {
@@ -35,7 +33,7 @@ export function GroupKeySelect({
     )
 
     const logic = groupKeySelectLogic({ groupTypeIndex, value: currentValues })
-    const { groupOptions, groupsLoading, resolvedNames } = useValues(logic)
+    const { groupOptions, groupsLoading, resolvedNames, searchQuery } = useValues(logic)
     const { setSearchQuery } = useActions(logic)
     const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
 
@@ -52,11 +50,6 @@ export function GroupKeySelect({
         return Array.from(optionMap.values())
     }, [groupOptions, currentValues, resolvedNames])
 
-    if (!editable) {
-        const formattedValues = currentValues.map((v) => resolvedNames[v] ?? v)
-        return <>{formattedValues.join(' or ')}</>
-    }
-
     return (
         <LemonInputSelect
             data-attr="prop-val"
@@ -66,7 +59,12 @@ export function GroupKeySelect({
             singleValueAsSnack
             allowCustomValues
             onChange={(nextVal) => (isMultiSelect ? onChange(nextVal) : onChange(nextVal[0]))}
-            onInputChange={(input) => setSearchQuery(input.trim())}
+            onInputChange={(input) => {
+                const trimmed = input.trim()
+                if (trimmed !== searchQuery) {
+                    setSearchQuery(trimmed)
+                }
+            }}
             placeholder="Search groups by name..."
             size={size}
             autoFocus={autoFocus}

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -48,6 +48,7 @@ export interface OperatorValueSelectProps {
     propertyDefinitions: PropertyDefinition[]
     addRelativeDateTimeOptions?: boolean
     groupTypeIndex?: GroupTypeIndex
+    groupKeyNames?: Record<string, string>
     size?: 'xsmall' | 'small' | 'medium'
     startVisible?: LemonDropdownProps['startVisible']
     /**
@@ -109,6 +110,7 @@ export function OperatorValueSelect({
     eventNames = [],
     addRelativeDateTimeOptions,
     groupTypeIndex = undefined,
+    groupKeyNames,
     size,
     editable,
     startVisible,
@@ -271,6 +273,7 @@ export function OperatorValueSelect({
                         autoFocus={!isMobile() && value === null}
                         addRelativeDateTimeOptions={addRelativeDateTimeOptions}
                         groupTypeIndex={groupTypeIndex}
+                        groupKeyNames={groupKeyNames}
                         editable={editable}
                         size={size}
                         forceSingleSelect={forceSingleSelect}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -43,6 +43,7 @@ export interface PropertyValueProps {
     addRelativeDateTimeOptions?: boolean
     inputClassName?: string
     groupTypeIndex?: GroupTypeIndex
+    groupKeyNames?: Record<string, string>
     size?: 'xsmall' | 'small' | 'medium'
     editable?: boolean
     preloadValues?: boolean
@@ -65,6 +66,7 @@ export function PropertyValue({
     addRelativeDateTimeOptions = false,
     inputClassName = undefined,
     groupTypeIndex = undefined,
+    groupKeyNames,
     editable = true,
     preloadValues = false,
     forceSingleSelect = false,
@@ -266,6 +268,13 @@ export function PropertyValue({
     )
 
     if (!editable) {
+        if (isGroupKeyProperty && groupKeyNames) {
+            const rawValues = (value === null || value === undefined ? [] : Array.isArray(value) ? value : [value]).map(
+                String
+            )
+            const displayValues = rawValues.map((key) => groupKeyNames[key] || key)
+            return <>{displayValues.join(' or ')}</>
+        }
         return <>{formattedValues.join(' or ')}</>
     }
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -125,17 +125,27 @@ export function PropertyValue({
 
     // preload values if preloadValues prop is set
     useEffect(() => {
-        if (preloadValues && propertyOptions?.status !== 'loading' && propertyOptions?.status !== 'loaded') {
+        if (
+            !isGroupKeyProperty &&
+            preloadValues &&
+            propertyOptions?.status !== 'loading' &&
+            propertyOptions?.status !== 'loaded'
+        ) {
             load('')
         }
-    }, [preloadValues, load, propertyOptions?.status])
+    }, [preloadValues, load, propertyOptions?.status, isGroupKeyProperty])
 
     // load options when propertyKey changes, unless it's a date/time property (since those don't have options to load)
     useEffect(() => {
-        if (!isDateTimeProperty && propertyOptions?.status !== 'loading' && propertyOptions?.status !== 'loaded') {
+        if (
+            !isGroupKeyProperty &&
+            !isDateTimeProperty &&
+            propertyOptions?.status !== 'loading' &&
+            propertyOptions?.status !== 'loaded'
+        ) {
             load('')
         }
-    }, [propertyKey, isDateTimeProperty, load, propertyOptions?.status])
+    }, [propertyKey, isDateTimeProperty, isGroupKeyProperty, load, propertyOptions?.status])
 
     // set initial suggested values when options are loaded, but only if there is no search input
     // (to avoid overwriting suggestions based on search input)
@@ -237,7 +247,7 @@ export function PropertyValue({
         )
     }
 
-    if (isGroupKeyProperty) {
+    if (isGroupKeyProperty && editable) {
         return (
             <GroupKeySelect
                 value={value ?? null}
@@ -245,7 +255,6 @@ export function PropertyValue({
                 operator={operator}
                 onChange={setValue}
                 size={size}
-                editable={editable}
                 autoFocus={autoFocus}
                 forceSingleSelect={forceSingleSelect}
             />

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -12,6 +12,7 @@ import { AssigneeSelect } from '@posthog/products-error-tracking/frontend/compon
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
+import { GroupKeySelect } from 'lib/components/PropertyFilters/components/GroupKeySelect'
 import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { propertyValueLogic } from 'lib/components/PropertyFilters/components/propertyValueLogic'
@@ -89,6 +90,8 @@ export function PropertyValue({
 
     const isNumericProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
+
+    const isGroupKeyProperty = propertyKey === '$group_key' && groupTypeIndex != null
 
     // TODO: Add semver input validation when a semver operator is selected.
     // This will require detecting isOperatorSemver(operator) and validating the input
@@ -231,6 +234,21 @@ export function PropertyValue({
                     </>
                 )}
             </AssigneeResolver>
+        )
+    }
+
+    if (isGroupKeyProperty) {
+        return (
+            <GroupKeySelect
+                value={value ?? null}
+                groupTypeIndex={groupTypeIndex}
+                operator={operator}
+                onChange={setValue}
+                size={size}
+                editable={editable}
+                autoFocus={autoFocus}
+                forceSingleSelect={forceSingleSelect}
+            />
         )
     }
 

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -221,6 +221,11 @@ export function TaxonomicPropertyFilter({
                     ? (filter?.group_type_index as GroupTypeIndex)
                     : undefined
             }
+            groupKeyNames={
+                isGroupPropertyFilter(filter) && 'group_key_names' in filter
+                    ? (filter as any).group_key_names
+                    : undefined
+            }
             operatorAllowlist={operatorAllowlist}
         />
     )

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -1,0 +1,132 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Group, GroupTypeIndex } from '~/types'
+
+import type { groupKeySelectLogicType } from './groupKeySelectLogicType'
+
+export interface GroupKeySelectLogicProps {
+    groupTypeIndex: GroupTypeIndex
+    value: string[]
+}
+
+async function resolveGroupNames(
+    teamId: number | null,
+    groupTypeIndex: GroupTypeIndex,
+    groupKeys: string[]
+): Promise<Record<string, string>> {
+    if (!teamId || groupKeys.length === 0) {
+        return {}
+    }
+    const results = await Promise.all(
+        groupKeys.map(async (groupKey) => {
+            try {
+                const response = await api.get(
+                    `api/environments/${teamId}/groups/find?${new URLSearchParams({
+                        group_type_index: String(groupTypeIndex),
+                        group_key: groupKey,
+                    }).toString()}`
+                )
+                return [groupKey, groupDisplayId(response.group_key, response.group_properties)] as const
+            } catch {
+                return [groupKey, groupKey] as const
+            }
+        })
+    )
+    return Object.fromEntries(results)
+}
+
+export const groupKeySelectLogic = kea<groupKeySelectLogicType>([
+    props({} as GroupKeySelectLogicProps),
+    key((props) => `${props.groupTypeIndex}`),
+    path((key) => ['lib', 'components', 'PropertyFilters', 'components', 'groupKeySelectLogic', key]),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        setSearchQuery: (query: string) => ({ query }),
+        setResolvedNames: (names: Record<string, string>) => ({ names }),
+    }),
+    reducers({
+        searchQuery: [
+            '',
+            {
+                setSearchQuery: (_, { query }: { query: string }) => query,
+            },
+        ],
+        resolvedNames: [
+            {} as Record<string, string>,
+            {
+                setResolvedNames: (state, { names }: { names: Record<string, string> }) => ({ ...state, ...names }),
+            },
+        ],
+    }),
+    loaders(({ values, props }) => ({
+        groups: [
+            [] as Group[],
+            {
+                loadGroups: async (_, breakpoint) => {
+                    await breakpoint(300)
+                    if (!values.currentTeamId) {
+                        return []
+                    }
+                    const params: Record<string, string | number> = {
+                        group_type_index: props.groupTypeIndex,
+                    }
+                    if (values.searchQuery) {
+                        params.search = values.searchQuery
+                    }
+                    const response = await api.get(
+                        `api/environments/${values.currentTeamId}/groups/?${new URLSearchParams(
+                            Object.entries(params).map(([k, v]) => [k, String(v)])
+                        ).toString()}`
+                    )
+                    breakpoint()
+                    return response.results ?? []
+                },
+            },
+        ],
+    })),
+    selectors({
+        groupOptions: [
+            (s) => [s.groups, s.resolvedNames],
+            (groups: Group[], resolvedNames: Record<string, string>): { key: string; label: string }[] => {
+                const optionMap = new Map<string, { key: string; label: string }>()
+                for (const g of groups) {
+                    const label = groupDisplayId(g.group_key, g.group_properties)
+                    optionMap.set(g.group_key, { key: g.group_key, label })
+                }
+                for (const [groupKey, name] of Object.entries(resolvedNames)) {
+                    if (!optionMap.has(groupKey)) {
+                        optionMap.set(groupKey, { key: groupKey, label: String(name) })
+                    }
+                }
+                return Array.from(optionMap.values())
+            },
+        ],
+    }),
+    listeners(({ actions }) => ({
+        setSearchQuery: () => {
+            actions.loadGroups({})
+        },
+        loadGroupsSuccess: ({ groups }) => {
+            const names: Record<string, string> = {}
+            for (const g of groups) {
+                names[g.group_key] = groupDisplayId(g.group_key, g.group_properties)
+            }
+            actions.setResolvedNames(names)
+        },
+    })),
+    afterMount(async ({ actions, props }) => {
+        actions.loadGroups({})
+        const teamId = teamLogic.findMounted()?.values.currentTeamId ?? null
+        const names = await resolveGroupNames(teamId, props.groupTypeIndex, props.value)
+        if (Object.keys(names).length > 0) {
+            actions.setResolvedNames(names)
+        }
+    }),
+])

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -26,7 +26,7 @@ async function resolveGroupNames(
         groupKeys.map(async (groupKey) => {
             try {
                 const response = await api.get(
-                    `api/environments/${teamId}/groups/find?${new URLSearchParams({
+                    `api/environments/${teamId}/groups/find/?${new URLSearchParams({
                         group_type_index: String(groupTypeIndex),
                         group_key: groupKey,
                     }).toString()}`
@@ -69,7 +69,7 @@ export const groupKeySelectLogic = kea<groupKeySelectLogicType>([
         groups: [
             [] as Group[],
             {
-                loadGroups: async (_, breakpoint) => {
+                loadGroups: async ({ search }: { search?: string }, breakpoint) => {
                     await breakpoint(300)
                     if (!values.currentTeamId) {
                         return []
@@ -77,8 +77,8 @@ export const groupKeySelectLogic = kea<groupKeySelectLogicType>([
                     const params: Record<string, string | number> = {
                         group_type_index: props.groupTypeIndex,
                     }
-                    if (values.searchQuery) {
-                        params.search = values.searchQuery
+                    if (search) {
+                        params.search = search
                     }
                     const response = await api.get(
                         `api/environments/${values.currentTeamId}/groups/?${new URLSearchParams(
@@ -93,25 +93,18 @@ export const groupKeySelectLogic = kea<groupKeySelectLogicType>([
     })),
     selectors({
         groupOptions: [
-            (s) => [s.groups, s.resolvedNames],
-            (groups: Group[], resolvedNames: Record<string, string>): { key: string; label: string }[] => {
-                const optionMap = new Map<string, { key: string; label: string }>()
-                for (const g of groups) {
-                    const label = groupDisplayId(g.group_key, g.group_properties)
-                    optionMap.set(g.group_key, { key: g.group_key, label })
-                }
-                for (const [groupKey, name] of Object.entries(resolvedNames)) {
-                    if (!optionMap.has(groupKey)) {
-                        optionMap.set(groupKey, { key: groupKey, label: String(name) })
-                    }
-                }
-                return Array.from(optionMap.values())
+            (s) => [s.groups],
+            (groups: Group[]): { key: string; label: string }[] => {
+                return groups.map((g) => ({
+                    key: g.group_key,
+                    label: groupDisplayId(g.group_key, g.group_properties),
+                }))
             },
         ],
     }),
     listeners(({ actions }) => ({
-        setSearchQuery: () => {
-            actions.loadGroups({})
+        setSearchQuery: ({ query }: { query: string }) => {
+            actions.loadGroups({ search: query })
         },
         loadGroupsSuccess: ({ groups }) => {
             const names: Record<string, string> = {}

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -33,11 +33,11 @@ async function resolveGroupNames(
                 )
                 return [groupKey, groupDisplayId(response.group_key, response.group_properties)] as const
             } catch {
-                return [groupKey, groupKey] as const
+                return null
             }
         })
     )
-    return Object.fromEntries(results)
+    return Object.fromEntries(results.filter((r): r is readonly [string, string] => r !== null))
 }
 
 export const groupKeySelectLogic = kea<groupKeySelectLogicType>([

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -14,7 +14,7 @@ export interface GroupKeySelectLogicProps {
     value: string[]
 }
 
-async function resolveGroupNames(
+export async function resolveGroupNames(
     teamId: number | null,
     groupTypeIndex: GroupTypeIndex,
     groupKeys: string[]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17115,6 +17115,12 @@
         "GroupPropertyFilter": {
             "additionalProperties": false,
             "properties": {
+                "group_key_names": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
                 "group_type_index": {
                     "anyOf": [
                         {

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -2347,6 +2347,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
 const schema33 = {
     additionalProperties: false,
     properties: {
+        group_key_names: { additionalProperties: { type: 'string' }, type: 'object' },
         group_type_index: { anyOf: [{ type: 'integer' }, { type: 'null' }] },
         key: { type: 'string' },
         label: { type: 'string' },
@@ -2383,6 +2384,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                 for (const key0 in data) {
                     if (
                         !(
+                            key0 === 'group_key_names' ||
                             key0 === 'group_type_index' ||
                             key0 === 'key' ||
                             key0 === 'label' ||
@@ -2405,126 +2407,21 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                     }
                 }
                 if (_errs1 === errors) {
-                    if (data.group_type_index !== undefined) {
-                        let data0 = data.group_type_index
+                    if (data.group_key_names !== undefined) {
+                        let data0 = data.group_key_names
                         const _errs2 = errors
-                        const _errs3 = errors
-                        let valid1 = false
-                        const _errs4 = errors
-                        if (!(typeof data0 == 'number' && !(data0 % 1) && !isNaN(data0) && isFinite(data0))) {
-                            const err0 = {
-                                instancePath: instancePath + '/group_type_index',
-                                schemaPath: '#/properties/group_type_index/anyOf/0/type',
-                                keyword: 'type',
-                                params: { type: 'integer' },
-                                message: 'must be integer',
-                            }
-                            if (vErrors === null) {
-                                vErrors = [err0]
-                            } else {
-                                vErrors.push(err0)
-                            }
-                            errors++
-                        }
-                        var _valid0 = _errs4 === errors
-                        valid1 = valid1 || _valid0
-                        if (!valid1) {
-                            const _errs6 = errors
-                            if (data0 !== null) {
-                                const err1 = {
-                                    instancePath: instancePath + '/group_type_index',
-                                    schemaPath: '#/properties/group_type_index/anyOf/1/type',
-                                    keyword: 'type',
-                                    params: { type: 'null' },
-                                    message: 'must be null',
-                                }
-                                if (vErrors === null) {
-                                    vErrors = [err1]
-                                } else {
-                                    vErrors.push(err1)
-                                }
-                                errors++
-                            }
-                            var _valid0 = _errs6 === errors
-                            valid1 = valid1 || _valid0
-                        }
-                        if (!valid1) {
-                            const err2 = {
-                                instancePath: instancePath + '/group_type_index',
-                                schemaPath: '#/properties/group_type_index/anyOf',
-                                keyword: 'anyOf',
-                                params: {},
-                                message: 'must match a schema in anyOf',
-                            }
-                            if (vErrors === null) {
-                                vErrors = [err2]
-                            } else {
-                                vErrors.push(err2)
-                            }
-                            errors++
-                            validate36.errors = vErrors
-                            return false
-                        } else {
-                            errors = _errs3
-                            if (vErrors !== null) {
-                                if (_errs3) {
-                                    vErrors.length = _errs3
-                                } else {
-                                    vErrors = null
-                                }
-                            }
-                        }
-                        var valid0 = _errs2 === errors
-                    } else {
-                        var valid0 = true
-                    }
-                    if (valid0) {
-                        if (data.key !== undefined) {
-                            const _errs8 = errors
-                            if (typeof data.key !== 'string') {
-                                validate36.errors = [
-                                    {
-                                        instancePath: instancePath + '/key',
-                                        schemaPath: '#/properties/key/type',
-                                        keyword: 'type',
-                                        params: { type: 'string' },
-                                        message: 'must be string',
-                                    },
-                                ]
-                                return false
-                            }
-                            var valid0 = _errs8 === errors
-                        } else {
-                            var valid0 = true
-                        }
-                        if (valid0) {
-                            if (data.label !== undefined) {
-                                const _errs10 = errors
-                                if (typeof data.label !== 'string') {
-                                    validate36.errors = [
-                                        {
-                                            instancePath: instancePath + '/label',
-                                            schemaPath: '#/properties/label/type',
-                                            keyword: 'type',
-                                            params: { type: 'string' },
-                                            message: 'must be string',
-                                        },
-                                    ]
-                                    return false
-                                }
-                                var valid0 = _errs10 === errors
-                            } else {
-                                var valid0 = true
-                            }
-                            if (valid0) {
-                                if (data.operator !== undefined) {
-                                    let data3 = data.operator
-                                    const _errs12 = errors
-                                    if (typeof data3 !== 'string') {
+                        if (errors === _errs2) {
+                            if (data0 && typeof data0 == 'object' && !Array.isArray(data0)) {
+                                for (const key1 in data0) {
+                                    const _errs5 = errors
+                                    if (typeof data0[key1] !== 'string') {
                                         validate36.errors = [
                                             {
-                                                instancePath: instancePath + '/operator',
-                                                schemaPath: '#/definitions/PropertyOperator/type',
+                                                instancePath:
+                                                    instancePath +
+                                                    '/group_key_names/' +
+                                                    key1.replace(/~/g, '~0').replace(/\//g, '~1'),
+                                                schemaPath: '#/properties/group_key_names/additionalProperties/type',
                                                 keyword: 'type',
                                                 params: { type: 'string' },
                                                 message: 'must be string',
@@ -2532,68 +2429,149 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if (
-                                        !(
-                                            data3 === 'exact' ||
-                                            data3 === 'is_not' ||
-                                            data3 === 'icontains' ||
-                                            data3 === 'not_icontains' ||
-                                            data3 === 'regex' ||
-                                            data3 === 'not_regex' ||
-                                            data3 === 'gt' ||
-                                            data3 === 'gte' ||
-                                            data3 === 'lt' ||
-                                            data3 === 'lte' ||
-                                            data3 === 'is_set' ||
-                                            data3 === 'is_not_set' ||
-                                            data3 === 'is_date_exact' ||
-                                            data3 === 'is_date_before' ||
-                                            data3 === 'is_date_after' ||
-                                            data3 === 'between' ||
-                                            data3 === 'not_between' ||
-                                            data3 === 'min' ||
-                                            data3 === 'max' ||
-                                            data3 === 'in' ||
-                                            data3 === 'not_in' ||
-                                            data3 === 'is_cleaned_path_exact' ||
-                                            data3 === 'flag_evaluates_to' ||
-                                            data3 === 'semver_eq' ||
-                                            data3 === 'semver_neq' ||
-                                            data3 === 'semver_gt' ||
-                                            data3 === 'semver_gte' ||
-                                            data3 === 'semver_lt' ||
-                                            data3 === 'semver_lte' ||
-                                            data3 === 'semver_tilde' ||
-                                            data3 === 'semver_caret' ||
-                                            data3 === 'semver_wildcard' ||
-                                            data3 === 'icontains_multi' ||
-                                            data3 === 'not_icontains_multi'
-                                        )
-                                    ) {
+                                    var valid1 = _errs5 === errors
+                                    if (!valid1) {
+                                        break
+                                    }
+                                }
+                            } else {
+                                validate36.errors = [
+                                    {
+                                        instancePath: instancePath + '/group_key_names',
+                                        schemaPath: '#/properties/group_key_names/type',
+                                        keyword: 'type',
+                                        params: { type: 'object' },
+                                        message: 'must be object',
+                                    },
+                                ]
+                                return false
+                            }
+                        }
+                        var valid0 = _errs2 === errors
+                    } else {
+                        var valid0 = true
+                    }
+                    if (valid0) {
+                        if (data.group_type_index !== undefined) {
+                            let data2 = data.group_type_index
+                            const _errs7 = errors
+                            const _errs8 = errors
+                            let valid2 = false
+                            const _errs9 = errors
+                            if (!(typeof data2 == 'number' && !(data2 % 1) && !isNaN(data2) && isFinite(data2))) {
+                                const err0 = {
+                                    instancePath: instancePath + '/group_type_index',
+                                    schemaPath: '#/properties/group_type_index/anyOf/0/type',
+                                    keyword: 'type',
+                                    params: { type: 'integer' },
+                                    message: 'must be integer',
+                                }
+                                if (vErrors === null) {
+                                    vErrors = [err0]
+                                } else {
+                                    vErrors.push(err0)
+                                }
+                                errors++
+                            }
+                            var _valid0 = _errs9 === errors
+                            valid2 = valid2 || _valid0
+                            if (!valid2) {
+                                const _errs11 = errors
+                                if (data2 !== null) {
+                                    const err1 = {
+                                        instancePath: instancePath + '/group_type_index',
+                                        schemaPath: '#/properties/group_type_index/anyOf/1/type',
+                                        keyword: 'type',
+                                        params: { type: 'null' },
+                                        message: 'must be null',
+                                    }
+                                    if (vErrors === null) {
+                                        vErrors = [err1]
+                                    } else {
+                                        vErrors.push(err1)
+                                    }
+                                    errors++
+                                }
+                                var _valid0 = _errs11 === errors
+                                valid2 = valid2 || _valid0
+                            }
+                            if (!valid2) {
+                                const err2 = {
+                                    instancePath: instancePath + '/group_type_index',
+                                    schemaPath: '#/properties/group_type_index/anyOf',
+                                    keyword: 'anyOf',
+                                    params: {},
+                                    message: 'must match a schema in anyOf',
+                                }
+                                if (vErrors === null) {
+                                    vErrors = [err2]
+                                } else {
+                                    vErrors.push(err2)
+                                }
+                                errors++
+                                validate36.errors = vErrors
+                                return false
+                            } else {
+                                errors = _errs8
+                                if (vErrors !== null) {
+                                    if (_errs8) {
+                                        vErrors.length = _errs8
+                                    } else {
+                                        vErrors = null
+                                    }
+                                }
+                            }
+                            var valid0 = _errs7 === errors
+                        } else {
+                            var valid0 = true
+                        }
+                        if (valid0) {
+                            if (data.key !== undefined) {
+                                const _errs13 = errors
+                                if (typeof data.key !== 'string') {
+                                    validate36.errors = [
+                                        {
+                                            instancePath: instancePath + '/key',
+                                            schemaPath: '#/properties/key/type',
+                                            keyword: 'type',
+                                            params: { type: 'string' },
+                                            message: 'must be string',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                var valid0 = _errs13 === errors
+                            } else {
+                                var valid0 = true
+                            }
+                            if (valid0) {
+                                if (data.label !== undefined) {
+                                    const _errs15 = errors
+                                    if (typeof data.label !== 'string') {
                                         validate36.errors = [
                                             {
-                                                instancePath: instancePath + '/operator',
-                                                schemaPath: '#/definitions/PropertyOperator/enum',
-                                                keyword: 'enum',
-                                                params: { allowedValues: schema14.enum },
-                                                message: 'must be equal to one of the allowed values',
+                                                instancePath: instancePath + '/label',
+                                                schemaPath: '#/properties/label/type',
+                                                keyword: 'type',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
                                             },
                                         ]
                                         return false
                                     }
-                                    var valid0 = _errs12 === errors
+                                    var valid0 = _errs15 === errors
                                 } else {
                                     var valid0 = true
                                 }
                                 if (valid0) {
-                                    if (data.type !== undefined) {
-                                        let data4 = data.type
-                                        const _errs15 = errors
-                                        if (typeof data4 !== 'string') {
+                                    if (data.operator !== undefined) {
+                                        let data5 = data.operator
+                                        const _errs17 = errors
+                                        if (typeof data5 !== 'string') {
                                             validate36.errors = [
                                                 {
-                                                    instancePath: instancePath + '/type',
-                                                    schemaPath: '#/properties/type/type',
+                                                    instancePath: instancePath + '/operator',
+                                                    schemaPath: '#/definitions/PropertyOperator/type',
                                                     keyword: 'type',
                                                     params: { type: 'string' },
                                                     message: 'must be string',
@@ -2601,42 +2579,112 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                             ]
                                             return false
                                         }
-                                        if ('group' !== data4) {
+                                        if (
+                                            !(
+                                                data5 === 'exact' ||
+                                                data5 === 'is_not' ||
+                                                data5 === 'icontains' ||
+                                                data5 === 'not_icontains' ||
+                                                data5 === 'regex' ||
+                                                data5 === 'not_regex' ||
+                                                data5 === 'gt' ||
+                                                data5 === 'gte' ||
+                                                data5 === 'lt' ||
+                                                data5 === 'lte' ||
+                                                data5 === 'is_set' ||
+                                                data5 === 'is_not_set' ||
+                                                data5 === 'is_date_exact' ||
+                                                data5 === 'is_date_before' ||
+                                                data5 === 'is_date_after' ||
+                                                data5 === 'between' ||
+                                                data5 === 'not_between' ||
+                                                data5 === 'min' ||
+                                                data5 === 'max' ||
+                                                data5 === 'in' ||
+                                                data5 === 'not_in' ||
+                                                data5 === 'is_cleaned_path_exact' ||
+                                                data5 === 'flag_evaluates_to' ||
+                                                data5 === 'semver_eq' ||
+                                                data5 === 'semver_neq' ||
+                                                data5 === 'semver_gt' ||
+                                                data5 === 'semver_gte' ||
+                                                data5 === 'semver_lt' ||
+                                                data5 === 'semver_lte' ||
+                                                data5 === 'semver_tilde' ||
+                                                data5 === 'semver_caret' ||
+                                                data5 === 'semver_wildcard' ||
+                                                data5 === 'icontains_multi' ||
+                                                data5 === 'not_icontains_multi'
+                                            )
+                                        ) {
                                             validate36.errors = [
                                                 {
-                                                    instancePath: instancePath + '/type',
-                                                    schemaPath: '#/properties/type/const',
-                                                    keyword: 'const',
-                                                    params: { allowedValue: 'group' },
-                                                    message: 'must be equal to constant',
+                                                    instancePath: instancePath + '/operator',
+                                                    schemaPath: '#/definitions/PropertyOperator/enum',
+                                                    keyword: 'enum',
+                                                    params: { allowedValues: schema14.enum },
+                                                    message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
                                             return false
                                         }
-                                        var valid0 = _errs15 === errors
+                                        var valid0 = _errs17 === errors
                                     } else {
                                         var valid0 = true
                                     }
                                     if (valid0) {
-                                        if (data.value !== undefined) {
-                                            const _errs17 = errors
-                                            if (
-                                                !validate13(data.value, {
-                                                    instancePath: instancePath + '/value',
-                                                    parentData: data,
-                                                    parentDataProperty: 'value',
-                                                    rootData,
-                                                })
-                                            ) {
-                                                vErrors =
-                                                    vErrors === null
-                                                        ? validate13.errors
-                                                        : vErrors.concat(validate13.errors)
-                                                errors = vErrors.length
+                                        if (data.type !== undefined) {
+                                            let data6 = data.type
+                                            const _errs20 = errors
+                                            if (typeof data6 !== 'string') {
+                                                validate36.errors = [
+                                                    {
+                                                        instancePath: instancePath + '/type',
+                                                        schemaPath: '#/properties/type/type',
+                                                        keyword: 'type',
+                                                        params: { type: 'string' },
+                                                        message: 'must be string',
+                                                    },
+                                                ]
+                                                return false
                                             }
-                                            var valid0 = _errs17 === errors
+                                            if ('group' !== data6) {
+                                                validate36.errors = [
+                                                    {
+                                                        instancePath: instancePath + '/type',
+                                                        schemaPath: '#/properties/type/const',
+                                                        keyword: 'const',
+                                                        params: { allowedValue: 'group' },
+                                                        message: 'must be equal to constant',
+                                                    },
+                                                ]
+                                                return false
+                                            }
+                                            var valid0 = _errs20 === errors
                                         } else {
                                             var valid0 = true
+                                        }
+                                        if (valid0) {
+                                            if (data.value !== undefined) {
+                                                const _errs22 = errors
+                                                if (
+                                                    !validate13(data.value, {
+                                                        instancePath: instancePath + '/value',
+                                                        parentData: data,
+                                                        parentDataProperty: 'value',
+                                                        rootData,
+                                                    })
+                                                ) {
+                                                    vErrors =
+                                                        vErrors === null
+                                                            ? validate13.errors
+                                                            : vErrors.concat(validate13.errors)
+                                                    errors = vErrors.length
+                                                }
+                                                var valid0 = _errs22 === errors
+                                            } else {
+                                                var valid0 = true
+                                            }
                                         }
                                     }
                                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
@@ -262,11 +262,12 @@ export function FeatureFlagOverviewV2({ featureFlag, onGetFeedback }: FeatureFla
                             <RecentFeatureFlagInsights />
 
                             <div className="flex flex-col gap-3 mt-2 pt-3 border-t border-border-light">
-                                <div className="flex items-center justify-between">
-                                    <span className="text-sm text-muted">
+                                <div className="flex items-start gap-2">
+                                    <span className="text-sm text-muted flex-1">
                                         Watch recordings of users exposed to this flag
                                     </span>
                                     <ViewRecordingsPlaylistButton
+                                        className="shrink-0"
                                         filters={recordingFilterForFlag}
                                         type="secondary"
                                         size="small"
@@ -282,11 +283,12 @@ export function FeatureFlagOverviewV2({ featureFlag, onGetFeedback }: FeatureFla
                                     />
                                 </div>
                                 {onGetFeedback && (
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-sm text-muted">
-                                            Gather feedback from users who see this flag
+                                    <div className="flex items-start gap-2">
+                                        <span className="text-sm text-muted flex-1">
+                                            Get feedback from users who see this flag
                                         </span>
                                         <LemonButton
+                                            className="shrink-0"
                                             onClick={() => onGetFeedback()}
                                             type="secondary"
                                             size="small"

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -62,16 +62,26 @@ function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetN
     const parts = properties.slice(0, 2).map((property) => {
         const key = property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key || 'property'
         const operator = isPropertyFilterWithOperator(property) ? allOperatorsToHumanName(property.operator) : 'is'
+        const groupKeyNames: Record<string, string> =
+            property.key === '$group_key' && property.type === PropertyFilterType.Group && 'group_key_names' in property
+                ? ((property as any).group_key_names ?? {})
+                : {}
+        const hasGroupKeyNames = Object.keys(groupKeyNames).length > 0
 
         let value: string | number
         if (property.type === PropertyFilterType.Cohort) {
             value = property.cohort_name || `ID ${property.value}`
         } else if (Array.isArray(property.value)) {
-            value = property.value.slice(0, 2).join(', ') + (property.value.length > 2 ? '...' : '')
+            const displayValues = hasGroupKeyNames
+                ? property.value.map((v) => groupKeyNames[String(v)] || String(v))
+                : property.value.map(String)
+            value = displayValues.slice(0, 2).join(', ') + (displayValues.length > 2 ? '...' : '')
         } else if (property.value === null || property.value === undefined) {
             value = ''
         } else {
-            value = String(property.value)
+            value = hasGroupKeyNames
+                ? groupKeyNames[String(property.value)] || String(property.value)
+                : String(property.value)
         }
 
         return `${key} ${operator} ${value}`

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -20,6 +20,14 @@ interface FeatureFlagReleaseConditionsReadonlyProps {
     isDisabled?: boolean
 }
 
+/** Extract server-provided group_key_names from a property, if present. */
+function getGroupKeyNames(property: AnyPropertyFilter): Record<string, string> {
+    if (property.type === PropertyFilterType.Group && 'group_key_names' in property) {
+        return (property as any).group_key_names ?? {}
+    }
+    return {}
+}
+
 function PropertyValueDisplay({ property }: { property: AnyPropertyFilter }): JSX.Element {
     if (property.type === PropertyFilterType.Cohort) {
         return (
@@ -30,12 +38,15 @@ function PropertyValueDisplay({ property }: { property: AnyPropertyFilter }): JS
     }
 
     const propertyValues = Array.isArray(property.value) ? property.value : [property.value]
+    const groupKeyNames = property.key === '$group_key' ? getGroupKeyNames(property) : {}
 
     return (
         <>
-            {propertyValues.map((val, idx) => (
-                <LemonSnack key={idx}>{String(val)}</LemonSnack>
-            ))}
+            {propertyValues.map((val, idx) => {
+                const strVal = String(val)
+                const display = groupKeyNames[strVal] || strVal
+                return <LemonSnack key={idx}>{display}</LemonSnack>
+            })}
         </>
     )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1013,6 +1013,7 @@ export interface GroupPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.Group
     group_type_index?: integer | null
     operator: PropertyOperator
+    group_key_names?: Record<string, string>
 }
 
 export type LogPropertyFilterType =

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -70,6 +70,7 @@ from posthog.models.feature_flag.local_evaluation import (
     get_flags_response_if_none_match,
 )
 from posthog.models.feature_flag.types import PropertyFilterType
+from posthog.models.group.group import Group
 from posthog.models.property import Property
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.surveys.survey import Survey
@@ -1043,6 +1044,14 @@ class FeatureFlagSerializer(
         """Extract cohort properties from filters."""
         return list(self._get_properties_from_filters(filters, PropertyFilterType.COHORT))
 
+    def _get_group_key_properties_from_filters(self, filters: dict):
+        """Extract $group_key properties from group-type filters."""
+        return [
+            prop
+            for prop in self._get_properties_from_filters(filters, PropertyFilterType.GROUP)
+            if prop.get("key") == "$group_key"
+        ]
+
     def _extract_flag_dependencies(self, filters):
         """Extract flag dependencies from filters."""
         dependencies = set()
@@ -1464,6 +1473,32 @@ class FeatureFlagSerializer(
         # Add cohort names to the response
         for cohort_prop in self._get_cohort_properties_from_filters(filters):
             cohort_prop["cohort_name"] = cohorts.get(str(cohort_prop.get("value")))
+
+        # Resolve group key display names for $group_key filters
+        group_key_props = self._get_group_key_properties_from_filters(filters)
+        if group_key_props:
+            group_type_index = filters.get("aggregation_group_type_index")
+            if group_type_index is not None:
+                group_keys: set[str] = set()
+                for prop in group_key_props:
+                    prop_value = prop.get("value")
+                    if isinstance(prop_value, list):
+                        group_keys.update(str(v) for v in prop_value)
+                    elif prop_value is not None:
+                        group_keys.add(str(prop_value))
+
+                if group_keys:
+                    group_names: dict[str, str] = {}
+                    for group in Group.objects.filter(
+                        team_id=instance.team_id,
+                        group_type_index=group_type_index,
+                        group_key__in=group_keys,
+                    ).only("group_key", "group_properties"):
+                        name = group.group_properties.get("name")
+                        group_names[group.group_key] = str(name) if name else group.group_key
+
+                    for prop in group_key_props:
+                        prop["group_key_names"] = group_names
 
         representation["filters"] = filters
         return representation

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -30,6 +30,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.feature_flag import FeatureFlagDashboards, get_feature_flags_for_team_in_cache
 from posthog.models.feature_flag.feature_flag import FeatureFlagHashKeyOverride
 from posthog.models.feature_flag.flag_status import FeatureFlagStatus
+from posthog.models.group.group import Group
 from posthog.models.group.util import create_group
 from posthog.models.organization import Organization
 from posthog.models.person import Person
@@ -5919,6 +5920,63 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "value": cohort.pk,
                 "cohort_name": "test_cohort",
             },
+        )
+
+    def test_feature_flag_includes_group_key_names(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        Group.objects.create(
+            team=self.team,
+            group_key="org-uuid-1",
+            group_type_index=0,
+            group_properties={"name": "Acme Corp"},
+            version=0,
+        )
+        Group.objects.create(
+            team=self.team,
+            group_key="org-uuid-2",
+            group_type_index=0,
+            group_properties={"name": "Widget Inc"},
+            version=0,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Group flag",
+                "key": "group-flag",
+                "filters": {
+                    "aggregation_group_type_index": 0,
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "$group_key",
+                                    "type": "group",
+                                    "value": ["org-uuid-1", "org-uuid-2"],
+                                    "operator": "exact",
+                                    "group_type_index": 0,
+                                }
+                            ]
+                        }
+                    ],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/{response.json()['id']}/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        prop = response.json()["filters"]["groups"][0]["properties"][0]
+        self.assertEqual(prop["key"], "$group_key")
+        self.assertEqual(
+            prop["group_key_names"],
+            {"org-uuid-1": "Acme Corp", "org-uuid-2": "Widget Inc"},
         )
 
     def test_create_feature_flag_in_specific_folder(self):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5627,6 +5627,7 @@ class GroupPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    group_key_names: dict[str, str] | None = None
     group_type_index: int | None = None
     key: str
     label: str | None = None

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -228,7 +228,14 @@ export const GroupPropertyFilterApiType = {
     Group: 'group',
 } as const
 
+/**
+ * @nullable
+ */
+export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null | null
+
 export interface GroupPropertyFilterApi {
+    /** @nullable */
+    group_key_names?: GroupPropertyFilterApiGroupKeyNames
     /** @nullable */
     group_type_index?: number | null
     key: string


### PR DESCRIPTION
## Problem

When setting up feature flag release conditions for a group (e.g., "organization"), the initial property filter popup shows a searchable list of groups by name. After selecting one, the match filter becomes `$group_key equals <uuid>`. To add more groups, the "Add value" input only shows raw UUIDs with no name search — users have to know the group key to add additional groups. The workaround is adding a separate condition set per group, which is clunky.

Root cause: `PropertyValue` used a generic property values endpoint (`groups/property_values?key=$group_key`) that queries ClickHouse's `group_properties` JSON — but `$group_key` is a separate column, not inside `group_properties`, so the endpoint returns nothing useful.

## Changes

- Add a `GroupKeySelect` component that fetches from the Groups list API, displays group names via `groupDisplayId()`, and stores group keys as filter values
- Wire it into `PropertyValue` as a special case following the existing assignee pattern
- No backend changes needed — the existing Groups API already supports search by name

## How did you test this code?

Unit tests in `GroupKeySelect.test.tsx` covering:
- Dropdown shows group names, not UUIDs
- Selecting a group stores the group_key (UUID) as the value
- Existing UUID values resolve to display names
- Read-only mode
- Multi-select with `IsOneOf` operator
- Fallback for groups without a `name` property

Manual testing steps:
1. Create a group-based feature flag ("Match by: Group")
2. Add a release condition, select a group by name from the "Organizations" list
3. Click "Add value" — verify the dropdown shows group names and supports search
4. Select another group — verify it stores correctly as a second value
5. Reload the page — verify existing values show group names, not UUIDs

## Publish to changelog?

no