### PR TITLE
revert(ci): undo backend path filter narrowing and legacy filter

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -62,6 +62,7 @@ jobs:
             tasks_temporal: ${{ steps.filter.outputs.tasks_temporal || 'true' }}
             llm_gateway: ${{ steps.filter.outputs.llm_gateway || 'true' }}
             openapi_types: ${{ steps.filter.outputs.openapi_types || 'true' }}
+            products: ${{ steps.filter.outputs.products || 'true' }}
             legacy: ${{ steps.filter.outputs.legacy || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
@@ -91,13 +92,7 @@ jobs:
                         # including the negated rule appears to work
                         # but makes it always match because the checked file always isn't `ee/frontend/**` 🙈
                         - 'ee/**/*'
-                        - 'common/hogli/**/*'
-                        - 'common/hogvm/python/**/*'
-                        - 'common/hogvm/stl/**/*'
-                        - 'common/hogql_parser/**/*'
-                        - 'common/migration_utils/**/*'
-                        - 'common/ingestion/**/*'
-                        - 'common/__init__.py'
+                        - 'common/**/*'
                         - 'posthog/**/*'
                         - 'products/**/backend/**/*'
                         - 'bin/*.py'
@@ -148,26 +143,6 @@ jobs:
                         - 'products/*/mcp/**/*.yaml'
                         - 'services/mcp/src/tools/generated/**/*'
                         - 'services/mcp/schema/generated-tool-definitions.json'
-                      legacy:
-                        # Non-product backend code — when only products/ change,
-                        # turbo-discover decides whether Django tests are needed
-                        - 'ee/**/*'
-                        - 'common/**/*'
-                        - 'posthog/**/*'
-                        - 'bin/*.py'
-                        - pyproject.toml
-                        - uv.lock
-                        - requirements.txt
-                        - requirements-dev.txt
-                        - mypy.ini
-                        - pytest.ini
-                        - .test_durations
-                        - frontend/src/queries/schema.json
-                        - .github/workflows/ci-backend.yml
-                        - .github/clickhouse-versions.json
-                        - docker-compose.dev.yml
-                        - docker-compose.profiles.yml
-                        - docker-compose.base.yml
 
     detect-snapshot-mode:
         name: Detect snapshot mode


### PR DESCRIPTION
Reverts 5c9211c (#50137).

**Why**
The `legacy` paths-filter excluded `products/**/backend/**/*`, relying on turbo's contract-check to decide whether Django tests should run for product-only changes. But virtually all products still have their views, serializers, and models directly imported by legacy code (`posthog/api/__init__.py`, `posthog/tasks/`, migrations, etc.), so changes to those files can affect legacy Django tests (e.g. `test_api_docs_generation_warnings_snapshot`). The contract-check only watches facade files and misses these cross-boundary dependencies.

Without the `legacy` filter defined, `steps.filter.outputs.legacy` falls back to `'true'` — Django always runs when backend files change, restoring safe behavior.

The `common/**/*` narrowing in the `backend` filter is also reverted since it was part of the same commit and risks missing dependencies.