### PR TITLE
feat(experiments): Let distribution modal use same UI as the wizard (and cleanup code)

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.test.tsx
@@ -1,0 +1,255 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, type RenderResult, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import {
+    computeUpdatedVariantSplit,
+    distributeVariantsEvenly,
+    VariantDistributionEditor,
+} from './VariantDistributionEditor'
+
+// Mock JSONEditorInput since it uses Monaco editor which doesn't work in Jest
+jest.mock('scenes/feature-flags/JSONEditorInput', () => ({
+    JSONEditorInput: ({ onChange, value, placeholder, readOnly }: any) => (
+        <input
+            data-testid="json-editor-mock"
+            value={value || ''}
+            onChange={(e) => onChange?.(e.target.value)}
+            placeholder={placeholder}
+            readOnly={readOnly}
+        />
+    ),
+}))
+
+describe('VariantDistributionEditor', () => {
+    describe('computeUpdatedVariantSplit', () => {
+        it.each([
+            { value: 70, expectedControl: 70, expectedTest: 30 },
+            { value: 0, expectedControl: 0, expectedTest: 100 },
+            { value: 100, expectedControl: 100, expectedTest: 0 },
+        ])(
+            'auto-completes other variant to $expectedTest% when first is set to $expectedControl% with 2 variants',
+            ({ value, expectedControl, expectedTest }) => {
+                const variants = [
+                    { key: 'control', rollout_percentage: 50 },
+                    { key: 'test', rollout_percentage: 50 },
+                ]
+                const result = computeUpdatedVariantSplit(variants, 0, value)
+                expect(result[0].rollout_percentage).toBe(expectedControl)
+                expect(result[1].rollout_percentage).toBe(expectedTest)
+            }
+        )
+
+        it('does not auto-complete other variants with 3+ variants', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 34 },
+                { key: 'test', rollout_percentage: 33 },
+                { key: 'test-2', rollout_percentage: 33 },
+            ]
+            const result = computeUpdatedVariantSplit(variants, 0, 10)
+            expect(result[0].rollout_percentage).toBe(10)
+            expect(result[1].rollout_percentage).toBe(33)
+            expect(result[2].rollout_percentage).toBe(33)
+        })
+
+        it('caps value to 0-100 range', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 50 },
+                { key: 'test', rollout_percentage: 50 },
+            ]
+            expect(computeUpdatedVariantSplit(variants, 0, 150)[0].rollout_percentage).toBe(100)
+            expect(computeUpdatedVariantSplit(variants, 0, -10)[0].rollout_percentage).toBe(0)
+        })
+
+        it('does not mutate the original array', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 50 },
+                { key: 'test', rollout_percentage: 50 },
+            ]
+            const result = computeUpdatedVariantSplit(variants, 0, 70)
+            expect(variants[0].rollout_percentage).toBe(50)
+            expect(result).not.toBe(variants)
+        })
+    })
+
+    describe('distributeVariantsEvenly', () => {
+        it('distributes evenly for 2 variants', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 0 },
+                { key: 'test', rollout_percentage: 0 },
+            ]
+            const result = distributeVariantsEvenly(variants)
+            expect(result[0].rollout_percentage).toBe(50)
+            expect(result[1].rollout_percentage).toBe(50)
+        })
+
+        it('distributes with remainder for 3 variants', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 0 },
+                { key: 'test', rollout_percentage: 0 },
+                { key: 'test-2', rollout_percentage: 0 },
+            ]
+            const result = distributeVariantsEvenly(variants)
+            const sum = result.reduce((s, v) => s + v.rollout_percentage, 0)
+            expect(sum).toBe(100)
+            // First variant gets the extra 1%
+            expect(result[0].rollout_percentage).toBe(34)
+            expect(result[1].rollout_percentage).toBe(33)
+            expect(result[2].rollout_percentage).toBe(33)
+        })
+
+        it('does not mutate the original array', () => {
+            const variants = [
+                { key: 'control', rollout_percentage: 0 },
+                { key: 'test', rollout_percentage: 0 },
+            ]
+            const result = distributeVariantsEvenly(variants)
+            expect(variants[0].rollout_percentage).toBe(0)
+            expect(result).not.toBe(variants)
+        })
+    })
+
+    describe('component', () => {
+        const mockOnVariantsChange = jest.fn()
+
+        const defaultVariants = [
+            { key: 'control', rollout_percentage: 50 },
+            { key: 'test', rollout_percentage: 50 },
+        ]
+
+        const renderEditor = (variants = defaultVariants, rolloutPercentage = 100): RenderResult => {
+            return render(
+                <VariantDistributionEditor
+                    variants={variants}
+                    onVariantsChange={mockOnVariantsChange}
+                    rolloutPercentage={rolloutPercentage}
+                />
+            )
+        }
+
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/projects/@current/feature_flags/': () => [200, { results: [], count: 0 }],
+                    '/api/projects/@current/experiments': () => [200, { results: [], count: 0 }],
+                },
+            })
+            initKeaTests()
+            jest.clearAllMocks()
+        })
+
+        afterEach(() => {
+            cleanup()
+        })
+
+        it('renders variant keys and split inputs', () => {
+            renderEditor()
+            expect(screen.getByText('control')).toBeInTheDocument()
+            expect(screen.getByText('test')).toBeInTheDocument()
+            expect(screen.getByText('Variant distribution')).toBeInTheDocument()
+        })
+
+        it('renders traffic preview', () => {
+            renderEditor()
+            expect(screen.getByText('Traffic preview')).toBeInTheDocument()
+        })
+
+        it('does not show "Add variant" button', () => {
+            renderEditor()
+            expect(screen.queryByRole('button', { name: /add variant/i })).not.toBeInTheDocument()
+        })
+
+        it('does not show pencil icon (customize split toggle)', () => {
+            renderEditor()
+            expect(screen.queryByRole('button', { name: /customize split/i })).not.toBeInTheDocument()
+        })
+
+        it('does not show rollout percentage slider', () => {
+            renderEditor()
+            expect(screen.queryByRole('slider')).not.toBeInTheDocument()
+            expect(screen.queryByText('Rollout percent')).not.toBeInTheDocument()
+        })
+
+        it('does not show "Persist flag across authentication steps" checkbox', () => {
+            renderEditor()
+            expect(screen.queryByText(/persist flag/i)).not.toBeInTheDocument()
+            expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+        })
+
+        it('split inputs are always editable without a toggle', () => {
+            const { container } = renderEditor()
+            const inputs = container.querySelectorAll('input[type="number"]')
+            expect(inputs.length).toBe(2)
+            inputs.forEach((input) => {
+                expect(input).not.toBeDisabled()
+            })
+        })
+
+        it('shows validation error when splits do not sum to 100', () => {
+            const invalidVariants = [
+                { key: 'control', rollout_percentage: 40 },
+                { key: 'test', rollout_percentage: 40 },
+            ]
+            renderEditor(invalidVariants)
+            expect(screen.getByText(/must sum to 100 \(currently 80\)/i)).toBeInTheDocument()
+        })
+
+        it('calls onVariantsChange with auto-completed split for 2 variants', async () => {
+            const { container } = renderEditor()
+            const inputs = container.querySelectorAll('input[type="number"]')
+
+            await fireEvent.change(inputs[0], { target: { value: '70' } })
+
+            const lastCall = mockOnVariantsChange.mock.calls[mockOnVariantsChange.mock.calls.length - 1][0]
+            expect(lastCall).toEqual([
+                expect.objectContaining({ key: 'control', rollout_percentage: 70 }),
+                expect.objectContaining({ key: 'test', rollout_percentage: 30 }),
+            ])
+        })
+
+        it('shows "Distribute evenly" button when splits are uneven', () => {
+            const unevenVariants = [
+                { key: 'control', rollout_percentage: 20 },
+                { key: 'test', rollout_percentage: 80 },
+            ]
+            renderEditor(unevenVariants)
+            const button = screen.getByText('Distribute evenly').closest('button')!
+            expect(button).toBeVisible()
+        })
+
+        it('hides "Distribute evenly" button when splits are already even', () => {
+            renderEditor()
+            const button = screen.getByText('Distribute evenly').closest('button')!
+            expect(button).toHaveClass('invisible')
+        })
+
+        it('calls onVariantsChange with even distribution when clicking "Distribute evenly"', async () => {
+            const unevenVariants = [
+                { key: 'control', rollout_percentage: 20 },
+                { key: 'test', rollout_percentage: 80 },
+            ]
+            renderEditor(unevenVariants)
+
+            await userEvent.click(screen.getByText('Distribute evenly').closest('button')!)
+
+            expect(mockOnVariantsChange).toHaveBeenCalledWith([
+                expect.objectContaining({ key: 'control', rollout_percentage: 50 }),
+                expect.objectContaining({ key: 'test', rollout_percentage: 50 }),
+            ])
+        })
+
+        it('shows "Not released" indicator when rollout is less than 100%', () => {
+            renderEditor(defaultVariants, 60)
+            expect(screen.getByText(/not released to 40%/i)).toBeInTheDocument()
+        })
+
+        it('does not show "Not released" indicator at 100% rollout', () => {
+            renderEditor(defaultVariants, 100)
+            expect(screen.queryByText(/not released/i)).not.toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.tsx
@@ -1,0 +1,255 @@
+import { IconBalance } from '@posthog/icons'
+
+import { getSeriesColor } from 'lib/colors'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
+import { alphabet, formatPercentage } from 'lib/utils'
+
+import type { MultivariateFlagVariant } from '~/types'
+
+import { isEvenlyDistributed, percentageDistribution } from '../utils'
+
+interface TrafficPreviewProps {
+    variants: MultivariateFlagVariant[]
+    rolloutPercentage: number
+    areVariantRolloutsValid: boolean
+}
+
+// Visualizes the bucketing logic performed by the backend
+export const TrafficPreview = ({
+    variants,
+    rolloutPercentage,
+    areVariantRolloutsValid,
+}: TrafficPreviewProps): JSX.Element => {
+    const excludedPercentage = Math.max(0, 100 - rolloutPercentage)
+
+    let cumulativeStart = 0
+    const previewVariants = variants.map((variant, index) => {
+        const slotSize = variant.rollout_percentage
+        const slotStart = cumulativeStart
+        cumulativeStart += slotSize
+        return {
+            ...variant,
+            index,
+            letter: alphabet[index] ?? `${index + 1}`,
+            slotSize,
+            slotStart,
+            previewPercentage: Math.max(0, (variant.rollout_percentage / 100) * rolloutPercentage),
+            color: getSeriesColor(index),
+        }
+    })
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+                <h4 className="m-0">Traffic preview</h4>
+                {excludedPercentage > 0 && (
+                    <div className="flex items-center gap-2 text-sm text-secondary">
+                        <span
+                            className="inline-block h-3 w-3 rounded-sm border border-primary"
+                            style={{
+                                backgroundImage:
+                                    'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
+                            }}
+                        />
+                        <span>
+                            Not released to {formatPercentage(excludedPercentage, { precise: true, compact: true })}
+                        </span>
+                    </div>
+                )}
+            </div>
+            <div className="h-10 rounded bg-fill-secondary border border-primary overflow-hidden flex relative">
+                {rolloutPercentage > 0 ? (
+                    previewVariants.map((variant) => (
+                        <div key={variant.key} className="h-full flex" style={{ width: `${variant.slotSize}%` }}>
+                            <div
+                                className="h-full"
+                                style={{
+                                    width: `${rolloutPercentage}%`,
+                                    backgroundColor: variant.color,
+                                }}
+                            />
+                            {rolloutPercentage < 100 && (
+                                <div
+                                    className="h-full flex-1"
+                                    style={{
+                                        backgroundImage:
+                                            'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
+                                    }}
+                                />
+                            )}
+                        </div>
+                    ))
+                ) : (
+                    <div
+                        className="h-full w-full"
+                        style={{
+                            backgroundImage:
+                                'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
+                        }}
+                    />
+                )}
+                {rolloutPercentage > 0 &&
+                    previewVariants.map((variant) => (
+                        <div
+                            key={`${variant.key}-letter`}
+                            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 text-[10px] font-semibold text-white pointer-events-none"
+                            style={{
+                                left: `${variant.slotStart + (variant.slotSize * rolloutPercentage) / 100 / 2}%`,
+                                textShadow: '0 1px 2px rgba(0, 0, 0, 0.35)',
+                            }}
+                        >
+                            {variant.letter}
+                        </div>
+                    ))}
+            </div>
+            <div className="flex" style={{ visibility: rolloutPercentage > 0 ? 'visible' : 'hidden' }}>
+                {previewVariants.map((variant) => (
+                    <div key={`${variant.key}-label`} className="flex" style={{ width: `${variant.slotSize}%` }}>
+                        <div
+                            className="text-xs text-secondary text-center whitespace-nowrap"
+                            style={{ width: `${rolloutPercentage}%` }}
+                        >
+                            {formatPercentage(variant.previewPercentage, { precise: true, compact: true })}
+                        </div>
+                    </div>
+                ))}
+            </div>
+            {!areVariantRolloutsValid && (
+                <p className="text-danger m-0">Preview is based on the current split and rollout percentage.</p>
+            )}
+        </div>
+    )
+}
+
+// In case of 2 variants we can improve the UX by automatically adjusting the other variant to ensure the total is always 100%
+export function computeUpdatedVariantSplit(
+    variants: MultivariateFlagVariant[],
+    index: number,
+    value: number
+): MultivariateFlagVariant[] {
+    const cappedValue = Math.min(100, Math.max(0, value))
+    const newVariants = [...variants]
+    newVariants[index] = { ...newVariants[index], rollout_percentage: cappedValue }
+    if (variants.length === 2) {
+        const otherIndex = index === 0 ? 1 : 0
+        newVariants[otherIndex] = { ...newVariants[otherIndex], rollout_percentage: 100 - cappedValue }
+    }
+    return newVariants
+}
+
+export function distributeVariantsEvenly(variants: MultivariateFlagVariant[]): MultivariateFlagVariant[] {
+    const percentages = percentageDistribution(variants.length)
+    return variants.map((variant, index) => ({
+        ...variant,
+        rollout_percentage: percentages[index],
+    }))
+}
+
+interface VariantDistributionEditorProps {
+    variants: MultivariateFlagVariant[]
+    onVariantsChange: (variants: MultivariateFlagVariant[]) => void
+    rolloutPercentage?: number
+}
+
+/**
+ * Self-contained variant distribution editor with split editing, 2-variant auto-complete,
+ * distribute evenly, validation, and traffic preview.
+ *
+ * Used by DistributionModal for changing experiment distribution, and can be embedded
+ * in any context that needs variant split editing with a traffic preview.
+ */
+export const VariantDistributionEditor = ({
+    variants,
+    onVariantsChange,
+    rolloutPercentage = 100,
+}: VariantDistributionEditorProps): JSX.Element => {
+    const { variantRolloutSum, areVariantRolloutsValid } = useVariantDistributionValidation(variants)
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div>
+                <div className="flex justify-between items-center mb-2">
+                    <h3 className="font-semibold mb-0">Variant distribution</h3>
+                    <LemonButton
+                        size="small"
+                        onClick={() => onVariantsChange(distributeVariantsEvenly(variants))}
+                        tooltip="Distribute split evenly"
+                        icon={<IconBalance />}
+                        className={isEvenlyDistributed(variants) ? 'invisible' : ''}
+                    >
+                        Distribute evenly
+                    </LemonButton>
+                </div>
+
+                <div className="border border-primary rounded p-4">
+                    <table className="w-full">
+                        <thead>
+                            <tr className="text-sm font-bold">
+                                <td className="w-8" />
+                                <td>Variant</td>
+                                <td>Split</td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {variants.map((variant, index) => (
+                                <tr key={variant.key}>
+                                    <td className="py-2 pr-2">
+                                        <div className="flex items-center justify-center">
+                                            <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
+                                        </div>
+                                    </td>
+                                    <td className="py-2 pr-2">
+                                        <span className="font-semibold">{variant.key}</span>
+                                    </td>
+                                    <td className="py-2">
+                                        <LemonInput
+                                            type="number"
+                                            min={0}
+                                            max={100}
+                                            value={variant.rollout_percentage}
+                                            onChange={(changedValue) => {
+                                                const valueInt =
+                                                    changedValue !== undefined && !Number.isNaN(changedValue)
+                                                        ? parseInt(changedValue.toString(), 10)
+                                                        : 0
+                                                onVariantsChange(computeUpdatedVariantSplit(variants, index, valueInt))
+                                            }}
+                                            suffix={<span>%</span>}
+                                            className="w-30"
+                                        />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+
+                    {!areVariantRolloutsValid && (
+                        <p className="text-danger mt-2">
+                            Percentage splits must sum to 100 (currently {variantRolloutSum}).
+                        </p>
+                    )}
+                </div>
+            </div>
+
+            <TrafficPreview
+                variants={variants}
+                rolloutPercentage={rolloutPercentage}
+                areVariantRolloutsValid={areVariantRolloutsValid}
+            />
+        </div>
+    )
+}
+
+/** Hook exposing validation state for variant distributions */
+export function useVariantDistributionValidation(variants: MultivariateFlagVariant[]): {
+    variantRolloutSum: number
+    areVariantRolloutsValid: boolean
+} {
+    const variantRolloutSum = variants.reduce((sum, { rollout_percentage }) => sum + rollout_percentage, 0)
+    const areVariantRolloutsValid =
+        variants.every(({ rollout_percentage }) => rollout_percentage >= 0 && rollout_percentage <= 100) &&
+        variantRolloutSum === 100
+    return { variantRolloutSum, areVariantRolloutsValid }
+}

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantDistributionEditor.tsx
@@ -147,6 +147,11 @@ export function distributeVariantsEvenly(variants: MultivariateFlagVariant[]): M
     }))
 }
 
+/** Parse a LemonInput number value into an integer suitable for variant rollout percentages */
+export function parseVariantPercentage(value: number | undefined): number {
+    return value !== undefined && !Number.isNaN(value) ? parseInt(value.toString(), 10) : 0
+}
+
 interface VariantDistributionEditorProps {
     variants: MultivariateFlagVariant[]
     onVariantsChange: (variants: MultivariateFlagVariant[]) => void
@@ -210,11 +215,13 @@ export const VariantDistributionEditor = ({
                                             max={100}
                                             value={variant.rollout_percentage}
                                             onChange={(changedValue) => {
-                                                const valueInt =
-                                                    changedValue !== undefined && !Number.isNaN(changedValue)
-                                                        ? parseInt(changedValue.toString(), 10)
-                                                        : 0
-                                                onVariantsChange(computeUpdatedVariantSplit(variants, index, valueInt))
+                                                onVariantsChange(
+                                                    computeUpdatedVariantSplit(
+                                                        variants,
+                                                        index,
+                                                        parseVariantPercentage(changedValue)
+                                                    )
+                                                )
                                             }}
                                             suffix={<span>%</span>}
                                             className="w-30"

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -20,6 +20,7 @@ import { ensureIsPercent, isEvenlyDistributed } from '../utils'
 import {
     computeUpdatedVariantSplit,
     distributeVariantsEvenly,
+    parseVariantPercentage,
     TrafficPreview,
     useVariantDistributionValidation,
 } from './VariantDistributionEditor'
@@ -240,16 +241,11 @@ export const VariantsPanelCreateFeatureFlag = ({
                                                             max={100}
                                                             value={variant.rollout_percentage}
                                                             onChange={(changedValue) => {
-                                                                const valueInt =
-                                                                    changedValue !== undefined &&
-                                                                    !Number.isNaN(changedValue)
-                                                                        ? parseInt(changedValue.toString(), 10)
-                                                                        : 0
                                                                 updateVariants(
                                                                     computeUpdatedVariantSplit(
                                                                         variants,
                                                                         index,
-                                                                        valueInt
+                                                                        parseVariantPercentage(changedValue)
                                                                     )
                                                                 )
                                                             }}

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import { IconBalance, IconInfo, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 
-import { getSeriesColor } from 'lib/colors'
 import { MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
@@ -17,7 +16,13 @@ import { alphabet, formatPercentage } from 'lib/utils'
 import type { Experiment, MultivariateFlagVariant } from '~/types'
 
 import { NEW_EXPERIMENT } from '../constants'
-import { ensureIsPercent, isEvenlyDistributed, percentageDistribution } from '../utils'
+import { ensureIsPercent, isEvenlyDistributed } from '../utils'
+import {
+    computeUpdatedVariantSplit,
+    distributeVariantsEvenly,
+    TrafficPreview,
+    useVariantDistributionValidation,
+} from './VariantDistributionEditor'
 
 interface VariantsPanelCreateFeatureFlagProps {
     experiment: Experiment
@@ -74,119 +79,6 @@ const RolloutPercentageControl = ({
     )
 }
 
-interface TrafficPreviewProps {
-    variants: MultivariateFlagVariant[]
-    rolloutPercentage: number
-    areVariantRolloutsValid: boolean
-}
-
-// Visualizes the bucketing logic performed by the backend
-export const TrafficPreview = ({
-    variants,
-    rolloutPercentage,
-    areVariantRolloutsValid,
-}: TrafficPreviewProps): JSX.Element => {
-    const excludedPercentage = Math.max(0, 100 - rolloutPercentage)
-
-    let cumulativeStart = 0
-    const previewVariants = variants.map((variant, index) => {
-        const slotSize = variant.rollout_percentage
-        const slotStart = cumulativeStart
-        cumulativeStart += slotSize
-        return {
-            ...variant,
-            index,
-            letter: alphabet[index] ?? `${index + 1}`,
-            slotSize,
-            slotStart,
-            previewPercentage: Math.max(0, (variant.rollout_percentage / 100) * rolloutPercentage),
-            color: getSeriesColor(index),
-        }
-    })
-
-    return (
-        <div className="flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-                <h4 className="m-0">Traffic preview</h4>
-                {excludedPercentage > 0 && (
-                    <div className="flex items-center gap-2 text-sm text-secondary">
-                        <span
-                            className="inline-block h-3 w-3 rounded-sm border border-primary"
-                            style={{
-                                backgroundImage:
-                                    'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
-                            }}
-                        />
-                        <span>
-                            Not released to {formatPercentage(excludedPercentage, { precise: true, compact: true })}
-                        </span>
-                    </div>
-                )}
-            </div>
-            <div className="h-10 rounded bg-fill-secondary border border-primary overflow-hidden flex relative">
-                {rolloutPercentage > 0 ? (
-                    previewVariants.map((variant) => (
-                        <div key={variant.key} className="h-full flex" style={{ width: `${variant.slotSize}%` }}>
-                            <div
-                                className="h-full"
-                                style={{
-                                    width: `${rolloutPercentage}%`,
-                                    backgroundColor: variant.color,
-                                }}
-                            />
-                            {rolloutPercentage < 100 && (
-                                <div
-                                    className="h-full flex-1"
-                                    style={{
-                                        backgroundImage:
-                                            'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
-                                    }}
-                                />
-                            )}
-                        </div>
-                    ))
-                ) : (
-                    <div
-                        className="h-full w-full"
-                        style={{
-                            backgroundImage:
-                                'repeating-linear-gradient(45deg, var(--color-bg-3000) 0 6px, var(--border-3000) 6px 12px)',
-                        }}
-                    />
-                )}
-                {rolloutPercentage > 0 &&
-                    previewVariants.map((variant) => (
-                        <div
-                            key={`${variant.key}-letter`}
-                            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 text-[10px] font-semibold text-white pointer-events-none"
-                            style={{
-                                left: `${variant.slotStart + (variant.slotSize * rolloutPercentage) / 100 / 2}%`,
-                                textShadow: '0 1px 2px rgba(0, 0, 0, 0.35)',
-                            }}
-                        >
-                            {variant.letter}
-                        </div>
-                    ))}
-            </div>
-            <div className="flex" style={{ visibility: rolloutPercentage > 0 ? 'visible' : 'hidden' }}>
-                {previewVariants.map((variant) => (
-                    <div key={`${variant.key}-label`} className="flex" style={{ width: `${variant.slotSize}%` }}>
-                        <div
-                            className="text-xs text-secondary text-center whitespace-nowrap"
-                            style={{ width: `${rolloutPercentage}%` }}
-                        >
-                            {formatPercentage(variant.previewPercentage, { precise: true, compact: true })}
-                        </div>
-                    </div>
-                ))}
-            </div>
-            {!areVariantRolloutsValid && (
-                <p className="text-danger m-0">Preview is based on the current split and rollout percentage.</p>
-            )}
-        </div>
-    )
-}
-
 export const VariantsPanelCreateFeatureFlag = ({
     experiment,
     onChange,
@@ -216,10 +108,7 @@ export const VariantsPanelCreateFeatureFlag = ({
         })
     }
 
-    const variantRolloutSum = variants.reduce((sum, { rollout_percentage }) => sum + rollout_percentage, 0)
-    const areVariantRolloutsValid =
-        variants.every(({ rollout_percentage }) => rollout_percentage >= 0 && rollout_percentage <= 100) &&
-        variantRolloutSum === 100
+    const { variantRolloutSum, areVariantRolloutsValid } = useVariantDistributionValidation(variants)
 
     const areVariantKeysValid = variants.every(({ key }) => key && key.trim().length > 0)
     const variantKeys = variants.map(({ key }) => key)
@@ -250,20 +139,6 @@ export const VariantsPanelCreateFeatureFlag = ({
         })
     }
 
-    // In case of 2 variants we can improve the UX by automatically adjusting the other variant to ensure the total is always 100%
-    const updateVariantSplit = (index: number, value: number): void => {
-        const cappedValue = Math.min(100, Math.max(0, value))
-        if (variants.length === 2) {
-            const otherIndex = index === 0 ? 1 : 0
-            const newVariants = [...variants]
-            newVariants[index] = { ...newVariants[index], rollout_percentage: cappedValue }
-            newVariants[otherIndex] = { ...newVariants[otherIndex], rollout_percentage: 100 - cappedValue }
-            updateVariants(newVariants)
-        } else {
-            updateVariant(index, { rollout_percentage: cappedValue })
-        }
-    }
-
     const addVariant = (): void => {
         if (variants.length >= MAX_EXPERIMENT_VARIANTS) {
             return
@@ -272,36 +147,14 @@ export const VariantsPanelCreateFeatureFlag = ({
             key: `test-${variants.length}`,
             rollout_percentage: 0,
         }
-        const newVariants = [...variants, newVariant]
-        distributeVariantsEqually(newVariants)
+        updateVariants(distributeVariantsEvenly([...variants, newVariant]))
     }
 
     const removeVariant = (index: number): void => {
         if (variants.length <= 2 || index === 0) {
             return
         }
-        const newVariants = variants.filter((_, i) => i !== index)
-        distributeVariantsEqually(newVariants)
-    }
-
-    const distributeVariantsEqually = (variantsToDistribute?: MultivariateFlagVariant[]): void => {
-        const variantsToUse = variantsToDistribute ||
-            experiment.parameters?.feature_flag_variants || [
-                { key: 'control', rollout_percentage: 50 },
-                { key: 'test', rollout_percentage: 50 },
-            ]
-        const percentages = percentageDistribution(variantsToUse.length)
-        const newVariants = variantsToUse.map((variant, index) => ({
-            ...variant,
-            rollout_percentage: percentages[index],
-        }))
-        onChange({
-            parameters: {
-                feature_flag_variants: newVariants,
-                ensure_experience_continuity: ensureExperienceContinuity,
-                rollout_percentage: rolloutPercentage,
-            },
-        })
+        updateVariants(distributeVariantsEvenly(variants.filter((_, i) => i !== index)))
     }
 
     return (
@@ -327,7 +180,9 @@ export const VariantsPanelCreateFeatureFlag = ({
                                                             <IconPencil />
                                                         </LemonButton>
                                                         <LemonButton
-                                                            onClick={() => distributeVariantsEqually()}
+                                                            onClick={() =>
+                                                                updateVariants(distributeVariantsEvenly(variants))
+                                                            }
                                                             tooltip="Distribute split evenly"
                                                             data-attr="distribute-variants-equally"
                                                             className={isEvenlyDistributed(variants) ? 'invisible' : ''}
@@ -390,7 +245,13 @@ export const VariantsPanelCreateFeatureFlag = ({
                                                                     !Number.isNaN(changedValue)
                                                                         ? parseInt(changedValue.toString(), 10)
                                                                         : 0
-                                                                updateVariantSplit(index, valueInt)
+                                                                updateVariants(
+                                                                    computeUpdatedVariantSplit(
+                                                                        variants,
+                                                                        index,
+                                                                        valueInt
+                                                                    )
+                                                                )
                                                             }}
                                                             suffix={<span>%</span>}
                                                             data-attr="experiment-variant-rollout-percentage-input"

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -1,26 +1,21 @@
 import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
 
-import { IconBalance, IconFlag } from '@posthog/icons'
-import {
-    LemonBanner,
-    LemonButton,
-    LemonDialog,
-    LemonInput,
-    LemonModal,
-    LemonTable,
-    LemonTableColumns,
-} from '@posthog/lemon-ui'
+import { IconFlag } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDialog, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { IconOpenInApp } from 'lib/lemon-ui/icons'
-import { FeatureFlagLogicProps, featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 
 import { MultivariateFlagVariant } from '~/types'
 
+import {
+    useVariantDistributionValidation,
+    VariantDistributionEditor,
+} from '../ExperimentForm/VariantDistributionEditor'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
-import { isEvenlyDistributed } from '../utils'
 import { VariantTag } from './components'
 import { HoldoutSelector } from './HoldoutSelector'
 import { VariantScreenshot } from './VariantScreenshot'
@@ -31,46 +26,51 @@ export function DistributionModal(): JSX.Element {
     const { closeDistributionModal } = useActions(modalsLogic)
     const { isDistributionModalOpen } = useValues(modalsLogic)
 
-    const _featureFlagLogic = featureFlagLogic({ id: experiment.feature_flag?.id ?? null } as FeatureFlagLogicProps)
-    const { featureFlag, areVariantRolloutsValid, variantRolloutSum } = useValues(_featureFlagLogic)
-    const { setFeatureFlagFilters, distributeVariantsEqually } = useActions(_featureFlagLogic)
+    const [variants, setVariants] = useState<MultivariateFlagVariant[]>([])
+    const { areVariantRolloutsValid } = useVariantDistributionValidation(variants)
 
-    const handleRolloutPercentageChange = (index: number, value: number | undefined): void => {
-        if (!featureFlag?.filters?.multivariate) {
+    // Reset local state when modal opens with fresh data from the experiment
+    useEffect(() => {
+        if (isDistributionModalOpen) {
+            setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
+        }
+    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
+
+    const handleClose = (): void => {
+        closeDistributionModal()
+    }
+
+    const handleSave = (): void => {
+        if (!experiment.feature_flag) {
             return
         }
-
-        const numericValue = value || 0
-
-        const updatedVariants = featureFlag.filters.multivariate.variants.map((variant, i) =>
-            i === index ? { ...variant, rollout_percentage: numericValue } : variant
-        )
-
-        setFeatureFlagFilters(
-            {
-                ...featureFlag.filters,
-                multivariate: { ...featureFlag.filters.multivariate, variants: updatedVariants },
+        // FeatureFlagBasicType has all fields updateDistribution needs (id, filters)
+        updateDistribution({
+            ...experiment.feature_flag,
+            filters: {
+                ...experiment.feature_flag.filters,
+                multivariate: {
+                    ...experiment.feature_flag.filters.multivariate,
+                    variants,
+                },
             },
-            null
-        )
+        } as any)
+        closeDistributionModal()
     }
 
     return (
         <LemonModal
             isOpen={isDistributionModalOpen}
-            onClose={closeDistributionModal}
+            onClose={handleClose}
             width={600}
             title="Change experiment distribution"
             footer={
                 <div className="flex items-center gap-2">
-                    <LemonButton type="secondary" onClick={closeDistributionModal}>
+                    <LemonButton type="secondary" onClick={handleClose}>
                         Cancel
                     </LemonButton>
                     <LemonButton
-                        onClick={() => {
-                            updateDistribution(featureFlag)
-                            closeDistributionModal()
-                        }}
+                        onClick={handleSave}
                         type="primary"
                         loading={experimentLoading}
                         disabled={!areVariantRolloutsValid}
@@ -80,61 +80,18 @@ export function DistributionModal(): JSX.Element {
                 </div>
             }
         >
-            <div className="deprecated-space-y-4">
+            <div className="flex flex-col gap-4">
                 <LemonBanner type="info">
                     Adjusting variant distribution may impact the validity of your results. Adjust only if you're aware
                     of how changes will affect your experiment.
                 </LemonBanner>
 
-                <div>
-                    <div className="flex justify-between items-center mb-2">
-                        <h3 className="font-semibold mb-0">Variant distribution</h3>
-                        <LemonButton
-                            size="small"
-                            onClick={distributeVariantsEqually}
-                            tooltip="Distribute split evenly"
-                            icon={<IconBalance />}
-                            className={
-                                isEvenlyDistributed(featureFlag?.filters?.multivariate?.variants || [])
-                                    ? 'invisible'
-                                    : ''
-                            }
-                        >
-                            Distribute evenly
-                        </LemonButton>
-                    </div>
+                <VariantDistributionEditor
+                    variants={variants}
+                    onVariantsChange={setVariants}
+                    rolloutPercentage={experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100}
+                />
 
-                    <LemonTable
-                        dataSource={featureFlag?.filters?.multivariate?.variants || []}
-                        columns={[
-                            {
-                                title: 'Variant',
-                                dataIndex: 'key',
-                                render: (value) => <span className="font-semibold">{value}</span>,
-                            },
-                            {
-                                title: 'Split',
-                                dataIndex: 'rollout_percentage',
-                                render: (_, record, index) => (
-                                    <LemonInput
-                                        type="number"
-                                        value={record.rollout_percentage}
-                                        onChange={(value) => handleRolloutPercentageChange(index, value)}
-                                        min={0}
-                                        max={100}
-                                        suffix={<span>%</span>}
-                                    />
-                                ),
-                            },
-                        ]}
-                    />
-
-                    {!areVariantRolloutsValid && (
-                        <p className="text-danger mt-2">
-                            Percentage splits must sum to 100 (currently {variantRolloutSum}).
-                        </p>
-                    )}
-                </div>
                 <HoldoutSelector />
             </div>
         </LemonModal>

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -29,12 +29,13 @@ export function DistributionModal(): JSX.Element {
     const [variants, setVariants] = useState<MultivariateFlagVariant[]>([])
     const { areVariantRolloutsValid } = useVariantDistributionValidation(variants)
 
-    // Reset local state when modal opens with fresh data from the experiment
+    // Initialize local state only when the modal transitions from closed to open.
+    // Intentionally omit experiment data from deps so auto-refresh doesn't clobber edits.
     useEffect(() => {
         if (isDistributionModalOpen) {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
         }
-    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
+    }, [isDistributionModalOpen])
 
     const handleClose = (): void => {
         closeDistributionModal()

--- a/frontend/src/scenes/experiments/ExperimentWizard/steps/VariantsStep.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/steps/VariantsStep.tsx
@@ -7,7 +7,8 @@ import { alphabet, formatPercentage } from 'lib/utils'
 
 import type { FeatureFlagType } from '~/types'
 
-import { TrafficPreview, VariantsPanelCreateFeatureFlag } from '../../ExperimentForm/VariantsPanelCreateFeatureFlag'
+import { TrafficPreview } from '../../ExperimentForm/VariantDistributionEditor'
+import { VariantsPanelCreateFeatureFlag } from '../../ExperimentForm/VariantsPanelCreateFeatureFlag'
 import { experimentWizardLogic } from '../experimentWizardLogic'
 
 const ReadOnlyVariantsStep = ({ flag }: { flag: FeatureFlagType }): JSX.Element => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

- The "Change experiment distribution" modal was missing the traffic preview visualization
- The modal also lacked the 2-variant auto-complete-percent behavior (automatically sum up to 100%)
- And there was some duplicated code

## Changes

- Extract TrafficPreview and other shared logic into a new VariantDistributionEditor component
- Refactor DistributionModal to use VariantDistributionEditor, replacing its dependency on featureFlagLogic with local React state
- Refactor VariantsPanelCreateFeatureFlag to reuse the shared logic
- Add test cases

|Before|After|
|-|-|
|<img width="603" height="463" alt="distribution-modal-before" src="https://github.com/user-attachments/assets/3b06c75c-f003-4d63-bd14-04e8606ab966" />|<img width="540" height="527" alt="distribution-modal-after" src="https://github.com/user-attachments/assets/244910ca-72e6-4568-8e8d-bcf1c44a43dc" />|

## How did you test this code?

- New test cases
- Manually

https://github.com/user-attachments/assets/a6f06265-89a9-4b02-89ec-b51365c99f29

## Publish to changelog?

No