### PR TITLE
Fix/remove unused sql dashboard filters 49911

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.test.ts
@@ -1,0 +1,169 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { DataVisualizationLogicProps, dataVisualizationLogic } from '../../dataVisualizationLogic'
+import { variablesLogic } from './variablesLogic'
+
+const testKey = 'test-variables-logic'
+const dataNodeCollectionId = 'test-variables-collection'
+
+const makeQuery = (withVariable: boolean): DataVisualizationNode => ({
+    kind: NodeKind.DataVisualizationNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: withVariable
+            ? 'SELECT event FROM events WHERE properties.$browser = {variables.browser}'
+            : 'SELECT event FROM events',
+        ...(withVariable
+            ? {
+                  variables: {
+                      'var-browser-id': {
+                          variableId: 'var-browser-id',
+                          code_name: 'browser',
+                          value: undefined,
+                          isNull: false,
+                      },
+                  },
+              }
+            : {}),
+    },
+    display: ChartDisplayType.ActionsTable,
+})
+
+describe('variablesLogic', () => {
+    let dvLogic: ReturnType<typeof dataVisualizationLogic.build>
+    let varLogic: ReturnType<typeof variablesLogic.build>
+    let mockSetQuery: jest.Mock
+
+    beforeEach(() => {
+        initKeaTests()
+        mockSetQuery = jest.fn()
+    })
+
+    afterEach(() => {
+        varLogic?.unmount()
+        dvLogic?.unmount()
+    })
+
+    const mountLogics = (withVariable: boolean): void => {
+        const query = makeQuery(withVariable)
+        // dataVisualizationLogic must be mounted first — variablesLogic connects to it
+        dvLogic = dataVisualizationLogic({
+            key: testKey,
+            query,
+            dataNodeCollectionId,
+        } as DataVisualizationLogicProps)
+        dvLogic.mount()
+
+        varLogic = variablesLogic({
+            key: testKey,
+            readOnly: false,
+            sourceQuery: query,
+            setQuery: mockSetQuery,
+        })
+        varLogic.mount()
+    }
+
+    describe('bug fix: removing a variable from SQL should update the query', () => {
+        it('calls setQuery when _removeVariable is triggered', async () => {
+            mountLogics(true)
+
+            // Explicitly add the variable (simulates what propsChanged does when SQL has {variables.browser})
+            varLogic.actions._addVariable({ variableId: 'var-browser-id', code_name: 'browser' })
+
+            await expectLogic(varLogic).toMatchValues({
+                internalSelectedVariables: expect.arrayContaining([
+                    expect.objectContaining({ variableId: 'var-browser-id' }),
+                ]),
+            })
+
+            // Reset mock so we only capture the _removeVariable-triggered call
+            mockSetQuery.mockClear()
+
+            // Simulate propsChanged detecting variable is no longer in SQL → calls _removeVariable
+            varLogic.actions._removeVariable('var-browser-id')
+
+            await expectLogic(varLogic).toMatchValues({
+                internalSelectedVariables: [],
+            })
+
+            // THE KEY ASSERTION: setQuery must be called with empty variables.
+            // Before the fix: _removeVariable had no listener → setQuery never called → stale filter on dashboard
+            expect(mockSetQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    source: expect.objectContaining({
+                        variables: {},
+                    }),
+                })
+            )
+        })
+
+        it('does not crash when removing a variable that does not exist', async () => {
+            mountLogics(false)
+
+            // Should not throw even if the variable is not in internalSelectedVariables
+            expect(() => varLogic.actions._removeVariable('var-browser-id')).not.toThrow()
+        })
+
+        it('keeps other variables when only one is removed', async () => {
+            const queryWithTwoVars: DataVisualizationNode = {
+                kind: NodeKind.DataVisualizationNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: 'SELECT * FROM events WHERE a = {variables.browser} AND b = {variables.platform}',
+                    variables: {
+                        'var-browser-id': {
+                            variableId: 'var-browser-id',
+                            code_name: 'browser',
+                            value: undefined,
+                            isNull: false,
+                        },
+                        'var-platform-id': {
+                            variableId: 'var-platform-id',
+                            code_name: 'platform',
+                            value: undefined,
+                            isNull: false,
+                        },
+                    },
+                },
+                display: ChartDisplayType.ActionsTable,
+            }
+
+            dvLogic = dataVisualizationLogic({
+                key: testKey,
+                query: queryWithTwoVars,
+                dataNodeCollectionId,
+            } as DataVisualizationLogicProps)
+            dvLogic.mount()
+
+            varLogic = variablesLogic({
+                key: testKey,
+                readOnly: false,
+                sourceQuery: queryWithTwoVars,
+                setQuery: mockSetQuery,
+            })
+            varLogic.mount()
+
+            // Seed both variables
+            varLogic.actions._addVariable({ variableId: 'var-browser-id', code_name: 'browser' })
+            varLogic.actions._addVariable({ variableId: 'var-platform-id', code_name: 'platform' })
+            mockSetQuery.mockClear()
+
+            // Remove only browser — platform should remain in the query
+            varLogic.actions._removeVariable('var-browser-id')
+
+            expect(mockSetQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    source: expect.objectContaining({
+                        variables: {
+                            'var-platform-id': expect.objectContaining({ variableId: 'var-platform-id' }),
+                        },
+                    }),
+                })
+            )
+        })
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -304,6 +304,9 @@ export const variablesLogic = kea<variablesLogicType>([
         removeVariable: () => {
             actions.updateSourceQuery()
         },
+        _removeVariable: () => {
+            actions.updateSourceQuery()
+        },
         updateVariableValue: () => {
             actions.updateSourceQuery()
         },


### PR DESCRIPTION
## Problem

When a variable like `{variables.browser}` is removed from a SQL insight, the dashboard still continues to display the old **browser filter**. This creates a mismatch between the SQL query and the dashboard filters.

Fixes #49911

**Root cause**

`propsChanged` correctly detects when a variable is removed from the SQL query and triggers `_removeVariable`.
However, `_removeVariable` had **no listener**, so `updateSourceQuery()` was never called.

As a result, the insight’s `query.source.variables` was not updated, and the dashboard continued to display the stale filter.

---

## Changes

1. **Added a listener for `_removeVariable`** in
   `frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts`

```typescript
_removeVariable: () => {
    actions.updateSourceQuery()
},
```

This mirrors the existing `removeVariable` listener and ensures the query state updates when variables are removed.

2. **Added unit tests** in
   `frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.test.ts`

Tests include:

* Reproducing the bug where `setQuery` was never called when a variable was removed.
* Verifying that after the fix, `updateSourceQuery()` is triggered correctly.
* Ensuring the variables list updates as expected.

---

## How did you test this code?

* Added unit tests for `variablesLogic`.
* Verified **red → green testing**:

  * **Before fix:** 2 failing tests (`Number of calls: 0` — `setQuery` not triggered)
  * **After fix:** All tests passing (3 tests)
* Confirmed that removing a variable now updates `query.source.variables` and removes the dashboard filter.