### PR TITLE
fix(ux): ai-first home page ux updates/fixes

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -177,8 +177,8 @@ export function Nav({ children }: { children?: React.ReactNode }): JSX.Element {
                         <Tabs.Panel value="chat" className="absolute inset-0 flex flex-col" keepMounted>
                             <Suspense
                                 fallback={
-                                    <div className="flex flex-col gap-px px-1">
-                                        {Array.from({ length: 10 }).map((_, index) => (
+                                    <div className="flex flex-col gap-px px-1 pt-2">
+                                        {Array.from({ length: 15 }).map((_, index) => (
                                             <WrappingLoadingSkeleton fullWidth key={index}>
                                                 <ButtonPrimitive aria-hidden inert menuItem />
                                             </WrappingLoadingSkeleton>

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -13,6 +13,7 @@ import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
 import { Label } from 'lib/ui/Label/Label'
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 import { sceneLogic } from 'scenes/sceneLogic'
 
@@ -174,7 +175,17 @@ export function Nav({ children }: { children?: React.ReactNode }): JSX.Element {
                             <NavTabBrowse />
                         </Tabs.Panel>
                         <Tabs.Panel value="chat" className="absolute inset-0 flex flex-col" keepMounted>
-                            <Suspense fallback={<div>Loading...</div>}>
+                            <Suspense
+                                fallback={
+                                    <div className="flex flex-col gap-px px-1">
+                                        {Array.from({ length: 10 }).map((_, index) => (
+                                            <WrappingLoadingSkeleton fullWidth key={index}>
+                                                <ButtonPrimitive aria-hidden inert menuItem />
+                                            </WrappingLoadingSkeleton>
+                                        ))}
+                                    </div>
+                                }
+                            >
                                 <NavTabChat />
                             </Suspense>
                         </Tabs.Panel>

--- a/frontend/src/layout/panel-layout/ai-first/NavTabInbox.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavTabInbox.tsx
@@ -1,0 +1,7 @@
+export function NavTabInbox(): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center h-full text-muted p-4">
+            <p className="text-sm mb-0">Inbox coming soon</p>
+        </div>
+    )
+}

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
@@ -132,7 +132,7 @@ export function NavTabChat(): JSX.Element {
                                             <Combobox.Group items={group.items}>
                                                 <Combobox.GroupLabel
                                                     render={
-                                                        <Collapsible.Trigger className="sticky top-0 bg-surface-tertiary z-10 pl-3" />
+                                                        <Collapsible.Trigger className="sticky top-0 bg-surface-tertiary z-5 pl-3" />
                                                     }
                                                 >
                                                     {group.value}

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
@@ -197,8 +197,10 @@ export function NavTabChat(): JSX.Element {
                                         </Collapsible>
                                     )}
                                 </Combobox.List>
-                                <Combobox.Empty className="flex flex-col items-center justify-center text-center py-8 text-muted empty:hidden">
-                                    <p className="text-sm mb-0">No chats found</p>
+                                <Combobox.Empty className="empty:hidden">
+                                    <div className="flex flex-col items-center justify-center text-center py-8 text-muted border border-dashed rounded-md">
+                                        <p className="text-xs mb-0">No chats found</p>
+                                    </div>
                                 </Combobox.Empty>
                             </>
                         )}

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -21,7 +21,15 @@ import { SidebarQuestionInputWithSuggestions } from './SidebarQuestionInputWithS
 import { ThreadAutoScroller } from './ThreadAutoScroller'
 
 /* Sits above the chat area */
-export function ChatHeader({ conversationId, tabId }: { conversationId: string | null; tabId?: string }): JSX.Element {
+export function ChatHeader({
+    conversationId,
+    tabId,
+    children,
+}: {
+    conversationId: string | null
+    tabId?: string
+    children?: React.ReactNode
+}): JSX.Element {
     const { openSidePanelMax } = useActions(maxGlobalLogic)
     const { chatTitle } = useValues(maxLogic)
     const { closeTabId } = useActions(sceneLogic)
@@ -30,6 +38,7 @@ export function ChatHeader({ conversationId, tabId }: { conversationId: string |
     return (
         <div className="flex w-full gap-2 py-2 border-b border-primary items-center justify-between px-2">
             <div className="flex items-center gap-2 pl-2 text-sm font-medium truncate min-w-0 flex-1">
+                {children}
                 {chatTitle === null ? null : isTitleLoading ? (
                     <div className="w-100">
                         <SceneName name="New chat" isLoading />

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -73,7 +73,7 @@ function IdleInput(): JSX.Element {
                 <div className="px-4 w-full">
                     <div className="w-full bg-surface-tertiary justify-between rounded-b-lg px-1 pt-0.5 pb-1 font-medium select-none flex items-center gap-1 border-l border-r border-b">
                         <div className="flex items-center gap-0.5">
-                            <ButtonPrimitive size="xs" className="text-tertiary" tooltip="Not implemented yet">
+                            <ButtonPrimitive size="xs" className="text-tertiary" onClick={() => enterAiMode('/')}>
                                 <KeyboardShortcut forwardslash /> <span className="text-xxs">For commands</span>
                             </ButtonPrimitive>
                         </div>
@@ -211,7 +211,7 @@ export function HomepageInput(): JSX.Element {
     const { user } = useValues(userLogic)
 
     return (
-        <div className="w-full max-w-180 mx-auto py-2">
+        <div className="w-full max-w-[614px] mx-auto py-2">
             {mode === 'idle' && (
                 <div className="flex flex-col items-center gap-3">
                     <Intro forceHeadline={`Hello ${user?.first_name || 'there'}`} forceSubheadline="POSTHOG ONLY" />

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -21,7 +21,7 @@ import { HOMEPAGE_TAB_ID } from './constants'
 
 function IdleInput(): JSX.Element {
     const { query, placeholder } = useValues(aiFirstHomepageLogic)
-    const { setQuery, submitQuery } = useActions(aiFirstHomepageLogic)
+    const { setQuery, submitQuery, enterAiMode } = useActions(aiFirstHomepageLogic)
     const inputRef = useRef<HTMLInputElement>(null)
 
     useEffect(() => {
@@ -45,7 +45,15 @@ function IdleInput(): JSX.Element {
                     ref={inputRef}
                     id="homepage-input"
                     value={query}
-                    onChange={(e) => setQuery(e.target.value)}
+                    onChange={(e) => {
+                        const value = e.target.value
+                        // Typing / or @ as the first character enters AI mode without sending
+                        if (value === '/' || value === '@') {
+                            enterAiMode(value)
+                            return
+                        }
+                        setQuery(value)
+                    }}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter' && query.trim()) {
                             e.preventDefault()
@@ -67,9 +75,6 @@ function IdleInput(): JSX.Element {
                         <div className="flex items-center gap-0.5">
                             <ButtonPrimitive size="xs" className="text-tertiary" tooltip="Not implemented yet">
                                 <KeyboardShortcut forwardslash /> <span className="text-xxs">For commands</span>
-                            </ButtonPrimitive>
-                            <ButtonPrimitive size="xs" className="text-tertiary" tooltip="Not implemented yet">
-                                <KeyboardShortcut atsign /> <span className="text-xxs">Add context</span>
                             </ButtonPrimitive>
                         </div>
 

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageSearchResults.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageSearchResults.tsx
@@ -4,7 +4,7 @@ export function HomepageSearchResults(): JSX.Element {
     return (
         <Search.Results
             className="w-full mx-auto grow min-h-0"
-            listClassName="max-w-180 mx-auto w-full"
+            listClassName="max-w-[614px] mx-auto w-full"
             groupLabelClassName="bg-[var(--scene-layout-background)]"
         />
     )

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageThread.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageThread.tsx
@@ -8,6 +8,9 @@ import { ThreadAutoScroller } from 'scenes/max/components/ThreadAutoScroller'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from 'scenes/max/maxThreadLogic'
 import { Thread } from 'scenes/max/Thread'
+import { urls } from 'scenes/urls'
+
+import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
 
 import { aiFirstHomepageLogic } from './aiFirstHomepageLogic'
 import { HOMEPAGE_TAB_ID } from './constants'
@@ -39,7 +42,16 @@ export function HomepageThread(): JSX.Element {
     return (
         <BindLogic logic={maxLogic} props={{ tabId: HOMEPAGE_TAB_ID }}>
             <BindLogic logic={maxThreadLogic} props={threadProps}>
-                <ChatHeader conversationId={conversationId} />
+                <ChatHeader conversationId={conversationId}>
+                    <SceneBreadcrumbBackButton
+                        forceBackTo={{
+                            name: 'Project homepage',
+                            path: urls.projectHomepage(),
+                            type: 'projectTree',
+                            key: 'projectHomepage',
+                        }}
+                    />
+                </ChatHeader>
                 <ScrollableShadows direction="vertical" styledScrollbars className="grow min-h-0">
                     <ThreadAutoScroller>
                         <Thread className="p-3" />

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -20,11 +20,12 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
 
     connect(() => ({
         values: [maxLogic({ tabId: HOMEPAGE_TAB_ID }), ['threadLogicKey']],
-        actions: [maxLogic({ tabId: HOMEPAGE_TAB_ID }), ['openConversation', 'startNewConversation']],
+        actions: [maxLogic({ tabId: HOMEPAGE_TAB_ID }), ['openConversation', 'startNewConversation', 'setQuestion']],
     })),
 
     actions({
         submitQuery: (mode: 'search' | 'ai') => ({ mode }),
+        enterAiMode: (trigger: string) => ({ trigger }),
         setQuery: (query: string) => ({ query }),
         setAnimationPhase: (phase: AnimationPhase) => ({ phase }),
         setHoveredSuggestion: (suggestion: string | null) => ({ suggestion }),
@@ -42,6 +43,12 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
                         return state
                     }
                     return { mode, animationPhase: 'moving' }
+                },
+                enterAiMode: (state): LayoutState => {
+                    if (state.mode === 'ai') {
+                        return state
+                    }
+                    return { mode: 'ai', animationPhase: 'moving' }
                 },
                 setAnimationPhase: (state, { phase }): LayoutState => ({
                     ...state,
@@ -91,6 +98,18 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             await breakpoint(200)
             actions.setAnimationPhase('content')
         },
+        enterAiMode: async ({ trigger }, breakpoint) => {
+            // Pass the trigger character (/ or @) to the AI input
+            if (trigger) {
+                actions.setQuestion(trigger)
+            }
+            // Just animate into AI mode without starting a conversation
+            await breakpoint(300)
+            actions.setAnimationPhase('separator')
+
+            await breakpoint(200)
+            actions.setAnimationPhase('content')
+        },
     })),
 
     actionToUrl(({ values }) => ({
@@ -105,6 +124,9 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
                 ]
             }
             return [urls.projectHomepage(), { mode, q: query || undefined }, undefined, { replace: false }]
+        },
+        enterAiMode: () => {
+            return [urls.projectHomepage(), { mode: 'ai' }, undefined, { replace: true }]
         },
         returnToIdle: () => {
             return [urls.projectHomepage(), {}, undefined, { replace: true }]

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -120,13 +120,13 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
                     urls.projectHomepage(),
                     { mode, chat: values.threadLogicKey || undefined },
                     undefined,
-                    { replace: false },
+                    { replace: true },
                 ]
             }
             return [urls.projectHomepage(), { mode, q: query || undefined }, undefined, { replace: false }]
         },
         enterAiMode: () => {
-            return [urls.projectHomepage(), { mode: 'ai' }, undefined, { replace: true }]
+            return [urls.projectHomepage(), { mode: 'ai' }, undefined, { replace: false }]
         },
         returnToIdle: () => {
             return [urls.projectHomepage(), {}, undefined, { replace: true }]


### PR DESCRIPTION

## Changes
* Implement the `/` command in ai-first homepage input
* `/` value enters `ai` mode, and doesn't send a message
* Fix history state, so once in ai-mode, pressing back in browser goes back to `/home` clean.
* Added back button to `<ChatHeader/>` through a children prop on homepage.

![2026-03-09 10 36 14](https://github.com/user-attachments/assets/0f904cad-b06d-4592-970e-a5b56e54c2ac)


## How did you test this code?

Locally

## Publish to changelog?
No