### PR TITLE
feat(llma): add missing eval tracking for hog code evals

### DIFF
--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -20,6 +20,7 @@ LOGGER = get_write_only_logger(__name__)
 EVAL_ACTIVITY_TYPES = {
     "fetch_evaluation_activity",
     "execute_llm_judge_activity",
+    "execute_hog_eval_activity",
     "emit_evaluation_event_activity",
     "emit_internal_telemetry_activity",
     "increment_trial_eval_count_activity",
@@ -56,16 +57,16 @@ def increment_workflow_started() -> None:
     counter.add(1)
 
 
-def increment_workflow_finished(status: str) -> None:
+def increment_workflow_finished(status: str, evaluation_type: str = "llm_judge") -> None:
     """Track workflow completions by outcome (completed/failed/skipped)."""
-    meter = get_metric_meter({"status": status})
+    meter = get_metric_meter({"status": status, "evaluation_type": evaluation_type})
     counter = meter.create_counter("llma_eval_workflow_finished", "Number of eval workflows finished")
     counter.add(1)
 
 
-def increment_verdict(verdict: str) -> None:
+def increment_verdict(verdict: str, evaluation_type: str = "llm_judge") -> None:
     """Track verdict distribution (true/false/na/error)."""
-    meter = get_metric_meter({"verdict": verdict})
+    meter = get_metric_meter({"verdict": verdict, "evaluation_type": evaluation_type})
     counter = meter.create_counter("llma_eval_verdict", "Verdict distribution")
     counter.add(1)
 
@@ -237,25 +238,30 @@ class _EvalsMetricsWorkflowInterceptor(WorkflowInboundInterceptor):
             try:
                 result = await super().execute_workflow(input)
 
+                # Extract evaluation_type for metric labeling
+                evaluation_type = "llm_judge"
+                if isinstance(result, dict):
+                    evaluation_type = result.get("evaluation_type", "llm_judge")
+
                 # Check if workflow was skipped
                 if isinstance(result, dict) and result.get("skipped"):
                     status = "SKIPPED"
                     recorder.set_status(status)
-                    increment_workflow_finished(status)
+                    increment_workflow_finished(status, evaluation_type)
                     return result
 
                 # Record verdict
                 if isinstance(result, dict):
                     verdict = result.get("verdict")
                     if verdict is True:
-                        increment_verdict("true")
+                        increment_verdict("true", evaluation_type)
                     elif verdict is False:
-                        increment_verdict("false")
+                        increment_verdict("false", evaluation_type)
                     elif verdict is None:
                         # N/A case (applicable=false)
-                        increment_verdict("na")
+                        increment_verdict("na", evaluation_type)
 
-                increment_workflow_finished(status)
+                increment_workflow_finished(status, evaluation_type)
                 return result
 
             except Exception:

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -803,6 +803,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                             "skip_reason": error_type,
                             "message": e.cause.message,
                             "evaluation_id": evaluation["id"],
+                            "evaluation_type": evaluation_type,
                         }
 
                     # Update key state for API-related errors
@@ -914,5 +915,6 @@ class RunEvaluationWorkflow(PostHogWorkflow):
             "verdict": result["verdict"],
             "reasoning": result["reasoning"],
             "evaluation_id": evaluation["id"],
+            "evaluation_type": evaluation_type,
             "is_byok": result.get("is_byok", False),
         }

--- a/posthog/temporal/llm_analytics/test_metrics.py
+++ b/posthog/temporal/llm_analytics/test_metrics.py
@@ -97,6 +97,7 @@ class TestActivityTypes:
         expected = {
             "fetch_evaluation_activity",
             "execute_llm_judge_activity",
+            "execute_hog_eval_activity",
             "emit_evaluation_event_activity",
             "emit_internal_telemetry_activity",
             "increment_trial_eval_count_activity",

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -146,6 +146,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 {
                     "evaluation_id": evaluation_id,
                     "evaluation_name": evaluation.name,
+                    "evaluation_type": evaluation.evaluation_type,
                     "target_event_id": target_event_id,
                     "workflow_id": workflow_id,
                     "trigger_type": "manual",

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -425,6 +425,23 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
         response = execute_hogql_query(query=query, team=team, limit_context=None)
 
         if not response.results:
+            report_user_action(
+                request.user,
+                "llma evaluation hog code tested",
+                {
+                    "sample_count": sample_count,
+                    "allows_na": allows_na,
+                    "condition_count": len(conditions),
+                    "result_count": 0,
+                    "pass_count": 0,
+                    "fail_count": 0,
+                    "error_count": 0,
+                    "na_count": 0,
+                    "no_events": True,
+                },
+                team=self.team,
+                request=self.request,
+            )
             return Response({"results": [], "message": "No recent AI events found in the last 7 days"})
 
         results = []
@@ -473,6 +490,7 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
                 "pass_count": sum(1 for r in results if r["result"] is True),
                 "fail_count": sum(1 for r in results if r["result"] is False),
                 "error_count": sum(1 for r in results if r["error"]),
+                "na_count": sum(1 for r in results if r["result"] is None and not r["error"]),
             },
             team=self.team,
             request=self.request,

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -462,6 +462,22 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
                 }
             )
 
+        report_user_action(
+            request.user,
+            "llma evaluation hog code tested",
+            {
+                "sample_count": sample_count,
+                "allows_na": allows_na,
+                "condition_count": len(conditions),
+                "result_count": len(results),
+                "pass_count": sum(1 for r in results if r["result"] is True),
+                "fail_count": sum(1 for r in results if r["result"] is False),
+                "error_count": sum(1 for r in results if r["error"]),
+            },
+            team=self.team,
+            request=self.request,
+        )
+
         return Response({"results": results})
 
 


### PR DESCRIPTION
## Summary

- Add `evaluation_type` property to `llma evaluation run triggered` event so manual runs can be segmented by hog vs llm_judge
- Add new `llma evaluation hog code tested` event on the `test_hog` endpoint with pass/fail/error counts to track Hog code editor usage
- Add `evaluation_type` label to `llma_eval_workflow_finished` and `llma_eval_verdict` Prometheus counters for Grafana breakdowns
- Add `execute_hog_eval_activity` to `EVAL_ACTIVITY_TYPES` so hog eval activity latency is tracked by the interceptor
- Include `evaluation_type` in workflow return dicts so the interceptor can extract it

## Test plan

- [ ] Create a Hog eval and trigger a manual run — verify `llma evaluation run triggered` event includes `evaluation_type: "hog"`
- [ ] Use the Hog code editor test button — verify `llma evaluation hog code tested` event fires with correct pass/fail/error counts
- [ ] Run a hog eval workflow — verify Prometheus metrics `llma_eval_workflow_finished` and `llma_eval_verdict` include `evaluation_type="hog"` label
- [ ] Run an LLM judge eval workflow — verify metrics still default to `evaluation_type="llm_judge"`