### PR TITLE
Fix canvas ref handling in BoxPlotChart to prevent stale closures

### DIFF
--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import 'scenes/insights/InsightTooltip/InsightTooltip.scss'
 import { Chart, ChartConfiguration, ChartEvent } from 'lib/Chart'
@@ -249,18 +249,26 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
         ],
     })
 
+    const [canvasEl, setCanvasEl] = useState<HTMLCanvasElement | null>(null)
+    const canvasCallbackRef = useCallback(
+        (node: HTMLCanvasElement | null) => {
+            canvasRef.current = node
+            setCanvasEl(node)
+        },
+        [canvasRef]
+    )
+
     useEffect(() => {
-        const canvas = canvasRef.current
-        if (!canvas) {
+        if (!canvasEl) {
             return
         }
         const onMouseLeave = (): void => {
             activeIndexRef.current = null
             hideTooltip()
         }
-        canvas.addEventListener('mouseleave', onMouseLeave)
-        return () => canvas.removeEventListener('mouseleave', onMouseLeave)
-    }, [hideTooltip, canvasRef.current])
+        canvasEl.addEventListener('mouseleave', onMouseLeave)
+        return () => canvasEl.removeEventListener('mouseleave', onMouseLeave)
+    }, [hideTooltip, canvasEl])
 
     if (!boxplotData || boxplotData.length === 0) {
         return <div className="flex items-center justify-center h-full text-muted">No data for this time range</div>
@@ -268,7 +276,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
 
     return (
         <div className="TrendsInsight w-full h-full" data-attr="box-plot-graph">
-            <canvas ref={canvasRef} />
+            <canvas ref={canvasCallbackRef} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The BoxPlotChart component had a potential issue with stale closures in the `useEffect` hook that manages the canvas `mouseleave` event listener. The effect dependency array included `canvasRef.current`, which is not a valid dependency since ref objects don't trigger effect re-runs when their `.current` property changes. This could lead to the event listener not being properly updated when the canvas element changes.

## Changes

- Added `useState` hook to track the canvas element state (`canvasEl`)
- Created a callback ref (`canvasCallbackRef`) that updates both the ref and state when the canvas element is mounted/unmounted
- Updated the `useEffect` hook to depend on `canvasEl` (state) instead of `canvasRef.current` (ref), ensuring the effect properly re-runs when the canvas element changes
- Updated the canvas element ref binding to use the new callback ref

This ensures that the event listener cleanup and setup logic properly responds to canvas element changes and prevents stale closures.

## How did you test this code?

This is a refactoring of the ref handling pattern. The change maintains the same functionality while fixing the dependency tracking. Existing tests for the BoxPlotChart component should continue to pass, and the event listener behavior remains unchanged.

No testing needed

https://claude.ai/code/session_01JgTka28i9xxBquDakQD8A3