### PR TITLE
fix: show selected config sub page after refresh

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/ErrorTrackingConfigurationScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/ErrorTrackingConfigurationScene.tsx
@@ -1,5 +1,5 @@
 import { actions, connect, kea, path, props, reducers, selectors } from 'kea'
-import { actionToUrl, router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { Settings } from 'scenes/settings/Settings'
@@ -83,12 +83,23 @@ export const errorTrackingConfigurationSceneLogic = kea<errorTrackingConfigurati
             ]
         },
     }),
+
+    urlToAction(({ actions, values }) => ({
+        '*': (_, __, hashParams) => {
+            const selectedSetting = hashParams.selectedSetting as ConfigurationSceneTabType | undefined
+            if (selectedSetting && values.tab !== selectedSetting) {
+                actions.selectSetting(selectedSetting)
+            }
+        },
+    })),
 ])
 
 export const scene: SceneExport<ErrorTrackingConfigurationSceneLogicProps> = {
     component: ErrorTrackingConfigurationScene,
     logic: errorTrackingConfigurationSceneLogic,
-    paramsToProps: ({ searchParams: { tab } }) => ({ initialTab: tab }),
+    paramsToProps: ({ searchParams: { tab }, hashParams: { selectedSetting } }) => ({
+        initialTab: (tab || selectedSetting) as ConfigurationSceneTabType | undefined,
+    }),
 }
 
 export function ErrorTrackingConfigurationScene(): JSX.Element {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
@@ -5,6 +5,7 @@ import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
 import { Params } from 'scenes/sceneTypes'
+import { settingsLogic } from 'scenes/settings/settingsLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { DataTableNode } from '~/queries/schema/schema-general'
@@ -19,7 +20,12 @@ import {
 import { issueQueryOptionsLogic } from '../../components/IssueQueryOptions/issueQueryOptionsLogic'
 import { bulkSelectLogic } from '../../logics/bulkSelectLogic'
 import { errorTrackingQuery } from '../../queries'
-import { ERROR_TRACKING_LISTING_RESOLUTION, syncSearchParams, updateSearchParams } from '../../utils'
+import {
+    ERROR_TRACKING_LISTING_RESOLUTION,
+    ERROR_TRACKING_LOGIC_KEY,
+    syncSearchParams,
+    updateSearchParams,
+} from '../../utils'
 import type { errorTrackingSceneLogicType } from './errorTrackingSceneLogicType'
 
 export const ERROR_TRACKING_SCENE_LOGIC_KEY = 'ErrorTrackingScene'
@@ -41,6 +47,12 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
             ['dateRange', 'filterTestAccounts', 'filterGroup', 'mergedFilterGroup', 'searchQuery'],
             issueQueryOptionsLogic({ logicKey: ERROR_TRACKING_SCENE_LOGIC_KEY }),
             ['assignee', 'orderBy', 'orderDirection', 'status'],
+            settingsLogic({
+                logicKey: ERROR_TRACKING_LOGIC_KEY,
+                sectionId: 'environment-error-tracking',
+                settingId: 'error-tracking-exception-autocapture',
+            }),
+            ['selectedSettingId'],
         ],
         actions: [
             issueActionsLogic,
@@ -49,6 +61,12 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
             ['setSelectedIssueIds'],
             issueFiltersLogic({ logicKey: ERROR_TRACKING_SCENE_LOGIC_KEY }),
             ['setDateRange', 'setFilterGroup', 'setSearchQuery', 'setFilterTestAccounts'],
+            settingsLogic({
+                logicKey: ERROR_TRACKING_LOGIC_KEY,
+                sectionId: 'environment-error-tracking',
+                settingId: 'error-tracking-exception-autocapture',
+            }),
+            ['selectSetting'],
         ],
     })),
 
@@ -133,9 +151,12 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
 
     urlToAction(({ actions, values }) => {
         return {
-            '**/error_tracking': (_, params) => {
+            '**/error_tracking': (_, params, hashParams) => {
                 if (params.activeTab && !equal(params.activeTab, values.activeTab)) {
                     actions.setActiveTab(params.activeTab)
+                }
+                if (hashParams.selectedSetting && hashParams.selectedSetting !== values.selectedSettingId) {
+                    actions.selectSetting(hashParams.selectedSetting)
                 }
                 triggerFilterActions(params, values, actions)
             },


### PR DESCRIPTION
Refreshing ET config page (or visiting it via URL) reset selected sub-page. This fixes it