### PR TITLE
feat(dashboard): use tooltip with keyboard shortcut for editing layout

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -577,10 +577,10 @@ export function DashboardHeader(): JSX.Element | null {
                                         </AccessControlAction>
                                         {canEditDashboard && hasTileRedesign && (
                                             <AppShortcut
-                                                name="ToggleEditMode"
+                                                name="EnterEditMode"
                                                 scope={Scene.Dashboard}
                                                 keybind={[keyBinds.edit]}
-                                                intent="Toggle edit mode"
+                                                intent="Enter edit mode"
                                                 interaction="click"
                                             >
                                                 <LemonButton

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -576,20 +576,30 @@ export function DashboardHeader(): JSX.Element | null {
                                             </AppShortcut>
                                         </AccessControlAction>
                                         {canEditDashboard && hasTileRedesign && (
-                                            <LemonButton
-                                                type="secondary"
-                                                data-attr="dashboard-edit-mode-button"
-                                                onClick={() =>
-                                                    setDashboardMode(
-                                                        DashboardMode.Edit,
-                                                        DashboardEventSource.SceneCommonButtons
-                                                    )
-                                                }
-                                                size="small"
-                                                icon={<IconPencil fontSize="16" />}
+                                            <AppShortcut
+                                                name="ToggleEditMode"
+                                                scope={Scene.Dashboard}
+                                                keybind={[keyBinds.edit]}
+                                                intent="Toggle edit mode"
+                                                interaction="click"
                                             >
-                                                Edit layout
-                                            </LemonButton>
+                                                <LemonButton
+                                                    type="secondary"
+                                                    data-attr="dashboard-edit-mode-button"
+                                                    onClick={() =>
+                                                        setDashboardMode(
+                                                            DashboardMode.Edit,
+                                                            DashboardEventSource.SceneCommonButtons
+                                                        )
+                                                    }
+                                                    size="small"
+                                                    icon={<IconPencil fontSize="16" />}
+                                                    tooltip="Edit layout"
+                                                    tooltipPlacement="top"
+                                                >
+                                                    Edit layout
+                                                </LemonButton>
+                                            </AppShortcut>
                                         )}
                                         <MaxTool
                                             identifier="upsert_dashboard"


### PR DESCRIPTION
## Problem

Edit layout button didnt have tooltip like other buttons

## Changes

Before
<img width="436" height="102" alt="image" src="https://github.com/user-attachments/assets/74255216-1eaf-4aa6-be24-73f6a5595320" />


After
<img width="504" height="130" alt="image" src="https://github.com/user-attachments/assets/790583d8-d9eb-46e1-8f70-1d77af073e7d" />


## How did you test this code?
Locally.

## Publish to changelog?
No.