### PR TITLE
feat(llma): add tool chart buttons and toolbar actions to tools tab

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -306,6 +306,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERS_TAB: 'llm-analytics-clusters-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_TOOLS_TAB: 'llm-analytics-tools-tab', // owner: #team-llm-analytics
+    LLM_ANALYTICS_TOOLS_CHARTS: 'llm-analytics-tools-charts', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERING_ADMIN: 'llm-analytics-clustering-admin', // owner: #team-llm-analytics
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-llm-analytics

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -774,6 +774,11 @@ export function DataTable({
         sourceFeatures.has(QueryFeature.linkDataButton) && hasCustomerAnalyticsEnabled ? (
             <ViewLinkButton key="view-link-button" tableName="groups" />
         ) : null,
+        ...(context?.customActions
+            ? Array.isArray(context.customActions)
+                ? context.customActions
+                : [context.customActions]
+            : []),
         (showColumnConfigurator || showPersistentColumnConfigurator) &&
         sourceFeatures.has(QueryFeature.columnConfigurator) ? (
             <ColumnConfigurator key="column-configurator" query={queryWithDefaults} setQuery={setQuery} />

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -64,6 +64,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     baseCurrency?: CurrencyCode
     /** Limit context sent to the /query endpoint */
     limitContext?: 'posthog_ai'
+    /** Custom action buttons rendered in the DataTable toolbar (second row, right side) */
+    customActions?: JSX.Element | JSX.Element[]
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,12 +1,17 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
+import { IconDecisionTree } from '@posthog/icons'
+
 import { escapeRegex } from 'lib/actionUtils'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { NodeKind } from '~/queries/schema/schema-general'
+import type { InsightVizNode } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
@@ -17,118 +22,136 @@ import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 export function LLMAnalyticsTools(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
-    const { toolsQuery, toolsSort } = useValues(llmAnalyticsToolsLogic)
+    const { toolsQuery, toolsSort, buildToolPathsQuery } = useValues(llmAnalyticsToolsLogic)
     const { searchParams } = useValues(router)
 
     const { renderSortableColumnTitle } = useSortableColumns(toolsSort, setToolsSort)
 
     return (
-        <DataTable
-            query={{
-                ...toolsQuery,
-                showSavedFilters: true,
-            }}
-            setQuery={(query) => {
-                if (!isHogQLQuery(query.source)) {
-                    console.warn('LLMAnalyticsTools received a non-HogQL query:', query.source)
-                    return
-                }
-                const { filters = {} } = query.source
-                const { dateRange = {} } = filters
-                setDates(dateRange.date_from || null, dateRange.date_to || null)
-                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                setPropertyFilters(filters.properties || [])
-            }}
-            context={{
-                columns: {
-                    tool: {
-                        render: function RenderTool(x) {
-                            const toolValue = x.value
-                            if (!toolValue || toolValue === 'null' || toolValue === '') {
-                                return <span className="text-muted">Unknown tool</span>
-                            }
+        <>
+            <DataTable
+                query={{
+                    ...toolsQuery,
+                    showSavedFilters: true,
+                }}
+                setQuery={(query) => {
+                    if (!isHogQLQuery(query.source)) {
+                        console.warn('LLMAnalyticsTools received a non-HogQL query:', query.source)
+                        return
+                    }
+                    const { filters = {} } = query.source
+                    const { dateRange = {} } = filters
+                    setDates(dateRange.date_from || null, dateRange.date_to || null)
+                    setShouldFilterTestAccounts(filters.filterTestAccounts || false)
+                    setPropertyFilters(filters.properties || [])
+                }}
+                context={{
+                    columns: {
+                        tool: {
+                            render: function RenderTool(x) {
+                                const toolValue = x.value
+                                if (!toolValue || toolValue === 'null' || toolValue === '') {
+                                    return <span className="text-muted">Unknown tool</span>
+                                }
 
-                            const toolString = String(toolValue)
+                                const toolString = String(toolValue)
 
-                            return (
-                                <Tooltip title={`View generations calling ${toolString}`}>
-                                    <Link
-                                        to={
-                                            combineUrl(urls.llmAnalyticsGenerations(), {
-                                                ...searchParams,
-                                                filters: [
-                                                    {
-                                                        type: PropertyFilterType.Event,
-                                                        key: '$ai_tools_called',
-                                                        operator: PropertyOperator.Regex,
-                                                        value: `(^|,)${escapeRegex(toolString)}(,|$)`,
-                                                    },
-                                                ],
-                                            }).url
-                                        }
-                                        className="font-mono text-sm"
-                                        data-attr="llm-tools-row-click"
-                                    >
-                                        {toolString}
-                                    </Link>
+                                return (
+                                    <div className="flex items-center gap-1">
+                                        <Tooltip title={`View generations calling ${toolString}`}>
+                                            <Link
+                                                to={
+                                                    combineUrl(urls.llmAnalyticsGenerations(), {
+                                                        ...searchParams,
+                                                        filters: [
+                                                            {
+                                                                type: PropertyFilterType.Event,
+                                                                key: '$ai_tools_called',
+                                                                operator: PropertyOperator.Regex,
+                                                                value: `(^|,)${escapeRegex(toolString)}(,|$)`,
+                                                            },
+                                                        ],
+                                                    }).url
+                                                }
+                                                className="font-mono text-sm"
+                                                data-attr="llm-tools-row-click"
+                                            >
+                                                {toolString}
+                                            </Link>
+                                        </Tooltip>
+                                        <Tooltip title={`View tool paths from ${toolString}`}>
+                                            <LemonButton
+                                                icon={<IconDecisionTree />}
+                                                size="xsmall"
+                                                to={urls.insightNew({
+                                                    query: {
+                                                        kind: NodeKind.InsightVizNode,
+                                                        source: buildToolPathsQuery(toolString),
+                                                    } as InsightVizNode,
+                                                })}
+                                                targetBlank
+                                                data-attr="llm-tools-paths-click"
+                                            />
+                                        </Tooltip>
+                                    </div>
+                                )
+                            },
+                        },
+                        total_calls: {
+                            renderTitle: () => (
+                                <Tooltip title="Total number of times this tool was called">
+                                    {renderSortableColumnTitle('total_calls', 'Total calls')}
                                 </Tooltip>
-                            )
+                            ),
+                        },
+                        traces: {
+                            renderTitle: () => (
+                                <Tooltip title="Number of unique traces where this tool was called">
+                                    {renderSortableColumnTitle('traces', 'Traces')}
+                                </Tooltip>
+                            ),
+                        },
+                        users: {
+                            renderTitle: () => (
+                                <Tooltip title="Number of unique users who triggered this tool">
+                                    {renderSortableColumnTitle('users', 'Users')}
+                                </Tooltip>
+                            ),
+                        },
+                        sessions: {
+                            renderTitle: () => (
+                                <Tooltip title="Number of unique sessions where this tool was called">
+                                    {renderSortableColumnTitle('sessions', 'Sessions')}
+                                </Tooltip>
+                            ),
+                        },
+                        single_pct: {
+                            renderTitle: () => (
+                                <Tooltip title="Percentage of calls where this was the only tool called">
+                                    {renderSortableColumnTitle('single_pct', 'Single %')}
+                                </Tooltip>
+                            ),
+                            render: function RenderSinglePct(x) {
+                                return <span>{String(x.value)}%</span>
+                            },
+                        },
+                        days_seen: {
+                            renderTitle: () => (
+                                <Tooltip title="Number of distinct days this tool was called">
+                                    {renderSortableColumnTitle('days_seen', 'Days seen')}
+                                </Tooltip>
+                            ),
+                        },
+                        first_seen: {
+                            renderTitle: () => renderSortableColumnTitle('first_seen', 'First seen'),
+                        },
+                        last_seen: {
+                            renderTitle: () => renderSortableColumnTitle('last_seen', 'Last seen'),
                         },
                     },
-                    total_calls: {
-                        renderTitle: () => (
-                            <Tooltip title="Total number of times this tool was called">
-                                {renderSortableColumnTitle('total_calls', 'Total calls')}
-                            </Tooltip>
-                        ),
-                    },
-                    traces: {
-                        renderTitle: () => (
-                            <Tooltip title="Number of unique traces where this tool was called">
-                                {renderSortableColumnTitle('traces', 'Traces')}
-                            </Tooltip>
-                        ),
-                    },
-                    users: {
-                        renderTitle: () => (
-                            <Tooltip title="Number of unique users who triggered this tool">
-                                {renderSortableColumnTitle('users', 'Users')}
-                            </Tooltip>
-                        ),
-                    },
-                    sessions: {
-                        renderTitle: () => (
-                            <Tooltip title="Number of unique sessions where this tool was called">
-                                {renderSortableColumnTitle('sessions', 'Sessions')}
-                            </Tooltip>
-                        ),
-                    },
-                    single_pct: {
-                        renderTitle: () => (
-                            <Tooltip title="Percentage of calls where this was the only tool called">
-                                {renderSortableColumnTitle('single_pct', 'Single %')}
-                            </Tooltip>
-                        ),
-                        render: function RenderSinglePct(x) {
-                            return <span>{String(x.value)}%</span>
-                        },
-                    },
-                    days_seen: {
-                        renderTitle: () => (
-                            <Tooltip title="Number of distinct days this tool was called">
-                                {renderSortableColumnTitle('days_seen', 'Days seen')}
-                            </Tooltip>
-                        ),
-                    },
-                    first_seen: {
-                        renderTitle: () => renderSortableColumnTitle('first_seen', 'First seen'),
-                    },
-                    last_seen: {
-                        renderTitle: () => renderSortableColumnTitle('last_seen', 'Last seen'),
-                    },
-                },
-            }}
-            uniqueKey="llm-analytics-tools"
-        />
+                }}
+                uniqueKey="llm-analytics-tools"
+            />
+        </>
     )
 }

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconTrends, IconUserPaths } from '@posthog/icons'
+import { IconGraph, IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -81,7 +81,7 @@ export function LLMAnalyticsTools(): JSX.Element {
                                         </Tooltip>
                                         <Tooltip title={`View tool sequences for ${toolString}`}>
                                             <LemonButton
-                                                icon={<IconTrends />}
+                                                icon={<IconGraph />}
                                                 size="xsmall"
                                                 to={urls.insightNew({
                                                     query: {

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconDecisionTree } from '@posthog/icons'
+import { IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -81,7 +81,7 @@ export function LLMAnalyticsTools(): JSX.Element {
                                         </Tooltip>
                                         <Tooltip title={`View tool paths from ${toolString}`}>
                                             <LemonButton
-                                                icon={<IconDecisionTree />}
+                                                icon={<IconUserPaths />}
                                                 size="xsmall"
                                                 to={urls.insightNew({
                                                     query: {

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconGraph, IconUserPaths } from '@posthog/icons'
+import { IconGraph, IconTrends, IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -24,7 +24,8 @@ import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 export function LLMAnalyticsTools(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
-    const { toolsQuery, toolsSort, buildToolPathsQuery, buildToolSequencesQuery } = useValues(llmAnalyticsToolsLogic)
+    const { toolsQuery, toolsSort, buildToolPathsQuery, buildToolSequencesQuery, buildToolTrendQuery } =
+        useValues(llmAnalyticsToolsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
     const showToolsCharts = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TOOLS_CHARTS]
@@ -85,7 +86,21 @@ export function LLMAnalyticsTools(): JSX.Element {
                                         </Tooltip>
                                         {showToolsCharts && (
                                             <>
-                                                <Tooltip title={`View tool sequences for ${toolString}`}>
+                                                <Tooltip title={`View ${toolString} usage over time`}>
+                                                    <LemonButton
+                                                        icon={<IconTrends />}
+                                                        size="xsmall"
+                                                        to={urls.insightNew({
+                                                            query: {
+                                                                kind: NodeKind.InsightVizNode,
+                                                                source: buildToolTrendQuery(toolString),
+                                                            } as InsightVizNode,
+                                                        })}
+                                                        targetBlank
+                                                        data-attr="llma-tools-trend-click"
+                                                    />
+                                                </Tooltip>
+                                                <Tooltip title={`View tool combinations with ${toolString}`}>
                                                     <LemonButton
                                                         icon={<IconGraph />}
                                                         size="xsmall"

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -4,9 +4,11 @@ import { combineUrl, router } from 'kea-router'
 import { IconGraph, IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
@@ -23,7 +25,9 @@ export function LLMAnalyticsTools(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
     const { toolsQuery, toolsSort, buildToolPathsQuery, buildToolSequencesQuery } = useValues(llmAnalyticsToolsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
+    const showToolsCharts = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TOOLS_CHARTS]
 
     const { renderSortableColumnTitle } = useSortableColumns(toolsSort, setToolsSort)
 
@@ -74,39 +78,43 @@ export function LLMAnalyticsTools(): JSX.Element {
                                                     }).url
                                                 }
                                                 className="font-mono text-sm"
-                                                data-attr="llm-tools-row-click"
+                                                data-attr="llma-tools-row-click"
                                             >
                                                 {toolString}
                                             </Link>
                                         </Tooltip>
-                                        <Tooltip title={`View tool sequences for ${toolString}`}>
-                                            <LemonButton
-                                                icon={<IconGraph />}
-                                                size="xsmall"
-                                                to={urls.insightNew({
-                                                    query: {
-                                                        kind: NodeKind.InsightVizNode,
-                                                        source: buildToolSequencesQuery(toolString),
-                                                    } as InsightVizNode,
-                                                })}
-                                                targetBlank
-                                                data-attr="llm-tools-sequences-click"
-                                            />
-                                        </Tooltip>
-                                        <Tooltip title={`View tool paths from ${toolString}`}>
-                                            <LemonButton
-                                                icon={<IconUserPaths />}
-                                                size="xsmall"
-                                                to={urls.insightNew({
-                                                    query: {
-                                                        kind: NodeKind.InsightVizNode,
-                                                        source: buildToolPathsQuery(toolString),
-                                                    } as InsightVizNode,
-                                                })}
-                                                targetBlank
-                                                data-attr="llm-tools-paths-click"
-                                            />
-                                        </Tooltip>
+                                        {showToolsCharts && (
+                                            <>
+                                                <Tooltip title={`View tool sequences for ${toolString}`}>
+                                                    <LemonButton
+                                                        icon={<IconGraph />}
+                                                        size="xsmall"
+                                                        to={urls.insightNew({
+                                                            query: {
+                                                                kind: NodeKind.InsightVizNode,
+                                                                source: buildToolSequencesQuery(toolString),
+                                                            } as InsightVizNode,
+                                                        })}
+                                                        targetBlank
+                                                        data-attr="llma-tools-sequences-click"
+                                                    />
+                                                </Tooltip>
+                                                <Tooltip title={`View tool paths from ${toolString}`}>
+                                                    <LemonButton
+                                                        icon={<IconUserPaths />}
+                                                        size="xsmall"
+                                                        to={urls.insightNew({
+                                                            query: {
+                                                                kind: NodeKind.InsightVizNode,
+                                                                source: buildToolPathsQuery(toolString),
+                                                            } as InsightVizNode,
+                                                        })}
+                                                        targetBlank
+                                                        data-attr="llma-tools-paths-click"
+                                                    />
+                                                </Tooltip>
+                                            </>
+                                        )}
                                     </div>
                                 )
                             },

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconGraph, IconTrends, IconUserPaths } from '@posthog/icons'
+import { IconGraph, IconRetentionHeatmap, IconTrends, IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -24,8 +24,14 @@ import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 export function LLMAnalyticsTools(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
-    const { toolsQuery, toolsSort, buildToolPathsQuery, buildToolSequencesQuery, buildToolTrendQuery } =
-        useValues(llmAnalyticsToolsLogic)
+    const {
+        toolsQuery,
+        toolsSort,
+        buildToolPathsQuery,
+        buildToolSequencesQuery,
+        buildToolTrendQuery,
+        buildToolHeatmapQuery,
+    } = useValues(llmAnalyticsToolsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
     const showToolsCharts = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TOOLS_CHARTS]
@@ -34,6 +40,22 @@ export function LLMAnalyticsTools(): JSX.Element {
 
     return (
         <>
+            {showToolsCharts && (
+                <div className="flex justify-end mb-2">
+                    <Tooltip title="View tool co-occurrence heatmap">
+                        <LemonButton
+                            icon={<IconRetentionHeatmap />}
+                            size="small"
+                            type="secondary"
+                            to={urls.insightNew({ query: buildToolHeatmapQuery })}
+                            targetBlank
+                            data-attr="llma-tools-heatmap-click"
+                        >
+                            Tool co-occurrence
+                        </LemonButton>
+                    </Tooltip>
+                </div>
+            )}
             <DataTable
                 query={{
                     ...toolsQuery,

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -12,8 +12,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
-import { NodeKind } from '~/queries/schema/schema-general'
-import type { InsightVizNode } from '~/queries/schema/schema-general'
+import { type InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconUserPaths } from '@posthog/icons'
+import { IconTrends, IconUserPaths } from '@posthog/icons'
 
 import { escapeRegex } from 'lib/actionUtils'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -22,7 +22,7 @@ import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 export function LLMAnalyticsTools(): JSX.Element {
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
-    const { toolsQuery, toolsSort, buildToolPathsQuery } = useValues(llmAnalyticsToolsLogic)
+    const { toolsQuery, toolsSort, buildToolPathsQuery, buildToolSequencesQuery } = useValues(llmAnalyticsToolsLogic)
     const { searchParams } = useValues(router)
 
     const { renderSortableColumnTitle } = useSortableColumns(toolsSort, setToolsSort)
@@ -78,6 +78,20 @@ export function LLMAnalyticsTools(): JSX.Element {
                                             >
                                                 {toolString}
                                             </Link>
+                                        </Tooltip>
+                                        <Tooltip title={`View tool sequences for ${toolString}`}>
+                                            <LemonButton
+                                                icon={<IconTrends />}
+                                                size="xsmall"
+                                                to={urls.insightNew({
+                                                    query: {
+                                                        kind: NodeKind.InsightVizNode,
+                                                        source: buildToolSequencesQuery(toolString),
+                                                    } as InsightVizNode,
+                                                })}
+                                                targetBlank
+                                                data-attr="llm-tools-sequences-click"
+                                            />
                                         </Tooltip>
                                         <Tooltip title={`View tool paths from ${toolString}`}>
                                             <LemonButton

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -30,6 +30,7 @@ export function LLMAnalyticsTools(): JSX.Element {
         buildToolPathsQuery,
         buildToolSequencesQuery,
         buildToolTrendQuery,
+        buildAllToolsTrendQuery,
         buildToolHeatmapQuery,
     } = useValues(llmAnalyticsToolsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -39,178 +40,188 @@ export function LLMAnalyticsTools(): JSX.Element {
     const { renderSortableColumnTitle } = useSortableColumns(toolsSort, setToolsSort)
 
     return (
-        <>
-            {showToolsCharts && (
-                <div className="flex justify-end mb-2">
-                    <Tooltip title="View tool co-occurrence heatmap">
-                        <LemonButton
-                            icon={<IconRetentionHeatmap />}
-                            size="small"
-                            type="secondary"
-                            to={urls.insightNew({ query: buildToolHeatmapQuery })}
-                            targetBlank
-                            data-attr="llma-tools-heatmap-click"
-                        >
-                            Tool co-occurrence
-                        </LemonButton>
-                    </Tooltip>
-                </div>
-            )}
-            <DataTable
-                query={{
-                    ...toolsQuery,
-                    showSavedFilters: true,
-                }}
-                setQuery={(query) => {
-                    if (!isHogQLQuery(query.source)) {
-                        console.warn('LLMAnalyticsTools received a non-HogQL query:', query.source)
-                        return
-                    }
-                    const { filters = {} } = query.source
-                    const { dateRange = {} } = filters
-                    setDates(dateRange.date_from || null, dateRange.date_to || null)
-                    setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                    setPropertyFilters(filters.properties || [])
-                }}
-                context={{
-                    columns: {
-                        tool: {
-                            render: function RenderTool(x) {
-                                const toolValue = x.value
-                                if (!toolValue || toolValue === 'null' || toolValue === '') {
-                                    return <span className="text-muted">Unknown tool</span>
-                                }
+        <DataTable
+            query={{
+                ...toolsQuery,
+                showSavedFilters: true,
+            }}
+            setQuery={(query) => {
+                if (!isHogQLQuery(query.source)) {
+                    console.warn('LLMAnalyticsTools received a non-HogQL query:', query.source)
+                    return
+                }
+                const { filters = {} } = query.source
+                const { dateRange = {} } = filters
+                setDates(dateRange.date_from || null, dateRange.date_to || null)
+                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
+                setPropertyFilters(filters.properties || [])
+            }}
+            context={{
+                customActions: showToolsCharts
+                    ? [
+                          <Tooltip title="View tool usage trends over time" key="trends">
+                              <LemonButton
+                                  icon={<IconTrends />}
+                                  size="small"
+                                  type="secondary"
+                                  to={urls.insightNew({ query: buildAllToolsTrendQuery })}
+                                  targetBlank
+                                  data-attr="llma-tools-all-trends-click"
+                              >
+                                  Tool trends
+                              </LemonButton>
+                          </Tooltip>,
+                          <Tooltip title="View tool co-occurrence heatmap" key="heatmap">
+                              <LemonButton
+                                  icon={<IconRetentionHeatmap />}
+                                  size="small"
+                                  type="secondary"
+                                  to={urls.insightNew({ query: buildToolHeatmapQuery })}
+                                  targetBlank
+                                  data-attr="llma-tools-heatmap-click"
+                              >
+                                  Tool co-occurrence
+                              </LemonButton>
+                          </Tooltip>,
+                      ]
+                    : undefined,
+                columns: {
+                    tool: {
+                        render: function RenderTool(x) {
+                            const toolValue = x.value
+                            if (!toolValue || toolValue === 'null' || toolValue === '') {
+                                return <span className="text-muted">Unknown tool</span>
+                            }
 
-                                const toolString = String(toolValue)
+                            const toolString = String(toolValue)
 
-                                return (
-                                    <div className="flex items-center gap-1">
-                                        <Tooltip title={`View generations calling ${toolString}`}>
-                                            <Link
-                                                to={
-                                                    combineUrl(urls.llmAnalyticsGenerations(), {
-                                                        ...searchParams,
-                                                        filters: [
-                                                            {
-                                                                type: PropertyFilterType.Event,
-                                                                key: '$ai_tools_called',
-                                                                operator: PropertyOperator.Regex,
-                                                                value: `(^|,)${escapeRegex(toolString)}(,|$)`,
-                                                            },
-                                                        ],
-                                                    }).url
-                                                }
-                                                className="font-mono text-sm"
-                                                data-attr="llma-tools-row-click"
-                                            >
-                                                {toolString}
-                                            </Link>
-                                        </Tooltip>
-                                        {showToolsCharts && (
-                                            <>
-                                                <Tooltip title={`View ${toolString} usage over time`}>
-                                                    <LemonButton
-                                                        icon={<IconTrends />}
-                                                        size="xsmall"
-                                                        to={urls.insightNew({
-                                                            query: {
-                                                                kind: NodeKind.InsightVizNode,
-                                                                source: buildToolTrendQuery(toolString),
-                                                            } as InsightVizNode,
-                                                        })}
-                                                        targetBlank
-                                                        data-attr="llma-tools-trend-click"
-                                                    />
-                                                </Tooltip>
-                                                <Tooltip title={`View tool combinations with ${toolString}`}>
-                                                    <LemonButton
-                                                        icon={<IconGraph />}
-                                                        size="xsmall"
-                                                        to={urls.insightNew({
-                                                            query: {
-                                                                kind: NodeKind.InsightVizNode,
-                                                                source: buildToolSequencesQuery(toolString),
-                                                            } as InsightVizNode,
-                                                        })}
-                                                        targetBlank
-                                                        data-attr="llma-tools-sequences-click"
-                                                    />
-                                                </Tooltip>
-                                                <Tooltip title={`View tool paths from ${toolString}`}>
-                                                    <LemonButton
-                                                        icon={<IconUserPaths />}
-                                                        size="xsmall"
-                                                        to={urls.insightNew({
-                                                            query: {
-                                                                kind: NodeKind.InsightVizNode,
-                                                                source: buildToolPathsQuery(toolString),
-                                                            } as InsightVizNode,
-                                                        })}
-                                                        targetBlank
-                                                        data-attr="llma-tools-paths-click"
-                                                    />
-                                                </Tooltip>
-                                            </>
-                                        )}
-                                    </div>
-                                )
-                            },
-                        },
-                        total_calls: {
-                            renderTitle: () => (
-                                <Tooltip title="Total number of times this tool was called">
-                                    {renderSortableColumnTitle('total_calls', 'Total calls')}
-                                </Tooltip>
-                            ),
-                        },
-                        traces: {
-                            renderTitle: () => (
-                                <Tooltip title="Number of unique traces where this tool was called">
-                                    {renderSortableColumnTitle('traces', 'Traces')}
-                                </Tooltip>
-                            ),
-                        },
-                        users: {
-                            renderTitle: () => (
-                                <Tooltip title="Number of unique users who triggered this tool">
-                                    {renderSortableColumnTitle('users', 'Users')}
-                                </Tooltip>
-                            ),
-                        },
-                        sessions: {
-                            renderTitle: () => (
-                                <Tooltip title="Number of unique sessions where this tool was called">
-                                    {renderSortableColumnTitle('sessions', 'Sessions')}
-                                </Tooltip>
-                            ),
-                        },
-                        single_pct: {
-                            renderTitle: () => (
-                                <Tooltip title="Percentage of calls where this was the only tool called">
-                                    {renderSortableColumnTitle('single_pct', 'Single %')}
-                                </Tooltip>
-                            ),
-                            render: function RenderSinglePct(x) {
-                                return <span>{String(x.value)}%</span>
-                            },
-                        },
-                        days_seen: {
-                            renderTitle: () => (
-                                <Tooltip title="Number of distinct days this tool was called">
-                                    {renderSortableColumnTitle('days_seen', 'Days seen')}
-                                </Tooltip>
-                            ),
-                        },
-                        first_seen: {
-                            renderTitle: () => renderSortableColumnTitle('first_seen', 'First seen'),
-                        },
-                        last_seen: {
-                            renderTitle: () => renderSortableColumnTitle('last_seen', 'Last seen'),
+                            return (
+                                <div className="flex items-center gap-1">
+                                    <Tooltip title={`View generations calling ${toolString}`}>
+                                        <Link
+                                            to={
+                                                combineUrl(urls.llmAnalyticsGenerations(), {
+                                                    ...searchParams,
+                                                    filters: [
+                                                        {
+                                                            type: PropertyFilterType.Event,
+                                                            key: '$ai_tools_called',
+                                                            operator: PropertyOperator.Regex,
+                                                            value: `(^|,)${escapeRegex(toolString)}(,|$)`,
+                                                        },
+                                                    ],
+                                                }).url
+                                            }
+                                            className="font-mono text-sm"
+                                            data-attr="llma-tools-row-click"
+                                        >
+                                            {toolString}
+                                        </Link>
+                                    </Tooltip>
+                                    {showToolsCharts && (
+                                        <>
+                                            <Tooltip title={`View ${toolString} usage over time`}>
+                                                <LemonButton
+                                                    icon={<IconTrends />}
+                                                    size="xsmall"
+                                                    to={urls.insightNew({
+                                                        query: {
+                                                            kind: NodeKind.InsightVizNode,
+                                                            source: buildToolTrendQuery(toolString),
+                                                        } as InsightVizNode,
+                                                    })}
+                                                    targetBlank
+                                                    data-attr="llma-tools-trend-click"
+                                                />
+                                            </Tooltip>
+                                            <Tooltip title={`View tool combinations with ${toolString}`}>
+                                                <LemonButton
+                                                    icon={<IconGraph />}
+                                                    size="xsmall"
+                                                    to={urls.insightNew({
+                                                        query: {
+                                                            kind: NodeKind.InsightVizNode,
+                                                            source: buildToolSequencesQuery(toolString),
+                                                        } as InsightVizNode,
+                                                    })}
+                                                    targetBlank
+                                                    data-attr="llma-tools-sequences-click"
+                                                />
+                                            </Tooltip>
+                                            <Tooltip title={`View tool paths from ${toolString}`}>
+                                                <LemonButton
+                                                    icon={<IconUserPaths />}
+                                                    size="xsmall"
+                                                    to={urls.insightNew({
+                                                        query: {
+                                                            kind: NodeKind.InsightVizNode,
+                                                            source: buildToolPathsQuery(toolString),
+                                                        } as InsightVizNode,
+                                                    })}
+                                                    targetBlank
+                                                    data-attr="llma-tools-paths-click"
+                                                />
+                                            </Tooltip>
+                                        </>
+                                    )}
+                                </div>
+                            )
                         },
                     },
-                }}
-                uniqueKey="llm-analytics-tools"
-            />
-        </>
+                    total_calls: {
+                        renderTitle: () => (
+                            <Tooltip title="Total number of times this tool was called">
+                                {renderSortableColumnTitle('total_calls', 'Total calls')}
+                            </Tooltip>
+                        ),
+                    },
+                    traces: {
+                        renderTitle: () => (
+                            <Tooltip title="Number of unique traces where this tool was called">
+                                {renderSortableColumnTitle('traces', 'Traces')}
+                            </Tooltip>
+                        ),
+                    },
+                    users: {
+                        renderTitle: () => (
+                            <Tooltip title="Number of unique users who triggered this tool">
+                                {renderSortableColumnTitle('users', 'Users')}
+                            </Tooltip>
+                        ),
+                    },
+                    sessions: {
+                        renderTitle: () => (
+                            <Tooltip title="Number of unique sessions where this tool was called">
+                                {renderSortableColumnTitle('sessions', 'Sessions')}
+                            </Tooltip>
+                        ),
+                    },
+                    single_pct: {
+                        renderTitle: () => (
+                            <Tooltip title="Percentage of calls where this was the only tool called">
+                                {renderSortableColumnTitle('single_pct', 'Single %')}
+                            </Tooltip>
+                        ),
+                        render: function RenderSinglePct(x) {
+                            return <span>{String(x.value)}%</span>
+                        },
+                    },
+                    days_seen: {
+                        renderTitle: () => (
+                            <Tooltip title="Number of distinct days this tool was called">
+                                {renderSortableColumnTitle('days_seen', 'Days seen')}
+                            </Tooltip>
+                        ),
+                    },
+                    first_seen: {
+                        renderTitle: () => renderSortableColumnTitle('first_seen', 'First seen'),
+                    },
+                    last_seen: {
+                        renderTitle: () => renderSortableColumnTitle('last_seen', 'Last seen'),
+                    },
+                },
+            }}
+            uniqueKey="llm-analytics-tools"
+        />
     )
 }

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -122,8 +122,8 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         ...propertyFilters,
                         {
                             key: '$ai_tools_called',
-                            operator: PropertyOperator.Regex,
-                            value: '.+',
+                            operator: PropertyOperator.IsNot,
+                            value: '',
                             type: PropertyFilterType.Event,
                         },
                     ],
@@ -229,8 +229,8 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         ...propertyFilters,
                         {
                             key: '$ai_tools_called',
-                            operator: PropertyOperator.Regex,
-                            value: '.+',
+                            operator: PropertyOperator.IsNot,
+                            value: '',
                             type: PropertyFilterType.Event,
                         },
                     ],
@@ -260,11 +260,14 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
 -- Find pairwise tool co-occurrences across AI generations
 WITH tool_arrays AS (
     -- Extract sorted, deduplicated tool lists from generations that called 2+ tools
-    SELECT arraySort(arrayDistinct(splitByChar(',', ifNull(properties.$ai_tools_called, '')))) as tools
-    FROM events
-    WHERE event = '$ai_generation'
-        AND length(splitByChar(',', ifNull(properties.$ai_tools_called, ''))) > 1
-        AND {filters}
+    SELECT tools FROM (
+        SELECT arraySort(arrayDistinct(splitByChar(',', ifNull(properties.$ai_tools_called, '')))) as tools
+        FROM events
+        WHERE event = '$ai_generation'
+            AND properties.$ai_tools_called != ''
+            AND {filters}
+    )
+    WHERE length(tools) > 1
 ),
 tool_pairs AS (
     -- Build cross product of tools within each generation, excluding self-pairs

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -3,8 +3,8 @@ import { actions, connect, kea, key, path, props, reducers, selectors } from 'ke
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
-import { DataTableNode, NodeKind, PathsQuery } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter, PathType, PropertyFilterType, PropertyOperator } from '~/types'
+import { DataTableNode, NodeKind, PathsQuery, TrendsQuery } from '~/queries/schema/schema-general'
+import { AnyPropertyFilter, ChartDisplayType, PathType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import toolsQueryTemplate from '../../backend/queries/tools.sql?raw'
 import { SortDirection, SortState, llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
@@ -124,6 +124,46 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         startPoint: toolName,
                         stepLimit: 5,
                         edgeLimit: 50,
+                    },
+                })
+            },
+        ],
+        buildToolSequencesQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): ((toolName: string) => TrendsQuery) => {
+                return (toolName: string): TrendsQuery => ({
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: propertyFilters,
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                            properties: [
+                                {
+                                    key: '$ai_tools_called',
+                                    operator: PropertyOperator.Regex,
+                                    value: `(^|,)${toolName}(,|$)`,
+                                    type: PropertyFilterType.Event,
+                                },
+                            ],
+                        },
+                    ],
+                    breakdownFilter: {
+                        breakdown: '$ai_tools_called',
+                        breakdown_type: 'event',
+                        breakdown_limit: 20,
+                    },
+                    trendsFilter: {
+                        display: ChartDisplayType.ActionsBarValue,
                     },
                 })
             },

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -158,8 +158,9 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         },
                     ],
                     breakdownFilter: {
-                        breakdown: '$ai_tools_called',
-                        breakdown_type: 'event',
+                        breakdown:
+                            "arrayStringConcat(arraySort(arrayDistinct(splitByChar(',', ifNull(properties.$ai_tools_called, '')))), ', ')",
+                        breakdown_type: 'hogql',
                         breakdown_limit: 20,
                     },
                     trendsFilter: {

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -3,8 +3,8 @@ import { actions, connect, kea, key, path, props, reducers, selectors } from 'ke
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter } from '~/types'
+import { DataTableNode, NodeKind, PathsQuery } from '~/queries/schema/schema-general'
+import { AnyPropertyFilter, PathType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import toolsQueryTemplate from '../../backend/queries/tools.sql?raw'
 import { SortDirection, SortState, llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
@@ -94,6 +94,38 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                     showColumnConfigurator: true,
                     allowSorting: true,
                 }
+            },
+        ],
+        buildToolPathsQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): ((toolName: string) => PathsQuery) => {
+                return (toolName: string): PathsQuery => ({
+                    kind: NodeKind.PathsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_tools_called',
+                            operator: PropertyOperator.IsSet,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    pathsFilter: {
+                        includeEventTypes: [PathType.HogQL],
+                        pathsHogQLExpression: "arrayJoin(splitByChar(',', ifNull(properties.$ai_tools_called, '')))",
+                        startPoint: toolName,
+                        stepLimit: 5,
+                        edgeLimit: 50,
+                    },
+                })
             },
         ],
     }),

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -3,7 +3,13 @@ import { actions, connect, kea, key, path, props, reducers, selectors } from 'ke
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
-import { DataTableNode, NodeKind, PathsQuery, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    DataTableNode,
+    DataVisualizationNode,
+    NodeKind,
+    PathsQuery,
+    TrendsQuery,
+} from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, ChartDisplayType, PathType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import toolsQueryTemplate from '../../backend/queries/tools.sql?raw'
@@ -199,6 +205,72 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         },
                     ],
                 })
+            },
+        ],
+        buildToolHeatmapQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): DataVisualizationNode => {
+                const heatmapSql = `
+-- Find pairwise tool co-occurrences across AI generations
+WITH tool_arrays AS (
+    -- Extract sorted, deduplicated tool lists from generations that called 2+ tools
+    SELECT arraySort(arrayDistinct(splitByChar(',', ifNull(properties.$ai_tools_called, '')))) as tools
+    FROM events
+    WHERE event = '$ai_generation'
+        AND length(splitByChar(',', ifNull(properties.$ai_tools_called, ''))) > 1
+        AND {filters}
+),
+tool_pairs AS (
+    -- Build cross product of tools within each generation, excluding self-pairs
+    SELECT
+        arrayJoin(
+            arrayFilter(
+                p -> tupleElement(p, 1) != tupleElement(p, 2),
+                arrayFlatten(arrayMap(a -> arrayMap(b -> tuple(a, b), tools), tools))
+            )
+        ) as pair
+    FROM tool_arrays
+)
+SELECT
+    tupleElement(pair, 1) as tool_a,
+    tupleElement(pair, 2) as tool_b,
+    count() as co_occurrences
+FROM tool_pairs
+GROUP BY tool_a, tool_b
+ORDER BY co_occurrences DESC
+LIMIT 200`
+
+                return {
+                    kind: NodeKind.DataVisualizationNode,
+                    source: {
+                        kind: NodeKind.HogQLQuery,
+                        query: heatmapSql,
+                        filters: {
+                            dateRange: {
+                                date_from: dateFilter.dateFrom || null,
+                                date_to: dateFilter.dateTo || null,
+                            },
+                            filterTestAccounts: shouldFilterTestAccounts,
+                            properties: propertyFilters,
+                        },
+                    },
+                    display: ChartDisplayType.TwoDimensionalHeatmap,
+                    chartSettings: {
+                        heatmap: {
+                            xAxisColumn: 'tool_a',
+                            yAxisColumn: 'tool_b',
+                            valueColumn: 'co_occurrences',
+                            xAxisLabel: 'Tool A',
+                            yAxisLabel: 'Tool B',
+                            gradientPreset: 'Blues',
+                            gradientScaleMode: 'relative',
+                        },
+                    },
+                }
             },
         ],
     }),

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -6,6 +6,7 @@ import { groupsModel } from '~/models/groupsModel'
 import {
     DataTableNode,
     DataVisualizationNode,
+    InsightVizNode,
     NodeKind,
     PathsQuery,
     TrendsQuery,
@@ -206,6 +207,44 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                     ],
                 })
             },
+        ],
+        buildAllToolsTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): InsightVizNode => ({
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_tools_called',
+                            operator: PropertyOperator.IsSet,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                        },
+                    ],
+                    breakdownFilter: {
+                        breakdown:
+                            "arrayJoin(arrayDistinct(splitByChar(',', ifNull(properties.$ai_tools_called, ''))))",
+                        breakdown_type: 'hogql',
+                        breakdown_limit: 10,
+                    },
+                },
+            }),
         ],
         buildToolHeatmapQuery: [
             (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 
+import { escapeRegex } from 'lib/actionUtils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -121,7 +122,8 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         ...propertyFilters,
                         {
                             key: '$ai_tools_called',
-                            operator: PropertyOperator.IsSet,
+                            operator: PropertyOperator.Regex,
+                            value: '.+',
                             type: PropertyFilterType.Event,
                         },
                     ],
@@ -158,7 +160,7 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                                 {
                                     key: '$ai_tools_called',
                                     operator: PropertyOperator.Regex,
-                                    value: `(^|,)${toolName}(,|$)`,
+                                    value: `(^|,)${escapeRegex(toolName)}(,|$)`,
                                     type: PropertyFilterType.Event,
                                 },
                             ],
@@ -199,7 +201,7 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                                 {
                                     key: '$ai_tools_called',
                                     operator: PropertyOperator.Regex,
-                                    value: `(^|,)${toolName}(,|$)`,
+                                    value: `(^|,)${escapeRegex(toolName)}(,|$)`,
                                     type: PropertyFilterType.Event,
                                 },
                             ],
@@ -227,7 +229,8 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                         ...propertyFilters,
                         {
                             key: '$ai_tools_called',
-                            operator: PropertyOperator.IsSet,
+                            operator: PropertyOperator.Regex,
+                            value: '.+',
                             type: PropertyFilterType.Event,
                         },
                     ],

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsToolsLogic.ts
@@ -169,5 +169,37 @@ export const llmAnalyticsToolsLogic = kea<llmAnalyticsToolsLogicType>([
                 })
             },
         ],
+        buildToolTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): ((toolName: string) => TrendsQuery) => {
+                return (toolName: string): TrendsQuery => ({
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: propertyFilters,
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                            properties: [
+                                {
+                                    key: '$ai_tools_called',
+                                    operator: PropertyOperator.Regex,
+                                    value: `(^|,)${toolName}(,|$)`,
+                                    type: PropertyFilterType.Event,
+                                },
+                            ],
+                        },
+                    ],
+                })
+            },
+        ],
     }),
 ])


### PR DESCRIPTION
## Summary

Adds interactive chart buttons to the LLM Analytics tools tab, gated behind the `llm-analytics-tools-charts` feature flag:

### Per-row buttons (next to each tool name)
- **Trend** (IconTrends) — opens a time series chart for that tool's usage over time
- **Combinations** (IconGraph) — opens a bar chart showing the most common tool call combinations containing that tool, with deduplicated sorted breakdowns
- **Paths** (IconUserPaths) — opens a Paths insight showing tool call flow sequences starting from that tool

### Toolbar buttons (DataTable second row)
- **Tool trends** — opens a trends insight with a line per tool (top 10 by usage), broken down via HogQL `arrayJoin`
- **Tool co-occurrence** — opens a 2D heatmap showing pairwise tool co-occurrence counts across AI generations

<img width="2600" height="1408" alt="image" src="https://github.com/user-attachments/assets/e47337a8-382f-48ee-bf57-014e86b0a079" />

<img width="2552" height="1508" alt="image" src="https://github.com/user-attachments/assets/6d43487d-78d8-4b69-ac8e-985eac45117e" />

<img width="1998" height="1386" alt="image" src="https://github.com/user-attachments/assets/9f299ffb-693b-48f4-ae11-741211b116a9" />


### Infrastructure
- Adds `customActions` prop to `QueryContext` so any DataTable consumer can inject buttons into the toolbar (second row, right side)

## Test plan

- [ ] Enable the `llm-analytics-tools-charts` feature flag
- [ ] Go to LLM Analytics > Tools tab
- [ ] Verify per-row trend, combinations, and paths icons appear next to each tool name
- [ ] Verify "Tool trends" and "Tool co-occurrence" buttons appear in the table toolbar
- [ ] Click each button and verify the correct insight opens in a new tab
- [ ] Disable the feature flag and verify all chart buttons are hidden