### PR TITLE
fix: don't use Actions step output in scripts

### DIFF
--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -47,9 +47,12 @@ jobs:
               if: steps.changed-files.outputs.parser_any_changed == 'true' && steps.check-package-version.outputs.is-new-version == 'false'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  COMMITTED_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+                  FORK_MESSAGE: ${{ github.event.pull_request.head.repo.full_name != 'PostHog/posthog' && '\nThis needs to be performed on a branch created on the PostHog/posthog repo itself. A PostHog team member will assist with this.' || '' }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
-                  message_body="It looks like the code of \`@posthog/hogql-parser\` (npm) has changed since last push, but its version stayed the same at ${{ steps.check-package-version.outputs.committed-version }}. 👀\nMake sure to resolve this in \`common/hogql_parser/package.json\` before merging!${{ github.event.pull_request.head.repo.full_name != 'PostHog/posthog' && '\nThis needs to be performed on a branch created on the PostHog/posthog repo itself. A PostHog team member will assist with this.' || ''}}"
-                  gh pr comment ${{ github.event.pull_request.number }} --body "$message_body"
+                  message_body="It looks like the code of \`@posthog/hogql-parser\` (npm) has changed since last push, but its version stayed the same at $COMMITTED_VERSION. 👀\nMake sure to resolve this in \`common/hogql_parser/package.json\` before merging!$FORK_MESSAGE"
+                  gh pr comment "$PR_NUMBER" --body "$message_body"
 
     build-wasm:
         name: Build WASM

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -40,16 +40,19 @@ jobs:
               id: version
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PARSER_CHANGED: ${{ steps.changed-files.outputs.parser_any_changed }}
+                  FORK_MESSAGE: ${{ github.event.pull_request.head.repo.full_name != 'PostHog/posthog' && '\nThis needs to be performed on a branch created on the PostHog/posthog repo itself. A PostHog team member will assist with this.' || '' }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
                   parser_release_needed='false'
-                  if [[ ${{ steps.changed-files.outputs.parser_any_changed }} == 'true' ]]; then
+                  if [[ "$PARSER_CHANGED" == 'true' ]]; then
                     published=$(curl -fSsl https://pypi.org/pypi/hogql-parser/json | jq -r '.info.version')
                     local=$(python common/hogql_parser/setup.py --version)
                     if [[ "$published" != "$local" ]]; then
                       parser_release_needed='true'
                     else
-                      message_body="It looks like the code of \`hogql-parser\` has changed since last push, but its version stayed the same at $local. 👀\nMake sure to resolve this in \`hogql_parser/setup.py\` before merging!${{ github.event.pull_request.head.repo.full_name != 'PostHog/posthog' && '\nThis needs to be performed on a branch created on the PostHog/posthog repo itself. A PostHog team member will assist with this.' || ''}}"
-                      gh pr comment ${{ github.event.pull_request.number }} --body "$message_body"
+                      message_body="It looks like the code of \`hogql-parser\` has changed since last push, but its version stayed the same at $local. 👀\nMake sure to resolve this in \`hogql_parser/setup.py\` before merging!$FORK_MESSAGE"
+                      gh pr comment "$PR_NUMBER" --body "$message_body"
                     fi
                   fi
                   echo "parser-release-needed=$parser_release_needed" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -204,10 +204,11 @@ jobs:
             - name: Create versioned release
               env:
                   GH_TOKEN: ${{ github.token }}
+                  RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
-                  gh release create "${{ steps.version.outputs.tag }}" \
+                  gh release create "$RELEASE_TAG" \
                       products/posthog_ai/dist/skills.zip \
-                      --title "Agent skills ${{ steps.version.outputs.tag }}" \
+                      --title "Agent skills $RELEASE_TAG" \
                       --notes "Build from ${{ github.sha }}" \
                       --target "${{ github.sha }}" \
                       --latest=false
@@ -215,17 +216,18 @@ jobs:
             - name: Update latest release
               env:
                   GH_TOKEN: ${{ github.token }}
+                  RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
                   if gh release view agent-skills-latest &>/dev/null; then
                       gh release upload agent-skills-latest \
                           products/posthog_ai/dist/skills.zip --clobber
                       gh release edit agent-skills-latest \
-                          --notes "Latest build — same as ${{ steps.version.outputs.tag }}"
+                          --notes "Latest build — same as $RELEASE_TAG"
                   else
                       gh release create agent-skills-latest \
                           products/posthog_ai/dist/skills.zip \
                           --title "Agent skills (Latest)" \
-                          --notes "Latest build — same as ${{ steps.version.outputs.tag }}" \
+                          --notes "Latest build — same as $RELEASE_TAG" \
                           --target "${{ github.sha }}" \
                           --latest=false
                   fi

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -90,8 +90,9 @@ jobs:
             - name: Download timing artifacts
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  RUN_ID: ${{ steps.find-run.outputs.run_id }}
               run: |
-                  gh run download ${{ steps.find-run.outputs.run_id }} --pattern "timing_data-*" --dir timing_artifacts
+                  gh run download "$RUN_ID" --pattern "timing_data-*" --dir timing_artifacts
 
             - name: Process timing data
               run: |

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -545,10 +545,12 @@ jobs:
 
             - name: Write report URL to job summary
               if: always() && steps.cf-deploy.outputs.deployment-url != ''
+              env:
+                  DEPLOYMENT_URL: ${{ steps.cf-deploy.outputs.deployment-url }}
               run: |
                   echo "## 🎭 Playwright report" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Report URL:** ${{ steps.cf-deploy.outputs.deployment-url }}" >> $GITHUB_STEP_SUMMARY
+                  echo "**Report URL:** $DEPLOYMENT_URL" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "- Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
@@ -556,12 +558,14 @@ jobs:
             - name: Upsert report URL comment on PR
               if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  DEPLOYMENT_URL: ${{ steps.cf-deploy.outputs.deployment-url }}
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       const fs = require('fs');
                       const marker = '<!-- playwright-report-comment -->';
-                      const reportUrl = '${{ steps.cf-deploy.outputs.deployment-url }}';
+                      const reportUrl = process.env.DEPLOYMENT_URL;
                       const jobPassed = '${{ job.status }}' === 'success';
 
                       // Collect failed and flaky tests from JSON report — only populated when

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -57,6 +57,8 @@ jobs:
             - name: Check for preview label
               id: check-label
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  HOBBY_CHANGED: ${{ steps.filter.outputs.hobby }}
               with:
                   script: |
                       const labels = context.payload.pull_request.labels || [];
@@ -66,7 +68,7 @@ jobs:
                       const labelRemoved = context.payload.action === 'unlabeled' &&
                           context.payload.label?.name?.toLowerCase() === 'hobby-preview';
 
-                      console.log(`hobby-preview label: ${hasLabel}, label removed: ${labelRemoved}, hobby files changed: ${{ steps.filter.outputs.hobby }}`);
+                      console.log(`hobby-preview label: ${hasLabel}, label removed: ${labelRemoved}, hobby files changed: ${process.env.HOBBY_CHANGED}`);
                       core.setOutput('has_label', hasLabel.toString());
                       core.setOutput('label_removed', labelRemoved.toString());
 
@@ -121,10 +123,12 @@ jobs:
               id: post-comment
               if: steps.check-preview.outputs.preview == 'true'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  PREVIEW_MODE: ${{ steps.check-preview.outputs.preview }}
               with:
                   script: |
                       const commentMarker = '<!-- hobby-ci-comment -->';
-                      const previewMode = '${{ steps.check-preview.outputs.preview }}' === 'true';
+                      const previewMode = process.env.PREVIEW_MODE === 'true';
 
                       // Find existing comment to update (in case of workflow retry)
                       const { data: comments } = await github.rest.issues.listComments({
@@ -225,11 +229,14 @@ jobs:
             - name: Update comment - Docker build failed
               if: always() && steps.check-preview.outputs.preview == 'true' && steps.wait-for-image.outputs.conclusion != 'success'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  COMMENT_ID: ${{ steps.post-comment.outputs.comment-id }}
+                  BUILD_CONCLUSION: ${{ steps.wait-for-image.outputs.conclusion }}
               with:
                   script: |
                       const commentMarker = '<!-- hobby-ci-comment -->';
-                      const commentId = '${{ steps.post-comment.outputs.comment-id }}';
-                      const buildConclusion = '${{ steps.wait-for-image.outputs.conclusion }}';
+                      const commentId = process.env.COMMENT_ID;
+                      const buildConclusion = process.env.BUILD_CONCLUSION;
 
                       const errorBody = `${commentMarker}
                       ## 🦔 Preview instance
@@ -255,8 +262,10 @@ jobs:
                           body: errorBody,
                       });
             - name: Check Docker image build result
+              env:
+                  BUILD_CONCLUSION: ${{ steps.wait-for-image.outputs.conclusion }}
               run: |
-                  conclusion="${{ steps.wait-for-image.outputs.conclusion }}"
+                  conclusion="$BUILD_CONCLUSION"
                   if [ "$conclusion" = "skipped" ]; then
                     echo "Docker image build skipped"
                     exit 0
@@ -267,11 +276,14 @@ jobs:
             - name: Update comment - Docker image ready
               if: steps.check-preview.outputs.preview == 'true' && steps.wait-for-image.outputs.conclusion == 'success'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  COMMENT_ID: ${{ steps.post-comment.outputs.comment-id }}
+                  PREVIEW_MODE: ${{ steps.check-preview.outputs.preview }}
               with:
                   script: |
                       const commentMarker = '<!-- hobby-ci-comment -->';
-                      const commentId = '${{ steps.post-comment.outputs.comment-id }}';
-                      const previewMode = '${{ steps.check-preview.outputs.preview }}' === 'true';
+                      const commentId = process.env.COMMENT_ID;
+                      const previewMode = process.env.PREVIEW_MODE === 'true';
 
                       const updatedBody = `${commentMarker}
                       ## 🦔 Preview instance

--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -114,10 +114,13 @@ jobs:
 
             - name: Save Slack info to state
               if: steps.process.outputs.action == 'create'
+              env:
+                  SLACK_CHANNEL_ID: ${{ steps.slack_new.outputs.channel_id }}
+                  SLACK_TS: ${{ steps.slack_new.outputs.ts }}
               run: |
                   jq \
-                    --arg channel "${{ steps.slack_new.outputs.channel_id }}" \
-                    --arg ts "${{ steps.slack_new.outputs.ts }}" \
+                    --arg channel "$SLACK_CHANNEL_ID" \
+                    --arg ts "$SLACK_TS" \
                     '. + {channel: $channel, ts: $ts}' \
                     .master-ci-incident > .master-ci-incident.tmp
                   mv .master-ci-incident.tmp .master-ci-incident
@@ -185,8 +188,10 @@ jobs:
             - name: Calculate duration
               if: steps.process.outputs.resolved == 'true'
               id: duration
+              env:
+                  INCIDENT_SINCE: ${{ steps.process.outputs.since }}
               run: |
-                  since="${{ steps.process.outputs.since }}"
+                  since="$INCIDENT_SINCE"
                   now=$(date +%s)
                   then=$(date -d "$since" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$since" +%s 2>/dev/null || echo "$now")
                   mins=$(( (now - then) / 60 ))

--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -50,24 +50,29 @@ jobs:
 
             - name: Check for conflicting changes
               id: check
+              env:
+                  MIGRATIONS_CHANGED: ${{ steps.filter.outputs.migrations }}
+                  NODEJS_CHANGED: ${{ steps.filter.outputs.nodejs }}
+                  SQLX_MIGRATIONS_CHANGED: ${{ steps.filter.outputs.sqlx_migrations }}
+                  RUST_SERVICES_CHANGED: ${{ steps.rust-filter.outputs.rust_services }}
               run: |
                   has_error=false
                   error_messages=""
 
                   # Check nodejs + Django migrations
-                  if [ "${{ steps.filter.outputs.migrations }}" == "true" ] && [ "${{ steps.filter.outputs.nodejs }}" == "true" ]; then
+                  if [ "$MIGRATIONS_CHANGED" == "true" ] && [ "$NODEJS_CHANGED" == "true" ]; then
                       error_messages="${error_messages}❌ Found both Django migration and nodejs changes\n"
                       has_error=true
                   fi
 
                   # Check nodejs + sqlx migrations
-                  if [ "${{ steps.filter.outputs.sqlx_migrations }}" == "true" ] && [ "${{ steps.filter.outputs.nodejs }}" == "true" ]; then
+                  if [ "$SQLX_MIGRATIONS_CHANGED" == "true" ] && [ "$NODEJS_CHANGED" == "true" ]; then
                       error_messages="${error_messages}❌ Found both sqlx migration and nodejs changes\n"
                       has_error=true
                   fi
 
                   # Check rust services + sqlx migrations
-                  if [ "${{ steps.filter.outputs.sqlx_migrations }}" == "true" ] && [ "${{ steps.rust-filter.outputs.rust_services }}" == "true" ]; then
+                  if [ "$SQLX_MIGRATIONS_CHANGED" == "true" ] && [ "$RUST_SERVICES_CHANGED" == "true" ]; then
                       error_messages="${error_messages}❌ Found both sqlx migration and rust service changes\n"
                       has_error=true
                   fi

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -128,17 +128,20 @@ jobs:
                       COMMIT_HASH=${{ github.sha }}
 
             - name: Container image digest
+              env:
+                  IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+                  IMAGE_REGISTRY: ${{ steps.aws-ecr.outputs.registry }}
               run: |
-                  echo "Image digest: ${{ steps.build.outputs.digest }}"
-                  echo "Full image reference: $${{ steps.aws-ecr.outputs.registry }}/posthog-node:${{ github.sha }}@${{ steps.build.outputs.digest }}"
+                  echo "Image digest: $IMAGE_DIGEST"
+                  echo "Full image reference: $IMAGE_REGISTRY/posthog-node:${{ github.sha }}@$IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$${{ steps.aws-ecr.outputs.registry }}/posthog-node:${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-node:${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image SHA:** \`${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Digest: \`$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
 
             - name: Report failure
               if: failure()

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -245,13 +245,17 @@ jobs:
 
             - name: Fetch base branch for diff
               if: github.event_name == 'pull_request'
-              run: git fetch origin ${{ github.base_ref }} --depth=1
+              env:
+                  BASE_REF: ${{ github.base_ref }}
+              run: git fetch origin "$BASE_REF" --depth=1
 
             - name: Check for migrations in this PR
               id: check_migrations
               if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.base_ref }}
               run: |
-                  if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E '(migrations/|rust/.*migrate)'; then
+                  if git diff --name-only "origin/$BASE_REF..HEAD" | grep -E '(migrations/|rust/.*migrate)'; then
                     echo "has_migrations=true" >> $GITHUB_OUTPUT
                   else
                     echo "has_migrations=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -78,12 +78,14 @@ jobs:
                       ${{ runner.os }}-${{ env.ARCH }}-node-gyp-node-18-
 
             - name: Run Python and Node setup in parallel
+              env:
+                  UV_CACHE_HIT: ${{ steps.setup-uv.outputs.cache-hit }}
               run: |
                   set -e
                   set -m
 
                   (
-                    if [ "${{ steps.setup-uv.outputs.cache-hit }}" != "true" ]; then
+                    if [ "$UV_CACHE_HIT" != "true" ]; then
                       echo ">>> [Python] Installing SAML (python3-saml) dependencies..."
                       sudo apt-get update
                       sudo apt-get install -y libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -62,16 +62,19 @@ jobs:
                   no-cache: ${{ contains(github.event.pull_request.labels.*.name, 'no-depot-docker-cache') }}
 
             - name: Container image digest
+              env:
+                  IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+                  IMAGE_REGISTRY: ${{ steps.build.outputs.registry }}
               run: |
-                  echo "Image digest: ${{ steps.build.outputs.digest }}"
+                  echo "Image digest: $IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`${{ steps.build.outputs.registry }}/posthog-cloud@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-cloud@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image SHA:** \`${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Digest: \`$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
 
     deploy_preview:
         name: Deploy preview environment

--- a/.github/workflows/docs-preview-trigger.yml
+++ b/.github/workflows/docs-preview-trigger.yml
@@ -33,16 +33,21 @@ jobs:
             - name: Comment on PR
               if: github.event_name == 'pull_request'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  TRIGGER_STATUS: ${{ steps.trigger-build.outputs.trigger_status }}
+                  DEPLOYMENT_URL: ${{ steps.trigger-build.outputs.deployment_url }}
+                  DEPLOYMENT_ID: ${{ steps.trigger-build.outputs.deployment_id }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
               with:
                   script: |
                       const commentFn = require('./.github/scripts/comment-pr-preview.js');
                       await commentFn({
                         github,
                         context,
-                        prNumber: ${{ github.event.pull_request.number }},
-                        triggerStatus: "${{ steps.trigger-build.outputs.trigger_status }}",
-                        deploymentUrl: "${{ steps.trigger-build.outputs.deployment_url }}",
-                        deploymentId: "${{ steps.trigger-build.outputs.deployment_id }}"
+                        prNumber: parseInt(process.env.PR_NUMBER),
+                        triggerStatus: process.env.TRIGGER_STATUS,
+                        deploymentUrl: process.env.DEPLOYMENT_URL,
+                        deploymentId: process.env.DEPLOYMENT_ID
                       });
 
     validate-docs:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -58,13 +58,15 @@ jobs:
 
             - name: Cleanup GitHub deployments and environments
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  INPUT_PR_NUMBER: ${{ inputs.pr_number }}
               with:
                   script: |
                       const fs = require('fs');
 
                       // Collect PR numbers to clean up from either input or stale cleanup output
                       let prsToClean = [];
-                      const inputPr = '${{ inputs.pr_number }}';
+                      const inputPr = process.env.INPUT_PR_NUMBER || '';
 
                       if (inputPr) {
                           prsToClean = [inputPr];

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -71,10 +71,13 @@ jobs:
                             text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}>\nby ${{ steps.meta.outputs.author }}"
 
             - name: Save Slack message info
+              env:
+                  SLACK_CHANNEL_ID: ${{ steps.slack.outputs.channel_id }}
+                  SLACK_TS: ${{ steps.slack.outputs.ts }}
               run: |
                   echo '{}' | jq \
-                    --arg channel "${{ steps.slack.outputs.channel_id }}" \
-                    --arg ts "${{ steps.slack.outputs.ts }}" \
+                    --arg channel "$SLACK_CHANNEL_ID" \
+                    --arg ts "$SLACK_TS" \
                     '{channel: $channel, ts: $ts}' > .priority-review-slack
 
             - name: Cache Slack message info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,10 @@ jobs:
             # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
             # but also really annoying to build CI around when it needs secrets to work right.)
             - id: plan
+              env:
+                  DIST_COMMAND: ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }}
               run: |
-                  dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+                  dist $DIST_COMMAND --output-format=json > plan-dist-manifest.json
                   echo "dist ran successfully"
                   cat plan-dist-manifest.json
                   echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -179,9 +179,12 @@ jobs:
 
             - name: Container image digest
               id: digest
+              env:
+                  IMAGE_DIGEST: ${{ steps.docker_build.outputs.digest }}
+                  IMAGE_NAME: ${{ matrix.image }}
               run: |
-                  echo ${{ steps.docker_build.outputs.digest }}
-                  echo "${{matrix.image}}_digest=${{ steps.docker_build.outputs.digest }}" >> $GITHUB_OUTPUT
+                  echo "$IMAGE_DIGEST"
+                  echo "${IMAGE_NAME}_digest=$IMAGE_DIGEST" >> $GITHUB_OUTPUT
                   cat $GITHUB_OUTPUT
 
     deploy:

--- a/.semgrep/rules/github-actions-shell-injection.test.yaml
+++ b/.semgrep/rules/github-actions-shell-injection.test.yaml
@@ -1,0 +1,30 @@
+# Push Semgrep Docker Image
+name: docker
+
+on:
+    workflow_dispatch:
+        inputs:
+            message_to_print:
+                type: string
+                required: false
+    push:
+        branches:
+            - develop
+    pull_request:
+        paths-ignore:
+            - '**.md'
+
+jobs:
+    docker-build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Use steps output
+              # ruleid: github-actions-shell-injection
+              run: |
+                  echo "${{ steps.shell_command.outputs.some_value }}"
+
+            # ruleid: github-actions-shell-injection
+            - run: echo "${{ steps.shell_command.outputs.some_value || 'ok' }}"
+
+            # ok: github-actions-shell-injection
+            - run: echo "${{ steps.shell_command.outputs.some_value && 'ok' }}"

--- a/.semgrep/rules/github-actions-shell-injection.yaml
+++ b/.semgrep/rules/github-actions-shell-injection.yaml
@@ -1,0 +1,56 @@
+# this rule is an extention of semgrep's oss run-shell-injection rule.
+# step output checking was removed due to high false positive rate/noisiness.
+# however we prefer to be extra cautious and thus have added this check back.
+# see https://github.com/semgrep/semgrep-rules/pull/3602
+rules:
+    - id: github-actions-shell-injection
+      languages:
+          - yaml
+      message: 'Using a steps output in another `run:` or `script:` step could allow an attacker to inject their own
+          code into the runner. This would allow them to steal secrets and code. Step output can have arbitrary
+          user input and should be treated as untrusted. Instead, use an intermediate environment variable with
+          `env:` to store the data and use the environment variable in the `run:` script. Be sure to
+          use double-quotes the environment variable, like this: "$ENVVAR".'
+      metadata:
+          category: security
+          cwe:
+              - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          owasp:
+              - A01:2017 - Injection
+              - A03:2021 - Injection
+              - A05:2025 - Injection
+          references:
+              - https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+              - https://securitylab.github.com/research/github-actions-untrusted-input/
+          technology:
+              - github-actions
+          cwe2022-top25: true
+          cwe2021-top25: true
+          subcategory:
+              - vuln
+          likelihood: HIGH
+          impact: HIGH
+          confidence: HIGH
+      patterns:
+          - pattern-inside: 'steps: [...]'
+          - pattern-either:
+                - patterns:
+                      - pattern-inside: |
+                            - run: ...
+                              ...
+                      - pattern: 'run: $SHELL'
+                - patterns:
+                      - pattern-inside: |
+                            - script: ...
+                              ...
+                      - pattern: 'script: $SHELL'
+          - metavariable-pattern:
+                language: generic
+                metavariable: $SHELL
+                patterns:
+                    - pattern-either:
+                          - pattern: ${{ ... steps. ... .outputs ... }}
+                    # Exclude safe patterns where variable is only checked for truthiness (left of &&)
+                    # e.g., ${{ github.head_ref && 'literal' }} is safe - value not interpolated
+                    - pattern-not: ${{ ... steps. ... .outputs ... && ... }}
+      severity: ERROR


### PR DESCRIPTION
This poses a potential script/shell injection risk. We should store the step output in an environment variable first.

Semgrep's own rules originally scanned for this, but they [removed it](https://github.com/semgrep/semgrep-rules/pull/3602) due to high false positive rate. I prefer to be overly cautious with GitHub Actions, given how often they're used to compromise repos, so I'm adding it back via a custom rule.