### PR TITLE
feat(lemon modal): centers the lemon modal when opened by default

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
@@ -32,6 +32,7 @@
 
 .LemonModal {
     position: relative;
+    top: 50%;
     display: flex;
     flex-direction: column;
     width: fit-content;
@@ -49,7 +50,7 @@
     transition:
         opacity var(--modal-transition-time) ease-out,
         transform var(--modal-transition-time) ease-out;
-    transform: scale(0.85);
+    transform: translateY(-50%) scale(0.85);
 
     // Transition properties
     will-change: transform;
@@ -66,7 +67,7 @@
 
     &.ReactModal__Content--after-open:not(.ReactModal__Content--before-close) {
         opacity: 1;
-        transform: scale(1);
+        transform: translateY(-50%) scale(1);
     }
 
     .LemonModal__close {


### PR DESCRIPTION
## Problem

When the LemonModal is used, by default it opens at the top of the page, which is much more exaggerated on bigger screens. This leads to a visual balance that feels slightly off.

## Changes

Before:
<img width="1739" height="1442" alt="image" src="https://github.com/user-attachments/assets/864331d9-a3ba-4ae7-b0b5-9c7be0ed56f4" />


After:
<img width="1798" height="1492" alt="image" src="https://github.com/user-attachments/assets/84a5813f-427a-44ea-a228-626a790d5f8d" />


## How did you test this code?

Locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No.