### PR TITLE
feat(flags): split flag definitions cache verification into two staggered tasks

### DIFF
--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -346,7 +346,7 @@ def _apply_flag_dependency_transformation(
         flags_list = cast(list[dict[str, Any]], response_data["flags"])
         transformed_flags = _transform_flag_property_dependencies(flags_list, flag_id_to_key)
 
-        logger.info("Flag dependency transformation completed")
+        logger.debug("Flag dependency transformation completed")
         return {**response_data, "flags": transformed_flags}
     except Exception as e:
         logger.warning(

--- a/posthog/storage/hypercache_verifier.py
+++ b/posthog/storage/hypercache_verifier.py
@@ -207,7 +207,14 @@ def _verify_and_fix_batch(
     db_batch_data = None
     if config.hypercache.batch_load_fn:
         try:
+            batch_load_start = time.time()
             db_batch_data = config.hypercache.batch_load_fn(teams)
+            logger.debug(
+                "Batch DB load completed",
+                cache_type=cache_type,
+                team_count=len(teams),
+                duration_seconds=time.time() - batch_load_start,
+            )
         except Exception as e:
             logger.warning("Batch load failed, falling back to individual loads", error=str(e))
 

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -34,10 +34,8 @@ logger = structlog.get_logger(__name__)
 CacheType = Literal["flags", "team_metadata"]
 
 # Lock timeout matches time_limit to ensure lock is released if task is killed.
-# Reduced from 1 hour to 25 minutes to enable faster recovery when tasks crash
-# (OOM, deploy kills) without executing their finally block. With 30-minute
-# scheduling and 25-minute lock timeout, a crashed task's lock expires before
-# the next scheduled run, so at most 1 run is skipped after a crash.
+# With 30-minute scheduling and 25-minute lock timeout, a crashed task's lock
+# expires before the next scheduled run, so at most 1 run is skipped after a crash.
 LOCK_TIMEOUT_SECONDS = 25 * 60  # 25 minutes
 
 # Flag definitions verification lock timeout matches time_limit (30 min) to ensure
@@ -47,17 +45,17 @@ LOCK_TIMEOUT_SECONDS = 25 * 60  # 25 minutes
 FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 
 
-def _run_single_flag_definitions_verification(
+def _run_flag_definitions_verification(
     config: HyperCacheManagementConfig,
     include_cohorts: bool,
     variant_name: str,
 ) -> None:
     """
-    Run verification for a single flag definitions cache variant.
+    Run verification for a flag definitions cache variant.
 
-    Acquires a per-variant distributed lock and runs verification for the given
-    config. Each variant (with-cohorts, without-cohorts) runs independently with
-    its own lock, allowing parallel execution when workers are available.
+    Acquires a distributed lock keyed by variant_name and runs verification for
+    the given config. The with-cohorts and without-cohorts variants use separate
+    locks, allowing parallel execution when workers are available.
 
     Note: Unlike the flags cache (which uses FLAGS_REDIS_URL), the flag definitions
     cache uses the default cache backend (REDIS_URL). No special guard needed since
@@ -207,7 +205,7 @@ def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_with-cohorts", issue_type="..."}
     """
-    _run_single_flag_definitions_verification(
+    _run_flag_definitions_verification(
         config=FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
         include_cohorts=True,
         variant_name="with-cohorts",
@@ -233,7 +231,7 @@ def verify_and_fix_flag_definitions_without_cohorts_cache_task(self: PushGateway
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_without-cohorts", issue_type="..."}
     """
-    _run_single_flag_definitions_verification(
+    _run_flag_definitions_verification(
         config=FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
         include_cohorts=False,
         variant_name="without-cohorts",

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -40,7 +40,7 @@ LOCK_TIMEOUT_SECONDS = 25 * 60  # 25 minutes
 
 # Flag definitions verification lock timeout matches time_limit (30 min) to ensure
 # the lock expires before the next scheduled run if a task crashes without executing
-# its finally block. Each variant runs hourly (with-cohorts at minute 10, without-cohorts
+# its finally block. Each variant runs hourly (without-cohorts at minute 10, with-cohorts
 # at minute 50), so a 30-minute lock expiry guarantees at most 1 run is skipped after a crash.
 FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 
@@ -198,7 +198,7 @@ def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
     """
     Periodic task to verify the flag definitions (with-cohorts) HyperCache and fix issues.
 
-    Runs hourly at minute 10. Verifies all teams' flag definitions cache entries
+    Runs hourly at minute 50. Verifies all teams' flag definitions cache entries
     that include cohort data, fixing cache misses, mismatches, or expiry tracking issues.
 
     Uses a per-variant distributed lock to skip execution if a previous run is still in progress.
@@ -224,7 +224,7 @@ def verify_and_fix_flag_definitions_without_cohorts_cache_task(self: PushGateway
     """
     Periodic task to verify the flag definitions (without-cohorts) HyperCache and fix issues.
 
-    Runs hourly at minute 50. Verifies all teams' flag definitions cache entries
+    Runs hourly at minute 10. Verifies all teams' flag definitions cache entries
     that exclude cohort data, fixing cache misses, mismatches, or expiry tracking issues.
 
     Uses a per-variant distributed lock to skip execution if a previous run is still in progress.

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -69,6 +69,8 @@ def _run_flag_definitions_verification(
         return
 
     try:
+        logger.info("Starting cache verification", cache_type=cache_type)
+        start_time = time.time()
         verify_fn = partial(verify_team_flag_definitions, include_cohorts=include_cohorts)
 
         try:
@@ -82,6 +84,9 @@ def _run_flag_definitions_verification(
             logger.exception("Failed cache verification", cache_type=cache_type, error=str(e))
             capture_exception(e)
             raise
+
+        duration = time.time() - start_time
+        logger.info("Completed cache verification", cache_type=cache_type, duration_seconds=duration)
     finally:
         django_cache.delete(lock_key)
 

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -2,7 +2,7 @@
 Celery tasks for HyperCache verification.
 
 Provides separate tasks for verifying and fixing each HyperCache-backed cache
-(flags, team metadata). Split into separate tasks to:
+(flags, flag definitions, team metadata). Split into separate tasks to:
 - Give each cache its own time budget (avoiding timeouts)
 - Enable independent monitoring and metrics
 - Allow parallel execution when workers are available
@@ -10,11 +10,11 @@ Provides separate tasks for verifying and fixing each HyperCache-backed cache
 """
 
 import time
+from functools import partial
 from typing import Literal
 
 from django.conf import settings
 from django.core.cache import cache as django_cache
-from django.db import close_old_connections
 
 import structlog
 from celery import shared_task
@@ -25,7 +25,6 @@ from posthog.models.feature_flag.local_evaluation import (
     FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
     verify_team_flag_definitions,
 )
-from posthog.models.team.team import Team
 from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 from posthog.storage.hypercache_verifier import _run_verification_for_cache
 from posthog.tasks.utils import CeleryQueue, PushGatewayTask
@@ -41,94 +40,50 @@ CacheType = Literal["flags", "team_metadata"]
 # the next scheduled run, so at most 1 run is skipped after a crash.
 LOCK_TIMEOUT_SECONDS = 25 * 60  # 25 minutes
 
-# Flag definitions verification has a 1-hour time limit (longer than the 25-minute limit
-# used by flags and team_metadata tasks) because it processes more data per team.
-# The lock timeout must match the task's time_limit to prevent concurrent executions.
-FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS = 60 * 60  # 1 hour
+# Flag definitions verification lock timeout matches time_limit (30 min) to ensure
+# the lock expires before the next scheduled run if a task crashes without executing
+# its finally block. Each variant runs hourly (with-cohorts at minute 10, without-cohorts
+# at minute 50), so a 30-minute lock expiry guarantees at most 1 run is skipped after a crash.
+FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 
 
-def _run_flag_definitions_verification() -> None:
+def _run_single_flag_definitions_verification(
+    config: HyperCacheManagementConfig,
+    include_cohorts: bool,
+    variant_name: str,
+) -> None:
     """
-    Run verification for the flag definitions cache.
+    Run verification for a single flag definitions cache variant.
 
-    Handles:
-    - Distributed lock to prevent concurrent executions
+    Acquires a per-variant distributed lock and runs verification for the given
+    config. Each variant (with-cohorts, without-cohorts) runs independently with
+    its own lock, allowing parallel execution when workers are available.
 
     Note: Unlike the flags cache (which uses FLAGS_REDIS_URL), the flag definitions
     cache uses the default cache backend (REDIS_URL). No special guard needed since
     Django's default cache is always available.
     """
-    cache_type = "flag_definitions"
-
+    cache_type = f"flag_definitions_{variant_name}"
     lock_key = f"posthog:hypercache_verification:{cache_type}:lock"
 
-    # Attempt to acquire lock - cache.add returns False if key already exists
-    # Use dedicated timeout that matches the task's 1-hour time limit
     if not django_cache.add(lock_key, "locked", timeout=FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS):
         logger.info("Skipping cache verification - already running", cache_type=cache_type)
         return
 
     try:
-        logger.info("Starting cache verification", cache_type=cache_type)
+        verify_fn = partial(verify_team_flag_definitions, include_cohorts=include_cohorts)
 
-        start_time = time.time()
-
-        variants: list[tuple[HyperCacheManagementConfig, bool, str]] = [
-            (FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG, True, "with-cohorts"),
-            (FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG, False, "without-cohorts"),
-        ]
-
-        errors: list[Exception] = []
-
-        for config, include_cohorts, variant_name in variants:
-
-            def verify_fn(
-                team: Team,
-                db_batch_data: dict | None = None,
-                cache_batch_data: dict | None = None,
-                verbose: bool = False,
-                _include_cohorts: bool = include_cohorts,
-            ) -> dict:
-                return verify_team_flag_definitions(
-                    team,
-                    db_batch_data=db_batch_data,
-                    cache_batch_data=cache_batch_data,
-                    include_cohorts=_include_cohorts,
-                    verbose=verbose,
-                )
-
-            try:
-                _run_verification_for_cache(
-                    config=config,
-                    verify_team_fn=verify_fn,
-                    cache_type=f"{cache_type}_{variant_name}",
-                    chunk_size=settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE,
-                )
-            except Exception as e:
-                logger.exception(
-                    "Failed cache verification",
-                    cache_type=cache_type,
-                    variant=variant_name,
-                    error=str(e),
-                )
-                capture_exception(e)
-                errors.append(e)
-                # Reset DB connections after a failure (e.g. SoftTimeLimitExceeded
-                # during an active query) so the next variant gets a clean connection
-                # instead of hitting "another command is already in progress".
-                close_old_connections()
-
-        duration = time.time() - start_time
-        if errors:
-            logger.warning(
-                "Cache verification finished with errors",
+        try:
+            _run_verification_for_cache(
+                config=config,
+                verify_team_fn=verify_fn,
                 cache_type=cache_type,
-                duration_seconds=duration,
-                failed_variants=len(errors),
+                chunk_size=settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE,
             )
-            raise errors[0]
-
-        logger.info("Completed cache verification", cache_type=cache_type, duration_seconds=duration)
+        except Exception as e:
+            logger.exception("Failed cache verification", cache_type=cache_type, error=str(e))
+            capture_exception(e)
+            raise
     finally:
         django_cache.delete(lock_key)
 
@@ -238,19 +193,48 @@ def verify_and_fix_team_metadata_cache_task(self: PushGatewayTask) -> None:
     base=PushGatewayTask,
     ignore_result=True,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
-    soft_time_limit=50 * 60,  # 50 min soft limit
-    time_limit=60 * 60,  # 1 hour hard limit (distributed lock prevents overlap)
+    soft_time_limit=25 * 60,  # 25 min soft limit
+    time_limit=30 * 60,  # 30 min hard limit (matches FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS)
 )
 def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
     """
-    Periodic task to verify the flag definitions HyperCache and fix issues.
+    Periodic task to verify the flag definitions (with-cohorts) HyperCache and fix issues.
 
-    Runs hourly at minute 50. Verifies both cache variants (with-cohorts and
-    without-cohorts) independently, fixing cache misses, mismatches, or expiry
-    tracking issues for each. Errors on one variant don't block the other.
+    Runs hourly at minute 10. Verifies all teams' flag definitions cache entries
+    that include cohort data, fixing cache misses, mismatches, or expiry tracking issues.
 
-    Uses a distributed lock to skip execution if a previous run is still in progress.
+    Uses a per-variant distributed lock to skip execution if a previous run is still in progress.
 
-    Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_<variant>", issue_type="..."}
+    Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_with-cohorts", issue_type="..."}
     """
-    _run_flag_definitions_verification()
+    _run_single_flag_definitions_verification(
+        config=FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG,
+        include_cohorts=True,
+        variant_name="with-cohorts",
+    )
+
+
+@shared_task(
+    bind=True,
+    base=PushGatewayTask,
+    ignore_result=True,
+    queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
+    soft_time_limit=25 * 60,  # 25 min soft limit
+    time_limit=30 * 60,  # 30 min hard limit (matches FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS)
+)
+def verify_and_fix_flag_definitions_without_cohorts_cache_task(self: PushGatewayTask) -> None:
+    """
+    Periodic task to verify the flag definitions (without-cohorts) HyperCache and fix issues.
+
+    Runs hourly at minute 50. Verifies all teams' flag definitions cache entries
+    that exclude cohort data, fixing cache misses, mismatches, or expiry tracking issues.
+
+    Uses a per-variant distributed lock to skip execution if a previous run is still in progress.
+
+    Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions_without-cohorts", issue_type="..."}
+    """
+    _run_single_flag_definitions_verification(
+        config=FLAG_DEFINITIONS_NO_COHORTS_HYPERCACHE_MANAGEMENT_CONFIG,
+        include_cohorts=False,
+        variant_name="without-cohorts",
+    )

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -253,6 +253,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Verify flag definitions cache without cohorts - hourly at minute 10
+    # Minute 10 reduces the likelihood of overlapping with team_metadata verification at minute 20 and helps spread load.
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="10"),

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -252,9 +252,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         expires_seconds=30 * 60,
     )
 
-    # Flag definitions cache verification - split into two staggered tasks (one per variant)
-    # so each gets its own time budget and they can run in parallel when workers are available.
-    # Minute 10 reduces overlap with team_metadata verification at minute 20.
+    # Verify flag definitions cache without cohorts - hourly at minute 10
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="10"),
@@ -262,7 +260,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="verify and fix flag definitions cache (without cohorts)",
     )
 
-    # Flag definitions cache verification (with cohorts) - kept at minute 50 (original schedule).
+    # Flag definitions cache verification (with cohorts) - hourly at minute 50
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="50"),

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -233,7 +233,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="flag definitions cache expiry tracking cleanup",
     )
 
-    # HyperCache verification - split into separate tasks for independent time budgets.
     # Team metadata cache verification - hourly at minute 20
     add_periodic_task_with_expiry(
         sender,

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -261,7 +261,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="10"),
         verify_and_fix_flag_definitions_cache_task.s(),
         name="verify and fix flag definitions cache (with cohorts)",
-        expires_seconds=30 * 60,
     )
 
     add_periodic_task_with_expiry(
@@ -269,7 +268,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="50"),
         verify_and_fix_flag_definitions_without_cohorts_cache_task.s(),
         name="verify and fix flag definitions cache (without cohorts)",
-        expires_seconds=30 * 60,
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -26,6 +26,7 @@ from posthog.tasks.feature_flags import (
 )
 from posthog.tasks.hypercache_verification import (
     verify_and_fix_flag_definitions_cache_task,
+    verify_and_fix_flag_definitions_without_cohorts_cache_task,
     verify_and_fix_flags_cache_task,
     verify_and_fix_team_metadata_cache_task,
 )
@@ -232,8 +233,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="flag definitions cache expiry tracking cleanup",
     )
 
-    # HyperCache verification - split into separate tasks for independent time budgets
-    # Tasks have 1-hour time limits, so expiry must match
+    # HyperCache verification - split into separate tasks for independent time budgets.
     # Team metadata cache verification - hourly at minute 20
     add_periodic_task_with_expiry(
         sender,
@@ -253,13 +253,23 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         expires_seconds=30 * 60,
     )
 
-    # Flag definitions cache verification - hourly at minute 50
+    # Flag definitions cache verification - split into two staggered tasks (one per variant)
+    # so each gets its own time budget and they can run in parallel when workers are available.
+    # Minute 10 avoids colliding with team_metadata verification at minute 20.
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(hour="*", minute="10"),
+        verify_and_fix_flag_definitions_cache_task.s(),
+        name="verify and fix flag definitions cache (with cohorts)",
+        expires_seconds=30 * 60,
+    )
+
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="50"),
-        verify_and_fix_flag_definitions_cache_task.s(),
-        name="verify and fix flag definitions cache",
-        expires_seconds=60 * 60,
+        verify_and_fix_flag_definitions_without_cohorts_cache_task.s(),
+        name="verify and fix flag definitions cache (without cohorts)",
+        expires_seconds=30 * 60,
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -259,15 +259,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="10"),
-        verify_and_fix_flag_definitions_cache_task.s(),
-        name="verify and fix flag definitions cache (with cohorts)",
+        verify_and_fix_flag_definitions_without_cohorts_cache_task.s(),
+        name="verify and fix flag definitions cache (without cohorts)",
     )
 
+    # Flag definitions cache verification (with cohorts) - kept at minute 50 (original schedule).
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="50"),
-        verify_and_fix_flag_definitions_without_cohorts_cache_task.s(),
-        name="verify and fix flag definitions cache (without cohorts)",
+        verify_and_fix_flag_definitions_cache_task.s(),
+        name="verify and fix flag definitions cache (with cohorts)",
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -258,6 +258,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="10"),
         verify_and_fix_flag_definitions_without_cohorts_cache_task.s(),
         name="verify and fix flag definitions cache (without cohorts)",
+        expires_seconds=60 * 60,
     )
 
     # Flag definitions cache verification (with cohorts) - hourly at minute 50
@@ -266,6 +267,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="50"),
         verify_and_fix_flag_definitions_cache_task.s(),
         name="verify and fix flag definitions cache (with cohorts)",
+        expires_seconds=60 * 60,
     )
 
     # Update events table partitions twice a week

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -255,7 +255,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     # Flag definitions cache verification - split into two staggered tasks (one per variant)
     # so each gets its own time budget and they can run in parallel when workers are available.
-    # Minute 10 avoids colliding with team_metadata verification at minute 20.
+    # Minute 10 reduces overlap with team_metadata verification at minute 20.
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="10"),

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -68,6 +68,7 @@
     'posthog.tasks.hog_functions.refresh_affected_hog_functions',
     'posthog.tasks.hog_functions.sync_hog_function_templates_task',
     'posthog.tasks.hypercache_verification.verify_and_fix_flag_definitions_cache_task',
+    'posthog.tasks.hypercache_verification.verify_and_fix_flag_definitions_without_cohorts_cache_task',
     'posthog.tasks.hypercache_verification.verify_and_fix_flags_cache_task',
     'posthog.tasks.hypercache_verification.verify_and_fix_team_metadata_cache_task',
     'posthog.tasks.integrations.push_vercel_secrets',

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -13,6 +13,7 @@ from django.test import TestCase, override_settings
 
 from posthog.tasks.hypercache_verification import (
     verify_and_fix_flag_definitions_cache_task,
+    verify_and_fix_flag_definitions_without_cohorts_cache_task,
     verify_and_fix_flags_cache_task,
     verify_and_fix_team_metadata_cache_task,
 )
@@ -130,75 +131,68 @@ class TestVerifyAndFixTeamMetadataCacheTaskDisabled(TestCase):
 
 
 class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCase):
-    """Tests for the flag definitions cache verification task."""
+    """Tests for the flag definitions (with-cohorts) cache verification task."""
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verifies_both_flag_definitions_variants(self, mock_run_verification: MagicMock) -> None:
+    def test_verifies_with_cohorts_variant(self, mock_run_verification: MagicMock) -> None:
         mock_run_verification.return_value = MagicMock()
 
         verify_and_fix_flag_definitions_cache_task()
 
-        assert mock_run_verification.call_count == 2
-        cache_types = [call[1]["cache_type"] for call in mock_run_verification.call_args_list]
-        assert cache_types == ["flag_definitions_with-cohorts", "flag_definitions_without-cohorts"]
+        mock_run_verification.assert_called_once()
+        call_kwargs = mock_run_verification.call_args[1]
+        assert call_kwargs["cache_type"] == "flag_definitions_with-cohorts"
 
-    @patch("posthog.tasks.hypercache_verification.verify_team_flag_definitions")
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_each_variant_captures_correct_include_cohorts(
-        self, mock_run_verification: MagicMock, mock_verify_team: MagicMock
-    ) -> None:
-        """Guard against the closure-in-loop bug: each verify_fn must capture its own include_cohorts value."""
+    def test_verify_fn_passes_include_cohorts_true(self, mock_run_verification: MagicMock) -> None:
+        from posthog.models.feature_flag.local_evaluation import verify_team_flag_definitions
+
         mock_run_verification.return_value = MagicMock()
-        mock_verify_team.return_value = {"status": "match", "issue": None}
 
         verify_and_fix_flag_definitions_cache_task()
 
-        verify_fn_with = mock_run_verification.call_args_list[0][1]["verify_team_fn"]
-        verify_fn_without = mock_run_verification.call_args_list[1][1]["verify_team_fn"]
-
-        mock_team = MagicMock()
-        verify_fn_with(mock_team)
-        mock_verify_team.assert_called_with(
-            mock_team, db_batch_data=None, cache_batch_data=None, include_cohorts=True, verbose=False
-        )
-
-        mock_verify_team.reset_mock()
-        verify_fn_without(mock_team)
-        mock_verify_team.assert_called_with(
-            mock_team, db_batch_data=None, cache_batch_data=None, include_cohorts=False, verbose=False
-        )
+        verify_fn = mock_run_verification.call_args[1]["verify_team_fn"]
+        assert verify_fn.func is verify_team_flag_definitions
+        assert verify_fn.keywords == {"include_cohorts": True}
 
     @patch("posthog.tasks.hypercache_verification.capture_exception")
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_captures_error_continues_to_next_variant_then_reraises(
-        self, mock_run_verification: MagicMock, mock_capture: MagicMock
-    ) -> None:
+    def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
         error = Exception("flag_definitions verification failed")
-        mock_run_verification.side_effect = [error, MagicMock()]
+        mock_run_verification.side_effect = error
 
         with self.assertRaises(Exception) as context:
             verify_and_fix_flag_definitions_cache_task()
 
-        assert context.exception is error
         mock_capture.assert_called_once_with(error)
-        assert mock_run_verification.call_count == 2
+        assert context.exception is error
 
-    @patch("posthog.tasks.hypercache_verification.capture_exception")
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_both_variants_fail_captures_both_reraises_first(
-        self, mock_run_verification: MagicMock, mock_capture: MagicMock
-    ) -> None:
-        error1 = Exception("with-cohorts failed")
-        error2 = Exception("without-cohorts failed")
-        mock_run_verification.side_effect = [error1, error2]
+    def test_releases_lock_after_error(self, mock_run_verification: MagicMock) -> None:
+        from django.core.cache import cache as django_cache
 
-        with self.assertRaises(Exception) as context:
+        mock_run_verification.side_effect = Exception("boom")
+
+        with self.assertRaises(Exception):
             verify_and_fix_flag_definitions_cache_task()
 
-        assert context.exception is error1
-        assert mock_capture.call_count == 2
-        mock_capture.assert_any_call(error1)
-        mock_capture.assert_any_call(error2)
+        lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
+        assert django_cache.add(lock_key, "test", timeout=1) is True
+        django_cache.delete(lock_key)
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_does_not_interfere_with_without_cohorts_lock(self, mock_run_verification: MagicMock) -> None:
+        """Each variant uses its own lock key, so locking one doesn't block the other."""
+        from django.core.cache import cache as django_cache
+
+        other_lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
+        django_cache.add(other_lock_key, "locked", timeout=60)
+        try:
+            mock_run_verification.return_value = MagicMock()
+            verify_and_fix_flag_definitions_cache_task()
+            mock_run_verification.assert_called_once()
+        finally:
+            django_cache.delete(other_lock_key)
 
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
@@ -217,10 +211,102 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     def test_skips_when_lock_already_held(self, mock_run_verification: MagicMock) -> None:
         from django.core.cache import cache as django_cache
 
-        lock_key = "posthog:hypercache_verification:flag_definitions:lock"
+        lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
         django_cache.add(lock_key, "locked", timeout=60)
         try:
             verify_and_fix_flag_definitions_cache_task()
             mock_run_verification.assert_not_called()
         finally:
             django_cache.delete(lock_key)
+
+
+class TestVerifyAndFixFlagDefinitionsWithoutCohortsCacheTask(PushGatewayTaskTestMixin, TestCase):
+    """Tests for the flag definitions (without-cohorts) cache verification task."""
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_verifies_without_cohorts_variant(self, mock_run_verification: MagicMock) -> None:
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_flag_definitions_without_cohorts_cache_task()
+
+        mock_run_verification.assert_called_once()
+        call_kwargs = mock_run_verification.call_args[1]
+        assert call_kwargs["cache_type"] == "flag_definitions_without-cohorts"
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_verify_fn_passes_include_cohorts_false(self, mock_run_verification: MagicMock) -> None:
+        from posthog.models.feature_flag.local_evaluation import verify_team_flag_definitions
+
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_flag_definitions_without_cohorts_cache_task()
+
+        verify_fn = mock_run_verification.call_args[1]["verify_team_fn"]
+        assert verify_fn.func is verify_team_flag_definitions
+        assert verify_fn.keywords == {"include_cohorts": False}
+
+    @patch("posthog.tasks.hypercache_verification.capture_exception")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
+        error = Exception("flag_definitions verification failed")
+        mock_run_verification.side_effect = error
+
+        with self.assertRaises(Exception) as context:
+            verify_and_fix_flag_definitions_without_cohorts_cache_task()
+
+        mock_capture.assert_called_once_with(error)
+        assert context.exception is error
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_releases_lock_after_error(self, mock_run_verification: MagicMock) -> None:
+        from django.core.cache import cache as django_cache
+
+        mock_run_verification.side_effect = Exception("boom")
+
+        with self.assertRaises(Exception):
+            verify_and_fix_flag_definitions_without_cohorts_cache_task()
+
+        lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
+        assert django_cache.add(lock_key, "test", timeout=1) is True
+        django_cache.delete(lock_key)
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
+        mock_run_verification.return_value = MagicMock()
+
+        verify_and_fix_flag_definitions_without_cohorts_cache_task()
+
+        success = self.registry.get_sample_value(
+            "posthog_celery_verify_and_fix_flag_definitions_without_cohorts_cache_task_success"
+        )
+        duration = self.registry.get_sample_value(
+            "posthog_celery_verify_and_fix_flag_definitions_without_cohorts_cache_task_duration_seconds"
+        )
+        assert success == 1
+        assert duration is not None and duration >= 0
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_skips_when_lock_already_held(self, mock_run_verification: MagicMock) -> None:
+        from django.core.cache import cache as django_cache
+
+        lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
+        django_cache.add(lock_key, "locked", timeout=60)
+        try:
+            verify_and_fix_flag_definitions_without_cohorts_cache_task()
+            mock_run_verification.assert_not_called()
+        finally:
+            django_cache.delete(lock_key)
+
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_does_not_interfere_with_with_cohorts_lock(self, mock_run_verification: MagicMock) -> None:
+        """Each variant uses its own lock key, so locking one doesn't block the other."""
+        from django.core.cache import cache as django_cache
+
+        other_lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
+        django_cache.add(other_lock_key, "locked", timeout=60)
+        try:
+            mock_run_verification.return_value = MagicMock()
+            verify_and_fix_flag_definitions_without_cohorts_cache_task()
+            mock_run_verification.assert_called_once()
+        finally:
+            django_cache.delete(other_lock_key)

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
+from parameterized import parameterized
+
 from posthog.tasks.hypercache_verification import (
     verify_and_fix_flag_definitions_cache_task,
     verify_and_fix_flag_definitions_without_cohorts_cache_task,
@@ -130,183 +132,140 @@ class TestVerifyAndFixTeamMetadataCacheTaskDisabled(TestCase):
         mock_run_verification.assert_not_called()
 
 
+# Parameterized test configuration for the two flag definitions cache variants.
+# Each tuple: (task_fn, include_cohorts, cache_type, other_cache_type, metric_name_fragment)
+FLAG_DEFINITIONS_VARIANTS = [
+    (
+        "with_cohorts",
+        verify_and_fix_flag_definitions_cache_task,
+        True,
+        "flag_definitions_with-cohorts",
+        "flag_definitions_without-cohorts",
+        "verify_and_fix_flag_definitions_cache_task",
+    ),
+    (
+        "without_cohorts",
+        verify_and_fix_flag_definitions_without_cohorts_cache_task,
+        False,
+        "flag_definitions_without-cohorts",
+        "flag_definitions_with-cohorts",
+        "verify_and_fix_flag_definitions_without_cohorts_cache_task",
+    ),
+]
+
+
 class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCase):
-    """Tests for the flag definitions (with-cohorts) cache verification task."""
+    """Tests for both flag definitions cache verification task variants."""
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verifies_with_cohorts_variant(self, mock_run_verification: MagicMock) -> None:
+    def test_verifies_correct_cache_type(
+        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+    ) -> None:
         mock_run_verification.return_value = MagicMock()
 
-        verify_and_fix_flag_definitions_cache_task()
+        task_fn()
 
         mock_run_verification.assert_called_once()
         call_kwargs = mock_run_verification.call_args[1]
-        assert call_kwargs["cache_type"] == "flag_definitions_with-cohorts"
+        assert call_kwargs["cache_type"] == cache_type
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verify_fn_passes_include_cohorts_true(self, mock_run_verification: MagicMock) -> None:
+    def test_verify_fn_passes_correct_include_cohorts(
+        self, _name, task_fn, include_cohorts, _cache_type, _other, _metric, mock_run_verification: MagicMock
+    ) -> None:
         from posthog.models.feature_flag.local_evaluation import verify_team_flag_definitions
 
         mock_run_verification.return_value = MagicMock()
 
-        verify_and_fix_flag_definitions_cache_task()
+        task_fn()
 
         verify_fn = mock_run_verification.call_args[1]["verify_team_fn"]
         assert verify_fn.func is verify_team_flag_definitions
-        assert verify_fn.keywords == {"include_cohorts": True}
+        assert verify_fn.keywords == {"include_cohorts": include_cohorts}
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification.capture_exception")
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
+    def test_captures_and_reraises_error(
+        self,
+        _name,
+        task_fn,
+        _include_cohorts,
+        _cache_type,
+        _other,
+        _metric,
+        mock_run_verification: MagicMock,
+        mock_capture: MagicMock,
+    ) -> None:
         error = Exception("flag_definitions verification failed")
         mock_run_verification.side_effect = error
 
         with self.assertRaises(Exception) as context:
-            verify_and_fix_flag_definitions_cache_task()
+            task_fn()
 
         mock_capture.assert_called_once_with(error)
         assert context.exception is error
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_releases_lock_after_error(self, mock_run_verification: MagicMock) -> None:
+    def test_releases_lock_after_error(
+        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+    ) -> None:
         from django.core.cache import cache as django_cache
 
         mock_run_verification.side_effect = Exception("boom")
 
         with self.assertRaises(Exception):
-            verify_and_fix_flag_definitions_cache_task()
+            task_fn()
 
-        lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
+        lock_key = f"posthog:hypercache_verification:{cache_type}:lock"
         assert django_cache.add(lock_key, "test", timeout=1) is True
         django_cache.delete(lock_key)
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_does_not_interfere_with_without_cohorts_lock(self, mock_run_verification: MagicMock) -> None:
+    def test_does_not_interfere_with_other_variant_lock(
+        self, _name, task_fn, _include_cohorts, _cache_type, other_cache_type, _metric, mock_run_verification: MagicMock
+    ) -> None:
         """Each variant uses its own lock key, so locking one doesn't block the other."""
         from django.core.cache import cache as django_cache
 
-        other_lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
+        other_lock_key = f"posthog:hypercache_verification:{other_cache_type}:lock"
         django_cache.add(other_lock_key, "locked", timeout=60)
         try:
             mock_run_verification.return_value = MagicMock()
-            verify_and_fix_flag_definitions_cache_task()
+            task_fn()
             mock_run_verification.assert_called_once()
         finally:
             django_cache.delete(other_lock_key)
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
+    def test_pushgateway_metrics_recorded_on_success(
+        self, _name, task_fn, _include_cohorts, _cache_type, _other, metric_name, mock_run_verification: MagicMock
+    ) -> None:
         mock_run_verification.return_value = MagicMock()
 
-        verify_and_fix_flag_definitions_cache_task()
+        task_fn()
 
-        success = self.registry.get_sample_value("posthog_celery_verify_and_fix_flag_definitions_cache_task_success")
-        duration = self.registry.get_sample_value(
-            "posthog_celery_verify_and_fix_flag_definitions_cache_task_duration_seconds"
-        )
+        success = self.registry.get_sample_value(f"posthog_celery_{metric_name}_success")
+        duration = self.registry.get_sample_value(f"posthog_celery_{metric_name}_duration_seconds")
         assert success == 1
         assert duration is not None and duration >= 0
 
+    @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_skips_when_lock_already_held(self, mock_run_verification: MagicMock) -> None:
+    def test_skips_when_lock_already_held(
+        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+    ) -> None:
         from django.core.cache import cache as django_cache
 
-        lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
+        lock_key = f"posthog:hypercache_verification:{cache_type}:lock"
         django_cache.add(lock_key, "locked", timeout=60)
         try:
-            verify_and_fix_flag_definitions_cache_task()
+            task_fn()
             mock_run_verification.assert_not_called()
         finally:
             django_cache.delete(lock_key)
-
-
-class TestVerifyAndFixFlagDefinitionsWithoutCohortsCacheTask(PushGatewayTaskTestMixin, TestCase):
-    """Tests for the flag definitions (without-cohorts) cache verification task."""
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verifies_without_cohorts_variant(self, mock_run_verification: MagicMock) -> None:
-        mock_run_verification.return_value = MagicMock()
-
-        verify_and_fix_flag_definitions_without_cohorts_cache_task()
-
-        mock_run_verification.assert_called_once()
-        call_kwargs = mock_run_verification.call_args[1]
-        assert call_kwargs["cache_type"] == "flag_definitions_without-cohorts"
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_verify_fn_passes_include_cohorts_false(self, mock_run_verification: MagicMock) -> None:
-        from posthog.models.feature_flag.local_evaluation import verify_team_flag_definitions
-
-        mock_run_verification.return_value = MagicMock()
-
-        verify_and_fix_flag_definitions_without_cohorts_cache_task()
-
-        verify_fn = mock_run_verification.call_args[1]["verify_team_fn"]
-        assert verify_fn.func is verify_team_flag_definitions
-        assert verify_fn.keywords == {"include_cohorts": False}
-
-    @patch("posthog.tasks.hypercache_verification.capture_exception")
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_captures_and_reraises_error(self, mock_run_verification: MagicMock, mock_capture: MagicMock) -> None:
-        error = Exception("flag_definitions verification failed")
-        mock_run_verification.side_effect = error
-
-        with self.assertRaises(Exception) as context:
-            verify_and_fix_flag_definitions_without_cohorts_cache_task()
-
-        mock_capture.assert_called_once_with(error)
-        assert context.exception is error
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_releases_lock_after_error(self, mock_run_verification: MagicMock) -> None:
-        from django.core.cache import cache as django_cache
-
-        mock_run_verification.side_effect = Exception("boom")
-
-        with self.assertRaises(Exception):
-            verify_and_fix_flag_definitions_without_cohorts_cache_task()
-
-        lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
-        assert django_cache.add(lock_key, "test", timeout=1) is True
-        django_cache.delete(lock_key)
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_pushgateway_metrics_recorded_on_success(self, mock_run_verification: MagicMock) -> None:
-        mock_run_verification.return_value = MagicMock()
-
-        verify_and_fix_flag_definitions_without_cohorts_cache_task()
-
-        success = self.registry.get_sample_value(
-            "posthog_celery_verify_and_fix_flag_definitions_without_cohorts_cache_task_success"
-        )
-        duration = self.registry.get_sample_value(
-            "posthog_celery_verify_and_fix_flag_definitions_without_cohorts_cache_task_duration_seconds"
-        )
-        assert success == 1
-        assert duration is not None and duration >= 0
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_skips_when_lock_already_held(self, mock_run_verification: MagicMock) -> None:
-        from django.core.cache import cache as django_cache
-
-        lock_key = "posthog:hypercache_verification:flag_definitions_without-cohorts:lock"
-        django_cache.add(lock_key, "locked", timeout=60)
-        try:
-            verify_and_fix_flag_definitions_without_cohorts_cache_task()
-            mock_run_verification.assert_not_called()
-        finally:
-            django_cache.delete(lock_key)
-
-    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
-    def test_does_not_interfere_with_with_cohorts_lock(self, mock_run_verification: MagicMock) -> None:
-        """Each variant uses its own lock key, so locking one doesn't block the other."""
-        from django.core.cache import cache as django_cache
-
-        other_lock_key = "posthog:hypercache_verification:flag_definitions_with-cohorts:lock"
-        django_cache.add(other_lock_key, "locked", timeout=60)
-        try:
-            mock_run_verification.return_value = MagicMock()
-            verify_and_fix_flag_definitions_without_cohorts_cache_task()
-            mock_run_verification.assert_called_once()
-        finally:
-            django_cache.delete(other_lock_key)

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -7,6 +7,8 @@ Tests cover:
 - Tasks skip when FLAGS_REDIS_URL not configured
 """
 
+from collections.abc import Callable
+
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
@@ -160,7 +162,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verifies_correct_cache_type(
-        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        cache_type: str,
+        _other: str,
+        _metric: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -173,7 +182,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_verify_fn_passes_correct_include_cohorts(
-        self, _name, task_fn, include_cohorts, _cache_type, _other, _metric, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        include_cohorts: bool,
+        _cache_type: str,
+        _other: str,
+        _metric: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         from posthog.models.feature_flag.local_evaluation import verify_team_flag_definitions
 
@@ -190,12 +206,12 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_captures_and_reraises_error(
         self,
-        _name,
-        task_fn,
-        _include_cohorts,
-        _cache_type,
-        _other,
-        _metric,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        _cache_type: str,
+        _other: str,
+        _metric: str,
         mock_run_verification: MagicMock,
         mock_capture: MagicMock,
     ) -> None:
@@ -211,7 +227,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_releases_lock_after_error(
-        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        cache_type: str,
+        _other: str,
+        _metric: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         from django.core.cache import cache as django_cache
 
@@ -227,7 +250,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_does_not_interfere_with_other_variant_lock(
-        self, _name, task_fn, _include_cohorts, _cache_type, other_cache_type, _metric, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        _cache_type: str,
+        other_cache_type: str,
+        _metric: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         """Each variant uses its own lock key, so locking one doesn't block the other."""
         from django.core.cache import cache as django_cache
@@ -244,7 +274,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_pushgateway_metrics_recorded_on_success(
-        self, _name, task_fn, _include_cohorts, _cache_type, _other, metric_name, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        _cache_type: str,
+        _other: str,
+        metric_name: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         mock_run_verification.return_value = MagicMock()
 
@@ -258,7 +295,14 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
     @parameterized.expand(FLAG_DEFINITIONS_VARIANTS)
     @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
     def test_skips_when_lock_already_held(
-        self, _name, task_fn, _include_cohorts, cache_type, _other, _metric, mock_run_verification: MagicMock
+        self,
+        _name: str,
+        task_fn: Callable[[], None],
+        _include_cohorts: bool,
+        cache_type: str,
+        _other: str,
+        _metric: str,
+        mock_run_verification: MagicMock,
     ) -> None:
         from django.core.cache import cache as django_cache
 


### PR DESCRIPTION
## Problem

The flag definitions cache verification task processes both variants (with-cohorts and without-cohorts) sequentially in a single task with a 1-hour time limit. If the first variant is slow or fails, it can starve or block the second variant. The shared lock also prevents any parallel execution.

## Changes

- Split `verify_and_fix_flag_definitions_cache_task` into two independent tasks: one for with-cohorts (runs at minute 50, its original schedule) and one for without-cohorts (runs at minute 10)
- Each task gets its own distributed lock, allowing independent execution and preventing one variant from blocking the other
- Time limits are 25min soft / 30min hard per task, since each now only handles one variant
- Uses `functools.partial` to bind `include_cohorts` when constructing the verify function
- Added debug-level timing for batch DB loads in the hypercache verifier
- Downgraded a noisy info log to debug in flag dependency transformation

## How did you test this code?

Unit tests updated and passing — the test suite covers each task independently, including lock isolation between variants, error handling, and pushgateway metrics.

## Publish to changelog?

No