### PR TITLE
chore(personhog): create context documents within codebase

### DIFF
--- a/rust/personhog-common/README.md
+++ b/rust/personhog-common/README.md
@@ -4,7 +4,7 @@ A living document to provide context around the architecture of the Personhog cl
 
 This document lays out the overall cluster architecture and defines the responsibilities of each piece of the architecture. It should avoid getting into the implementation details of the different services.
 
-Context for the implementation details and current state of each piece should live in the README.md in the root of the respective service's folder, e.g more context on personhog-replica will live at posthog/rust/personhog-replica/README.md
+Context for the implementation details and current state of each service lives in the README.md in the root of the respective service's folder, e.g more context on personhog-replica lives at posthog/rust/personhog-replica/README.md
 
 ## Personhog Cluster
 
@@ -59,9 +59,9 @@ graph TB
 ### Coordinator + Metadata store
 
 - responsible for handling vNode ownership:
-- implements a handoff protocol that will facilitate the following system changes:
+- implements a handoff protocol that facilitates the following system changes:
 - N + 1 pods in system (scaling up)
 - N - 1 pods in system (scaling down)
 - N -> M pods (deployment handoff)
 - crashed pods/corrupted disks
-- ensures handoffs do not introduce split brain invariant or cause service interruptions amongst the multiple Actors in the distributed system
+- ensures handoffs do not introduce split brain invariant or cause service interruptions amongst the different actors in the distributed system

--- a/rust/personhog-common/README.md
+++ b/rust/personhog-common/README.md
@@ -1,0 +1,67 @@
+# Personhog Context Document
+
+A living document to provide context around the architecture of the Personhog cluster.
+
+This document lays out the overall cluster architecture and defines the responsibilities of each piece of the architecture. It should avoid getting into the implementation details of the different services.
+
+Context for the implementation details and current state of each piece should live in the README.md in the root of the respective service's folder, e.g more context on personhog-replica will live at posthog/rust/personhog-replica/README.md
+
+## Personhog Cluster
+
+The personhog cluster is composed of the following pieces:
+
+- personhog-router
+- personhog-replica
+- personhog-leader cluster
+- personhog-coordinator + metdata store
+
+Basic Architecture Diagram
+
+```mermaid
+---
+title: PersonHog Cluster
+---
+graph TB
+    C[Clients] --> R[Router]
+    R --> RP1[PersonHog Replica BE]
+    R --> L1[PersonHog Leader Cluster]
+ L1 --> PGP[(Durable Store Primary)]
+ RP1 --> PGR[(Durable Store Replica)]
+    L1 --> MS[(Metadata Store)]
+    R --> MS
+    COORD[Coordinator] --> MS
+
+```
+
+### Router/Frontend (FE)
+
+- responsible for routing requests to the correct personhog pod
+- serves as a single entry point into all things person/personhog
+- no state or dependencies are needed for the router to route a request to a personhog-replica pod
+- stateful/protocol enabled routing to decide which personhog-leader pod should serve an incoming request
+
+### Personhog-replica Backend (BE)
+
+- responsible for handling eventually consistent person reads, strong reads and writes to non-cached tables
+- isolates all the simple data access patterns from the stateful personhog-leader BE
+- gRPC service
+- creates a request path that is cheaper and easier to scale/operate for clients that don't need strong consistent reads/writes to the cached tables on personhog-leader BEs
+
+### Personhog-leader Backend Cluster
+
+- responsible for providing a more efficient, but durable write path for data in the persons table
+- serves requests that need strong consistent reads/writes against data in the persons table
+- stateful API that caches person data on it
+- cached data allows for incredibly fast/efficient person writes; we can only update properties that have actually changed on the person rather than re-writing the entire person row
+- distribute cache across pods using a virtual node (vNode) schem to minimize shuffling needed to be done when the number of pods in the system changes
+- provides durability for the single point of failure caches on pods through a distributed changelog that gets sinked into a durable store
+
+### Coordinator + Metadata store
+
+- responsible for handling vNode ownership:
+- implements a handoff protocol that will facilitate the following system changes:
+- N + 1 pods in system (scaling up)
+- N - 1 pods in system (scaling down)
+- N -> M pods (deployment handoff)
+- crashed pods/corrupted disks
+- ensures handoffs do not introduce split brain invariant or cause service interruptions amongst the multiple Actors in the distributed system

--- a/rust/personhog-leader/README.md
+++ b/rust/personhog-leader/README.md
@@ -55,6 +55,8 @@ TBD:
 
 #### vNode ownership
 
+TBD
+
 #### Request Path
 
 ```mermaid
@@ -65,10 +67,10 @@ graph TB
         direction TB
         PARSE[Parse request] --> DECIDE{Consistent Read/Write?}
         DECIDE -->|"Yes"| HASH["Hash person_id → vnode"]
-        HASH --> LOOKUP["Lookup vnode → pod(from metadata store cache)"]
+        HASH --> WATCH["Lookup vnode → pod(from metadata store cache)"]
     end
 
-    LOOKUP -->|"cache miss"| MS[(Metadata Store)]
+    WATCH -->|"handoff"| MS[(Metadata Store)]
     MS -->|"vnode assignments"| LOOKUP
 
     LOOKUP --> POD

--- a/rust/personhog-leader/README.md
+++ b/rust/personhog-leader/README.md
@@ -1,0 +1,57 @@
+## personhog-leader cluster
+
+### Requirements
+
+- provides API contract allowing strong consistent reads/writes to person state
+- enables faster/more efficient writes to person properties than writing directly to Postgres
+- durably stores any write that a personhog client has received a status OK for
+- new service versions can be deployed without service disruptions or inconsistent writes
+- pods can scale up and down without service disruptions or inconsistent writes
+- crashed pods can be recovered from with minimal downtime
+
+### To Implement
+
+### Known Implementation Details
+
+```mermaid
+---
+title: PersonHog Leader Cluster
+---
+graph TB
+    subgraph P[Leader Pod]
+        C1[vNode Cache]
+    end
+
+    P -->|produce merged state| K[(Kafka person_state topic)]
+
+    K -.->|"consume from O_pg_writer (cache warm)"| P
+
+    K -->|consume + batch| PGW[Postgres Writer Service]
+    PGW -->|idempotent upsert| PG[(PostgreSQL)]
+
+```
+
+#### Efficient Writes
+
+- stateful API that caches person data on pods
+- API can receive a list of property updates and only update/writes the changed property fields, doesn't replace the entire property field
+
+TODOS:
+
+- what technology to use for the cache? how does a pod recover from a crash/restore its cache? how long does that take? does every pod crash result in service disruption? for how long?
+
+#### Durability
+
+- with writes going to the cache, the head of application state now lives in the cache (single point of failure), not in Postgres (durable store). we need durability
+- after each person write to the cache and before we ack to client, we emit a message to kafka (acting as a distributed log)
+- the head of our application state can always be materialized through replaying Kafka messages onto the outdated PG state
+- a separate PG writer service consumes messages from the kafka topic and batch write to PG
+- maintains a committed offset per partition, i.e. O_pg_writer(P)
+- this offset is the boundary:
+- below the offset: state is durably in Postgres
+- at or above the offset: state is PG + the changes in our distributed log (the kafka topic)
+- new pods can warm their caches/materialize state by seeding from PG then applying messages from kafka changelog past the indicated offset O_pg_writer(P)
+
+#### vNode assignment/ownership/handoff supporting deployments, scaling, irrecoverable pod crashes
+
+<TODO>

--- a/rust/personhog-leader/README.md
+++ b/rust/personhog-leader/README.md
@@ -36,7 +36,7 @@ graph TB
 - stateful API that caches person data on pods
 - API can receive a list of property updates and only update/writes the changed property fields, doesn't replace the entire property field
 
-TODOS:
+TBD:
 
 - what technology to use for the cache? how does a pod recover from a crash/restore its cache? how long does that take? does every pod crash result in service disruption? for how long?
 
@@ -50,8 +50,36 @@ TODOS:
 - this offset is the boundary:
 - below the offset: state is durably in Postgres
 - at or above the offset: state is PG + the changes in our distributed log (the kafka topic)
-- new pods can warm their caches/materialize state by seeding from PG then applying messages from kafka changelog past the indicated offset O_pg_writer(P)
+TBD:
+- new pods can warm their caches/materialize state by seeding from PG then applying messages from kafka changelog past the indicated offset O_pg_writer(P) (could change depending on caching/embedded store choice)
 
-#### vNode assignment/ownership/handoff supporting deployments, scaling, irrecoverable pod crashes
+#### vNode ownership
 
-<TODO>
+#### Request Path
+
+```mermaid
+graph TB
+    C[Client] -->|"UPDATE /persons/<id>"| R
+
+    subgraph R[Router]
+        direction TB
+        PARSE[Parse request] --> DECIDE{Consistent Read/Write?}
+        DECIDE -->|"Yes"| HASH["Hash person_id → vnode"]
+        HASH --> LOOKUP["Lookup vnode → pod(from metadata store cache)"]
+    end
+
+    LOOKUP -->|"cache miss"| MS[(Metadata Store)]
+    MS -->|"vnode assignments"| LOOKUP
+
+    LOOKUP --> POD
+
+    subgraph POD[PersonHog Leader BE]
+        direction TB
+        VALIDATE[Validate ownership] --> COMPUTE[Compute write]
+        COMPUTE --> CACHE[Update in-memory cache]
+        CACHE --> KAFKA[Durably store to Kafka]
+    end
+
+    KAFKA --> ACK[Ack to client]
+
+```

--- a/rust/personhog-replica/README.md
+++ b/rust/personhog-replica/README.md
@@ -1,0 +1,29 @@
+### personhog-replica cluster
+
+### Requirements
+
+- provides an API contract for eventual person reads, strong reads to non-persons tables, writes to non-persons tables
+- provides a cheap, quickly scalable, operationally simple request path for simple data access patterns
+- gRPC service
+
+### Known Implementation Details
+
+```mermaid
+---
+title: PersonHog Replica Read Path
+---
+graph TB
+    C[Client] -->|"GET /persons?..."| R
+
+    subgraph R[Router]
+        direction TB
+        PARSE[Parse request] --> DECIDE{Consistent Read/Write?}
+        DECIDE -->|"Yes"| LEADER[Route to Leader BE]
+        DECIDE -->|"No"| REPLICA[Route to Replica BE]
+    end
+
+    REPLICA --> RP1[PersonHog Replica BE]
+
+    RP1 -->|query| PG[(Durable Store Replica)]
+    RP1 -->|response| C
+```

--- a/rust/personhog-router/README.md
+++ b/rust/personhog-router/README.md
@@ -18,8 +18,6 @@
 
 ### Implementation Details
 
-This section can chunk out any major portions/complicated implementations of the service into sections and provide relevant context. As a simple example:
-
 #### personhog-replica routing
 
 Routing decisions are made per-request in `src/router/routing.rs` based on two dimensions:
@@ -35,3 +33,7 @@ Person data (person, persondistinctid) checks the `ConsistencyLevel` on the requ
 - `EVENTUAL` or unset → routes to personhog-replica
 - `STRONG` → returns `UNIMPLEMENTED` (requires personhog-leader)
 - Writes → returns `UNIMPLEMENTED` (requires personhog-leader)
+
+#### personhog-leader routing
+
+TBD

--- a/rust/personhog-router/README.md
+++ b/rust/personhog-router/README.md
@@ -1,0 +1,37 @@
+### personhog-router context
+
+### Requirements
+
+- defines the API contract for all external personhog clients to consume
+- provides a stateless/dependency-less routing path to personhog-replica pods
+- participates in the handoff protocol to ensure requests are correctly and efficiently routed to personhog-leader pods
+- scales horizontally through k8s
+- accepts protobuf requests
+- sends protobuf requests to respective BEs
+
+### To Implement
+
+- routers participate in handoff protocol/have vNode ownership awareness
+- consistently/correctly/efficiently route requests to personhog-leader pods
+- personhog-leader client installed on service to consume personhog-leader API
+- define API contract that allows clients to consume strongly consistent/write to person state (consume personhog-leader BE capabilities)
+
+### Implementation Details
+
+This section can chunk out any major portions/complicated implementations of the service into sections and provide relevant context. As a simple example:
+
+#### personhog-replica routing
+
+Routing decisions are made per-request in `src/router/routing.rs` based on two dimensions:
+the data category and the consistency level from the request's `ReadOptions`.
+
+Non-person data (hash key overrides, cohort membership, groups, group type mappings)
+always routes to personhog-replica regardless of consistency level or operation type.
+The replica service handles strong vs eventual consistency internally
+by choosing the appropriate Postgres pool.
+
+Person data (person, persondistinctid) checks the `ConsistencyLevel` on the request:
+
+- `EVENTUAL` or unset → routes to personhog-replica
+- `STRONG` → returns `UNIMPLEMENTED` (requires personhog-leader)
+- Writes → returns `UNIMPLEMENTED` (requires personhog-leader)


### PR DESCRIPTION
## Problem

Personhog cluster has quite a few different components that interact. Managing the context of how all these pieces fit together will be important during development. 

## Changes

Adds "living documents" to each of the personhog service directories to document context around architectural decisions and implementation details.

## How did you test this code?

It's all documentation
