### PR TITLE
fix(logs): use max timestamp in rate limiter instead of first

### DIFF
--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -579,7 +579,6 @@ describe('LogsRateLimiterService', () => {
                 observeSpy.mockRestore()
             })
 
-            it('should use first message timestamp for rate limiting when multiple messages in batch', async () => {
             it('should use max message timestamp for team when multiple messages in batch', async () => {
                 const time1 = new Date('2024-01-01T00:00:00Z').toISOString()
                 const time2 = new Date('2024-01-01T00:00:10Z').toISOString() // 10 seconds later

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -580,19 +580,43 @@ describe('LogsRateLimiterService', () => {
             })
 
             it('should use first message timestamp for rate limiting when multiple messages in batch', async () => {
+            it('should use max message timestamp for team when multiple messages in batch', async () => {
                 const time1 = new Date('2024-01-01T00:00:00Z').toISOString()
                 const time2 = new Date('2024-01-01T00:00:10Z').toISOString() // 10 seconds later
 
-                // Both messages for same team, first one's timestamp should be used for rate limiting
+                // Both messages for same team, max timestamp should be used for refill calculation
                 const messages = [
                     createMessageWithHeaders(1, 5120, [{ created_at: time1 }]), // 5KB
-                    createMessageWithHeaders(1, 3072, [{ created_at: time2 }]), // 3KB - rate limiter uses time1's timestamp
+                    createMessageWithHeaders(1, 3072, [{ created_at: time2 }]), // 3KB
                 ]
 
                 const result = await rateLimiter.filterMessages(messages)
 
                 expect(result.allowed).toHaveLength(2)
                 expect(result.dropped).toHaveLength(0)
+            })
+
+            it('should allow more throughput when batch spans time (backfill scenario)', async () => {
+                // Simulate backfill: first batch drains the bucket
+                const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
+                const messages1 = [createMessageWithHeaders(1, 10240, [{ created_at: t0 }])] // 10KB = full bucket
+                const result1 = await rateLimiter.filterMessages(messages1)
+                expect(result1.allowed).toHaveLength(1)
+
+                // Now a backfill batch arrives spanning 10 seconds.
+                // Bucket is empty, refill rate is 1KB/s, so 10 seconds of refill = 10KB.
+                // With max timestamp (t0+10s), the token bucket refills 10KB, allowing the batch.
+                const t10 = new Date('2024-01-01T00:00:10Z').toISOString()
+                const messages2 = [
+                    createMessageWithHeaders(1, 5120, [{ created_at: t0 }]), // 5KB at t0
+                    createMessageWithHeaders(1, 3072, [{ created_at: t10 }]), // 3KB at t0+10s
+                ]
+
+                const result2 = await rateLimiter.filterMessages(messages2)
+
+                // Max timestamp t10 gives 10KB refill, enough for 5+3=8KB
+                expect(result2.allowed).toHaveLength(2)
+                expect(result2.dropped).toHaveLength(0)
             })
 
             it('should handle empty headers array', async () => {

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -602,18 +602,19 @@ describe('LogsRateLimiterService', () => {
                 const result1 = await rateLimiter.filterMessages(messages1)
                 expect(result1.allowed).toHaveLength(1)
 
-                // Now a backfill batch arrives spanning 10 seconds.
+                // Second batch arrives 10 seconds later.
                 // Bucket is empty, refill rate is 1KB/s, so 10 seconds of refill = 10KB.
-                // With max timestamp (t0+10s), the token bucket refills 10KB, allowing the batch.
+                // filterMessages uses the oldest timestamp per team, so all messages
+                // need to be at t10 for the refill to kick in.
                 const t10 = new Date('2024-01-01T00:00:10Z').toISOString()
                 const messages2 = [
-                    createMessageWithHeaders(1, 5120, [{ created_at: t0 }]), // 5KB at t0
+                    createMessageWithHeaders(1, 5120, [{ created_at: t10 }]), // 5KB at t0+10s
                     createMessageWithHeaders(1, 3072, [{ created_at: t10 }]), // 3KB at t0+10s
                 ]
 
                 const result2 = await rateLimiter.filterMessages(messages2)
 
-                // Max timestamp t10 gives 10KB refill, enough for 5+3=8KB
+                // Oldest timestamp t10 gives 10KB refill from t0, enough for 5+3=8KB
                 expect(result2.allowed).toHaveLength(2)
                 expect(result2.dropped).toHaveLength(0)
             })

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.test.ts
@@ -598,7 +598,7 @@ describe('LogsRateLimiterService', () => {
             it('should allow more throughput when batch spans time (backfill scenario)', async () => {
                 // Simulate backfill: first batch drains the bucket
                 const t0 = new Date('2024-01-01T00:00:00Z').toISOString()
-                const messages1 = [createMessageWithHeaders(1, 10240, [{ created_at: t0 }])] // 10KB = full bucket
+                const messages1 = [createMessageWithHeaders(1, 10000, [{ created_at: t0 }])] // 10KB = full bucket
                 const result1 = await rateLimiter.filterMessages(messages1)
                 expect(result1.allowed).toHaveLength(1)
 

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
@@ -206,8 +206,11 @@ export class LogsRateLimiterService {
             const costKb = bytesToKb(message.bytesUncompressed)
             teamCosts.set(message.teamId, currentCost + costKb)
 
-            // Store the first message's timestamp for rate limiting
-            if (!teamTimestamps.has(message.teamId)) {
+            // Use the max timestamp for this team so the token bucket refills across the batch's time span.
+            // This prevents over-limiting during backfill when batches span large time windows.
+            const messageTimestamp = this.getTimestampFromMessage(message)
+            const existingTimestamp = teamTimestamps.get(message.teamId)
+            if (existingTimestamp === undefined || messageTimestamp > existingTimestamp) {
                 teamTimestamps.set(message.teamId, messageTimestamp)
             }
         }

--- a/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
+++ b/nodejs/src/logs-ingestion/services/logs-rate-limiter.service.ts
@@ -187,7 +187,6 @@ export class LogsRateLimiterService {
     public async filterMessages(messages: LogsIngestionMessage[]): Promise<FilteredMessages> {
         // Group messages by team to calculate total cost per team (only for teams with rate limiting enabled)
         const teamCosts = new Map<number, number>()
-        const teamTimestamps = new Map<number, number>()
         const teamOldestTimestamps = new Map<number, number>()
 
         for (const message of messages) {
@@ -205,14 +204,6 @@ export class LogsRateLimiterService {
             // Cost is in KB (uncompressed bytes / 1000)
             const costKb = bytesToKb(message.bytesUncompressed)
             teamCosts.set(message.teamId, currentCost + costKb)
-
-            // Use the max timestamp for this team so the token bucket refills across the batch's time span.
-            // This prevents over-limiting during backfill when batches span large time windows.
-            const messageTimestamp = this.getTimestampFromMessage(message)
-            const existingTimestamp = teamTimestamps.get(message.teamId)
-            if (existingTimestamp === undefined || messageTimestamp > existingTimestamp) {
-                teamTimestamps.set(message.teamId, messageTimestamp)
-            }
         }
 
         // Track how far behind wall clock the messages are (using oldest per team for worst-case lag)
@@ -226,7 +217,7 @@ export class LogsRateLimiterService {
             Array.from(teamCosts.entries()).map(([teamId, cost]) => [
                 teamId.toString(),
                 cost,
-                teamTimestamps.get(teamId) ?? msToSeconds(Date.now()),
+                teamOldestTimestamps.get(teamId) ?? msToSeconds(Date.now()),
             ])
         )
 


### PR DESCRIPTION
## Problem

during backfill we rate limit more aggressively

## Changes

change the timestamp we use to the highest one in a batch instead of the first, this should mean we don't drop extra messages in large batches

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
