### PR TITLE
fix(logs-rate-limiter): explicitly reset env vars to prevent failling tests on local environments

### DIFF
--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -244,6 +244,9 @@ describe('LogsRateLimiterService', () => {
             hub.LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND = 1
             hub.LOGS_LIMITER_TTL_SECONDS = 3600
             hub.LOGS_LIMITER_ENABLED_TEAMS = '*'
+            hub.LOGS_LIMITER_DISABLED_FOR_TEAMS = ''
+            hub.LOGS_LIMITER_TEAM_BUCKET_SIZE_KB = ''
+            hub.LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND = ''
 
             redis = createRedisV2PoolFromConfig({
                 connection: hub.LOGS_REDIS_HOST


### PR DESCRIPTION
## Problem

Logs rate limiter service tests were being affected by local env variables and failing

## Changes

Added initialization of three missing configuration parameters in the logs rate limiter service test setup:
- `LOGS_LIMITER_DISABLED_FOR_TEAMS` set to empty string
- `LOGS_LIMITER_TEAM_BUCKET_SIZE_KB` set to empty string  
- `LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND` set to empty string

## How did you test this code?

running the tests

## Publish to changelog?

No