### PR TITLE
feat(dashboards): allow users to move dashboards into projects from the list page

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconHome, IconLock, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -74,6 +75,7 @@ export function DashboardsTable({
     const { currentTeam } = useValues(teamLogic)
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
+    const { openMoveToModal } = useActions(moveToLogic)
     const { itemsByRef } = useValues(projectTreeDataLogic)
 
     const columns: LemonTableColumns<DashboardType> = [
@@ -209,9 +211,26 @@ export function DashboardsTable({
                                           Duplicate
                                       </LemonButton>
 
+                                      {itemsByRef[`dashboard::${id}`] && (
+                                          <LemonButton
+                                              onClick={() => {
+                                                  const entry = itemsByRef[`dashboard::${id}`]
+                                                  openMoveToModal([entry as any])
+                                              }}
+                                              fullWidth
+                                              data-attr="dashboard-move-to-folder"
+                                          >
+                                              Move to another folder
+                                          </LemonButton>
+                                      )}
+
                                       <LemonDivider />
 
-                                      <LemonRow icon={<IconHome className="text-warning" />} fullWidth status="warning">
+                                      <LemonRow
+                                          icon={<IconHome className="size-4 text-warning" />}
+                                          fullWidth
+                                          status="warning"
+                                      >
                                           <span className="text-secondary">
                                               Change the default dashboard
                                               <br />

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -212,16 +212,22 @@ export function DashboardsTable({
                                       </LemonButton>
 
                                       {itemsByRef[`dashboard::${id}`] && (
-                                          <LemonButton
-                                              onClick={() => {
-                                                  const entry = itemsByRef[`dashboard::${id}`]
-                                                  openMoveToModal([entry as any])
-                                              }}
-                                              fullWidth
-                                              data-attr="dashboard-move-to-folder"
+                                          <AccessControlAction
+                                              resourceType={AccessControlResourceType.Dashboard}
+                                              minAccessLevel={AccessControlLevel.Editor}
+                                              userAccessLevel={user_access_level}
                                           >
-                                              Move to another folder
-                                          </LemonButton>
+                                              <LemonButton
+                                                  onClick={() => {
+                                                      const entry = itemsByRef[`dashboard::${id}`]
+                                                      openMoveToModal([entry as any])
+                                                  }}
+                                                  fullWidth
+                                                  data-attr="dashboard-move-to-folder"
+                                              >
+                                                  Move to another folder
+                                              </LemonButton>
+                                          </AccessControlAction>
                                       )}
 
                                       <LemonDivider />


### PR DESCRIPTION
## Problem

If a user wanted to put a dashboard into a project, it could only be done through the sidebar inside an individual dashboard.

## Changes

Adds a new action to move a dashboard into a folder from the actions menu in the dashboard lists page.

<img width="405" height="500" alt="image" src="https://github.com/user-attachments/assets/1f12ae9e-f49c-486e-be57-afe620817d59" />
<img width="1260" height="1293" alt="image" src="https://github.com/user-attachments/assets/533a3fb6-503f-40ca-9e5b-22871c0111ef" />


## How did you test this code?

Locally.

