### PR TITLE
fix: new messages sidebar support

### DIFF
--- a/products/conversations/backend/api/tests/test_cache.py
+++ b/products/conversations/backend/api/tests/test_cache.py
@@ -12,6 +12,7 @@ from products.conversations.backend.cache import (
     get_messages_cache_key,
     get_tickets_cache_key,
     get_unread_count_cache_key,
+    invalidate_messages_cache,
     invalidate_tickets_cache,
     invalidate_unread_count_cache,
     set_cached_messages,
@@ -85,6 +86,22 @@ class TestMessagesCacheOperations(TestCase):
 
         # Should not raise
         set_cached_messages(team_id=1, ticket_id="abc", response_data={})
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_messages_cache_deletes_key(self, mock_cache):
+        invalidate_messages_cache(team_id=1, ticket_id="abc-123")
+
+        mock_cache.delete.assert_called_once()
+        call_key = mock_cache.delete.call_args[0][0]
+        assert "messages" in call_key
+        assert "abc-123" in call_key
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_messages_cache_swallows_exception(self, mock_cache):
+        mock_cache.delete.side_effect = Exception("Redis error")
+
+        # Should not raise
+        invalidate_messages_cache(team_id=1, ticket_id="abc")
 
 
 class TestTicketsCacheOperations(TestCase):

--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -318,6 +318,20 @@ class TestTicketMessageSignals(BaseTest):
 
         mock_invalidate.assert_called_once_with(self.team.id, self.widget_session_id)
 
+    @patch("products.conversations.backend.signals.invalidate_messages_cache")
+    def test_message_invalidates_messages_cache(self, mock_invalidate, mock_on_commit):
+        """Sending a message should invalidate the widget messages cache."""
+        self._create_customer_message("Hello")
+
+        mock_invalidate.assert_called_once_with(self.team.id, str(self.ticket.id))
+
+    @patch("products.conversations.backend.signals.invalidate_messages_cache")
+    def test_private_message_does_not_invalidate_messages_cache(self, mock_invalidate, mock_on_commit):
+        """Private messages should not invalidate the messages cache."""
+        self._create_team_message("Private note", is_private=True)
+
+        mock_invalidate.assert_not_called()
+
     @patch("products.conversations.backend.signals.invalidate_tickets_cache")
     def test_private_message_does_not_invalidate_cache(self, mock_invalidate, mock_on_commit):
         """Private messages should not invalidate the cache (they don't affect widget display)."""

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -475,3 +475,25 @@ class TestWidgetCacheInvalidation(BaseTest):
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             mock_invalidate.assert_called_once_with(self.team.id)
+
+    def test_create_message_invalidates_messages_cache(self):
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=self.widget_session_id,
+            distinct_id=self.distinct_id,
+            channel_source="widget",
+        )
+
+        with patch("products.conversations.backend.api.widget.invalidate_messages_cache") as mock_invalidate:
+            response = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Follow up message",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                    "ticket_id": str(ticket.id),
+                },
+                **self._get_headers(),
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_invalidate.assert_called_once_with(self.team.id, str(ticket.id))

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -475,25 +475,3 @@ class TestWidgetCacheInvalidation(BaseTest):
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             mock_invalidate.assert_called_once_with(self.team.id)
-
-    def test_create_message_invalidates_messages_cache(self):
-        ticket = Ticket.objects.create_with_number(
-            team=self.team,
-            widget_session_id=self.widget_session_id,
-            distinct_id=self.distinct_id,
-            channel_source="widget",
-        )
-
-        with patch("products.conversations.backend.api.widget.invalidate_messages_cache") as mock_invalidate:
-            response = self.client.post(
-                "/api/conversations/v1/widget/message",
-                {
-                    "message": "Follow up message",
-                    "widget_session_id": self.widget_session_id,
-                    "distinct_id": self.distinct_id,
-                    "ticket_id": str(ticket.id),
-                },
-                **self._get_headers(),
-            )
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            mock_invalidate.assert_called_once_with(self.team.id, str(ticket.id))

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -39,7 +39,6 @@ from products.conversations.backend.api.serializers import (
 from products.conversations.backend.cache import (
     get_cached_messages,
     get_cached_tickets,
-    invalidate_messages_cache,
     invalidate_tickets_cache,
     invalidate_unread_count_cache,
     set_cached_messages,
@@ -176,10 +175,10 @@ class WidgetMessageView(APIView):
             item_context={"author_type": "customer", "distinct_id": distinct_id, "is_private": False},
         )
 
-        # Invalidate caches AFTER writing so concurrent reads don't re-cache stale data
+        # tickets + messages caches are invalidated by the post_save signal
+        # via transaction.on_commit (see signals.py). Only unread_count needs
+        # explicit invalidation here since the signal doesn't cover it.
         invalidate_unread_count_cache(team.id)
-        invalidate_tickets_cache(team.id, widget_session_id)
-        invalidate_messages_cache(team.id, str(ticket.id))
 
         # Send email notification for new tickets
         if not ticket_id:

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -39,6 +39,7 @@ from products.conversations.backend.api.serializers import (
 from products.conversations.backend.cache import (
     get_cached_messages,
     get_cached_tickets,
+    invalidate_messages_cache,
     invalidate_tickets_cache,
     invalidate_unread_count_cache,
     set_cached_messages,
@@ -166,10 +167,6 @@ class WidgetMessageView(APIView):
             except Exception as e:
                 capture_exception(e, {"ticket_id": str(ticket.id)})
 
-        # Invalidate caches
-        invalidate_unread_count_cache(team.id)
-        invalidate_tickets_cache(team.id, widget_session_id)
-
         # Create message
         comment = Comment.objects.create(
             team=team,
@@ -178,6 +175,11 @@ class WidgetMessageView(APIView):
             content=message_content,
             item_context={"author_type": "customer", "distinct_id": distinct_id, "is_private": False},
         )
+
+        # Invalidate caches AFTER writing so concurrent reads don't re-cache stale data
+        invalidate_unread_count_cache(team.id)
+        invalidate_tickets_cache(team.id, widget_session_id)
+        invalidate_messages_cache(team.id, str(ticket.id))
 
         # Send email notification for new tickets
         if not ticket_id:

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -118,6 +118,15 @@ def invalidate_unread_count_cache(team_id: int) -> None:
         logger.warning("conversations_cache_delete_error", key=key)
 
 
+def invalidate_messages_cache(team_id: int, ticket_id: str) -> None:
+    """Invalidate all messages cache entries for a ticket (initial load + any after= variants)."""
+    key = get_messages_cache_key(team_id, ticket_id, None)
+    try:
+        cache.delete(key)
+    except Exception:
+        logger.warning("conversations_cache_delete_error", key=key)
+
+
 def invalidate_tickets_cache(team_id: int, widget_session_id: str) -> None:
     """Invalidate tickets list cache for a widget session (no status filter)."""
     key = get_tickets_cache_key(team_id, widget_session_id, None)

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -119,7 +119,7 @@ def invalidate_unread_count_cache(team_id: int) -> None:
 
 
 def invalidate_messages_cache(team_id: int, ticket_id: str) -> None:
-    """Invalidate all messages cache entries for a ticket (initial load + any after= variants)."""
+    """Invalidate the initial-load messages cache entry for a ticket (after=None). Polling entries (after=<ts>) expire via TTL."""
     key = get_messages_cache_key(team_id, ticket_id, None)
     try:
         cache.delete(key)

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -13,7 +13,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models import User
 from posthog.models.comment import Comment
 
-from .cache import invalidate_tickets_cache
+from .cache import invalidate_messages_cache, invalidate_tickets_cache
 from .events import capture_message_received, capture_message_sent
 from .models import Ticket
 from .models.constants import Channel
@@ -88,9 +88,10 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
         # Emit analytics events and invalidate cache
         try:
             ticket = Ticket.objects.select_related("team").get(id=item_id, team_id=team_id)
-            # Invalidate widget tickets cache so list shows updated last_message
+            # Invalidate widget caches so list and messages reflect the new message
             if ticket.widget_session_id:
                 invalidate_tickets_cache(team_id, ticket.widget_session_id)
+            invalidate_messages_cache(team_id, item_id)
 
             # Customer-facing analytics (to customer's project)
             if is_team_message:


### PR DESCRIPTION
## Problem

In sidebar support tickets when you send a message it does not appear until you refresh or wait for 15 seconds.

## Changes

Invalidate tickets cache on the new message.
