### PR TITLE
chore: add query api response event 

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -184,7 +184,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                         "response_bytes": response_bytes,
                         "client_query_id": client_query_id,
                     },
-                    user=request.user if hasattr(request.user, "distinct_id") else None,
+                    user=request.user if isinstance(request.user, User) else None,
                     team=self.team,
                     organization=self.team.organization,
                     request=request,

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -172,22 +172,25 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 result = result.model_dump(by_alias=True)
 
             total_time_ms = round((perf_counter() - start_time) * 1000, 2)
-            response_bytes = len(orjson.dumps(result))
-            report_user_or_team_action(
-                "query api response",
-                {
-                    "query_type": getattr(query, "kind", "Other"),
-                    "is_cached": result.get("is_cached", False),
-                    "execution_mode": execution_mode.value,
-                    "total_time_ms": total_time_ms,
-                    "response_bytes": response_bytes,
-                    "client_query_id": client_query_id,
-                },
-                user=request.user if hasattr(request.user, "distinct_id") else None,
-                team=self.team,
-                organization=self.team.organization,
-                request=request,
-            )
+            try:
+                response_bytes = len(orjson.dumps(result))
+                report_user_or_team_action(
+                    "query api response",
+                    {
+                        "query_type": getattr(query, "kind", "Other"),
+                        "is_cached": result.get("is_cached", False),
+                        "execution_mode": execution_mode.value,
+                        "total_time_ms": total_time_ms,
+                        "response_bytes": response_bytes,
+                        "client_query_id": client_query_id,
+                    },
+                    user=request.user if hasattr(request.user, "distinct_id") else None,
+                    team=self.team,
+                    organization=self.team.organization,
+                    request=request,
+                )
+            except Exception:
+                pass
 
             response_status = (
                 status.HTTP_202_ACCEPTED

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -1,8 +1,10 @@
 import re
+from time import perf_counter
 
 from django.core.cache import cache
 from django.http import JsonResponse, StreamingHttpResponse
 
+import orjson
 from drf_spectacular.utils import OpenApiResponse
 from pydantic import BaseModel
 from rest_framework import status, viewsets
@@ -37,6 +39,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
+from posthog.event_usage import report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters, apply_dashboard_variables
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -133,6 +136,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     )
     @monitor(feature=Feature.QUERY, endpoint="query", method="POST")
     def create(self, request: Request, *args, **kwargs) -> Response:
+        start_time = perf_counter()
         upgraded_query = upgrade(request.data)
         data = self.get_model(upgraded_query, QueryRequest)
         try:
@@ -166,6 +170,25 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)
+
+            total_time_ms = round((perf_counter() - start_time) * 1000, 2)
+            response_bytes = len(orjson.dumps(result))
+            report_user_or_team_action(
+                "query api response",
+                {
+                    "query_type": getattr(query, "kind", "Other"),
+                    "is_cached": result.get("is_cached", False),
+                    "execution_mode": execution_mode.value,
+                    "total_time_ms": total_time_ms,
+                    "response_bytes": response_bytes,
+                    "client_query_id": client_query_id,
+                },
+                user=request.user if hasattr(request.user, "distinct_id") else None,
+                team=self.team,
+                organization=self.team.organization,
+                request=request,
+            )
+
             response_status = (
                 status.HTTP_202_ACCEPTED
                 if result.get("query_status") and result["query_status"].get("complete") is False


### PR DESCRIPTION
## Problem

Cache-hit insight loads show p90 of 4.7s on the frontend (`time_to_see_data_ms`) and an upward trend over the past 90 days. 

<img width="1509" height="708" alt="Screenshot 2026-03-05 at 8 41 14 PM" src="https://github.com/user-attachments/assets/87ce8850-01ef-4aa1-a269-6ab028420174" />
https://us.posthog.com/project/2/insights/YwHuJ0h8

Contour metrics don't discriminate based on if the insight was cached or not so we have no way of telling if the time is mostly attributed to the server or frontend. 

## Changes

Adds a `query api response` PostHog event in the query API endpoint.

## How did you test this code?
n/a
