### PR TITLE
fix(llma): relabel prompt management as beta

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1491,7 +1491,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
         href: urls.llmAnalyticsPrompts(),
         flag: FEATURE_FLAGS.PROMPT_MANAGEMENT,
-        tags: ['alpha'],
+        tags: ['beta'],
         sceneKey: 'LLMAnalyticsPrompts',
         sceneKeys: [
             'LLMAnalytics',

--- a/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
+++ b/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
@@ -276,6 +276,5 @@ export function LLMPromptScene(): JSX.Element {
             </SceneContent>
         </Form>
     )
-
     return content
 }

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -158,8 +158,7 @@ export function PromptUsage({ prompt }: { prompt: LLMPrompt }): JSX.Element {
     return (
         <div data-attr="prompt-usage-container">
             <LemonBanner type="info" className="mb-4">
-                During the beta period, each prompt fetch is currently charged as a Product analytics event.
-                See the{' '}
+                During the beta period, each prompt fetch is currently charged as a Product analytics event. See the{' '}
                 <Link to="https://posthog.com/pricing" target="_blank">
                     pricing page
                 </Link>

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -158,7 +158,7 @@ export function PromptUsage({ prompt }: { prompt: LLMPrompt }): JSX.Element {
     return (
         <div data-attr="prompt-usage-container">
             <LemonBanner type="info" className="mb-4">
-                During the alpha and beta period, each prompt fetch is currently charged as a Product analytics event.
+                During the beta period, each prompt fetch is currently charged as a Product analytics event.
                 See the{' '}
                 <Link to="https://posthog.com/pricing" target="_blank">
                     pricing page

--- a/products/llm_analytics/manifest.tsx
+++ b/products/llm_analytics/manifest.tsx
@@ -303,7 +303,7 @@ export const manifest: ProductManifest = {
             iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
             href: urls.llmAnalyticsPrompts(),
             flag: FEATURE_FLAGS.PROMPT_MANAGEMENT,
-            tags: ['alpha'],
+            tags: ['beta'],
             sceneKey: 'LLMAnalyticsPrompts',
         },
     ],


### PR DESCRIPTION
## Problem
- Prompt management is still labeled alpha in parts of the UI.

## Changes
- Change the prompt management product tag from `alpha` to `beta` in the frontend product catalog.
- Update prompt management copy to refer to the beta period.

## How did you test this code?
- Not run.

## Publish to changelog?
- no