### PR TITLE
feat(hogflows): add debug logs for conditional branch results

### DIFF
--- a/nodejs/src/cdp/services/hogflows/actions/conditional_branch.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/conditional_branch.test.ts
@@ -123,6 +123,7 @@ describe('action.conditional_branch', () => {
             const result = await checkConditions(invocation, action)
             expect(result).toEqual({
                 nextAction: findActionById(invocation.hogFlow, 'condition_1'),
+                matchedConditionIndex: 0,
             })
         })
 
@@ -132,13 +133,14 @@ describe('action.conditional_branch', () => {
                     filters: HOG_FILTERS_EXAMPLES.elements_text_filter.filters, // No match
                 },
                 {
-                    filters: HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter.filters, // No match
+                    filters: HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter.filters, // Match
                 },
             ]
 
             const result = await checkConditions(invocation, action)
             expect(result).toEqual({
                 nextAction: findActionById(invocation.hogFlow, 'condition_2'),
+                matchedConditionIndex: 1,
             })
         })
     })

--- a/nodejs/src/cdp/services/hogflows/actions/conditional_branch.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/conditional_branch.ts
@@ -1,10 +1,10 @@
 import { DateTime } from 'luxon'
 
-import { CyclotronJobInvocationHogFlow } from '~/cdp/types'
+import { CyclotronJobInvocationHogFlow, CyclotronJobInvocationResult } from '~/cdp/types'
 import { filterFunctionInstrumented } from '~/cdp/utils/hog-function-filtering'
 import { HogFlowAction } from '~/schema/hogflow'
 
-import { findContinueAction, findNextAction } from '../hogflow-utils'
+import { actionIdForLogging, findContinueAction, findNextAction } from '../hogflow-utils'
 import { ActionHandler, ActionHandlerOptions, ActionHandlerResult } from './action.interface'
 import { calculatedScheduledAt } from './delay'
 
@@ -14,6 +14,7 @@ export class ConditionalBranchHandler implements ActionHandler {
     async execute({
         invocation,
         action,
+        result,
     }: ActionHandlerOptions<
         Extract<HogFlowAction, { type: 'conditional_branch' | 'wait_until_condition' }>
     >): Promise<ActionHandlerResult> {
@@ -32,11 +33,20 @@ export class ConditionalBranchHandler implements ActionHandler {
         )
 
         if (conditionResult.scheduledAt) {
+            logDebug(
+                result,
+                `${actionIdForLogging(action)} matched no condition and was scheduled for re-evaluation at ${conditionResult.scheduledAt.toUTC().toISO()}`
+            )
             return { scheduledAt: conditionResult.scheduledAt, result: { conditionResult } }
         } else if (conditionResult.nextAction) {
+            logDebug(
+                result,
+                `${actionIdForLogging(action)} matched ${formatConditionName(conditionResult.matchedConditionIndex, conditionResult.matchedConditionName)}`
+            )
             return { nextAction: conditionResult.nextAction, result: { conditionResult } }
         }
 
+        logDebug(result, `${actionIdForLogging(action)} matched no condition`)
         return { nextAction: findContinueAction(invocation), result: { conditionResult } }
     }
 }
@@ -47,6 +57,8 @@ export async function checkConditions(
 ): Promise<{
     scheduledAt?: DateTime
     nextAction?: HogFlowAction
+    matchedConditionIndex?: number
+    matchedConditionName?: string
 }> {
     // the index is used to find the right edge
     for (const [index, condition] of action.config.conditions.entries()) {
@@ -60,6 +72,8 @@ export async function checkConditions(
         if (filterResults.match) {
             return {
                 nextAction: findNextAction(invocation.hogFlow, action.id, index),
+                matchedConditionIndex: index,
+                matchedConditionName: condition.name,
             }
         }
     }
@@ -79,4 +93,18 @@ export async function checkConditions(
         }
     }
     return {}
+}
+
+function formatConditionName(matchedConditionIndex?: number, matchedConditionName?: string): string {
+    if (matchedConditionIndex === undefined) {
+        return 'a condition'
+    }
+    if (!matchedConditionName) {
+        return `condition ${matchedConditionIndex + 1}`
+    }
+    return `condition ${matchedConditionIndex + 1} (${matchedConditionName})`
+}
+
+function logDebug(result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow>, message: string): void {
+    result.logs.push({ level: 'debug', timestamp: DateTime.now(), message })
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #42029


## Changes
added logs so people can see which condition matched on conditional branches when viewing workflow logs, includes matched condition's name if set


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manually tested by running a workflow with and without a matching condition + with/without custom condition name set.
<img width="997" height="609" alt="image" src="https://github.com/user-attachments/assets/295ffcb1-6079-4e16-bcae-c790c4e15167" />
<img width="631" height="170" alt="image" src="https://github.com/user-attachments/assets/11e0a70d-68e4-4d29-81c4-330afe2a2377" />

I was not sure how to test the "scheduledAt" case via the UI so I tested it by overriding scheduledAt in the code to simulate that state.
<img width="899" height="74" alt="image" src="https://github.com/user-attachments/assets/e0abca5b-3fe1-477e-9bbf-3536b9929e4a" />

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
