### PR TITLE
feat(experiments): backfill experiment status field

### DIFF
--- a/posthog/migrations/1038_experiment_status_backfill.py
+++ b/posthog/migrations/1038_experiment_status_backfill.py
@@ -1,15 +1,16 @@
 from django.db import migrations
+from django.db.models import Case, Value, When
 
 
 def backfill_experiment_status(apps, schema_editor):
     Experiment = apps.get_model("posthog", "Experiment")
 
-    Experiment.objects.filter(status__isnull=True, start_date__isnull=True).update(status="draft")
-    Experiment.objects.filter(status__isnull=True, start_date__isnull=False, end_date__isnull=True).update(
-        status="running"
-    )
-    Experiment.objects.filter(status__isnull=True, start_date__isnull=False, end_date__isnull=False).update(
-        status="stopped"
+    Experiment.objects.filter(status__isnull=True).update(
+        status=Case(
+            When(start_date__isnull=True, then=Value("draft")),
+            When(start_date__isnull=False, end_date__isnull=True, then=Value("running")),
+            When(start_date__isnull=False, end_date__isnull=False, then=Value("stopped")),
+        )
     )
 
 

--- a/posthog/migrations/1038_experiment_status_backfill.py
+++ b/posthog/migrations/1038_experiment_status_backfill.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def backfill_experiment_status(apps, schema_editor):
+    Experiment = apps.get_model("posthog", "Experiment")
+
+    Experiment.objects.filter(status__isnull=True, start_date__isnull=True).update(status="draft")
+    Experiment.objects.filter(status__isnull=True, start_date__isnull=False, end_date__isnull=True).update(
+        status="running"
+    )
+    Experiment.objects.filter(status__isnull=True, start_date__isnull=False, end_date__isnull=False).update(
+        status="stopped"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1037_add_redirect_to_topic_restriction_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_experiment_status, reverse_code=migrations.RunPython.noop),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1037_add_redirect_to_topic_restriction_type
+1038_experiment_status_backfill


### PR DESCRIPTION
## Problem

Existing experiments has `status = None`

## Changes

Add a data migration to update status field on existing experiments.

This migration will run a single UPDATE statement on the experiments table in a single transaction. Given the size of the experiment table, and that no indexes has to be rewritten, this should be a safe operation, and run fast. Also, there is not much write activity to this table.

```
UPDATE "posthog_experiment"
SET "status" = CASE
    WHEN "start_date" IS NULL THEN 'draft'
    WHEN "start_date" IS NOT NULL AND "end_date" IS NULL THEN 'running'
    WHEN "start_date" IS NOT NULL AND "end_date" IS NOT NULL THEN 'stopped'
END
WHERE "status" IS NULL;
```

## How did you test this code?

- Ran the migration locally and verified that status field were set correctly
