### PR TITLE
test: verify signals-only change triggers CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -118,6 +118,32 @@ jobs:
                         - bin/wait-for-docker
                         - frontend/public/email/*
                         - docker/clickhouse
+                      legacy:
+                        # Non-product backend code — when only products/ change,
+                        # turbo contract-check decides whether Django tests run.
+                        # Everything from backend: EXCEPT products/**/backend/**/*
+                        - 'ee/**/*'
+                        - 'common/**/*'
+                        - 'posthog/**/*'
+                        - 'bin/*.py'
+                        - pyproject.toml
+                        - uv.lock
+                        - requirements.txt
+                        - requirements-dev.txt
+                        - mypy.ini
+                        - pytest.ini
+                        - .test_durations
+                        - frontend/src/queries/schema.json
+                        - rust/feature-flags/src/properties/property_models.rs
+                        - common/plugin_transpiler/src
+                        - .github/workflows/ci-backend.yml
+                        - .github/clickhouse-versions.json
+                        - docker-compose.dev.yml
+                        - docker-compose.profiles.yml
+                        - docker-compose.base.yml
+                        - bin/wait-for-docker
+                        - frontend/public/email/*
+                        - docker/clickhouse
                       migrations:
                         - docker/clickhouse
                         - 'posthog/migrations/*.py'

--- a/common/hogli/product.py
+++ b/common/hogli/product.py
@@ -267,30 +267,32 @@ def lint_product(name: str, verbose: bool = True) -> list[str]:
     for f in missing_root:
         issues.append(f"Missing required root file: {f}")
 
-    # 2. backend:test in package.json (if product has backend/)
+    # 2. Required scripts in package.json (if product has backend/)
     if backend_dir.exists():
         package_json = product_dir / "package.json"
         if package_json.exists():
             try:
                 pkg_data = json.loads(package_json.read_text())
-                has_backend_test = "backend:test" in pkg_data.get("scripts", {})
+                scripts = pkg_data.get("scripts", {})
             except json.JSONDecodeError:
-                has_backend_test = False
+                scripts = {}
                 issues.append("package.json is not valid JSON")
         else:
-            has_backend_test = False
+            scripts = {}
 
-        if verbose:
-            click.echo("  backend:test in package.json...")
-        if not has_backend_test:
-            issues.append(
-                "Product has backend/ but package.json is missing 'backend:test' script — "
-                "turbo cannot discover this product for testing"
-            )
+        for script in ("backend:test", "backend:contract-check"):
+            has_script = script in scripts
             if verbose:
-                click.echo("    ✗ missing")
-        elif verbose:
-            click.echo("    ✓ ok")
+                click.echo(f"  {script} in package.json...")
+            if not has_script:
+                issues.append(
+                    f"Product has backend/ but package.json is missing '{script}' script — "
+                    "turbo cannot discover this product"
+                )
+                if verbose:
+                    click.echo("    ✗ missing")
+            elif verbose:
+                click.echo("    ✓ ok")
 
     # 3. Misplaced backend files (strict only — legacy products have flat structure by design)
     if is_isolated:
@@ -415,7 +417,9 @@ def _lint_all_products() -> None:
     lenient = [d.name for d in product_dirs if not _is_isolated_product(d / "backend")]
 
     click.echo(f"Linting {len(product_dirs)} products ({len(strict)} strict, {len(lenient)} lenient)")
-    click.echo("Checks: required root files, backend:test script, misplaced files, file/folder conflicts\n")
+    click.echo(
+        "Checks: required root files, backend:test, backend:contract-check, misplaced files, file/folder conflicts\n"
+    )
 
     failed: list[str] = []
 

--- a/common/hogli/product_structure.yaml
+++ b/common/hogli/product_structure.yaml
@@ -53,7 +53,8 @@ root_files:
             {{
                 "name": "@posthog/products-{product}",
                 "scripts": {{
-                    "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+                    "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+                    "backend:contract-check": "echo 'Contract files unchanged'"
                 }}
             }}
 

--- a/products/actions/package.json
+++ b/products/actions/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-actions",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-forms": "catalog:",

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-alerts",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/analytics_platform/package.json
+++ b/products/analytics_platform/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-analytics-platform",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/batch_exports/package.json
+++ b/products/batch_exports/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-batch-exports",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests --ignore=backend/tests/temporal -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests --ignore=backend/tests/temporal -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/cdp/package.json
+++ b/products/cdp/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-cdp",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-cohorts",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-conversations",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/core_events/package.json
+++ b/products/core_events/package.json
@@ -1,3 +1,6 @@
 {
-    "name": "@posthog/products-core-events"
+    "name": "@posthog/products-core-events",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    }
 }

--- a/products/customer_analytics/package.json
+++ b/products/customer_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-customer-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/dashboards/package.json
+++ b/products/dashboards/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-dashboards",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/data_modeling/package.json
+++ b/products/data_modeling/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-data-modeling",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/data_warehouse/package.json
+++ b/products/data_warehouse/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-data-warehouse",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/desktop_recordings/package.json
+++ b/products/desktop_recordings/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-desktop_recordings",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/early_access_features/package.json
+++ b/products/early_access_features/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-early-access-features",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/endpoints/package.json
+++ b/products/endpoints/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-endpoints",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-error-tracking",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/event_definitions/package.json
+++ b/products/event_definitions/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-event-definitions",
     "scripts": {
-        "backend:test": "echo 'No backend tests'"
+        "backend:test": "echo 'No backend tests'",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-experiments",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/feature_flags/package.json
+++ b/products/feature_flags/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-feature-flags",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/games/package.json
+++ b/products/games/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-games",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/groups/package.json
+++ b/products/groups/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-groups",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/growth/package.json
+++ b/products/growth/package.json
@@ -1,3 +1,6 @@
 {
-    "name": "@posthog/products-growth"
+    "name": "@posthog/products-growth",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    }
 }

--- a/products/links/package.json
+++ b/products/links/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-links",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/live_debugger/package.json
+++ b/products/live_debugger/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-live-debugger",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "fuse.js": "catalog:"

--- a/products/llm_analytics/package.json
+++ b/products/llm_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-llm-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-logs",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/managed_migrations/package.json
+++ b/products/managed_migrations/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-managed-migrations",
     "scripts": {
-        "backend:test": "echo 'No backend tests'"
+        "backend:test": "echo 'No backend tests'",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/marketing_analytics/package.json
+++ b/products/marketing_analytics/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-marketing-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/mcp_store/package.json
+++ b/products/mcp_store/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-mcp-store",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-notebooks",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/persons/package.json
+++ b/products/persons/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-persons",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/posthog_ai/package.json
+++ b/products/posthog_ai/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-posthog-ai",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-product-analytics",
     "scripts": {
-        "backend:test": "echo 'No backend tests'"
+        "backend:test": "echo 'No backend tests'",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/product_tours/package.json
+++ b/products/product_tours/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-product-tours",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-replay",
     "scripts": {
-        "backend:test": "echo 'No backend tests'"
+        "backend:test": "echo 'No backend tests'",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/revenue_analytics/package.json
+++ b/products/revenue_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-revenue-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/session_summaries/package.json
+++ b/products/session_summaries/package.json
@@ -1,5 +1,8 @@
 {
     "name": "@posthog/products-session-summaries",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1,3 +1,4 @@
+# CI test: product-only change should trigger Django tests via contract-check
 import json
 import uuid
 import logging

--- a/products/signals/package.json
+++ b/products/signals/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-signals",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/slack_app/package.json
+++ b/products/slack_app/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-slack-app",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/surveys/package.json
+++ b/products/surveys/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-surveys",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/tasks/package.json
+++ b/products/tasks/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-tasks",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests backend/services -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests backend/services -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "fast-deep-equal": "catalog:",

--- a/products/toolbar/package.json
+++ b/products/toolbar/package.json
@@ -1,3 +1,6 @@
 {
-    "name": "@posthog/products-toolbar"
+    "name": "@posthog/products-toolbar",
+    "scripts": {
+        "backend:contract-check": "echo 'Contract files unchanged'"
+    }
 }

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-user-interviews",
     "scripts": {
-        "backend:test": "echo 'No backend tests'"
+        "backend:test": "echo 'No backend tests'",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/web_analytics/package.json
+++ b/products/web_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-web-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-workflows",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",


### PR DESCRIPTION
Throwaway PR to verify the fix from #50215 + #50220.

Only changes `products/signals/backend/views.py` (a comment). On the old master this would silently skip Django tests. With the legacy filter + contract-check fix, we expect:
- `backend=true`, `legacy=false`
- contract-check sees signals has `backend:contract-check`, cache MISS (backend file changed)
- Django tests run
- Product tests for signals run