### PR TITLE
feat(flags): pre-compute evaluation_info in hypercache

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -50,6 +50,7 @@ from posthog.models.feature_flag.feature_flag import (
     get_feature_flags,
     serialize_feature_flags,
 )
+from posthog.models.feature_flag.types import PropertyFilterType
 from posthog.models.tag import Tag
 from posthog.models.team import Team
 from posthog.storage.cache_expiry_manager import (
@@ -69,6 +70,54 @@ logger = structlog.get_logger(__name__)
 FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
+def _compute_evaluation_info(flags_data: list[dict]) -> dict[str, bool]:
+    """
+    Pre-compute which database resources are needed to evaluate the given flags.
+
+    The Rust feature flags service uses these booleans to short-circuit DB calls
+    for teams whose flags never touch person properties, group properties, or
+    experience continuity. When all three are False the service can skip the
+    persons DB entirely.
+    """
+    requires_person_properties = False
+    requires_group_type_mappings = False
+    requires_experience_continuity = False
+
+    person_property_types = (PropertyFilterType.PERSON, PropertyFilterType.COHORT, PropertyFilterType.GROUP)
+
+    for flag in flags_data:
+        if not flag.get("active", True):
+            continue
+
+        filters = flag.get("filters") or {}
+
+        if filters.get("aggregation_group_type_index") is not None:
+            requires_group_type_mappings = True
+            # Group-aggregated flags still require person data for hash-key resolution.
+            requires_person_properties = True
+
+        if flag.get("ensure_experience_continuity"):
+            requires_experience_continuity = True
+
+        if not requires_person_properties:
+            requires_person_properties = any(
+                prop.get("type") in person_property_types
+                for group_key in ("groups", "super_groups")
+                for group in (filters.get(group_key) or [])
+                if group.get("rollout_percentage") != 0
+                for prop in (group.get("properties") or [])
+            )
+
+        if requires_person_properties and requires_group_type_mappings and requires_experience_continuity:
+            break
+
+    return {
+        "requires_person_properties": requires_person_properties,
+        "requires_group_type_mappings": requires_group_type_mappings,
+        "requires_experience_continuity": requires_experience_continuity,
+    }
+
+
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     Get feature flags for the feature-flags service.
@@ -82,7 +131,9 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...]} where flags is a list of flag dictionaries
+        dict: {"flags": [...], "evaluation_info": {...}} where flags is a list of flag
+        dictionaries and evaluation_info contains pre-computed booleans for the Rust
+        flags service to short-circuit DB lookups.
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
@@ -96,7 +147,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data}
+    return {"flags": flags_data, "evaluation_info": _compute_evaluation_info(flags_data)}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -114,7 +165,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...]} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_info": {...}} for each team
     """
     if not teams:
         return {}
@@ -162,7 +213,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
             flag_count=len(flags_data),
         )
 
-        result[team.id] = {"flags": flags_data}
+        result[team.id] = {"flags": flags_data, "evaluation_info": _compute_evaluation_info(flags_data)}
 
     return result
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -100,10 +100,11 @@ def _compute_evaluation_info(flags_data: list[dict]) -> dict[str, bool]:
             requires_experience_continuity = True
 
         if not requires_person_properties:
-            requires_person_properties = any(
+            # Super groups always contain person properties ($feature_enrollment/{key}),
+            # so their presence alone is sufficient.
+            requires_person_properties = bool(filters.get("super_groups")) or any(
                 prop.get("type") in person_property_types
-                for group_key in ("groups", "super_groups")
-                for group in (filters.get(group_key) or [])
+                for group in (filters.get("groups") or [])
                 if group.get("rollout_percentage") != 0
                 for prop in (group.get("properties") or [])
             )

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -102,12 +102,21 @@ def _compute_evaluation_info(flags_data: list[dict]) -> dict[str, bool]:
         if not requires_person_properties:
             # Super groups always contain person properties ($feature_enrollment/{key}),
             # so their presence alone is sufficient.
-            requires_person_properties = bool(filters.get("super_groups")) or any(
-                prop.get("type") in person_property_types
-                for group in (filters.get("groups") or [])
-                if group.get("rollout_percentage") != 0
-                for prop in (group.get("properties") or [])
-            )
+            if filters.get("super_groups"):
+                requires_person_properties = True
+            else:
+                for group in filters.get("groups") or []:
+                    if group.get("rollout_percentage") == 0:
+                        continue
+                    for prop in group.get("properties") or []:
+                        prop_type = prop.get("type")
+                        if prop_type in person_property_types:
+                            requires_person_properties = True
+                            if prop_type == PropertyFilterType.GROUP:
+                                requires_group_type_mappings = True
+                            break
+                    if requires_person_properties:
+                        break
 
         if requires_person_properties and requires_group_type_mappings and requires_experience_continuity:
             break

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -19,6 +19,7 @@ from parameterized import parameterized
 from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
+    _compute_evaluation_info,
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_team_ids_with_recently_updated_flags,
@@ -48,7 +49,14 @@ class TestServiceFlagsCache(BaseTest):
         """Test fetching flags when team has no flags."""
         result = _get_feature_flags_for_service(self.team)
 
-        assert result == {"flags": []}
+        assert result == {
+            "flags": [],
+            "evaluation_info": {
+                "requires_person_properties": False,
+                "requires_group_type_mappings": False,
+                "requires_experience_continuity": False,
+            },
+        }
 
     def test_get_feature_flags_for_service_with_flags(self):
         """Test fetching flags returns correct format for service."""
@@ -2240,3 +2248,298 @@ class TestGetTeamsWithFlagsQueryset(BaseTest):
         qs = get_teams_with_flags_queryset()
         team_ids = list(qs.values_list("id", flat=True))
         assert team_ids.count(self.team.id) == 1
+
+
+class TestComputeEvaluationInfo(BaseTest):
+    def test_empty_flags_list(self):
+        result = _compute_evaluation_info([])
+        assert result == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }
+
+    def test_percentage_only_flags(self):
+        flags = [
+            {
+                "key": "simple-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }
+
+    def test_person_property_filter(self):
+        flags = [
+            {
+                "key": "person-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+        assert result["requires_group_type_mappings"] is False
+
+    def test_cohort_filter(self):
+        flags = [
+            {
+                "key": "cohort-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "cohort", "key": "id", "value": 1}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    def test_group_aggregation(self):
+        flags = [
+            {
+                "key": "group-flag",
+                "filters": {
+                    "aggregation_group_type_index": 0,
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+        assert result["requires_group_type_mappings"] is True
+
+    def test_experience_continuity(self):
+        flags = [
+            {
+                "key": "continuity-flag",
+                "ensure_experience_continuity": True,
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_experience_continuity"] is True
+        assert result["requires_person_properties"] is False
+
+    def test_zero_rollout_with_person_properties(self):
+        flags = [
+            {
+                "key": "zero-rollout",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 0,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_super_group_with_person_property(self):
+        flags = [
+            {
+                "key": "super-group-flag",
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                    "super_groups": [
+                        {
+                            "properties": [{"type": "person", "key": "is_admin", "value": True}],
+                        }
+                    ],
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    @parameterized.expand(
+        [
+            (
+                "mixed_simple_and_person",
+                [
+                    {
+                        "key": "simple-flag",
+                        "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+                    },
+                    {
+                        "key": "person-flag",
+                        "filters": {
+                            "groups": [
+                                {
+                                    "rollout_percentage": 100,
+                                    "properties": [{"type": "person", "key": "email", "value": "x"}],
+                                }
+                            ]
+                        },
+                    },
+                ],
+                True,
+                False,
+                False,
+            ),
+            (
+                "all_requirements",
+                [
+                    {
+                        "key": "group-flag",
+                        "ensure_experience_continuity": True,
+                        "filters": {
+                            "aggregation_group_type_index": 1,
+                            "groups": [
+                                {
+                                    "rollout_percentage": 100,
+                                    "properties": [{"type": "person", "key": "k", "value": "v"}],
+                                }
+                            ],
+                        },
+                    },
+                ],
+                True,
+                True,
+                True,
+            ),
+        ]
+    )
+    def test_mixed_flags(self, _name, flags, expect_person, expect_group, expect_continuity):
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is expect_person
+        assert result["requires_group_type_mappings"] is expect_group
+        assert result["requires_experience_continuity"] is expect_continuity
+
+    def test_non_person_property_types_do_not_trigger_person_properties(self):
+        flags = [
+            {
+                "key": "event-prop-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "event", "key": "url", "value": "/home"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_zero_rollout_skipped_but_nonzero_rollout_still_detected(self):
+        flags = [
+            {
+                "key": "multi-group-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 0,
+                            "properties": [{"type": "person", "key": "email", "value": "skip@me.com"}],
+                        },
+                        {
+                            "rollout_percentage": 50,
+                            "properties": [{"type": "person", "key": "plan", "value": "pro"}],
+                        },
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    def test_inactive_flag_excluded_from_evaluation_info(self):
+        flags = [
+            {
+                "key": "inactive-person-flag",
+                "active": False,
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_null_rollout_percentage_treated_as_active(self):
+        """When rollout_percentage is None (not set), the group is active and should be checked."""
+        flags = [
+            {
+                "key": "no-rollout",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_service_response_includes_evaluation_info(self):
+        FeatureFlag.objects.all().delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="simple-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+
+        assert "evaluation_info" in result
+        assert result["evaluation_info"]["requires_person_properties"] is False
+        assert result["evaluation_info"]["requires_group_type_mappings"] is False
+        assert result["evaluation_info"]["requires_experience_continuity"] is False
+
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_batch_response_includes_evaluation_info(self):
+        FeatureFlag.objects.all().delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="simple-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        results = _get_feature_flags_for_teams_batch([self.team])
+        response = results[self.team.id]
+
+        assert "evaluation_info" in response
+        assert response["evaluation_info"]["requires_person_properties"] is False
+        assert response["evaluation_info"]["requires_group_type_mappings"] is False
+        assert response["evaluation_info"]["requires_experience_continuity"] is False
+
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_batch_response_evaluation_info_for_team_with_no_flags(self):
+        FeatureFlag.objects.all().delete()
+
+        results = _get_feature_flags_for_teams_batch([self.team])
+        response = results[self.team.id]
+
+        assert "evaluation_info" in response
+        assert response["evaluation_info"] == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -2422,6 +2422,24 @@ class TestComputeEvaluationInfo(BaseTest):
         assert result["requires_group_type_mappings"] is expect_group
         assert result["requires_experience_continuity"] is expect_continuity
 
+    def test_group_property_without_aggregation_index_sets_both_flags(self):
+        flags = [
+            {
+                "key": "group-prop-no-agg",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "group", "key": "industry", "value": "tech"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+        assert result["requires_group_type_mappings"] is True
+
     def test_non_person_property_types_do_not_trigger_person_properties(self):
         flags = [
             {


### PR DESCRIPTION
## Problem

The Rust feature flags service currently computes whether it needs person properties, group type mappings, and experience continuity on every flag evaluation request. For teams whose flags never touch these resources, this is wasted work that could be short-circuited entirely, skipping the persons DB lookup.

This PR is phase-1 of an optimization to pre-compute whether the flags service needs these. First, we update the up-front cache. Phase 2 - we start reading from these.

## Changes

**Primary: Pre-compute `evaluation_info` in hypercache** (`flags_cache.py`)
- New `_compute_evaluation_info()` function pre-computes three booleans at cache-write time:
  - `requires_person_properties` — set when any active flag has person/cohort/group property filters
  - `requires_group_type_mappings` — set when any active flag uses group aggregation
  - `requires_experience_continuity` — set when any active flag has `ensure_experience_continuity`
- Included in the cached result alongside `flags` as `evaluation_info`
- Skips inactive flags (they evaluate to `false` without DB lookups)
- Skips groups with `rollout_percentage == 0` (disabled groups)
- Backwards-compatible: Python consumers access `result.get("flags", [])`, Rust serde ignores unknown fields

**Other changes in this branch:**
- Realtime cohort calculation schedule tuning: faster intervals, higher parallelism, fewer config knobs for P80-P100 tiers
- Rust personhog-replica type fixes: `default_columns` (`Vec<String>` → `serde_json::Value`), `detail_dashboard_id` (`i32` → `i64`)
- Rust personhog-router: added `Code::Internal` to retryable gRPC codes
- Admin form fix: separated validation and persistence in `EventIngestionRestrictionConfigForm`
- Removed agentic provisioning routes

## How did you test this code?

- 17 unit tests covering `_compute_evaluation_info()`: empty flags, percentage-only, person/cohort/group property filters, group aggregation, experience continuity, zero rollout, null rollout, super groups, inactive flags, mixed flags (parameterized), negative property type tests, multi-group zero-rollout boundary, and integration tests with both `_get_feature_flags_for_service` and `_get_feature_flags_for_teams_batch`
- All existing tests pass

## Publish to changelog?

No