### PR TITLE
fix(cdp): remove include_all_properties toggle from destinations

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -44,10 +44,7 @@ if (action == 'automatic') {
     }
 }
 
-let attributes := inputs.include_all_properties ? action == 'identify' ? person.properties : event.properties : {}
-if (inputs.include_all_properties and action != 'identify' and not empty(event.elements_chain)) {
-    attributes['$elements_chain'] := event.elements_chain
-}
+let attributes := {}
 let timestamp := toInt(toUnixTimestamp(toDateTime(event.timestamp)))
 
 for (let key, value in inputs.attributes) {
@@ -187,15 +184,6 @@ if (res.status >= 400) {
             "required": True,
         },
         {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below. For identify events the Person properties will be used.",
-            "default": False,
-            "secret": False,
-            "required": True,
-        },
-        {
             "key": "attributes",
             "type": "dictionary",
             "label": "Attribute mapping",
@@ -273,7 +261,6 @@ class TemplateCustomerioMigrator(HogFunctionTemplateMigrator):
             "host": {"value": host},
             "identifier_key": {"value": "email" if identify_by_email else "id"},
             "identifier_value": {"value": "{person.properties.email}" if identify_by_email else "{event.distinct_id}"},
-            "include_all_properties": {"value": True},
             "attributes": {"value": {}},
         }
 

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -17,7 +17,6 @@ def create_inputs(**kwargs):
         "token": "TOKEN",
         "host": "track.customer.io",
         "action": "automatic",
-        "include_all_properties": False,
         "identifier_key": "email",
         "identifier_value": "example@posthog.com",
         "attributes": {"name": "example"},
@@ -60,7 +59,7 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
 
     def test_will_truncate_long_values(self):
         self.run_function(
-            inputs=create_inputs(include_all_properties=True),
+            inputs=create_inputs(attributes={"url": "https://example.com/" + "12345" * 200, "name": "example"}),
             globals={
                 "event": {"event": "$pageview", "properties": {"url": "https://example.com/" + "12345" * 200}},
             },
@@ -88,25 +87,6 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
                 },
             },
         )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(inputs=create_inputs(include_all_properties=False))
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["attributes"] == {"name": "example"}
-
-        self.run_function(inputs=create_inputs(include_all_properties=True))
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["attributes"] == {
-            "$current_url": "https://example.com",
-            "name": "example",
-        }
-
-        self.run_function(inputs=create_inputs(include_all_properties=True, action="identify"))
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["attributes"] == {
-            "email": "example@posthog.com",
-            "name": "example",
-        }
 
     def test_automatic_action_mapping(self):
         for event_name, expected_action in [
@@ -181,7 +161,6 @@ class TestTemplateMigration(BaseTest):
             "host": {"value": "track.customer.io"},
             "identifier_key": {"value": "id"},
             "identifier_value": {"value": "{event.distinct_id}"},
-            "include_all_properties": {"value": True},
             "attributes": {"value": {}},
         }
 

--- a/posthog/cdp/templates/gleap/template_gleap.py
+++ b/posthog/cdp/templates/gleap/template_gleap.py
@@ -19,7 +19,7 @@ if (empty(inputs.userId)) {
     return
 }
 
-let attributes := inputs.include_all_properties ? person.properties : {}
+let attributes := {}
 
 attributes['userId'] := inputs.userId
 
@@ -58,15 +58,6 @@ if (res.status >= 400) {
             "label": "User ID",
             "description": "You can choose to fill this from an `email` property or an `id` property. If the value is empty nothing will be sent. See here for more information: https://docs.gleap.io/server/rest-api",
             "default": "{person.id}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all person properties will be included as attributes. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/gleap/test_template_gleap.py
+++ b/posthog/cdp/templates/gleap/test_template_gleap.py
@@ -5,7 +5,6 @@ from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 def create_inputs(**kwargs):
     inputs = {
         "apiKey": "uB6Jymn60NN5EEIWgiUzZx13geVlEx26",
-        "include_all_properties": False,
         "userId": "edad9282-25d0-4cf1-af0e-415535ee1161",
         "attributes": {"name": "example", "email": "example@posthog.com"},
     }
@@ -41,34 +40,6 @@ class TestTemplateGleap(BaseHogFunctionTemplateTest):
                 },
             },
         )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=create_inputs(include_all_properties=False),
-            globals={
-                "person": {"properties": {"account_status": "paid"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"] == {
-            "userId": "edad9282-25d0-4cf1-af0e-415535ee1161",
-            "name": "example",
-            "email": "example@posthog.com",
-        }
-
-        self.run_function(
-            inputs=create_inputs(include_all_properties=True),
-            globals={
-                "person": {"properties": {"account_status": "paid"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"] == {
-            "userId": "edad9282-25d0-4cf1-af0e-415535ee1161",
-            "account_status": "paid",
-            "name": "example",
-            "email": "example@posthog.com",
-        }
 
     def test_function_requires_identifier(self):
         self.run_function(inputs=create_inputs(userId=""))

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -132,18 +132,6 @@ for (let key, value in inputs.properties) {
     }
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in event.properties) {
-        if (not empty(value) and not key like '$%') {
-            if (typeof(value) in ('object', 'array', 'tuple')) {
-                properties[key] := jsonStringify(value)
-            } else {
-                properties[key] := value
-            }
-        }
-    }
-}
-
 let eventSchema := fetch(f'https://api.hubapi.com/events/v3/event-definitions/{eventName}/?includeProperties=true', {
     'method': 'GET',
     'headers': {
@@ -331,15 +319,6 @@ if (res.status >= 400) {
             "label": "Email of the user",
             "description": "Where to find the email for the contact to be created. You can use the filters section to filter out unwanted emails or internal users.",
             "default": "{person.properties.email}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all event properties",
-            "description": "If set, all event properties will be included. Individual properties can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/hubspot/test_template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/test_template_hubspot.py
@@ -93,7 +93,6 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
             "oauth": {"access_token": "TOKEN"},
             "eventName": "purchase",
             "email": "example@posthog.com",
-            "include_all_properties": False,
             "properties": {
                 "price": 50,
                 "currency": "USD",
@@ -121,31 +120,6 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
             },
         )
 
-    def test_body_includes_all_properties_if_set(self):
-        self.mock_fetch_response = lambda *args: EVENT_DEFINITION_RESPONSE  # type: ignore
-
-        self.run_function(
-            inputs=self._inputs(include_all_properties=False, event="purchase subscription"),
-            globals={
-                "event": {"properties": {"product": "CDP"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1][1]["body"]["properties"] == {"price": 50, "currency": "USD"}
-
-        self.run_function(
-            inputs=self._inputs(include_all_properties=True),
-            globals={
-                "event": {"event": "purchase subscription", "properties": {"product": "CDP"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1][1]["body"]["properties"] == {
-            "price": 50,
-            "currency": "USD",
-            "product": "CDP",
-        }
-
     def test_new_event_creation(self):
         self.fetch_responses = {
             "https://api.hubapi.com/events/v3/event-definitions/sign_up/?includeProperties=true": {
@@ -159,12 +133,9 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
         }
 
         self.run_function(
-            inputs=self._inputs(include_all_properties=True, eventName="sign_up"),
-            globals={
-                "event": {
-                    "properties": {"price": 50, "currency": "USD", "expressDelivery": True},
-                },
-            },
+            inputs=self._inputs(
+                eventName="sign_up", properties={"price": 50, "currency": "USD", "expressDelivery": True}
+            ),
         )
 
         assert self.get_mock_fetch_calls()[1] == (
@@ -242,18 +213,15 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
         }
 
         self.run_function(
-            inputs=self._inputs(include_all_properties=True, event="purchase"),
-            globals={
-                "event": {
-                    "properties": {
-                        "price": 50,
-                        "currency": "USD",
-                        "expressDelivery": True,
-                        "location": "Planet Earth",
-                        "timestamp": "2024-11-11T17:25:59.812Z",
-                    },
-                },
-            },
+            inputs=self._inputs(
+                properties={
+                    "price": 50,
+                    "currency": "USD",
+                    "expressDelivery": True,
+                    "location": "Planet Earth",
+                    "timestamp": "2024-11-11T17:25:59.812Z",
+                }
+            ),
         )
 
         assert self.get_mock_fetch_calls()[1] == (
@@ -343,12 +311,7 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
         }
         with pytest.raises(UncaughtHogVMException) as e:
             self.run_function(
-                inputs=self._inputs(include_all_properties=True, event="purchase"),
-                globals={
-                    "event": {
-                        "properties": {"price": "50 coins"},
-                    },
-                },
+                inputs=self._inputs(properties={"price": "50 coins", "currency": "USD"}),
             )
 
         assert len(self.get_mock_fetch_calls()) == 1

--- a/posthog/cdp/templates/intercom/template_intercom.py
+++ b/posthog/cdp/templates/intercom/template_intercom.py
@@ -48,14 +48,6 @@ let payload := {
     'custom_attributes': {}
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in person.properties) {
-        if (not empty(value) and not key like '$%') {
-            payload[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
         payload[key] := value
@@ -117,15 +109,6 @@ if (res.status >= 400) {
             "label": "Email of the user",
             "description": "Where to find the email of the user.",
             "default": "{person.properties.email}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all person properties will be included. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },
@@ -212,14 +195,6 @@ let payload := {
     'metadata': {}
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in event.properties) {
-        if (not empty(value) and not key like '$%') {
-            payload.metadata[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
         payload.metadata[key] := value
@@ -282,15 +257,6 @@ if (res.status >= 400) {
             "label": "Event time",
             "description": "A Unix timestamp in seconds indicating when the actual event occurred.",
             "default": "{toInt(toUnixTimestamp(event.timestamp))}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all person properties will be included. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/intercom/test_template_intercom.py
+++ b/posthog/cdp/templates/intercom/test_template_intercom.py
@@ -19,7 +19,6 @@ class TestTemplateIntercom(BaseHogFunctionTemplateTest):
                 "app.region": "US",
             },
             "email": "max@posthog.com",
-            "include_all_properties": False,
             "properties": {
                 "name": "Max AI",
                 "phone": "+1234567890",
@@ -73,78 +72,6 @@ class TestTemplateIntercom(BaseHogFunctionTemplateTest):
                     "name": "Max AI",
                     "phone": "+1234567890",
                     "last_seen_at": "1234567890",
-                },
-            },
-        )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.mock_fetch_response = lambda url, options: {  # type: ignore
-            "status": 200,
-            "body": {"total_count": 1, "data": [{"id": "123"}]},
-        }
-
-        self.run_function(
-            inputs=self.create_inputs(
-                include_all_properties=False, customProperties={"custom_property": "custom_value"}
-            ),
-            globals={
-                "person": {"properties": {"plan": "pay-as-you-go", "company": "PostHog"}},
-            },
-        )
-
-        res = self.get_mock_fetch_calls()[1]
-        res[1]["body"]["last_seen_at"] = "1234567890"
-
-        assert res == (
-            "https://api.intercom.io/contacts/123",
-            {
-                "method": "PUT",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Intercom-Version": "2.11",
-                    "Accept": "application/json",
-                    "Authorization": "Bearer ACCESS_TOKEN",
-                },
-                "body": {
-                    "email": "max@posthog.com",
-                    "custom_attributes": {
-                        "custom_property": "custom_value",
-                    },
-                    "name": "Max AI",
-                    "phone": "+1234567890",
-                    "last_seen_at": "1234567890",
-                },
-            },
-        )
-
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=True),
-            globals={
-                "person": {"properties": {"plan": "pay-as-you-go", "company": "PostHog"}},
-            },
-        )
-
-        res = self.get_mock_fetch_calls()[1]
-        res[1]["body"]["last_seen_at"] = "1234567890"
-
-        assert self.get_mock_fetch_calls()[1] == (
-            "https://api.intercom.io/contacts/123",
-            {
-                "method": "PUT",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Intercom-Version": "2.11",
-                    "Accept": "application/json",
-                    "Authorization": "Bearer ACCESS_TOKEN",
-                },
-                "body": {
-                    "email": "max@posthog.com",
-                    "custom_attributes": {},
-                    "name": "Max AI",
-                    "phone": "+1234567890",
-                    "last_seen_at": "1234567890",
-                    "plan": "pay-as-you-go",
-                    "company": "PostHog",
                 },
             },
         )
@@ -206,7 +133,6 @@ class TestTemplateIntercomEvent(BaseHogFunctionTemplateTest):
             "email": "max@posthog.com",
             "eventName": "purchase",
             "eventTime": "1234567890",
-            "include_all_properties": False,
             "properties": {
                 "revenue": "50",
                 "currency": "USD",
@@ -265,74 +191,6 @@ class TestTemplateIntercomEvent(BaseHogFunctionTemplateTest):
                     "created_at": "1234567890",
                     "email": "max@posthog.com",
                     "metadata": {"revenue": "50", "currency": "USD"},
-                },
-            },
-        )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.mock_fetch_response = lambda url, options: {  # type: ignore
-            "status": 200,
-            "body": {"total_count": 1, "data": [{"id": "123"}]},
-        }
-
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=False),
-            globals={
-                "event": {
-                    "event": "purchase",
-                    "properties": {"customerType": "B2C"},
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1] == (
-            "https://api.intercom.io/events",
-            {
-                "method": "POST",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Intercom-Version": "2.11",
-                    "Accept": "application/json",
-                    "Authorization": "Bearer ACCESS_TOKEN",
-                },
-                "body": {
-                    "event_name": "purchase",
-                    "created_at": "1234567890",
-                    "email": "max@posthog.com",
-                    "metadata": {"revenue": "50", "currency": "USD"},
-                },
-            },
-        )
-
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=True),
-            globals={
-                "event": {
-                    "event": "purchase",
-                    "properties": {"customerType": "B2C"},
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1] == (
-            "https://api.intercom.io/events",
-            {
-                "method": "POST",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Intercom-Version": "2.11",
-                    "Accept": "application/json",
-                    "Authorization": "Bearer ACCESS_TOKEN",
-                },
-                "body": {
-                    "event_name": "purchase",
-                    "created_at": "1234567890",
-                    "email": "max@posthog.com",
-                    "metadata": {
-                        "revenue": "50",
-                        "currency": "USD",
-                        "customerType": "B2C",
-                    },
                 },
             },
         )

--- a/posthog/cdp/templates/june/template_june.py
+++ b/posthog/cdp/templates/june/template_june.py
@@ -72,14 +72,6 @@ for (let key, value in inputs.properties) {
     }
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in (type == 'identify' ? person.properties : event.properties)) {
-        if (not empty(value) and not key like '$%') {
-            traits[key] := value
-        }
-    }
-}
-
 let body := {
     'properties': properties,
     'traits': traits,
@@ -115,15 +107,6 @@ if (res.status >= 400) {
             "type": "string",
             "label": "June.so Write API key",
             "secret": True,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all event properties will be included as traits. Individual traits can be overridden below. For identify events the Person properties will be used.",
-            "default": False,
-            "secret": False,
             "required": True,
         },
         {

--- a/posthog/cdp/templates/june/test_june_template.py
+++ b/posthog/cdp/templates/june/test_june_template.py
@@ -5,7 +5,6 @@ from posthog.cdp.templates.june.template_june import template as template_june
 def create_inputs(**kwargs):
     inputs = {
         "apiKey": "abcdef123456",
-        "include_all_properties": False,
         "properties": {"name": "Max AI", "email": "max@posthog.com"},
     }
     inputs.update(kwargs)
@@ -102,108 +101,6 @@ class TestTemplateJune(BaseHogFunctionTemplateTest):
                         "locale": "test13",
                         "timezone": "test18",
                         "userAgent": "test19",
-                    },
-                    "messageId": "151234234",
-                    "userId": "abc123",
-                },
-            },
-        )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=create_inputs(include_all_properties=True),
-            globals={
-                "event": {
-                    "event": "$pageview",
-                    "uuid": "151234234",
-                    "distinct_id": "abc123",
-                    "timestamp": "2024-10-24T23:03:50.941Z",
-                    "properties": {
-                        "$is_identified": True,
-                        "$current_url": "https://hedgebox.net/faq?billing",
-                        "$pathname": "/faq",
-                        "title": "Hedgebox",
-                    },
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0] == (
-            "https://api.june.so/sdk/page",
-            {
-                "method": "POST",
-                "headers": {
-                    "Authorization": "Basic abcdef123456",
-                    "Content-Type": "application/json",
-                },
-                "body": {
-                    "properties": {
-                        "url": "https://hedgebox.net/faq?billing",
-                        "path": "/faq",
-                        "title": "Hedgebox",
-                        "search": "?billing",
-                    },
-                    "traits": {"name": "Max AI", "email": "max@posthog.com", "title": "Hedgebox"},
-                    "timestamp": "2024-10-24T23:03:50.941Z",
-                    "context": {
-                        "app": {},
-                        "campaign": {},
-                        "device": {},
-                        "os": {},
-                        "referrer": {},
-                        "screen": {},
-                    },
-                    "messageId": "151234234",
-                    "userId": "abc123",
-                },
-            },
-        )
-
-        self.run_function(
-            inputs=create_inputs(include_all_properties=False),
-            globals={
-                "event": {
-                    "event": "$pageview",
-                    "uuid": "151234234",
-                    "distinct_id": "abc123",
-                    "timestamp": "2024-10-24T23:03:50.941Z",
-                    "properties": {
-                        "$is_identified": True,
-                        "$current_url": "https://hedgebox.net/faq?billing",
-                        "$pathname": "/faq",
-                        "title": "Hedgebox",
-                    },
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0] == (
-            "https://api.june.so/sdk/page",
-            {
-                "method": "POST",
-                "headers": {
-                    "Authorization": "Basic abcdef123456",
-                    "Content-Type": "application/json",
-                },
-                "body": {
-                    "properties": {
-                        "url": "https://hedgebox.net/faq?billing",
-                        "path": "/faq",
-                        "title": "Hedgebox",
-                        "search": "?billing",
-                    },
-                    "traits": {
-                        "name": "Max AI",
-                        "email": "max@posthog.com",
-                    },
-                    "timestamp": "2024-10-24T23:03:50.941Z",
-                    "context": {
-                        "app": {},
-                        "campaign": {},
-                        "device": {},
-                        "os": {},
-                        "referrer": {},
-                        "screen": {},
                     },
                     "messageId": "151234234",
                     "userId": "abc123",

--- a/posthog/cdp/templates/klaviyo/template_klaviyo.py
+++ b/posthog/cdp/templates/klaviyo/template_klaviyo.py
@@ -37,14 +37,6 @@ if (not empty(person.properties.$geoip_time_zone)) body.data.attributes.location
 if (not empty(inputs.email)) body.data.attributes.email := inputs.email
 if (not empty(inputs.externalId)) body.data.attributes.external_id := inputs.externalId
 
-if (inputs.include_all_properties) {
-    for (let key, value in person.properties) {
-        if (not empty(value) and not key like '$%') {
-            body.data.attributes.properties[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.customProperties) {
     if (not empty(value)) {
         body.data.attributes.properties[key] := value
@@ -97,15 +89,6 @@ print(f'{action} profile successfully: id={profileId}')
             "label": "External ID",
             "description": "A unique identifier used to associate Klaviyo profiles with profiles in an external system",
             "default": "{person.id}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all person properties as custom properties",
-            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below. For identify events the Person properties will be used.",
-            "default": False,
             "secret": False,
             "required": True,
         },
@@ -177,14 +160,6 @@ let body := {
 if (not empty(inputs.email)) body.data.attributes.profile.data.attributes.email := inputs.email
 if (not empty(inputs.externalId)) body.data.attributes.profile.data.attributes.external_id := inputs.externalId
 
-if (inputs.include_all_properties) {
-    for (let key, value in event.properties) {
-        if (not empty(value) and not key like '$%') {
-            body.data.attributes.properties[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.attributes) {
     if (not empty(value)) {
         body.data.attributes.properties[key] := value
@@ -231,15 +206,6 @@ if (res.status >= 400) {
             "label": "External ID",
             "description": "A unique identifier used to associate Klaviyo profiles with profiles in an external system",
             "default": "{person.id}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all event properties as event attributes",
-            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/klaviyo/test_template_klaviyo.py
+++ b/posthog/cdp/templates/klaviyo/test_template_klaviyo.py
@@ -17,7 +17,6 @@ class TestTemplateKlaviyoUser(BaseHogFunctionTemplateTest):
             "apiKey": "API_KEY",
             "email": "max@posthog.com",
             "externalId": "EXTERNAL_ID",
-            "include_all_properties": False,
             "customProperties": {
                 "first_name": "Max",
                 "last_name": "AI",
@@ -67,33 +66,6 @@ class TestTemplateKlaviyoUser(BaseHogFunctionTemplateTest):
             },
         )
 
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=False),
-            globals={"person": {"properties": {"$geoip_country_name": "United States", "plan": "pay-as-you-go"}}},
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["data"]["attributes"]["properties"] == {
-            "first_name": "Max",
-            "last_name": "AI",
-            "title": "Hedgehog in Residence",
-            "organization": "PostHog",
-            "phone_number": "+0123456789",
-        }
-
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=True),
-            globals={"person": {"properties": {"$geoip_country_name": "United States", "plan": "pay-as-you-go"}}},
-        )
-        assert self.get_mock_fetch_calls()[0][1]["body"]["data"]["attributes"]["properties"] == {
-            "first_name": "Max",
-            "last_name": "AI",
-            "title": "Hedgehog in Residence",
-            "organization": "PostHog",
-            "phone_number": "+0123456789",
-            "plan": "pay-as-you-go",
-        }
-
     def test_function_requires_identifier(self):
         self.run_function(inputs=self.create_inputs(email=None, externalId=""))
 
@@ -113,7 +85,6 @@ class TestTemplateKlaviyoEvent(BaseHogFunctionTemplateTest):
             "apiKey": "API_KEY",
             "email": "max@posthog.com",
             "externalId": "EXTERNAL_ID",
-            "include_all_properties": False,
             "attributes": {"price": "25.99", "currency": "USD"},
         }
         inputs.update(kwargs)
@@ -158,31 +129,6 @@ class TestTemplateKlaviyoEvent(BaseHogFunctionTemplateTest):
                 },
             },
         )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=False),
-            globals={
-                "event": {"event": "purchase", "properties": {"customerType": "B2C"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["data"]["attributes"]["properties"] == {
-            "price": "25.99",
-            "currency": "USD",
-        }
-
-        self.run_function(
-            inputs=self.create_inputs(include_all_properties=True),
-            globals={
-                "event": {"event": "purchase", "properties": {"customerType": "B2C"}},
-            },
-        )
-        assert self.get_mock_fetch_calls()[0][1]["body"]["data"]["attributes"]["properties"] == {
-            "price": "25.99",
-            "currency": "USD",
-            "customerType": "B2C",
-        }
 
     def test_function_requires_identifier(self):
         self.run_function(inputs=self.create_inputs(email=None, externalId=""))

--- a/posthog/cdp/templates/knock/template_knock.py
+++ b/posthog/cdp/templates/knock/template_knock.py
@@ -20,12 +20,9 @@ let body := {
     'type': 'track',
     'event': event.event,
     'userId': inputs.userId,
-    'properties': inputs.include_all_properties ? event.properties : {},
+    'properties': {},
     'messageId': event.uuid,
     'timestamp': event.timestamp
-}
-if (inputs.include_all_properties and not empty(event.elements_chain)) {
-    body['properties']['$elements_chain'] := event.elements_chain
 }
 
 for (let key, value in inputs.attributes) {
@@ -61,15 +58,6 @@ if (res.status >= 400) {
             "label": "User ID",
             "description": "You can choose to fill this from an `email` property or an `id` property. If the value is empty nothing will be sent. See here for more information: https://docs.gleap.io/server/rest-api",
             "default": "{person.id}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/knock/test_knock_template.py
+++ b/posthog/cdp/templates/knock/test_knock_template.py
@@ -5,7 +5,6 @@ from posthog.cdp.templates.knock.template_knock import template as template_knoc
 def create_inputs(**kwargs):
     inputs = {
         "webhookUrl": "https://api.knock.app/integrations/receive/tkN_P18rTjBq30waf1RLp",
-        "include_all_properties": False,
         "userId": "edad9282-25d0-4cf1-af0e-415535ee1161",
         "attributes": {"phone": "0123456789"},
     }
@@ -54,52 +53,6 @@ class TestTemplateKnock(BaseHogFunctionTemplateTest):
                 },
             },
         )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=create_inputs(include_all_properties=False),
-            globals={
-                "event": {
-                    "uuid": "9d67cc3f-edf7-490d-b311-f03c21c64caf",
-                    "distinct_id": "8b9c729c-c59b-4c39-b5a6-af9fa1233054",
-                    "event": "$pageview",
-                    "timestamp": "2024-09-16T16:11:48.577Z",
-                    "url": "http://localhost:8000/project/1/events/",
-                    "properties": {
-                        "$current_url": "http://localhost:8000/project/1/pipeline/destinations/hog-0191fb90-bb37-0000-fba4-3377db3ac5e6/configuration",
-                        "$browser": "Chrome",
-                        "price": 15,
-                    },
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {"phone": "0123456789"}
-
-        self.run_function(
-            inputs=create_inputs(include_all_properties=True),
-            globals={
-                "event": {
-                    "uuid": "9d67cc3f-edf7-490d-b311-f03c21c64caf",
-                    "distinct_id": "8b9c729c-c59b-4c39-b5a6-af9fa1233054",
-                    "event": "$pageview",
-                    "timestamp": "2024-09-16T16:11:48.577Z",
-                    "url": "http://localhost:8000/project/1/events/",
-                    "properties": {
-                        "$current_url": "http://localhost:8000/project/1/pipeline/destinations/hog-0191fb90-bb37-0000-fba4-3377db3ac5e6/configuration",
-                        "$browser": "Chrome",
-                        "price": 15,
-                    },
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {
-            "price": 15,
-            "$current_url": "http://localhost:8000/project/1/pipeline/destinations/hog-0191fb90-bb37-0000-fba4-3377db3ac5e6/configuration",
-            "$browser": "Chrome",
-            "phone": "0123456789",
-        }
 
     def test_function_requires_identifier(self):
         self.run_function(inputs=create_inputs(userId=""))

--- a/posthog/cdp/templates/loops/template_loops.py
+++ b/posthog/cdp/templates/loops/template_loops.py
@@ -24,14 +24,6 @@ let payload := {
     'userId': person.id,
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in person.properties) {
-        if (not empty(value) and not key like '$%') {
-            payload[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
         payload[key] := value
@@ -67,15 +59,6 @@ if (res.status >= 400) {
             "label": "Email of the user",
             "description": "Where to find the email of the user.",
             "default": "{person.properties.email}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all person properties will be included. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },
@@ -125,14 +108,6 @@ let payload := {
     'eventProperties': {}
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in event.properties) {
-        if (not empty(value) and not key like '$%') {
-            payload.eventProperties[key] := value
-        }
-    }
-}
-
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
         payload.eventProperties[key] := value
@@ -168,15 +143,6 @@ if (res.status >= 400) {
             "label": "Email of the user",
             "description": "Where to find the email of the user.",
             "default": "{person.properties.email}",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties as attributes",
-            "description": "If set, all event properties will be included. Individual attributes can be overridden below.",
-            "default": False,
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/loops/test_template_loops.py
+++ b/posthog/cdp/templates/loops/test_template_loops.py
@@ -12,7 +12,6 @@ class TestTemplateLoops(BaseHogFunctionTemplateTest):
         inputs = {
             "apiKey": "1cac089e00a708680bdb1ed9f082d5bf",
             "email": "max@posthog.com",
-            "include_all_properties": False,
             "properties": {"firstName": "Max", "lastName": "AI"},
         }
         inputs.update(kwargs)
@@ -46,35 +45,6 @@ class TestTemplateLoops(BaseHogFunctionTemplateTest):
             },
         )
 
-    def test_include_all_properties(self):
-        self.run_function(
-            inputs=self._inputs(include_all_properties=True),
-            globals={
-                "person": {
-                    "id": "c44562aa-c649-426a-a9d4-093fef0c2a4a",
-                    "properties": {"company": "PostHog"},
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0] == (
-            "https://app.loops.so/api/v1/contacts/update",
-            {
-                "method": "POST",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Authorization": "Bearer 1cac089e00a708680bdb1ed9f082d5bf",
-                },
-                "body": {
-                    "email": "max@posthog.com",
-                    "userId": "c44562aa-c649-426a-a9d4-093fef0c2a4a",
-                    "company": "PostHog",
-                    "firstName": "Max",
-                    "lastName": "AI",
-                },
-            },
-        )
-
     def test_function_requires_identifier(self):
         self.run_function(
             inputs=self._inputs(email=""),
@@ -91,7 +61,6 @@ class TestTemplateLoopsEvent(BaseHogFunctionTemplateTest):
         inputs = {
             "apiKey": "1cac089e00a708680bdb1ed9f082d5bf",
             "email": "max@posthog.com",
-            "include_all_properties": False,
             "properties": {"product": "PostHog"},
         }
         inputs.update(kwargs)
@@ -126,41 +95,6 @@ class TestTemplateLoopsEvent(BaseHogFunctionTemplateTest):
                     "eventName": "pageview",
                     "eventProperties": {
                         "product": "PostHog",
-                    },
-                },
-            },
-        )
-
-    def test_include_all_properties(self):
-        self.run_function(
-            inputs=self._inputs(include_all_properties=True),
-            globals={
-                "person": {
-                    "id": "c44562aa-c649-426a-a9d4-093fef0c2a4a",
-                    "properties": {"company": "PostHog"},
-                },
-                "event": {
-                    "event": "pageview",
-                    "properties": {"pathname": "/pricing"},
-                },
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[0] == (
-            "https://app.loops.so/api/v1/events/send",
-            {
-                "method": "POST",
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Authorization": "Bearer 1cac089e00a708680bdb1ed9f082d5bf",
-                },
-                "body": {
-                    "email": "max@posthog.com",
-                    "userId": "c44562aa-c649-426a-a9d4-093fef0c2a4a",
-                    "eventName": "pageview",
-                    "eventProperties": {
-                        "product": "PostHog",
-                        "pathname": "/pricing",
                     },
                 },
             },

--- a/posthog/cdp/templates/mailchimp/template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/template_mailchimp.py
@@ -28,14 +28,6 @@ for (let key, value in inputs.properties) {
     }
 }
 
-if (inputs.include_all_properties) {
-    for (let key, value in event.properties) {
-        if (not empty(value) and not key like '$%') {
-            properties[key] := value
-        }
-    }
-}
-
 let userStatus := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/lists/{inputs.audienceId}/members/{subscriberHash}', {
     'method': 'GET',
     'headers': {
@@ -104,15 +96,6 @@ if (userStatus.status == 404 or userStatus.status == 200) {
             "type": "boolean",
             "label": "Enable double opt-in",
             "description": "If enabled, Mailchimp sends a confirmation email to that user, and that email is tagged with a pending subscriber status. The subscriber status automatically changes to subscribed once the user confirms the email.",
-            "default": False,
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all event properties",
-            "description": "If set, all person properties will be included. Individual properties can be overridden below.",
             "default": False,
             "secret": False,
             "required": True,

--- a/posthog/cdp/templates/mailchimp/test_template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/test_template_mailchimp.py
@@ -8,7 +8,6 @@ def create_inputs(**kwargs):
         "audienceId": "a1b2c3",
         "dataCenterId": "us1",
         "email": "max@posthog.com",
-        "include_all_properties": False,
         "doubleOptIn": False,
         "properties": {"FNAME": "Max", "LNAME": "AI", "COMPANY": "PostHog"},
     }
@@ -38,34 +37,6 @@ class TestTemplateMailchimp(BaseHogFunctionTemplateTest):
                 },
             },
         )
-
-    def test_body_includes_all_properties_if_set(self):
-        self.run_function(
-            inputs=create_inputs(include_all_properties=False),
-            globals={
-                "event": {"properties": {"PHONE": "+1415000000"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1][1]["body"]["merge_fields"] == {
-            "FNAME": "Max",
-            "LNAME": "AI",
-            "COMPANY": "PostHog",
-        }
-
-        self.run_function(
-            inputs=create_inputs(include_all_properties=True),
-            globals={
-                "event": {"properties": {"PHONE": "+1415000000"}},
-            },
-        )
-
-        assert self.get_mock_fetch_calls()[1][1]["body"]["merge_fields"] == {
-            "FNAME": "Max",
-            "LNAME": "AI",
-            "COMPANY": "PostHog",
-            "PHONE": "+1415000000",
-        }
 
     def test_double_opt_in(self):
         self.run_function(

--- a/posthog/cdp/templates/posthog/template_posthog.py
+++ b/posthog/cdp/templates/posthog/template_posthog.py
@@ -18,9 +18,8 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
     code="""
 let host := inputs.host
 let token := inputs.token
-let include_all_properties := inputs.include_all_properties
 let propertyOverrides := inputs.properties
-let properties := include_all_properties ? event.properties : {}
+let properties := {}
 
 for (let key, value in propertyOverrides) {
     properties[key] := value
@@ -59,15 +58,6 @@ fetch(f'{host}/e', {
             "required": True,
         },
         {
-            "key": "include_all_properties",
-            "type": "boolean",
-            "label": "Include all properties by default",
-            "description": "If set, all event properties will be included in the payload. Individual properties can be overridden below.",
-            "default": True,
-            "secret": False,
-            "required": True,
-        },
-        {
             "key": "properties",
             "type": "dictionary",
             "label": "Property overrides",
@@ -98,7 +88,6 @@ class TemplatePostHogMigrator(HogFunctionTemplateMigrator):
         hf["inputs"] = {
             "host": {"value": host},
             "token": {"value": project_api_key},
-            "include_all_properties": {"value": True},
             "properties": {"value": {"$geoip_disable": True} if disable_geoip else {}},
         }
 

--- a/posthog/cdp/templates/posthog/test_template_posthog.py
+++ b/posthog/cdp/templates/posthog/test_template_posthog.py
@@ -16,7 +16,6 @@ class TestTemplatePosthog(BaseHogFunctionTemplateTest):
             inputs={
                 "host": "https://us.i.posthog.com",
                 "token": "TOKEN",
-                "include_all_properties": True,
                 "properties": {"additional": "value"},
             }
         )
@@ -32,22 +31,10 @@ class TestTemplatePosthog(BaseHogFunctionTemplateTest):
                     "event": "event-name",
                     "timestamp": "2024-01-01T00:00:00Z",
                     "distinct_id": "distinct-id",
-                    "properties": {"$current_url": "https://example.com", "additional": "value"},
+                    "properties": {"additional": "value"},
                 },
             },
         )
-
-    def test_function_doesnt_include_all_properties(self):
-        self.run_function(
-            inputs={
-                "host": "https://us.i.posthog.com",
-                "token": "TOKEN",
-                "include_all_properties": False,
-                "properties": {"additional": "value"},
-            }
-        )
-
-        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {"additional": "value"}
 
 
 class TestTemplateMigration(BaseTest):
@@ -68,7 +55,6 @@ class TestTemplateMigration(BaseTest):
         assert template["inputs"] == {
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
-            "include_all_properties": {"value": True},
             "properties": {"value": {}},
         }
 
@@ -80,7 +66,6 @@ class TestTemplateMigration(BaseTest):
         assert template["inputs"] == {
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
-            "include_all_properties": {"value": True},
             "properties": {"value": {"$geoip_disable": True}},
         }
 
@@ -92,7 +77,6 @@ class TestTemplateMigration(BaseTest):
         assert template["inputs"] == {
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
-            "include_all_properties": {"value": True},
             "properties": {"value": {}},
         }
 


### PR DESCRIPTION
### Problem                                                                                                 
                                                                                                          
The "include all properties" toggle on CDP destination templates causes HogVM execution timeouts when    events have many properties.  This leads to exceeding the VM's ops / time budget — producing errors like:                                                  
                                                                                                          
  `Execution timed out after 0.3 seconds. Performed 31704 ops`
                                                                                                          
This timeout is purely bytecode execution cost (fetch/HTTP time is not counted against it), so the issue is the iteration time and complexity, not slow API responses.                                   
                                                                                                          
### Solution                                                                                                
                                                            
Remove the include_all_properties toggle and its implementation. Users must now explicitly map the properties they want to send via the property/attribute mapping dictionary inputs. This keeps bytecode execution lean.