### PR TITLE
feat(toolbar): refactor loading state

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -379,7 +379,7 @@ export function Toolbar(): JSX.Element | null {
         useValues(toolbarLogic)
     const { setVisibleMenu, toggleMinimized, onMouseOrTouchDown, setElement, setIsBlurred, completeGracefulExit } =
         useActions(toolbarLogic)
-    const { isAuthenticated, userIntent, uiHostCheckStatus, uiHostConfigModalVisible } = useValues(toolbarConfigLogic)
+    const { isAuthenticated, userIntent, authStatus, uiHostConfigModalVisible } = useValues(toolbarConfigLogic)
     const { authenticate, openUiHostConfigModal, closeUiHostConfigModal } = useActions(toolbarConfigLogic)
     const { selectedTourId, isPreviewing } = useValues(productToursLogic)
 
@@ -455,7 +455,7 @@ export function Toolbar(): JSX.Element | null {
                     titleMinimized={isAuthenticated ? 'Expand the toolbar' : 'Authenticate the PostHog Toolbar'}
                 >
                     <AnimatedLogomark
-                        animate={isLoading || uiHostCheckStatus === 'checking'}
+                        animate={isLoading || authStatus === 'checking' || authStatus === 'authenticating'}
                         animateOnce={isExiting ? completeGracefulExit : undefined}
                         className="Toolbar__logomark"
                     />
@@ -491,13 +491,13 @@ export function Toolbar(): JSX.Element | null {
                             </ToolbarButton>
                         )}
                     </>
-                ) : uiHostCheckStatus === 'checking' ? (
+                ) : authStatus === 'checking' || authStatus === 'authenticating' ? (
                     <ToolbarButton flex>
                         <span className="flex items-center gap-1">
-                            <Spinner /> Checking…
+                            <Spinner /> {authStatus === 'authenticating' ? 'Authenticating…' : 'Checking…'}
                         </span>
                     </ToolbarButton>
-                ) : uiHostCheckStatus === 'error' ? (
+                ) : authStatus === 'error' ? (
                     <ToolbarButton
                         flex
                         onClick={openUiHostConfigModal}

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -134,7 +134,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             }
 
             // Don't start OAuth while the reachability check is still in flight.
-            if (values.authStatus === 'checking') {
+            if (values.authStatus === 'checking' || values.authStatus === 'authenticating') {
                 return
             }
 
@@ -439,13 +439,11 @@ async function exchangeCodeForTokens(
     if (!pkceData.verifier) {
         console.warn('PostHog Toolbar: no PKCE verifier found, cannot exchange code')
         lemonToast.error('Authentication failed: session data missing. Please try again.')
-        actions.setAuthStatus('idle')
         return
     }
     if (pkceData.ts && Date.now() - pkceData.ts > PKCE_TTL_MS) {
         console.warn('PostHog Toolbar: PKCE verifier expired')
         lemonToast.error('Authentication timed out. Please try again.')
-        actions.setAuthStatus('idle')
         return
     }
 

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -27,7 +27,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             refreshToken,
             clientId,
         }),
-        setUiHostCheckStatus: (status: 'idle' | 'checking' | 'ok' | 'error') => ({ status }),
+        setAuthStatus: (status: 'idle' | 'checking' | 'authenticating' | 'error') => ({ status }),
         openUiHostConfigModal: true,
         closeUiHostConfigModal: true,
     }),
@@ -64,9 +64,9 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
         productTourId: [props.productTourId || null, { logout: () => null, clearUserIntent: () => null }],
         userIntent: [props.userIntent || null, { logout: () => null, clearUserIntent: () => null }],
         buttonVisible: [true, { showButton: () => true, hideButton: () => false, logout: () => false }],
-        uiHostCheckStatus: [
-            'idle' as 'idle' | 'checking' | 'ok' | 'error',
-            { setUiHostCheckStatus: (_, { status }) => status },
+        authStatus: [
+            'idle' as 'idle' | 'checking' | 'authenticating' | 'error',
+            { setAuthStatus: (_, { status }) => status },
         ],
         uiHostConfigModalVisible: [false, { openUiHostConfigModal: () => true, closeUiHostConfigModal: () => false }],
     })),
@@ -127,14 +127,14 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
     listeners(({ values, actions }) => ({
         authenticate: async () => {
             // If the uiHost check found a problem, open the config modal instead of proceeding.
-            if (values.uiHostCheckStatus === 'error') {
+            if (values.authStatus === 'error') {
                 toolbarPosthogJS.capture('toolbar ui host config modal opened', { ui_host: values.uiHost })
                 actions.openUiHostConfigModal()
                 return
             }
 
             // Don't start OAuth while the reachability check is still in flight.
-            if (values.uiHostCheckStatus === 'checking') {
+            if (values.authStatus === 'checking') {
                 return
             }
 
@@ -254,9 +254,11 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
 // afterMount helpers — extracted to keep the mount handler readable
 // ---------------------------------------------------------------------------
 
-type TokenActions = { setOAuthTokens: (accessToken: string, refreshToken: string, clientId: string) => void }
+type TokenActions = {
+    setOAuthTokens: (accessToken: string, refreshToken: string, clientId: string) => void
+    setAuthStatus: (status: 'idle' | 'checking' | 'authenticating' | 'error') => void
+}
 type CheckActions = TokenActions & {
-    setUiHostCheckStatus: (status: 'idle' | 'checking' | 'ok' | 'error') => void
     openUiHostConfigModal: () => void
 }
 
@@ -342,7 +344,7 @@ function verifyUiHostReachability(
     actions: CheckActions,
     authParams: { code: string; clientId: string } | null
 ): void {
-    actions.setUiHostCheckStatus('checking')
+    actions.setAuthStatus('checking')
 
     const uiHostSource = (props.posthog as any)?.requestRouter?.uiHost
         ? 'request_router'
@@ -369,7 +371,7 @@ function verifyUiHostReachability(
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`)
             }
-            actions.setUiHostCheckStatus('ok')
+            actions.setAuthStatus('idle')
             toolbarPosthogJS.capture('toolbar ui host check', {
                 ...checkBaseProps,
                 status: 'ok',
@@ -381,7 +383,7 @@ function verifyUiHostReachability(
             }
         })
         .catch((error: unknown) => {
-            actions.setUiHostCheckStatus('error')
+            actions.setAuthStatus('error')
             toolbarPosthogJS.capture('toolbar ui host check', {
                 ...checkBaseProps,
                 status: 'error',
@@ -423,6 +425,8 @@ async function exchangeCodeForTokens(
     clientId: string,
     actions: TokenActions
 ): Promise<void> {
+    actions.setAuthStatus('authenticating')
+
     let pkceData: { verifier?: string; ts?: number } = {}
     try {
         const raw = localStorage.getItem(PKCE_STORAGE_KEY)
@@ -435,11 +439,13 @@ async function exchangeCodeForTokens(
     if (!pkceData.verifier) {
         console.warn('PostHog Toolbar: no PKCE verifier found, cannot exchange code')
         lemonToast.error('Authentication failed: session data missing. Please try again.')
+        actions.setAuthStatus('idle')
         return
     }
     if (pkceData.ts && Date.now() - pkceData.ts > PKCE_TTL_MS) {
         console.warn('PostHog Toolbar: PKCE verifier expired')
         lemonToast.error('Authentication timed out. Please try again.')
+        actions.setAuthStatus('idle')
         return
     }
 
@@ -467,6 +473,8 @@ async function exchangeCodeForTokens(
     } catch (err) {
         console.error('PostHog Toolbar: token exchange network error', err)
         lemonToast.error('Authentication failed due to a network error. Please try again.')
+    } finally {
+        actions.setAuthStatus('idle')
     }
 }
 


### PR DESCRIPTION
## Problem

When the toolbar loads after an OAuth redirect, there's a time window during the token exchange where the button still shows "Authenticate" with no loading feedback, making it look like authentication didn't work.

## Changes

- Added a loading state ("Authenticating…" with spinner) shown during the OAuth code exchange after redirect
- Refactored two separate loading states (`uiHostCheckStatus` and `codeExchangeInProgress`) into a single `authStatus` enum (`idle | checking | authenticating | error`) for cleaner state management

## How did you test this code?

Manual testing.

## Publish to changelog?

No
