### PR TITLE
refactor: Separate interceptors by task queue

### DIFF
--- a/posthog/temporal/common/interceptor.py
+++ b/posthog/temporal/common/interceptor.py
@@ -2,6 +2,10 @@ import typing
 
 from temporalio.worker import Interceptor
 
+from posthog.temporal.common.logger import get_write_only_logger
+
+LOGGER = get_write_only_logger(__name__)
+
 
 class AllTaskQueues:
     """Sentinel type indicating all task queues are supported."""
@@ -30,7 +34,8 @@ def is_task_queue_supported(
     # TODO: Should support also checking activities and workflows.
     # For when the queue is shared among many products.
     if not _is_has_task_queue(interceptor):
-        raise ValueError("Interceptor does not have a defined task queue")
+        LOGGER.warning("Interceptor '%s' missing task queue", interceptor)
+        return False
 
     match interceptor.task_queue:
         case AllTaskQueues():

--- a/posthog/temporal/common/interceptor.py
+++ b/posthog/temporal/common/interceptor.py
@@ -1,0 +1,35 @@
+import typing
+
+
+class AllTaskQueues:
+    """Sentinel type indicating all task queues are supported."""
+
+    pass
+
+
+ALL_TASK_QUEUES = AllTaskQueues()
+
+
+class _HasTaskQueue(typing.Protocol):
+    """Protocol for interceptors to indicate which task queue(s) they support."""
+
+    task_queue: typing.ClassVar[str | tuple[str, ...] | AllTaskQueues]
+
+
+def is_task_queue_supported(
+    task_queue: str,
+    interceptor: _HasTaskQueue,
+) -> bool:
+    """Return whether the ``task_queue`` is supported by ``interceptor``."""
+    # TODO: Should support also checking activities and workflows.
+    # For when the queue is shared among many products.
+
+    match interceptor.task_queue:
+        case AllTaskQueues():
+            return True
+        case tuple():
+            return task_queue in interceptor.task_queue
+        case str():
+            return task_queue == interceptor.task_queue
+        case _ as unreachable:
+            typing.assert_never(unreachable)

--- a/posthog/temporal/common/interceptor.py
+++ b/posthog/temporal/common/interceptor.py
@@ -1,5 +1,7 @@
 import typing
 
+from temporalio.worker import Interceptor
+
 
 class AllTaskQueues:
     """Sentinel type indicating all task queues are supported."""
@@ -16,13 +18,19 @@ class _HasTaskQueue(typing.Protocol):
     task_queue: typing.ClassVar[str | tuple[str, ...] | AllTaskQueues]
 
 
+def _is_has_task_queue(interceptor: Interceptor | type[Interceptor]) -> typing.TypeGuard[_HasTaskQueue]:
+    return hasattr(interceptor, "task_queue")
+
+
 def is_task_queue_supported(
     task_queue: str,
-    interceptor: _HasTaskQueue,
+    interceptor: Interceptor | type[Interceptor],
 ) -> bool:
     """Return whether the ``task_queue`` is supported by ``interceptor``."""
     # TODO: Should support also checking activities and workflows.
     # For when the queue is shared among many products.
+    if not _is_has_task_queue(interceptor):
+        raise ValueError("Interceptor does not have a defined task queue")
 
     match interceptor.task_queue:
         case AllTaskQueues():

--- a/posthog/temporal/common/liveness_tracker.py
+++ b/posthog/temporal/common/liveness_tracker.py
@@ -2,6 +2,8 @@ import time
 import threading
 from typing import Any
 
+from django.conf import settings
+
 from temporalio.worker import (
     ActivityInboundInterceptor,
     ExecuteActivityInput,
@@ -118,6 +120,8 @@ class _LivenessWorkflowInterceptor(WorkflowInboundInterceptor):
 
 class LivenessInterceptor(Interceptor):
     """Interceptor that tracks worker liveness for health checks."""
+
+    task_queue = settings.DATA_WAREHOUSE_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _LivenessActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/common/liveness_tracker.py
+++ b/posthog/temporal/common/liveness_tracker.py
@@ -121,7 +121,7 @@ class _LivenessWorkflowInterceptor(WorkflowInboundInterceptor):
 class LivenessInterceptor(Interceptor):
     """Interceptor that tracks worker liveness for health checks."""
 
-    task_queue = settings.DATA_WAREHOUSE_TASK_QUEUE
+    task_queue = (settings.DATA_WAREHOUSE_TASK_QUEUE, settings.MAX_AI_TASK_QUEUE)
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _LivenessActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -13,6 +13,7 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
+from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 from posthog.temporal.common.logger import get_write_only_logger
 
 logger = get_write_only_logger()
@@ -100,6 +101,8 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
 
 class PostHogClientInterceptor(Interceptor):
     """PostHog Interceptor class which will report workflow & activity exceptions to PostHog"""
+
+    task_queue = ALL_TASK_QUEUES
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         """Implementation of

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -1,4 +1,5 @@
 import socket
+import typing
 import datetime as dt
 import itertools
 import collections.abc
@@ -11,6 +12,7 @@ from temporalio.worker import ResourceBasedSlotConfig, UnsandboxedWorkflowRunner
 
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer
+from posthog.temporal.common.interceptor import is_task_queue_supported
 from posthog.temporal.common.liveness_tracker import LivenessInterceptor
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
@@ -94,6 +96,18 @@ SUMMARIZATION_LATENCY_HISTOGRAM_BUCKETS = [
 ]
 
 
+ALL_INTERCEPTOR_CLASSES = [
+    LivenessInterceptor,
+    PostHogClientInterceptor,
+    BatchExportsMetricsInterceptor,
+    DeleteRecordingsMetricsInterceptor,
+    EvalsMetricsInterceptor,
+    SummarizationMetricsInterceptor,
+    ClusteringMetricsInterceptor,
+    SentimentMetricsInterceptor,
+]
+
+
 @dataclass
 class ManagedWorker:
     """A Temporal worker bundled with its associated resources for unified lifecycle management."""
@@ -122,7 +136,7 @@ async def create_worker(
     namespace: str,
     task_queue: str,
     workflows: collections.abc.Sequence[type],
-    activities,
+    activities: collections.abc.Sequence[typing.Callable],
     server_root_ca_cert: str | None = None,
     client_cert: str | None = None,
     client_key: str | None = None,
@@ -248,6 +262,9 @@ async def create_worker(
         runtime=runtime,
         use_pydantic_converter=use_pydantic_converter,
     )
+    supported_interceptors = [
+        interceptor() for interceptor in ALL_INTERCEPTOR_CLASSES if is_task_queue_supported(task_queue, interceptor)
+    ]
 
     if target_memory_usage is not None:
         worker = Worker(
@@ -257,16 +274,7 @@ async def create_worker(
             activities=activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
             graceful_shutdown_timeout=graceful_shutdown_timeout or dt.timedelta(minutes=5),
-            interceptors=[
-                LivenessInterceptor(),
-                PostHogClientInterceptor(),
-                BatchExportsMetricsInterceptor(),
-                DeleteRecordingsMetricsInterceptor(),
-                EvalsMetricsInterceptor(),
-                SummarizationMetricsInterceptor(),
-                ClusteringMetricsInterceptor(),
-                SentimentMetricsInterceptor(),
-            ],
+            interceptors=supported_interceptors,
             activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
             tuner=WorkerTuner.create_resource_based(
                 target_memory_usage=target_memory_usage,
@@ -286,16 +294,7 @@ async def create_worker(
             activities=activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
             graceful_shutdown_timeout=graceful_shutdown_timeout or dt.timedelta(minutes=5),
-            interceptors=[
-                LivenessInterceptor(),
-                PostHogClientInterceptor(),
-                BatchExportsMetricsInterceptor(),
-                DeleteRecordingsMetricsInterceptor(),
-                EvalsMetricsInterceptor(),
-                SummarizationMetricsInterceptor(),
-                ClusteringMetricsInterceptor(),
-                SentimentMetricsInterceptor(),
-            ],
+            interceptors=supported_interceptors,
             activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
             max_concurrent_activities=max_concurrent_activities or 50,
             max_concurrent_workflow_tasks=max_concurrent_workflow_tasks or 50,

--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -1,6 +1,8 @@
 import typing
 import datetime as dt
 
+from django.conf import settings
+
 from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
@@ -88,6 +90,8 @@ def increment_recordings_failed(count: int) -> None:
 
 
 class DeleteRecordingsMetricsInterceptor(Interceptor):
+    task_queue = settings.SESSION_REPLAY_TASK_QUEUE
+
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _DeleteRecordingsActivityInterceptor(super().intercept_activity(next))
 

--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -2,6 +2,8 @@ import time
 import typing
 import datetime as dt
 
+from django.conf import settings
+
 from temporalio import activity, workflow
 from temporalio.common import MetricMeter
 from temporalio.worker import (
@@ -201,6 +203,8 @@ class ExecutionTimeRecorder:
 
 class EvalsMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for evals workflows."""
+
+    task_queue = settings.LLMA_EVALS_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _EvalsMetricsActivityInboundInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/llm_analytics/sentiment/metrics.py
+++ b/posthog/temporal/llm_analytics/sentiment/metrics.py
@@ -158,7 +158,7 @@ def increment_errors(error_type: str) -> None:
 class SentimentMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for sentiment workflows."""
 
-    task_queue = settings.LLMA_TASK_QUEUE
+    task_queue = settings.LLMA_SENTIMENT_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _SentimentActivityInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/llm_analytics/sentiment/metrics.py
+++ b/posthog/temporal/llm_analytics/sentiment/metrics.py
@@ -8,6 +8,8 @@ and scraped by the Prometheus endpoint on the worker pod.
 import typing
 import datetime as dt
 
+from django.conf import settings
+
 from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
@@ -155,6 +157,8 @@ def increment_errors(error_type: str) -> None:
 
 class SentimentMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for sentiment workflows."""
+
+    task_queue = settings.LLMA_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _SentimentActivityInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/llm_analytics/trace_clustering/metrics.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/metrics.py
@@ -8,6 +8,8 @@ and scraped by the Prometheus endpoint on the worker pod.
 import typing
 import datetime as dt
 
+from django.conf import settings
+
 from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
@@ -118,6 +120,8 @@ def increment_errors(error_type: str) -> None:
 
 class ClusteringMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for clustering workflows."""
+
+    task_queue = settings.LLMA_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _ClusteringActivityInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/llm_analytics/trace_summarization/metrics.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/metrics.py
@@ -8,6 +8,8 @@ and scraped by the Prometheus endpoint on the worker pod.
 import typing
 import datetime as dt
 
+from django.conf import settings
+
 from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
@@ -106,6 +108,8 @@ def increment_errors(error_type: str) -> None:
 
 class SummarizationMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for summarization workflows."""
+
+    task_queue = settings.LLMA_TASK_QUEUE
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _SummarizationActivityInterceptor(super().intercept_activity(next))

--- a/posthog/temporal/tests/common/test_interceptor.py
+++ b/posthog/temporal/tests/common/test_interceptor.py
@@ -23,3 +23,11 @@ def test_is_task_queue_supported(task_queue, interceptor_task_queue, supported):
     result = is_task_queue_supported(task_queue, MockInterceptor)
 
     assert result is supported
+
+
+def test_is_task_queue_supported_raises_without_task_queue():
+    class NoQueueInterceptor(Interceptor):
+        pass
+
+    with pytest.raises(ValueError):
+        is_task_queue_supported("any-queue", NoQueueInterceptor)

--- a/posthog/temporal/tests/common/test_interceptor.py
+++ b/posthog/temporal/tests/common/test_interceptor.py
@@ -1,5 +1,6 @@
 import pytest
 
+from structlog.testing import capture_logs
 from temporalio.worker import Interceptor
 
 from posthog.temporal.common.interceptor import ALL_TASK_QUEUES, is_task_queue_supported
@@ -25,9 +26,16 @@ def test_is_task_queue_supported(task_queue, interceptor_task_queue, supported):
     assert result is supported
 
 
-def test_is_task_queue_supported_raises_without_task_queue():
+def test_is_task_queue_supported_warns_without_task_queue():
     class NoQueueInterceptor(Interceptor):
         pass
 
-    with pytest.raises(ValueError):
-        is_task_queue_supported("any-queue", NoQueueInterceptor)
+    with capture_logs() as cap_logs:
+        result = is_task_queue_supported("any-queue", NoQueueInterceptor)
+
+    assert len(cap_logs) == 1
+    record = cap_logs[0]
+
+    assert record["log_level"] == "warning"
+    assert "missing task queue" in record["event"]
+    assert result is False

--- a/posthog/temporal/tests/common/test_interceptor.py
+++ b/posthog/temporal/tests/common/test_interceptor.py
@@ -1,0 +1,23 @@
+import pytest
+
+from posthog.temporal.common.interceptor import ALL_TASK_QUEUES, is_task_queue_supported
+
+
+@pytest.mark.parametrize(
+    "task_queue,interceptor_task_queue,supported",
+    (
+        ("test", "test", True),
+        ("test", "not-test", False),
+        ("test", ("not-test", "test"), True),
+        ("test", ("not-test",), False),
+        ("test", ALL_TASK_QUEUES, True),
+        ("another", ALL_TASK_QUEUES, True),
+    ),
+)
+def test_is_task_queue_supported(task_queue, interceptor_task_queue, supported):
+    class MockInterceptor:
+        task_queue = interceptor_task_queue
+
+    result = is_task_queue_supported(task_queue, MockInterceptor)
+
+    assert result is supported

--- a/posthog/temporal/tests/common/test_interceptor.py
+++ b/posthog/temporal/tests/common/test_interceptor.py
@@ -1,5 +1,7 @@
 import pytest
 
+from temporalio.worker import Interceptor
+
 from posthog.temporal.common.interceptor import ALL_TASK_QUEUES, is_task_queue_supported
 
 
@@ -15,7 +17,7 @@ from posthog.temporal.common.interceptor import ALL_TASK_QUEUES, is_task_queue_s
     ),
 )
 def test_is_task_queue_supported(task_queue, interceptor_task_queue, supported):
-    class MockInterceptor:
+    class MockInterceptor(Interceptor):
         task_queue = interceptor_task_queue
 
     result = is_task_queue_supported(task_queue, MockInterceptor)

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -3,6 +3,8 @@ import typing
 import asyncio
 import datetime as dt
 
+from django.conf import settings
+
 import structlog
 from temporalio import activity, workflow
 from temporalio.common import MetricCounter, MetricMeter
@@ -78,6 +80,8 @@ Attributes = dict[str, str | int | float | bool]
 
 class BatchExportsMetricsInterceptor(Interceptor):
     """Interceptor to emit Prometheus metrics for batch exports."""
+
+    task_queue = (settings.BATCH_EXPORTS_TASK_QUEUE, settings.SYNC_BATCH_EXPORTS_TASK_QUEUE)
 
     def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
         return _BatchExportsMetricsActivityInboundInterceptor(super().intercept_activity(next))

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18166,6 +18166,8 @@ export namespace Schemas {
       /** @nullable */
       readonly next_delivery_date: string | null;
       /** @nullable */
+      integration_id?: number | null;
+      /** @nullable */
       invite_message?: string | null;
     }
 
@@ -21304,6 +21306,8 @@ export namespace Schemas {
       readonly summary?: string;
       /** @nullable */
       readonly next_delivery_date?: string | null;
+      /** @nullable */
+      integration_id?: number | null;
       /** @nullable */
       invite_message?: string | null;
     }


### PR DESCRIPTION
## Problem

We have too many interceptors running in our temporal workers. This causes problems:
* Tracebacks are now extremely long as they traverse the whole interceptor chain. They can no longer render sometimes.
* Each interceptor adds overhead, which is unnecessary if a particular set of workflows/activities does not rely on it (e.g. a lot of interceptors check for activity name and return if not supported, which means they could just be removed).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This assigns interceptors one or more task queues, and checks which interceptors match the given queue when initializing a worker. Only interceptors that do match are simply are initialized and passed to the worker, otherwise no overhead is added.

Here is a breakdown of each interceptor and what they do/care about:
* `BatchExportsMetricsInterceptor`:
	* Only relevant in batch export queues, otherwise does nothing and can be removed.
* `PostHogClientInterceptor`:
	* Error tracking. Used by all queues.
* `DeleteRecordingsMetricsInterceptor`:
	* Only operates in delete recordings workflows which execute in the session replay task queue. Otherwise does nothing and can be removed.
* `EvalsMetricsInterceptor`:
	* Only operates on worfklow `run-evaluation` and its activities. This workflow runs in the `LLMA_EVALS_TASK_QUEUE`, so the interceptor only targets that queue. Otherwise, does nothing and is removed.
* `SummarizationMetricsInterceptor`:
	* Only operates on workflow `BatchTraceSummarizationWorkflow` and its activities. This workflow is configured for both the `LLMA_TASK_QUEUE` and general purpose task queue, but I've checked with the team and they only trigger it on `LLMA_TASK_QUEUE`. So, for all other queues, it does nothing and can be removed.
* `ClusteringMetricsInterceptor`
    * Same behavior and queue as above.
* `SentimentMetricsInterceptor`
    * Only operates on workflow `llma-sentiment-classify` and its activities. This workflow runs in the `LLMA_SENTIMENT_TASK_QUEUE`, so the interceptor only targets that queue. Otherwise, does nothing and is removed.
* `LivenessInterceptor`
    * This one currently runs for everyone, but only one team has configured liveness probes at the moment (Max AI), and data stack is the only team besides them who used to have liveness probes configured.
    * So, leaving it enabled for their queues, and removing it otherwise.
  
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
