### PR TITLE
fix(devex): Lower priority of corepack to fix pnpm collision issue

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -15,6 +15,8 @@ xmlsec = { pkg-path = "xmlsec", version = "1.3.7" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node
 nodejs = { pkg-path = "nodejs_24", pkg-group = "nodejs", version = "24.12.0" } # Same maj.min ver as in Dockerfile; diverges from patch ver
+# Set a lower priority on corepack so it takes precedence over nodejs (both bundle pnpm)
+# https://flox.dev/docs/man/manifest.toml/#catalog-descriptors
 corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.12.0", priority = 4 } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 zstd = { pkg-path = "zstd", pkg-group = "nodejs" }

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -15,7 +15,7 @@ xmlsec = { pkg-path = "xmlsec", version = "1.3.7" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node
 nodejs = { pkg-path = "nodejs_24", pkg-group = "nodejs", version = "24.12.0" } # Same maj.min ver as in Dockerfile; diverges from patch ver
-corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.12.0" } # Same maj.min as in Dockerfile; diverges from patch ver
+corepack = { pkg-path = "corepack_24", pkg-group = "nodejs", version = "24.12.0", priority = 4 } # Same maj.min as in Dockerfile; diverges from patch ver
 brotli = { pkg-path = "brotli", pkg-group = "nodejs" }
 zstd = { pkg-path = "zstd", pkg-group = "nodejs" }
 openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Devs are seeing a flox environment conflict between corepack-nodejs and nodejs , which both provide `bin/pnpm`.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Lower the `priority` of `corepack` so it takes precedence over nodejs (as per [the docs](https://flox.dev/docs/man/manifest.toml/#catalog-descriptors)).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
