### PR TITLE
fix(batch-exports): handle DST transitions in daily/weekly interval calculations

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -299,16 +299,10 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
     jitter = batch_export.jitter
 
     # Assert time between runs is roughly the interval time delta.
-    # For daily/weekly intervals with DST-observing timezones, the UTC difference
-    # can be 23 or 25 hours instead of 24 due to spring-forward/fall-back transitions.
+    # For daily/weekly intervals, DST transitions can shift the UTC difference by up to 1 hour.
     next_run_2_local = next_run_2.astimezone(tz)
-    dst_offset_1 = next_run_local.utcoffset() or dt.timedelta(0)
-    dst_offset_2 = next_run_2_local.utcoffset() or dt.timedelta(0)
-    dst_shift = abs((dst_offset_2 - dst_offset_1).total_seconds())
-    min_expected_time_diff = batch_export.interval_time_delta.total_seconds() - jitter.total_seconds() - dst_shift
-    max_expected_time_diff = batch_export.interval_time_delta.total_seconds() + jitter.total_seconds() + dst_shift
-    assert abs((next_run_2 - next_run).total_seconds()) >= min_expected_time_diff
-    assert abs((next_run_2 - next_run).total_seconds()) <= max_expected_time_diff
+    dst_shift = abs((next_run_2_local.utcoffset() or dt.timedelta(0)) - (next_run_local.utcoffset() or dt.timedelta(0)))
+    assert abs((next_run_2 - next_run) - batch_export.interval_time_delta) <= jitter + dst_shift
 
     if interval == "day":
         # For daily exports, check that it runs at the expected hour (based on offset_hour)

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -96,6 +96,7 @@ class BaseBatchExportInputs:
     batch_export_id: str
     team_id: int
     interval: str = "hour"
+    timezone: str = "UTC"
     data_interval_end: str | None = None
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
@@ -906,6 +907,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
                     team_id=batch_export.team.id,
                     batch_export_id=str(batch_export.id),
                     interval=str(batch_export.interval),
+                    timezone=str(batch_export.timezone_info),
                     batch_export_model=BatchExportModel(
                         name=batch_export.model or "events",
                         schema=batch_export.schema,

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -5,6 +5,7 @@ import asyncio
 import datetime as dt
 import dataclasses
 import collections.abc
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.db.models import Sum
@@ -684,7 +685,8 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
         frequency = dt.timedelta(seconds=inputs.frequency_seconds)
 
-        full_backfill_range = backfill_range(start_at, end_at, frequency)
+        timezone = description.schedule.spec.time_zone_name or None
+        full_backfill_range = backfill_range(start_at=start_at, end_at=end_at, step=frequency, timezone=timezone)
 
         for _, backfill_end_at in full_backfill_range:
             if await check_temporal_schedule_exists(client, description.id) is False:
@@ -779,9 +781,21 @@ async def check_temporal_schedule_exists(client: temporalio.client.Client, sched
 
 
 def backfill_range(
-    start_at: dt.datetime | None, end_at: dt.datetime | None, step: dt.timedelta
+    start_at: dt.datetime | None,
+    end_at: dt.datetime | None,
+    step: dt.timedelta,
+    timezone: str | None = None,
 ) -> typing.Generator[tuple[dt.datetime | None, dt.datetime], None, None]:
-    """Generate range of dates between start_at and end_at."""
+    """Generate range of dates between start_at and end_at.
+
+    Args:
+        start_at: Start of the backfill range (UTC). None means backfill from earliest data.
+        end_at: End of the backfill range (UTC). None means backfill until now.
+        step: The interval duration to step by.
+        timezone: IANA timezone name (e.g. "US/Eastern"). When provided and step >= 1 day,
+            stepping is done in local time so that DST transitions produce correct
+            interval lengths (23h or 25h for daily) instead of fixed 24h.
+    """
     if start_at is None:
         if end_at is None:
             now = get_utcnow()
@@ -793,18 +807,19 @@ def backfill_range(
 
         return
 
-    current = start_at
+    tz = ZoneInfo(timezone) if timezone and step >= dt.timedelta(days=1) else dt.UTC
+    current = start_at.astimezone(tz)
+    local_end = end_at.astimezone(tz) if end_at else None
 
-    while end_at is None or current < end_at:
+    while local_end is None or current < local_end:
         current_end = current + step
 
-        if end_at and current_end > end_at:
+        if local_end and current_end > local_end:
             # Do not yield a range that is less than step.
             # Same as built-in range.
             break
 
-        yield current, current_end
-
+        yield current.astimezone(dt.UTC), current_end.astimezone(dt.UTC)
         current = current_end
 
 

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -7,6 +7,7 @@ import datetime as dt
 import operator
 import dataclasses
 import collections.abc
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 
@@ -283,13 +284,18 @@ def iter_records(
     yield from client.stream_query_as_arrow(query_str, query_parameters=query_parameters)
 
 
-def get_data_interval(interval: str, data_interval_end: str | None) -> tuple[dt.datetime, dt.datetime]:
+def get_data_interval(
+    interval: str, data_interval_end: str | None, timezone: str | None = None
+) -> tuple[dt.datetime, dt.datetime]:
     """Return the start and end of an export's data interval.
 
     Args:
         interval: The interval of the BatchExport associated with this Workflow.
         data_interval_end: The optional end of the BatchExport period. If not included, we will
             attempt to extract it from Temporal SearchAttributes.
+        timezone: The IANA timezone of the batch export (e.g. "US/Eastern"). When provided,
+            daily/weekly intervals use timezone-aware arithmetic so that DST transitions
+            produce correct interval lengths (23h or 25h) instead of a fixed 24h.
 
     Raises:
         TypeError: If when trying to obtain the data interval end we run into non-str types.
@@ -317,10 +323,8 @@ def get_data_interval(interval: str, data_interval_end: str | None) -> tuple[dt.
         if isinstance(data_interval_end_search_attr[0], str):
             data_interval_end_str = data_interval_end_search_attr[0]
             data_interval_end_dt = dt.datetime.fromisoformat(data_interval_end_str)
-
         elif isinstance(data_interval_end_search_attr[0], dt.datetime):
             data_interval_end_dt = data_interval_end_search_attr[0]
-
         else:
             msg = (
                 f"Expected search attribute to be of type 'str' or 'datetime' but found '{data_interval_end_search_attr[0]}' "
@@ -330,12 +334,16 @@ def get_data_interval(interval: str, data_interval_end: str | None) -> tuple[dt.
     else:
         data_interval_end_dt = dt.datetime.fromisoformat(data_interval_end_str)
 
+    tz = ZoneInfo(timezone) if timezone else dt.UTC
+
     if interval == "hour":
         data_interval_start_dt = data_interval_end_dt - dt.timedelta(hours=1)
     elif interval == "day":
-        data_interval_start_dt = data_interval_end_dt - dt.timedelta(days=1)
+        local_end = data_interval_end_dt.astimezone(tz)
+        data_interval_start_dt = (local_end - dt.timedelta(days=1)).astimezone(dt.UTC)
     elif interval == "week":
-        data_interval_start_dt = data_interval_end_dt - dt.timedelta(weeks=1)
+        local_end = data_interval_end_dt.astimezone(tz)
+        data_interval_start_dt = (local_end - dt.timedelta(weeks=1)).astimezone(dt.UTC)
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -335,7 +335,9 @@ class AzureBlobBatchExportWorkflow(PostHogWorkflow):
     async def run(self, inputs: AzureBlobBatchExportInputs):
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -1170,7 +1170,9 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to BigQuery."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -1197,7 +1197,9 @@ class DatabricksBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to Databricks table."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -354,7 +354,9 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to an HTTP Endpoint."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -966,7 +966,9 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to Postgres."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1374,7 +1374,9 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to Redshift."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -227,7 +227,9 @@ class S3BatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to S3 bucket."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1465,7 +1465,9 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to Snowflake table."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -236,7 +236,9 @@ class WorkflowsBatchExportWorkflow(PostHogWorkflow):
         """Workflow implementation to export data to Workflows API."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_range.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_range.py
@@ -136,72 +136,35 @@ def test_backfill_range(start_at, end_at, step, expected):
     assert result == expected
 
 
-def test_backfill_range_dst_spring_forward():
-    """backfill_range with timezone produces DST-aware intervals during spring-forward.
-
-    For a daily batch export at midnight US/Eastern, intervals spanning the 2024
-    spring-forward (March 10) should have variable UTC lengths: 24h before,
-    23h on the transition day, then 24h after.
-    """
-    # _align_timestamp_to_interval outputs UTC. A daily export at midnight ET:
-    # Mar 9 midnight EST = 05:00 UTC
-    start_at = dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC)
-    # Mar 12 midnight EDT = 04:00 UTC (after spring-forward)
-    end_at = dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC)
-    step = dt.timedelta(days=1)
-
-    result = list(backfill_range(start_at, end_at, step, timezone="US/Eastern"))
-
-    # Should produce 3 intervals aligned to local midnight:
-    # [Mar 9 05:00, Mar 10 05:00) = 24h (pre-DST)
-    # [Mar 10 05:00, Mar 11 04:00) = 23h (DST transition day)
-    # [Mar 11 04:00, Mar 12 04:00) = 24h (post-DST)
-    assert len(result) == 3, f"Expected 3 intervals covering the full range, got {len(result)}"
-
-    assert result[0] == (
-        dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC),
-    )
-    assert result[1] == (
-        dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC),
-    )
-    assert result[2] == (
-        dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC),
-    )
-
-
-def test_backfill_range_dst_fall_back():
-    """backfill_range with timezone produces DST-aware intervals during fall-back.
-
-    During fall-back (2024-11-03), midnight ET shifts from 04:00 UTC (EDT) to
-    05:00 UTC (EST). With timezone awareness, intervals align to local midnight,
-    producing a 25h interval on the transition day.
-    """
-    # Midnight EDT on Nov 2 = 04:00 UTC
-    start_at = dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC)
-    # Midnight EST on Nov 5 = 05:00 UTC (after fall-back)
-    end_at = dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC)
-    step = dt.timedelta(days=1)
-
-    result = list(backfill_range(start_at, end_at, step, timezone="US/Eastern"))
-
-    # Should produce 3 intervals aligned to local midnight:
-    # [Nov 2 04:00, Nov 3 04:00) = 24h (pre-DST)
-    # [Nov 3 04:00, Nov 4 05:00) = 25h (DST transition day)
-    # [Nov 4 05:00, Nov 5 05:00) = 24h (post-DST)
-    assert len(result) == 3
-
-    assert result[0] == (
-        dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC),
-    )
-    assert result[1] == (
-        dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC),
-    )
-    assert result[2] == (
-        dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC),
-        dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC),
-    )
+@pytest.mark.parametrize(
+    "start_at,end_at,expected_intervals",
+    [
+        pytest.param(
+            # Spring-forward: 2024-03-10 clocks skip 2am->3am
+            # Midnight EST = 05:00 UTC, midnight EDT = 04:00 UTC
+            dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC),
+            [
+                (dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC)),
+                (dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC)),
+                (dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC)),
+            ],
+            id="spring_forward",
+        ),
+        pytest.param(
+            # Fall-back: 2024-11-03 clocks repeat 1am->2am
+            # Midnight EDT = 04:00 UTC, midnight EST = 05:00 UTC
+            dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC),
+            [
+                (dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC)),
+                (dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC)),
+                (dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC), dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC)),
+            ],
+            id="fall_back",
+        ),
+    ],
+)
+def test_backfill_range_dst_transitions(start_at, end_at, expected_intervals):
+    result = list(backfill_range(start_at, end_at, dt.timedelta(days=1), timezone="US/Eastern"))
+    assert result == expected_intervals

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_range.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_range.py
@@ -134,3 +134,74 @@ def test_backfill_range(start_at, end_at, step, expected):
         result = [next(generator) for _ in range(len(expected))]
 
     assert result == expected
+
+
+def test_backfill_range_dst_spring_forward():
+    """backfill_range with timezone produces DST-aware intervals during spring-forward.
+
+    For a daily batch export at midnight US/Eastern, intervals spanning the 2024
+    spring-forward (March 10) should have variable UTC lengths: 24h before,
+    23h on the transition day, then 24h after.
+    """
+    # _align_timestamp_to_interval outputs UTC. A daily export at midnight ET:
+    # Mar 9 midnight EST = 05:00 UTC
+    start_at = dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC)
+    # Mar 12 midnight EDT = 04:00 UTC (after spring-forward)
+    end_at = dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC)
+    step = dt.timedelta(days=1)
+
+    result = list(backfill_range(start_at, end_at, step, timezone="US/Eastern"))
+
+    # Should produce 3 intervals aligned to local midnight:
+    # [Mar 9 05:00, Mar 10 05:00) = 24h (pre-DST)
+    # [Mar 10 05:00, Mar 11 04:00) = 23h (DST transition day)
+    # [Mar 11 04:00, Mar 12 04:00) = 24h (post-DST)
+    assert len(result) == 3, f"Expected 3 intervals covering the full range, got {len(result)}"
+
+    assert result[0] == (
+        dt.datetime(2024, 3, 9, 5, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC),
+    )
+    assert result[1] == (
+        dt.datetime(2024, 3, 10, 5, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC),
+    )
+    assert result[2] == (
+        dt.datetime(2024, 3, 11, 4, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 3, 12, 4, 0, 0, tzinfo=dt.UTC),
+    )
+
+
+def test_backfill_range_dst_fall_back():
+    """backfill_range with timezone produces DST-aware intervals during fall-back.
+
+    During fall-back (2024-11-03), midnight ET shifts from 04:00 UTC (EDT) to
+    05:00 UTC (EST). With timezone awareness, intervals align to local midnight,
+    producing a 25h interval on the transition day.
+    """
+    # Midnight EDT on Nov 2 = 04:00 UTC
+    start_at = dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC)
+    # Midnight EST on Nov 5 = 05:00 UTC (after fall-back)
+    end_at = dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC)
+    step = dt.timedelta(days=1)
+
+    result = list(backfill_range(start_at, end_at, step, timezone="US/Eastern"))
+
+    # Should produce 3 intervals aligned to local midnight:
+    # [Nov 2 04:00, Nov 3 04:00) = 24h (pre-DST)
+    # [Nov 3 04:00, Nov 4 05:00) = 25h (DST transition day)
+    # [Nov 4 05:00, Nov 5 05:00) = 24h (post-DST)
+    assert len(result) == 3
+
+    assert result[0] == (
+        dt.datetime(2024, 11, 2, 4, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC),
+    )
+    assert result[1] == (
+        dt.datetime(2024, 11, 3, 4, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC),
+    )
+    assert result[2] == (
+        dt.datetime(2024, 11, 4, 5, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2024, 11, 5, 5, 0, 0, tzinfo=dt.UTC),
+    )

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -119,7 +119,9 @@ class DummyExportWorkflow(PostHogWorkflow):
         """Workflow implementation to test the batch export entrypoint."""
         is_backfill = inputs.get_is_backfill()
         is_earliest_backfill = inputs.get_is_earliest_backfill()
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
+        data_interval_start, data_interval_end = get_data_interval(
+            inputs.interval, inputs.data_interval_end, inputs.timezone
+        )
         should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(

--- a/products/batch_exports/backend/tests/temporal/test_batch_exports.py
+++ b/products/batch_exports/backend/tests/temporal/test_batch_exports.py
@@ -347,6 +347,39 @@ def test_get_data_interval(interval, data_interval_end, expected):
 
 
 @pytest.mark.parametrize(
+    "interval,data_interval_end,expected_duration_hours",
+    [
+        # US/Eastern spring forward: 2024-03-10 clocks skip 2am->3am, so the calendar day is 23 hours.
+        (
+            "day",
+            "2024-03-11T04:00:00+00:00",
+            23,
+        ),
+        # US/Eastern fall back: 2024-11-03 clocks repeat 1am->2am, so the calendar day is 25 hours.
+        (
+            "day",
+            "2024-11-04T05:00:00+00:00",
+            25,
+        ),
+    ],
+)
+def test_get_data_interval_dst_transition(interval, data_interval_end, expected_duration_hours):
+    """get_data_interval should match Temporal's calendar-aware scheduling.
+
+    Temporal's ScheduleCalendarSpec fires at the correct local time each day,
+    so consecutive data_interval_end values may be 23h apart (spring forward)
+    or 25h apart (fall back). get_data_interval must produce a matching window
+    so intervals don't overlap or have gaps.
+    """
+    start, end = get_data_interval(interval, data_interval_end, timezone="US/Eastern")
+    actual_duration_hours = (end - start).total_seconds() / 3600
+
+    assert actual_duration_hours == expected_duration_hours, (
+        f"Expected {expected_duration_hours}h interval for DST transition day, got {actual_duration_hours}h"
+    )
+
+
+@pytest.mark.parametrize(
     "remaining_range,done_ranges,expected",
     [
         # Case 1: One done range at the beginning


### PR DESCRIPTION
## Problem

Batch exports with daily/weekly intervals configured with a timezone that uses daylight savings time (DST) (e.g. `US/Eastern`) produces incorrect data intervals during DST transitions.

Hourly and sub-hourly intervals are unaffected since they use fixed UTC durations.

## Changes

- **`get_data_interval`** (`products/batch_exports/backend/temporal/batch_exports.py`): Added `timezone` parameter. For day/week intervals, converts to local time before subtracting so `timedelta(days=1)` preserves wall clock time across DST transitions.
- **`backfill_range`** (`products/batch_exports/backend/temporal/backfill_batch_export.py`): Added `timezone` parameter. For steps >= 1 day, steps in local time and yields UTC results. Extracts timezone from the existing `schedule_handle.describe()` call — no new API calls.
- **`BaseBatchExportInputs`** (`posthog/batch_exports/service.py`): Added `timezone: str = "UTC"` field (backwards-compatible default). Populated from `batch_export.timezone_info` in `sync_batch_export`.
- All 9 destination workflows + 1 test updated to pass `inputs.timezone` to `get_data_interval`.
- Simplified existing `posthog/api/test/batch_exports/test_create.py` test

## How did you test this code?

- Added 4 new tests covering spring-forward and fall-back for both `get_data_interval` and `backfill_range`.
  - These tests reproduced the issue before the fix was implemented.

## Post-deployment

Will need to sync Temporal schedules in order to add `timezone` input to workflows

## 🤖 LLM context

Co-authored with Claude Code. The session started by analyzing potential DST issues in batch export interval calculations, then wrote failing tests to reproduce the bugs, and implemented the fix.