### PR TITLE
fix(phai): coerce numeric search query to string

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -203,7 +203,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                             const isSlashCommandResponse =
                                 message.type !== 'human' &&
                                 prevMessage?.type === 'human' &&
-                                typeof prevMessage.content === 'string' &&
+                                'content' in prevMessage &&
                                 (prevMessage.content.startsWith(SlashCommandName.SlashFeedback) ||
                                     prevMessage.content.startsWith(SlashCommandName.SlashTicket))
 

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -203,7 +203,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                             const isSlashCommandResponse =
                                 message.type !== 'human' &&
                                 prevMessage?.type === 'human' &&
-                                'content' in prevMessage &&
+                                typeof prevMessage.content === 'string' &&
                                 (prevMessage.content.startsWith(SlashCommandName.SlashFeedback) ||
                                     prevMessage.content.startsWith(SlashCommandName.SlashTicket))
 

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -560,7 +560,7 @@ export const maxLogic = kea<maxLogicType>([
                 window.setTimeout(() => {
                     // ensure maxThreadLogic is mounted
                     // Pass context directly to askMax to avoid timing issues
-                    actions.askMax(search.ask, true, uiContext)
+                    actions.askMax(String(search.ask), true, uiContext)
                 }, 100)
                 return
             }

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -560,6 +560,7 @@ export const maxLogic = kea<maxLogicType>([
                 window.setTimeout(() => {
                     // ensure maxThreadLogic is mounted
                     // Pass context directly to askMax to avoid timing issues
+                    // kea-router coerces numeric-looking URL params to numbers
                     actions.askMax(String(search.ask), true, uiContext)
                 }, 100)
                 return


### PR DESCRIPTION
## Problem

Users hitting a `TypeError: content.startsWith is not a function` crash when asking PostHog AI a numeric question via the search popover ([error tracking](https://us.posthog.com/project/2/error_tracking/019b369b-98b0-72a3-84ed-14872594a8fa)).

`kea-router`'s `decodeParams` runs URL query parameter values through a `parseValue` function that converts numeric-looking strings to JavaScript numbers. When a user searches for a number like `123456` in the search popover and clicks "PostHog AI", the URL `/ai?ask=123456` is parsed as `{ ask: 123456 }` (number) instead of `{ ask: "123456" }` (string). This number flows through `askMax` → `streamConversation` → `addMessage`, creating a `HumanMessage` with numeric `content`. Any downstream code calling `.startsWith()`, `.split()`, `.length`, etc. on `content` then crashes.

## Changes

Coerces `search.ask` to a string in `maxLogic.tsx` before passing it to `askMax`. This is the single entry point where URL search params flow into the Max AI thread, so it fixes all downstream crash sites at once (~10 places that call string methods on `message.content`).

## How did you test this code?

I have not tested this manually. The fix is a single `String()` coercion at the entry point.

## Publish to changelog?

No.

## 🤖 LLM context

Co-authored by Claude Code (claude-opus-4-6). Root cause was found by tracing `kea-router`'s `parseValue` function in `node_modules/kea-router/src/utils.ts`, which converts numeric-looking URL param values to numbers. 
