### PR TITLE
feat(llma): add telemetry for eval event emission failures

### DIFF
--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -108,6 +108,22 @@ def increment_tokens(token_type: str, count: int) -> None:
     counter.add(count)
 
 
+def increment_emit_event_outcome(outcome: str) -> None:
+    """Track $ai_evaluation event emission outcomes (success/failed).
+
+    Distinguishes Activity 4 failures from other workflow failures so we can
+    measure and alert on dropped eval events specifically.
+    """
+    if not activity.in_activity() and not workflow.in_workflow():
+        return
+    meter = get_metric_meter({"outcome": outcome})
+    counter = meter.create_counter(
+        "llma_eval_emit_event_outcome",
+        "Outcome of $ai_evaluation event emission (success/failed)",
+    )
+    counter.add(1)
+
+
 def record_schedule_to_start_latency(activity_type: str, latency_ms: int) -> None:
     """Record queue depth indicator for alerting."""
     meter = get_metric_meter({"activity_type": activity_type})

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -18,6 +18,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.message_utils import extract_text_from_messages
 from posthog.temporal.llm_analytics.metrics import (
+    increment_emit_event_outcome,
     increment_errors,
     increment_key_type,
     increment_provider_model,
@@ -693,7 +694,12 @@ async def emit_evaluation_event_activity(inputs: EmitEvaluationEventInputs) -> N
         )
         resp.raise_for_status()
 
-    await database_sync_to_async(_emit, thread_sensitive=False)()
+    try:
+        await database_sync_to_async(_emit, thread_sensitive=False)()
+        increment_emit_event_outcome("success")
+    except Exception:
+        increment_emit_event_outcome("failed")
+        raise
 
 
 @dataclass
@@ -831,17 +837,21 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                 )
 
         # Activity 4: Emit evaluation event
-        await temporalio.workflow.execute_activity(
-            emit_evaluation_event_activity,
-            EmitEvaluationEventInputs(
-                evaluation=evaluation,
-                event_data=inputs.event_data,
-                result=result,
-                start_time=start_time,
-            ),
-            schedule_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_evaluation_event_activity,
+                EmitEvaluationEventInputs(
+                    evaluation=evaluation,
+                    event_data=inputs.event_data,
+                    result=result,
+                    start_time=start_time,
+                ),
+                schedule_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+        except Exception:
+            increment_errors("emit_evaluation_event_failed")
+            raise
 
         # Activity 5: Emit internal telemetry (fire-and-forget)
         await temporalio.workflow.execute_activity(


### PR DESCRIPTION
## Problem

When `emit_evaluation_event_activity` (Activity 4) fails in the eval workflow, the failure shows up as a generic `workflow_exception` in `llma_eval_errors` — indistinguishable from failures in any other activity. This means we cannot measure or alert on dropped `$ai_evaluation` events specifically.

During a recent ingestion backpressure incident, Activity 4 failures caused eval events to be silently dropped (the eval was computed and tokens were spent, but the result event was never recorded). We had no targeted metric to detect or measure this.

## Changes

Two new telemetry points:

- **`llma_eval_emit_event_outcome{outcome=success/failed}`** — counter in the activity itself, tracking every attempt to emit a `$ai_evaluation` event. Enables alerting on `rate(failed) > 0` and dashboarding the drop rate.
- **`llma_eval_errors{error_type=emit_evaluation_event_failed}`** — labeled error counter in the workflow, distinguishing Activity 4 failures from other workflow errors in the existing `llma_eval_errors` metric.

Suggested alerts:
- `rate(llma_eval_emit_event_outcome{outcome="failed"}[5m]) > 0`
- `rate(llma_eval_emit_event_outcome{outcome="failed"}[5m]) / rate(llma_eval_emit_event_outcome[5m]) > 0.01`

## How did you test this code?

Code review. The new metrics follow the same pattern as existing eval metrics (`increment_errors`, `increment_eval_signal_outcome`) using Temporal's built-in metric meter. No behavioral changes — the activity and workflow still raise on failure as before.

## Publish to changelog?

No