### PR TITLE
fix(signals): update temporal module integrity test for reingestion/deletion

### DIFF
--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -20,6 +20,8 @@ class TestAITemporalModuleIntegrity:
             "VideoSegmentClusteringCoordinatorWorkflow",
             "TeamSignalGroupingWorkflow",
             "SignalReportSummaryWorkflow",
+            "SignalReportReingestionWorkflow",
+            "SignalReportDeletionWorkflow",
             "EmitEvalSignalWorkflow",
         ]
         actual_workflow_names = [workflow.__name__ for workflow in ai.AI_WORKFLOWS + ai.SIGNALS_WORKFLOWS]
@@ -101,6 +103,9 @@ class TestAITemporalModuleIntegrity:
             "wait_for_signal_in_clickhouse_activity",
             "summarize_signals_activity",
             "emit_eval_signal_activity",
+            "delete_report_activity",
+            "reingest_signals_activity",
+            "soft_delete_report_signals_activity",
         ]
         actual_activity_names = [activity.__name__ for activity in ai.AI_ACTIVITIES + ai.SIGNALS_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (


### PR DESCRIPTION

## Changes

  - Add missing `SignalReportReingestionWorkflow`, `SignalReportDeletionWorkflow`, and their activities (`delete_report_activity`, `reingest_signals_activity`, `soft_delete_report_signals_activity`) to the temporal module integrity test                                                                 
  - These were added in #50009 but the test was not updated, causing CI failures on other PRs (e.g. #50177)                                                                                                                                                                                                  
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no