### PR TITLE
feat(subscriptions): Include subscription title in the slack message

### DIFF
--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -116,11 +116,16 @@ def _prepare_slack_message(
     channel = subscription.target_value.split("|")[0]
     first_asset, *other_assets = assets
 
+    if subscription.title:
+        display_name = f"*{subscription.title}* ({resource_info.kind}: {resource_info.name})"
+    else:
+        display_name = f"the {resource_info.kind} *{resource_info.name}*"
+
     if is_new_subscription:
-        title = f"This channel has been subscribed to the {resource_info.kind} *{resource_info.name}* on PostHog! 🎉"
+        title = f"This channel has been subscribed to {display_name} on PostHog! 🎉"
         title += f"\nThis subscription is {subscription.summary}. The next one will be sent on {subscription.next_delivery_date.strftime('%A %B %d, %Y')}"
     else:
-        title = f"Your subscription to the {resource_info.kind} *{resource_info.name}* is ready! 🎉"
+        title = f"Your subscription to {display_name} is ready! 🎉"
 
     blocks = [
         {"type": "section", "text": {"type": "mrkdwn", "text": title}},

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -5,6 +5,8 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from parameterized import parameterized
+
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
@@ -92,21 +94,50 @@ class TestSlackSubscriptionsTasks(APIBaseTest):
             },
         ]
 
-    def test_subscription_delivery_new(self, MockSlackIntegration: MagicMock) -> None:
+    @parameterized.expand(
+        [
+            (
+                "recurring_without_title",
+                None,
+                False,
+                "Your subscription to the Insight *My Test subscription* is ready! 🎉",
+            ),
+            (
+                "recurring_with_title",
+                "Weekly KPI Report",
+                False,
+                "Your subscription to *Weekly KPI Report* (Insight: My Test subscription) is ready! 🎉",
+            ),
+            (
+                "new_without_title",
+                None,
+                True,
+                "This channel has been subscribed to the Insight *My Test subscription* on PostHog! 🎉\nThis subscription is sent every day. The next one will be sent on Wednesday February 02, 2022",
+            ),
+            (
+                "new_with_title",
+                "Weekly KPI Report",
+                True,
+                "This channel has been subscribed to *Weekly KPI Report* (Insight: My Test subscription) on PostHog! 🎉\nThis subscription is sent every day. The next one will be sent on Wednesday February 02, 2022",
+            ),
+        ]
+    )
+    def test_subscription_delivery_title(
+        self, MockSlackIntegration: MagicMock, _name: str, title: str | None, is_new: bool, expected_text: str
+    ) -> None:
         mock_slack_integration = MagicMock()
         MockSlackIntegration.return_value = mock_slack_integration
         mock_slack_integration.client.chat_postMessage.return_value = {"ts": "1.234"}
 
-        send_slack_subscription_report(self.subscription, [self.asset], 1, is_new_subscription=True)
+        if title:
+            self.subscription.title = title
+            self.subscription.save()
+
+        send_slack_subscription_report(self.subscription, [self.asset], 1, is_new_subscription=is_new)
 
         assert mock_slack_integration.client.chat_postMessage.call_count == 1
-        post_message_calls = mock_slack_integration.client.chat_postMessage.call_args_list
-        first_call = post_message_calls[0].kwargs
-
-        assert (
-            first_call["text"]
-            == "This channel has been subscribed to the Insight *My Test subscription* on PostHog! 🎉\nThis subscription is sent every day. The next one will be sent on Wednesday February 02, 2022"
-        )
+        first_call = mock_slack_integration.client.chat_postMessage.call_args_list[0].kwargs
+        assert first_call["text"] == expected_text
 
     def test_subscription_dashboard_delivery(self, MockSlackIntegration: MagicMock) -> None:
         mock_slack_integration = MagicMock()


### PR DESCRIPTION
## Problem

Slack subscription messages currently only display the resource type and name, making it difficult for users to distinguish between multiple subscriptions to the same resource when they have custom titles configured.

This became apparent after merging: https://github.com/PostHog/posthog/pull/45987 through which users can configure different "sized" subscriptions based on their needs. 

Example: https://posthog.slack.com/archives/C09S5802LMU/p1773063382724529, as you can see here, it's not possible to see which subscription generated this, causing some lost context.

## Changes

Enhanced Slack subscription messages to display custom subscription titles when available. The message format now shows:
- `*Custom Title* (dashboard: Dashboard Name)` when a subscription has a custom title
- `the dashboard *Dashboard Name*` when no custom title is set

This applies to both new subscription confirmation messages and regular subscription delivery messages.

## How did you test this code?

✅ CI (including the new test) is passing

## Publish to changelog?

No