### PR TITLE
fix(slack): Restore dev region email override for Slack testing

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -39,6 +39,7 @@ from posthog.temporal.ai.twig_slack_interactivity import TwigSlackInteractivityI
 from posthog.temporal.ai.twig_slack_mention import TwigSlackMentionWorkflow, TwigSlackMentionWorkflowInputs
 from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
+from posthog.utils import get_instance_region
 
 from ee.models.assistant import Conversation
 
@@ -232,6 +233,10 @@ def resolve_slack_user(
                 prefer_thread_message=True,
             )
             return None
+
+        if get_instance_region() == "DEV":
+            # Dev region override for testing on any workspace (for Slack review team)
+            slack_email = "twixes3d+slacktest@gmail.com"
 
         # Trust model: Slack signature validation proves the payload is authentic.
         # The email comes from Slack's `users.info` API via `users:read.email` scope, not from


### PR DESCRIPTION
## Problem

The dev region Slack email override was accidentally removed in #48910. This override redirects non-PostHog Slack users to a single test account in the DEV environment, which is needed for the Slack review team to test the app.

## Changes

Restore the `get_instance_region() == "DEV"` check in `resolve_slack_user()` that overrides `slack_email` to `twixes3d+slacktest@gmail.com` for dev region testing.

## Publish to changelog?

no