### PR TITLE
fix: the toolbar clickmap is hella slow - no bueno

### DIFF
--- a/frontend/src/toolbar/elements/AutocaptureElement.tsx
+++ b/frontend/src/toolbar/elements/AutocaptureElement.tsx
@@ -1,4 +1,9 @@
+import { memo } from 'react'
+
+import { objectsEqual } from 'lib/utils'
+
 import { ElementRect } from '~/toolbar/types'
+import { EMPTY_STYLE, rectEqual } from '~/toolbar/utils'
 
 interface AutocaptureElementProps {
     rect?: ElementRect
@@ -8,30 +13,36 @@ interface AutocaptureElementProps {
     onMouseOut: (event: React.MouseEvent) => void
 }
 
-export function AutocaptureElement({
-    rect,
-    style = {},
-    onClick,
-    onMouseOver,
-    onMouseOut,
-}: AutocaptureElementProps): JSX.Element | null {
-    if (!rect) {
-        return null
-    }
-    return (
-        <div
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                position: 'absolute',
-                top: `${rect.top + window.pageYOffset}px`,
-                left: `${rect.left + window.pageXOffset}px`,
-                width: `${rect.right - rect.left}px`,
-                height: `${rect.bottom - rect.top}px`,
-                ...style,
-            }}
-            onClick={onClick}
-            onMouseOver={onMouseOver}
-            onMouseOut={onMouseOut}
-        />
-    )
-}
+export const AutocaptureElement = memo(
+    function AutocaptureElement({
+        rect,
+        style = EMPTY_STYLE,
+        onClick,
+        onMouseOver,
+        onMouseOut,
+    }: AutocaptureElementProps): JSX.Element | null {
+        if (!rect) {
+            return null
+        }
+        return (
+            <div
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    position: 'absolute',
+                    top: `${rect.top + window.pageYOffset}px`,
+                    left: `${rect.left + window.pageXOffset}px`,
+                    width: `${rect.right - rect.left}px`,
+                    height: `${rect.bottom - rect.top}px`,
+                    ...style,
+                }}
+                onClick={onClick}
+                onMouseOver={onMouseOver}
+                onMouseOut={onMouseOut}
+            />
+        )
+    },
+    // Handlers are intentionally excluded: the sole caller (Elements.tsx) closes over
+    // stable kea actions (selectElement, setHoverElement) and per-element refs that
+    // don't change for a given key, so comparing them would only defeat memoization.
+    (prev, next) => rectEqual(prev.rect, next.rect) && objectsEqual(prev.style, next.style)
+)

--- a/frontend/src/toolbar/elements/AutocaptureElementLabel.tsx
+++ b/frontend/src/toolbar/elements/AutocaptureElementLabel.tsx
@@ -1,5 +1,9 @@
+import { memo } from 'react'
+
+import { objectsEqual } from 'lib/utils'
+
 import { ElementRect } from '~/toolbar/types'
-import { inBounds } from '~/toolbar/utils'
+import { EMPTY_STYLE, inBounds, rectEqual } from '~/toolbar/utils'
 
 const heatmapLabelStyle = {
     lineHeight: '14px',
@@ -17,40 +21,50 @@ interface AutocaptureElementLabelProps extends React.PropsWithoutRef<JSX.Intrins
     align?: 'left' | 'right'
 }
 
-export function AutocaptureElementLabel({
-    rect,
-    style = {},
-    align = 'right',
-    children,
-    ...props
-}: AutocaptureElementLabelProps): JSX.Element | null {
-    if (!rect) {
-        return null
-    }
+export const AutocaptureElementLabel = memo(
+    function AutocaptureElementLabel({
+        rect,
+        style = EMPTY_STYLE,
+        align = 'right',
+        children,
+        ...props
+    }: AutocaptureElementLabelProps): JSX.Element | null {
+        if (!rect) {
+            return null
+        }
 
-    const width = typeof children === 'string' ? children.length * 10 + 4 : 14
+        const width = typeof children === 'string' ? children.length * 10 + 4 : 14
 
-    return (
-        <div
-            className="absolute"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                top: `${inBounds(
-                    window.pageYOffset - 1,
-                    rect.top - 7 + window.pageYOffset,
-                    window.pageYOffset + window.innerHeight - 14
-                )}px`,
-                left: `${inBounds(
-                    window.pageXOffset,
-                    rect.left + (align === 'left' ? 10 : rect.width) - width + window.pageXOffset,
-                    window.pageXOffset + window.innerWidth - 14
-                )}px`,
-                ...heatmapLabelStyle,
-                ...style,
-            }}
-            {...props}
-        >
-            {children}
-        </div>
-    )
-}
+        return (
+            <div
+                className="absolute"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    top: `${inBounds(
+                        window.pageYOffset - 1,
+                        rect.top - 7 + window.pageYOffset,
+                        window.pageYOffset + window.innerHeight - 14
+                    )}px`,
+                    left: `${inBounds(
+                        window.pageXOffset,
+                        rect.left + (align === 'left' ? 10 : rect.width) - width + window.pageXOffset,
+                        window.pageXOffset + window.innerWidth - 14
+                    )}px`,
+                    ...heatmapLabelStyle,
+                    ...style,
+                }}
+                {...props}
+            >
+                {children}
+            </div>
+        )
+    },
+    // Handlers are intentionally excluded: the sole caller (Elements.tsx) closes over
+    // stable kea actions (selectElement, setHoverElement) and per-element refs that
+    // don't change for a given key, so comparing them would only defeat memoization.
+    (prev, next) =>
+        rectEqual(prev.rect, next.rect) &&
+        objectsEqual(prev.style ?? EMPTY_STYLE, next.style ?? EMPTY_STYLE) &&
+        prev.align === next.align &&
+        prev.children === next.children
+)

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { Fragment } from 'react'
+import { Fragment, memo } from 'react'
 
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
 import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
@@ -13,10 +13,23 @@ import { FocusRect } from '~/toolbar/elements/FocusRect'
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { ElementHighlight } from '~/toolbar/product-tours/ElementHighlight'
 import { productToursLogic } from '~/toolbar/product-tours/productToursLogic'
+import { ElementWithMetadata } from '~/toolbar/types'
 import { getBoxColors, getHeatMapHue } from '~/toolbar/utils'
 
 import { toolbarLogic } from '../bar/toolbarLogic'
 import { ScrollDepth } from './ScrollDepth'
+
+let nextElementId = 0
+const elementIdMap = new WeakMap<HTMLElement, number>()
+
+function getStableElementId(element: HTMLElement): number {
+    let id = elementIdMap.get(element)
+    if (id === undefined) {
+        id = nextElementId++
+        elementIdMap.set(element, id)
+    }
+    return id
+}
 
 export function Elements(): JSX.Element {
     const { visibleMenu: activeToolbarMode } = useValues(toolbarLogic)
@@ -74,10 +87,10 @@ export function Elements(): JSX.Element {
                 {productToursSelecting && productToursHoverRect && <ElementHighlight rect={productToursHoverRect} />}
                 {productToursSelectedStepRect && <ElementHighlight rect={productToursSelectedStepRect} isSelected />}
 
-                {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {
+                {elementsToDisplay.map(({ rect, element, apparentZIndex }) => {
                     return (
                         <AutocaptureElement
-                            key={`inspect-${index}`}
+                            key={`inspect-${getStableElementId(element)}`}
                             rect={rect}
                             style={{
                                 pointerEvents: heatmapPointerEvents,
@@ -100,128 +113,16 @@ export function Elements(): JSX.Element {
                     )
                 })}
 
-                {heatmapElements.map(
-                    ({ rect, count, clickCount, rageclickCount, deadclickCount, element, visible }, index) => {
-                        if (!visible) {
-                            return null
-                        }
-                        return (
-                            <Fragment key={`heatmap-${index}`}>
-                                <AutocaptureElement
-                                    rect={rect}
-                                    style={{
-                                        pointerEvents: inspectEnabled ? 'none' : heatmapPointerEvents,
-                                        zIndex: hoverElement === element ? 4 : 3,
-                                        opacity: !hoverElement || hoverElement === element ? 1 : 0.4,
-                                        transition: 'opacity 0.2s, box-shadow 0.2s',
-                                        cursor: 'pointer',
-                                        borderRadius: 5,
-                                        ...getBoxColors(
-                                            'red',
-                                            hoverElement === element,
-                                            ((count || 0) / highestClickCount) * 0.4
-                                        ),
-                                    }}
-                                    onClick={() => selectElement(element)}
-                                    onMouseOver={() => selectedElement === null && setHoverElement(element)}
-                                    onMouseOut={() => selectedElement === null && setHoverElement(null)}
-                                />
-                                {!!clickCount && (
-                                    <AutocaptureElementLabel
-                                        rect={rect}
-                                        style={{
-                                            pointerEvents: heatmapPointerEvents,
-                                            zIndex: 5,
-                                            opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
-                                            transition: 'opacity 0.2s, transform 0.2s linear',
-                                            transform: hoverElement === element ? 'scale(1.3)' : 'none',
-                                            cursor: 'pointer',
-                                            color: `hsla(${getHeatMapHue(
-                                                clickCount || 0,
-                                                highestClickCount
-                                            )}, 20%, 12%, 1)`,
-                                            background: `hsla(${getHeatMapHue(
-                                                clickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 62%, 1)`,
-                                            boxShadow: `hsla(${getHeatMapHue(
-                                                clickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 32%, 1) 0px 1px 5px 1px`,
-                                        }}
-                                        onClick={() => selectElement(element)}
-                                        onMouseOver={() => selectedElement === null && setHoverElement(element)}
-                                        onMouseOut={() => selectedElement === null && setHoverElement(null)}
-                                    >
-                                        {compactNumber(clickCount || 0)}
-                                    </AutocaptureElementLabel>
-                                )}
-                                {!!rageclickCount && (
-                                    <AutocaptureElementLabel
-                                        rect={rect}
-                                        style={{
-                                            pointerEvents: heatmapPointerEvents,
-                                            zIndex: 5,
-                                            opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
-                                            transition: 'opacity 0.2s, transform 0.2s linear',
-                                            transform: hoverElement === element ? 'scale(1.3)' : 'none',
-                                            cursor: 'pointer',
-                                            color: `hsla(${getHeatMapHue(
-                                                rageclickCount || 0,
-                                                highestClickCount
-                                            )}, 20%, 12%, 1)`,
-                                            background: `hsla(${getHeatMapHue(
-                                                rageclickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 62%, 1)`,
-                                            boxShadow: `hsla(${getHeatMapHue(
-                                                rageclickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 32%, 1) 0px 1px 5px 1px`,
-                                        }}
-                                        align="left"
-                                        onClick={() => selectElement(element)}
-                                        onMouseOver={() => selectedElement === null && setHoverElement(element)}
-                                        onMouseOut={() => selectedElement === null && setHoverElement(null)}
-                                    >
-                                        {compactNumber(rageclickCount)}&#128545;
-                                    </AutocaptureElementLabel>
-                                )}
-                                {!!deadclickCount && (
-                                    <AutocaptureElementLabel
-                                        rect={rect}
-                                        style={{
-                                            pointerEvents: heatmapPointerEvents,
-                                            zIndex: 5,
-                                            opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
-                                            transition: 'opacity 0.2s, transform 0.2s linear',
-                                            transform: hoverElement === element ? 'scale(1.3)' : 'none',
-                                            cursor: 'pointer',
-                                            color: `hsla(${getHeatMapHue(
-                                                deadclickCount || 0,
-                                                highestClickCount
-                                            )}, 20%, 12%, 1)`,
-                                            background: `hsla(${getHeatMapHue(
-                                                deadclickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 62%, 1)`,
-                                            boxShadow: `hsla(${getHeatMapHue(
-                                                deadclickCount || 0,
-                                                highestClickCount
-                                            )}, 100%, 32%, 1) 0px 1px 5px 1px`,
-                                        }}
-                                        align="left"
-                                        onClick={() => selectElement(element)}
-                                        onMouseOver={() => selectedElement === null && setHoverElement(element)}
-                                        onMouseOut={() => selectedElement === null && setHoverElement(null)}
-                                    >
-                                        {compactNumber(deadclickCount)}&#128565;
-                                    </AutocaptureElementLabel>
-                                )}
-                            </Fragment>
-                        )
-                    }
-                )}
+                <HeatmapOverlayElements
+                    heatmapElements={heatmapElements}
+                    hoverElement={hoverElement}
+                    selectedElement={selectedElement}
+                    inspectEnabled={inspectEnabled}
+                    heatmapPointerEvents={heatmapPointerEvents}
+                    highestClickCount={highestClickCount}
+                    selectElement={selectElement}
+                    setHoverElement={setHoverElement}
+                />
 
                 {labelsToDisplay.map(({ element, rect, index, visible }, loopIndex) => {
                     if (!visible || !rect) {
@@ -229,7 +130,7 @@ export function Elements(): JSX.Element {
                     }
                     return (
                         <AutocaptureElementLabel
-                            key={`label-${loopIndex}`}
+                            key={`label-${getStableElementId(element)}`}
                             rect={rect}
                             align="left"
                             style={{
@@ -255,3 +156,124 @@ export function Elements(): JSX.Element {
         </>
     )
 }
+
+interface HeatmapOverlayElementsProps {
+    heatmapElements: ElementWithMetadata[]
+    hoverElement: HTMLElement | null
+    selectedElement: HTMLElement | null
+    inspectEnabled: boolean
+    heatmapPointerEvents: 'none' | 'all'
+    highestClickCount: number
+    selectElement: (element: HTMLElement) => void
+    setHoverElement: (element: HTMLElement | null) => void
+}
+
+const HeatmapOverlayElements = memo(function HeatmapOverlayElements({
+    heatmapElements,
+    hoverElement,
+    selectedElement,
+    inspectEnabled,
+    heatmapPointerEvents,
+    highestClickCount,
+    selectElement,
+    setHoverElement,
+}: HeatmapOverlayElementsProps): JSX.Element {
+    return (
+        <>
+            {heatmapElements.map(({ rect, count, clickCount, rageclickCount, deadclickCount, element, visible }) => {
+                if (!visible) {
+                    return null
+                }
+                const elementId = getStableElementId(element)
+                return (
+                    <Fragment key={`heatmap-${elementId}`}>
+                        <AutocaptureElement
+                            rect={rect}
+                            style={{
+                                pointerEvents: inspectEnabled ? 'none' : heatmapPointerEvents,
+                                zIndex: hoverElement === element ? 4 : 3,
+                                opacity: !hoverElement || hoverElement === element ? 1 : 0.4,
+                                transition: 'opacity 0.2s, box-shadow 0.2s',
+                                cursor: 'pointer',
+                                borderRadius: 5,
+                                ...getBoxColors(
+                                    'red',
+                                    hoverElement === element,
+                                    ((count || 0) / highestClickCount) * 0.4
+                                ),
+                            }}
+                            onClick={() => selectElement(element)}
+                            onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                            onMouseOut={() => selectedElement === null && setHoverElement(null)}
+                        />
+                        {!!clickCount && (
+                            <AutocaptureElementLabel
+                                rect={rect}
+                                style={{
+                                    pointerEvents: heatmapPointerEvents,
+                                    zIndex: 5,
+                                    opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
+                                    transition: 'opacity 0.2s, transform 0.2s linear',
+                                    transform: hoverElement === element ? 'scale(1.3)' : 'none',
+                                    cursor: 'pointer',
+                                    color: `hsla(${getHeatMapHue(clickCount || 0, highestClickCount)}, 20%, 12%, 1)`,
+                                    background: `hsla(${getHeatMapHue(clickCount || 0, highestClickCount)}, 100%, 62%, 1)`,
+                                    boxShadow: `hsla(${getHeatMapHue(clickCount || 0, highestClickCount)}, 100%, 32%, 1) 0px 1px 5px 1px`,
+                                }}
+                                onClick={() => selectElement(element)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
+                            >
+                                {compactNumber(clickCount || 0)}
+                            </AutocaptureElementLabel>
+                        )}
+                        {!!rageclickCount && (
+                            <AutocaptureElementLabel
+                                rect={rect}
+                                style={{
+                                    pointerEvents: heatmapPointerEvents,
+                                    zIndex: 5,
+                                    opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
+                                    transition: 'opacity 0.2s, transform 0.2s linear',
+                                    transform: hoverElement === element ? 'scale(1.3)' : 'none',
+                                    cursor: 'pointer',
+                                    color: `hsla(${getHeatMapHue(rageclickCount || 0, highestClickCount)}, 20%, 12%, 1)`,
+                                    background: `hsla(${getHeatMapHue(rageclickCount || 0, highestClickCount)}, 100%, 62%, 1)`,
+                                    boxShadow: `hsla(${getHeatMapHue(rageclickCount || 0, highestClickCount)}, 100%, 32%, 1) 0px 1px 5px 1px`,
+                                }}
+                                align="left"
+                                onClick={() => selectElement(element)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
+                            >
+                                {compactNumber(rageclickCount)}&#128545;
+                            </AutocaptureElementLabel>
+                        )}
+                        {!!deadclickCount && (
+                            <AutocaptureElementLabel
+                                rect={rect}
+                                style={{
+                                    pointerEvents: heatmapPointerEvents,
+                                    zIndex: 5,
+                                    opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
+                                    transition: 'opacity 0.2s, transform 0.2s linear',
+                                    transform: hoverElement === element ? 'scale(1.3)' : 'none',
+                                    cursor: 'pointer',
+                                    color: `hsla(${getHeatMapHue(deadclickCount || 0, highestClickCount)}, 20%, 12%, 1)`,
+                                    background: `hsla(${getHeatMapHue(deadclickCount || 0, highestClickCount)}, 100%, 62%, 1)`,
+                                    boxShadow: `hsla(${getHeatMapHue(deadclickCount || 0, highestClickCount)}, 100%, 32%, 1) 0px 1px 5px 1px`,
+                                }}
+                                align="left"
+                                onClick={() => selectElement(element)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
+                            >
+                                {compactNumber(deadclickCount)}&#128565;
+                            </AutocaptureElementLabel>
+                        )}
+                    </Fragment>
+                )
+            })}
+        </>
+    )
+})

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -10,7 +10,8 @@ import { experimentsTabLogic } from '~/toolbar/experiments/experimentsTabLogic'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
-import { ActionElementWithMetadata, ElementWithMetadata } from '~/toolbar/types'
+import { ActionElementWithMetadata, ActionForm, ElementWithMetadata } from '~/toolbar/types'
+import { ActionType } from '~/types'
 
 import { elementToActionStep, getAllClickTargets, getElementForStep, getRectForElement } from '../utils'
 import { FragileSelectorResult, checkSelectorFragilityCached } from '../utils/selectorQuality'
@@ -47,11 +48,27 @@ function getElementMetaWithSelectorQuality(
     }
 }
 
+let zIndexCache = new WeakMap<Element, number>()
+
+function clearZIndexCache(): void {
+    zIndexCache = new WeakMap()
+}
+
 const getMaxZIndex = (element: Element): number => {
+    const cached = zIndexCache.get(element)
+    if (cached !== undefined) {
+        return cached
+    }
+
     let maxZIndex = 0
     let currentElement: Element | null = element
 
     while (currentElement) {
+        const parentCached = zIndexCache.get(currentElement)
+        if (parentCached !== undefined) {
+            maxZIndex = Math.max(maxZIndex, parentCached)
+            break
+        }
         const zIndex = parseInt(getComputedStyle(currentElement).zIndex)
         if (!isNaN(zIndex) && zIndex > maxZIndex) {
             maxZIndex = zIndex
@@ -59,6 +76,7 @@ const getMaxZIndex = (element: Element): number => {
         currentElement = currentElement.parentElement
     }
 
+    zIndexCache.set(element, maxZIndex)
     return maxZIndex
 }
 
@@ -187,6 +205,9 @@ export const elementsLogic = kea<elementsLogicType>([
                 const result: ElementWithMetadata[] = []
 
                 for (const e of countedElements) {
+                    if (e.visible === false) {
+                        continue
+                    }
                     const rect = getRectForElement(e.element)
                     const inViewport =
                         rect.bottom >= -VIEWPORT_BUFFER_PX && rect.top <= windowHeight + VIEWPORT_BUFFER_PX
@@ -239,8 +260,7 @@ export const elementsLogic = kea<elementsLogicType>([
 
         _actionElements: [
             (s) => [s.displayActionElements, s.actionForm],
-            (displayActionElements, actionForm): ElementWithMetadata[] => {
-                // This function is expensive so should be calculated as rarely as possible
+            (displayActionElements: boolean, actionForm: ActionForm): ElementWithMetadata[] => {
                 if (displayActionElements && actionForm?.steps) {
                     const allElements = collectAllElementsDeep('*', document)
                     const steps: ElementWithMetadata[] = []
@@ -292,8 +312,7 @@ export const elementsLogic = kea<elementsLogicType>([
 
         _actionsForElementMap: [
             () => [actionsLogic.selectors.sortedActions],
-            (sortedActions): ActionElementMap => {
-                // This function is expensive so should be calculated as rarely as possible
+            (sortedActions: ActionType[]): ActionElementMap => {
                 const allElements = collectAllElementsDeep('*', document)
                 const actionsForElementMap = new Map<HTMLElement, ActionElementWithMetadata[]>()
                 sortedActions.forEach((action, index) => {
@@ -437,6 +456,9 @@ export const elementsLogic = kea<elementsLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        updateRects: () => {
+            clearZIndexCache()
+        },
         enableInspect: () => {
             toolbarPosthogJS.capture('toolbar mode triggered', { mode: 'inspect', enabled: true })
             actionsLogic.actions.getActions()
@@ -533,17 +555,14 @@ export const elementsLogic = kea<elementsLogicType>([
             }, 'clickListener')
 
             const onScrollResize = (): void => {
-                // Clear any existing timeout
-                cache.disposables.dispose('clickDelayTimeout')
-                actions.updateRects()
-
-                // Add new timeout
-                cache.disposables.add(() => {
-                    const timeout = window.setTimeout(actions.updateRects, 100)
-                    return () => window.clearTimeout(timeout)
-                }, 'clickDelayTimeout')
-
-                cache.updateRelativePosition()
+                if (!cache.rectUpdateScheduled) {
+                    cache.rectUpdateScheduled = true
+                    actions.updateRects()
+                    cache.updateRelativePosition()
+                    requestAnimationFrame(() => {
+                        cache.rectUpdateScheduled = false
+                    })
+                }
             }
 
             cache.disposables.add(() => {
@@ -581,8 +600,8 @@ export const elementsLogic = kea<elementsLogicType>([
             }, 'keydownListener')
 
             cache.disposables.add(() => {
-                window.document.addEventListener('scroll', onScrollResize, true)
-                return () => window.document.removeEventListener('scroll', onScrollResize, true)
+                window.document.addEventListener('scroll', onScrollResize, { capture: true, passive: true })
+                return () => window.document.removeEventListener('scroll', onScrollResize, { capture: true })
             }, 'scrollListener')
             cache.updateRelativePosition()
         },

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -11,12 +11,12 @@ import type { PaginatedResponse } from 'lib/api'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { createVersionChecker } from 'lib/utils/semver'
 
-import { buildDOMIndex, matchEventToElementUsingIndex } from '~/toolbar/elements/domElementIndex'
+import { DOMIndex, buildDOMIndex, matchEventToElementUsingIndex } from '~/toolbar/elements/domElementIndex'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { elementIsVisible, trimElement } from '~/toolbar/utils'
+import { elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
 import { FilterType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
@@ -37,6 +37,7 @@ function yieldToMain(): Promise<void> {
 
 interface ElementProcessingCache {
     pageElements?: HTMLElement[]
+    domIndex?: DOMIndex
     selectorToElements: Record<string, HTMLElement[]>
     lastHref?: string
     intersectionObserver?: IntersectionObserver
@@ -48,21 +49,26 @@ interface ElementProcessingCache {
 function invalidatePageElementsCache(cache: ElementProcessingCache): void {
     cache.cacheInvalidated = true
     cache.visibilityCache = new WeakMap()
+    cache.domIndex = undefined
 }
 
-function getCachedPageElements(cache: ElementProcessingCache, href: string): HTMLElement[] {
+function getCachedPageElements(
+    cache: ElementProcessingCache,
+    href: string
+): { pageElements: HTMLElement[]; domIndex: DOMIndex } {
     const hrefChanged = cache.lastHref !== href
     const cacheValid = cache.pageElements && !hrefChanged && !cache.cacheInvalidated
 
-    if (cacheValid && cache.pageElements) {
-        return cache.pageElements
+    if (cacheValid && cache.pageElements && cache.domIndex) {
+        return { pageElements: cache.pageElements, domIndex: cache.domIndex }
     }
 
     cache.pageElements = collectAllElementsDeep('*', document)
+    cache.domIndex = buildDOMIndex(cache.pageElements)
     cache.lastHref = href
     cache.selectorToElements = {}
     cache.cacheInvalidated = false
-    return cache.pageElements
+    return { pageElements: cache.pageElements, domIndex: cache.domIndex }
 }
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
@@ -351,9 +357,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         viewportRange: () => {
             actions.maybeLoadHeatmap()
         },
-        countedElements: () => {
-            actions.startElementObservation()
-        },
     })),
     listeners(({ actions, values, cache }) => ({
         processElements: async (_, breakpoint) => {
@@ -369,8 +372,8 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             }
 
             cache.visibilityCache = cache.visibilityCache || new WeakMap<HTMLElement, boolean>()
-            const pageElements = getCachedPageElements(cache as ElementProcessingCache, href)
-            const domIndex = buildDOMIndex(pageElements)
+            const cursorPointerCache = new WeakMap<HTMLElement, boolean>()
+            const { pageElements, domIndex } = getCachedPageElements(cache as ElementProcessingCache, href)
             const eventsToProcess = elementStats.results
             const totalEvents = eventsToProcess.length
 
@@ -394,7 +397,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                         )
 
                     if (matched) {
-                        const trimmed = trimElement(matched.element)
+                        const trimmed = trimElement(matched.element, { cursorPointerCache })
                         if (
                             trimmed &&
                             elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)
@@ -405,13 +408,14 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 }
 
                 processedCount = batchEnd
-                actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
                 actions.setProcessingProgress(processedCount, totalEvents)
 
                 breakpoint()
                 await yieldToMain()
             }
 
+            actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
+            actions.startElementObservation()
             actions.setIsRefreshing(false)
         },
 
@@ -554,6 +558,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 }
                 debounceTimer = setTimeout(() => {
                     invalidatePageElementsCache(cache as ElementProcessingCache)
+                    invalidateZoomCache()
                     debounceTimer = null
                 }, 500)
             })

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -167,8 +167,12 @@ export function getParent(element: HTMLElement): HTMLElement | null {
     return null
 }
 
-export function trimElement(element: HTMLElement, selector?: string): HTMLElement | null {
-    const target_selector = selector || CLICK_TARGET_SELECTOR
+export function trimElement(
+    element: HTMLElement,
+    options?: { selector?: string; cursorPointerCache?: WeakMap<HTMLElement, boolean> }
+): HTMLElement | null {
+    const target_selector = options?.selector || CLICK_TARGET_SELECTOR
+    const cursorPointerCache = options?.cursorPointerCache
     if (!element) {
         return null
     }
@@ -179,8 +183,6 @@ export function trimElement(element: HTMLElement, selector?: string): HTMLElemen
 
     let loopElement = element
 
-    // if it's an element with only one child, go down to the lowest node as far as we can
-    // we'll come back up later
     while (true) {
         if (loopElement.children.length === 1) {
             loopElement = loopElement.children[0] as HTMLElement
@@ -189,23 +191,31 @@ export function trimElement(element: HTMLElement, selector?: string): HTMLElemen
         }
     }
 
+    const hasCachedPointer = (el: HTMLElement): boolean => {
+        if (!cursorPointerCache) {
+            return window.getComputedStyle(el).getPropertyValue('cursor') === 'pointer'
+        }
+        const cached = cursorPointerCache.get(el)
+        if (cached !== undefined) {
+            return cached
+        }
+        const result = window.getComputedStyle(el).getPropertyValue('cursor') === 'pointer'
+        cursorPointerCache.set(el, result)
+        return result
+    }
+
     while (loopElement) {
         const parent = getParent(loopElement)
         if (!parent) {
             return null
         }
 
-        // return when we find a click target
         if (loopElement.matches?.(target_selector)) {
             return loopElement
         }
 
-        const compStyles = window.getComputedStyle(loopElement)
-        if (compStyles.getPropertyValue('cursor') === 'pointer') {
-            const parentStyles = parent ? window.getComputedStyle(parent) : null
-            if (!parentStyles || parentStyles.getPropertyValue('cursor') !== 'pointer') {
-                return loopElement
-            }
+        if (hasCachedPointer(loopElement) && !hasCachedPointer(parent)) {
+            return loopElement
         }
 
         loopElement = parent
@@ -307,7 +317,7 @@ export function getAllClickTargets(
             return a
         }, [] as HTMLElement[])
     const selectedElements = [...elements, ...pointerElements, ...shadowElements]
-        .map((e) => trimElement(e, targetSelector))
+        .map((e) => trimElement(e, { selector: targetSelector }))
         .filter((e) => e)
     const uniqueElements = Array.from(new Set(selectedElements)) as HTMLElement[]
 
@@ -473,6 +483,18 @@ export function stepToDatabaseFormat(step: ActionStepForm): ActionStepType {
     }
 }
 
+export function rectEqual(a?: ElementRect, b?: ElementRect): boolean {
+    if (a === b) {
+        return true
+    }
+    if (!a || !b) {
+        return false
+    }
+    return a.top === b.top && a.left === b.left && a.right === b.right && a.bottom === b.bottom
+}
+
+export const EMPTY_STYLE: Record<string, any> = {}
+
 export function getRectForElement(element: HTMLElement): ElementRect {
     const elements = [elementToAreaRect(element)]
 
@@ -495,20 +517,43 @@ export function getRectForElement(element: HTMLElement): ElementRect {
     return maxRect
 }
 
+let zoomCache = new WeakMap<HTMLElement, number[]>()
+let pageUsesZoom: boolean | undefined
+
+export function invalidateZoomCache(): void {
+    pageUsesZoom = undefined
+    zoomCache = new WeakMap()
+}
+
 export const getZoomLevel = (el: HTMLElement): number[] => {
+    if (pageUsesZoom === false) {
+        return []
+    }
+
+    const cached = zoomCache.get(el)
+    if (cached !== undefined) {
+        return cached
+    }
+
     const zooms: number[] = []
-    const getZoom = (el: HTMLElement): void => {
-        const zoom = window.getComputedStyle(el).getPropertyValue('zoom')
+    const getZoom = (current: HTMLElement): void => {
+        const zoom = window.getComputedStyle(current).getPropertyValue('zoom')
         const rzoom = zoom ? parseFloat(zoom) : 1
         if (rzoom !== 1) {
             zooms.push(rzoom)
         }
-        if (el.parentElement?.parentElement) {
-            getZoom(el.parentElement)
+        if (current.parentElement?.parentElement) {
+            getZoom(current.parentElement)
         }
     }
     getZoom(el)
     zooms.reverse()
+
+    if (zooms.length > 0) {
+        pageUsesZoom = true
+    }
+
+    zoomCache.set(el, zooms)
     return zooms
 }
 export const getRect = (el: HTMLElement): ElementRect => {


### PR DESCRIPTION
loading date for the toolbar's click map was improved
which means we can load so much data the screen freezes
no bueno
so, i asked the robot to do clever things to avoid it



tested by building locally and seeing i could still load the clickmap

![CleanShot 2026-03-09 at 13.52.53@2x.png](https://app.graphite.com/user-attachments/assets/e7331bb4-6f45-4338-a083-be8982a34e0b.png)

