### PR TITLE
fix: allow overriding minSearchLength for taxonomic filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
@@ -37,6 +37,7 @@ export function PathItemSelector({
                     }}
                     taxonomicGroupTypes={taxonomicGroupTypes}
                     optionsFromProp={{ wildcard: wildcardOptions }}
+                    minSearchQueryLength={0}
                 />
             }
         >

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -70,20 +70,12 @@ function CategoryPillContent({
                         <>
                             {': '}
                             {showLoading ? (
-                                <Spinner
-                                    className="text-sm inline-block ml-1"
-                                    textColored
-                                    speed="0.8s"
-                                />
+                                <Spinner className="text-sm inline-block ml-1" textColored speed="0.8s" />
                             ) : (
                                 totalResultCount
                             )}
                             {/* This is a workaround. We need to make the logic fetch more results when querying from clickhouse*/}
-                            <span
-                                aria-label={
-                                    hasMore ? `${totalResultCount} or more` : `${totalResultCount}`
-                                }
-                            >
+                            <span aria-label={hasMore ? `${totalResultCount} or more` : `${totalResultCount}`}>
                                 {hasMore ? '+' : ''}
                             </span>
                         </>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -41,7 +41,8 @@ function CategoryPillContent({
     onClick: () => void
 }): JSX.Element {
     const { taxonomicGroups } = useValues(taxonomicFilterLogic)
-    const { totalResultCount, totalListCount, isLoading, hasRemoteDataSource, hasMore } = useValues(infiniteListLogic)
+    const { totalResultCount, totalListCount, isLoading, hasRemoteDataSource, hasMore, needsMoreSearchCharacters } =
+        useValues(infiniteListLogic)
 
     const group = taxonomicGroups.find((g) => g.type === groupType)
 
@@ -65,16 +66,28 @@ function CategoryPillContent({
             ) : (
                 <>
                     {group?.name}
-                    {': '}
-                    {showLoading ? (
-                        <Spinner className="text-sm inline-block ml-1" textColored speed="0.8s" />
-                    ) : (
-                        totalResultCount
+                    {!needsMoreSearchCharacters && (
+                        <>
+                            {': '}
+                            {showLoading ? (
+                                <Spinner
+                                    className="text-sm inline-block ml-1"
+                                    textColored
+                                    speed="0.8s"
+                                />
+                            ) : (
+                                totalResultCount
+                            )}
+                            {/* This is a workaround. We need to make the logic fetch more results when querying from clickhouse*/}
+                            <span
+                                aria-label={
+                                    hasMore ? `${totalResultCount} or more` : `${totalResultCount}`
+                                }
+                            >
+                                {hasMore ? '+' : ''}
+                            </span>
+                        </>
                     )}
-                    {/* This is a workaround. We need to make the logic fetch more results when querying from clickhouse*/}
-                    <span aria-label={hasMore ? `${totalResultCount} or more` : `${totalResultCount}`}>
-                        {hasMore ? '+' : ''}
-                    </span>
                 </>
             )}
         </LemonTag>

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -49,6 +49,7 @@ export function TaxonomicFilter({
     allowNonCapturedEvents = false,
     hogQLGlobals,
     definitionPopoverRenderer,
+    minSearchQueryLength,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -83,6 +84,7 @@ export function TaxonomicFilter({
         allowNonCapturedEvents,
         maxContextOptions,
         hogQLGlobals,
+        minSearchQueryLength,
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -292,7 +292,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         ],
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         minSearchQueryLength: [
-            (s, p) => [s.group, p.minSearchQueryLength],
+            (s) => [s.group, (_, props) => props.minSearchQueryLength],
             (group, propsMinSearchQueryLength) => propsMinSearchQueryLength ?? group?.minSearchQueryLength ?? 0,
         ],
         needsMoreSearchCharacters: [

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -291,7 +291,11 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 taxonomicGroups.find((g) => g.type === listGroupType) as TaxonomicFilterGroup,
         ],
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
-        minSearchQueryLength: [(s) => [s.group], (group) => group?.minSearchQueryLength ?? 0],
+        minSearchQueryLength: [
+            (s, p) => [s.group, p.minSearchQueryLength],
+            (group, propsMinSearchQueryLength) =>
+                propsMinSearchQueryLength ?? group?.minSearchQueryLength ?? 0,
+        ],
         needsMoreSearchCharacters: [
             (s) => [s.minSearchQueryLength, s.searchQuery],
             (minSearchQueryLength, searchQuery) => {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -77,7 +77,7 @@ async function fetchCachedListResponse(path: string, searchParams: Record<string
 }
 
 export const infiniteListLogic = kea<infiniteListLogicType>([
-    props({ showNumericalPropsOnly: false } as InfiniteListLogicProps),
+    props({ showNumericalPropsOnly: false, minSearchQueryLength: undefined } as InfiniteListLogicProps),
     key((props) => `${props.taxonomicFilterLogicKey}-${props.listGroupType}`),
     path((key) => ['lib', 'components', 'TaxonomicFilter', 'infiniteListLogic', key]),
 
@@ -293,8 +293,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         remoteEndpoint: [(s) => [s.group], (group) => group?.endpoint || null],
         minSearchQueryLength: [
             (s, p) => [s.group, p.minSearchQueryLength],
-            (group, propsMinSearchQueryLength) =>
-                propsMinSearchQueryLength ?? group?.minSearchQueryLength ?? 0,
+            (group, propsMinSearchQueryLength) => propsMinSearchQueryLength ?? group?.minSearchQueryLength ?? 0,
         ],
         needsMoreSearchCharacters: [
             (s) => [s.minSearchQueryLength, s.searchQuery],

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -98,6 +98,8 @@ export interface TaxonomicFilterProps {
     hogQLGlobals?: Record<string, any>
     /** Optionally customize definition popover contents for selected items. */
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    /** Override the group-level minSearchQueryLength for all groups in this instance. */
+    minSearchQueryLength?: number
 }
 
 export interface DataWarehousePopoverField {


### PR DESCRIPTION
see https://posthog.slack.com/archives/C0ACRAMJUAG/p1772810916101069

## Problem

<img width="1684" height="1396" alt="image" src="https://github.com/user-attachments/assets/275ce62c-60d3-45d1-82e8-4ba9738833ec" />

minSearchLength is good for performance but not so great for humans
who don't know they're helping our cluster by typing a query
_and_ we show 0 in the group count before someone searches which isn't true - we have no results not zero as a result

## Changes

allow setting the minSearchLength, in the paths case the query is always filtered by event name so is relatively cheap (compared to an any event url search)

## How did you test this code?

![CleanShot 2026-03-09 at 14 19 42](https://github.com/user-attachments/assets/68e56eaa-844d-4f5a-b707-ba44dd288a52)



https://claude.ai/code/session_01RDYCmqtxW1v1SGcTaEkDhC