### PR TITLE
fix: add environment variable for cohort Kafka batch size to mitigate timeouts

### DIFF
--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -1,3 +1,4 @@
+import os
 import time
 import asyncio
 import datetime as dt
@@ -26,6 +27,9 @@ from posthog.temporal.common.logger import get_logger
 
 if TYPE_CHECKING:
     from posthog.kafka_client.client import _KafkaProducer
+
+# Configuration
+FLUSH_BATCH_SIZE = int(os.environ.get("COHORT_KAFKA_FLUSH_BATCH_SIZE", "1000"))
 
 # Cohort calculation timing histograms
 COHORT_CALCULATION_TOTAL_DURATION_HISTOGRAM = Histogram(
@@ -358,7 +362,6 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                 ):
                     status_counts = {"entered": 0, "left": 0}
                     pending_kafka_messages = []
-                    FLUSH_BATCH_SIZE = 10_000  # Flush every 10k messages to allow heartbeats
                     # Count of messages successfully produced to Kafka (pending flush), excluding failed produce attempts
                     total_messages = 0
                     total_flushed = 0

--- a/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
@@ -257,15 +257,26 @@ class TestFlushKafkaBatch:
 class TestBatchFlushingBehavior:
     """Tests for batch flushing logic and integration."""
 
-    def test_flush_batch_size_constant_is_10k(self):
-        """Verify the FLUSH_BATCH_SIZE constant is set to 10,000."""
-        # Read the source to verify the constant
-        import inspect
+    def test_flush_batch_size_env_var_configuration(self):
+        """Verify FLUSH_BATCH_SIZE uses environment variable configuration."""
+        import os
 
+        # Test default value (1000 when env var is not set)
+        with patch.dict(os.environ, {}, clear=True):
+            # Test the env parsing logic directly
+            default_value = int(os.environ.get("COHORT_KAFKA_FLUSH_BATCH_SIZE", "1000"))
+            assert default_value == 1000
+
+        # Test env var override
+        with patch.dict(os.environ, {"COHORT_KAFKA_FLUSH_BATCH_SIZE": "500"}):
+            env_value = int(os.environ.get("COHORT_KAFKA_FLUSH_BATCH_SIZE", "1000"))
+            assert env_value == 500
+
+        # Test that the module constant exists and is configurable
         import posthog.temporal.messaging.realtime_cohort_calculation_workflow as module
 
-        source = inspect.getsource(module.process_realtime_cohort_calculation_activity)
-        assert "FLUSH_BATCH_SIZE = 10_000" in source
+        assert hasattr(module, "FLUSH_BATCH_SIZE")
+        assert isinstance(module.FLUSH_BATCH_SIZE, int)
 
     @pytest.mark.asyncio
     async def test_multiple_batches_handled_correctly(self):

--- a/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
@@ -1,3 +1,4 @@
+import os
 import statistics
 
 import pytest
@@ -259,8 +260,6 @@ class TestBatchFlushingBehavior:
 
     def test_flush_batch_size_env_var_configuration(self):
         """Verify FLUSH_BATCH_SIZE uses environment variable configuration."""
-        import os
-
         # Test default value (1000 when env var is not set)
         with patch.dict(os.environ, {}, clear=True):
             # Test the env parsing logic directly


### PR DESCRIPTION
## Problem

Cohort calculations are experiencing Kafka timeout issues causing total workflow failures. The `COHORT_QUERY_EXECUTION_DURATION_HISTOGRAM` metric shows spikes from 400ms to 10s, but ClickHouse queries themselves remain stable, indicating the bottleneck is in Kafka operations.

Error logs show:
```
KafkaError{code=_MSG_TIMED_OUT,val=-192,str="Local: Message timed out"}
Failed to send 7/7 Kafka messages for cohort
```

## Changes

- Add `COHORT_KAFKA_FLUSH_BATCH_SIZE` environment variable to control Kafka batch size
- Default reduced from 10,000 to 1,000 messages per batch