### PR TITLE
fix: do not show insight details on publicly shared dashboards

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -285,7 +285,9 @@ export function InsightMeta({
                     : undefined
             }
             metaDetails={
-                <InsightDetails query={insight.query} footerInfo={insight} variablesOverride={variablesOverride} />
+                showDetailsControls ? (
+                    <InsightDetails query={insight.query} footerInfo={insight} variablesOverride={variablesOverride} />
+                ) : null
             }
             samplingFactor={samplingFactor}
             moreButtons={

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -251,6 +251,7 @@ export function DashboardItems(): JSX.Element {
                                     setOverride={() => setTileOverride(tile)}
                                     showDetailsControls={
                                         placement != DashboardPlacement.Export &&
+                                        placement != DashboardPlacement.Public &&
                                         !getCurrentExporterData()?.hideExtraDetails
                                     }
                                     placement={placement}


### PR DESCRIPTION
## Problem

Right now if I visit a public dashboard, there is a button to view the insight details. We should not be displaying this on publicly shared dashboards since it is visual clutter and probably means nothing to the people viewing the public dashboard.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Hide 'Show details' and meta buttons on insights which are viewed through a public shared link.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
