### PR TITLE
fix(flags): use filter set instead of removing flags for dependency graph integrity

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -11,7 +11,10 @@ use metrics::counter;
 
 impl FeatureFlagList {
     pub fn new(flags: Vec<FeatureFlag>) -> Self {
-        Self { flags }
+        Self {
+            flags,
+            ..Default::default()
+        }
     }
 
     /// Parses a JSON Value from hypercache into a list of feature flags.

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -312,6 +312,10 @@ impl FeatureFlagMatcher {
         self
     }
 
+    /// Sets filtered-out flag IDs for tests and lower-level evaluation flows.
+    /// Note: `evaluate_all_feature_flags` overwrites this field from the
+    /// `FeatureFlagList`, so this method only takes effect when calling
+    /// evaluation helpers (e.g. `evaluate_flags_in_order`) directly.
     pub fn with_filtered_out_flag_ids(mut self, ids: HashSet<i32>) -> Self {
         self.filtered_out_flag_ids = ids;
         self
@@ -846,7 +850,9 @@ impl FeatureFlagMatcher {
         let flags_to_evaluate: Vec<FeatureFlag> = flags
             .into_iter()
             .filter(|flag| {
-                !self.filtered_out_flag_ids.contains(&flag.id)
+                !flag.deleted
+                    && flag.active
+                    && !self.filtered_out_flag_ids.contains(&flag.id)
                     && !evaluated_flags_map.contains_key(&flag.key)
             })
             .collect();

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -25,7 +25,7 @@ use crate::metrics::consts::{
     FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED, FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER,
     FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
     FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
-    PROPERTY_CACHE_MISSES_COUNTER, TOMBSTONE_COUNTER,
+    PROPERTY_CACHE_MISSES_COUNTER,
 };
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
@@ -309,15 +309,6 @@ impl FeatureFlagMatcher {
 
     pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
         self.skip_writes = skip_writes;
-        self
-    }
-
-    /// Sets filtered-out flag IDs for tests and lower-level evaluation flows.
-    /// Note: `evaluate_all_feature_flags` overwrites this field from the
-    /// `FeatureFlagList`, so this method only takes effect when calling
-    /// evaluation helpers (e.g. `evaluate_flags_in_order`) directly.
-    pub fn with_filtered_out_flag_ids(mut self, ids: HashSet<i32>) -> Self {
-        self.filtered_out_flag_ids = ids;
         self
     }
 
@@ -856,24 +847,6 @@ impl FeatureFlagMatcher {
                     && !evaluated_flags_map.contains_key(&flag.key)
             })
             .collect();
-
-        // Inactive flags should never reach evaluation — filtered_out_flag_ids must include them.
-        // Fire a tombstone metric if this invariant is violated so we catch it in production.
-        let inactive_count = flags_to_evaluate.iter().filter(|f| !f.active).count();
-        if inactive_count > 0 {
-            inc(
-                TOMBSTONE_COUNTER,
-                &[
-                    ("namespace".to_string(), "feature_flags".to_string()),
-                    (
-                        "operation".to_string(),
-                        "inactive_flag_reached_evaluation".to_string(),
-                    ),
-                    ("component".to_string(), "flag_matching".to_string()),
-                ],
-                inactive_count as u64,
-            );
-        }
 
         let precomputed_property_overrides = self.precompute_property_overrides(
             &flags_to_evaluate,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -25,7 +25,7 @@ use crate::metrics::consts::{
     FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED, FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER,
     FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
     FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
-    PROPERTY_CACHE_MISSES_COUNTER,
+    PROPERTY_CACHE_MISSES_COUNTER, TOMBSTONE_COUNTER,
 };
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
@@ -245,6 +245,9 @@ pub struct FeatureFlagMatcher {
     rayon_dispatcher: Option<RayonDispatcher>,
     /// When true, skip all writes to PostgreSQL and Redis.
     skip_writes: bool,
+    /// Flag IDs that should be skipped during evaluation.
+    /// Populated once per request from `FeatureFlagList::filtered_out_flag_ids`.
+    pub(crate) filtered_out_flag_ids: HashSet<i32>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -253,7 +256,6 @@ pub struct FeatureFlagMatcher {
 struct FlagSnapshot {
     key: String,
     id: FeatureFlagId,
-    active: bool,
     version: Option<i32>,
 }
 
@@ -262,7 +264,6 @@ impl FlagSnapshot {
         FlagSnapshot {
             key: flag.key.clone(),
             id: flag.id,
-            active: flag.active,
             version: flag.version,
         }
     }
@@ -292,6 +293,7 @@ impl FeatureFlagMatcher {
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
             skip_writes: false,
+            filtered_out_flag_ids: HashSet::new(),
         }
     }
 
@@ -307,6 +309,11 @@ impl FeatureFlagMatcher {
 
     pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
         self.skip_writes = skip_writes;
+        self
+    }
+
+    pub fn with_filtered_out_flag_ids(mut self, ids: HashSet<i32>) -> Self {
+        self.filtered_out_flag_ids = ids;
         self
     }
 
@@ -347,6 +354,10 @@ impl FeatureFlagMatcher {
             None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
         };
 
+        // Move the filter set onto the matcher now that the borrow from graph construction has ended.
+        // This is the single source of truth for "should this flag be skipped" during evaluation.
+        self.filtered_out_flag_ids = feature_flags.filtered_out_flag_ids;
+
         // Filter graph by flag_keys if specified (includes transitive dependencies)
         let (dependency_graph, flags_with_missing_deps) = if let Some(ref keys) = flag_keys {
             match filter_graph_by_keys(
@@ -375,7 +386,9 @@ impl FeatureFlagMatcher {
             let mut needs_override = false;
 
             for flag in dependency_graph.iter_nodes() {
-                if flag.has_experience_continuity() {
+                if !self.filtered_out_flag_ids.contains(&flag.id)
+                    && flag.has_experience_continuity()
+                {
                     continuity_count += 1;
                     if !needs_override && flag.needs_hash_key_override() {
                         needs_override = true;
@@ -647,10 +660,10 @@ impl FeatureFlagMatcher {
         // Handle hash key override errors by creating error responses for flags that need experience continuity
         if overrides.hash_key_override_error && overrides.hash_key_overrides.is_none() {
             let hash_key_error = FlagError::HashKeyOverrideError;
-            for flag in flags
-                .iter()
-                .filter(|flag| flag.ensure_experience_continuity.unwrap_or(false))
-            {
+            for flag in flags.iter().filter(|flag| {
+                !self.filtered_out_flag_ids.contains(&flag.id)
+                    && flag.ensure_experience_continuity.unwrap_or(false)
+            }) {
                 evaluated_flags_map.insert(
                     flag.key.clone(),
                     FlagDetails::create_error(flag, &hash_key_error, None),
@@ -670,6 +683,13 @@ impl FeatureFlagMatcher {
             )
             .await;
         errors_while_computing_flags |= db_prep_errors;
+
+        // Pre-seed filtered-out flags as false so dependency conditions like
+        // `flag_evaluates_to=false` can match against them.
+        for &flag_id in &self.filtered_out_flag_ids {
+            self.flag_evaluation_state
+                .add_flag_evaluation_result(flag_id, FlagValue::Boolean(false));
+        }
 
         // Step 3: Evaluate flags using the dependency graph
         let graph_evaluation_errors = self
@@ -750,6 +770,7 @@ impl FeatureFlagMatcher {
             person_property_overrides
                 .as_ref()
                 .unwrap_or(&HashMap::new()),
+            &self.filtered_out_flag_ids,
         );
 
         if flags_requiring_db_preparation.is_empty() {
@@ -824,8 +845,29 @@ impl FeatureFlagMatcher {
 
         let flags_to_evaluate: Vec<FeatureFlag> = flags
             .into_iter()
-            .filter(|flag| !flag.deleted && !evaluated_flags_map.contains_key(&flag.key))
+            .filter(|flag| {
+                !self.filtered_out_flag_ids.contains(&flag.id)
+                    && !evaluated_flags_map.contains_key(&flag.key)
+            })
             .collect();
+
+        // Inactive flags should never reach evaluation — filtered_out_flag_ids must include them.
+        // Fire a tombstone metric if this invariant is violated so we catch it in production.
+        let inactive_count = flags_to_evaluate.iter().filter(|f| !f.active).count();
+        if inactive_count > 0 {
+            inc(
+                TOMBSTONE_COUNTER,
+                &[
+                    ("namespace".to_string(), "feature_flags".to_string()),
+                    (
+                        "operation".to_string(),
+                        "inactive_flag_reached_evaluation".to_string(),
+                    ),
+                    ("component".to_string(), "flag_matching".to_string()),
+                ],
+                inactive_count as u64,
+            );
+        }
 
         let precomputed_property_overrides = self.precompute_property_overrides(
             &flags_to_evaluate,
@@ -840,7 +882,7 @@ impl FeatureFlagMatcher {
         };
 
         // Record evaluation type in canonical log for E2E latency metrics.
-        // Skip if no flags to evaluate (all deleted or already evaluated) — lets the
+        // Skip if no flags to evaluate (all deleted, filtered out, or already evaluated) — lets the
         // metric label stay None → "none" rather than incorrectly reporting Sequential.
         if !flags_to_evaluate.is_empty() {
             with_canonical_log(|log| {
@@ -955,10 +997,8 @@ impl FeatureFlagMatcher {
             Ok(flag_match) => {
                 self.flag_evaluation_state
                     .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
-                if flag.active {
-                    level_evaluated_flags_map
-                        .insert(flag.key.clone(), FlagDetails::create(flag, flag_match));
-                }
+                level_evaluated_flags_map
+                    .insert(flag.key.clone(), FlagDetails::create(flag, flag_match));
             }
             Err(e) => {
                 *errors_while_computing_flags = true;
@@ -982,10 +1022,8 @@ impl FeatureFlagMatcher {
                     &[("reason".to_string(), reason)],
                     1,
                 );
-                if flag.active {
-                    level_evaluated_flags_map
-                        .insert(flag.key.clone(), FlagDetails::create_error(flag, e, None));
-                }
+                level_evaluated_flags_map
+                    .insert(flag.key.clone(), FlagDetails::create_error(flag, e, None));
             }
         }
     }
@@ -1115,7 +1153,7 @@ impl FeatureFlagMatcher {
                 let stub = FeatureFlag {
                     id: snapshot.id,
                     key: snapshot.key,
-                    active: snapshot.active,
+                    active: true,
                     version: snapshot.version,
                     filters: FlagFilters::default(),
                     team_id,
@@ -1175,15 +1213,6 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<FeatureFlagMatch, FlagError> {
-        if !flag.active {
-            return Ok(FeatureFlagMatch {
-                matches: false,
-                variant: None,
-                reason: FeatureFlagMatchReason::FlagDisabled,
-                condition_index: None,
-                payload: None,
-            });
-        }
         // Check if this is a group-based flag with missing group
         let hashed_id =
             self.hashed_identifier(flag, hash_key_overrides, request_hash_key_override)?;
@@ -2080,9 +2109,9 @@ impl FeatureFlagMatcher {
     /// It returns a boolean indicating if there were any errors while initializing the group type mapping cache.
     async fn initialize_group_type_mappings_if_needed(&mut self, flags: &[&FeatureFlag]) -> bool {
         // Check if we need to fetch group type mappings – we have flags that use group properties (have group type indices)
-        let has_type_indexes = flags
-            .iter()
-            .any(|flag| flag.active && !flag.deleted && flag.get_group_type_index().is_some());
+        let has_type_indexes = flags.iter().any(|flag| {
+            !self.filtered_out_flag_ids.contains(&flag.id) && flag.get_group_type_index().is_some()
+        });
 
         if !has_type_indexes {
             return false;
@@ -2166,19 +2195,16 @@ mod tests {
             FlagSnapshot {
                 key: "flag_a".to_string(),
                 id: 10,
-                active: true,
                 version: Some(3),
             },
             FlagSnapshot {
                 key: "flag_b".to_string(),
                 id: 20,
-                active: false,
                 version: None,
             },
             FlagSnapshot {
                 key: "flag_c".to_string(),
                 id: 30,
-                active: true,
                 version: Some(1),
             },
         ];
@@ -2190,26 +2216,24 @@ mod tests {
         let (stub_a, err_a) = &results[0];
         assert_eq!(stub_a.key, "flag_a");
         assert_eq!(stub_a.id, 10);
-        assert!(stub_a.active);
         assert_eq!(stub_a.version, Some(3));
         assert!(matches!(err_a, Err(FlagError::BatchEvaluationPanicked)));
 
         let (stub_b, err_b) = &results[1];
         assert_eq!(stub_b.key, "flag_b");
         assert_eq!(stub_b.id, 20);
-        assert!(!stub_b.active);
         assert_eq!(stub_b.version, None);
         assert!(matches!(err_b, Err(FlagError::BatchEvaluationPanicked)));
 
         let (stub_c, err_c) = &results[2];
         assert_eq!(stub_c.key, "flag_c");
         assert_eq!(stub_c.id, 30);
-        assert!(stub_c.active);
         assert_eq!(stub_c.version, Some(1));
         assert!(matches!(err_c, Err(FlagError::BatchEvaluationPanicked)));
 
         for (stub, _) in &results {
             assert_eq!(stub.team_id, team_id);
+            assert!(stub.active);
             assert_eq!(stub.name, None);
             assert!(!stub.deleted);
             assert!(stub.filters.groups.is_empty());

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -148,7 +148,7 @@ pub struct FeatureFlagRow {
 pub struct FeatureFlagList {
     pub flags: Vec<FeatureFlag>,
     /// Runtime-only set of flag IDs that should be skipped during evaluation.
-    /// Populated by runtime/tag filtering and user-disabled flags (DB `active = false`).
+    /// Includes inactive, deleted, survey-excluded, and tag-filtered flags.
     /// Not serialized — this is a request-scoped concern, not a cache concern.
     #[serde(skip)]
     pub filtered_out_flag_ids: HashSet<i32>,

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 use crate::properties::property_models::PropertyFilter;
 
@@ -146,4 +147,9 @@ pub struct FeatureFlagRow {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FeatureFlagList {
     pub flags: Vec<FeatureFlag>,
+    /// Runtime-only set of flag IDs that should be skipped during evaluation.
+    /// Populated by runtime/tag filtering and user-disabled flags (DB `active = false`).
+    /// Not serialized — this is a request-scoped concern, not a cache concern.
+    #[serde(skip)]
+    pub filtered_out_flag_ids: HashSet<i32>,
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -148,7 +148,7 @@ pub struct FeatureFlagRow {
 pub struct FeatureFlagList {
     pub flags: Vec<FeatureFlag>,
     /// Runtime-only set of flag IDs that should be skipped during evaluation.
-    /// Includes inactive, deleted, survey-excluded, and tag-filtered flags.
+    /// Includes inactive, deleted, survey-excluded, runtime-mismatched, and tag-filtered flags.
     /// Not serialized — this is a request-scoped concern, not a cache concern.
     #[serde(skip)]
     pub filtered_out_flag_ids: HashSet<i32>,

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -115,14 +115,19 @@ impl FeatureFlag {
     }
 }
 
-/// Returns the set of flags that require DB preparation
+/// Returns the set of non-filtered flags that require DB preparation.
+/// Filtered-out flags (inactive, deleted, runtime/tag mismatches) are skipped
+/// since they won't be evaluated.
 pub fn flags_require_db_preparation<'a>(
     flags: &[&'a FeatureFlag],
     overrides: &HashMap<String, Value>,
+    filtered_out_flag_ids: &HashSet<i32>,
 ) -> Vec<&'a FeatureFlag> {
     flags
         .iter()
-        .filter(|flag| flag.requires_db_preparation(overrides))
+        .filter(|flag| {
+            !filtered_out_flag_ids.contains(&flag.id) && flag.requires_db_preparation(overrides)
+        })
         .copied()
         .collect()
 }
@@ -136,9 +141,10 @@ impl DependencyProvider for FeatureFlag {
     }
 
     fn extract_dependencies(&self) -> Result<HashSet<Self::Id>, Self::Error> {
-        // Inactive flags evaluate to false regardless of their dependencies,
-        // so skip extraction to avoid MissingDependency errors for stale references.
-        if !self.active {
+        // User-disabled or deleted flags don't need dependency extraction. Since
+        // runtime/tag filtering uses `filtered_out_flag_ids` (not `active`), this
+        // check only applies to genuinely user-disabled flags in the DB.
+        if !self.active || self.deleted {
             return Ok(HashSet::new());
         }
 
@@ -449,19 +455,27 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_dependencies_respects_active_state() {
+    fn test_extract_dependencies_respects_active_and_deleted_state() {
         use crate::utils::graph_utils::DependencyProvider;
 
-        for (active, expected_deps, label) in [
+        for (active, deleted, expected_deps, label) in [
             (
+                false,
                 false,
                 HashSet::new(),
                 "inactive flags should return no dependencies",
             ),
             (
                 true,
+                false,
                 HashSet::from([999]),
                 "active flags should still extract dependencies",
+            ),
+            (
+                true,
+                true,
+                HashSet::new(),
+                "deleted flags should return no dependencies even if active",
             ),
         ] {
             let mut flag = create_test_flag(
@@ -470,7 +484,7 @@ mod tests {
                 None,
                 Some("test_flag".to_string()),
                 None,
-                None,
+                Some(deleted),
                 Some(active),
                 None,
             );
@@ -1494,7 +1508,13 @@ mod tests {
             .expect("Failed to fetch flags from Postgres");
 
         // Verify rollout percentages
-        for flags in &[redis_flags, FeatureFlagList { flags: pg_flags }] {
+        for flags in &[
+            redis_flags,
+            FeatureFlagList {
+                flags: pg_flags,
+                ..Default::default()
+            },
+        ] {
             assert!(flags
                 .flags
                 .iter()
@@ -1900,5 +1920,35 @@ mod tests {
         });
         // Both conditions satisfied -> needs lookup
         assert!(flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_flags_require_db_preparation_skips_filtered_out() {
+        let person_property =
+            create_simple_property_filter("email", PropertyType::Person, OperatorType::Exact);
+        let mut flag_a = create_simple_flag(vec![person_property.clone()], 100.0);
+        flag_a.id = 1;
+        flag_a.key = "flag_a".to_string();
+        let mut flag_b = create_simple_flag(vec![person_property], 100.0);
+        flag_b.id = 2;
+        flag_b.key = "flag_b".to_string();
+
+        let flags: Vec<&FeatureFlag> = vec![&flag_a, &flag_b];
+        let overrides = HashMap::new();
+
+        // Without filtering, both flags require DB preparation
+        let result = flags_require_db_preparation(&flags, &overrides, &HashSet::new());
+        assert_eq!(result.len(), 2);
+
+        // With flag_a filtered out, only flag_b requires preparation
+        let filtered = HashSet::from([1]);
+        let result = flags_require_db_preparation(&flags, &overrides, &filtered);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].key, "flag_b");
+
+        // With both filtered, none require preparation
+        let filtered = HashSet::from([1, 2]);
+        let result = flags_require_db_preparation(&flags, &overrides, &filtered);
+        assert!(result.is_empty());
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -177,7 +177,10 @@ impl FlagService {
         let flags = FeatureFlagList::parse_hypercache_value(data, team_id)?;
 
         Ok(FlagResult {
-            flag_list: FeatureFlagList { flags },
+            flag_list: FeatureFlagList {
+                flags,
+                ..Default::default()
+            },
             cache_source: source,
         })
     }
@@ -387,6 +390,7 @@ mod tests {
                     bucketing_identifier: None,
                 },
             ],
+            ..Default::default()
         };
 
         // Write to hypercache (new format: {"flags": [...]})
@@ -507,6 +511,7 @@ mod tests {
                     bucketing_identifier: None,
                 })
                 .collect(),
+            ..Default::default()
         };
 
         // Serialize exactly like Django does for large payloads: JSON -> Pickle -> Zstd

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -203,6 +203,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
         let result = matcher
             .evaluate_all_feature_flags(
@@ -294,6 +295,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
         let result = matcher
             .evaluate_all_feature_flags(
@@ -383,6 +385,7 @@ mod tests {
                 leaf_flag.clone(),
                 parent_flag.clone(),
             ],
+            ..Default::default()
         };
 
         {
@@ -547,6 +550,7 @@ mod tests {
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
+            ..Default::default()
         };
 
         {
@@ -715,6 +719,7 @@ mod tests {
                 intermediate_flag.clone(),
                 parent_flag.clone(),
             ],
+            ..Default::default()
         };
 
         reset_fetch_calls_count();
@@ -851,6 +856,7 @@ mod tests {
                 parent_flag.clone(),
                 missing_dependency_flag.clone(),
             ],
+            ..Default::default()
         };
 
         {
@@ -1016,6 +1022,7 @@ mod tests {
         );
         let flags = FeatureFlagList {
             flags: vec![leaf_flag.clone(), parent_flag.clone()],
+            ..Default::default()
         };
 
         {
@@ -1379,6 +1386,7 @@ mod tests {
             .evaluate_all_feature_flags(
                 FeatureFlagList {
                     flags: vec![flag.clone()],
+                    ..Default::default()
                 },
                 Some(person_property_overrides),
                 None,
@@ -3554,6 +3562,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         let router = context.create_postgres_router();
@@ -3648,6 +3657,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         let router = context.create_postgres_router();
@@ -3777,6 +3787,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag_continuity.clone(), flag_no_continuity.clone()],
+            ..Default::default()
         };
 
         let router = context.create_postgres_router();
@@ -4480,6 +4491,7 @@ mod tests {
             .evaluate_all_feature_flags(
                 FeatureFlagList {
                     flags: vec![flag.clone()],
+                    ..Default::default()
                 },
                 Some(person_property_overrides),
                 None,
@@ -5222,6 +5234,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
         reset_fetch_calls_count();
 
@@ -5498,6 +5511,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         let result = matcher
@@ -5870,6 +5884,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag_with_continuity, flag_without_continuity],
+            ..Default::default()
         };
 
         // Build dependency graph for the flags
@@ -5928,10 +5943,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_disabled_flag_evaluates_to_false() {
+    async fn test_filtered_out_flag_with_experience_continuity_excluded_from_hash_key_error_response(
+    ) {
         let context = TestContext::new(None).await;
+        let router = context.create_postgres_router();
         let cohort_cache = Arc::new(CohortCacheManager::new(
-            context.non_persons_reader.clone(),
+            context.persons_reader.clone(),
             None,
             None,
         ));
@@ -5941,50 +5958,80 @@ mod tests {
             .await
             .expect("Failed to insert team in pg");
 
-        let flag: FeatureFlag = serde_json::from_value(json!(
-            {
-                "id": 1,
-                "team_id": team.id,
-                "name": "disabled_flag",
-                "key": "disabled_flag",
-                "active": false,
-                "filters": {
-                    "groups": [
-                        {
-                            "properties": [],
-                            "rollout_percentage": 100
-                        }
-                    ]
-                }
-            }
-        ))
-        .unwrap();
+        let distinct_id = "user_distinct_id".to_string();
+        let mut matcher =
+            FeatureFlagMatcher::new(distinct_id, None, team.id, router, cohort_cache, None, None);
 
-        let router = context.create_postgres_router();
-        let matcher = FeatureFlagMatcher::new(
-            "test_user".to_string(),
+        // A filtered-out flag with experience continuity should not trigger
+        // hash-key-override error handling or appear in the response.
+        let filtered_continuity_flag = create_test_flag(
+            Some(1),
+            Some(team.id),
+            Some("Filtered Continuity".to_string()),
+            Some("filtered-continuity".to_string()),
             None,
-            team.id,
-            router,
-            cohort_cache,
-            None,
-            None,
+            Some(false),
+            Some(true),
+            Some(true), // ensure_experience_continuity
         );
 
-        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
-        assert!(!match_result.matches, "Disabled flag should not match");
-        assert_eq!(
-            match_result.reason,
-            FeatureFlagMatchReason::FlagDisabled,
-            "Reason should be FlagDisabled"
+        let active_normal_flag = create_test_flag(
+            Some(2),
+            Some(team.id),
+            Some("Active Normal".to_string()),
+            Some("active-normal".to_string()),
+            None,
+            Some(false),
+            Some(true),
+            Some(false),
         );
-        assert_eq!(
-            match_result.variant, None,
-            "Disabled flag should have no variant"
+
+        // Flag 1 is filtered out by runtime/tag filtering
+        let filtered_out = std::collections::HashSet::from([1]);
+
+        let flags = FeatureFlagList {
+            flags: vec![filtered_continuity_flag, active_normal_flag],
+            filtered_out_flag_ids: filtered_out.clone(),
+        };
+
+        let graph_result =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
+        // Simulate a hash-key-override read failure
+        let overrides = crate::flags::flag_matching::FlagEvaluationOverrides {
+            person_property_overrides: None,
+            group_property_overrides: None,
+            hash_key_overrides: None,
+            hash_key_override_error: true,
+            request_hash_key_override: None,
+        };
+
+        matcher.filtered_out_flag_ids = filtered_out;
+
+        let response = matcher
+            .evaluate_flags_with_overrides(
+                overrides,
+                Uuid::new_v4(),
+                graph_result.graph,
+                graph_result.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // The filtered-out continuity flag must not appear with a hash_key_override_error
+        assert!(
+            !response.flags.contains_key("filtered-continuity"),
+            "Filtered-out flag should not appear in the response at all"
         );
-        assert_eq!(
-            match_result.condition_index, None,
-            "Disabled flag should have no condition index"
+
+        // The active non-continuity flag should be evaluated normally
+        let active_response = response
+            .flags
+            .get("active-normal")
+            .expect("Active flag should be present");
+        assert_ne!(
+            active_response.reason.code, "hash_key_override_error",
+            "Active flag without continuity should not have hash override error"
         );
     }
 
@@ -6035,6 +6082,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![base_flag, dependent_flag],
+            ..Default::default()
         };
 
         // Build dependency graph for the flags
@@ -6052,6 +6100,9 @@ mod tests {
             None,
         );
 
+        // The base flag is user-disabled (active=false in DB), so it's in the filter set
+        matcher.filtered_out_flag_ids = std::collections::HashSet::from([1]);
+
         let result = matcher
             .evaluate_flags_with_overrides(
                 Default::default(),
@@ -6062,7 +6113,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Disabled base flag should NOT be in the response (only active flags are returned)
+        // Disabled base flag should NOT be in the response (filtered out)
         assert!(
             !result.flags.contains_key("base_flag"),
             "Disabled flags should not be included in the response"
@@ -6079,6 +6130,198 @@ mod tests {
         assert_ne!(
             dependent_result.reason.code, "flag_disabled",
             "Dependent flag should not have flag_disabled reason (it's not disabled, its dependency is)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_filtered_out_flag_satisfies_evaluates_to_false_dependency() {
+        use crate::utils::test_utils::create_test_flag_that_depends_on_flag;
+
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        // Flag A: active in DB, but will be filtered out by runtime/tags
+        let flag_a: FeatureFlag = serde_json::from_value(json!(
+            {
+                "id": 1,
+                "team_id": team.id,
+                "name": "flag_a",
+                "key": "flag_a",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [],
+                            "rollout_percentage": 100
+                        }
+                    ]
+                }
+            }
+        ))
+        .unwrap();
+
+        // Flag B depends on flag A with flag_evaluates_to=false.
+        // Since A is filtered out (conceptually false), B's dependency should be satisfied.
+        let flag_b = create_test_flag_that_depends_on_flag(
+            2,
+            team.id,
+            "flag_b",
+            1, // depends on flag id 1
+            FlagValue::Boolean(false),
+        );
+
+        // Flag A is filtered out by runtime/tag filtering
+        let filtered_out = std::collections::HashSet::from([1]);
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_a, flag_b],
+            filtered_out_flag_ids: filtered_out.clone(),
+        };
+
+        let graph_result =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+        matcher.filtered_out_flag_ids = filtered_out;
+
+        let result = matcher
+            .evaluate_flags_with_overrides(
+                Default::default(),
+                Uuid::new_v4(),
+                graph_result.graph,
+                graph_result.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // Filtered-out flag A should not appear in the response
+        assert!(
+            !result.flags.contains_key("flag_a"),
+            "Filtered-out flag should not appear in the response"
+        );
+
+        // Flag B should be enabled because its dependency (A evaluates to false) is satisfied
+        let flag_b_result = result
+            .flags
+            .get("flag_b")
+            .expect("Flag B should be in the response");
+        assert!(
+            flag_b_result.enabled,
+            "Flag B should be enabled because filtered-out flag A is treated as false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_filtered_out_flag_fails_evaluates_to_true_dependency() {
+        use crate::utils::test_utils::create_test_flag_that_depends_on_flag;
+
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        // Flag A: active in DB, but will be filtered out by runtime/tags
+        let flag_a: FeatureFlag = serde_json::from_value(json!(
+            {
+                "id": 1,
+                "team_id": team.id,
+                "name": "flag_a",
+                "key": "flag_a",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [],
+                            "rollout_percentage": 100
+                        }
+                    ]
+                }
+            }
+        ))
+        .unwrap();
+
+        // Flag B depends on flag A with flag_evaluates_to=true.
+        // Since A is filtered out (pre-seeded as false), B's dependency should NOT be satisfied.
+        let flag_b = create_test_flag_that_depends_on_flag(
+            2,
+            team.id,
+            "flag_b",
+            1, // depends on flag id 1
+            FlagValue::Boolean(true),
+        );
+
+        // Flag A is filtered out by runtime/tag filtering
+        let filtered_out = std::collections::HashSet::from([1]);
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_a, flag_b],
+            filtered_out_flag_ids: filtered_out.clone(),
+        };
+
+        let graph_result =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+        matcher.filtered_out_flag_ids = filtered_out;
+
+        let result = matcher
+            .evaluate_flags_with_overrides(
+                Default::default(),
+                Uuid::new_v4(),
+                graph_result.graph,
+                graph_result.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // Filtered-out flag A should not appear in the response
+        assert!(
+            !result.flags.contains_key("flag_a"),
+            "Filtered-out flag should not appear in the response"
+        );
+
+        // Flag B should be disabled because its dependency (A evaluates to true) is NOT satisfied
+        let flag_b_result = result
+            .flags
+            .get("flag_b")
+            .expect("Flag B should be in the response");
+        assert!(
+            !flag_b_result.enabled,
+            "Flag B should be disabled because filtered-out flag A is treated as false, not true"
         );
     }
 
@@ -6138,6 +6381,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![disabled_standalone, active_flag],
+            ..Default::default()
         };
 
         let graph_result =
@@ -6153,6 +6397,9 @@ mod tests {
             None,
             None,
         );
+
+        // The standalone flag is user-disabled (active=false in DB), so it's in the filter set
+        matcher.filtered_out_flag_ids = std::collections::HashSet::from([1]);
 
         let result = matcher
             .evaluate_flags_with_overrides(
@@ -6173,6 +6420,104 @@ mod tests {
         // Active flag should be in the response
         let active_result = result.flags.get("active_flag").unwrap();
         assert!(active_result.enabled, "Active flag should be enabled");
+    }
+
+    #[tokio::test]
+    async fn test_multi_level_dependency_with_filtered_out_intermediate() {
+        use crate::utils::test_utils::create_test_flag_that_depends_on_flag;
+
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        // Three flags: C depends on B, B depends on A, and B is filtered out.
+        // A is active and evaluates to true. B is filtered out (pre-seeded as false).
+        // C depends on B with evaluates_to=false, so C should be enabled.
+        let flag_a: FeatureFlag = serde_json::from_value(json!({
+            "id": 1,
+            "team_id": team.id,
+            "name": "flag_a",
+            "key": "flag_a",
+            "active": true,
+            "filters": {
+                "groups": [{"properties": [], "rollout_percentage": 100}]
+            }
+        }))
+        .unwrap();
+
+        let flag_b = create_test_flag_that_depends_on_flag(
+            2,
+            team.id,
+            "flag_b",
+            1, // depends on A
+            FlagValue::Boolean(true),
+        );
+
+        let flag_c = create_test_flag_that_depends_on_flag(
+            3,
+            team.id,
+            "flag_c",
+            2,                         // depends on B
+            FlagValue::Boolean(false), // expects B to be false
+        );
+
+        // B is filtered out by runtime filtering
+        let filtered_out = std::collections::HashSet::from([2]);
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_a, flag_b, flag_c],
+            filtered_out_flag_ids: filtered_out.clone(),
+        };
+
+        let graph_result =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+        matcher.filtered_out_flag_ids = filtered_out;
+
+        let result = matcher
+            .evaluate_flags_with_overrides(
+                Default::default(),
+                Uuid::new_v4(),
+                graph_result.graph,
+                graph_result.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // A should be evaluated normally
+        let flag_a_result = result.flags.get("flag_a").unwrap();
+        assert!(flag_a_result.enabled, "Flag A should be enabled");
+
+        // B is filtered out, should not appear
+        assert!(
+            !result.flags.contains_key("flag_b"),
+            "Filtered-out flag B should not appear in the response"
+        );
+
+        // C depends on B (evaluates_to=false). B is pre-seeded as false, so C's dependency is satisfied.
+        let flag_c_result = result.flags.get("flag_c").unwrap();
+        assert!(
+            flag_c_result.enabled,
+            "Flag C should be enabled because filtered-out B is treated as false"
+        );
     }
 
     // ======== Integration tests for experience continuity optimization ========
@@ -6223,6 +6568,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -6314,6 +6660,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -6418,6 +6765,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -6527,6 +6875,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -6623,6 +6972,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         let router = context.create_postgres_router();
@@ -6753,6 +7103,7 @@ mod tests {
                 flag_needs_lookup.clone(),
                 flag_no_continuity.clone(),
             ],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -6890,6 +7241,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag_optimizable.clone(), flag_needs_lookup.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -7033,6 +7385,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag_needs_lookup.clone(), flag_depends_on_b.clone()],
+            ..Default::default()
         };
 
         // Reset counter before the test
@@ -7135,6 +7488,7 @@ mod tests {
             HashMap::from([("$feature_enrollment/my-flag".to_string(), json!("true"))]);
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         reset_fetch_calls_count();
@@ -7248,6 +7602,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
         let router = context.create_postgres_router();
         let result = FeatureFlagMatcher::new(
@@ -7350,6 +7705,7 @@ mod tests {
 
         let flags = FeatureFlagList {
             flags: vec![flag.clone()],
+            ..Default::default()
         };
 
         let router = context.create_postgres_router();

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -5948,7 +5948,7 @@ mod tests {
         let context = TestContext::new(None).await;
         let router = context.create_postgres_router();
         let cohort_cache = Arc::new(CohortCacheManager::new(
-            context.persons_reader.clone(),
+            context.non_persons_reader.clone(),
             None,
             None,
         ));

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -131,6 +131,7 @@ pub async fn get_flags_from_redis(
 
     Ok(FeatureFlagList {
         flags: wrapper.flags,
+        ..Default::default()
     })
 }
 

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -76,19 +76,15 @@ pub async fn record_usage(
 
 /// Checks if the flag list contains any billable flags.
 ///
-/// Returns true if there are any flags that are both active and NOT survey or
-/// product tour targeting flags.
+/// Returns true if there are any non-filtered flags that are NOT survey or
+/// product tour targeting flags. Deleted and inactive flags are already in
+/// `filtered_out_flag_ids`, so no separate check is needed.
 fn contains_billable_flags(filtered_flags: &FeatureFlagList) -> bool {
-    filtered_flags.flags.iter().any(is_billable_flag)
-}
-
-/// Determines if a flag is billable based on its key and active status.
-///
-/// Returns true for active regular feature flags, false for survey/product tour targeting flags or disabled flags.
-fn is_billable_flag(flag: &crate::flags::flag_models::FeatureFlag) -> bool {
-    flag.active
-        && !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
-        && !flag.key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+    filtered_flags.flags.iter().any(|flag| {
+        !filtered_flags.filtered_out_flag_ids.contains(&flag.id)
+            && !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+            && !flag.key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+    })
 }
 
 /// Helper function to determine if usage should be recorded
@@ -102,9 +98,14 @@ mod tests {
     use super::*;
     use crate::flags::flag_models::{FeatureFlag, FlagFilters, FlagPropertyGroup};
 
+    use std::collections::HashSet;
+
+    static NEXT_FLAG_ID: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(1);
+
     fn create_test_flag(key: &str) -> FeatureFlag {
+        let id = NEXT_FLAG_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         FeatureFlag {
-            id: 1,
+            id,
             team_id: 1,
             name: Some(key.to_string()),
             key: key.to_string(),
@@ -137,6 +138,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![survey_flag1, survey_flag2],
+            ..Default::default()
         };
 
         // Should NOT record usage when only survey flags are present
@@ -150,6 +152,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![regular_flag1, regular_flag2],
+            ..Default::default()
         };
 
         // Should record usage when only regular flags are present
@@ -163,6 +166,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![survey_flag, regular_flag],
+            ..Default::default()
         };
 
         // Should record usage when there's at least one regular flag, even with survey flags
@@ -171,7 +175,10 @@ mod tests {
 
     #[test]
     fn test_should_record_usage_empty_flags() {
-        let flag_list = FeatureFlagList { flags: vec![] };
+        let flag_list = FeatureFlagList {
+            flags: vec![],
+            ..Default::default()
+        };
 
         // Should NOT record usage when there are no flags at all
         assert!(!should_record_usage(&flag_list));
@@ -188,6 +195,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![flag_with_prefix_inside, survey_flag_with_suffix],
+            ..Default::default()
         };
 
         // Should record usage: first flag doesn't START with prefix, second does start with prefix
@@ -196,57 +204,57 @@ mod tests {
     }
 
     #[test]
-    fn test_should_record_usage_disabled_flags_not_billable() {
-        let mut disabled_flag = create_test_flag("regular_flag");
-        disabled_flag.active = false;
+    fn test_should_record_usage_filtered_out_flags_not_billable() {
+        let disabled_flag = create_test_flag("regular_flag");
 
         let flag_list = FeatureFlagList {
-            flags: vec![disabled_flag],
+            flags: vec![disabled_flag.clone()],
+            filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
         };
 
-        // Should NOT record usage when only disabled flags are present
+        // Should NOT record usage when only filtered-out flags are present
         assert!(!should_record_usage(&flag_list));
     }
 
     #[test]
-    fn test_should_record_usage_mixed_active_and_disabled() {
-        let mut disabled_flag = create_test_flag("disabled_flag");
-        disabled_flag.active = false;
+    fn test_should_record_usage_mixed_active_and_filtered_out() {
+        let disabled_flag = create_test_flag("disabled_flag");
         let active_flag = create_test_flag("active_flag");
 
         let flag_list = FeatureFlagList {
-            flags: vec![disabled_flag, active_flag],
+            flags: vec![disabled_flag.clone(), active_flag],
+            filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
         };
 
-        // Should record usage when at least one active, non-survey flag is present
+        // Should record usage when at least one non-filtered, non-survey flag is present
         assert!(should_record_usage(&flag_list));
     }
 
     #[test]
-    fn test_should_record_usage_disabled_survey_flag() {
-        let mut disabled_survey_flag =
+    fn test_should_record_usage_filtered_out_survey_flag() {
+        let disabled_survey_flag =
             create_test_flag(&format!("{SURVEY_TARGETING_FLAG_PREFIX}survey1"));
-        disabled_survey_flag.active = false;
 
         let flag_list = FeatureFlagList {
-            flags: vec![disabled_survey_flag],
+            flags: vec![disabled_survey_flag.clone()],
+            filtered_out_flag_ids: HashSet::from([disabled_survey_flag.id]),
         };
 
-        // Should NOT record usage for disabled survey flags
+        // Should NOT record usage for filtered-out survey flags
         assert!(!should_record_usage(&flag_list));
     }
 
     #[test]
-    fn test_should_record_usage_only_disabled_and_survey_flags() {
-        let mut disabled_flag = create_test_flag("disabled_flag");
-        disabled_flag.active = false;
+    fn test_should_record_usage_only_filtered_out_and_survey_flags() {
+        let disabled_flag = create_test_flag("disabled_flag");
         let survey_flag = create_test_flag(&format!("{SURVEY_TARGETING_FLAG_PREFIX}survey1"));
 
         let flag_list = FeatureFlagList {
-            flags: vec![disabled_flag, survey_flag],
+            flags: vec![disabled_flag.clone(), survey_flag],
+            filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
         };
 
-        // Should NOT record usage when only disabled and survey flags are present
+        // Should NOT record usage when only filtered-out and survey flags are present
         assert!(!should_record_usage(&flag_list));
     }
 
@@ -257,6 +265,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![tour_flag1, tour_flag2],
+            ..Default::default()
         };
 
         // Should NOT record usage when only product tour flags are present
@@ -270,6 +279,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![tour_flag, regular_flag],
+            ..Default::default()
         };
 
         // Should record usage when there's at least one regular flag, even with product tour flags
@@ -277,16 +287,16 @@ mod tests {
     }
 
     #[test]
-    fn test_should_record_usage_disabled_product_tour_flag() {
-        let mut disabled_tour_flag =
+    fn test_should_record_usage_filtered_out_product_tour_flag() {
+        let disabled_tour_flag =
             create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour1"));
-        disabled_tour_flag.active = false;
 
         let flag_list = FeatureFlagList {
-            flags: vec![disabled_tour_flag],
+            flags: vec![disabled_tour_flag.clone()],
+            filtered_out_flag_ids: HashSet::from([disabled_tour_flag.id]),
         };
 
-        // Should NOT record usage for disabled product tour flags
+        // Should NOT record usage for filtered-out product tour flags
         assert!(!should_record_usage(&flag_list));
     }
 
@@ -297,6 +307,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![survey_flag, tour_flag],
+            ..Default::default()
         };
 
         // Should NOT record usage when only survey and product tour flags are present
@@ -316,6 +327,7 @@ mod tests {
 
         let flag_list = FeatureFlagList {
             flags: vec![flag_with_prefix_inside, tour_flag_with_suffix],
+            ..Default::default()
         };
 
         // Should record usage: first flag doesn't START with prefix, second does start with prefix

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -14,7 +14,7 @@ use axum::extract::State;
 use common_types::TeamId;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use super::{evaluation, types::FeatureFlagEvaluationContext, with_canonical_log};
@@ -102,17 +102,12 @@ fn detect_evaluation_runtime_from_request(
     None
 }
 
-/// Filters flags to only include those that can be evaluated in the current runtime.
-/// If no runtime is specified for a flag (evaluation_runtime is None), it's included
-/// to maintain backward compatibility.
-///
-/// Note: When specific flags are requested via flag_keys, they will be evaluated
-/// after this runtime filtering step. The runtime filter helps prevent unnecessary
-/// evaluation of flags that don't match the current runtime environment.
-fn filter_flags_by_runtime(
-    flags: Vec<FeatureFlag>,
+/// Returns the set of flag IDs that don't match the current runtime.
+/// Flags with no runtime or runtime "all" are never filtered out.
+fn collect_excluded_by_runtime(
+    flags: &[FeatureFlag],
     current_runtime: Option<EvaluationRuntime>,
-) -> Vec<FeatureFlag> {
+) -> HashSet<i32> {
     #[inline]
     fn flag_runtime(flag: &FeatureFlag) -> Option<EvaluationRuntime> {
         flag.evaluation_runtime
@@ -121,23 +116,16 @@ fn filter_flags_by_runtime(
     }
 
     match current_runtime {
-        Some(EvaluationRuntime::All) => {
-            // All runtime can evaluate any flag
-            flags
-        }
+        Some(EvaluationRuntime::All) => HashSet::new(),
         runtime_opt => flags
-            .into_iter()
-            .filter(|flag| match flag_runtime(flag) {
-                // Include flags that:
-                // 1. Have no specific runtime requirement (backward compatibility)
-                // 2. Are configured for "all" runtimes
-                None | Some(EvaluationRuntime::All) => true,
-                // 3. Are specifically configured for the current runtime
-                Some(flag_rt) => match runtime_opt {
-                    Some(current_rt) => flag_rt == current_rt,
-                    None => false,
-                },
+            .iter()
+            .filter(|flag| match (runtime_opt, flag_runtime(flag)) {
+                // Flags with no runtime or "all" are never filtered
+                (_, None | Some(EvaluationRuntime::All)) => false,
+                (Some(current_rt), Some(flag_rt)) => flag_rt != current_rt,
+                (None, Some(_)) => true,
             })
+            .map(|flag| flag.id)
             .collect(),
     }
 }
@@ -155,66 +143,86 @@ pub async fn fetch_and_filter(
     // Record cache source in canonical log for observability
     with_canonical_log(|log| log.flags_cache_source = Some(flag_result.cache_source.as_log_str()));
 
-    // First filter by survey flags if requested
-    let flags_after_survey_filter = filter_survey_flags(
-        flag_result.flag_list.flags,
+    let flags = flag_result.flag_list.flags;
+
+    // Build the filtered-out set: user-disabled, deleted, survey filter, runtime/tag mismatches.
+    // This is the single source of truth for "should this flag be skipped during evaluation."
+    let mut filtered_out_flag_ids: HashSet<i32> = flags
+        .iter()
+        .filter(|f| !f.active || f.deleted)
+        .map(|f| f.id)
+        .collect();
+
+    filtered_out_flag_ids.extend(collect_excluded_by_survey_filter(
+        &flags,
         query_params
             .only_evaluate_survey_feature_flags
             .unwrap_or(false),
-    );
-
-    // Then filter by evaluation runtime using request analysis
+    ));
     let current_runtime = detect_evaluation_runtime_from_request(headers, explicit_runtime);
-    let flags_after_runtime_filter =
-        filter_flags_by_runtime(flags_after_survey_filter, current_runtime);
+    filtered_out_flag_ids.extend(collect_excluded_by_runtime(&flags, current_runtime));
+    filtered_out_flag_ids.extend(collect_excluded_by_tags(&flags, environment_tags));
 
-    // Finally filter by evaluation tags
-    let flags_after_tag_filter =
-        filter_flags_by_evaluation_tags(flags_after_runtime_filter, environment_tags);
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        let active_count = flags
+            .iter()
+            .filter(|f| !filtered_out_flag_ids.contains(&f.id))
+            .count();
+        tracing::debug!(
+            "Flag filtering: detected_runtime={:?}, environment_tags={:?}, total={}, active={}",
+            current_runtime,
+            environment_tags,
+            flags.len(),
+            active_count,
+        );
+    }
 
-    tracing::debug!(
-        "Flag filtering: detected_runtime={:?}, environment_tags={:?}, final_count={}",
-        current_runtime,
-        environment_tags,
-        flags_after_tag_filter.len()
-    );
-
-    Ok(FeatureFlagList::new(flags_after_tag_filter))
+    Ok(FeatureFlagList {
+        flags,
+        filtered_out_flag_ids,
+    })
 }
 
-/// Filters flags to only include survey flags if requested
-/// This field is optional, passed in as a query param, and defaults to false
-fn filter_survey_flags(flags: Vec<FeatureFlag>, only_survey_flags: bool) -> Vec<FeatureFlag> {
+/// Returns flag IDs that should be excluded when only survey flags are requested.
+/// When `only_survey_flags` is true, all non-survey flags are excluded.
+fn collect_excluded_by_survey_filter(
+    flags: &[FeatureFlag],
+    only_survey_flags: bool,
+) -> HashSet<i32> {
     if only_survey_flags {
         flags
-            .into_iter()
-            .filter(|flag| flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX))
+            .iter()
+            .filter(|flag| !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX))
+            .map(|f| f.id)
             .collect()
     } else {
-        flags
+        HashSet::new()
     }
 }
 
-/// Filters flags based on evaluation tags.
-/// Only includes flags that either:
-/// 1. Have no evaluation tags (backward compatibility)
-/// 2. Have at least one evaluation tag that matches the provided environment tags
-fn filter_flags_by_evaluation_tags(
-    flags: Vec<FeatureFlag>,
+/// Returns the set of flag IDs that don't match the provided evaluation tags.
+/// Flags with no tags or matching tags are never filtered out.
+fn collect_excluded_by_tags(
+    flags: &[FeatureFlag],
     environment_tags: Option<&Vec<String>>,
-) -> Vec<FeatureFlag> {
+) -> HashSet<i32> {
     let env_tags = match environment_tags {
         Some(t) if !t.is_empty() => t,
-        _ => return flags,
+        _ => return HashSet::new(),
     };
 
+    let env_tag_set: HashSet<&str> = env_tags.iter().map(|s| s.as_str()).collect();
+
     flags
-        .into_iter()
+        .iter()
         .filter(|flag| match &flag.evaluation_tags {
-            None => true,
-            Some(flag_tags) if flag_tags.is_empty() => true,
-            Some(flag_tags) => flag_tags.iter().any(|tag| env_tags.contains(tag)),
+            None => false,
+            Some(flag_tags) if flag_tags.is_empty() => false,
+            Some(flag_tags) => !flag_tags
+                .iter()
+                .any(|tag| env_tag_set.contains(tag.as_str())),
         })
+        .map(|flag| flag.id)
         .collect()
 }
 
@@ -239,6 +247,12 @@ pub async fn evaluate_for_request(
     }
 
     if filtered_flags.flags.is_empty() {
+        return Ok(FlagsResponse::new(false, HashMap::new(), None, request_id));
+    }
+
+    // Every flag is in the filter set (inactive, deleted, runtime/tag mismatch) — nothing to evaluate.
+    // This is O(1) since the filter set includes deleted flags.
+    if filtered_flags.filtered_out_flag_ids.len() >= filtered_flags.flags.len() {
         return Ok(FlagsResponse::new(false, HashMap::new(), None, request_id));
     }
 
@@ -275,20 +289,7 @@ mod tests {
     use crate::flags::flag_models::{FeatureFlag, FlagFilters};
 
     fn create_test_flag(id: i32, key: &str, evaluation_runtime: Option<String>) -> FeatureFlag {
-        FeatureFlag {
-            id,
-            team_id: 1,
-            name: Some(format!("Test Flag {id}")),
-            key: key.to_string(),
-            filters: FlagFilters::default(),
-            deleted: false,
-            active: true,
-            ensure_experience_continuity: None,
-            version: None,
-            evaluation_runtime,
-            evaluation_tags: None,
-            bucketing_identifier: None,
-        }
+        create_test_flag_with_tags(id, key, evaluation_runtime, None)
     }
 
     fn create_test_flag_with_tags(
@@ -313,8 +314,21 @@ mod tests {
         }
     }
 
+    fn assert_filtered(filtered: &HashSet<i32>, flags: &[FeatureFlag], key: &str, expected: bool) {
+        let flag = flags
+            .iter()
+            .find(|f| f.key == key)
+            .unwrap_or_else(|| panic!("flag '{key}' not found"));
+        let is_filtered = filtered.contains(&flag.id);
+        assert_eq!(
+            is_filtered, expected,
+            "flag '{key}' (id={}) expected filtered_out={expected}, got filtered_out={is_filtered}",
+            flag.id
+        );
+    }
+
     #[test]
-    fn test_filter_flags_by_runtime_with_no_runtime() {
+    fn test_collect_excluded_by_runtime_with_no_runtime() {
         let flags = vec![
             create_test_flag(1, "flag1", None),
             create_test_flag(2, "flag2", Some("client".to_string())),
@@ -322,16 +336,17 @@ mod tests {
             create_test_flag(4, "flag4", Some("all".to_string())),
         ];
 
-        let filtered = filter_flags_by_runtime(flags, None);
+        let filtered = collect_excluded_by_runtime(&flags, None);
 
-        // Should only return flags with no runtime requirement or "all"
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().any(|f| f.key == "flag1"));
-        assert!(filtered.iter().any(|f| f.key == "flag4"));
+        // client/server-specific ones are filtered out
+        assert_filtered(&filtered, &flags, "flag1", false);
+        assert_filtered(&filtered, &flags, "flag2", true);
+        assert_filtered(&filtered, &flags, "flag3", true);
+        assert_filtered(&filtered, &flags, "flag4", false);
     }
 
     #[test]
-    fn test_filter_flags_by_runtime_with_client() {
+    fn test_collect_excluded_by_runtime_with_client() {
         let flags = vec![
             create_test_flag(1, "flag1", None),
             create_test_flag(2, "flag2", Some("client".to_string())),
@@ -339,18 +354,17 @@ mod tests {
             create_test_flag(4, "flag4", Some("all".to_string())),
         ];
 
-        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::Client));
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Client));
 
-        // Should return flags with no runtime requirement + client flags + all flags
-        assert_eq!(filtered.len(), 3);
-        assert!(filtered.iter().any(|f| f.key == "flag1"));
-        assert!(filtered.iter().any(|f| f.key == "flag2"));
-        assert!(filtered.iter().any(|f| f.key == "flag4"));
-        assert!(!filtered.iter().any(|f| f.key == "flag3"));
+        // Server-only flag filtered out
+        assert_filtered(&filtered, &flags, "flag1", false);
+        assert_filtered(&filtered, &flags, "flag2", false);
+        assert_filtered(&filtered, &flags, "flag3", true);
+        assert_filtered(&filtered, &flags, "flag4", false);
     }
 
     #[test]
-    fn test_filter_flags_by_runtime_with_server() {
+    fn test_collect_excluded_by_runtime_with_server() {
         let flags = vec![
             create_test_flag(1, "flag1", None),
             create_test_flag(2, "flag2", Some("client".to_string())),
@@ -358,18 +372,17 @@ mod tests {
             create_test_flag(4, "flag4", Some("all".to_string())),
         ];
 
-        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::Server));
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Server));
 
-        // Should return flags with no runtime requirement + server flags + all flags
-        assert_eq!(filtered.len(), 3);
-        assert!(filtered.iter().any(|f| f.key == "flag1"));
-        assert!(filtered.iter().any(|f| f.key == "flag3"));
-        assert!(filtered.iter().any(|f| f.key == "flag4"));
-        assert!(!filtered.iter().any(|f| f.key == "flag2"));
+        // Client-only flag filtered out
+        assert_filtered(&filtered, &flags, "flag1", false);
+        assert_filtered(&filtered, &flags, "flag2", true);
+        assert_filtered(&filtered, &flags, "flag3", false);
+        assert_filtered(&filtered, &flags, "flag4", false);
     }
 
     #[test]
-    fn test_filter_flags_by_runtime_with_all() {
+    fn test_collect_excluded_by_runtime_with_all() {
         let flags = vec![
             create_test_flag(1, "flag1", None),
             create_test_flag(2, "flag2", Some("client".to_string())),
@@ -377,18 +390,14 @@ mod tests {
             create_test_flag(4, "flag4", Some("all".to_string())),
         ];
 
-        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::All));
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::All));
 
-        // Should return all flags since All runtime should include everything
-        assert_eq!(filtered.len(), 4);
-        assert!(filtered.iter().any(|f| f.key == "flag1"));
-        assert!(filtered.iter().any(|f| f.key == "flag2"));
-        assert!(filtered.iter().any(|f| f.key == "flag3"));
-        assert!(filtered.iter().any(|f| f.key == "flag4"));
+        // All runtime includes everything, nothing filtered
+        assert!(filtered.is_empty());
     }
 
     #[test]
-    fn test_filter_flags_by_runtime_with_unknown_value() {
+    fn test_collect_excluded_by_runtime_with_unknown_value() {
         let flags = vec![
             create_test_flag(1, "flag1", None),
             create_test_flag(2, "flag2", Some("client".to_string())),
@@ -396,14 +405,13 @@ mod tests {
             create_test_flag(4, "flag4", Some("all".to_string())),
         ];
 
-        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::Client));
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Client));
 
-        // Unknown runtime values default to "all", so "unknown_runtime" flag should be included
-        assert_eq!(filtered.len(), 4);
-        assert!(filtered.iter().any(|f| f.key == "flag1"));
-        assert!(filtered.iter().any(|f| f.key == "flag2"));
-        assert!(filtered.iter().any(|f| f.key == "flag3")); // unknown_runtime -> all
-        assert!(filtered.iter().any(|f| f.key == "flag4"));
+        // Unknown runtime values default to "all", so not filtered
+        assert_filtered(&filtered, &flags, "flag1", false);
+        assert_filtered(&filtered, &flags, "flag2", false);
+        assert_filtered(&filtered, &flags, "flag3", false); // unknown_runtime -> all
+        assert_filtered(&filtered, &flags, "flag4", false);
     }
 
     #[test]
@@ -568,34 +576,20 @@ mod tests {
 
     #[test]
     fn test_filter_flags_with_explicit_flag_keys_should_respect_runtime() {
-        // Test scenario from @haacked's comment:
-        // When specific flags are requested via flag_keys (flags_to_evaluate),
-        // they still need to respect runtime filtering for security/correctness.
-        // Only flags that match the runtime should be evaluated.
-
         let flags = vec![
             create_test_flag(1, "client-flag", Some("client".to_string())),
             create_test_flag(2, "server-flag", Some("server".to_string())),
             create_test_flag(3, "all-flag", Some("all".to_string())),
         ];
 
-        // Client runtime should only get client and all flags
-        let filtered = filter_flags_by_runtime(flags, Some(EvaluationRuntime::Client));
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().any(|f| f.key == "client-flag"));
-        assert!(filtered.iter().any(|f| f.key == "all-flag"));
-        assert!(!filtered.iter().any(|f| f.key == "server-flag"));
-
-        // Note: The actual flag_keys filtering happens later in the evaluation pipeline
-        // after runtime filtering, so explicitly requested flags still go through runtime checks
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Client));
+        assert_filtered(&filtered, &flags, "client-flag", false);
+        assert_filtered(&filtered, &flags, "server-flag", true);
+        assert_filtered(&filtered, &flags, "all-flag", false);
     }
 
     #[test]
     fn test_runtime_filtering_takes_precedence_over_flag_keys() {
-        // This test verifies that runtime filtering happens BEFORE flag_keys filtering
-        // So if a client explicitly requests a server-only flag, they won't get it
-
-        // Create flags with different runtime requirements
         let all_flags = vec![
             create_test_flag(1, "client-only-flag", Some("client".to_string())),
             create_test_flag(2, "server-only-flag", Some("server".to_string())),
@@ -603,37 +597,23 @@ mod tests {
             create_test_flag(4, "no-runtime-flag", None),
         ];
 
-        // Simulate a client runtime
-        let client_runtime = Some(EvaluationRuntime::Client);
-        let client_filtered = filter_flags_by_runtime(all_flags.clone(), client_runtime);
+        let client_filtered =
+            collect_excluded_by_runtime(&all_flags, Some(EvaluationRuntime::Client));
+        assert_filtered(&client_filtered, &all_flags, "client-only-flag", false);
+        assert_filtered(&client_filtered, &all_flags, "server-only-flag", true);
+        assert_filtered(&client_filtered, &all_flags, "all-flag", false);
+        assert_filtered(&client_filtered, &all_flags, "no-runtime-flag", false);
 
-        // Client should get: client-only-flag, all-flag, no-runtime-flag
-        // But NOT server-only-flag
-        assert_eq!(client_filtered.len(), 3);
-        assert!(client_filtered.iter().any(|f| f.key == "client-only-flag"));
-        assert!(client_filtered.iter().any(|f| f.key == "all-flag"));
-        assert!(client_filtered.iter().any(|f| f.key == "no-runtime-flag"));
-        assert!(!client_filtered.iter().any(|f| f.key == "server-only-flag"));
-
-        // Simulate a server runtime
-        let server_runtime = Some(EvaluationRuntime::Server);
-        let filtered = filter_flags_by_runtime(all_flags, server_runtime);
-
-        // Server should get: server-only-flag, all-flag, no-runtime-flag
-        // But NOT client-only-flag
-        assert_eq!(filtered.len(), 3);
-        assert!(filtered.iter().any(|f| f.key == "server-only-flag"));
-        assert!(filtered.iter().any(|f| f.key == "all-flag"));
-        assert!(filtered.iter().any(|f| f.key == "no-runtime-flag"));
-        assert!(!filtered.iter().any(|f| f.key == "client-only-flag"));
-
-        // Note: Even if flag_keys explicitly requests a server-only flag from a client,
-        // the runtime filter will prevent it from being evaluated
+        let server_filtered =
+            collect_excluded_by_runtime(&all_flags, Some(EvaluationRuntime::Server));
+        assert_filtered(&server_filtered, &all_flags, "client-only-flag", true);
+        assert_filtered(&server_filtered, &all_flags, "server-only-flag", false);
+        assert_filtered(&server_filtered, &all_flags, "all-flag", false);
+        assert_filtered(&server_filtered, &all_flags, "no-runtime-flag", false);
     }
 
     #[test]
-    fn test_filter_flags_by_evaluation_tags_no_environment_tags() {
-        // When no environment tags are provided, all flags should be returned
+    fn test_collect_excluded_by_tags_no_environment_tags() {
         let flags = vec![
             create_test_flag_with_tags(1, "flag1", None, None),
             create_test_flag_with_tags(2, "flag2", None, Some(vec!["app".to_string()])),
@@ -645,15 +625,12 @@ mod tests {
             ),
         ];
 
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), None);
-        assert_eq!(filtered.len(), 3);
-
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&vec![]));
-        assert_eq!(filtered.len(), 3);
+        assert!(collect_excluded_by_tags(&flags, None).is_empty());
+        assert!(collect_excluded_by_tags(&flags, Some(&vec![])).is_empty());
     }
 
     #[test]
-    fn test_filter_flags_by_evaluation_tags_with_matching_tags() {
+    fn test_collect_excluded_by_tags_with_matching_tags() {
         let flags = vec![
             create_test_flag_with_tags(1, "no-tags", None, None),
             create_test_flag_with_tags(2, "app-only", None, Some(vec!["app".to_string()])),
@@ -666,55 +643,51 @@ mod tests {
             ),
         ];
 
-        // Test with "app" environment
+        // "app" environment — docs-only filtered out
         let app_env = vec!["app".to_string()];
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&app_env));
-        assert_eq!(filtered.len(), 3); // no-tags, app-only, multi-env
-        assert!(filtered.iter().any(|f| f.key == "no-tags"));
-        assert!(filtered.iter().any(|f| f.key == "app-only"));
-        assert!(filtered.iter().any(|f| f.key == "multi-env"));
-        assert!(!filtered.iter().any(|f| f.key == "docs-only"));
+        let filtered = collect_excluded_by_tags(&flags, Some(&app_env));
+        assert_filtered(&filtered, &flags, "no-tags", false);
+        assert_filtered(&filtered, &flags, "app-only", false);
+        assert_filtered(&filtered, &flags, "docs-only", true);
+        assert_filtered(&filtered, &flags, "multi-env", false);
 
-        // Test with "docs" environment
+        // "docs" environment — app-only filtered out
         let docs_env = vec!["docs".to_string()];
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&docs_env));
-        assert_eq!(filtered.len(), 3); // no-tags, docs-only, multi-env
-        assert!(filtered.iter().any(|f| f.key == "no-tags"));
-        assert!(filtered.iter().any(|f| f.key == "docs-only"));
-        assert!(filtered.iter().any(|f| f.key == "multi-env"));
-        assert!(!filtered.iter().any(|f| f.key == "app-only"));
+        let filtered = collect_excluded_by_tags(&flags, Some(&docs_env));
+        assert_filtered(&filtered, &flags, "no-tags", false);
+        assert_filtered(&filtered, &flags, "app-only", true);
+        assert_filtered(&filtered, &flags, "docs-only", false);
+        assert_filtered(&filtered, &flags, "multi-env", false);
     }
 
     #[test]
-    fn test_filter_flags_by_evaluation_tags_no_matching_tags() {
+    fn test_collect_excluded_by_tags_no_matching_tags() {
         let flags = vec![
             create_test_flag_with_tags(1, "app-only", None, Some(vec!["app".to_string()])),
             create_test_flag_with_tags(2, "docs-only", None, Some(vec!["docs".to_string()])),
         ];
 
-        // Test with unmatched environment
         let marketing_env = vec!["marketing".to_string()];
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&marketing_env));
-        assert_eq!(filtered.len(), 0);
+        let filtered = collect_excluded_by_tags(&flags, Some(&marketing_env));
+        assert_filtered(&filtered, &flags, "app-only", true);
+        assert_filtered(&filtered, &flags, "docs-only", true);
     }
 
     #[test]
-    fn test_filter_flags_by_evaluation_tags_empty_flag_tags() {
-        // Flags with empty evaluation_tags should be included (backward compatibility)
+    fn test_collect_excluded_by_tags_empty_flag_tags() {
         let flags = vec![
             create_test_flag_with_tags(1, "empty-tags", None, Some(vec![])),
             create_test_flag_with_tags(2, "app-only", None, Some(vec!["app".to_string()])),
         ];
 
         let app_env = vec!["app".to_string()];
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&app_env));
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.iter().any(|f| f.key == "empty-tags"));
-        assert!(filtered.iter().any(|f| f.key == "app-only"));
+        let filtered = collect_excluded_by_tags(&flags, Some(&app_env));
+        assert_filtered(&filtered, &flags, "empty-tags", false);
+        assert_filtered(&filtered, &flags, "app-only", false);
     }
 
     #[test]
-    fn test_filter_flags_by_evaluation_tags_multiple_environment_tags() {
+    fn test_collect_excluded_by_tags_multiple_environment_tags() {
         let flags = vec![
             create_test_flag_with_tags(1, "app-only", None, Some(vec!["app".to_string()])),
             create_test_flag_with_tags(2, "docs-only", None, Some(vec!["docs".to_string()])),
@@ -727,14 +700,59 @@ mod tests {
             create_test_flag_with_tags(4, "no-tags", None, None),
         ];
 
-        // Test with multiple environment tags - should match ANY of them
         let multi_env = vec!["app".to_string(), "docs".to_string()];
-        let filtered = filter_flags_by_evaluation_tags(flags.clone(), Some(&multi_env));
-        assert_eq!(filtered.len(), 3); // app-only, docs-only, no-tags
-        assert!(filtered.iter().any(|f| f.key == "app-only"));
-        assert!(filtered.iter().any(|f| f.key == "docs-only"));
-        assert!(filtered.iter().any(|f| f.key == "no-tags"));
-        assert!(!filtered.iter().any(|f| f.key == "marketing-only"));
+        let filtered = collect_excluded_by_tags(&flags, Some(&multi_env));
+        assert_filtered(&filtered, &flags, "app-only", false);
+        assert_filtered(&filtered, &flags, "docs-only", false);
+        assert_filtered(&filtered, &flags, "marketing-only", true);
+        assert_filtered(&filtered, &flags, "no-tags", false);
+    }
+
+    #[test]
+    fn test_runtime_and_tag_filtering_stacks() {
+        let flags = vec![
+            create_test_flag_with_tags(
+                1,
+                "server-app",
+                Some("server".to_string()),
+                Some(vec!["app".to_string()]),
+            ),
+            create_test_flag_with_tags(
+                2,
+                "client-app",
+                Some("client".to_string()),
+                Some(vec!["app".to_string()]),
+            ),
+            create_test_flag_with_tags(
+                3,
+                "server-docs",
+                Some("server".to_string()),
+                Some(vec!["docs".to_string()]),
+            ),
+        ];
+
+        let mut combined = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Server));
+        let app_env = vec!["app".to_string()];
+        combined.extend(collect_excluded_by_tags(&flags, Some(&app_env)));
+
+        assert_filtered(&combined, &flags, "server-app", false);
+        assert_filtered(&combined, &flags, "client-app", true);
+        assert_filtered(&combined, &flags, "server-docs", true);
+    }
+
+    #[test]
+    fn test_all_flags_filtered_after_runtime_mismatch() {
+        let flags = vec![
+            create_test_flag(1, "client-only", Some("client".to_string())),
+            create_test_flag(2, "also-client", Some("client".to_string())),
+        ];
+
+        let filtered = collect_excluded_by_runtime(&flags, Some(EvaluationRuntime::Server));
+        assert_eq!(
+            filtered.len(),
+            2,
+            "All client-only flags should be filtered when requesting server runtime"
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -171,7 +171,10 @@ async fn test_evaluate_feature_flags() {
         bucketing_identifier: None,
     };
 
-    let feature_flag_list = FeatureFlagList { flags: vec![flag] };
+    let feature_flag_list = FeatureFlagList {
+        flags: vec![flag],
+        ..Default::default()
+    };
 
     let mut person_properties = HashMap::new();
     person_properties.insert("country".to_string(), json!("US"));
@@ -269,7 +272,10 @@ async fn test_evaluate_feature_flags_with_errors() {
         bucketing_identifier: None,
     }];
 
-    let feature_flag_list = FeatureFlagList { flags };
+    let feature_flag_list = FeatureFlagList {
+        flags,
+        ..Default::default()
+    };
 
     // Set up evaluation context
     let evaluation_context = FeatureFlagEvaluationContext {
@@ -680,7 +686,10 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         },
     ];
 
-    let feature_flag_list = FeatureFlagList { flags };
+    let feature_flag_list = FeatureFlagList {
+        flags,
+        ..Default::default()
+    };
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
@@ -789,7 +798,10 @@ async fn test_evaluate_feature_flags_details() {
         },
     ];
 
-    let feature_flag_list = FeatureFlagList { flags };
+    let feature_flag_list = FeatureFlagList {
+        flags,
+        ..Default::default()
+    };
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
@@ -941,7 +953,10 @@ async fn test_evaluate_feature_flags_with_overrides() {
         evaluation_tags: None,
         bucketing_identifier: None,
     };
-    let feature_flag_list = FeatureFlagList { flags: vec![flag] };
+    let feature_flag_list = FeatureFlagList {
+        flags: vec![flag],
+        ..Default::default()
+    };
 
     let groups = HashMap::from([("project".to_string(), json!("project_123"))]);
     let group_property_overrides = HashMap::from([(
@@ -1046,7 +1061,10 @@ async fn test_long_distinct_id() {
         bucketing_identifier: None,
     };
 
-    let feature_flag_list = FeatureFlagList { flags: vec![flag] };
+    let feature_flag_list = FeatureFlagList {
+        flags: vec![flag],
+        ..Default::default()
+    };
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
@@ -1288,9 +1306,15 @@ async fn test_fetch_and_filter_flags() {
     )
     .await
     .unwrap();
-    assert_eq!(result.flags.len(), 2);
-    assert!(result
+    // All flags remain in the Vec; non-survey flags are in the filter set
+    assert_eq!(result.flags.len(), 4);
+    let active_flags: Vec<_> = result
         .flags
+        .iter()
+        .filter(|f| !result.filtered_out_flag_ids.contains(&f.id))
+        .collect();
+    assert_eq!(active_flags.len(), 2);
+    assert!(active_flags
         .iter()
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
 
@@ -1346,11 +1370,15 @@ async fn test_fetch_and_filter_flags() {
     .await
     .unwrap();
 
-    // Should return all survey flags since flag_keys filtering now happens in evaluation logic
-    // Survey filter keeps only survey flags, but flag_keys filtering is deferred to evaluation
-    assert_eq!(result.flags.len(), 2);
-    assert!(result
+    // All flags remain in the Vec; non-survey flags are in the filter set
+    assert_eq!(result.flags.len(), 4);
+    let active_flags: Vec<_> = result
         .flags
+        .iter()
+        .filter(|f| !result.filtered_out_flag_ids.contains(&f.id))
+        .collect();
+    assert_eq!(active_flags.len(), 2);
+    assert!(active_flags
         .iter()
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
 }
@@ -1567,6 +1595,9 @@ async fn test_parallel_path_matches_sequential_results() {
         },
     ];
 
+    // Flag id=4 is inactive (active=false), so it must be in the filter set
+    let filtered_out_flag_ids = std::collections::HashSet::from([4]);
+
     // Run sequential (threshold = 100, well above 4 flags)
     let sequential_context = FeatureFlagEvaluationContext {
         team_id: team.id,
@@ -1574,6 +1605,7 @@ async fn test_parallel_path_matches_sequential_results() {
         device_id: None,
         feature_flags: FeatureFlagList {
             flags: flags.clone(),
+            filtered_out_flag_ids: filtered_out_flag_ids.clone(),
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
@@ -1599,7 +1631,10 @@ async fn test_parallel_path_matches_sequential_results() {
         team_id: team.id,
         distinct_id: distinct_id.clone(),
         device_id: None,
-        feature_flags: FeatureFlagList { flags },
+        feature_flags: FeatureFlagList {
+            flags,
+            filtered_out_flag_ids,
+        },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
         non_persons_reader: reader.clone(),

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -908,7 +908,10 @@ mod filter_graph_by_keys_tests {
         let flag3 = create_test_flag_with_dependencies(3, "flag3", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -935,7 +938,10 @@ mod filter_graph_by_keys_tests {
         let flag3 = create_test_flag_with_dependencies(3, "flag3", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -970,7 +976,10 @@ mod filter_graph_by_keys_tests {
         let flag3 = create_test_flag_with_dependencies(3, "flag3", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1011,7 +1020,10 @@ mod filter_graph_by_keys_tests {
         let flag4 = create_test_flag_with_dependencies(4, "flag4", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3, flag4];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1052,7 +1064,10 @@ mod filter_graph_by_keys_tests {
         let flag2 = create_test_flag_with_dependencies(2, "flag2", HashSet::new());
 
         let flags = vec![flag1, flag2];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1082,7 +1097,10 @@ mod filter_graph_by_keys_tests {
         let flag2 = create_test_flag_with_dependencies(2, "flag2", HashSet::new());
 
         let flags = vec![flag1, flag2];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1123,7 +1141,10 @@ mod filter_graph_by_keys_tests {
         let flag6 = create_test_flag_with_dependencies(6, "flag6", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3, flag4, flag5, flag6];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1173,7 +1194,10 @@ mod filter_graph_by_keys_tests {
         let flag4 = create_test_flag_with_dependencies(4, "flag4", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3, flag4];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1220,7 +1244,10 @@ mod filter_graph_by_keys_tests {
         let flag3 = create_test_flag_with_dependencies(3, "flag3", HashSet::new());
 
         let flags = vec![flag1, flag2, flag3];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
         let team_id = 1;
 
         let DependencyGraphResult {
@@ -1313,7 +1340,10 @@ mod inactive_flag_dependency_tests {
         let other_flag = create_flag(2, "other_flag", HashSet::new(), true);
 
         let flags = vec![inactive_flag, other_flag];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
 
         let result = build_dependency_graph(&feature_flags, 1).unwrap();
         assert!(
@@ -1333,7 +1363,10 @@ mod inactive_flag_dependency_tests {
         let inactive_dep = create_flag(2, "inactive_dep", HashSet::new(), false);
 
         let flags = vec![active_flag, inactive_dep];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
 
         let result = build_dependency_graph(&feature_flags, 1).unwrap();
         assert!(
@@ -1358,7 +1391,10 @@ mod inactive_flag_dependency_tests {
         let inactive_flag = create_flag(2, "inactive_flag", HashSet::from([999]), false);
 
         let flags = vec![active_flag, inactive_flag];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
 
         let result = build_dependency_graph(&feature_flags, 1).unwrap();
         assert!(result.errors.is_empty());
@@ -1374,7 +1410,10 @@ mod inactive_flag_dependency_tests {
         let present_dep = create_flag(2, "present_dep", HashSet::new(), true);
 
         let flags = vec![inactive_flag, present_dep];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
 
         let result = build_dependency_graph(&feature_flags, 1).unwrap();
         assert!(result.errors.is_empty());
@@ -1393,7 +1432,10 @@ mod inactive_flag_dependency_tests {
         let active_flag = create_flag(1, "active_flag", HashSet::from([999]), true);
 
         let flags = vec![active_flag];
-        let feature_flags = FeatureFlagList { flags };
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
 
         let result = build_dependency_graph(&feature_flags, 1).unwrap();
         assert_eq!(result.errors.len(), 1);


### PR DESCRIPTION
## Problem

When flag B depends on flag A, and flag A is filtered out by runtime or evaluation tag filtering, the dependency resolver errors with `MissingDependency`. This happens because the old approach removed non-matching flags from the collection entirely, breaking the dependency graph.

## Changes

Instead of removing flags from the collection, we now track filtered-out flag IDs in a `HashSet<i32>` on `FeatureFlagList`. Flags stay in the collection so the dependency graph remains intact, but are skipped during evaluation, billing, experience continuity checks, DB preparation, and group type mapping initialization.

- **`FeatureFlagList`**: Add `filtered_out_flag_ids: HashSet<i32>` field (serde-skipped, request-scoped). Built from inactive, deleted, survey-excluded, runtime-mismatched, and tag-mismatched flags in `fetch_and_filter`.
- **Filter functions renamed**: `filter_flags_by_runtime` → `collect_excluded_by_runtime`, `filter_flags_by_evaluation_tags` → `collect_excluded_by_tags`. They now return IDs to exclude rather than filtered flag lists.
- **Evaluation pipeline**: `FeatureFlagMatcher` stores `filtered_out_flag_ids` as a field, set once from `FeatureFlagList` at the start of `evaluate_all_feature_flags`. Downstream functions (`evaluate_flags_in_level`, `initialize_group_type_mappings_if_needed`) read from `self.filtered_out_flag_ids`. `flags_require_db_preparation` takes it as a parameter.
- **Pre-seeding**: Filtered-out flags are pre-seeded as `false` in `flag_evaluation_state` so dependency conditions like `flag_evaluates_to=false` can match against them.
- **Dependency extraction**: `extract_dependencies` skips inactive and deleted flags to prevent stale references from causing graph construction errors.
- **Billing**: `contains_billable_flags` checks `filtered_out_flag_ids` instead of `flag.active`.
- **Performance**: Uses `HashSet` for tag lookups in `collect_excluded_by_tags`; skips already-filtered flags to avoid redundant work.

## How did you test this code?

- All affected unit tests pass (renamed + new tests added)
- Full `feature-flags` test suite passes
- `cargo clippy -p feature-flags -- -D warnings` clean
- New tests cover: deleted flag dependency extraction, tag filter preserving already-filtered flags, filtered-out flags excluded from hash key error response

## Publish to changelog?

No