### PR TITLE
feat: add server-side timing breakdown to query responses

### DIFF
--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -23,6 +23,9 @@ export interface TimeToSeeDataPayload {
     max_last_refresh?: string | null
     // Signifies whether the action was user-initiated or a secondary effect
     is_primary_interaction?: boolean
+    // Server-side timing breakdown
+    server_total_ms?: number
+    server_serialize_ms?: number
 }
 
 export function currentSessionId(): string | undefined {

--- a/frontend/src/scenes/insights/insightDataTimingLogic.ts
+++ b/frontend/src/scenes/insights/insightDataTimingLogic.ts
@@ -70,6 +70,8 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
                 // api_url: values.response?.apiUrl,
                 insight: values.query.kind,
                 is_primary_interaction: true,
+                server_total_ms: values.response?.server_total_ms,
+                server_serialize_ms: values.response?.server_serialize_ms,
             })
 
             actions.removeQuery(payload.queryId)

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -1,4 +1,5 @@
 import re
+from time import perf_counter
 
 from django.core.cache import cache
 from django.http import JsonResponse, StreamingHttpResponse
@@ -133,6 +134,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     )
     @monitor(feature=Feature.QUERY, endpoint="query", method="POST")
     def create(self, request: Request, *args, **kwargs) -> Response:
+        request_start = perf_counter()
         upgraded_query = upgrade(request.data)
         data = self.get_model(upgraded_query, QueryRequest)
         try:
@@ -164,8 +166,14 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 limit_context=limit_context,
                 request=request,
             )
+            serialize_start = perf_counter()
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)
+            serialize_ms = round((perf_counter() - serialize_start) * 1000, 2)
+            total_ms = round((perf_counter() - request_start) * 1000, 2)
+            result["server_total_ms"] = total_ms
+            result["server_serialize_ms"] = serialize_ms
+
             response_status = (
                 status.HTTP_202_ACCEPTED
                 if result.get("query_status") and result["query_status"].get("complete") is False


### PR DESCRIPTION
## Problem

Cache-hit insight loads show p90 of **4.7s** on the frontend (`time_to_see_data_ms`), but the backend `response_time_ms` is only **130ms**. The ~4.5s gap is unaccounted for — it could be `model_dump()` serialization, DRF JSON rendering, network transfer, or browser parsing. We have no way to tell because:

- `response_time_ms` stops timing before `model_dump()` and DRF serialization
- `time_to_see_data_ms` is measured on the frontend and includes everything
- There's no metric for full server-side response time filtered to cache hits

## Changes

Injects two timing fields into the query response body:

| Field | What it measures |
|---|---|
| `server_total_ms` | From request handler entry → response ready (includes query execution + serialization) |
| `server_serialize_ms` | Just the `model_dump(by_alias=True)` call |

These get forwarded into the `time to see data` event, enabling:

```sql
-- Break down where time is spent for cache hits
SELECT
    quantile(0.90)(toFloat(properties.server_total_ms)) AS server_p90,
    quantile(0.90)(toFloat(properties.server_serialize_ms)) AS serialize_p90,
    quantile(0.90)(toFloat(properties.time_to_see_data_ms) - toFloat(properties.server_total_ms)) AS network_browser_p90
FROM events
WHERE event = 'time to see data'
    AND properties.type = 'insight_load'
    AND toFloat(properties.insights_fetched_cached) = toFloat(properties.insights_fetched)
```

## How did you test this code?

I'm an agent and haven't tested this manually. The change is minimal instrumentation — `perf_counter()` timing around existing code paths with no behavioral changes. Verification plan:

- Load an insight, verify `server_total_ms` and `server_serialize_ms` appear in the response JSON
- Verify `time to see data` event in PostHog includes both new properties
- After a day of data collection, run the query above to identify the latency bottleneck

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. This came out of an investigation into why cache-hit load times are 4-5s at p90 and climbing. We traced the full code path, compared backend vs frontend timing metrics, and identified a gap in observability between `response_time_ms` (partial backend) and `time_to_see_data_ms` (full frontend). This PR closes that gap.