### PR TITLE
feat: added sql viewer to tool call result

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -921,6 +921,12 @@ function AssistantActionComponent({
     let markdownContent = <MarkdownMessage id={id} content={content} />
     const result = toolCall?.result
     const uiPayload = result?.ui_payload
+    const executedSQLQuery =
+        typeof uiPayload?.execute_sql === 'string'
+            ? uiPayload.execute_sql
+            : toolCall?.name === 'execute_sql' && typeof toolCall.args.query === 'string'
+              ? toolCall.args.query
+              : null
 
     return (
         <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
@@ -1031,6 +1037,14 @@ function AssistantActionComponent({
                                     />
                                 </div>
                             ))}
+                    {executedSQLQuery && (
+                        <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
+                            <b className="text-secondary">SQL query</b>
+                            <CodeSnippet language={Language.SQL} className="text-xs" compact>
+                                {executedSQLQuery}
+                            </CodeSnippet>
+                        </div>
+                    )}
                     <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
                         <LemonButton
                             size="xxsmall"


### PR DESCRIPTION
## Problem

User wants to see the SQL generated from the execute_sql tool call, but we don't show it to them in an easy-to-use format

## Changes

- Added a display for the SQL query that the user can easily copy

<img width="700" height="258" alt="Screenshot 2026-03-06 at 2 29 59 PM" src="https://github.com/user-attachments/assets/f7f968dd-2aa4-4014-80b1-1d2ea72b7389" />

## How did you test this code?

- Local

## Publish to changelog?

yes