### PR TITLE
fix(flags): bypass RootTeamQuerySet in flags cache and reset DB connections between verification variants

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -387,7 +387,10 @@ def get_teams_with_flags_queryset() -> "QuerySet[Team]":
     Used as the single source of truth for scoping both Celery verification
     tasks and management commands to the ~10% of teams that have flags.
     """
-    has_flags = FeatureFlag.objects_including_soft_deleted.filter(team_id=OuterRef("pk"))
+    # Use Q() to pass team_id as a positional arg, bypassing RootTeamQuerySet.filter()
+    # which intercepts team_id kwargs and adds expensive parent-team JOIN/subquery logic
+    # that makes the correlated EXISTS subquery unusable at scale.
+    has_flags = FeatureFlag.objects_including_soft_deleted.filter(Q(team_id=OuterRef("pk")))
     return Team.objects.filter(Exists(has_flags))
 
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -2219,6 +2219,21 @@ class TestGetTeamsWithFlagsQueryset(BaseTest):
         qs = get_teams_with_flags_queryset()
         assert team_no_flags.id not in qs.values_list("id", flat=True)
 
+    def test_queryset_does_not_include_parent_team_join(self):
+        """The Q() wrapper in get_teams_with_flags_queryset bypasses
+        RootTeamQuerySet.filter() to keep the EXISTS subquery simple.
+        If someone removes the Q() wrapper, the query will regress to
+        include parent_team joins that are unusable at scale."""
+        qs = get_teams_with_flags_queryset()
+        sql = str(qs.query).lower()
+        # Extract the EXISTS subquery — this is where the regression would appear.
+        # The SELECT column list legitimately contains parent_team_id as a Team field.
+        exists_start = sql.index("exists(")
+        subquery_sql = sql[exists_start:]
+        assert "parent_team" not in subquery_sql, (
+            f"EXISTS subquery should not reference parent_team, got: {subquery_sql}"
+        )
+
     def test_team_with_multiple_flags_returned_once(self):
         FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
         FeatureFlag.objects.create(team=self.team, key="flag-2", created_by=self.user)

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -14,6 +14,7 @@ from typing import Literal
 
 from django.conf import settings
 from django.core.cache import cache as django_cache
+from django.db import close_old_connections
 
 import structlog
 from celery import shared_task
@@ -112,6 +113,10 @@ def _run_flag_definitions_verification() -> None:
                 )
                 capture_exception(e)
                 errors.append(e)
+                # Reset DB connections after a failure (e.g. SoftTimeLimitExceeded
+                # during an active query) so the next variant gets a clean connection
+                # instead of hitting "another command is already in progress".
+                close_old_connections()
 
         duration = time.time() - start_time
         if errors:


### PR DESCRIPTION
## Problem

The `verify_flag_definitions_cache` task had several failures. We recently simplified a query to use the `EXISTS` subquery that should have made it more efficient.

However, I did not anticipate that `get_teams_with_flags_queryset()` passes `team_id` as a kwarg to `FeatureFlag.objects_including_soft_deleted.filter()`, which gets intercepted by `RootTeamQuerySet.filter()` and adds expensive parent-team JOIN/subquery logic. This makes the correlated `EXISTS` subquery unusable at scale.

Secondly, When a verification variant fails mid-query (e.g. `SoftTimeLimitExceeded`), the DB connection is left in a broken state, causing subsequent variants to fail with "another command is already in progress" errors.

## Changes

- Wrap the `team_id` filter in `Q()` to bypass `RootTeamQuerySet.filter()` interception, producing a simple `EXISTS` subquery without parent-team joins.
- Call `close_old_connections()` after a failure in the hypercache verification loop so subsequent variants get a clean DB connection.

## How did you test this code?

- [x] Verify `get_teams_with_flags_queryset()` generates a simple `EXISTS` subquery without parent-team joins
- [x] Confirm hypercache verification recovers gracefully when one variant fails mid-query

## Publish to changelog?

No