### PR TITLE
fix(turbo): add missing package.json and lint guardrails for product structure

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -485,6 +485,9 @@ jobs:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Lint product structure
+              run: ./bin/hogli product:lint --all
+
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |

--- a/common/hogli/product.py
+++ b/common/hogli/product.py
@@ -359,8 +359,9 @@ def lint_product(name: str, verbose: bool = True) -> list[str]:
             ("presentation/urls.py", "urls"),
         ]
 
-        present = sum(1 for path, _ in isolation_files if _check_file_exists(backend_dir, path))
-        labels = [f"{'✓' if _check_file_exists(backend_dir, path) else '○'} {label}" for path, label in isolation_files]
+        checks = [_check_file_exists(backend_dir, path) for path, _ in isolation_files]
+        present = sum(checks)
+        labels = [f"{'✓' if ok else '○'} {label}" for ok, (_, label) in zip(checks, isolation_files)]
         click.echo(f"    {', '.join(labels)} ({present}/{len(isolation_files)})")
 
     return issues
@@ -424,8 +425,6 @@ def _lint_all_products() -> None:
 
         if issues:
             failed.append(product_dir.name)
-            for issue in issues:
-                click.echo(f"  ✗ {issue}")
 
         click.echo("")
 

--- a/common/hogli/product.py
+++ b/common/hogli/product.py
@@ -216,10 +216,21 @@ def _check_file_exists(backend_dir: Path, path: str) -> bool:
     return False
 
 
+def _is_isolated_product(backend_dir: Path) -> bool:
+    contracts_file = backend_dir / "facade" / "contracts.py"
+    contracts_folder = backend_dir / "facade" / "contracts"
+    return contracts_file.exists() or contracts_folder.exists()
+
+
 def lint_product(name: str, verbose: bool = True) -> list[str]:
     """
-    Check for known files in wrong places.
-    Returns list of issues found.
+    Lint a product's structure. Returns list of issues found.
+
+    Runs in two modes based on whether the product has backend/facade/contracts.py:
+      strict  — isolated product, all structure rules enforced
+      lenient — legacy product, subset of rules enforced (see product_structure.yaml)
+
+    Both modes fail on violations. Lenient just checks fewer things.
     """
     product_dir = PRODUCTS_DIR / name
     backend_dir = product_dir / "backend"
@@ -228,75 +239,91 @@ def lint_product(name: str, verbose: bool = True) -> list[str]:
         raise click.ClickException(f"Product '{name}' not found at {product_dir}")
 
     structure = load_structure()
+    issues: list[str] = []
 
-    issues = []
-
-    # First, check if this is an isolated product (has contracts.py)
-    contracts_file = backend_dir / "facade" / "contracts.py"
-    contracts_folder = backend_dir / "facade" / "contracts"
-    is_isolated = contracts_file.exists() or contracts_folder.exists()
+    is_isolated = _is_isolated_product(backend_dir)
+    mode = "strict" if is_isolated else "lenient"
     required_key = "required" if is_isolated else "required_lenient"
 
     if verbose:
-        click.echo("  Checking for isolated architecture...")
-        if is_isolated:
-            click.echo("    ✓ Has backend/facade/contracts.py - running strict checks")
-        else:
-            click.echo("    ○ No backend/facade/contracts.py - legacy product, showing progress toward isolation")
+        click.echo(f"  mode: {mode}" + (" (has backend/facade/contracts.py)" if is_isolated else " (legacy)"))
 
-    # Check for root files (manifest.tsx, package.json, tsconfig.json)
+    # 1. Required root files
     if verbose:
-        click.echo("  Checking for root files...")
+        click.echo("  required root files...")
     root_files = structure.get("root_files", {})
     missing_root = []
     for filename, config in root_files.items():
         if config.get(required_key, False):
-            file_path = product_dir / filename
-            if not file_path.exists():
+            if not (product_dir / filename).exists():
                 missing_root.append(filename)
 
     if verbose:
         if missing_root:
-            click.echo(f"    ✗ Missing {len(missing_root)} required file(s): {', '.join(missing_root)}")
+            click.echo(f"    ✗ missing: {', '.join(missing_root)}")
         else:
-            click.echo("    ✓ All required root files present")
+            click.echo("    ✓ ok")
 
     for f in missing_root:
         issues.append(f"Missing required root file: {f}")
 
-    # Check for misplaced files in backend
-    if verbose:
-        click.echo("  Checking for misplaced backend files...")
-    backend_known_files = structure.get("backend_known_files", {})
-    misplaced = []
+    # 2. backend:test in package.json (if product has backend/)
     if backend_dir.exists():
-        for filename, correct_path in backend_known_files.items():
-            wrong_location = backend_dir / filename
-            correct_location = backend_dir / correct_path
-
-            if wrong_location.exists() and wrong_location.is_file():
-                if correct_location.exists():
-                    misplaced.append(
-                        f"'{filename}' exists at backend/ root but also at correct location '{correct_path}'"
-                    )
-                else:
-                    misplaced.append(f"backend/{filename} should be at backend/{correct_path}")
-
-    if verbose:
-        if misplaced:
-            click.echo(f"    ✗ Found {len(misplaced)} misplaced file(s)")
+        package_json = product_dir / "package.json"
+        if package_json.exists():
+            try:
+                pkg_data = json.loads(package_json.read_text())
+                has_backend_test = "backend:test" in pkg_data.get("scripts", {})
+            except json.JSONDecodeError:
+                has_backend_test = False
+                issues.append("package.json is not valid JSON")
         else:
-            click.echo("    ✓ No misplaced files")
+            has_backend_test = False
 
+        if verbose:
+            click.echo("  backend:test in package.json...")
+        if not has_backend_test:
+            issues.append(
+                "Product has backend/ but package.json is missing 'backend:test' script — "
+                "turbo cannot discover this product for testing"
+            )
+            if verbose:
+                click.echo("    ✗ missing")
+        elif verbose:
+            click.echo("    ✓ ok")
+
+    # 3. Misplaced backend files (strict only — legacy products have flat structure by design)
     if is_isolated:
-        issues.extend(misplaced)
-    elif misplaced and verbose:
-        for m in misplaced:
-            click.echo(f"      → {m}")
+        if verbose:
+            click.echo("  misplaced backend files...")
+        backend_known_files = structure.get("backend_known_files", {})
+        misplaced = []
+        if backend_dir.exists():
+            for filename, correct_path in backend_known_files.items():
+                wrong_location = backend_dir / filename
+                correct_location = backend_dir / correct_path
 
-    # Check for files that can_be_folder violations
+                if wrong_location.exists() and wrong_location.is_file():
+                    if correct_location.exists():
+                        misplaced.append(
+                            f"'{filename}' exists at backend/ root but also at correct location '{correct_path}'"
+                        )
+                    else:
+                        misplaced.append(f"backend/{filename} should be at backend/{correct_path}")
+
+        if verbose:
+            if misplaced:
+                click.echo(f"    ✗ {len(misplaced)} misplaced file(s)")
+                for m in misplaced:
+                    click.echo(f"      → {m}")
+            else:
+                click.echo("    ✓ ok")
+
+        issues.extend(misplaced)
+
+    # 4. File/folder conflicts
     if verbose:
-        click.echo("  Checking for file/folder conflicts...")
+        click.echo("  file/folder conflicts...")
     backend_files_config = _flatten_structure(structure.get("backend_files", {}))
     conflicts = []
     if backend_dir.exists():
@@ -312,40 +339,29 @@ def lint_product(name: str, verbose: bool = True) -> list[str]:
 
     if verbose:
         if conflicts:
-            click.echo(f"    ✗ Found {len(conflicts)} conflict(s)")
+            click.echo(f"    ✗ {len(conflicts)} conflict(s)")
+            for c in conflicts:
+                click.echo(f"      → {c}")
         else:
-            click.echo("    ✓ No conflicts")
+            click.echo("    ✓ ok")
 
-    if is_isolated:
-        issues.extend(conflicts)
-    elif conflicts and verbose:
-        for c in conflicts:
-            click.echo(f"      → {c}")
+    issues.extend(conflicts)
 
-    # Show progress toward isolation for legacy products
-    if not is_isolated and verbose:
-        click.echo("  Progress toward isolation...")
+    # 5. Isolation progress (informational, not enforced)
+    if not is_isolated and verbose and backend_dir.exists():
+        click.echo("  isolation progress...")
 
-        # Key isolation files to check
         isolation_files = [
-            ("facade/contracts.py", "Contract types defined"),
-            ("facade/api.py", "Facade API"),
-            ("presentation/views.py", "DRF views in presentation/"),
-            ("presentation/serializers.py", "Serializers in presentation/"),
-            ("presentation/urls.py", "URLs in presentation/"),
+            ("facade/contracts.py", "contracts"),
+            ("facade/api.py", "facade"),
+            ("presentation/views.py", "views"),
+            ("presentation/serializers.py", "serializers"),
+            ("presentation/urls.py", "urls"),
         ]
 
-        present = 0
-        total = len(isolation_files)
-        for path, label in isolation_files:
-            exists = _check_file_exists(backend_dir, path)
-            if exists:
-                present += 1
-                click.echo(f"    ✓ {label}")
-            else:
-                click.echo(f"    ○ {label}")
-
-        click.echo(f"    ({present}/{total} isolation requirements met)")
+        present = sum(1 for path, _ in isolation_files if _check_file_exists(backend_dir, path))
+        labels = [f"{'✓' if _check_file_exists(backend_dir, path) else '○'} {label}" for path, label in isolation_files]
+        click.echo(f"    {', '.join(labels)} ({present}/{len(isolation_files)})")
 
     return issues
 
@@ -360,9 +376,17 @@ def cmd_bootstrap(name: str, dry_run: bool, force: bool) -> None:
 
 
 @cli.command(name="product:lint", help="Check product structure for misplaced files")
-@click.argument("name")
-def cmd_lint(name: str) -> None:
+@click.argument("name", required=False)
+@click.option("--all", "lint_all", is_flag=True, help="Lint all products")
+def cmd_lint(name: str | None, lint_all: bool) -> None:
     """Lint a product's structure."""
+    if lint_all:
+        _lint_all_products()
+        return
+
+    if not name:
+        raise click.UsageError("Provide a product name or use --all")
+
     click.echo(f"Linting product '{name}'...\n")
 
     issues = lint_product(name, verbose=True)
@@ -377,3 +401,36 @@ def cmd_lint(name: str) -> None:
         click.echo(f"  • {issue}")
 
     raise SystemExit(1)
+
+
+def _lint_all_products() -> None:
+    product_dirs = sorted(
+        d
+        for d in PRODUCTS_DIR.iterdir()
+        if d.is_dir() and not d.name.startswith((".", "_")) and (d / "__init__.py").exists()
+    )
+
+    strict = [d.name for d in product_dirs if _is_isolated_product(d / "backend")]
+    lenient = [d.name for d in product_dirs if not _is_isolated_product(d / "backend")]
+
+    click.echo(f"Linting {len(product_dirs)} products ({len(strict)} strict, {len(lenient)} lenient)")
+    click.echo("Checks: required root files, backend:test script, misplaced files, file/folder conflicts\n")
+
+    failed: list[str] = []
+
+    for product_dir in product_dirs:
+        click.echo(f"─ {product_dir.name}")
+        issues = lint_product(product_dir.name, verbose=True)
+
+        if issues:
+            failed.append(product_dir.name)
+            for issue in issues:
+                click.echo(f"  ✗ {issue}")
+
+        click.echo("")
+
+    if failed:
+        click.echo(f"✗ {len(failed)} product(s) failed: {', '.join(failed)}")
+        raise SystemExit(1)
+
+    click.echo(f"✓ All {len(product_dirs)} products passed")

--- a/common/hogli/product_structure.yaml
+++ b/common/hogli/product_structure.yaml
@@ -48,7 +48,7 @@ root_files:
 
     package.json:
         required: true
-        required_lenient: false
+        required_lenient: true
         template: |
             {{
                 "name": "@posthog/products-{product}",
@@ -316,8 +316,9 @@ frontend_files:
 
 # Files that are known but should live in specific locations
 # Used by lint to detect misplaced files in backend/
+# Only checked for isolated (strict) products — legacy products have flat backend/ by design
 backend_known_files:
-    api.py: facade/api.py
+    api.py: presentation/api.py
     contracts.py: facade/contracts.py
     serializers.py: presentation/serializers.py
     views.py: presentation/views.py

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1764,6 +1764,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
 
+  products/alerts: {}
+
   products/analytics_platform: {}
 
   products/batch_exports: {}
@@ -1868,6 +1870,8 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 4.3.0
+
+  products/core_events: {}
 
   products/customer_analytics:
     dependencies:
@@ -2081,6 +2085,8 @@ importers:
       use-resize-observer:
         specifier: '*'
         version: 8.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  products/event_definitions: {}
 
   products/experiments:
     dependencies:
@@ -2632,6 +2638,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+
+  products/signals: {}
+
+  products/slack_app: {}
 
   products/surveys:
     dependencies:

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@posthog/products-cdp",
+    "name": "@posthog/products-alerts",
     "scripts": {
         "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
     }

--- a/products/core_events/package.json
+++ b/products/core_events/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "@posthog/products-core-events"
+}

--- a/products/event_definitions/package.json
+++ b/products/event_definitions/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@posthog/products-event-definitions",
+    "scripts": {
+        "backend:test": "echo 'No backend tests'"
+    }
+}

--- a/products/managed_migrations/package.json
+++ b/products/managed_migrations/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-managed-migrations",
+    "scripts": {
+        "backend:test": "echo 'No backend tests'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-forms": "catalog:",

--- a/products/mcp_store/package.json
+++ b/products/mcp_store/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-mcp-store",
+    "scripts": {
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-forms": "catalog:",

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-product-analytics",
+    "scripts": {
+        "backend:test": "echo 'No backend tests'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-replay",
+    "scripts": {
+        "backend:test": "echo 'No backend tests'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/signals/package.json
+++ b/products/signals/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@posthog/products-signals",
+    "scripts": {
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
+    }
+}

--- a/products/slack_app/package.json
+++ b/products/slack_app/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@posthog/products-slack-app",
+    "scripts": {
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+    }
+}

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-user-interviews",
+    "scripts": {
+        "backend:test": "echo 'No backend tests'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",


### PR DESCRIPTION
**Context**
Products without `package.json` (or without a `backend:test` script in it) are invisible to turbo — it can't discover them for testing or contract-checking. This caused a silent CI skip for product-only changes (e.g. signals) where Django tests never ran. 

**What this does**
- Adds `package.json` to 5 products missing it entirely (alerts, core_events, event_definitions, signals, slack_app)
- Adds `backend:test` script to 6 products that had `package.json` but no script (cdp, managed_migrations, mcp_store, product_analytics, replay, user_interviews)
- Makes `package.json` required for all products (lenient + strict) in `product_structure.yaml`
- Adds new lint check: products with `backend/` must have `package.json` with `backend:test`
- Adds `--all` flag to `hogli product:lint` with summary output showing strict/lenient mode per product
- Wires `hogli product:lint --all` into `check-migrations` job in ci-backend.yml
- Fixes `api.py` known-file mapping from `facade/api.py` → `presentation/api.py`
- Misplaced file + facade checks now only enforced for isolated (strict) products