### PR TITLE
fix(ph-ai): show inline validation errors on create_form submit

### DIFF
--- a/frontend/src/scenes/max/components/QuestionField.test.tsx
+++ b/frontend/src/scenes/max/components/QuestionField.test.tsx
@@ -40,7 +40,7 @@ describe('QuestionField', () => {
         expect(screen.getAllByRole('checkbox')).toHaveLength(2)
     })
 
-    it('multi_select submit button is disabled with no selection', () => {
+    it('multi_select shows error message when submitting with no selection', () => {
         const onAnswer = jest.fn()
         const question: MultiQuestionFormQuestion = {
             ...baseQuestion,
@@ -52,7 +52,9 @@ describe('QuestionField', () => {
         const buttons = screen.getAllByRole('button')
         const submitButton = buttons.find((b) => b.textContent?.includes('Next'))
         expect(submitButton).toBeInTheDocument()
-        expect(submitButton).toHaveAttribute('aria-disabled', 'true')
+        fireEvent.click(submitButton!)
+        expect(screen.getByText('Select at least one option')).toBeInTheDocument()
+        expect(onAnswer).not.toHaveBeenCalled()
     })
 
     describe('MultiFieldQuestion', () => {
@@ -81,19 +83,22 @@ describe('QuestionField', () => {
             expect(screen.getByText('Notify on complete')).toBeInTheDocument()
         })
 
-        it('submit button is disabled when required fields are empty', () => {
-            render(
+        it('shows validation errors when submitting with empty required fields', () => {
+            const onSubmit = jest.fn()
+            const { container } = render(
                 <MultiFieldQuestion
                     question={multiFieldQuestion}
                     answers={{ confidence: '80', notify: 'false' }}
                     onFieldChange={jest.fn()}
-                    onSubmit={jest.fn()}
+                    onSubmit={onSubmit}
                 />
             )
-            const buttons = screen.getAllByRole('button')
-            const submitButton = buttons.find((b) => b.textContent?.includes('Next'))
-            expect(submitButton).toBeInTheDocument()
-            expect(submitButton).toHaveAttribute('aria-disabled', 'true')
+            const submitButton = container.querySelector('.LemonButton--primary')
+            expect(submitButton).not.toBeNull()
+            fireEvent.click(submitButton!)
+            expect(container.querySelector('.text-danger')).not.toBeNull()
+            expect(container.querySelector('.text-danger')?.textContent).toBe('This field is required')
+            expect(onSubmit).not.toHaveBeenCalled()
         })
 
         it('calls onSubmit when all fields are valid and button is clicked', () => {

--- a/frontend/src/scenes/max/components/QuestionField.tsx
+++ b/frontend/src/scenes/max/components/QuestionField.tsx
@@ -85,6 +85,7 @@ function MultiSelectField({
     submitLabel: string
 }): JSX.Element {
     const [selected, setSelected] = useState<string[]>(value ?? [])
+    const [showError, setShowError] = useState(false)
 
     const handleToggle = (optionValue: string): void => {
         setSelected((prev) => {
@@ -93,6 +94,15 @@ function MultiSelectField({
             }
             return [...prev, optionValue]
         })
+        setShowError(false)
+    }
+
+    const handleSubmit = (): void => {
+        if (selected.length === 0) {
+            setShowError(true)
+            return
+        }
+        onAnswer(selected)
     }
 
     return (
@@ -110,13 +120,8 @@ function MultiSelectField({
                     }
                 />
             ))}
-            <LemonButton
-                type="primary"
-                size="small"
-                disabledReason={selected.length === 0 ? 'Select at least one option' : undefined}
-                onClick={() => onAnswer(selected)}
-                className="self-start"
-            >
+            {showError && <p className="text-danger text-xs m-0">Select at least one option</p>}
+            <LemonButton type="primary" size="small" onClick={handleSubmit} className="self-start">
                 {submitLabel}
             </LemonButton>
         </div>
@@ -152,25 +157,37 @@ export function MultiFieldQuestion({
 }: MultiFieldQuestionProps): JSX.Element {
     const fields = question.fields ?? []
     const allFieldsValid = fields.every((field) => isFieldValid(field, answers[field.id]))
+    const [showErrors, setShowErrors] = useState(false)
+
+    const handleSubmit = (): void => {
+        if (!allFieldsValid) {
+            setShowErrors(true)
+            return
+        }
+        onSubmit()
+    }
 
     return (
         <div className="flex flex-col gap-3">
-            {fields.map((field) => (
-                <div key={field.id} className="flex flex-col gap-1">
-                    <label className="text-xs font-medium text-secondary">
-                        {field.label}
-                        {field.optional && <span className="text-muted font-normal ml-1">(optional)</span>}
-                    </label>
-                    <MultiFieldInput field={field} value={answers[field.id]} onChange={onFieldChange} />
-                </div>
-            ))}
-            <LemonButton
-                type="primary"
-                size="small"
-                disabledReason={!allFieldsValid ? 'Please fill in all fields' : undefined}
-                onClick={onSubmit}
-                className="self-end"
-            >
+            {fields.map((field) => {
+                const fieldInvalid = showErrors && !isFieldValid(field, answers[field.id])
+                return (
+                    <div key={field.id} className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-secondary">
+                            {field.label}
+                            {field.optional && <span className="text-muted font-normal ml-1">(optional)</span>}
+                        </label>
+                        <MultiFieldInput
+                            field={field}
+                            value={answers[field.id]}
+                            onChange={onFieldChange}
+                            showError={fieldInvalid}
+                        />
+                        {fieldInvalid && <p className="text-danger text-xs m-0">This field is required</p>}
+                    </div>
+                )
+            })}
+            <LemonButton type="primary" size="small" onClick={handleSubmit} className="self-end">
                 {submitLabel}
             </LemonButton>
         </div>
@@ -181,10 +198,12 @@ function MultiFieldInput({
     field,
     value,
     onChange,
+    showError,
 }: {
     field: MultiQuestionFormField
     value: string | string[] | undefined
     onChange: (fieldId: string, value: string | string[]) => void
+    showError?: boolean
 }): JSX.Element {
     switch (field.type) {
         case 'dropdown': {
@@ -193,14 +212,16 @@ function MultiFieldInput({
                 label: opt.value,
             }))
             return (
-                <LemonSelect
-                    options={options}
-                    value={value as string | undefined}
-                    onChange={(v) => v && onChange(field.id, v)}
-                    placeholder="Select an option..."
-                    fullWidth
-                    size="small"
-                />
+                <div className={showError ? '[&_.LemonButton]:border-danger' : undefined}>
+                    <LemonSelect
+                        options={options}
+                        value={value as string | undefined}
+                        onChange={(v) => v && onChange(field.id, v)}
+                        placeholder="Select an option..."
+                        fullWidth
+                        size="small"
+                    />
+                </div>
             )
         }
         case 'text':
@@ -211,6 +232,7 @@ function MultiFieldInput({
                     size="small"
                     value={(value as string) ?? ''}
                     onChange={(v) => onChange(field.id, v)}
+                    status={showError ? 'danger' : 'default'}
                 />
             )
         case 'number':
@@ -229,6 +251,7 @@ function MultiFieldInput({
                     min={field.min}
                     max={field.max}
                     step={field.step}
+                    status={showError ? 'danger' : 'default'}
                 />
             )
         case 'slider': {


### PR DESCRIPTION
## Problem

When a user hasn't filled out required fields in a PostHog AI form, the "Next" button just goes dim with no clear indication of what's wrong. The only feedback is a tooltip on hover via `disabledReason`, which isn't obvious enough.

![image.png](https://app.graphite.com/user-attachments/assets/c6aa9fc7-1d7c-4094-8f47-ae8f3edc7ae0.png)

## Changes

- **MultiSelectField**: The submit button is always clickable. Clicking with no selections shows an inline "Select at least one option" error message in red. The error clears when the user toggles any checkbox.
- **MultiFieldQuestion**: The submit button is always clickable. Clicking with invalid fields shows a "This field is required" error below each invalid field, with `status="danger"` on text/number inputs and a red border on dropdowns.
- Updated tests to verify error messages appear on click instead of checking `aria-disabled`.

## How did you test this code?

Automated tests updated and passing — `QuestionField.test.tsx` (6/6 pass). Tests verify that:
- Clicking submit with no multi-select options shows the error message and doesn't call `onAnswer`
- Clicking submit with empty required fields shows "This field is required" and doesn't call `onSubmit`
- Valid submissions still work correctly

## Publish to changelog?
No