### PR TITLE
feat(logs): add message lag histogram to rate limiter

### DIFF
--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -3,7 +3,7 @@ import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { Hub } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
 
-import { BASE_REDIS_KEY, LogsRateLimiterService } from './logs-rate-limiter.service'
+import { BASE_REDIS_KEY, LogsRateLimiterService, logsMessageLagHistogram } from './logs-rate-limiter.service'
 
 const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
 
@@ -519,14 +519,74 @@ describe('LogsRateLimiterService', () => {
                 expect(result.dropped).toHaveLength(0)
             })
 
-            it('should use first message timestamp for team when multiple messages in batch', async () => {
+            it('should observe lag histogram for teams without rate limiting enabled', async () => {
+                hub.LOGS_LIMITER_ENABLED_TEAMS = '999' // Only team 999 is rate-limited
+                rateLimiter = new LogsRateLimiterService(hub, redis)
+
+                const observeSpy = jest.spyOn(logsMessageLagHistogram, 'observe')
+
+                const pastTime = new Date('2024-01-01T00:00:00Z').toISOString()
+                const nowMs = new Date('2024-01-01T00:00:45Z').getTime()
+                mockNow.mockReturnValue(nowMs)
+
+                const messages = [createMessageWithHeaders(1, 1024, [{ created_at: pastTime }])]
+
+                await rateLimiter.filterMessages(messages)
+
+                expect(observeSpy).toHaveBeenCalledTimes(1)
+                expect(observeSpy).toHaveBeenCalledWith(45)
+
+                observeSpy.mockRestore()
+            })
+
+            it('should observe lag histogram with Date.now() fallback when no timestamp header', async () => {
+                const observeSpy = jest.spyOn(logsMessageLagHistogram, 'observe')
+
+                const nowMs = new Date('2024-01-01T00:01:00Z').getTime()
+                mockNow.mockReturnValue(nowMs)
+
+                const messages = [createMessageWithHeaders(1, 1024)] // no headers
+
+                await rateLimiter.filterMessages(messages)
+
+                // Lag should be ~0 since both message timestamp and nowSeconds use Date.now()
+                expect(observeSpy).toHaveBeenCalledTimes(1)
+                expect(observeSpy).toHaveBeenCalledWith(0)
+
+                observeSpy.mockRestore()
+            })
+
+            it('should observe lag histogram using oldest timestamp per team', async () => {
+                const observeSpy = jest.spyOn(logsMessageLagHistogram, 'observe')
+
+                const olderTime = new Date('2024-01-01T00:00:00Z').toISOString() // oldest
+                const newerTime = new Date('2024-01-01T00:00:30Z').toISOString() // 30s later
+
+                const nowMs = new Date('2024-01-01T00:01:00Z').getTime() // 60s after older, 30s after newer
+                mockNow.mockReturnValue(nowMs)
+
+                const messages = [
+                    createMessageWithHeaders(1, 1024, [{ created_at: newerTime }]),
+                    createMessageWithHeaders(1, 1024, [{ created_at: olderTime }]),
+                ]
+
+                await rateLimiter.filterMessages(messages)
+
+                // Should observe lag of 60s (using oldest timestamp), not 30s (first message)
+                expect(observeSpy).toHaveBeenCalledTimes(1)
+                expect(observeSpy).toHaveBeenCalledWith(60)
+
+                observeSpy.mockRestore()
+            })
+
+            it('should use first message timestamp for rate limiting when multiple messages in batch', async () => {
                 const time1 = new Date('2024-01-01T00:00:00Z').toISOString()
                 const time2 = new Date('2024-01-01T00:00:10Z').toISOString() // 10 seconds later
 
-                // Both messages for same team, first one's timestamp should be used
+                // Both messages for same team, first one's timestamp should be used for rate limiting
                 const messages = [
                     createMessageWithHeaders(1, 5120, [{ created_at: time1 }]), // 5KB
-                    createMessageWithHeaders(1, 3072, [{ created_at: time2 }]), // 3KB - should use time1's timestamp
+                    createMessageWithHeaders(1, 3072, [{ created_at: time2 }]), // 3KB - rate limiter uses time1's timestamp
                 ]
 
                 const result = await rateLimiter.filterMessages(messages)

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
@@ -1,3 +1,5 @@
+import { Histogram } from 'prom-client'
+
 import { RedisV2, getRedisPipelineResults } from '~/common/redis/redis-v2'
 import { LogsIngestionConsumerConfig } from '~/types'
 
@@ -8,6 +10,12 @@ const msToSeconds = (ms: number): number => Math.round(ms / 1000)
 
 /** Convert bytes to kilobytes (rounded up) */
 const bytesToKb = (bytes: number): number => Math.ceil(bytes / 1000)
+
+export const logsMessageLagHistogram = new Histogram({
+    name: 'logs_rate_limiter_message_lag_seconds',
+    help: 'Lag between message observed timestamp and wall clock time (seconds)',
+    buckets: [-60, 0, 1, 5, 10, 30, 60, 300, 600, 1800, 3600],
+})
 
 export type LogsRateLimiterConfig = Pick<
     LogsIngestionConsumerConfig,
@@ -180,8 +188,16 @@ export class LogsRateLimiterService {
         // Group messages by team to calculate total cost per team (only for teams with rate limiting enabled)
         const teamCosts = new Map<number, number>()
         const teamTimestamps = new Map<number, number>()
+        const teamOldestTimestamps = new Map<number, number>()
 
         for (const message of messages) {
+            const messageTimestamp = this.getTimestampFromMessage(message)
+
+            const existing = teamOldestTimestamps.get(message.teamId)
+            if (existing === undefined || messageTimestamp < existing) {
+                teamOldestTimestamps.set(message.teamId, messageTimestamp)
+            }
+
             if (!this.isRateLimitingEnabledForTeam(message.teamId)) {
                 continue
             }
@@ -190,10 +206,16 @@ export class LogsRateLimiterService {
             const costKb = bytesToKb(message.bytesUncompressed)
             teamCosts.set(message.teamId, currentCost + costKb)
 
-            // Store the timestamp for this team (use the first message's timestamp)
+            // Store the first message's timestamp for rate limiting
             if (!teamTimestamps.has(message.teamId)) {
-                teamTimestamps.set(message.teamId, this.getTimestampFromMessage(message))
+                teamTimestamps.set(message.teamId, messageTimestamp)
             }
+        }
+
+        // Track how far behind wall clock the messages are (using oldest per team for worst-case lag)
+        const nowSeconds = msToSeconds(Date.now())
+        for (const [, timestamp] of teamOldestTimestamps) {
+            logsMessageLagHistogram.observe(nowSeconds - timestamp)
         }
 
         // Check rate limits for all teams


### PR DESCRIPTION
## Problem

Logs rate limiter uses message observed timestamps for the token bucket, which causes incorrect rate limiting when the consumer is catching up after lag spikes.

It's possible that partitions that are behind get no refill because another partition already advanced the Redis timestamp.

## Changes

Adds a logs_rate_limiter_message_lag_seconds histogram tracking the gap between message timestamps and wall clock time, so we can observe catch-up behavior before changing rate limiter logic.  
  
This will let us know how effective it will be to disable the rate limiter for messages from the past

## How did you test this code?

local dev

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no