### PR TITLE
feat(llma): add playground analytics events and remove beta tag

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1438,7 +1438,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'llm_playground' as FileSystemIconType,
         iconColor: ['var(--color-product-llm-analytics-light)'] as FileSystemIconColor,
         href: urls.llmAnalyticsPlayground(),
-        tags: ['beta'],
         sceneKey: 'LLMAnalyticsPlayground',
         sceneKeys: [
             'LLMAnalytics',

--- a/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 import React from 'react'
 
 import {
@@ -463,6 +464,10 @@ function PlaygroundModelPicker({ promptId }: { promptId: string }): JSX.Element 
                 selectedProviderKeyId={prompt.selectedProviderKeyId}
                 onSelect={(modelId, providerKeyId) => {
                     const trialProvider = parseTrialProviderKeyId(providerKeyId)
+                    posthog.capture('llma playground model changed', {
+                        model: modelId,
+                        is_byok: !trialProvider,
+                    })
                     setModel(modelId, trialProvider ? undefined : providerKeyId, promptId)
                 }}
                 groups={groups}
@@ -595,6 +600,17 @@ function ModelConfigBar({ promptId }: { promptId: string }): JSX.Element {
                 overlay={<SettingsDropdownOverlay promptId={promptId} />}
                 closeOnClickInside={false}
                 placement="bottom-end"
+                onVisibilityChange={(visible) => {
+                    if (!visible && prompt) {
+                        posthog.capture('llma playground parameters configured', {
+                            max_tokens: prompt.maxTokens,
+                            temperature: prompt.temperature,
+                            top_p: prompt.topP,
+                            reasoning_level: prompt.reasoningLevel,
+                            thinking: prompt.thinking,
+                        })
+                    }
+                }}
             >
                 <LemonButton
                     type="secondary"
@@ -720,6 +736,7 @@ function ToolsButton({ promptId }: { promptId: string }): JSX.Element {
                                 type="button"
                                 className="text-xs text-link"
                                 onClick={() => {
+                                    posthog.capture('llma playground tools example inserted')
                                     const exampleJson = JSON.stringify(EXAMPLE_TOOL, null, 2)
                                     handleToolsChange(exampleJson)
                                     setLocalToolsJson(exampleJson, promptId)
@@ -802,6 +819,9 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
             return
         }
 
+        posthog.capture('llma playground system prompt synced', {
+            target_prompt_count: promptConfigs.length - 1,
+        })
         for (const otherPrompt of promptConfigs) {
             if (otherPrompt.id !== promptId) {
                 setSystemPrompt(prompt.systemPrompt, otherPrompt.id)
@@ -820,7 +840,10 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
                         icon={<IconCopy />}
                         tooltip="Copy system prompt"
                         noPadding
-                        onClick={() => void copyToClipboard(prompt.systemPrompt, 'system prompt')}
+                        onClick={() => {
+                            posthog.capture('llma playground response copied', { content_type: 'system_prompt' })
+                            void copyToClipboard(prompt.systemPrompt, 'system prompt')
+                        }}
                         data-attr="llma-playground-copy-system-prompt"
                     />
                     {hasOtherPrompts && (
@@ -928,6 +951,7 @@ function MessageDisplay({
         editModal?.type === 'message' && editModal.promptId === promptId && editModal.messageIndex === index
 
     const handleRoleChange = (newRole: MessageRole): void => {
+        posthog.capture('llma playground message role changed', { from: message.role, to: newRole })
         updateMessage(index, { role: newRole }, promptId)
     }
 
@@ -978,7 +1002,12 @@ function MessageDisplay({
                         icon={<IconCopy />}
                         tooltip="Copy message"
                         noPadding
-                        onClick={() => void copyToClipboard(message.content, `${message.role} message`)}
+                        onClick={() => {
+                            posthog.capture('llma playground response copied', {
+                                content_type: message.role === 'assistant' ? 'assistant_message' : 'user_message',
+                            })
+                            void copyToClipboard(message.content, `${message.role} message`)
+                        }}
                     />
                     <LemonButton
                         size="small"

--- a/products/llm_analytics/frontend/playground/PlaygroundSaveMenu.tsx
+++ b/products/llm_analytics/frontend/playground/PlaygroundSaveMenu.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
+import posthog from 'posthog-js'
 import React from 'react'
 
 import { IconLlmPromptManagement } from '@posthog/icons'
@@ -92,6 +93,7 @@ export function PlaygroundSaveMenu({ prompt }: { prompt: PromptConfig }): JSX.El
     }
 
     const clearLinkedSourceState = (): void => {
+        posthog.capture('llma playground source unlinked')
         clearLinkedSource()
         router.actions.replace(combineUrl(urls.llmAnalyticsPlayground(), cleanSourceSearchParams(searchParams)).url)
     }

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -616,6 +616,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             }
         },
         addPromptConfig: () => {
+            // New total after adding — listeners run post-reducer
             posthog.capture('llma playground prompt config added', {
                 prompt_count: values.promptConfigs.length,
             })

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -622,6 +622,9 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             })
         },
         removePromptConfig: ({ promptId }) => {
+            posthog.capture('llma playground prompt config removed', {
+                prompt_count: values.promptConfigs.length,
+            })
             if (values.promptConfigs.length === 0) {
                 actions.setPromptConfigs([createPromptConfig({ id: INITIAL_PROMPT.id })])
                 actions.setActivePromptId(INITIAL_PROMPT.id)
@@ -631,6 +634,23 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             if (values.activePromptId === null || values.activePromptId === promptId) {
                 actions.setActivePromptId(values.promptConfigs[0]?.id ?? null)
             }
+        },
+
+        addMessage: () => {
+            posthog.capture('llma playground message added', {
+                message_count: values.activePromptConfig?.messages.length ?? 0,
+            })
+        },
+        deleteMessage: () => {
+            posthog.capture('llma playground message removed', {
+                message_count: values.activePromptConfig?.messages.length ?? 0,
+            })
+        },
+        setTools: ({ tools }) => {
+            posthog.capture('llma playground tools configured', {
+                action: tools ? 'set' : 'clear',
+                tool_count: tools?.length ?? 0,
+            })
         },
 
         setupPlaygroundFromEvent: async ({ payload }) => {

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -1,5 +1,6 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { combineUrl, router, urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -605,6 +606,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
 
     listeners(({ actions, values, props }) => ({
         resetPlayground: () => {
+            posthog.capture('llma playground reset')
             const activeTabId = sceneLogic.findMounted()?.values.activeTabId
             const isActiveTab = !activeTabId || activeTabId === props.tabId
             if (isActiveTab) {
@@ -612,6 +614,11 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                     combineUrl(urls.llmAnalyticsPlayground(), cleanSourceSearchParams(router.values.searchParams)).url
                 )
             }
+        },
+        addPromptConfig: () => {
+            posthog.capture('llma playground prompt config added', {
+                prompt_count: values.promptConfigs.length,
+            })
         },
         removePromptConfig: ({ promptId }) => {
             if (values.promptConfigs.length === 0) {
@@ -626,6 +633,10 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         },
 
         setupPlaygroundFromEvent: async ({ payload }) => {
+            const sourceType = payload.sourceType ?? (payload.input ? 'trace' : null)
+            posthog.capture('llma playground opened from source', {
+                source_type: sourceType ?? 'unknown',
+            })
             actions.setSourceSetupLoading(true)
             const { input, tools, systemPrompt } = payload
             const currentPrompt = values.promptConfigs[0] ?? createPromptConfig({ id: INITIAL_PROMPT.id })
@@ -748,6 +759,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         },
 
         saveToLinkedPrompt: async () => {
+            posthog.capture('llma playground saved to source', { action: 'save_to_linked_prompt' })
             const { linkedSource, promptConfigs } = values
             if (!linkedSource.promptName) {
                 lemonToast.error('No linked prompt to save to')
@@ -798,6 +810,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         },
 
         saveToLinkedEvaluation: async ({ modelConfig }) => {
+            posthog.capture('llma playground saved to source', { action: 'save_to_linked_evaluation' })
             const { linkedSource, promptConfigs } = values
             if (!linkedSource.evaluationId) {
                 lemonToast.error('No linked evaluation to save to')
@@ -842,6 +855,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         },
 
         saveAsNewPrompt: async ({ name }) => {
+            posthog.capture('llma playground saved to source', { action: 'save_as_new_prompt' })
             const prompt = values.promptConfigs[0]
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')
@@ -881,6 +895,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         },
 
         saveAsNewEvaluation: async ({ name, modelConfig }) => {
+            posthog.capture('llma playground saved to source', { action: 'save_as_new_evaluation' })
             const prompt = values.promptConfigs[0]
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')

--- a/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
@@ -207,8 +207,17 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
 
     listeners(({ actions, values, props }) => ({
         abortRun: () => {
+            posthog.capture('llma playground prompt aborted')
             const key = props.tabId ?? 'default'
             abortControllersByKey.get(key)?.abort()
+        },
+        setRateLimited: ({ retryAfterSeconds }) => {
+            posthog.capture('llma playground rate limited', { retry_after_seconds: retryAfterSeconds })
+        },
+        setSubscriptionRequired: ({ required }) => {
+            if (required) {
+                posthog.capture('llma playground subscription required')
+            }
         },
 
         submitPrompt: async (_: unknown, breakpoint: () => void) => {

--- a/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundRunLogic.ts
@@ -1,4 +1,5 @@
 import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -225,6 +226,16 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                 return
             }
 
+            posthog.capture('llma playground prompt submitted', {
+                prompt_count: runnablePrompts.length,
+                models: runnablePrompts.map(({ prompt }) => prompt.model),
+                has_tools: runnablePrompts.some(({ prompt }) => !!prompt.tools?.length),
+                total_message_count: runnablePrompts.reduce(
+                    (sum, { messagesToSend }) => sum + messagesToSend.length,
+                    0
+                ),
+            })
+
             const key = props.tabId ?? 'default'
             const abortController = new AbortController()
             abortControllersByKey.set(key, abortController)
@@ -419,6 +430,18 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                         responseText += separator + toolCallsText
                     }
                     upsertLiveItem()
+
+                    posthog.capture('llma playground prompt completed', {
+                        model: prompt.model,
+                        provider: selectedModelProvider,
+                        latency_ms: latencyMs,
+                        ttft_ms: ttftMs,
+                        prompt_tokens: responseUsage.prompt_tokens,
+                        completion_tokens: responseUsage.completion_tokens,
+                        success: !responseHasError,
+                        has_tools: !!prompt.tools?.length,
+                        aborted: abortController.signal.aborted,
+                    })
                 })
 
                 await Promise.allSettled(runs)

--- a/products/llm_analytics/manifest.tsx
+++ b/products/llm_analytics/manifest.tsx
@@ -255,7 +255,6 @@ export const manifest: ProductManifest = {
             iconType: 'llm_playground' as FileSystemIconType,
             iconColor: ['var(--color-product-llm-analytics-light)'] as FileSystemIconColor,
             href: urls.llmAnalyticsPlayground(),
-            tags: ['beta'],
             sceneKey: 'LLMAnalyticsPlayground',
         },
         {


### PR DESCRIPTION
## Problem

We have no visibility into how users interact with the LLM analytics playground — which models they pick, whether they tweak parameters, how they use tools, or where they hit friction like rate limits. We also want to take the playground out of beta.

## Changes

- Remove `tags: ['beta']` from the playground entry in `manifest.tsx` and `products.tsx`
- Add 20 `posthog.capture` events covering all meaningful playground interactions:

| Event | Properties | Trigger |
|-------|-----------|---------|
| `llma playground prompt submitted` | `prompt_count`, `models`, `has_tools`, `total_message_count` | User runs prompts |
| `llma playground prompt completed` | `model`, `provider`, `latency_ms`, `ttft_ms`, tokens, `success`, `aborted` | Prompt stream finishes |
| `llma playground prompt aborted` | — | User stops generation |
| `llma playground opened from source` | `source_type` | Opened from trace/prompt/evaluation |
| `llma playground saved to source` | `action` | Save to linked or save as new |
| `llma playground source unlinked` | — | User unlinks from source |
| `llma playground reset` | — | User resets playground |
| `llma playground prompt config added` | `prompt_count` | User adds a prompt config |
| `llma playground prompt config removed` | `prompt_count` | User removes a prompt config |
| `llma playground model changed` | `model`, `is_byok` | User picks a different model |
| `llma playground parameters configured` | `max_tokens`, `temperature`, `top_p`, `reasoning_level`, `thinking` | User closes settings dropdown |
| `llma playground message added` | `message_count` | User adds a message |
| `llma playground message removed` | `message_count` | User removes a message |
| `llma playground message role changed` | `from`, `to` | User changes message role |
| `llma playground tools configured` | `action`, `tool_count` | User sets or clears tools |
| `llma playground tools example inserted` | — | User inserts example tool |
| `llma playground response copied` | `content_type` | User copies content to clipboard |
| `llma playground system prompt synced` | `target_prompt_count` | User syncs system prompt across configs |
| `llma playground rate limited` | `retry_after_seconds` | User hits rate limit |
| `llma playground subscription required` | — | User hits paywall |

Parameters are captured as a snapshot when the settings dropdown closes (not per keystroke) to avoid noise, following the same pattern used by the logs product.

Stacked on #49892.

## How did you test this code?

All 69 existing playground tests pass. TypeScript compiles cleanly.

## Publish to changelog?

no