### PR TITLE
fix: account for side panel width in layout in replay

### DIFF
--- a/frontend/src/lib/hooks/useWindowSize.ts
+++ b/frontend/src/lib/hooks/useWindowSize.ts
@@ -1,60 +1,55 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from 'react'
 
-import { TAILWIND_BREAKPOINTS } from "lib/constants";
+import { TAILWIND_BREAKPOINTS } from 'lib/constants'
 
 type WindowSize = {
-  width: number | undefined;
-  height: number | undefined;
-};
+    width: number | undefined
+    height: number | undefined
+}
 
-type Breakpoint = keyof typeof TAILWIND_BREAKPOINTS;
+type Breakpoint = keyof typeof TAILWIND_BREAKPOINTS
 
 type UseWindowSizeOptions = {
-  /** Pixels to subtract from window width when checking breakpoints (e.g. side panel width) */
-  widthOffset?: number;
-};
+    /** Pixels to subtract from window width when checking breakpoints (e.g. side panel width) */
+    widthOffset?: number
+}
 
 type UseWindowSize = {
-  windowSize: WindowSize;
-  isWindowLessThan: (breakpoint: Breakpoint) => boolean;
-};
+    windowSize: WindowSize
+    isWindowLessThan: (breakpoint: Breakpoint) => boolean
+}
 
 function subscribeToResize(callback: () => void): () => void {
-  window.addEventListener("resize", callback);
-  return () => window.removeEventListener("resize", callback);
+    window.addEventListener('resize', callback)
+    return () => window.removeEventListener('resize', callback)
 }
 
-let cachedSize: WindowSize = { width: undefined, height: undefined };
+let cachedSize: WindowSize = { width: undefined, height: undefined }
 
 function getWindowSize(): WindowSize {
-  const width = window.innerWidth;
-  const height = window.innerHeight;
-  if (cachedSize.width !== width || cachedSize.height !== height) {
-    cachedSize = { width, height };
-  }
-  return cachedSize;
+    const width = window.innerWidth
+    const height = window.innerHeight
+    if (cachedSize.width !== width || cachedSize.height !== height) {
+        cachedSize = { width, height }
+    }
+    return cachedSize
 }
 
-const serverSnapshot: WindowSize = { width: undefined, height: undefined };
+const serverSnapshot: WindowSize = { width: undefined, height: undefined }
 
 function getServerSnapshot(): WindowSize {
-  return serverSnapshot;
+    return serverSnapshot
 }
 
 export function useWindowSize(options?: UseWindowSizeOptions): UseWindowSize {
-  const windowSize = useSyncExternalStore(
-    subscribeToResize,
-    getWindowSize,
-    getServerSnapshot,
-  );
-  const widthOffset = options?.widthOffset ?? 0;
+    const windowSize = useSyncExternalStore(subscribeToResize, getWindowSize, getServerSnapshot)
+    const widthOffset = options?.widthOffset ?? 0
 
-  const isWindowLessThan = useCallback(
-    (breakpoint: keyof typeof TAILWIND_BREAKPOINTS) =>
-      !!windowSize?.width &&
-      windowSize.width - widthOffset < TAILWIND_BREAKPOINTS[breakpoint],
-    [windowSize, widthOffset],
-  );
+    const isWindowLessThan = useCallback(
+        (breakpoint: keyof typeof TAILWIND_BREAKPOINTS) =>
+            !!windowSize?.width && windowSize.width - widthOffset < TAILWIND_BREAKPOINTS[breakpoint],
+        [windowSize, widthOffset]
+    )
 
-  return { windowSize, isWindowLessThan };
+    return { windowSize, isWindowLessThan }
 }

--- a/frontend/src/lib/hooks/useWindowSize.ts
+++ b/frontend/src/lib/hooks/useWindowSize.ts
@@ -1,49 +1,60 @@
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useSyncExternalStore } from "react";
 
-import { TAILWIND_BREAKPOINTS } from 'lib/constants'
+import { TAILWIND_BREAKPOINTS } from "lib/constants";
 
 type WindowSize = {
-    width: number | undefined
-    height: number | undefined
-}
+  width: number | undefined;
+  height: number | undefined;
+};
 
-type Breakpoint = keyof typeof TAILWIND_BREAKPOINTS
+type Breakpoint = keyof typeof TAILWIND_BREAKPOINTS;
+
+type UseWindowSizeOptions = {
+  /** Pixels to subtract from window width when checking breakpoints (e.g. side panel width) */
+  widthOffset?: number;
+};
 
 type UseWindowSize = {
-    windowSize: WindowSize
-    isWindowLessThan: (breakpoint: Breakpoint) => boolean
-}
+  windowSize: WindowSize;
+  isWindowLessThan: (breakpoint: Breakpoint) => boolean;
+};
 
 function subscribeToResize(callback: () => void): () => void {
-    window.addEventListener('resize', callback)
-    return () => window.removeEventListener('resize', callback)
+  window.addEventListener("resize", callback);
+  return () => window.removeEventListener("resize", callback);
 }
 
-let cachedSize: WindowSize = { width: undefined, height: undefined }
+let cachedSize: WindowSize = { width: undefined, height: undefined };
 
 function getWindowSize(): WindowSize {
-    const width = window.innerWidth
-    const height = window.innerHeight
-    if (cachedSize.width !== width || cachedSize.height !== height) {
-        cachedSize = { width, height }
-    }
-    return cachedSize
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  if (cachedSize.width !== width || cachedSize.height !== height) {
+    cachedSize = { width, height };
+  }
+  return cachedSize;
 }
 
-const serverSnapshot: WindowSize = { width: undefined, height: undefined }
+const serverSnapshot: WindowSize = { width: undefined, height: undefined };
 
 function getServerSnapshot(): WindowSize {
-    return serverSnapshot
+  return serverSnapshot;
 }
 
-export function useWindowSize(): UseWindowSize {
-    const windowSize = useSyncExternalStore(subscribeToResize, getWindowSize, getServerSnapshot)
+export function useWindowSize(options?: UseWindowSizeOptions): UseWindowSize {
+  const windowSize = useSyncExternalStore(
+    subscribeToResize,
+    getWindowSize,
+    getServerSnapshot,
+  );
+  const widthOffset = options?.widthOffset ?? 0;
 
-    const isWindowLessThan = useCallback(
-        (breakpoint: keyof typeof TAILWIND_BREAKPOINTS) =>
-            !!windowSize?.width && windowSize.width < TAILWIND_BREAKPOINTS[breakpoint],
-        [windowSize]
-    )
+  const isWindowLessThan = useCallback(
+    (breakpoint: keyof typeof TAILWIND_BREAKPOINTS) =>
+      !!windowSize?.width &&
+      windowSize.width - widthOffset < TAILWIND_BREAKPOINTS[breakpoint],
+    [windowSize, widthOffset],
+  );
 
-    return { windowSize, isWindowLessThan }
+  return { windowSize, isWindowLessThan };
 }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -1,281 +1,245 @@
-import clsx from "clsx";
-import { BindLogic, useActions, useValues } from "kea";
-import { useCallback, useRef } from "react";
+import { BindLogic, useActions, useValues } from 'kea'
+import { useCallback, useRef } from 'react'
 
-import { EmptyMessage } from "lib/components/EmptyMessage/EmptyMessage";
-import { Resizer } from "lib/components/Resizer/Resizer";
-import {
-  ResizerLogicProps,
-  resizerLogic,
-} from "lib/components/Resizer/resizerLogic";
-import { useWindowSize } from "lib/hooks/useWindowSize";
-import { Playlist } from "scenes/session-recordings/playlist/Playlist";
+import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { Resizer } from 'lib/components/Resizer/Resizer'
+import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
+import { useWindowSize } from 'lib/hooks/useWindowSize'
+import { cn } from 'lib/utils/css-classes'
+import { Playlist } from 'scenes/session-recordings/playlist/Playlist'
 
-import { panelLayoutLogic } from "~/layout/panel-layout/panelLayoutLogic";
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
-import { RecordingsUniversalFiltersEmbed } from "../filters/RecordingsUniversalFiltersEmbed";
-import { playerSettingsLogic } from "../player/playerSettingsLogic";
-import { SessionRecordingPlayer } from "../player/SessionRecordingPlayer";
-import { playlistFiltersLogic } from "./playlistFiltersLogic";
-import {
-  SessionRecordingPlaylistLogicProps,
-  sessionRecordingsPlaylistLogic,
-} from "./sessionRecordingsPlaylistLogic";
+import { RecordingsUniversalFiltersEmbed } from '../filters/RecordingsUniversalFiltersEmbed'
+import { playerSettingsLogic } from '../player/playerSettingsLogic'
+import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
+import { playlistFiltersLogic } from './playlistFiltersLogic'
+import { SessionRecordingPlaylistLogicProps, sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic'
 
 export function SessionRecordingsPlaylist({
-  ...props
+    ...props
 }: SessionRecordingPlaylistLogicProps & {
-  showContent?: boolean;
-  type?: "filters" | "collection";
-  isSynthetic?: boolean;
-  description?: string;
+    showContent?: boolean
+    type?: 'filters' | 'collection'
+    isSynthetic?: boolean
+    description?: string
 }): JSX.Element {
-  const logicProps: SessionRecordingPlaylistLogicProps = {
-    ...props,
-    autoPlay: props.autoPlay ?? true,
-    onlyPinned: props.type === "collection",
-  };
+    const logicProps: SessionRecordingPlaylistLogicProps = {
+        ...props,
+        autoPlay: props.autoPlay ?? true,
+        onlyPinned: props.type === 'collection',
+    }
 
-  const { sidePanelWidth } = useValues(panelLayoutLogic);
-  const { isWindowLessThan } = useWindowSize({ widthOffset: sidePanelWidth });
-  const windowSaysVertical = isWindowLessThan("xl");
+    const { sidePanelWidth } = useValues(panelLayoutLogic)
+    const { isWindowLessThan } = useWindowSize({ widthOffset: sidePanelWidth })
+    const windowSaysVertical = isWindowLessThan('xl')
 
-  // Don't switch layout while in fullscreen — it would unmount the fullscreen element
-  const layoutRef = useRef(windowSaysVertical);
-  if (!document.fullscreenElement) {
-    layoutRef.current = windowSaysVertical;
-  }
-  const isVerticalLayout = layoutRef.current;
+    // Don't switch layout while in fullscreen — it would unmount the fullscreen element
+    const layoutRef = useRef(windowSaysVertical)
+    if (!document.fullscreenElement) {
+        layoutRef.current = windowSaysVertical
+    }
+    const isVerticalLayout = layoutRef.current
 
-  return (
-    <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
-      <div className="w-full h-full flex flex-col xl:flex-row xl:gap-2">
-        {isVerticalLayout ? (
-          <VerticalLayout {...props} />
-        ) : (
-          <HorizontalLayout {...props} />
-        )}
-      </div>
-    </BindLogic>
-  );
+    return (
+        <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
+            <div className={cn('w-full h-full flex', isVerticalLayout ? 'flex-col' : 'flex-row gap-2')}>
+                {isVerticalLayout ? <VerticalLayout {...props} /> : <HorizontalLayout {...props} />}
+            </div>
+        </BindLogic>
+    )
 }
 
 function HorizontalLayout({
-  ...props
+    ...props
 }: SessionRecordingPlaylistLogicProps & {
-  showContent?: boolean;
-  type?: "filters" | "collection";
-  isSynthetic?: boolean;
-  description?: string;
+    showContent?: boolean
+    type?: 'filters' | 'collection'
+    isSynthetic?: boolean
+    description?: string
 }): JSX.Element {
-  const playlistRef = useRef<HTMLDivElement>(null);
+    const playlistRef = useRef<HTMLDivElement>(null)
 
-  const { isPlaylistCollapsed } = useValues(playerSettingsLogic);
-  const { setPlaylistCollapsed } = useActions(playerSettingsLogic);
-  const resizerLogicProps: ResizerLogicProps = {
-    logicKey: "playlist-resizer-horizontal",
-    containerRef: playlistRef,
-    persistent: true,
-    persistPrefix: "2025-12-29",
-    placement: "right",
-    closeThreshold: 100,
-    onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
-  };
+    const { isPlaylistCollapsed } = useValues(playerSettingsLogic)
+    const { setPlaylistCollapsed } = useActions(playerSettingsLogic)
+    const resizerLogicProps: ResizerLogicProps = {
+        logicKey: 'playlist-resizer-horizontal',
+        containerRef: playlistRef,
+        persistent: true,
+        persistPrefix: '2025-12-29',
+        placement: 'right',
+        closeThreshold: 100,
+        onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
+    }
 
-  const { desiredSize } = useValues(resizerLogic(resizerLogicProps));
+    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
 
-  return (
-    <>
-      <div
-        ref={playlistRef}
-        className={clsx("relative flex flex-col shrink-0", {
-          "w-3": isPlaylistCollapsed,
-        })}
-        // eslint-disable-next-line react/forbid-dom-props
-        style={
-          isPlaylistCollapsed
-            ? {}
-            : {
-                width: desiredSize ?? 320,
-                minWidth: "min-content",
-                maxWidth: "50%",
-              }
-        }
-      >
-        <Playlist {...props} />
-        {!isPlaylistCollapsed && (
-          <Resizer
-            {...resizerLogicProps}
-            visible={false}
-            offset="0.25rem"
-            handleClassName="rounded my-1"
-          />
-        )}
-      </div>
-      <PlayerWrapper {...props} className="h-full flex-1 shrink" />
-    </>
-  );
+    return (
+        <>
+            <div
+                ref={playlistRef}
+                className={cn('relative flex flex-col shrink-0', {
+                    'w-3': isPlaylistCollapsed,
+                })}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={
+                    isPlaylistCollapsed
+                        ? {}
+                        : {
+                              width: desiredSize ?? 320,
+                              minWidth: 'min-content',
+                              maxWidth: '50%',
+                          }
+                }
+            >
+                <Playlist {...props} />
+                {!isPlaylistCollapsed && (
+                    <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
+                )}
+            </div>
+            <PlayerWrapper {...props} className="h-full flex-1 shrink" />
+        </>
+    )
 }
 
 function VerticalLayout({
-  ...props
+    ...props
 }: SessionRecordingPlaylistLogicProps & {
-  showContent?: boolean;
-  type?: "filters" | "collection";
-  isSynthetic?: boolean;
-  description?: string;
+    showContent?: boolean
+    type?: 'filters' | 'collection'
+    isSynthetic?: boolean
+    description?: string
 }): JSX.Element {
-  const playerRef = useRef<HTMLDivElement>(null);
+    const playerRef = useRef<HTMLDivElement>(null)
 
-  const { isPlaylistCollapsed } = useValues(playerSettingsLogic);
-  const { setPlaylistCollapsed } = useActions(playerSettingsLogic);
+    const { isPlaylistCollapsed } = useValues(playerSettingsLogic)
+    const { setPlaylistCollapsed } = useActions(playerSettingsLogic)
 
-  const resizerLogicProps: ResizerLogicProps = {
-    logicKey: "playlist-resizer-vertical",
-    containerRef: playerRef,
-    persistent: true,
-    persistPrefix: "2025-12-29",
-    placement: "bottom",
-    closeThreshold: 100,
-    onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
-  };
+    const resizerLogicProps: ResizerLogicProps = {
+        logicKey: 'playlist-resizer-vertical',
+        containerRef: playerRef,
+        persistent: true,
+        persistPrefix: '2025-12-29',
+        placement: 'bottom',
+        closeThreshold: 100,
+        onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
+    }
 
-  const { desiredSize } = useValues(resizerLogic(resizerLogicProps));
+    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
 
-  return (
-    <>
-      <PlayerWrapper
-        {...props}
-        containerRef={playerRef}
-        style={
-          isPlaylistCollapsed
-            ? {}
-            : { height: desiredSize ?? undefined, minHeight: 300 }
-        }
-        className={isPlaylistCollapsed ? "flex-1" : "pb-2 shrink-0"}
-        resizer={
-          !isPlaylistCollapsed ? (
-            <Resizer
-              {...resizerLogicProps}
-              visible={false}
-              offset="0.25rem"
-              handleClassName="rounded mx-1"
+    return (
+        <>
+            <PlayerWrapper
+                {...props}
+                containerRef={playerRef}
+                style={isPlaylistCollapsed ? {} : { height: desiredSize ?? undefined, minHeight: 300 }}
+                className={isPlaylistCollapsed ? 'flex-1' : 'pb-2 shrink-0'}
+                resizer={
+                    !isPlaylistCollapsed ? (
+                        <Resizer
+                            {...resizerLogicProps}
+                            visible={false}
+                            offset="0.25rem"
+                            handleClassName="rounded mx-1"
+                        />
+                    ) : null
+                }
             />
-          ) : null
-        }
-      />
-      <div
-        className={clsx(
-          "relative flex flex-col min-h-0",
-          isPlaylistCollapsed ? "h-5" : "flex-1",
-        )}
-      >
-        <Playlist {...props} />
-      </div>
-    </>
-  );
+            <div className={cn('relative flex flex-col min-h-0', isPlaylistCollapsed ? 'h-5' : 'flex-1')}>
+                <Playlist {...props} />
+            </div>
+        </>
+    )
 }
 
 function PlayerWrapper({
-  showContent = true,
-  containerRef,
-  style,
-  resizer,
-  className,
-  ...props
+    showContent = true,
+    containerRef,
+    style,
+    resizer,
+    className,
+    ...props
 }: SessionRecordingPlaylistLogicProps & {
-  showContent?: boolean;
-  type?: "filters" | "collection";
-  isSynthetic?: boolean;
-  description?: string;
-  containerRef?: React.RefObject<HTMLDivElement>;
-  style?: React.CSSProperties;
-  resizer?: React.ReactNode;
-  className?: string;
+    showContent?: boolean
+    type?: 'filters' | 'collection'
+    isSynthetic?: boolean
+    description?: string
+    containerRef?: React.RefObject<HTMLDivElement>
+    style?: React.CSSProperties
+    resizer?: React.ReactNode
+    className?: string
 }): JSX.Element {
-  const {
-    filters,
-    pinnedRecordings,
-    matchingEventsMatchType,
-    activeSessionRecording,
-    allowHogQLFilters,
-    totalFiltersCount,
-    nextSessionRecording,
-  } = useValues(sessionRecordingsPlaylistLogic);
-  const {
-    setFilters,
-    resetFilters,
-    setSelectedRecordingId,
-    loadAllRecordings,
-  } = useActions(sessionRecordingsPlaylistLogic);
+    const {
+        filters,
+        pinnedRecordings,
+        matchingEventsMatchType,
+        activeSessionRecording,
+        allowHogQLFilters,
+        totalFiltersCount,
+        nextSessionRecording,
+    } = useValues(sessionRecordingsPlaylistLogic)
+    const { setFilters, resetFilters, setSelectedRecordingId, loadAllRecordings } =
+        useActions(sessionRecordingsPlaylistLogic)
 
-  const { isFiltersExpanded } = useValues(playlistFiltersLogic);
+    const { isFiltersExpanded } = useValues(playlistFiltersLogic)
 
-  const onPlayNextRecording = useCallback(() => {
-    if (nextSessionRecording?.id) {
-      setSelectedRecordingId(nextSessionRecording.id);
-    }
-  }, [nextSessionRecording, setSelectedRecordingId]);
+    const onPlayNextRecording = useCallback(() => {
+        if (nextSessionRecording?.id) {
+            setSelectedRecordingId(nextSessionRecording.id)
+        }
+    }, [nextSessionRecording, setSelectedRecordingId])
 
-  return (
-    <div
-      ref={containerRef}
-      className={clsx(
-        "Playlist__main relative overflow-hidden",
-        className,
-        "min-h-96",
-      )}
-      // eslint-disable-next-line react/forbid-dom-props
-      style={style}
-    >
-      {isFiltersExpanded ? (
-        <div className="h-full rounded border">
-          <RecordingsUniversalFiltersEmbed
-            resetFilters={resetFilters}
-            filters={filters}
-            setFilters={setFilters}
-            totalFiltersCount={totalFiltersCount}
-            allowReplayHogQLFilters={allowHogQLFilters}
-          />
+    return (
+        <div
+            ref={containerRef}
+            className={cn('Playlist__main relative overflow-hidden', className, 'min-h-96')}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={style}
+        >
+            {isFiltersExpanded ? (
+                <div className="h-full rounded border">
+                    <RecordingsUniversalFiltersEmbed
+                        resetFilters={resetFilters}
+                        filters={filters}
+                        setFilters={setFilters}
+                        totalFiltersCount={totalFiltersCount}
+                        allowReplayHogQLFilters={allowHogQLFilters}
+                    />
+                </div>
+            ) : showContent && activeSessionRecording ? (
+                <SessionRecordingPlayer
+                    playerKey={props.logicKey ?? 'playlist'}
+                    sessionRecordingId={activeSessionRecording.id}
+                    matchingEventsMatchType={matchingEventsMatchType}
+                    autoPlay={props.autoPlay}
+                    onRecordingDeleted={() => {
+                        loadAllRecordings()
+                        setSelectedRecordingId(null)
+                    }}
+                    pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
+                    setPinned={
+                        props.onPinnedChange
+                            ? (pinned) => {
+                                  if (!activeSessionRecording.id) {
+                                      return
+                                  }
+                                  props.onPinnedChange?.(activeSessionRecording, pinned)
+                              }
+                            : undefined
+                    }
+                    playNextRecording={nextSessionRecording?.id ? onPlayNextRecording : undefined}
+                />
+            ) : (
+                <div className="mt-20">
+                    <EmptyMessage
+                        title="No recording selected"
+                        description="Please select a recording from the list on the left"
+                        buttonText="Learn more about recordings"
+                        buttonTo="https://posthog.com/docs/user-guides/recordings"
+                    />
+                </div>
+            )}
+            {resizer}
         </div>
-      ) : showContent && activeSessionRecording ? (
-        <SessionRecordingPlayer
-          playerKey={props.logicKey ?? "playlist"}
-          sessionRecordingId={activeSessionRecording.id}
-          matchingEventsMatchType={matchingEventsMatchType}
-          autoPlay={props.autoPlay}
-          onRecordingDeleted={() => {
-            loadAllRecordings();
-            setSelectedRecordingId(null);
-          }}
-          pinned={
-            !!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)
-          }
-          setPinned={
-            props.onPinnedChange
-              ? (pinned) => {
-                  if (!activeSessionRecording.id) {
-                    return;
-                  }
-                  props.onPinnedChange?.(activeSessionRecording, pinned);
-                }
-              : undefined
-          }
-          playNextRecording={
-            nextSessionRecording?.id ? onPlayNextRecording : undefined
-          }
-        />
-      ) : (
-        <div className="mt-20">
-          <EmptyMessage
-            title="No recording selected"
-            description="Please select a recording from the list on the left"
-            buttonText="Learn more about recordings"
-            buttonTo="https://posthog.com/docs/user-guides/recordings"
-          />
-        </div>
-      )}
-      {resizer}
-    </div>
-  );
+    )
 }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -1,236 +1,281 @@
-import clsx from 'clsx'
-import { BindLogic, useActions, useValues } from 'kea'
-import { useCallback, useRef } from 'react'
+import clsx from "clsx";
+import { BindLogic, useActions, useValues } from "kea";
+import { useCallback, useRef } from "react";
 
-import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
-import { Resizer } from 'lib/components/Resizer/Resizer'
-import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
-import { useWindowSize } from 'lib/hooks/useWindowSize'
-import { Playlist } from 'scenes/session-recordings/playlist/Playlist'
+import { EmptyMessage } from "lib/components/EmptyMessage/EmptyMessage";
+import { Resizer } from "lib/components/Resizer/Resizer";
+import {
+  ResizerLogicProps,
+  resizerLogic,
+} from "lib/components/Resizer/resizerLogic";
+import { useWindowSize } from "lib/hooks/useWindowSize";
+import { Playlist } from "scenes/session-recordings/playlist/Playlist";
 
-import { RecordingsUniversalFiltersEmbed } from '../filters/RecordingsUniversalFiltersEmbed'
-import { playerSettingsLogic } from '../player/playerSettingsLogic'
-import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
-import { playlistFiltersLogic } from './playlistFiltersLogic'
-import { SessionRecordingPlaylistLogicProps, sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic'
+import { panelLayoutLogic } from "~/layout/panel-layout/panelLayoutLogic";
+
+import { RecordingsUniversalFiltersEmbed } from "../filters/RecordingsUniversalFiltersEmbed";
+import { playerSettingsLogic } from "../player/playerSettingsLogic";
+import { SessionRecordingPlayer } from "../player/SessionRecordingPlayer";
+import { playlistFiltersLogic } from "./playlistFiltersLogic";
+import {
+  SessionRecordingPlaylistLogicProps,
+  sessionRecordingsPlaylistLogic,
+} from "./sessionRecordingsPlaylistLogic";
 
 export function SessionRecordingsPlaylist({
-    ...props
+  ...props
 }: SessionRecordingPlaylistLogicProps & {
-    showContent?: boolean
-    type?: 'filters' | 'collection'
-    isSynthetic?: boolean
-    description?: string
+  showContent?: boolean;
+  type?: "filters" | "collection";
+  isSynthetic?: boolean;
+  description?: string;
 }): JSX.Element {
-    const logicProps: SessionRecordingPlaylistLogicProps = {
-        ...props,
-        autoPlay: props.autoPlay ?? true,
-        onlyPinned: props.type === 'collection',
-    }
+  const logicProps: SessionRecordingPlaylistLogicProps = {
+    ...props,
+    autoPlay: props.autoPlay ?? true,
+    onlyPinned: props.type === "collection",
+  };
 
-    const { isWindowLessThan } = useWindowSize()
-    const windowSaysVertical = isWindowLessThan('xl')
+  const { sidePanelWidth } = useValues(panelLayoutLogic);
+  const { isWindowLessThan } = useWindowSize({ widthOffset: sidePanelWidth });
+  const windowSaysVertical = isWindowLessThan("xl");
 
-    // Don't switch layout while in fullscreen — it would unmount the fullscreen element
-    const layoutRef = useRef(windowSaysVertical)
-    if (!document.fullscreenElement) {
-        layoutRef.current = windowSaysVertical
-    }
-    const isVerticalLayout = layoutRef.current
+  // Don't switch layout while in fullscreen — it would unmount the fullscreen element
+  const layoutRef = useRef(windowSaysVertical);
+  if (!document.fullscreenElement) {
+    layoutRef.current = windowSaysVertical;
+  }
+  const isVerticalLayout = layoutRef.current;
 
-    return (
-        <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
-            <div className="w-full h-full flex flex-col xl:flex-row xl:gap-2">
-                {isVerticalLayout ? <VerticalLayout {...props} /> : <HorizontalLayout {...props} />}
-            </div>
-        </BindLogic>
-    )
+  return (
+    <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
+      <div className="w-full h-full flex flex-col xl:flex-row xl:gap-2">
+        {isVerticalLayout ? (
+          <VerticalLayout {...props} />
+        ) : (
+          <HorizontalLayout {...props} />
+        )}
+      </div>
+    </BindLogic>
+  );
 }
 
 function HorizontalLayout({
-    ...props
+  ...props
 }: SessionRecordingPlaylistLogicProps & {
-    showContent?: boolean
-    type?: 'filters' | 'collection'
-    isSynthetic?: boolean
-    description?: string
+  showContent?: boolean;
+  type?: "filters" | "collection";
+  isSynthetic?: boolean;
+  description?: string;
 }): JSX.Element {
-    const playlistRef = useRef<HTMLDivElement>(null)
+  const playlistRef = useRef<HTMLDivElement>(null);
 
-    const { isPlaylistCollapsed } = useValues(playerSettingsLogic)
-    const { setPlaylistCollapsed } = useActions(playerSettingsLogic)
-    const resizerLogicProps: ResizerLogicProps = {
-        logicKey: 'playlist-resizer-horizontal',
-        containerRef: playlistRef,
-        persistent: true,
-        persistPrefix: '2025-12-29',
-        placement: 'right',
-        closeThreshold: 100,
-        onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
-    }
+  const { isPlaylistCollapsed } = useValues(playerSettingsLogic);
+  const { setPlaylistCollapsed } = useActions(playerSettingsLogic);
+  const resizerLogicProps: ResizerLogicProps = {
+    logicKey: "playlist-resizer-horizontal",
+    containerRef: playlistRef,
+    persistent: true,
+    persistPrefix: "2025-12-29",
+    placement: "right",
+    closeThreshold: 100,
+    onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
+  };
 
-    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
+  const { desiredSize } = useValues(resizerLogic(resizerLogicProps));
 
-    return (
-        <>
-            <div
-                ref={playlistRef}
-                className={clsx('relative flex flex-col shrink-0', {
-                    'w-3': isPlaylistCollapsed,
-                })}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={
-                    isPlaylistCollapsed ? {} : { width: desiredSize ?? 320, minWidth: 'min-content', maxWidth: '50%' }
-                }
-            >
-                <Playlist {...props} />
-                {!isPlaylistCollapsed && (
-                    <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
-                )}
-            </div>
-            <PlayerWrapper {...props} className="h-full flex-1 shrink" />
-        </>
-    )
+  return (
+    <>
+      <div
+        ref={playlistRef}
+        className={clsx("relative flex flex-col shrink-0", {
+          "w-3": isPlaylistCollapsed,
+        })}
+        // eslint-disable-next-line react/forbid-dom-props
+        style={
+          isPlaylistCollapsed
+            ? {}
+            : {
+                width: desiredSize ?? 320,
+                minWidth: "min-content",
+                maxWidth: "50%",
+              }
+        }
+      >
+        <Playlist {...props} />
+        {!isPlaylistCollapsed && (
+          <Resizer
+            {...resizerLogicProps}
+            visible={false}
+            offset="0.25rem"
+            handleClassName="rounded my-1"
+          />
+        )}
+      </div>
+      <PlayerWrapper {...props} className="h-full flex-1 shrink" />
+    </>
+  );
 }
 
 function VerticalLayout({
-    ...props
+  ...props
 }: SessionRecordingPlaylistLogicProps & {
-    showContent?: boolean
-    type?: 'filters' | 'collection'
-    isSynthetic?: boolean
-    description?: string
+  showContent?: boolean;
+  type?: "filters" | "collection";
+  isSynthetic?: boolean;
+  description?: string;
 }): JSX.Element {
-    const playerRef = useRef<HTMLDivElement>(null)
+  const playerRef = useRef<HTMLDivElement>(null);
 
-    const { isPlaylistCollapsed } = useValues(playerSettingsLogic)
-    const { setPlaylistCollapsed } = useActions(playerSettingsLogic)
+  const { isPlaylistCollapsed } = useValues(playerSettingsLogic);
+  const { setPlaylistCollapsed } = useActions(playerSettingsLogic);
 
-    const resizerLogicProps: ResizerLogicProps = {
-        logicKey: 'playlist-resizer-vertical',
-        containerRef: playerRef,
-        persistent: true,
-        persistPrefix: '2025-12-29',
-        placement: 'bottom',
-        closeThreshold: 100,
-        onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
-    }
+  const resizerLogicProps: ResizerLogicProps = {
+    logicKey: "playlist-resizer-vertical",
+    containerRef: playerRef,
+    persistent: true,
+    persistPrefix: "2025-12-29",
+    placement: "bottom",
+    closeThreshold: 100,
+    onToggleClosed: (shouldBeClosed) => setPlaylistCollapsed(shouldBeClosed),
+  };
 
-    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
+  const { desiredSize } = useValues(resizerLogic(resizerLogicProps));
 
-    return (
-        <>
-            <PlayerWrapper
-                {...props}
-                containerRef={playerRef}
-                style={isPlaylistCollapsed ? {} : { height: desiredSize ?? undefined, minHeight: 300 }}
-                className={isPlaylistCollapsed ? 'flex-1' : 'pb-2 shrink-0'}
-                resizer={
-                    !isPlaylistCollapsed ? (
-                        <Resizer
-                            {...resizerLogicProps}
-                            visible={false}
-                            offset="0.25rem"
-                            handleClassName="rounded mx-1"
-                        />
-                    ) : null
-                }
+  return (
+    <>
+      <PlayerWrapper
+        {...props}
+        containerRef={playerRef}
+        style={
+          isPlaylistCollapsed
+            ? {}
+            : { height: desiredSize ?? undefined, minHeight: 300 }
+        }
+        className={isPlaylistCollapsed ? "flex-1" : "pb-2 shrink-0"}
+        resizer={
+          !isPlaylistCollapsed ? (
+            <Resizer
+              {...resizerLogicProps}
+              visible={false}
+              offset="0.25rem"
+              handleClassName="rounded mx-1"
             />
-            <div className={clsx('relative flex flex-col min-h-0', isPlaylistCollapsed ? 'h-5' : 'flex-1')}>
-                <Playlist {...props} />
-            </div>
-        </>
-    )
+          ) : null
+        }
+      />
+      <div
+        className={clsx(
+          "relative flex flex-col min-h-0",
+          isPlaylistCollapsed ? "h-5" : "flex-1",
+        )}
+      >
+        <Playlist {...props} />
+      </div>
+    </>
+  );
 }
 
 function PlayerWrapper({
-    showContent = true,
-    containerRef,
-    style,
-    resizer,
-    className,
-    ...props
+  showContent = true,
+  containerRef,
+  style,
+  resizer,
+  className,
+  ...props
 }: SessionRecordingPlaylistLogicProps & {
-    showContent?: boolean
-    type?: 'filters' | 'collection'
-    isSynthetic?: boolean
-    description?: string
-    containerRef?: React.RefObject<HTMLDivElement>
-    style?: React.CSSProperties
-    resizer?: React.ReactNode
-    className?: string
+  showContent?: boolean;
+  type?: "filters" | "collection";
+  isSynthetic?: boolean;
+  description?: string;
+  containerRef?: React.RefObject<HTMLDivElement>;
+  style?: React.CSSProperties;
+  resizer?: React.ReactNode;
+  className?: string;
 }): JSX.Element {
-    const {
-        filters,
-        pinnedRecordings,
-        matchingEventsMatchType,
-        activeSessionRecording,
-        allowHogQLFilters,
-        totalFiltersCount,
-        nextSessionRecording,
-    } = useValues(sessionRecordingsPlaylistLogic)
-    const { setFilters, resetFilters, setSelectedRecordingId, loadAllRecordings } =
-        useActions(sessionRecordingsPlaylistLogic)
+  const {
+    filters,
+    pinnedRecordings,
+    matchingEventsMatchType,
+    activeSessionRecording,
+    allowHogQLFilters,
+    totalFiltersCount,
+    nextSessionRecording,
+  } = useValues(sessionRecordingsPlaylistLogic);
+  const {
+    setFilters,
+    resetFilters,
+    setSelectedRecordingId,
+    loadAllRecordings,
+  } = useActions(sessionRecordingsPlaylistLogic);
 
-    const { isFiltersExpanded } = useValues(playlistFiltersLogic)
+  const { isFiltersExpanded } = useValues(playlistFiltersLogic);
 
-    const onPlayNextRecording = useCallback(() => {
-        if (nextSessionRecording?.id) {
-            setSelectedRecordingId(nextSessionRecording.id)
-        }
-    }, [nextSessionRecording, setSelectedRecordingId])
+  const onPlayNextRecording = useCallback(() => {
+    if (nextSessionRecording?.id) {
+      setSelectedRecordingId(nextSessionRecording.id);
+    }
+  }, [nextSessionRecording, setSelectedRecordingId]);
 
-    return (
-        <div
-            ref={containerRef}
-            className={clsx('Playlist__main relative overflow-hidden', className, 'min-h-96')}
-            // eslint-disable-next-line react/forbid-dom-props
-            style={style}
-        >
-            {isFiltersExpanded ? (
-                <div className="h-full rounded border">
-                    <RecordingsUniversalFiltersEmbed
-                        resetFilters={resetFilters}
-                        filters={filters}
-                        setFilters={setFilters}
-                        totalFiltersCount={totalFiltersCount}
-                        allowReplayHogQLFilters={allowHogQLFilters}
-                    />
-                </div>
-            ) : showContent && activeSessionRecording ? (
-                <SessionRecordingPlayer
-                    playerKey={props.logicKey ?? 'playlist'}
-                    sessionRecordingId={activeSessionRecording.id}
-                    matchingEventsMatchType={matchingEventsMatchType}
-                    autoPlay={props.autoPlay}
-                    onRecordingDeleted={() => {
-                        loadAllRecordings()
-                        setSelectedRecordingId(null)
-                    }}
-                    pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
-                    setPinned={
-                        props.onPinnedChange
-                            ? (pinned) => {
-                                  if (!activeSessionRecording.id) {
-                                      return
-                                  }
-                                  props.onPinnedChange?.(activeSessionRecording, pinned)
-                              }
-                            : undefined
-                    }
-                    playNextRecording={nextSessionRecording?.id ? onPlayNextRecording : undefined}
-                />
-            ) : (
-                <div className="mt-20">
-                    <EmptyMessage
-                        title="No recording selected"
-                        description="Please select a recording from the list on the left"
-                        buttonText="Learn more about recordings"
-                        buttonTo="https://posthog.com/docs/user-guides/recordings"
-                    />
-                </div>
-            )}
-            {resizer}
+  return (
+    <div
+      ref={containerRef}
+      className={clsx(
+        "Playlist__main relative overflow-hidden",
+        className,
+        "min-h-96",
+      )}
+      // eslint-disable-next-line react/forbid-dom-props
+      style={style}
+    >
+      {isFiltersExpanded ? (
+        <div className="h-full rounded border">
+          <RecordingsUniversalFiltersEmbed
+            resetFilters={resetFilters}
+            filters={filters}
+            setFilters={setFilters}
+            totalFiltersCount={totalFiltersCount}
+            allowReplayHogQLFilters={allowHogQLFilters}
+          />
         </div>
-    )
+      ) : showContent && activeSessionRecording ? (
+        <SessionRecordingPlayer
+          playerKey={props.logicKey ?? "playlist"}
+          sessionRecordingId={activeSessionRecording.id}
+          matchingEventsMatchType={matchingEventsMatchType}
+          autoPlay={props.autoPlay}
+          onRecordingDeleted={() => {
+            loadAllRecordings();
+            setSelectedRecordingId(null);
+          }}
+          pinned={
+            !!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)
+          }
+          setPinned={
+            props.onPinnedChange
+              ? (pinned) => {
+                  if (!activeSessionRecording.id) {
+                    return;
+                  }
+                  props.onPinnedChange?.(activeSessionRecording, pinned);
+                }
+              : undefined
+          }
+          playNextRecording={
+            nextSessionRecording?.id ? onPlayNextRecording : undefined
+          }
+        />
+      ) : (
+        <div className="mt-20">
+          <EmptyMessage
+            title="No recording selected"
+            description="Please select a recording from the list on the left"
+            buttonText="Learn more about recordings"
+            buttonTo="https://posthog.com/docs/user-guides/recordings"
+          />
+        </div>
+      )}
+      {resizer}
+    </div>
+  );
 }


### PR DESCRIPTION
## Problem

The session recordings playlist component needs to account for the side panel width when determining responsive layout breakpoints. Additionally, the codebase has inconsistent formatting that should be standardized.

## Changes
![CleanShot 2026-03-06 at 15 47 34](https://github.com/user-attachments/assets/c0264577-032a-45b2-b88b-c10632bb0696)

- **Account for side panel width**: Modified `useWindowSize` hook to accept an optional `widthOffset` parameter that subtracts from the window width when checking breakpoints
- **Update playlist component**: Integrated `panelLayoutLogic` to get the side panel width and pass it to `useWindowSize` hook, ensuring the layout responsiveness accounts for the side panel's actual space consumption
- **Improve hook flexibility**: Added `UseWindowSizeOptions` type to make the hook more extensible for future width offset needs

## How did you test this code?

tried it manually

## Publish to changelog?

No

https://claude.ai/code/session_01GvSH4qXrqUt7NYpVqaCzB7