### PR TITLE
feat(flags): add beta tag and docs link to device bucketing option

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -710,9 +710,25 @@ export function FeatureFlagReleaseConditions({
                             },
                             {
                                 value: 'device',
-                                label: 'Device',
-                                description:
-                                    'Stable assignment per device. Good fit for experiments on anonymous users.',
+                                label: (
+                                    <span>
+                                        Device{' '}
+                                        <LemonTag type="warning" size="small">
+                                            BETA
+                                        </LemonTag>
+                                    </span>
+                                ),
+                                description: (
+                                    <span>
+                                        Stable assignment per device. Good fit for experiments on anonymous users.{' '}
+                                        <Link
+                                            to="https://posthog.com/docs/feature-flags/device-bucketing"
+                                            target="_blank"
+                                        >
+                                            Learn more
+                                        </Link>
+                                    </span>
+                                ),
                             },
                             {
                                 value: 'group',

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -21,6 +21,7 @@ import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/uti
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
@@ -343,10 +344,21 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                           value: 'device',
                                           label: (
                                               <div>
-                                                  <div className="font-medium">Device</div>
+                                                  <div className="font-medium">
+                                                      Device{' '}
+                                                      <LemonTag type="warning" size="small">
+                                                          BETA
+                                                      </LemonTag>
+                                                  </div>
                                                   <div className="text-xs text-muted">
                                                       Stable assignment per device. Good fit for experiments on
-                                                      anonymous users.
+                                                      anonymous users.{' '}
+                                                      <Link
+                                                          to="https://posthog.com/docs/feature-flags/device-bucketing"
+                                                          target="_blank"
+                                                      >
+                                                          Learn more
+                                                      </Link>
                                                   </div>
                                               </div>
                                           ),


### PR DESCRIPTION
## Problem

The "Device" option in feature flag release conditions ("Match by") is in beta but has no visual indicator or link to documentation.

## Changes

- Added a yellow `BETA` tag next to the "Device" label in both the old and v2 flags UI
- Added a "Learn more" link to https://posthog.com/docs/feature-flags/device-bucketing in the description

<img width="562" height="177" alt="Screenshot 2026-03-06 at 10 45 58" src="https://github.com/user-attachments/assets/d90e2fbd-73c7-4715-a7df-93e9cfc02490" />

## Testing

- Tested locally and verified that the UI looked as expected on both old and new flags UI