### PR TITLE
feat(query-cache): add team_id label and eviction age histogram to query cache metrics

### DIFF
--- a/posthog/caching/cache_size_tracker.py
+++ b/posthog/caching/cache_size_tracker.py
@@ -17,19 +17,36 @@ logger = structlog.get_logger(__name__)
 CACHE_EVICTION_COUNTER = Counter(
     "query_cache_size_limit_evictions_total",
     "Cache entries evicted due to per-team size limits",
-    labelnames=["backend"],
+    labelnames=["team_id", "backend"],
 )
 
 CACHE_EVICTION_BYTES_COUNTER = Counter(
     "query_cache_size_limit_evicted_bytes_total",
     "Bytes evicted due to per-team size limits",
-    labelnames=["backend"],
+    labelnames=["team_id", "backend"],
+)
+
+CACHE_EVICTION_AGE_HISTOGRAM = Histogram(
+    "query_cache_eviction_age_seconds",
+    "Age of cache entries at eviction time (seconds since write)",
+    labelnames=["team_id", "backend"],
+    buckets=[
+        1800,  # 30 min
+        3600,  # 1 hour
+        14400,  # 4 hours
+        43200,  # 12 hours
+        86400,  # 1 day
+        172800,  # 2 days
+        345600,  # 4 days
+        604800,  # 7 days
+        float("inf"),
+    ],
 )
 
 CACHE_SIZE_HISTOGRAM = Histogram(
     "query_cache_team_size_bytes",
     "Distribution of per-team cache sizes in bytes",
-    labelnames=["backend"],
+    labelnames=["team_id", "backend"],
     buckets=[
         1_000_000,  # 1MB
         10_000_000,  # 10MB
@@ -167,7 +184,7 @@ class TeamCacheSizeTracker:
         total_size = self.get_total_size()
         entry_count = self.redis_client.zcard(self.entries_key)
         backend = BACKEND_CLUSTER if self._is_cluster else BACKEND_DEFAULT
-        CACHE_SIZE_HISTOGRAM.labels(backend=backend).observe(total_size)
+        CACHE_SIZE_HISTOGRAM.labels(team_id=self.team_id, backend=backend).observe(total_size)
 
         logger.info(
             "query_cache_write",
@@ -208,7 +225,7 @@ class TeamCacheSizeTracker:
             if not result:
                 break
 
-            cache_key = result[0][0]
+            cache_key, write_timestamp = result[0]
             if isinstance(cache_key, bytes):
                 cache_key = cache_key.decode()
 
@@ -226,8 +243,10 @@ class TeamCacheSizeTracker:
             evicted_keys.append(cache_key)
 
             backend = BACKEND_CLUSTER if self._is_cluster else BACKEND_DEFAULT
-            CACHE_EVICTION_COUNTER.labels(backend=backend).inc()
-            CACHE_EVICTION_BYTES_COUNTER.labels(backend=backend).inc(removed_size)
+            CACHE_EVICTION_COUNTER.labels(team_id=self.team_id, backend=backend).inc()
+            CACHE_EVICTION_BYTES_COUNTER.labels(team_id=self.team_id, backend=backend).inc(removed_size)
+            eviction_age = time.time() - float(write_timestamp)
+            CACHE_EVICTION_AGE_HISTOGRAM.labels(team_id=self.team_id, backend=backend).observe(eviction_age)
 
         return evicted_keys
 


### PR DESCRIPTION
## Problem

When investigating query cache effectiveness per team, the eviction and cache size metrics (`query_cache_size_limit_evictions_total`, `query_cache_size_limit_evicted_bytes_total`, `query_cache_team_size_bytes`) only had a  `backend` label, making it impossible to break down by team. Additionally, there was no way to tell whether evictions were healthy (evicting old/cold entries) or problematic (evicting young entries due to insufficient cache space).

After these fixes, some of the following metrics can be observed through Grafana:  


```
## Hit rate (% of queries served from cache)

#### Overall hit rate
sum(rate(posthog_query_cache_hit_total{cache_hit="hit"}[5m]))
/
sum(rate(posthog_query_cache_hit_total[5m]))

#### Per team
sum by (team_id) (rate(posthog_query_cache_hit_total{cache_hit="hit"}[5m]))
/
sum by (team_id) (rate(posthog_query_cache_hit_total[5m]))

## Stale rate (served stale data, triggered async refresh)

sum by (team_id) (rate(posthog_query_cache_hit_total{cache_hit="stale"}[5m]))
/
sum by (team_id) (rate(posthog_query_cache_hit_total[5m]))

## Eviction rate (entries/sec evicted per team)

sum by (team_id) (rate(query_cache_size_limit_evictions_total[5m]))

## Eviction pressure (what fraction of written bytes get evicted)

sum by (team_id) (rate(query_cache_size_limit_evicted_bytes_total[5m]))
/
sum by (team_id) (rate(posthog_query_cache_write_bytes_total[5m]))

## Median eviction age (p50 — are we evicting young or old entries?)

histogram_quantile(0.50,
  sum by (team_id, le) (rate(query_cache_eviction_age_seconds_bucket[5m]))
)

## p95 eviction age

histogram_quantile(0.95,
  sum by (team_id, le) (rate(query_cache_eviction_age_seconds_bucket[5m]))
)

## Cache utilization (p50 of per-team cache size)

histogram_quantile(0.50,
  sum by (team_id, le) (rate(query_cache_team_size_bytes_bucket[5m]))
)

## Write throughput (writes/sec per team)

sum by (team_id) (rate(posthog_query_cache_write_total[5m]))

> The key signal to watch: if eviction age p50 < 1 hour AND hit rate is low for a team, their cache limit is too small. If eviction age is in the days range, LRU is healthy.
```

## Changes

- Added `team_id` label to the three existing cache size tracker metrics in `posthog/caching/cache_size_tracker.py`, matching the pattern already used by the sibling metrics in `query_cache.py`
- Added a new `query_cache_eviction_age_seconds` histogram that records how old each entry was at eviction time (seconds since write). Uses the write timestamp already stored in the Redis sorted set — no extra Redis
calls. Buckets span 1 min to 24 hours
    - Entries evicted after seconds/minutes → cache is too small for that team
    - Entries evicted after hours → LRU is working as expected

## How did you test this code?

✅  The `test_cache_size_tracker.py` tests are passing in the CI

## Publish to changelog?

No