### PR TITLE
fix(llma): show input/output for trace and span events in person profile

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.tsx
@@ -21,10 +21,12 @@ export interface ConversationDisplayProps {
 export function ConversationDisplay({ eventProperties, eventId }: ConversationDisplayProps): JSX.Element {
     const { setupPlaygroundFromEvent } = useActions(llmPlaygroundPromptsLogic)
 
+    const rawInput = eventProperties.$ai_input ?? eventProperties.$ai_input_state
+    const rawOutput = eventProperties.$ai_output_choices ?? eventProperties.$ai_output_state
     const { input, output, isLoading } = useAIData({
         uuid: eventId,
-        input: eventProperties.$ai_input,
-        output: eventProperties.$ai_output_choices,
+        input: rawInput,
+        output: rawOutput,
     })
 
     const handleTryInPlayground = (): void => {


### PR DESCRIPTION
## Problem

`$ai_trace` and `$ai_span` events show "No input" / "No output" in the person profile events list, even though they contain valid data in `$ai_input_state` / `$ai_output_state`. `ConversationDisplay` only read `$ai_input` / `$ai_output_choices` (used by `$ai_generation` events).

## Changes

Fall back to `$ai_input_state` / `$ai_output_state` when `$ai_input` / `$ai_output_choices` are absent in `ConversationDisplay`. The state properties contain arbitrary JSON which `normalizeMessages` already handles via its fallback path (JSON.stringify).

## How did you test this code?

- Existing `ConversationDisplay` tests pass (47/47)
- Manual verification: expand a `$ai_trace` event in person profile and confirm the Conversation tab shows input/output content

## Publish to changelog?

no