### PR TITLE
fix(llma): reduce generation sentiment batch size to prevent timeouts

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -33,7 +33,7 @@ CACHE_KEY_PREFIX = "llma_sentiment"  # key format: {prefix}:{level}:{team_id}:{i
 
 # API config
 BATCH_MAX_TRACE_IDS = 5
-BATCH_MAX_GENERATION_IDS = 20  # generations tab can send more per batch
+BATCH_MAX_GENERATION_IDS = 5  # keep small to avoid upstream request timeouts
 
 # HogQL query template for fetching $ai_generation events.
 # Uses a window function to cap rows per trace at the ClickHouse level,

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -440,7 +440,7 @@ export interface PatchedLLMProviderKeyApi {
 export interface SentimentRequestApi {
     /**
      * @minItems 1
-     * @maxItems 20
+     * @maxItems 5
      */
     ids: string[]
     analysis_level?: AnalysisLevelEnumApi

--- a/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
@@ -19,7 +19,7 @@ function isValidGenerationSentiment(value: unknown): value is GenerationSentimen
     return !!value && typeof value === 'object' && 'label' in value && !('error' in value)
 }
 
-const BATCH_MAX_SIZE = 20
+const BATCH_MAX_SIZE = 5
 
 function chunk<T>(arr: T[], size: number): T[][] {
     const chunks: T[][] = []


### PR DESCRIPTION
## Problem

On the trace view, loading sentiment for generations with many IDs (e.g. 20) in a single API call causes an upstream request timeout. The Temporal workflow running ClickHouse queries + ONNX classification for all 20 generations cannot finish within the proxy timeout window.

## Changes

- Reduced `BATCH_MAX_SIZE` in `llmGenerationSentimentLazyLoaderLogic.ts` from 20 to 5
- Reduced `BATCH_MAX_GENERATION_IDS` in backend constants from 20 to 5
- Regenerated OpenAPI types to reflect the new limit

The existing `chunk()` + `Promise.allSettled()` logic already handles splitting into parallel requests, so a trace with 20 generations now sends 4 parallel requests of 5 instead of 1 request of 20. Each individual request completes within the timeout. This matches the trace-level sentiment loader which already uses batch size 5.

## How did you test this code?

This is a configuration change. The trace-level loader has been using batch size 5 successfully. The generation loader now matches that behavior.