### PR TITLE
fix(personhog): wrong types on group type mapping

### DIFF
--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -44,8 +44,8 @@ struct GroupTypeMappingRow {
     group_type_index: i32,
     name_singular: Option<String>,
     name_plural: Option<String>,
-    default_columns: Option<serde_json::Value>,
-    detail_dashboard_id: Option<i64>,
+    default_columns: Option<Vec<String>>,
+    detail_dashboard_id: Option<i32>,
     created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -60,7 +60,7 @@ impl From<GroupTypeMappingRow> for GroupTypeMapping {
             name_singular: row.name_singular,
             name_plural: row.name_plural,
             default_columns: row.default_columns,
-            detail_dashboard_id: row.detail_dashboard_id,
+            detail_dashboard_id: row.detail_dashboard_id.map(|id| id.into()),
             created_at: row.created_at,
         }
     }

--- a/rust/personhog-replica/src/storage/types/group.rs
+++ b/rust/personhog-replica/src/storage/types/group.rs
@@ -20,7 +20,7 @@ pub struct GroupTypeMapping {
     pub group_type_index: i32,
     pub name_singular: Option<String>,
     pub name_plural: Option<String>,
-    pub default_columns: Option<serde_json::Value>,
+    pub default_columns: Option<Vec<String>>,
     pub detail_dashboard_id: Option<i64>,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/rust/personhog-replica/tests/common/mod.rs
+++ b/rust/personhog-replica/tests/common/mod.rs
@@ -114,14 +114,19 @@ impl TestContext {
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             r#"INSERT INTO posthog_grouptypemapping
-            (team_id, project_id, group_type, group_type_index, name_singular, name_plural)
-            VALUES ($1, $2, $3, $4, NULL, NULL)
+            (team_id, project_id, group_type, group_type_index,
+             name_singular, name_plural, default_columns, detail_dashboard_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT DO NOTHING"#,
         )
         .bind(self.team_id)
         .bind(self.team_id)
         .bind(group_type)
         .bind(group_type_index)
+        .bind(format!("{group_type} (singular)"))
+        .bind(format!("{group_type}s"))
+        .bind(vec!["col_a".to_string(), "col_b".to_string()])
+        .bind(group_type_index + 1000)
         .execute(&self.pool)
         .await?;
 

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -9,10 +9,7 @@ use tracing::warn;
 use crate::config::RetryConfig;
 
 fn is_retryable(code: Code) -> bool {
-    matches!(
-        code,
-        Code::Unavailable | Code::DeadlineExceeded | Code::Internal
-    )
+    matches!(code, Code::Unavailable | Code::DeadlineExceeded)
 }
 
 fn code_as_str(code: Code) -> &'static str {
@@ -39,8 +36,8 @@ fn code_as_str(code: Code) -> &'static str {
 
 /// Executes an async operation with exponential backoff and jitter on transient gRPC errors.
 ///
-/// Only retries on `Unavailable`, `DeadlineExceeded`, and `Internal` status codes.
-/// Permanent errors (e.g. `InvalidArgument`, `NotFound`) are returned immediately.
+/// Only retries on `Unavailable` and `DeadlineExceeded` status codes.
+/// All other errors (e.g. `Internal`, `InvalidArgument`, `NotFound`) are returned immediately.
 pub async fn with_retry<F, Fut, T>(
     config: &RetryConfig,
     method: &'static str,
@@ -114,7 +111,7 @@ mod tests {
 
     #[tokio::test]
     async fn retries_transient_then_succeeds() {
-        let transient_codes = vec![Code::Unavailable, Code::DeadlineExceeded, Code::Internal];
+        let transient_codes = vec![Code::Unavailable, Code::DeadlineExceeded];
         for code in transient_codes {
             let calls = AtomicU32::new(0);
             let result = with_retry(&test_config(), "test", || {
@@ -189,7 +186,6 @@ mod tests {
         let cases = vec![
             (Code::Unavailable, "unavailable"),
             (Code::DeadlineExceeded, "deadline_exceeded"),
-            (Code::Internal, "internal"),
         ];
         for (code, msg) in cases {
             let calls = AtomicU32::new(0);


### PR DESCRIPTION
## Problem

After enabling `get_group_type_mappings_by_project_id` calls to the personhog-replica service,
we hit two runtime type decode errors:

1. `detail_dashboard_id`: Rust struct used `Option<i64>` (`INT8`) but the Postgres column is `INT4`
   (Django `ForeignKey` maps to a 32-bit integer).
2. `default_columns`: Rust struct used `Option<serde_json::Value>` (`JSONB`) but the Postgres column
   is `TEXT[]` (Django `ArrayField(TextField())`).

These errors were returned as `Code::Internal` by the replica, and the personhog-router incorrectly
retried them up to 3 times — wasting resources on a permanent error that could never succeed.

Our integration tests didn't catch this because the test helper only inserted `NULL` values for
these columns. sqlx happily decodes `NULL` into any `Option<T>` without validating the inner type.

## Changes

**personhog-replica: fix type mismatches**
- `src/storage/postgres/group.rs`: Changed `GroupTypeMappingRow.detail_dashboard_id` from
  `Option<i64>` to `Option<i32>`, with `.map(|id| id.into())` to widen to `i64` in the
  service/proto layer.
- `src/storage/postgres/group.rs` and `src/storage/types/group.rs`: Changed `default_columns`
  from `Option<serde_json::Value>` to `Option<Vec<String>>` to match the actual `TEXT[]` column.

**personhog-router: fix retry policy**
- `src/backend/retry.rs`: Removed `Code::Internal` from the retryable status code set.
  Only `Unavailable` and `DeadlineExceeded` are retried now, per gRPC conventions.
  `Internal` errors (type mismatches, bugs) are permanent and should fail fast.

**personhog-replica: improve test coverage**
- `tests/common/mod.rs`: Updated `insert_group_type_mapping` to populate all columns
  (`name_singular`, `name_plural`, `default_columns`, `detail_dashboard_id`) with non-null
  values. This ensures sqlx validates the full type mapping against the real schema, so any
  future mismatches are caught immediately in CI instead of in production.


## How did you test this code?

- `cargo check` passes for personhog-replica
- `cargo test --lib backend::retry` passes for personhog-router (6/6 tests)
- `cargo check --tests` passes for personhog-replica (confirms test helper compiles with correct types)
 	- addedtests to the personhog-replica service to cover the missed cases
- Verified Rust types against the Django model definitions in `posthog/models/group_type_mapping.py`
