### PR TITLE
fix(rbac): enforce object-level permissions on detail actions

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -1240,14 +1240,13 @@ class DashboardsViewSet(
     @action(methods=["PATCH"], detail=True)
     def move_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # TODO could things be rearranged so this is  PATCH call on a resource and not a custom endpoint?
-        tile = request.data["tile"]
-        from_dashboard = kwargs["pk"]
+        from_dashboard = self.get_object()
         to_dashboard = request.data["toDashboard"]
 
         tile = get_object_or_404(
             DashboardTile,
-            dashboard_id=from_dashboard,
-            id=tile["id"],
+            dashboard_id=from_dashboard.pk,
+            id=request.data["tile"]["id"],
             dashboard__team__project_id=self.team.project_id,
         )
         to_dashboard_obj = get_object_or_404(Dashboard, id=to_dashboard, team__project_id=self.team.project_id)
@@ -1263,7 +1262,7 @@ class DashboardsViewSet(
             raise exceptions.ValidationError("Invalid request data for moving tile.")
 
         serializer = DashboardSerializer(
-            get_object_or_404(Dashboard, id=from_dashboard, team__project_id=self.team.project_id),
+            from_dashboard,
             context=self.get_serializer_context(),
         )
         return Response(serializer.data)

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -1250,6 +1250,7 @@ class DashboardsViewSet(
             dashboard__team__project_id=self.team.project_id,
         )
         to_dashboard_obj = get_object_or_404(Dashboard, id=to_dashboard, team__project_id=self.team.project_id)
+        self.check_object_permissions(request, to_dashboard_obj)
         if not self.user_permissions.dashboard(to_dashboard_obj).can_edit:
             raise exceptions.PermissionDenied("You don't have edit permissions for the destination dashboard.")
         try:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -3129,14 +3129,12 @@ class FeatureFlagViewSet(
         limit = request.validated_query_data["limit"]
         page = request.validated_query_data["page"]
 
-        item_id = kwargs["pk"]
-        if not FeatureFlag.objects_including_soft_deleted.filter(id=item_id, team__project_id=self.project_id).exists():
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        item = self.get_object()
 
         activity_page = load_activity(
             scope="FeatureFlag",
             team_id=self.team_id,
-            item_ids=[str(item_id)],
+            item_ids=[str(item.id)],
             limit=limit,
             page=page,
         )

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1732,14 +1732,12 @@ When set, the specified dashboard's filters and date range override will be appl
         limit = int(request.query_params.get("limit", "10"))
         page = int(request.query_params.get("page", "1"))
 
-        item_id = kwargs["pk"]
-        if not Insight.objects.filter(id=item_id, team__project_id=self.team.project_id).exists():
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        item = self.get_object()
 
         activity_page = load_activity(
             scope="Insight",
             team_id=self.team_id,
-            item_ids=[str(item_id)],
+            item_ids=[str(item.id)],
             limit=limit,
             page=page,
         )

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1754,6 +1754,35 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(move_response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_move_tile_respects_target_dashboard_access_control(self) -> None:
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+        dashboard_one_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard one"})
+        dashboard_two_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard two"})
+        self.dashboard_api.create_insight(
+            {"filters": {"events": [{"id": "$pageview"}], "insight": "TRENDS"}, "dashboards": [dashboard_one_id]}
+        )
+        dashboard_one = self.dashboard_api.get_dashboard(dashboard_one_id)
+        tile = dashboard_one["tiles"][0]
+
+        AccessControl.objects.create(
+            resource="dashboard", resource_id=dashboard_two_id, team=self.team, access_level="none"
+        )
+
+        self.client.force_login(user2)
+
+        move_response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_one_id}/move_tile",
+            {"tile": tile, "toDashboard": dashboard_two_id},
+        )
+        self.assertEqual(move_response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_update_text_tile_cannot_hijack_other_teams_tile(self) -> None:
         other_org, _, other_team = Organization.objects.bootstrap(self.user, name="other org")
         other_dashboard = Dashboard.objects.create(team=other_team, name="other dashboard")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -25,7 +25,7 @@ from posthog.models.dashboard_tile import Text
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog
 from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX, GROUP_TYPES_STALE_CACHE_KEY_PREFIX
 from posthog.models.insight_variable import InsightVariable
-from posthog.models.organization import Organization
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.project import Project
 from posthog.models.quick_filter import QuickFilter
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -1721,6 +1721,38 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         dashboard = self.dashboard_api.get_dashboard(dashboard_id)
         assert len(dashboard["tiles"]) == 1
+
+    def test_move_tile_respects_access_control(self) -> None:
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+        dashboard_one_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard one"})
+        dashboard_two_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard two"})
+        self.dashboard_api.create_insight(
+            {"filters": {"events": [{"id": "$pageview"}], "insight": "TRENDS"}, "dashboards": [dashboard_one_id]}
+        )
+        dashboard_one = self.dashboard_api.get_dashboard(dashboard_one_id)
+        tile = dashboard_one["tiles"][0]
+
+        AccessControl.objects.create(
+            resource="dashboard", resource_id=dashboard_one_id, team=self.team, access_level="none"
+        )
+
+        self.client.force_login(user2)
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_one_id}/")
+        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        move_response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_one_id}/move_tile",
+            {"tile": tile, "toDashboard": dashboard_two_id},
+        )
+        self.assertEqual(move_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_text_tile_cannot_hijack_other_teams_tile(self) -> None:
         other_org, _, other_team = Organization.objects.bootstrap(self.user, name="other org")

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1722,7 +1722,8 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard = self.dashboard_api.get_dashboard(dashboard_id)
         assert len(dashboard["tiles"]) == 1
 
-    def test_move_tile_respects_access_control(self) -> None:
+    @parameterized.expand([("source",), ("target",)])
+    def test_move_tile_respects_access_control(self, blocked_dashboard: str) -> None:
         self.organization.available_product_features = [
             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
             {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
@@ -1739,41 +1740,8 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard_one = self.dashboard_api.get_dashboard(dashboard_one_id)
         tile = dashboard_one["tiles"][0]
 
-        AccessControl.objects.create(
-            resource="dashboard", resource_id=dashboard_one_id, team=self.team, access_level="none"
-        )
-
-        self.client.force_login(user2)
-
-        retrieve_response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_one_id}/")
-        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
-
-        move_response = self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{dashboard_one_id}/move_tile",
-            {"tile": tile, "toDashboard": dashboard_two_id},
-        )
-        self.assertEqual(move_response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_move_tile_respects_target_dashboard_access_control(self) -> None:
-        self.organization.available_product_features = [
-            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
-            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
-        ]
-        self.organization.save()
-
-        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
-
-        dashboard_one_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard one"})
-        dashboard_two_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard two"})
-        self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "insight": "TRENDS"}, "dashboards": [dashboard_one_id]}
-        )
-        dashboard_one = self.dashboard_api.get_dashboard(dashboard_one_id)
-        tile = dashboard_one["tiles"][0]
-
-        AccessControl.objects.create(
-            resource="dashboard", resource_id=dashboard_two_id, team=self.team, access_level="none"
-        )
+        blocked_id = dashboard_one_id if blocked_dashboard == "source" else dashboard_two_id
+        AccessControl.objects.create(resource="dashboard", resource_id=blocked_id, team=self.team, access_level="none")
 
         self.client.force_login(user2)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -24,6 +24,7 @@ from rest_framework import status
 from posthog import redis
 from posthog.api.cohort import get_cohort_actors_for_feature_flag
 from posthog.api.feature_flag import FeatureFlagSerializer, extract_etag_from_header
+from posthog.constants import AvailableFeature
 from posthog.models import FeatureFlag, GroupTypeMapping, TaggedItem, User
 from posthog.models.cohort import Cohort
 from posthog.models.dashboard import Dashboard
@@ -7628,9 +7629,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(
             LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="body")._value.get(), before_body
         )
-    def test_feature_flag_activity_respects_access_control(self) -> None:
-        from posthog.constants import AvailableFeature
 
+    def test_feature_flag_detail_actions_respect_access_control(self) -> None:
         self.organization.available_product_features = [
             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
             {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
@@ -7654,6 +7654,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         activity_response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags/{flag.id}/activity/")
         self.assertEqual(activity_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        status_response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags/{flag.id}/status/")
+        self.assertEqual(status_response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -32,7 +32,7 @@ from posthog.models.feature_flag.feature_flag import FeatureFlagHashKeyOverride
 from posthog.models.feature_flag.flag_status import FeatureFlagStatus
 from posthog.models.group.group import Group
 from posthog.models.group.util import create_group
-from posthog.models.organization import Organization
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.person import Person
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.team.team import Team
@@ -44,6 +44,8 @@ from products.early_access_features.backend.models import EarlyAccessFeature
 from products.experiments.backend.models.experiment import Experiment
 from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
+
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestExtractEtagFromHeader:
@@ -7626,6 +7628,32 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(
             LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="body")._value.get(), before_body
         )
+    def test_feature_flag_activity_respects_access_control(self) -> None:
+        from posthog.constants import AvailableFeature
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="secret flag",
+            key="secret-flag",
+        )
+        AccessControl.objects.create(resource="feature_flag", resource_id=flag.id, team=self.team, access_level="none")
+
+        self.client.force_login(user2)
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags/{flag.id}/")
+        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        activity_response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags/{flag.id}/activity/")
+        self.assertEqual(activity_response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -3600,6 +3600,32 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertIn(visible_insight.id, [insight["id"] for insight in response.json()["results"]])
         self.assertIn(hidden_insight.id, [insight["id"] for insight in response.json()["results"]])
 
+    def test_insight_activity_respects_access_control(self) -> None:
+        from posthog.constants import AvailableFeature
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Hidden Insight",
+            created_by=self.user,
+        )
+        AccessControl.objects.create(resource="insight", resource_id=insight.id, team=self.team, access_level="none")
+
+        self.client.force_login(user2)
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.pk}/insights/{insight.id}/")
+        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        activity_response = self.client.get(f"/api/projects/{self.team.pk}/insights/{insight.id}/activity/")
+        self.assertEqual(activity_response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_create_insight_in_specific_folder(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/",

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -49,6 +49,7 @@ from posthog import settings
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.caching.insight_cache import update_cache
 from posthog.caching.insight_caching_state import TargetCacheAge
+from posthog.constants import AvailableFeature
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import (
     Cohort,
@@ -3601,8 +3602,6 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertIn(hidden_insight.id, [insight["id"] for insight in response.json()["results"]])
 
     def test_insight_activity_respects_access_control(self) -> None:
-        from posthog.constants import AvailableFeature
-
         self.organization.available_product_features = [
             {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
             {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1425,13 +1425,13 @@ class SessionRecordingViewSet(
 
         user = cast(User, request.user)
 
-        cache_key = f"summarize_recording_{self.team.pk}_{self.kwargs['pk']}"
+        recording = self.get_object()
+
+        cache_key = f"summarize_recording_{self.team.pk}_{recording.session_id}"
         # Check if the response is cached
         cached_response = cache.get(cache_key)
         if cached_response is not None:
             return Response(cached_response)
-
-        recording = self.get_object()
 
         if not SessionReplayEvents().exists(session_id=str(recording.session_id), team=self.team):
             raise exceptions.NotFound("Recording not found")

--- a/posthog/session_recordings/test/test_session_recording_access_control.py
+++ b/posthog/session_recordings/test/test_session_recording_access_control.py
@@ -2,6 +2,8 @@ import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.core.cache import cache
+
 from rest_framework import status
 
 from posthog.constants import AvailableFeature
@@ -212,3 +214,24 @@ class TestSessionRecordingAccessControl(APIBaseTest):
         can_modify = uac.check_can_modify_access_levels_for_object(self.recording)
 
         self.assertTrue(can_modify)
+
+    def test_summarize_respects_access_control(self):
+        self._create_access_control(self.no_access_user, resource_id=str(self.recording.id), access_level="none")
+
+        self.client.force_login(self.no_access_user)
+
+        retrieve_response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings/{self.recording.session_id}/"
+        )
+        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        cache_key = f"summarize_recording_{self.team.pk}_{self.recording.session_id}"
+        cache.set(cache_key, {"content": "sensitive session summary"}, timeout=30)
+
+        try:
+            summarize_response = self.client.post(
+                f"/api/projects/{self.team.id}/session_recordings/{self.recording.session_id}/summarize/"
+            )
+            self.assertEqual(summarize_response.status_code, status.HTTP_403_FORBIDDEN)
+        finally:
+            cache.delete(cache_key)

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -2102,15 +2102,12 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         limit = int(request.query_params.get("limit", "10"))
         page = int(request.query_params.get("page", "1"))
 
-        item_id = kwargs["pk"]
-
-        if not Survey.objects.filter(id=item_id, team__project_id=self.project_id).exists():
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        item = self.get_object()
 
         activity_page = load_activity(
             scope="Survey",
             team_id=self.team_id,
-            item_ids=[item_id],
+            item_ids=[str(item.id)],
             limit=limit,
             page=page,
         )

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -29,11 +29,13 @@ from posthog.api.test.test_personal_api_keys import PersonalAPIKeysBaseTest
 from posthog.constants import AvailableFeature
 from posthog.models import Action, FeatureFlag, Person, Team
 from posthog.models.cohort.cohort import Cohort
-from posthog.models.organization import Organization
+from posthog.models.organization import Organization, OrganizationMembership
 
 from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.api.survey import nh3_clean_with_allow_list
 from products.surveys.backend.models import MAX_ITERATION_COUNT, Survey, SurveyResponseArchive, surveys_hypercache
+
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestSurvey(APIBaseTest):
@@ -2742,6 +2744,30 @@ class TestSurvey(APIBaseTest):
         assert "Special Folder/Surveys" in fs_entry.path, (
             f"Expected path to include 'Special Folder/Surveys', got '{fs_entry.path}'."
         )
+
+    def test_survey_activity_respects_access_control(self) -> None:
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        user2 = self._create_user("test2@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+        survey = Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="secret survey",
+        )
+        AccessControl.objects.create(resource="survey", resource_id=survey.id, team=self.team, access_level="none")
+
+        self.client.force_login(user2)
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.pk}/surveys/{survey.id}/")
+        self.assertEqual(retrieve_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        activity_response = self.client.get(f"/api/projects/{self.team.pk}/surveys/{survey.id}/activity/")
+        self.assertEqual(activity_response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestMultipleChoiceQuestions(APIBaseTest):


### PR DESCRIPTION
## Problem

Several `@action(detail=True)` endpoints on viewsets that use `AccessControlViewSetMixin` bypass object-level permission checks. They fetch objects via manual queryset lookups (`Model.objects.filter(...)`, `get_object_or_404(...)`) instead of calling `self.get_object()`, which means `AccessControlPermission.has_object_permission()` is never invoked. A user with RBAC restrictions (e.g., `access_level="none"`) on a specific resource can still access these detail actions.

Affected endpoints:
- `DashboardsViewSet.move_tile`
- `FeatureFlagViewSet.activity`
- `InsightViewSet.activity`
- `SurveyViewSet.activity`
- `SessionRecordingViewSet.summarize` (cache check before permission check)

## Changes

- Call `self.get_object()` (which triggers `check_object_permissions`) instead of manual queryset lookups
- Move `self.get_object()` before the cache check in `SessionRecordingViewSet.summarize` so permissions are enforced on cached responses
- Add tests for each fixed endpoint

## How did you test this code?

- New integration tests for each endpoint verify that a user with `access_level="none"` gets 403 on both the standard retrieve and the previously-broken detail action

## Publish to changelog?

No
