### PR TITLE
docs: add remote configuration note to iOS error tracking onboarding

### DIFF
--- a/docs/onboarding/error-tracking/ios.tsx
+++ b/docs/onboarding/error-tracking/ios.tsx
@@ -24,6 +24,14 @@ export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
         badge: 'recommended',
         content: (
             <>
+                <CalloutBox type="fyi" title="Remote configuration">
+                    <Markdown>
+                        {dedent`
+                            Exception autocapture can also be managed remotely via the 
+                            [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture).
+                        `}
+                    </Markdown>
+                </CalloutBox>
                 <CalloutBox type="fyi" title="Platform support">
                     <Markdown>
                         {dedent`


### PR DESCRIPTION
## Problem

The iOS error tracking onboarding instructions don't mention that exception autocapture can be managed remotely via the error tracking settings, unlike the Android onboarding which includes this information.

## Changes

Added a "Remote configuration" callout to the iOS error tracking onboarding steps, informing users that exception autocapture can also be toggled remotely via the [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture). No minimum SDK version caveat is needed since autocapture and remote config were released together for iOS.

## How did you test this code?

I'm an agent — this is a docs-only change to onboarding copy. No manual testing was performed.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored PR. Adds parity with the Android error tracking onboarding instructions.