### PR TITLE
fix(surveys): fix comparison on llma survey view

### DIFF
--- a/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
@@ -13,7 +13,7 @@ import { GroupedResponse } from './utils'
 
 function QuestionResponse({ question, value }: { question: SurveyQuestion; value: unknown }): JSX.Element {
     if (isThumbQuestion(question)) {
-        return <ThumbsResponse isPositive={value === '1'} question={question} />
+        return <ThumbsResponse isPositive={String(value) === '1'} question={question} />
     }
 
     if (question.type === SurveyQuestionType.Rating) {


### PR DESCRIPTION
## Problem

someone silly (me) used strict equality for checking thumbs up/down in llma survey responses

but we do not have any guarantee on the type of these values

so it doesn't work sometimes!

https://posthoghelp.zendesk.com/agent/tickets/52378 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54115)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

swaps `x === '1'` to `String(x) === '1'`

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->