### PR TITLE
chore(flags): test - set default semaphore timeout to 150ms

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -490,7 +490,7 @@ pub struct Config {
     // When the wait exceeds this threshold, the request returns 504 so that
     // ingress can retry it on a less-loaded pod.
     // 0 = no timeout (await indefinitely, backwards-compatible).
-    #[envconfig(from = "RAYON_SEMAPHORE_TIMEOUT_MS", default = "0")]
+    #[envconfig(from = "RAYON_SEMAPHORE_TIMEOUT_MS", default = "150")]
     pub rayon_semaphore_timeout_ms: u64,
 
     // When true, skip all writes to PostgreSQL and Redis.


### PR DESCRIPTION
Dummy PR to test out the new semaphore timeout mechanism using our canary infra.