### PR TITLE
fix(flags): use cohort.team_id to avoid N+1 without loading Team

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -876,7 +876,7 @@ def get_all_cohort_dependencies(
                     continue
             else:
                 current_cohort = Cohort.objects.db_manager(using_database).get(
-                    pk=cohort_id, team__project_id=cohort.team.project_id, deleted=False
+                    pk=cohort_id, team_id=cohort.team_id, deleted=False
                 )
                 seen_cohorts_cache[cohort_id] = current_cohort
             if current_cohort.id not in seen_cohort_ids:


### PR DESCRIPTION
## Problem

`get_all_cohort_dependencies` accesses `cohort.team.project_id` when looking up dependent cohorts, which triggers a lazy load of the full `Team` object for every cohort in the dependency chain. This causes N+1 queries in the feature flags evaluation path.

## Changes

Replace `team__project_id=cohort.team.project_id` with `team_id=cohort.team_id`. The `team_id` foreign key is stored directly on the `Cohort` row, so no additional query is needed.

This narrows the filter from "any team in the same project" to "the exact same team," but cohorts are always team-scoped — cross-team cohort references don't exist. Confirmed by querying production data: zero cohorts reference a cohort on a different team within the same project.

## How did you test this code?

- Ran a production SQL query to confirm no cross-team cohort dependencies exist
- Existing tests pass — cohort dependency resolution is covered by `get_all_cohort_dependencies` tests

## Publish to changelog?

no