### PR TITLE
fix(insights): fix react key warning

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -107,8 +107,12 @@ const SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN = new Set([
     PropertyMathType.Maximum,
 ])
 
-const DragHandle = (props: DraggableSyntheticListeners | undefined): JSX.Element => (
-    <span className="ActionFilterRowDragHandle" {...props}>
+interface DragHandleProps {
+    listeners: DraggableSyntheticListeners | undefined
+}
+
+const DragHandle = ({ listeners }: DragHandleProps): JSX.Element => (
+    <span className="ActionFilterRowDragHandle" {...listeners}>
         <SortableDragIcon />
     </span>
 )
@@ -599,7 +603,7 @@ export function ActionFilterRow({
     )
 
     const rowStartElements = [
-        sortable && filterCount > 1 ? <DragHandle key="drag-handle" {...listeners} /> : null,
+        sortable && filterCount > 1 ? <DragHandle key="drag-handle" listeners={listeners} /> : null,
         showSeriesIndicator && <div key="series-indicator">{seriesIndicator}</div>,
     ].filter(Boolean)
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -108,7 +108,7 @@ const SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN = new Set([
 ])
 
 const DragHandle = (props: DraggableSyntheticListeners | undefined): JSX.Element => (
-    <span className="ActionFilterRowDragHandle" key="drag-handle" {...props}>
+    <span className="ActionFilterRowDragHandle" {...props}>
         <SortableDragIcon />
     </span>
 )
@@ -599,7 +599,7 @@ export function ActionFilterRow({
     )
 
     const rowStartElements = [
-        sortable && filterCount > 1 ? <DragHandle {...listeners} /> : null,
+        sortable && filterCount > 1 ? <DragHandle key="drag-handle" {...listeners} /> : null,
         showSeriesIndicator && <div key="series-indicator">{seriesIndicator}</div>,
     ].filter(Boolean)
 


### PR DESCRIPTION
## Problem

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ActionFilterRow`. See https://reactjs.org/link/warning-keys for more information.
    at DragHandle
    at ActionFilterRow (http://localhost:8234/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx?t=1773077259369:130:3)
    at SortableContext (http://localhost:8234/node_modules/.vite/deps/@dnd-kit_sortable.js?v=89cbe130:261:5)
    at DndContext2 (http://localhost:8234/node_modules/.vite/deps/chunk-QD4JC76Y.js?v=e5339108:2485:5)
    at ul
    at div
    at ActionFilter2 (http://localhost:8234/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx?t=1773077259369:43:3)
    at div
    at FunnelsQuerySteps (http://localhost:8234/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx?t=1773077259369:39:37)
    at div
    at LemonPureField (http://localhost:8234/src/lib/lemon-ui/LemonField/LemonField.tsx?t=1773076017651:39:3)
    at div
    at div
    at EditorFilterGroup (http://localhost:8234/src/queries/nodes/InsightViz/EditorFilterGroup.tsx?t=1773076017651:24:37)
    at div
    at div
    at div
    at MaxTool (http://localhost:8234/src/scenes/max/MaxTool.tsx?t=1773077259369:23:3)
    at div
    at div
    at Transition2 (http://localhost:8234/node_modules/.vite/deps/chunk-ZJX6PT7L.js?v=e5339108:76:30)
    at CSSTransition2 (http://localhost:8234/node_modules/.vite/deps/react-transition-group.js?v=374dc3c7:84:35)
    at EditorFilters (http://localhost:8234/src/queries/nodes/InsightViz/EditorFilters.tsx?t=1773077259369:67:33)
    at div
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-KIPGAHOF.js?v=e5339108:2057:20)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-KIPGAHOF.js?v=e5339108:2057:20)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-KIPGAHOF.js?v=e5339108:2057:20)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=dda99392:364:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx?t=1773076017651:35:33)
    at InsightViz (http://localhost:8234/src/queries/nodes/InsightViz/InsightViz.tsx?t=1773077259369:41:3)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=dda99392:364:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx?t=1773076017651:35:33)
    at Query (http://localhost:8234/src/queries/Query/Query.tsx?t=1773077259369:61:12)
    at div
    at SceneContent (http://localhost:8234/src/layout/scenes/components/SceneContent.tsx?t=1773076017651:23:32)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-KIPGAHOF.js?v=e5339108:2057:20)
    at InsightAsScene (http://localhost:8234/src/scenes/insights/InsightAsScene.tsx?t=1773077259369:37:34)
    at InsightScene (http://localhost:8234/src/scenes/insights/InsightScene.tsx?t=1773077259369:31:11)
    at BindLogic (http://localhost:8234/node_modules/.vite/deps/chunk-KIPGAHOF.js?v=e5339108:2057:20)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=dda99392:364:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx?t=1773076017651:35:33)
    at SceneLayout (http://localhost:8234/src/layout/scenes/SceneLayout.tsx?t=1773077259369:94:31)
    at main
    at div
    at DndContext2 (http://localhost:8234/node_modules/.vite/deps/chunk-QD4JC76Y.js?v=e5339108:2485:5)
    at ProjectDragAndDropProvider (http://localhost:8234/src/layout/panel-layout/ProjectTree/ProjectDragAndDropContext.tsx?t=1773077259369:81:46)
    at div
    at Navigation (http://localhost:8234/src/layout/navigation-3000/Navigation.tsx?t=1773077259369:43:3)
    at div
    at AppScene (http://localhost:8234/src/scenes/App.tsx?t=1773077259369:81:3)
    at App (http://localhost:8234/src/scenes/App.tsx?t=1773077259369:45:63)
    at FloatingDelayGroup (http://localhost:8234/node_modules/.vite/deps/chunk-BQEUVYYO.js?v=e5339108:269:5)
    at TooltipProvider2 (http://localhost:8234/node_modules/.vite/deps/@base-ui_react_tooltip.js?v=70c26b49:860:5)
    at PostHogProvider (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=dda99392:49:21)
    at PostHogErrorBoundary2 (http://localhost:8234/node_modules/.vite/deps/posthog-js_react.js?v=dda99392:364:24)
    at ErrorBoundary (http://localhost:8234/src/layout/ErrorBoundary/ErrorBoundary.tsx?t=1773076017651:35:33)
```

## Changes

- Fixed the React key warning in ActionFilterRow by removing the key from inside DragHandle’s returned <span> and placing the key on the DragHandle element at the list construction site (rowStartElements), which is where React requires list keys to live. 

## How did you test this code?

Observed that the warning isn't logged with these changes any more