### PR TITLE
feat: add network timing breakdown to time-to-see-data events

### DIFF
--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -23,6 +23,9 @@ export interface TimeToSeeDataPayload {
     max_last_refresh?: string | null
     // Signifies whether the action was user-initiated or a secondary effect
     is_primary_interaction?: boolean
+    // Network timing breakdown from Resource Timing API
+    ttfb_ms?: number
+    download_ms?: number
 }
 
 export function currentSessionId(): string | undefined {

--- a/frontend/src/scenes/insights/insightDataTimingLogic.ts
+++ b/frontend/src/scenes/insights/insightDataTimingLogic.ts
@@ -10,6 +10,25 @@ import { InsightLogicProps } from '~/types'
 import type { insightDataTimingLogicType } from './insightDataTimingLogicType'
 import { keyForInsightLogicProps } from './sharedUtils'
 
+function getQueryResourceTiming(): {
+    ttfb_ms?: number
+    download_ms?: number
+    api_response_bytes?: number
+} {
+    const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[]
+    for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i]
+        if (entry.name.includes('/api/') && entry.name.includes('query') && entry.responseStart > 0) {
+            return {
+                ttfb_ms: Math.round(entry.responseStart - entry.requestStart),
+                download_ms: Math.round(entry.responseEnd - entry.responseStart),
+                api_response_bytes: entry.transferSize || undefined,
+            }
+        }
+    }
+    return {}
+}
+
 export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
@@ -70,6 +89,7 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
                 // api_url: values.response?.apiUrl,
                 insight: values.query.kind,
                 is_primary_interaction: true,
+                ...getQueryResourceTiming(),
             })
 
             actions.removeQuery(payload.queryId)


### PR DESCRIPTION
## Problem

Cache-hit insight loads show p90 of **4.7s** on the frontend (`time_to_see_data_ms`), but the backend `response_time_ms` is only **130ms**. The ~4.5s gap is unaccounted for — we can't tell if it's network transfer time (large payloads), browser JSON parsing, or frontend processing.

## Changes

Uses the browser's Resource Timing API to capture network timing for query requests and includes them in `time to see data` events:

- `ttfb_ms` — time to first byte (server processing + network latency)
- `download_ms` — response body transfer time (correlates with payload size)
- `api_response_bytes` — response size via `transferSize`

No backend changes — all timing comes from the browser's built-in performance instrumentation.

## How did you test this code?

I'm an agent and haven't tested this manually. The Resource Timing API is a standard browser API (`PerformanceResourceTiming`). The change reads from `performance.getEntriesByType('resource')` and spreads the values into the existing event payload.

- [ ] Load a cached insight, verify `ttfb_ms`, `download_ms`, and `api_response_bytes` appear in the `time to see data` event
- [ ] After data collection, run:

```sql
SELECT
    quantile(0.90)(toFloat(properties.ttfb_ms)) AS ttfb_p90,
    quantile(0.90)(toFloat(properties.download_ms)) AS download_p90,
    quantile(0.90)(toFloat(properties.api_response_bytes)) AS bytes_p90,
    quantile(0.90)(toFloat(properties.time_to_see_data_ms)) AS total_p90
FROM events
WHERE event = 'time to see data'
    AND properties.type = 'insight_load'
    AND toFloat(properties.insights_fetched_cached) = toFloat(properties.insights_fetched)
    AND properties.ttfb_ms != ''
```

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. This came out of investigating why cache-hit load times are 4-5s at p90 and climbing, while backend response time is only 130ms. We need these metrics to identify whether the bottleneck is network transfer (large payloads) or frontend processing.