### PR TITLE
fix(logsViewer): handle null sparkline in sparklineData and ensure safe reduction in totalLogsMatchingFilters

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -85,6 +85,45 @@ describe('logsViewerDataLogic', () => {
         })
     })
 
+    describe('sparklineData selector', () => {
+        it.each([
+            ['null', null, { labels: [], dates: [], data: [] }],
+            ['an empty array', [], { labels: [], dates: [], data: [] }],
+            [
+                'valid data',
+                [
+                    { time: '2024-01-01T00:00:00Z', severity: 'info', count: 5 },
+                    { time: '2024-01-01T00:01:00Z', severity: 'error', count: 3 },
+                ],
+                { labels: expect.any(Array), dates: expect.any(Array), data: expect.any(Array) },
+            ],
+        ])('returns correct data when sparkline is %s', async (_, sparklineInput, expected) => {
+            logic.actions.setSparkline(sparklineInput as any[] | null)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.sparklineData).toEqual(expected)
+        })
+    })
+
+    describe('totalLogsMatchingFilters selector', () => {
+        it.each([
+            ['null', null, 0],
+            [
+                'valid data',
+                [
+                    { time: '2024-01-01T00:00:00Z', severity: 'info', count: 5 },
+                    { time: '2024-01-01T00:00:00Z', severity: 'error', count: 3 },
+                ],
+                8,
+            ],
+        ])('returns correct total when sparkline is %s', async (_, sparklineInput, expected) => {
+            logic.actions.setSparkline(sparklineInput as any[] | null)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.totalLogsMatchingFilters).toEqual(expected)
+        })
+    })
+
     describe('query failure event capture', () => {
         beforeEach(() => {
             jest.clearAllMocks()

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -110,7 +110,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         setLiveTailRunning: (enabled: boolean) => ({ enabled }),
         setLiveTailInterval: (interval: number) => ({ interval }),
         setLogs: (logs: LogMessage[]) => ({ logs }),
-        setSparkline: (sparkline: any[]) => ({ sparkline }),
+        setSparkline: (sparkline: any[] | null) => ({ sparkline }),
         setNextCursor: (nextCursor: string | null) => ({ nextCursor }),
         expireLiveTail: () => true,
         setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
@@ -305,7 +305,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                     actions.setSparklineAbortController(null)
                     return response
                 },
-                setSparkline: ({ sparkline }) => sparkline,
+                setSparkline: ({ sparkline }) => sparkline ?? [],
             },
         ],
     })),
@@ -370,7 +370,11 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         ],
         sparklineData: [
             (s) => [s.sparkline, s.sparklineBreakdownBy],
-            (sparkline: any[], sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
+            (sparkline: any[] | null, sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
+                if (!sparkline) {
+                    return { labels: [], dates: [], data: [] }
+                }
+
                 const breakdownKey = sparklineBreakdownBy
 
                 let lastTime = ''
@@ -429,7 +433,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         ],
         totalLogsMatchingFilters: [
             (s) => [s.sparkline],
-            (sparkline): number => sparkline.reduce((sum, item) => sum + item.count, 0),
+            (sparkline): number => sparkline?.reduce((sum: number, item: any) => sum + item.count, 0) ?? 0,
         ],
         logsRemainingToLoad: [
             (s) => [s.totalLogsMatchingFilters, s.logs],


### PR DESCRIPTION
## Problem

When severity levels change, the sparkline query gets cancelled and the aborted fetch sets `sparkline` to `null`, breaking the `.reduce()` operations in the `sparklineData` and `totalLogsMatchingFilters` selectors.

## Changes

- Add null guard in `sparklineData` selector, returning empty `{ labels: [], dates: [], data: [] }` when sparkline is null
- Add optional chaining in `totalLogsMatchingFilters` selector, returning `0` when sparkline is null

## How did you test this code?

- Added unit tests for `sparklineData` and `totalLogsMatchingFilters` selectors covering null sparkline, empty array, and valid data cases

## Publish to changelog?

No
