### PR TITLE
fix(workflows): add recommended DNS record to email setup list

### DIFF
--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -146,6 +146,16 @@ class SESProvider:
             }
         )
 
+        dns_records.append(
+            {
+                "type": "dmarc",
+                "recordType": "TXT",
+                "recordHostname": f"_dmarc.{domain}",
+                "recordValue": "v=DMARC1; p=none;",
+                "status": "pending",
+            }
+        )
+
         # Current verification / DKIM statuses to compute overall status & per-record statuses ---
         try:
             id_attrs = self.ses_client.get_identity_verification_attributes(Identities=[domain])

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -155,7 +155,7 @@ class SESProvider:
                 "recordType": "TXT",
                 "recordHostname": f"_dmarc.{domain}",
                 "recordValue": "v=DMARC1; p=none;",
-                "status": "unknown",
+                "status": "pending",
             }
         )
 

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -155,7 +155,7 @@ class SESProvider:
                 "recordType": "TXT",
                 "recordHostname": f"_dmarc.{domain}",
                 "recordValue": "v=DMARC1; p=none;",
-                "status": "pending",
+                "status": "unknown",
             }
         )
 

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -146,6 +146,9 @@ class SESProvider:
             }
         )
 
+        # DMARC is recommended but not verified — the AWS SDK has no method to check
+        # its presence, so the status always stays "pending" and it is excluded from
+        # the overall status computation below.
         dns_records.append(
             {
                 "type": "dmarc",

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -179,6 +179,13 @@ class TestSESProvider(TestCase):
                     "status": "pending",
                     "type": "mail_from",
                 },
+                {
+                    "type": "dmarc",
+                    "recordType": "TXT",
+                    "recordHostname": "_dmarc.test.posthog.com",
+                    "recordValue": "v=DMARC1; p=none;",
+                    "status": "pending",
+                },
             ],
         }
 


### PR DESCRIPTION
## Problem

While not strictly required this record is highly recommended. Adding it to the list for channel setup. Unfortunately, the AWS SDK doesn't have a method to check for its presence

## Changes

- adds DMARC record to DNS record list during channel setup

## How did you test this code?

Updated tests

## Publish to changelog?

No