### PR TITLE
fix(surveys): batch queries for large surveys

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -88,7 +88,7 @@ import {
     DATE_FORMAT,
     type OpenEndedColumnMap,
     type SurveyQueryFilters,
-    buildAggregateQuery,
+    buildAggregateQueries,
     buildOpenEndedQuery,
     buildPartialResponsesFilter,
     buildSurveyTimestampFilter,
@@ -822,28 +822,29 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
                 const queryOpts = { scene: 'Survey' as const, productKey: 'surveys' as const }
 
-                const aggregateQuery = buildAggregateQuery(survey, queryFilters, values.dateRange)
+                const aggregateQueries = buildAggregateQueries(survey, queryFilters, values.dateRange)
                 const openEndedResult = buildOpenEndedQuery(survey, queryFilters, values.dateRange)
 
                 const startMs = performance.now()
                 let aggregateDuration = 0
                 let openEndedDuration = 0
 
-                const [aggregateResponse, openEndedResponse] = await Promise.all([
-                    aggregateQuery
-                        ? api.queryHogQL(aggregateQuery as HogQLQueryString, queryOpts, queryParams).then((r) => {
-                              aggregateDuration = performance.now() - startMs
-                              return r
-                          })
-                        : Promise.resolve({ results: null }),
-                    openEndedResult
-                        ? api
-                              .queryHogQL(openEndedResult.query as HogQLQueryString, queryOpts, queryParams)
-                              .then((r) => {
-                                  openEndedDuration = performance.now() - startMs
-                                  return r
-                              })
-                        : Promise.resolve({ results: null }),
+                const aggregatePromises = aggregateQueries.map((q) =>
+                    api.queryHogQL(q as HogQLQueryString, queryOpts, queryParams)
+                )
+                const openEndedPromise = openEndedResult
+                    ? api.queryHogQL(openEndedResult.query as HogQLQueryString, queryOpts, queryParams)
+                    : Promise.resolve({ results: null })
+
+                const [aggregateResponses, openEndedResponse] = await Promise.all([
+                    Promise.all(aggregatePromises).then((responses) => {
+                        aggregateDuration = performance.now() - startMs
+                        return responses
+                    }),
+                    openEndedPromise.then((r) => {
+                        openEndedDuration = performance.now() - startMs
+                        return r
+                    }),
                 ])
 
                 const endMs = performance.now()
@@ -853,7 +854,8 @@ export const surveyLogic = kea<surveyLogicType>([
                     openEnded: openEndedDuration,
                 })
 
-                const aggregate = processResultsForSurveyQuestions(survey.questions, aggregateResponse.results)
+                const allAggregateRows = aggregateResponses.flatMap((r) => r.results ?? [])
+                const aggregate = processResultsForSurveyQuestions(survey.questions, allAggregateRows)
                 const openEnded = openEndedResult
                     ? processOpenEndedResults(survey.questions, openEndedResult.columnMap, openEndedResponse.results)
                     : {}

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -513,11 +513,18 @@ export interface OpenEndedColumnMap {
     }
 }
 
-export function buildAggregateQuery(
+// TEMP BANDAID FIX @adboio
+// the c++ hogql parser fails on very large queries. this aggregate query does
+// a bunch of UNION ALLs and hits the limit when a survey has a very large
+// number of questions (bug discovered on a survey with 47 questions)
+// TODO: remove when we migrate surveys queries to a python query runner.
+const MAX_AGGREGATE_BRANCHES = 30
+
+export function buildAggregateQueries(
     survey: Survey,
     filters: SurveyQueryFilters,
     dateRange?: SurveyDateRange | null
-): string | null {
+): string[] {
     const dedupFilter = buildPartialResponsesFilter(survey, dateRange)
     const branches: string[] = []
 
@@ -566,10 +573,14 @@ export function buildAggregateQuery(
     }
 
     if (branches.length === 0) {
-        return null
+        return []
     }
 
-    return branches.join('\nUNION ALL\n')
+    const queries: string[] = []
+    for (let i = 0; i < branches.length; i += MAX_AGGREGATE_BRANCHES) {
+        queries.push(branches.slice(i, i + MAX_AGGREGATE_BRANCHES).join('\nUNION ALL\n'))
+    }
+    return queries
 }
 
 export function buildOpenEndedQuery(

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -340,6 +340,11 @@ class Command(BaseCommand):
             choices=QUESTION_TYPE_CHOICES,
             help="Specific question types to include in each generated survey. Example: --question-types nps open",
         )
+        parser.add_argument(
+            "--num-questions",
+            type=int,
+            help="Number of questions per survey. Use 50+ to test the HogQL parser batch limit.",
+        )
 
     def generate_question_of_type(
         self, question_type: QuestionType, choice_type: Literal["single_choice", "multiple_choice"] | None = None
@@ -673,12 +678,21 @@ class Command(BaseCommand):
         }
 
     def generate_random_survey(
-        self, team_id: int, user_id: int, question_types: list[RequestedQuestionType] | None = None
+        self,
+        team_id: int,
+        user_id: int,
+        question_types: list[RequestedQuestionType] | None = None,
+        num_questions: int | None = None,
     ) -> dict[str, Any]:
         # By default include required actionable question types; optionally allow explicit selection.
         questions = self.generate_required_questions()
         if question_types:
             questions = self.generate_questions_for_types(question_types)
+
+        if num_questions is not None:
+            while len(questions) < num_questions:
+                questions.append(self.generate_random_question())
+            questions = questions[:num_questions]
 
         # Preserve order for explicitly requested question types to keep branching indexes stable.
         if not question_types:
@@ -1092,9 +1106,13 @@ class Command(BaseCommand):
         llm_feedback = options["llm_feedback"]
         wipe = options["wipe"]
         question_types: list[RequestedQuestionType] | None = options["question_types"]
+        num_questions: int | None = options["num_questions"]
 
         if llm_feedback and question_types:
             raise CommandError("--question-types cannot be used with --llm-feedback")
+
+        if llm_feedback and num_questions:
+            raise CommandError("--num-questions cannot be used with --llm-feedback")
 
         if team_id:
             team = Team.objects.filter(id=team_id).first()
@@ -1160,7 +1178,9 @@ class Command(BaseCommand):
             if llm_feedback:
                 survey_data = self.generate_llm_feedback_survey(team.id, user.id)
             else:
-                survey_data = self.generate_random_survey(team.id, user.id, question_types=question_types)
+                survey_data = self.generate_random_survey(
+                    team.id, user.id, question_types=question_types, num_questions=num_questions
+                )
             survey = Survey.objects.create(**survey_data)
 
             # Backdate created_at so that generated events (spread over days_back days) fall within


### PR DESCRIPTION
## Problem

the new aggregate query for consolidated survey results `UNION ALL`s a bunch of statements

that number of statements scales linearly with the number of survey questions

and there is a point at which the hogql parser fails when there are too many statements (or characters, or something else, i can't really tell)

https://posthoghelp.zendesk.com/agent/tickets/52561 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54499)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

runs the aggregate query in batches of 30 statements

this change will only impact surveys with > 30 rating/choice questions

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manually tested with small and large surveys

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
