### PR TITLE
fix(ducklake): skip default client cert lookup in duckgres connections

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -37,6 +37,8 @@ def _make_duckgres_conninfo(team_id: int) -> str:
         user=config["DUCKGRES_USERNAME"],
         password=config["DUCKGRES_PASSWORD"],
         sslmode="require",
+        sslcert="",
+        sslkey="",
     )
 
 


### PR DESCRIPTION
## Summary

- Fixes `OperationalError: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied` when the Django pods connect to duckgres
- libpq automatically tries to load a client certificate from `~/.postgresql/postgresql.crt` when SSL is enabled. In the Django pods this path (`/root/.postgresql/postgresql.crt`) exists but isn't readable by the process, causing every duckgres connection to fail
- Setting `sslcert=""` and `sslkey=""` tells libpq to skip client cert lookup. The connection is still TLS-encrypted (`sslmode=require`)

## Test plan

- [ ] Deploy and verify duckgres endpoint queries succeed (e.g. `duckgres-thundy`)
- [ ] Verify TLS is still active on the connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)