### PR TITLE
feat(llma): add markdown rendering toggle to prompt view

### DIFF
--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -166,6 +166,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         setMode: (mode: PromptMode) => ({ mode }),
         setAnalyticsScope: (analyticsScope: PromptAnalyticsScope) => ({ analyticsScope }),
         setRelatedTracesQuery: (query: DataTableNode) => ({ query }),
+        toggleMarkdownRendering: true,
     }),
 
     reducers(({ props }) => ({
@@ -200,6 +201,12 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             null as DataTableNode | null,
             {
                 setRelatedTracesQuery: (_, { query }) => query,
+            },
+        ],
+        isRenderingMarkdown: [
+            false,
+            {
+                toggleMarkdownRendering: (state) => !state,
             },
         ],
     })),

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
-import React from 'react'
 
 import { IconMarkdown, IconMarkdownFilled } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
@@ -19,8 +18,8 @@ import { useTracesQueryContext } from '../LLMAnalyticsTracesScene'
 import { PROMPT_NAME_MAX_LENGTH, PromptAnalyticsScope, isPrompt, llmPromptLogic } from './llmPromptLogic'
 
 export function PromptViewDetails(): JSX.Element {
-    const { prompt } = useValues(llmPromptLogic)
-    const [isRenderingMarkdown, setIsRenderingMarkdown] = React.useState(false)
+    const { prompt, isRenderingMarkdown } = useValues(llmPromptLogic)
+    const { toggleMarkdownRendering } = useActions(llmPromptLogic)
 
     if (!prompt || !isPrompt(prompt)) {
         return <></>
@@ -65,7 +64,7 @@ export function PromptViewDetails(): JSX.Element {
                         noPadding
                         icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
                         tooltip="Toggle markdown rendering"
-                        onClick={() => setIsRenderingMarkdown(!isRenderingMarkdown)}
+                        onClick={toggleMarkdownRendering}
                     />
                 </div>
                 {isRenderingMarkdown ? (

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -1,11 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
+import React from 'react'
 
+import { IconMarkdown, IconMarkdownFilled } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
@@ -17,6 +20,7 @@ import { PROMPT_NAME_MAX_LENGTH, PromptAnalyticsScope, isPrompt, llmPromptLogic 
 
 export function PromptViewDetails(): JSX.Element {
     const { prompt } = useValues(llmPromptLogic)
+    const [isRenderingMarkdown, setIsRenderingMarkdown] = React.useState(false)
 
     if (!prompt || !isPrompt(prompt)) {
         return <></>
@@ -54,8 +58,21 @@ export function PromptViewDetails(): JSX.Element {
             </div>
 
             <div>
-                <label className="text-xs font-semibold uppercase text-secondary">Prompt</label>
-                <pre className="mt-1 rounded border bg-bg-light p-3 whitespace-pre-wrap">{prompt.prompt}</pre>
+                <div className="flex items-center gap-2">
+                    <label className="text-xs font-semibold uppercase text-secondary">Prompt</label>
+                    <LemonButton
+                        size="xsmall"
+                        noPadding
+                        icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
+                        tooltip="Toggle markdown rendering"
+                        onClick={() => setIsRenderingMarkdown(!isRenderingMarkdown)}
+                    />
+                </div>
+                {isRenderingMarkdown ? (
+                    <LemonMarkdown className="mt-1 rounded border bg-bg-light p-3">{prompt.prompt}</LemonMarkdown>
+                ) : (
+                    <pre className="mt-1 rounded border bg-bg-light p-3 whitespace-pre-wrap">{prompt.prompt}</pre>
+                )}
             </div>
 
             <div className="grid gap-3 text-sm text-secondary sm:grid-cols-2">

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -60,7 +60,7 @@ export function PromptViewDetails(): JSX.Element {
                 <div className="flex items-center gap-2">
                     <label className="text-xs font-semibold uppercase text-secondary">Prompt</label>
                     <LemonButton
-                        size="xsmall"
+                        size="small"
                         noPadding
                         icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
                         tooltip="Toggle markdown rendering"
@@ -200,7 +200,8 @@ export function PromptEditForm({
     isHistoricalVersion: boolean
     selectedVersion: number | null
 }): JSX.Element {
-    const { promptVariables, isNewPrompt } = useValues(llmPromptLogic)
+    const { promptVariables, isNewPrompt, isRenderingMarkdown, promptForm } = useValues(llmPromptLogic)
+    const { toggleMarkdownRendering } = useActions(llmPromptLogic)
 
     return (
         <div className="mt-4 max-w-3xl space-y-4">
@@ -230,14 +231,34 @@ export function PromptEditForm({
 
             <LemonField
                 name="prompt"
-                label="Prompt"
+                label={
+                    <div className="flex items-center gap-2">
+                        <span>Prompt</span>
+                        <LemonButton
+                            size="small"
+                            noPadding
+                            icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
+                            tooltip="Toggle markdown preview"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                toggleMarkdownRendering()
+                            }}
+                        />
+                    </div>
+                }
                 help="Use {{variable_name}} to define variables that will be replaced when fetching the prompt from your backend."
             >
-                <LemonTextArea
-                    placeholder="You are a helpful assistant for {{company_name}}. Help the user with their question about {{topic}}."
-                    minRows={10}
-                    className="font-mono"
-                />
+                {isRenderingMarkdown ? (
+                    <LemonMarkdown className="rounded border bg-bg-light p-3 whitespace-pre-wrap">
+                        {promptForm.prompt || '*No prompt content yet*'}
+                    </LemonMarkdown>
+                ) : (
+                    <LemonTextArea
+                        placeholder="You are a helpful assistant for {{company_name}}. Help the user with their question about {{topic}}."
+                        minRows={10}
+                        className="font-mono"
+                    />
+                )}
             </LemonField>
 
             {promptVariables.length > 0 && (


### PR DESCRIPTION
## Summary
- Adds a markdown toggle button next to the "Prompt" label in the prompt management view
- When toggled, renders the prompt text as markdown using `LemonMarkdown` instead of plain text in a `<pre>` tag
- Defaults to plain text (current behavior), so it's opt-in
- Reuses the same `IconMarkdown`/`IconMarkdownFilled` toggle pattern already used in conversation message display

<img width="872" height="526" alt="image" src="https://github.com/user-attachments/assets/4075ee33-c4f6-4fc5-a768-025e6ad3d9cf" />

## Test plan
- [ ] Navigate to LLM analytics > Prompts > select any prompt
- [ ] Verify the markdown toggle icon appears next to the "Prompt" label
- [ ] Click the toggle — prompt should render as markdown (headings, lists, bold, etc.)
- [ ] Click again — should return to plain text view

🤖 Generated with [Claude Code](https://claude.com/claude-code)