### PR TITLE
fix(dashboards): pass size to variable select for list vars

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -347,6 +347,7 @@ export const VariableComponent = ({
                     value={variable.value ?? variable.default_value}
                     onChange={(value) => onChange(variable.id, value, variable.isNull ?? false)}
                     options={variable.values.map((n) => ({ label: n, value: n }))}
+                    size={size}
                 />
             </LemonField.Pure>
         )


### PR DESCRIPTION
## Problem

The size of variables for the list type was off in the dashboard header.

![Screenshot 2026-03-09 at 15.09.51.png](https://app.graphite.com/user-attachments/assets/7e9d22c5-28f3-4248-868b-2151487a5085.png)

## Changes

Passes the size to the component.
![Screenshot 2026-03-09 at 15.08.49.png](https://app.graphite.com/user-attachments/assets/863c9d7b-d281-47cd-aaea-90014238c3b4.png)

## How did you test this code?

👀 