### PR TITLE
fix: Use all data for total instead of tooltip data

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -464,7 +464,9 @@ export const LineGraph = ({
                                 })
 
                                 const tooltipTotalData = ySeriesData.filter(
-                                    (n) => n.settings?.formatting?.style !== 'percent'
+                                    (n) =>
+                                        n.settings?.formatting?.style !== 'percent' &&
+                                        n.data[referenceDataPoint.dataIndex] !== null
                                 )
 
                                 // Don't show total row when highlighting a single bar

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -463,7 +463,7 @@ export const LineGraph = ({
                                     }
                                 })
 
-                                const tooltipTotalData = filteredSeriesData.filter(
+                                const tooltipTotalData = ySeriesData.filter(
                                     (n) => n.settings?.formatting?.style !== 'percent'
                                 )
 


### PR DESCRIPTION
## Problem

The tooltip total was only accounting for tooltip data, not all data.

https://posthoghelp.zendesk.com/agent/tickets/52870 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55179)

## Changes

Use `ySeriesData` instead of `filteredSeriesData`.

## How did you test this code?

Tested locally with stacked bar chart to verify the fix.