### PR TITLE
test: below-facade visual_review change (contract-check should HIT)

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -2,7 +2,7 @@
 Business logic for visual_review.
 
 ORM queries, validation, calculations, business rules.
-Called by api/api.py facade. Do not call from outside this module.
+Called by facade. Do not call from outside this module.
 """
 
 from uuid import UUID


### PR DESCRIPTION
Throwaway PR to verify contract-check works for visual_review.

Changes `backend/logic.py` (below facade) — turbo contract-check inputs only watch `backend/facade/**`, so this should be a cache HIT and Django tests should be skippable.