### PR TITLE
feat(experiments): Fire internal event on significance change

### DIFF
--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -10,6 +10,7 @@ import temporalio.activity
 
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
@@ -33,6 +34,62 @@ from posthog.temporal.experiments.utils import (
 from products.experiments.stats.shared.statistics import StatisticError
 
 logger = structlog.get_logger(__name__)
+
+
+def _check_significance_transition(
+    experiment: Experiment,
+    metric_uuid: str,
+    fingerprint: str,
+    result_dict: dict,
+    query_to_utc: datetime,
+) -> None:
+    try:
+        if not result_dict.get("significant"):
+            return
+
+        previous = (
+            ExperimentMetricResultModel.objects.filter(
+                experiment=experiment,
+                metric_uuid=metric_uuid,
+                fingerprint=fingerprint,
+                status=ExperimentMetricResultModel.Status.COMPLETED,
+                query_to__lt=query_to_utc,
+            )
+            .order_by("-query_to")
+            .first()
+        )
+
+        if previous and previous.result and previous.result.get("significant"):
+            return
+
+        experiment_url = f"/project/{experiment.team_id}/experiments/{experiment.id}"
+
+        logger.info(
+            "Producing internal event for experiment significance transition",
+            experiment_id=experiment.id,
+            metric_uuid=metric_uuid,
+        )
+
+        produce_internal_event(
+            team_id=experiment.team_id,
+            event=InternalEventEvent(
+                event="$experiment_significant",
+                distinct_id=f"team_{experiment.team_id}",
+                properties={
+                    "experiment_id": experiment.id,
+                    "experiment_name": experiment.name,
+                    "metric_uuid": metric_uuid,
+                    "significance_code": result_dict.get("significance_code"),
+                    "experiment_url": experiment_url,
+                },
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to check significance transition",
+            experiment_id=experiment.id,
+            metric_uuid=metric_uuid,
+        )
 
 
 @database_sync_to_async
@@ -205,6 +262,8 @@ def _calculate_experiment_regular_metric_sync(
                 "error_message": None,
             },
         )
+
+        _check_significance_transition(experiment, metric_uuid, fingerprint, result_dict, query_to_utc)
 
         logger.info(
             "Successfully calculated experiment metric",
@@ -452,6 +511,8 @@ def _calculate_experiment_saved_metric_sync(
                 "error_message": None,
             },
         )
+
+        _check_significance_transition(experiment, metric_uuid, fingerprint, result_dict, query_to_utc)
 
         logger.info(
             "Successfully calculated experiment saved metric",

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -73,7 +73,7 @@ def _check_significance_transition(
         produce_internal_event(
             team_id=experiment.team_id,
             event=InternalEventEvent(
-                event="$experiment_significant",
+                event="$experiment_metric_significant",
                 distinct_id=f"team_{experiment.team_id}",
                 properties={
                     "experiment_id": experiment.id,

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -85,8 +85,9 @@ def _check_significance_transition(
             ),
         )
     except Exception:
-        logger.exception(
-            "Failed to check significance transition",
+        # produce_internal_event already logs on failure; use warning to avoid duplicate tracebacks
+        logger.warning(
+            "Significance transition check failed, skipping notification",
             experiment_id=experiment.id,
             metric_uuid=metric_uuid,
         )

--- a/posthog/temporal/experiments/test_significance_transition.py
+++ b/posthog/temporal/experiments/test_significance_transition.py
@@ -85,7 +85,7 @@ class TestCheckSignificanceTransition(BaseTest):
             mock_produce.assert_called_once()
             call_kwargs = mock_produce.call_args
             event = call_kwargs.kwargs.get("event") or call_kwargs[1].get("event") or call_kwargs[0][1]
-            assert event.event == "$experiment_significant"
+            assert event.event == "$experiment_metric_significant"
             assert event.properties["experiment_id"] == experiment.id
             assert event.properties["experiment_name"] == "Test Experiment"
             assert event.properties["metric_uuid"] == metric_uuid

--- a/posthog/temporal/experiments/test_significance_transition.py
+++ b/posthog/temporal/experiments/test_significance_transition.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.models.experiment import Experiment, ExperimentMetricResult
+from posthog.models.feature_flag import FeatureFlag
+from posthog.temporal.experiments.activities import _check_significance_transition
+
+
+@pytest.mark.django_db
+class TestCheckSignificanceTransition(BaseTest):
+    def _create_experiment(self) -> Experiment:
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+        )
+        return Experiment.objects.create(
+            team=self.team,
+            name="Test Experiment",
+            feature_flag=flag,
+            start_date=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+        )
+
+    @parameterized.expand(
+        [
+            ("no_previous_significant", None, True, True),
+            ("no_previous_not_significant", None, False, False),
+            ("previous_not_significant_new_significant", False, True, True),
+            ("previous_significant_new_significant", True, True, False),
+            ("previous_failed_new_significant", "no_result", True, True),
+            ("previous_significant_new_not_significant", True, False, False),
+        ]
+    )
+    @patch("posthog.temporal.experiments.activities.produce_internal_event")
+    def test_significance_transition(
+        self,
+        _name: str,
+        previous_significant: object,
+        new_significant: bool,
+        expect_event: bool,
+        mock_produce: object,
+    ) -> None:
+        experiment = self._create_experiment()
+        metric_uuid = "metric-123"
+        fingerprint = "abc123"
+        query_to_utc = datetime(2024, 1, 10, tzinfo=ZoneInfo("UTC"))
+
+        if previous_significant is not None:
+            if previous_significant == "no_result":
+                # Previous result failed — no result dict
+                ExperimentMetricResult.objects.create(
+                    experiment=experiment,
+                    metric_uuid=metric_uuid,
+                    fingerprint=fingerprint,
+                    query_from=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                    query_to=query_to_utc - timedelta(days=1),
+                    status=ExperimentMetricResult.Status.FAILED,
+                    result=None,
+                )
+            else:
+                ExperimentMetricResult.objects.create(
+                    experiment=experiment,
+                    metric_uuid=metric_uuid,
+                    fingerprint=fingerprint,
+                    query_from=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                    query_to=query_to_utc - timedelta(days=1),
+                    status=ExperimentMetricResult.Status.COMPLETED,
+                    result={"significant": previous_significant, "significance_code": "significant"},
+                )
+
+        result_dict = {
+            "significant": new_significant,
+            "significance_code": "significant" if new_significant else "low_win_probability",
+        }
+
+        _check_significance_transition(experiment, metric_uuid, fingerprint, result_dict, query_to_utc)
+
+        if expect_event:
+            mock_produce.assert_called_once()
+            call_kwargs = mock_produce.call_args
+            event = call_kwargs.kwargs.get("event") or call_kwargs[1].get("event") or call_kwargs[0][1]
+            assert event.event == "$experiment_significant"
+            assert event.properties["experiment_id"] == experiment.id
+            assert event.properties["experiment_name"] == "Test Experiment"
+            assert event.properties["metric_uuid"] == metric_uuid
+            assert event.properties["experiment_url"] == f"/project/{self.team.pk}/experiments/{experiment.id}"
+        else:
+            mock_produce.assert_not_called()

--- a/posthog/temporal/experiments/test_significance_transition.py
+++ b/posthog/temporal/experiments/test_significance_transition.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -44,7 +44,7 @@ class TestCheckSignificanceTransition(BaseTest):
         previous_significant: object,
         new_significant: bool,
         expect_event: bool,
-        mock_produce: object,
+        mock_produce: MagicMock,
     ) -> None:
         experiment = self._create_experiment()
         metric_uuid = "metric-123"


### PR DESCRIPTION
## Problem

Users want a way to get notified when an experiment metric reaches significance.

## Changes

First PR in the notification series. Adds detection logic that fires a `$experiment_significant` internal event when a metric transitions from not-significant to significant during Temporal recalculation. Does nothing yet - a follow-up PR will wire up the notification delivery.

## How did you test this code?
- Parameterized unit tests covering all transition scenarios.