### PR TITLE
fix(ducklake): use non-existent path to suppress libpq client cert lookup

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -37,8 +37,9 @@ def _make_duckgres_conninfo(team_id: int) -> str:
         user=config["DUCKGRES_USERNAME"],
         password=config["DUCKGRES_PASSWORD"],
         sslmode="require",
-        sslcert="",
-        sslkey="",
+        sslcert="/tmp/no.txt",
+        sslkey="/tmp/no.txt",
+        sslrootcert="/tmp/no.txt",
     )
 
 


### PR DESCRIPTION
## Summary

- Fixes `OperationalError: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied` when Django pods connect to duckgres
- The previous fix (`sslcert=""`, `sslkey=""`) didn't work because libpq treats empty strings as "use the default path", still falling back to `~/.postgresql/postgresql.crt`
- Uses `/tmp/no.txt` (a non-existent file) instead — libpq silently skips `ENOENT` but treats `EACCES` as fatal. This matches the pattern already used by data imports: [`posthog/temporal/data_imports/sources/postgres/postgres.py#L89-L91`](https://github.com/PostHog/posthog/blob/master/posthog/temporal/data_imports/sources/postgres/postgres.py#L89-L91)

## Test plan

- [ ] Deploy and verify duckgres endpoint queries succeed (e.g. `duckgres-thundy`)
- [ ] Verify TLS is still active on the connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)