### PR TITLE
fix(experiments): shift status reads to explicit field

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -7,9 +7,10 @@ import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { humanFriendlyNumber } from 'lib/utils'
 
-import { Experiment, InsightType } from '~/types'
+import { Experiment, ExperimentProgressStatus, InsightType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
+import { getExperimentStatus } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { formatUnitByQuantity } from '../utils'
 import { EllipsisAnimation } from './components'
@@ -70,6 +71,7 @@ export function DataCollection(): JSX.Element {
             : (actualRunningTime / recommendedRunningTime) * 100
 
     const hasHighRunningTime = recommendedRunningTime > 62
+    const hasEnded = getExperimentStatus(experiment) === ExperimentProgressStatus.Complete
 
     return (
         <div>
@@ -160,7 +162,7 @@ export function DataCollection(): JSX.Element {
                             <IconInfo className="text-secondary text-base" />
                         </Tooltip>
                     </div>
-                    {!experiment.end_date && (
+                    {!hasEnded && (
                         <div className="w-24">
                             <LemonButton
                                 className="mt-2"

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
@@ -13,6 +13,7 @@ import { ExperimentIdType, InsightType } from '~/types'
 
 import { MetricInsightId } from '../constants'
 import { experimentLogic } from '../experimentLogic'
+import { isLaunched } from '../experimentsLogic'
 import { minimumSampleSizePerVariant, recommendedExposureForCountData } from '../legacyExperimentCalculations'
 
 interface ExperimentCalculatorProps {
@@ -36,7 +37,7 @@ function FunnelCalculation({ experimentId }: ExperimentCalculatorProps): JSX.Ele
 
     return (
         <div className="flex flex-wrap">
-            {!experiment?.start_date && (
+            {!isLaunched(experiment) && (
                 <>
                     <div className="mb-4 w-1/2">
                         <div className="card-secondary">Baseline Conversion Rate</div>
@@ -54,7 +55,7 @@ function FunnelCalculation({ experimentId }: ExperimentCalculatorProps): JSX.Ele
                     <span className="l4">~{recommendedSampleSize}</span> persons
                 </div>
             </div>
-            {!experiment?.start_date && (
+            {!isLaunched(experiment) && (
                 <div className="w-1/2">
                     <div className="card-secondary">Recommended running time</div>
                     <div>
@@ -81,7 +82,7 @@ function TrendCalculation({ experimentId }: ExperimentCalculatorProps): JSX.Elem
 
     return (
         <div className="flex flex-wrap">
-            {!experiment?.start_date && (
+            {!isLaunched(experiment) && (
                 <>
                     <div className="mb-4 w-1/2">
                         <div className="card-secondary">Baseline Count</div>

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -211,7 +211,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                                     isExperimentDraft={isExperimentDraft}
                                 />
                             )}
-                            {experiment.start_date && (
+                            {status !== ExperimentProgressStatus.Draft && (
                                 <ExperimentReloadAction
                                     isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
                                     lastRefresh={lastRefresh}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -456,7 +456,7 @@ export function PageHeaderCustom(): JSX.Element {
 
                         <LemonDivider />
 
-                        {!experiment.end_date &&
+                        {isExperimentRunning &&
                             experiment.feature_flag &&
                             (experiment.feature_flag.active ? (
                                 <ButtonPrimitive

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -352,8 +352,7 @@ const ExperimentsTable = ({
                                     }}
                                 />
                                 {!experiment.archived &&
-                                    experiment?.end_date &&
-                                    dayjs().isSameOrAfter(dayjs(experiment.end_date), 'day') && (
+                                    getExperimentStatus(experiment) === ExperimentProgressStatus.Complete && (
                                         <AccessControlAction
                                             resourceType={AccessControlResourceType.Experiment}
                                             minAccessLevel={AccessControlLevel.Editor}

--- a/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/DeltaChart.tsx
@@ -11,6 +11,7 @@ import { Experiment, FunnelExperimentVariant, InsightType, TrendExperimentVarian
 
 import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS, EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS } from '../../constants'
 import { experimentLogic } from '../../experimentLogic'
+import { isLaunched } from '../../experimentsLogic'
 import { VariantTag } from '../../ExperimentView/components'
 import {
     calculateDelta,
@@ -463,7 +464,7 @@ function DeltaChartContent({ chartSvgRef }: { chartSvgRef: React.RefObject<SVGSV
         <div className="relative w-full max-w-screen">
             <ChartEmptyState
                 height={chartHeight}
-                experimentStarted={!!experiment.start_date}
+                experimentStarted={isLaunched(experiment)}
                 metric={metric}
                 error={error}
             />

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -23,6 +23,7 @@ import { NodeKind } from '~/queries/schema/schema-general'
 import { Experiment, InsightType } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
+import { isLaunched } from '../../experimentsLogic'
 import { useColumnWidthSync } from '../hooks/useColumnWidthSync'
 import { ChartEmptyState } from '../shared/ChartEmptyState'
 import { ChartLoadingState } from '../shared/ChartLoadingState'
@@ -229,7 +230,7 @@ function CollapsibleBreakdownSection({
                                                                 ) : (
                                                                     <ChartEmptyState
                                                                         height={CELL_HEIGHT}
-                                                                        experimentStarted={!!experiment.start_date}
+                                                                        experimentStarted={isLaunched(experiment)}
                                                                         metric={metric}
                                                                         query={query}
                                                                         onRetry={onRetry}
@@ -674,7 +675,7 @@ export function MetricRowGroup({
                         ) : (
                             <ChartEmptyState
                                 height={noResultHeight}
-                                experimentStarted={!!experiment.start_date}
+                                experimentStarted={isLaunched(experiment)}
                                 metric={metric}
                                 error={error}
                                 query={debugQuery}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -9,6 +9,7 @@ import {
 import { ExperimentStatsMethod, InsightType } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
+import { isLaunched } from '../../experimentsLogic'
 import { type ExperimentVariantResult, getVariantInterval } from '../shared/utils'
 import { MAX_AXIS_RANGE } from './constants'
 import { MetricRowGroup } from './MetricRowGroup'
@@ -99,7 +100,7 @@ export function MetricsTable({
                         const error = errors[index]
                         const metricIndex = metricIndexes[index]
 
-                        const isLoading = !result && !error && !!experiment.start_date
+                        const isLoading = !result && !error && isLaunched(experiment)
 
                         return (
                             <MetricRowGroup

--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -12,6 +12,7 @@ import { urls } from 'scenes/urls'
 import { ExperimentMetric, isExperimentRatioMetric } from '~/queries/schema/schema-general'
 import type { Experiment } from '~/types'
 
+import { hasEnded, isLaunched } from '../../experimentsLogic'
 import { experimentTimeseriesLogic } from '../../experimentTimeseriesLogic'
 import { VariantTag } from '../../ExperimentView/components'
 import { MetricTitle } from '../shared/MetricTitle'
@@ -44,9 +45,9 @@ export function TimeseriesModal({
     }, [chartData, variantResult.key])
 
     const isStaleExperiment =
-        !experiment.start_date || experiment.end_date
-            ? false
-            : dayjs(experiment.start_date).isBefore(dayjs().subtract(30, 'days'))
+        isLaunched(experiment) && !hasEnded(experiment)
+            ? dayjs(experiment.start_date).isBefore(dayjs().subtract(30, 'days'))
+            : false
 
     const handleRecalculate = (): void => {
         LemonDialog.open({

--- a/frontend/src/scenes/experiments/RunningTimeCalculatorNew/RunningTimeConfigModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculatorNew/RunningTimeConfigModal.tsx
@@ -8,6 +8,7 @@ import { Label } from 'lib/ui/Label/Label'
 
 import { Experiment } from '~/types'
 
+import { isLaunched } from '../experimentsLogic'
 import { ManualCalculatorMetricType } from './calculations'
 import { runningTimeLogic } from './runningTimeLogic'
 
@@ -58,7 +59,7 @@ export function RunningTimeConfigModal({ experimentId, tabId }: RunningTimeConfi
     const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId, tabId }))
 
     const hasAutomaticData = remainingDays !== null
-    const isPreLaunch = !experiment?.start_date
+    const isPreLaunch = !isLaunched(experiment)
 
     return (
         <LemonModal isOpen={isRunningTimeConfigModalOpen} onClose={cancel} width={480} simple>

--- a/frontend/src/scenes/experiments/RunningTimeCalculatorNew/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculatorNew/runningTimeLogic.ts
@@ -6,6 +6,7 @@ import api from 'lib/api'
 import { ConversionRateInputType, Experiment } from '~/types'
 
 import { DEFAULT_MDE, experimentLogic } from '../experimentLogic'
+import { isLaunched } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import {
     ManualCalculatorMetricType,
@@ -86,7 +87,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
             (s) => [s.experiment, s.isManualMode],
             (experiment, isManualMode): RunningTimeConfig => {
                 // Pre-launch experiments must use manual mode (no data available for automatic)
-                const isPreLaunch = !experiment?.start_date
+                const isPreLaunch = !isLaunched(experiment)
                 return {
                     mode: isPreLaunch || isManualMode ? 'manual' : 'automatic',
                     mde: experiment?.parameters?.minimum_detectable_effect ?? DEFAULT_MDE,
@@ -219,7 +220,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
         persistRunningTimeEstimate: async () => {
             const { isManualMode, remainingDays, targetSampleSize, experiment, currentProjectId } = values
 
-            if (isManualMode || !experiment?.start_date || remainingDays === null || targetSampleSize === null) {
+            if (isManualMode || !isLaunched(experiment) || remainingDays === null || targetSampleSize === null) {
                 return
             }
 

--- a/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeExperimentButton.tsx
@@ -12,6 +12,7 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { experimentLogic } from '../experimentLogic'
+import { isLaunched } from '../experimentsLogic'
 
 /**
  * Minimal context sent to the backend for experiment summarization.
@@ -52,9 +53,9 @@ function useExperimentSummaryMaxTool(): ReturnType<typeof useMaxTool> {
 
     const shouldShowMaxSummaryTool = useMemo(() => {
         const hasResults = orderedPrimaryMetricsWithResults.length > 0
-        const hasStarted = !!experiment.start_date
+        const hasStarted = isLaunched(experiment)
         return hasResults && hasStarted
-    }, [orderedPrimaryMetricsWithResults, experiment.start_date])
+    }, [orderedPrimaryMetricsWithResults, experiment.status, experiment.start_date, experiment.end_date])
 
     const maxToolResult = useMaxTool({
         identifier: 'experiment_results_summary',

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1367,8 +1367,8 @@ export const experimentLogic = kea<experimentLogicType>([
             const duration = experiment?.start_date ? dayjs().diff(experiment.start_date, 'second') : null
             experiment && actions.reportExperimentViewed(experiment, duration)
 
-            // Load metrics for running experiments (will set up auto-refresh after load completes)
-            if (experiment?.start_date) {
+            // Load metrics for launched experiments (will set up auto-refresh after load completes)
+            if (experiment && isLaunched(experiment)) {
                 actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual')
             }
         },
@@ -1482,7 +1482,12 @@ export const experimentLogic = kea<experimentLogicType>([
 
                 // Only set up auto-refresh if enabled AND page is visible
                 // This prevents the interval from restarting when async operations complete after the page becomes invisible
-                if (values.autoRefresh.enabled && values.experiment?.start_date && values.isPageVisible) {
+                if (
+                    values.experiment &&
+                    values.autoRefresh.enabled &&
+                    isLaunched(values.experiment) &&
+                    values.isPageVisible
+                ) {
                     actions.resetAutoRefreshInterval()
                 }
             }
@@ -1527,8 +1532,8 @@ export const experimentLogic = kea<experimentLogicType>([
         },
         updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)
-            if (experiment.start_date) {
-                // For running experiments, refresh results if any of these fields are updated
+            if (isLaunched(experiment)) {
+                // For launched experiments, refresh results if any of these fields are updated
                 const forceRefresh =
                     payload?.start_date !== undefined ||
                     payload?.end_date !== undefined ||
@@ -1832,8 +1837,8 @@ export const experimentLogic = kea<experimentLogicType>([
 
             actions.setPrimaryMetricsResultsLoading(false)
 
-            // Mark the review results task as complete when results are loaded for a running experiment
-            if (values.experiment?.start_date) {
+            // Mark the review results task as complete when results are loaded for a launched experiment
+            if (values.experiment && isLaunched(values.experiment)) {
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.ReviewExperimentResults)
             }
         },
@@ -2218,13 +2223,13 @@ export const experimentLogic = kea<experimentLogicType>([
         isExperimentDraft: [
             (s) => [s.experiment],
             (experiment): boolean => {
-                return !experiment?.start_date && !experiment?.end_date && !experiment?.archived
+                return !!experiment && !isLaunched(experiment) && !experiment.archived
             },
         ],
         isExperimentLaunched: [
             (s) => [s.experiment],
             (experiment): boolean => {
-                return !!experiment?.start_date
+                return !!experiment && isLaunched(experiment)
             },
         ],
         isExperimentRunning: [

--- a/frontend/src/scenes/experiments/experimentsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.test.ts
@@ -6,7 +6,7 @@ import { expectLogic } from 'kea-test-utils'
 import { NEW_FLAG } from 'scenes/feature-flags/featureFlagLogic'
 
 import { initKeaTests } from '~/test/init'
-import { Experiment, ExperimentProgressStatus, FeatureFlagType } from '~/types'
+import { Experiment, ExperimentProgressStatus, ExperimentStatus, FeatureFlagType } from '~/types'
 
 import { experimentsLogic, getExperimentStatus, getExperimentStatusColor, hasEnded } from './experimentsLogic'
 
@@ -17,6 +17,7 @@ const createMockExperiment = (overrides: any = {}): Experiment =>
         feature_flag_key: 'test-experiment',
         start_date: '2023-01-01T00:00:00Z',
         end_date: '2023-01-07T00:00:00Z',
+        status: ExperimentStatus.Stopped,
         archived: false,
         ...overrides,
     }) as Experiment
@@ -28,6 +29,7 @@ const mockRunningExperiment = createMockExperiment({
     name: 'Running Experiment',
     start_date: '2023-01-01T00:00:00Z',
     end_date: null,
+    status: ExperimentStatus.Running,
 })
 
 const mockDraftExperiment = createMockExperiment({
@@ -35,6 +37,7 @@ const mockDraftExperiment = createMockExperiment({
     name: 'Draft Experiment',
     start_date: null,
     end_date: null,
+    status: ExperimentStatus.Draft,
 })
 
 const mkFlag = (id: number, key: string): FeatureFlagType => ({ ...NEW_FLAG, id, key })
@@ -403,6 +406,7 @@ describe('utility functions', () => {
             const pausedExperiment = createMockExperiment({
                 start_date: '2024-01-01',
                 end_date: null,
+                status: ExperimentStatus.Running,
                 feature_flag: { active: false },
             })
             expect(getExperimentStatus(pausedExperiment)).toBe(ExperimentProgressStatus.Paused)
@@ -412,6 +416,7 @@ describe('utility functions', () => {
             const runningExperiment = createMockExperiment({
                 start_date: '2024-01-01',
                 end_date: null,
+                status: ExperimentStatus.Running,
                 feature_flag: { active: true },
             })
             expect(getExperimentStatus(runningExperiment)).toBe(ExperimentProgressStatus.Running)
@@ -429,23 +434,17 @@ describe('utility functions', () => {
 
     describe('hasEnded', () => {
         it.each([
-            { end_date: null, expected: false, desc: 'no end date' },
-            { end_date: undefined, expected: false, desc: 'undefined end date' },
-            { end_date: '2020-01-01T00:00:00Z', expected: true, desc: 'end date in the past' },
+            { status: ExperimentStatus.Running, expected: false, desc: 'running experiment' },
+            { status: ExperimentStatus.Draft, expected: false, desc: 'draft experiment' },
+            { status: ExperimentStatus.Stopped, expected: true, desc: 'stopped experiment' },
             {
                 end_date: '2099-01-01T00:00:00Z',
-                expected: false,
-                desc: 'end date in the future (not possible yet, but just to cover it already)',
-            },
-            {
-                end_date: '2020-01-01T00:00:00Z',
-                archived: true,
+                status: undefined,
                 expected: true,
-                desc: 'archived with end date in the past',
+                desc: 'legacy fallback still treats any saved end date as stopped',
             },
-            { end_date: null, archived: true, expected: false, desc: 'archived without end date' },
-        ])('returns $expected when $desc', ({ end_date, archived, expected }) => {
-            expect(hasEnded(createMockExperiment({ end_date, archived }))).toBe(expected)
+        ])('returns $expected when $desc', ({ end_date, status, expected }) => {
+            expect(hasEnded(createMockExperiment({ end_date, status }))).toBe(expected)
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -6,7 +6,6 @@ import { LemonTagType, PaginationManual } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual, toParams } from 'lib/utils'
@@ -22,6 +21,7 @@ import {
     Breadcrumb,
     Experiment,
     ExperimentProgressStatus,
+    ExperimentStatus,
     ExperimentVelocityStats,
     ExperimentsTabs,
     FeatureFlagType,
@@ -72,25 +72,51 @@ const DEFAULT_MODAL_FILTERS: FeatureFlagModalFilters = {
     evaluation_runtime: undefined,
 }
 
-export function isLaunched(experiment: Experiment): boolean {
-    return !!experiment?.start_date
+type StoredExperimentStatusInput = Pick<Experiment, 'status' | 'start_date' | 'end_date'> | null | undefined
+
+export function getStoredExperimentStatus(experiment: StoredExperimentStatusInput): ExperimentStatus {
+    if (!experiment) {
+        return ExperimentStatus.Draft
+    }
+
+    if (experiment.status) {
+        return experiment.status
+    }
+
+    // Fallback for stale fixtures and older mocked data during the transition.
+    if (experiment.end_date) {
+        return ExperimentStatus.Stopped
+    }
+    if (experiment.start_date) {
+        return ExperimentStatus.Running
+    }
+    return ExperimentStatus.Draft
 }
 
-export function hasEnded(experiment: Experiment): boolean {
-    return !!experiment?.end_date && dayjs().isSameOrAfter(dayjs(experiment.end_date), 'day')
+export function isLaunched(experiment: StoredExperimentStatusInput): boolean {
+    return getStoredExperimentStatus(experiment) !== ExperimentStatus.Draft
 }
 
-export function getExperimentStatus(experiment: Experiment): ExperimentProgressStatus {
-    if (!isLaunched(experiment)) {
+export function hasEnded(experiment: StoredExperimentStatusInput): boolean {
+    return getStoredExperimentStatus(experiment) === ExperimentStatus.Stopped
+}
+
+export function getExperimentStatus(experiment: Experiment | null | undefined): ExperimentProgressStatus {
+    const status = getStoredExperimentStatus(experiment)
+
+    if (status === ExperimentStatus.Draft) {
         return ExperimentProgressStatus.Draft
-    } else if (!hasEnded(experiment)) {
+    }
+
+    if (status === ExperimentStatus.Running) {
         // When the feature flag is disabled, we show "Paused" to the user for better UX.
         // This is just a virtual status, the backend still considers the experiment "running".
-        if (experiment.feature_flag && !experiment.feature_flag.active) {
+        if (experiment?.feature_flag && !experiment.feature_flag.active) {
             return ExperimentProgressStatus.Paused
         }
         return ExperimentProgressStatus.Running
     }
+
     return ExperimentProgressStatus.Complete
 }
 

--- a/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
+++ b/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
@@ -7,6 +7,7 @@ import { useMaxTool } from 'scenes/max/useMaxTool'
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 
 import { experimentLogic } from '../experimentLogic'
+import { isLaunched } from '../experimentsLogic'
 
 /**
  * Minimal context sent to the backend for session replay summarization.
@@ -31,9 +32,9 @@ export const useSessionReplaySummaryMaxTool = (): ReturnType<typeof useMaxTool> 
     const resultsCount = orderedPrimaryMetricsWithResults.length
     const shouldShowButton = useMemo(() => {
         const hasResults = resultsCount > 0
-        const hasStarted = !!experiment.start_date
+        const hasStarted = isLaunched(experiment)
         return hasResults && hasStarted
-    }, [resultsCount, experiment.start_date])
+    }, [resultsCount, experiment.status, experiment.start_date, experiment.end_date])
 
     const maxToolResult = useMaxTool({
         identifier: 'experiment_session_replays_summary',

--- a/frontend/src/scenes/experiments/legacy/LegacyExperimentInfo.tsx
+++ b/frontend/src/scenes/experiments/legacy/LegacyExperimentInfo.tsx
@@ -188,7 +188,7 @@ export function LegacyExperimentInfo(): JSX.Element | null {
 
                 <div className="flex flex-col">
                     <div className="inline-flex deprecated-space-x-8">
-                        {experiment.start_date && (
+                        {status !== ExperimentProgressStatus.Draft && (
                             <ExperimentLastRefresh
                                 isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
                                 lastRefresh={lastRefresh}

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -4,6 +4,7 @@ import { subscriptions } from 'kea-subscriptions'
 
 import { EXPERIMENT_TARGET_SELECTOR } from 'lib/actionUtils'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { isLaunched } from 'scenes/experiments/experimentsLogic'
 import { urls } from 'scenes/urls'
 
 import { percentageDistribution } from '~/scenes/experiments/utils'
@@ -237,7 +238,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 1. The experiment is still in draft form
                 2. there's more than one test variant, and the variant is not control*/
                 return (
-                    experimentForm.start_date == null &&
+                    !isLaunched(experimentForm as Experiment) &&
                     experimentForm.variants &&
                     Object.keys(experimentForm.variants).length > 2
                 )
@@ -248,7 +249,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             (experimentForm: WebExperimentForm): boolean | undefined => {
                 /*Only show the add button if all of these conditions are met:
                 1. The experiment is still in draft form*/
-                return experimentForm.start_date == null
+                return !isLaunched(experimentForm as Experiment)
             },
         ],
         selectedExperiment: [

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -238,7 +238,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 1. The experiment is still in draft form
                 2. there's more than one test variant, and the variant is not control*/
                 return (
-                    !isLaunched(experimentForm as Experiment) &&
+                    !isLaunched(experimentForm) &&
                     experimentForm.variants &&
                     Object.keys(experimentForm.variants).length > 2
                 )
@@ -249,7 +249,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             (experimentForm: WebExperimentForm): boolean | undefined => {
                 /*Only show the add button if all of these conditions are met:
                 1. The experiment is still in draft form*/
-                return !isLaunched(experimentForm as Experiment)
+                return !isLaunched(experimentForm)
             },
         ],
         selectedExperiment: [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -903,6 +903,12 @@ export enum ExperimentProgressStatus {
     Complete = 'complete',
 }
 
+export enum ExperimentStatus {
+    Draft = 'draft',
+    Running = 'running',
+    Stopped = 'stopped',
+}
+
 export enum PropertyFilterType {
     /** Event metadata and fields on the clickhouse events table */
     Meta = 'meta',
@@ -4344,6 +4350,7 @@ export interface Experiment {
     }
     start_date?: string | null
     end_date?: string | null
+    status?: ExperimentStatus | null
     archived?: boolean
     secondary_metrics: SecondaryExperimentMetric[]
     created_at: string | null

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -15,7 +15,7 @@ from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import get_token
 from posthog.exceptions import generate_exception_response
-from posthog.models import Team, WebExperiment
+from posthog.models import Experiment, Team, WebExperiment
 from posthog.utils_cors import cors_response
 
 
@@ -302,7 +302,7 @@ def web_experiments(request: Request):
             WebExperiment.objects.filter(team_id=team.id)
             .exclude(archived=True)
             .exclude(deleted=True)
-            .exclude(end_date__isnull=False)
+            .filter(status__in=[Experiment.Status.DRAFT, Experiment.Status.RUNNING])
             .select_related("feature_flag", "created_by")
             .order_by("-created_at"),
             many=True,

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -122,7 +122,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
 
     @property
     def is_draft(self):
-        return not self.start_date
+        return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.DRAFT
 
     @classmethod
     def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Experiment"]:

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -106,7 +106,9 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
 
     def has_activated_experiments(self) -> bool:
         # the team has any launched experiments
-        return Experiment.objects.filter(team=self.team, start_date__isnull=False).exists()
+        return Experiment.objects.filter(
+            team=self.team, status__in=[Experiment.Status.RUNNING, Experiment.Status.STOPPED]
+        ).exists()
 
     def has_activated_error_tracking(self) -> bool:
         # the team has resolved any issues

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -53,9 +53,8 @@ def _get_experiment_regular_metrics_for_hour_sync(hour: int) -> list[ExperimentR
         time_filter,
         deleted=False,
         scheduling_config__timeseries=True,
-        start_date__isnull=False,
+        status=Experiment.Status.RUNNING,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
-        end_date__isnull=True,
     ).exclude(
         Q(metrics__isnull=True) | Q(metrics=[]),
         Q(metrics_secondary__isnull=True) | Q(metrics_secondary=[]),
@@ -302,9 +301,8 @@ def _get_experiment_saved_metrics_for_hour_sync(hour: int) -> list[ExperimentSav
         time_filter,
         deleted=False,
         scheduling_config__timeseries=True,
-        start_date__isnull=False,
+        status=Experiment.Status.RUNNING,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
-        end_date__isnull=True,
     ).prefetch_related("experimenttosavedmetric_set__saved_metric")
 
     for experiment in experiments:

--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -180,8 +180,10 @@ class ExperimentSummaryDataService:
         except Experiment.DoesNotExist:
             raise ValueError(f"Experiment {experiment_id} not found or access denied")
 
-        if not experiment.start_date:
+        if experiment.is_draft:
             raise ValueError(f"Experiment {experiment_id} has not been started yet")
+        if not experiment.start_date:
+            raise ValueError(f"Experiment {experiment_id} has no start date")
 
         feature_flag = experiment.feature_flag
         if not feature_flag:

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -442,13 +442,15 @@ class SessionReplaySummaryTool(MaxTool):
 
             experiment = await get_experiment()
 
-            if not experiment.start_date:
+            if experiment.is_draft:
                 output = SessionReplaySummaryOutput(
                     experiment_id=experiment_id,
                     experiment_name=experiment.name,
                     error="not_started",
                 )
                 return "❌ Experiment has not started yet. No session replays available.", output.model_dump()
+            if not experiment.start_date:
+                raise ValueError(f"Experiment {experiment_id} has no start date")
 
             # Get variants from feature flag
             feature_flag = experiment.feature_flag

--- a/products/experiments/dags/utils.py
+++ b/products/experiments/dags/utils.py
@@ -88,9 +88,8 @@ def schedule_experiment_metric_partitions(
             Experiment.objects.filter(
                 deleted=False,
                 scheduling_config__timeseries=True,
-                start_date__isnull=False,
+                status=Experiment.Status.RUNNING,
                 start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
-                end_date__isnull=True,
                 team__in=Team.objects.filter(time_filter),
             ).values_list("id", flat=True)
         )


### PR DESCRIPTION
## Problem
As part of the broader transition away from inferring experiment state from `start_date` and `end_date`, status reads still derive launched/completed state from those date fields across the codebase.

## Changes
- shift experiment status reads from date inference to the explicit `status` field
- update the shared frontend status logic so experiment flows read from the same source of truth
- keep a narrow fallback for stale mocks and fixtures during the transition

Note to the reviewer:
* there still is a type `ExperimentProgressStatus` that now can be removed. I will do that in a follow-up PR

## Testing
- Tested locally
- CI passes