### PR TITLE
fix: Flush batches of stats in Livestream

### DIFF
--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -25,9 +25,10 @@ type SessionRecordingConfig struct {
 }
 
 type RedisConfig struct {
-	Address string `mapstructure:"address"`
-	Port    string `mapstructure:"port"`
-	TLS     bool   `mapstructure:"tls"`
+	Address         string `mapstructure:"address"`
+	Port            string `mapstructure:"port"`
+	TLS             bool   `mapstructure:"tls"`
+	FlushIntervalMs int    `mapstructure:"flush_interval_ms"`
 }
 
 type Config struct {
@@ -63,6 +64,7 @@ func InitConfigs(filename, configPath string) {
 	viper.SetDefault("kafka.group_id", "livestream")
 	viper.SetDefault("kafka.session_recording_enabled", true)
 	viper.SetDefault("session_recording.max_lru_entries", 2_000_000_000)
+	viper.SetDefault("redis.flush_interval_ms", 500)
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -107,9 +109,10 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("session_recording.max_lru_entries") // LIVESTREAM_SESSION_RECORDING_MAX_LRU_ENTRIES
 
 	// Redis settings
-	_ = viper.BindEnv("redis.address") // LIVESTREAM_REDIS_ADDRESS
-	_ = viper.BindEnv("redis.port")    // LIVESTREAM_REDIS_PORT
-	_ = viper.BindEnv("redis.tls")     // LIVESTREAM_REDIS_TLS
+	_ = viper.BindEnv("redis.address")            // LIVESTREAM_REDIS_ADDRESS
+	_ = viper.BindEnv("redis.port")               // LIVESTREAM_REDIS_PORT
+	_ = viper.BindEnv("redis.tls")                // LIVESTREAM_REDIS_TLS
+	_ = viper.BindEnv("redis.flush_interval_ms")  // LIVESTREAM_REDIS_FLUSH_INTERVAL_MS
 }
 
 func LoadConfig() (*Config, error) {
@@ -156,6 +159,11 @@ func LoadConfig() (*Config, error) {
 	}
 	if config.Kafka.GroupID == "" {
 		return nil, errors.New("kafka.group_id must be set")
+	}
+
+	if config.Redis.FlushIntervalMs < 50 {
+		log.Printf("redis.flush_interval_ms=%d is below minimum 50, using default 500", config.Redis.FlushIntervalMs)
+		config.Redis.FlushIntervalMs = 500
 	}
 
 	return &config, nil

--- a/livestream/events/live_stats.go
+++ b/livestream/events/live_stats.go
@@ -104,7 +104,5 @@ func (ts *Stats) flushUsersToRedis(pending map[string]map[string]float64) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := ts.RedisStore.FlushUsers(ctx, pending); err != nil {
-		log.Printf("Redis flush error: %v", err)
-	}
+	ts.RedisStore.FlushUsers(ctx, pending)
 }

--- a/livestream/events/live_stats.go
+++ b/livestream/events/live_stats.go
@@ -64,21 +64,47 @@ func (ts *Stats) GetStoreForToken(token string) *expirable.LRU[string, NoSpaceTy
 	return store
 }
 
-func (ts *Stats) KeepStats(statsChan chan CountEvent) {
-	log.Println("starting stats keeper...")
+func (ts *Stats) KeepStats(statsChan chan CountEvent, flushInterval time.Duration) {
+	log.Printf("starting stats keeper (flush interval: %s)...", flushInterval)
 
-	for event := range statsChan {
-		ts.Counter.Increment()
-		ts.GetStoreForToken(event.Token).Add(event.DistinctID, NoSpaceType{})
-		ts.GlobalStore.Add(event.DistinctID, NoSpaceType{})
-		metrics.HandledEvents.Inc()
+	pending := make(map[string]map[string]float64)
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
 
-		if ts.RedisStore != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := ts.RedisStore.AddUser(ctx, event.Token, event.DistinctID); err != nil {
-				log.Printf("Redis AddUser error: %v", err)
+	for {
+		select {
+		case event, ok := <-statsChan:
+			if !ok {
+				ts.flushUsersToRedis(pending)
+				return
 			}
-			cancel()
+
+			ts.Counter.Increment()
+			ts.GetStoreForToken(event.Token).Add(event.DistinctID, NoSpaceType{})
+			ts.GlobalStore.Add(event.DistinctID, NoSpaceType{})
+			metrics.HandledEvents.Inc()
+
+			if ts.RedisStore != nil {
+				if pending[event.Token] == nil {
+					pending[event.Token] = make(map[string]float64)
+				}
+
+				pending[event.Token][event.DistinctID] = float64(time.Now().Unix())
+			}
+		case <-ticker.C:
+			ts.flushUsersToRedis(pending)
+			pending = make(map[string]map[string]float64)
 		}
+	}
+}
+
+func (ts *Stats) flushUsersToRedis(pending map[string]map[string]float64) {
+	if ts.RedisStore == nil || len(pending) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := ts.RedisStore.FlushUsers(ctx, pending); err != nil {
+		log.Printf("Redis flush error: %v", err)
 	}
 }

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -1,19 +1,21 @@
 /*
-	StatsInRedis provides a shared storage backed by Redis.
-	It enables the /stats endpoint to serve consistent user
-	and session counts across multiple service instances by
-	adding tokens to a sorted set with a short-lived TTL.
+StatsInRedis provides a shared storage backed by Redis.
+It enables the /stats endpoint to serve consistent user
+and session counts across multiple service instances by
+adding tokens to a sorted set with a short-lived TTL.
 
-	Redis pipelines (DoMulti) are used to batch multiple commands into a single round-trip.
-	Each pipeline targets a single key, so all commands hit the same hash slot
-	and are safe by default in cluster mode.
+Redis pipelines (DoMulti) are used to batch multiple commands into a single round-trip.
+Each pipeline targets a single key, so all commands hit the same hash slot
+and are safe by default in cluster mode.
 */
 package events
 
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/posthog/posthog/livestream/configs"
@@ -124,6 +126,53 @@ func (s *StatsInRedis) getCount(ctx context.Context, key string, ttl time.Durati
 		return 0, err
 	}
 	return count, nil
+}
+
+// Writes a batch of user updates to Redis.
+// pending maps token: (distinctID: score).
+func (s *StatsInRedis) FlushUsers(ctx context.Context, pending map[string]map[string]float64) error {
+	return s.flushKeys(ctx, pending, userKeyTTL, "batch_add_user", userKey)
+}
+
+// Writes a batch of session updates to Redis.
+// pending maps token: (sessionID: score).
+func (s *StatsInRedis) FlushSessions(ctx context.Context, pending map[string]map[string]float64) error {
+	return s.flushKeys(ctx, pending, sessionKeyTTL, "batch_add_session", sessionKey)
+}
+
+func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[string]float64, ttl time.Duration, metricsLabel string, keyFn func(string) string) error {
+	if len(pending) == 0 {
+		return nil
+	}
+
+	metrics.RedisFlushBatchSize.WithLabelValues(metricsLabel).Observe(float64(len(pending)))
+	metrics.RedisFlushTotal.WithLabelValues(metricsLabel).Inc()
+
+	now := time.Now()
+	var wg sync.WaitGroup
+
+	for token, members := range pending {
+		wg.Add(1)
+		go func(token string, members map[string]float64) {
+			defer wg.Done()
+
+			key := keyFn(token)
+			cmds := make(rueidis.Commands, 2)
+			cmds[0] = s.client.B().Zadd().Key(key).Gt().ScoreMember().ScoreMemberIter(maps.All(members)).Build()
+			cmds[1] = s.client.B().Expire().Key(key).Seconds(int64(ttl.Seconds())).Build()
+
+			results := s.client.DoMulti(ctx, cmds...)
+			for _, r := range results {
+				if err := r.Error(); err != nil {
+					metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
+				}
+			}
+		}(token, members)
+	}
+
+	wg.Wait()
+	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(now).Seconds())
+	return nil
 }
 
 // Testing helper

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -131,19 +131,19 @@ func (s *StatsInRedis) getCount(ctx context.Context, key string, ttl time.Durati
 
 // Writes a batch of user updates to Redis.
 // pending maps token: (distinctID: score).
-func (s *StatsInRedis) FlushUsers(ctx context.Context, pending map[string]map[string]float64) error {
-	return s.flushKeys(ctx, pending, userKeyTTL, "batch_add_user", userKey)
+func (s *StatsInRedis) FlushUsers(ctx context.Context, pending map[string]map[string]float64) {
+	s.flushKeys(ctx, pending, userKeyTTL, "batch_add_user", userKey)
 }
 
 // Writes a batch of session updates to Redis.
 // pending maps token: (sessionID: score).
-func (s *StatsInRedis) FlushSessions(ctx context.Context, pending map[string]map[string]float64) error {
-	return s.flushKeys(ctx, pending, sessionKeyTTL, "batch_add_session", sessionKey)
+func (s *StatsInRedis) FlushSessions(ctx context.Context, pending map[string]map[string]float64) {
+	s.flushKeys(ctx, pending, sessionKeyTTL, "batch_add_session", sessionKey)
 }
 
-func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[string]float64, ttl time.Duration, metricsLabel string, keyFn func(string) string) error {
+func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[string]float64, ttl time.Duration, metricsLabel string, keyFn func(string) string) {
 	if len(pending) == 0 {
-		return nil
+		return
 	}
 
 	metrics.RedisFlushBatchSize.WithLabelValues(metricsLabel).Observe(float64(len(pending)))
@@ -174,7 +174,6 @@ func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[str
 
 	wg.Wait()
 	metrics.RedisLatency.WithLabelValues(metricsLabel).Observe(time.Since(now).Seconds())
-	return nil
 }
 
 // Testing helper

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -13,6 +13,7 @@ package events
 import (
 	"context"
 	"fmt"
+	"log"
 	"maps"
 	"strconv"
 	"sync"
@@ -164,6 +165,7 @@ func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[str
 			results := s.client.DoMulti(ctx, cmds...)
 			for _, r := range results {
 				if err := r.Error(); err != nil {
+					log.Printf("Redis flush error for key %s: %v", key, err)
 					metrics.RedisErrors.WithLabelValues(metricsLabel).Inc()
 				}
 			}

--- a/livestream/events/session_stats.go
+++ b/livestream/events/session_stats.go
@@ -202,7 +202,5 @@ func (ss *SessionStats) flushSessionsToRedis(pending map[string]map[string]float
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := ss.RedisStore.FlushSessions(ctx, pending); err != nil {
-		log.Printf("Redis flush error: %v", err)
-	}
+	ss.RedisStore.FlushSessions(ctx, pending)
 }

--- a/livestream/events/session_stats.go
+++ b/livestream/events/session_stats.go
@@ -134,30 +134,38 @@ func (ss *SessionStats) Add(token, sessionId string) {
 	ss.getOrCreateCounter(token).Add(1)
 }
 
-func (ss *SessionStats) KeepStats(ctx context.Context, statsChan chan SessionRecordingEvent) {
-	log.Println("starting session recording stats keeper...")
+func (ss *SessionStats) KeepStats(ctx context.Context, statsChan chan SessionRecordingEvent, flushInterval time.Duration) {
+	log.Printf("starting session recording stats keeper (flush interval: %s)...", flushInterval)
 
 	metricsTicker := time.NewTicker(10 * time.Second)
 	defer metricsTicker.Stop()
 
+	flushTicker := time.NewTicker(flushInterval)
+	defer flushTicker.Stop()
+
+	pending := make(map[string]map[string]float64)
+
 	for {
 		select {
 		case <-ctx.Done():
+			ss.flushSessionsToRedis(pending)
 			log.Println("session recording stats keeper shutting down...")
 			return
 		case <-metricsTicker.C:
 			metrics.SessionRecordingLRUSize.Set(float64(ss.Len()))
 			metrics.SessionRecordingTokenCount.Set(float64(ss.TokenCount()))
+		case <-flushTicker.C:
+			ss.flushSessionsToRedis(pending)
+			pending = make(map[string]map[string]float64)
 		case event := <-statsChan:
 			ss.Add(event.Token, event.SessionId)
 			metrics.SessionRecordingHandledEvents.Inc()
 
 			if ss.RedisStore != nil {
-				rCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				if err := ss.RedisStore.AddSession(rCtx, event.Token, event.SessionId); err != nil {
-					log.Printf("Redis AddSession error: %v", err)
+				if pending[event.Token] == nil {
+					pending[event.Token] = make(map[string]float64)
 				}
-				cancel()
+				pending[event.Token][event.SessionId] = float64(time.Now().Unix())
 			}
 		}
 	}
@@ -186,4 +194,15 @@ func (ss *SessionStats) KeysForToken(token string) []string {
 		}
 	}
 	return sessions
+}
+
+func (ss *SessionStats) flushSessionsToRedis(pending map[string]map[string]float64) {
+	if ss.RedisStore == nil || len(pending) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := ss.RedisStore.FlushSessions(ctx, pending); err != nil {
+		log.Printf("Redis flush error: %v", err)
+	}
 }

--- a/livestream/events/session_stats_test.go
+++ b/livestream/events/session_stats_test.go
@@ -124,7 +124,7 @@ func TestSessionStats_Count(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			go ss.KeepStats(ctx, statsChan)
+			go ss.KeepStats(ctx, statsChan, 500*time.Millisecond)
 
 			for _, event := range tt.events {
 				statsChan <- event
@@ -147,7 +147,7 @@ func TestSessionStats_Concurrency(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go ss.KeepStats(ctx, statsChan)
+	go ss.KeepStats(ctx, statsChan, 500*time.Millisecond)
 
 	iterations := 100
 	var wg sync.WaitGroup

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -74,8 +74,9 @@ func main() {
 	subChan := make(chan events.Subscription, 10000)
 	unSubChan := make(chan events.Subscription, 10000)
 
-	go stats.KeepStats(statsChan)
-	go sessionStats.KeepStats(ctx, sessionStatsChan)
+	flushInterval := time.Duration(config.Redis.FlushIntervalMs) * time.Millisecond
+	go stats.KeepStats(statsChan, flushInterval)
+	go sessionStats.KeepStats(ctx, sessionStatsChan, flushInterval)
 
 	consumer, err := events.NewPostHogKafkaConsumer(config.Kafka, geolocator, phEventChan, statsChan, config.Parallelism)
 	if err != nil {

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -110,6 +110,22 @@ var (
 		Buckets: []float64{1, 2, 5, 10, 30, 60, 120, 300, 600, 900, 1800, 3600},
 	})
 
+	RedisFlushBatchSize = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "livestream_redis_flush_batch_size",
+			Help:    "Number of Redis keys per flush",
+			Buckets: []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000},
+		},
+		[]string{"operation"},
+	)
+	RedisFlushTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "livestream_redis_flush_total",
+			Help: "Total number of Redis batch flushes",
+		},
+		[]string{"operation"},
+	)
+
 	RedisErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "livestream_redis_errors_total",


### PR DESCRIPTION
## Problem
Every event was triggering a synchronous AddUser/AddSession Redis call in the stats loop. Under high event volume, these Redis calls would cause the stats and event queue to back up since we could not process message quickly enough.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
This PR batches per-event Redis writes into periodic flushes every `LIVESTREAM_REDIS_FLUSH_INTERVAL_MS` milliseconds. Events are deduplicated per token and pipelined into a single add/expire per flush. Within each flush, token keys are written to Redis in parallel using a goroutine per token.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally tested 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
