### PR TITLE
fix(ai): persist AI consent popover dismissal

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -362,6 +362,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                         <AIConsentPopoverWrapper
                             placement="bottom-end"
                             showArrow
+                            ignoreDismissal
                             onApprove={() => askMax(pendingPrompt || question)}
                             onDismiss={() => completeThreadGeneration()}
                             middleware={[

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -94,6 +94,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         deregisterTool: (key: string) => ({ key }),
         prependOrReplaceConversation: (conversation: ConversationDetail | Conversation) => ({ conversation }),
         dismissLiabilityNotice: true,
+        dismissDataProcessing: true,
     }),
 
     loaders(({ values }) => ({
@@ -153,6 +154,12 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             { persist: true, storageKey: AI_LIABILITY_NOTICE_STORAGE_KEY },
             {
                 dismissLiabilityNotice: () => true,
+            },
+        ],
+        dataProcessingDismissed: [
+            false,
+            {
+                dismissDataProcessing: () => true,
             },
         ],
     }),

--- a/frontend/src/scenes/onboarding/OnboardingMax.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingMax.tsx
@@ -166,7 +166,7 @@ export function OnboardingMax(): JSX.Element {
     return (
         <BindLogic logic={maxLogic} props={{ tabId: ONBOARDING_TAB_ID }}>
             <BindLogic logic={maxThreadLogic} props={threadProps}>
-                <AIConsentPopoverWrapper>
+                <AIConsentPopoverWrapper ignoreDismissal>
                     <div className="flex flex-col items-center min-h-[calc(100vh-var(--scene-layout-header-height))]">
                         {!threadVisible ? (
                             <OnboardingWelcome />

--- a/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
@@ -1,5 +1,4 @@
-import { useAsyncActions, useValues } from 'kea'
-import { useState } from 'react'
+import { useActions, useAsyncActions, useValues } from 'kea'
 
 import { IconArrowRight, IconLock } from '@posthog/icons'
 import { LemonButton, Popover, PopoverProps, Tooltip } from '@posthog/lemon-ui'
@@ -11,21 +10,27 @@ import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 export function AIConsentPopoverWrapper({
     hidden,
     children,
+    ignoreDismissal,
     onApprove,
     onDismiss,
     ...popoverProps
 }: Pick<PopoverProps, 'placement' | 'fallbackPlacements' | 'middleware' | 'showArrow'> & {
     children: JSX.Element
     hidden?: boolean
+    /** Always show popover regardless of prior dismissal. */
+    ignoreDismissal?: boolean
     onApprove?: () => void
     onDismiss?: () => void
 }): JSX.Element {
     const { acceptDataProcessing } = useAsyncActions(maxGlobalLogic)
-    const { dataProcessingApprovalDisabledReason, dataProcessingAccepted } = useValues(maxGlobalLogic)
-    const [dismissed, setDismissed] = useState(false)
+    const { dataProcessingApprovalDisabledReason, dataProcessingAccepted, dataProcessingDismissed } =
+        useValues(maxGlobalLogic)
+    const { dismissDataProcessing } = useActions(maxGlobalLogic)
 
     const handleDismiss = (): void => {
-        setDismissed(true)
+        if (!ignoreDismissal) {
+            dismissDataProcessing()
+        }
         onDismiss?.()
     }
 
@@ -81,7 +86,7 @@ export function AIConsentPopoverWrapper({
                 </div>
             }
             style={{ zIndex: 'var(--z-modal)' }} // Don't show above the re-authentication modal
-            visible={!hidden && !dataProcessingAccepted && !dismissed}
+            visible={!hidden && !dataProcessingAccepted && (ignoreDismissal || !dataProcessingDismissed)}
             onClickOutside={handleDismiss}
             {...popoverProps}
         >


### PR DESCRIPTION
### Problem
Users who haven't approved AI data processing see the consent popover on every page navigation because the dismissed state was local React state (useState), resetting on each mount. ([ticket](https://posthoghelp.zendesk.com/agent/tickets/52874))

### Changes
* moved popover dismissal state from component-level useState to session-level reducer
* added ignoreDismissal prop to AIConsentPopoverWrapper for primary cases where consent must always show until approved

## Publish to changelog?
no
<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
