### PR TITLE
fix(flags): Payloads are modifiable in v2 UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -97,7 +97,10 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
     const handleShowImplementation = (): void => {
         setShowImplementation(true)
         setTimeout(() => {
-            implementationRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            implementationRef.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+            })
         }, 150)
     }
 
@@ -108,17 +111,9 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
     ): void => {
         const coercedValue = field === 'rollout_percentage' ? Number(value) || 0 : String(value)
         const currentVariants = [...variants]
-        const oldKey = currentVariants[index]?.key
-        currentVariants[index] = { ...currentVariants[index], [field]: coercedValue }
-
-        // If the key is being changed, migrate any existing payload to the new key
-        let updatedPayloads = { ...featureFlag?.filters?.payloads }
-        if (field === 'key' && oldKey && oldKey !== coercedValue) {
-            const existingPayload = updatedPayloads[oldKey]
-            if (existingPayload !== undefined) {
-                delete updatedPayloads[oldKey]
-                updatedPayloads[coercedValue as string] = existingPayload
-            }
+        currentVariants[index] = {
+            ...currentVariants[index],
+            [field]: coercedValue,
         }
 
         setFeatureFlag({
@@ -129,21 +124,16 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                     ...featureFlag?.filters?.multivariate,
                     variants: currentVariants,
                 },
-                payloads: updatedPayloads,
             },
         })
     }
 
     const updateVariantPayload = (index: number, value: string | undefined): void => {
-        const variantKey = variants[index]?.key
-        if (!variantKey) {
-            return
-        }
         const currentPayloads = { ...featureFlag?.filters?.payloads }
         if (value === '' || value === undefined) {
-            delete currentPayloads[variantKey]
+            delete currentPayloads[index]
         } else {
-            currentPayloads[variantKey] = value
+            currentPayloads[index] = value
         }
         setFeatureFlag({
             ...featureFlag,
@@ -178,7 +168,11 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                     }}
                     forceBackTo={
                         isNewFeatureFlag && featureFlagsV2Enabled
-                            ? { key: 'FeatureFlagTemplates', name: 'Templates', path: urls.featureFlagTemplates() }
+                            ? {
+                                  key: 'FeatureFlagTemplates',
+                                  name: 'Templates',
+                                  path: urls.featureFlagTemplates(),
+                              }
                             : undefined
                     }
                     actions={
@@ -686,7 +680,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                                         </LemonLabel>
                                                         <JSONEditorInput
                                                             onChange={(value) => updateVariantPayload(index, value)}
-                                                            value={featureFlag.filters?.payloads?.[variant.key]}
+                                                            value={featureFlag.filters?.payloads?.[index]}
                                                             placeholder='{"key": "value"}'
                                                         />
 
@@ -701,7 +695,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                                                     const variantKey =
                                                                         variant.key || `Variant ${index + 1}`
                                                                     const hasPayload =
-                                                                        !!featureFlag.filters?.payloads?.[variant.key]
+                                                                        !!featureFlag.filters?.payloads?.[index]
                                                                     LemonDialog.open({
                                                                         title: `Remove variant "${variantKey}"?`,
                                                                         description: hasPayload

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsSection.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsSection.tsx
@@ -53,10 +53,10 @@ export function FeatureFlagVariantsSection({ featureFlag, variants }: FeatureFla
                                 </div>
                             )}
 
-                            {payloads[variant.key] && (
+                            {payloads[index] && (
                                 <div className="flex flex-col gap-1">
                                     <label className="text-xs font-medium text-muted">Payload</label>
-                                    <JSONEditorInput readOnly value={payloads[variant.key]} />
+                                    <JSONEditorInput readOnly value={payloads[index]} />
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## Problem

Editing flag payloads in the new v2 UI wasn't working

## Changes

The v2 UI references payloads by index instead of by key, same as the v1 UI

## How did you test this code?

Manually tested on v1 and v2 UI. Existing tests pass without changes.