### PR TITLE
fix: warehouse source table selection scroll

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -33,7 +33,7 @@ export default function SchemaForm(): JSX.Element {
     return (
         <>
             <div className="flex flex-col gap-2">
-                <div>
+                <div className="max-h-[60vh] overflow-y-auto">
                     <LemonTable
                         emptyState="No schemas found"
                         dataSource={databaseSchema}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When creating a Postgres warehouse source, the table selection list does not scroll, making it impossible to select tables if the list exceeds the available screen height.

## Changes

Added `max-h-[60vh] overflow-y-auto` to the wrapper around the `LemonTable` component in `SchemaForm.tsx` to enable vertical scrolling for long table lists.

## How did you test this code?

Automated tests were not run as per user instruction. Manual testing was not completed by the agent.

## Publish to changelog?

no

## 🤖 LLM context

This PR was authored by an LLM agent.

---
<p><a href="https://cursor.com/agents/bc-302f465c-595b-401f-8fa8-9971e9dc8cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-302f465c-595b-401f-8fa8-9971e9dc8cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->