### PR TITLE
fix: shortcuts in input

### DIFF
--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -107,7 +107,7 @@ const LinkShortcutExtension = Extension.create<LinkShortcutExtensionOptions>({
 
     addKeyboardShortcuts() {
         return {
-            'Mod-Shift-l': () => {
+            'Mod-Shift-u': () => {
                 this.options.onLinkShortcut()
                 return true
             },
@@ -346,6 +346,12 @@ export function SupportEditor({
     const { objectStorageAvailable } = useValues(preflightLogic)
     const { emojiUsed } = useActions(emojiUsageLogic)
 
+    const openLinkPopover = useCallback(() => {
+        const existingHref = ttEditor?.getAttributes('link').href
+        setLinkUrl(existingHref || '')
+        setLinkPopoverOpen(true)
+    }, [ttEditor])
+
     // Use ref to hold the link shortcut callback so it can access latest state
     const linkShortcutCallbackRef = useRef<() => void>(() => {})
     const handleLinkShortcut = useCallback(() => {
@@ -395,12 +401,8 @@ export function SupportEditor({
 
     // Update the link shortcut callback ref when ttEditor changes
     useEffect(() => {
-        linkShortcutCallbackRef.current = () => {
-            const existingHref = ttEditor?.getAttributes('link').href
-            setLinkUrl(existingHref || '')
-            setLinkPopoverOpen(true)
-        }
-    }, [ttEditor])
+        linkShortcutCallbackRef.current = openLinkPopover
+    }, [openLinkPopover])
 
     // Notify parent of upload state changes
     useEffect(() => {
@@ -547,14 +549,9 @@ export function SupportEditor({
                         <LemonButton
                             size="small"
                             active={ttEditor?.isActive('link')}
-                            onClick={() => {
-                                // Pre-fill with existing link URL if editing
-                                const existingHref = ttEditor?.getAttributes('link').href
-                                setLinkUrl(existingHref || '')
-                                setLinkPopoverOpen(true)
-                            }}
+                            onClick={openLinkPopover}
                             icon={<IconLink />}
-                            tooltip="Add link (Cmd+Shift+L)"
+                            tooltip="Add link (Cmd+Shift+U)"
                         />
                     </Popover>
                     <div className="w-px h-4 bg-border mx-1" />

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -7,12 +7,19 @@ import { Image } from '@tiptap/extension-image'
 import { Link } from '@tiptap/extension-link'
 import { Underline } from '@tiptap/extension-underline'
 import { Placeholder } from '@tiptap/extensions'
-import { EditorContent, NodeViewContent, NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import {
+    EditorContent,
+    Extension,
+    NodeViewContent,
+    NodeViewProps,
+    NodeViewWrapper,
+    ReactNodeViewRenderer,
+} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useActions, useValues } from 'kea'
 import { common, createLowlight } from 'lowlight'
 import posthog from 'posthog-js'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { IconCode, IconCopy, IconImage, IconTerminal } from '@posthog/icons'
 
@@ -84,6 +91,29 @@ const SupportCodeBlockExtension = CodeBlockLowlight.extend({
         }
     },
 }).configure({ lowlight })
+
+type LinkShortcutExtensionOptions = {
+    onLinkShortcut: () => void
+}
+
+const LinkShortcutExtension = Extension.create<LinkShortcutExtensionOptions>({
+    name: 'link-shortcut',
+
+    addOptions() {
+        return {
+            onLinkShortcut: () => {},
+        }
+    },
+
+    addKeyboardShortcuts() {
+        return {
+            'Mod-Shift-l': () => {
+                this.options.onLinkShortcut()
+                return true
+            },
+        }
+    },
+})
 
 // Underline icon (not in @posthog/icons)
 function IconUnderline(): JSX.Element {
@@ -315,11 +345,19 @@ export function SupportEditor({
     const [linkUrl, setLinkUrl] = useState('')
     const { objectStorageAvailable } = useValues(preflightLogic)
     const { emojiUsed } = useActions(emojiUsageLogic)
+
+    // Use ref to hold the link shortcut callback so it can access latest state
+    const linkShortcutCallbackRef = useRef<() => void>(() => {})
+    const handleLinkShortcut = useCallback(() => {
+        linkShortcutCallbackRef.current()
+    }, [])
+
     const editor = useRichContentEditor({
         extensions: [
             ...SUPPORT_EXTENSIONS,
             Placeholder.configure({ placeholder }),
             CommandEnterExtension.configure({ onPressCmdEnter }),
+            LinkShortcutExtension.configure({ onLinkShortcut: handleLinkShortcut }),
         ],
         disabled,
         initialContent: initialContent ?? DEFAULT_INITIAL_CONTENT,
@@ -354,6 +392,15 @@ export function SupportEditor({
             lemonToast.error(`Error uploading image: ${detail}`)
         },
     })
+
+    // Update the link shortcut callback ref when ttEditor changes
+    useEffect(() => {
+        linkShortcutCallbackRef.current = () => {
+            const existingHref = ttEditor?.getAttributes('link').href
+            setLinkUrl(existingHref || '')
+            setLinkPopoverOpen(true)
+        }
+    }, [ttEditor])
 
     // Notify parent of upload state changes
     useEffect(() => {
@@ -507,7 +554,7 @@ export function SupportEditor({
                                 setLinkPopoverOpen(true)
                             }}
                             icon={<IconLink />}
-                            tooltip="Add link (Cmd+K)"
+                            tooltip="Add link (Cmd+Shift+L)"
                         />
                     </Popover>
                     <div className="w-px h-4 bg-border mx-1" />


### PR DESCRIPTION
## Problem

Keyboard shortcuts don't work in support input

## Changes

Fix it with extension of tiptap

Note: We cannot use cmd+k / cmd+l for links so we use cmd+shift+l

<img width="365" height="129" alt="Screenshot 2026-03-06 at 16 34 08" src="https://github.com/user-attachments/assets/c9d6d933-a05e-424e-a0d5-a01bc6eb5320" />
