### PR TITLE
fix(dashboards): don't commit dashboard refresh if there are failing tiles

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -7,6 +7,7 @@ import api from 'lib/api'
 import { now } from 'lib/dayjs'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import * as dashboardUtils from 'scenes/dashboard/dashboardUtils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
@@ -574,6 +575,34 @@ describe('dashboardLogic', () => {
                             total: 2,
                         },
                     })
+            })
+
+            it('manual refresh does not update last refresh when insights fail', async () => {
+                const dashboard = dashboards[5]
+                const insight1 = dashboard.tiles[0].insight!
+                const insight2 = dashboard.tiles[1].insight!
+                const refreshError = new Error('Queries are a little too busy right now.')
+                const getInsightWithRetrySpy = jest
+                    .spyOn(dashboardUtils, 'getInsightWithRetry')
+                    .mockRejectedValue(refreshError)
+
+                ;(api.update as jest.Mock).mockClear()
+
+                await expectLogic(logic, () => {
+                    logic.actions.triggerDashboardRefresh()
+                })
+                    .toDispatchActions([
+                        'triggerDashboardRefresh',
+                        'refreshDashboardItems',
+                        logic.actionCreators.setRefreshStatuses([insight1.short_id, insight2.short_id], false, true),
+                    ])
+                    .toFinishAllListeners()
+
+                expect(logic.values.lastDashboardRefresh).toBeNull()
+                expect(logic.values.blockRefresh).toBe(false)
+                expect(api.update).not.toHaveBeenCalled()
+
+                getInsightWithRetrySpy.mockRestore()
             })
 
             it('automatic refresh reloads stale insights (but not fresh ones)', async () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1763,7 +1763,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                 // update last refresh time, only if we've forced a blocking refresh of the dashboard
                 // and all tiles were refreshed
-                if (forceRefresh && tilesAbortedCount === 0) {
+                if (forceRefresh && tilesAbortedCount === 0 && tilesErroredCount === 0) {
                     actions.updateDashboardLastRefresh(dayjs())
                 }
 


### PR DESCRIPTION
## Problem

Dashboard can't be refresh if some tiles are failing https://posthog.slack.com/archives/C0ACRAMJUAG/p1773060103963249

## Changes

Allows to do so. We might want to separate retryable and not-retryable exceptions in the future, but this seems fine for now.

## How did you test this code?

Tried locally by raising an exception