### PR TITLE
feat: Add organization members inline to project and team admin pages

### DIFF
--- a/posthog/admin/admins/project_admin.py
+++ b/posthog/admin/admins/project_admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
+from posthog.admin.inlines.organization_member_for_related_inline import OrganizationMemberForRelatedInline
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.models import Project
 
@@ -24,7 +25,7 @@ class ProjectAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ["organization"]
     readonly_fields = ["created_at"]
-    inlines = [TeamInline]
+    inlines = [OrganizationMemberForRelatedInline, TeamInline]
 
     def organization_link(self, project: Project):
         return format_html(

--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -22,6 +22,7 @@ from structlog import get_logger
 from temporalio import common
 from temporalio.client import WorkflowExecutionStatus
 
+from posthog.admin.inlines.organization_member_for_related_inline import OrganizationMemberForRelatedInline
 from posthog.admin.inlines.team_marketing_analytics_config_inline import TeamMarketingAnalyticsConfigInline
 from posthog.admin.inlines.user_product_list_inline import UserProductListInline
 from posthog.cloud_utils import is_cloud
@@ -91,7 +92,7 @@ class TeamAdmin(admin.ModelAdmin):
     ]
 
     exclude = DEPRECATED_ATTRS
-    inlines = [TeamMarketingAnalyticsConfigInline, UserProductListInline]
+    inlines = [OrganizationMemberForRelatedInline, TeamMarketingAnalyticsConfigInline, UserProductListInline]
 
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
         self._current_request = request

--- a/posthog/admin/inlines/organization_member_for_related_inline.py
+++ b/posthog/admin/inlines/organization_member_for_related_inline.py
@@ -105,7 +105,7 @@ class OrganizationMemberForRelatedInline(TabularInlinePaginated):
             max_num=self.max_num,
             can_delete=False,
         )
-        formset_cls.fk = _ORGANIZATION_FK  # type: ignore[attr-defined] — needed by Django's inline rendering
+        formset_cls.fk = _ORGANIZATION_FK  # type: ignore[attr-defined]
         return formset_cls
 
     @classmethod

--- a/posthog/admin/inlines/organization_member_for_related_inline.py
+++ b/posthog/admin/inlines/organization_member_for_related_inline.py
@@ -1,0 +1,112 @@
+from django.contrib import admin
+from django.forms import BaseInlineFormSet, ModelForm, modelformset_factory
+from django.urls import reverse
+from django.utils.html import format_html
+
+from django_admin_inline_paginator.admin import PaginationFormSetBase, TabularInlinePaginated
+
+from posthog.models.organization import Organization, OrganizationMembership
+
+_ORGANIZATION_FK = OrganizationMembership._meta.get_field("organization")
+
+
+class _ReadOnlyForm(ModelForm):
+    class Meta:
+        model = OrganizationMembership
+        fields = ()
+
+
+class _OrganizationMemberFormSet(PaginationFormSetBase, BaseInlineFormSet):
+    """FormSet that filters OrganizationMembership by the parent object's organization.
+
+    Django's BaseInlineFormSet normally filters by a FK pointing at the parent
+    model.  Here the parent is Team or Project, but the FK points at
+    Organization.  We skip BaseInlineFormSet's __init__
+    (via explicit super(BaseInlineFormSet, self) call) to bypass its FK
+    wiring and provide our own queryset instead.
+    """
+
+    fk = _ORGANIZATION_FK
+
+    def __init__(self, data=None, files=None, instance=None, save_as_new=False, **kwargs):
+        self.instance = instance
+        # Django's admin template reads formset.save_as_new.
+        self.save_as_new = save_as_new
+        if instance and hasattr(instance, "organization_id"):
+            qs = (
+                OrganizationMembership.objects.filter(organization_id=instance.organization_id)
+                .select_related("user")
+                .order_by("-level", "user__email")
+            )
+        else:
+            qs = OrganizationMembership.objects.none()
+
+        kwargs["queryset"] = qs
+        # Django's add_fields reads instance._state; provide a stub when None.
+        if self.instance is None:
+            self.instance = Organization()
+        super(BaseInlineFormSet, self).__init__(data=data, files=files, **kwargs)
+
+    def save(self, commit=True):
+        return []
+
+
+class OrganizationMemberForRelatedInline(TabularInlinePaginated):
+    """Read-only inline showing OrganizationMembership on Team/Project pages.
+
+    Both Team and Project have a FK to Organization, but
+    OrganizationMembership's FK also points to Organization — not Team/Project.
+    We bypass Django's FK validation and build the formset manually.
+    """
+
+    model = OrganizationMembership
+    fk_name = "organization"
+    template = "admin/edit_inline/readonly_tabular.html"
+    extra = 0
+    per_page = 20
+    pagination_key = "page-member"
+    verbose_name = "organization member"
+    verbose_name_plural = "organization members"
+
+    fields = ("user_link", "role", "joined_at")
+    readonly_fields = ("user_link", "role", "joined_at")
+
+    can_delete = False
+    max_num = 0
+
+    @admin.display(description="User")
+    def user_link(self, membership: OrganizationMembership) -> str:
+        url = reverse("admin:posthog_user_change", args=[membership.user_id])
+        return format_html('<a href="{}">{}</a>', url, membership.user.email)
+
+    @admin.display(description="Role")
+    def role(self, membership: OrganizationMembership) -> str:
+        return membership.get_level_display()
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_formset(self, request, obj=None, **kwargs):
+        # Build formset class manually, bypassing inlineformset_factory's FK check.
+        formset_cls = modelformset_factory(
+            OrganizationMembership,
+            form=_ReadOnlyForm,
+            formset=_OrganizationMemberFormSet,
+            fields=(),
+            extra=0,
+            max_num=self.max_num,
+            can_delete=False,
+        )
+        formset_cls.fk = _ORGANIZATION_FK
+        return formset_cls
+
+    @classmethod
+    def check(cls, **kwargs):
+        # Skip the standard InlineModelAdmin checks which validate FK relationships.
+        return []

--- a/posthog/admin/inlines/organization_member_for_related_inline.py
+++ b/posthog/admin/inlines/organization_member_for_related_inline.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.contrib import admin
 from django.forms import BaseInlineFormSet, ModelForm, modelformset_factory
 from django.urls import reverse
@@ -26,10 +28,10 @@ class _OrganizationMemberFormSet(PaginationFormSetBase, BaseInlineFormSet):
     wiring and provide our own queryset instead.
     """
 
-    fk = _ORGANIZATION_FK
+    fk: Any = _ORGANIZATION_FK
 
     def __init__(self, data=None, files=None, instance=None, save_as_new=False, **kwargs):
-        self.instance = instance
+        self.instance: Any = instance
         # Django's admin template reads formset.save_as_new.
         self.save_as_new = save_as_new
         if instance and hasattr(instance, "organization_id"):
@@ -103,7 +105,7 @@ class OrganizationMemberForRelatedInline(TabularInlinePaginated):
             max_num=self.max_num,
             can_delete=False,
         )
-        formset_cls.fk = _ORGANIZATION_FK
+        formset_cls.fk = _ORGANIZATION_FK  # type: ignore[attr-defined] — needed by Django's inline rendering
         return formset_cls
 
     @classmethod

--- a/posthog/templates/admin/edit_inline/readonly_tabular.html
+++ b/posthog/templates/admin/edit_inline/readonly_tabular.html
@@ -1,0 +1,50 @@
+{% load i18n admin_urls static admin_modify %}
+<div class="inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module {{ inline_admin_formset.classes }}">
+   {% if inline_admin_formset.formset.max_num == 1 %}
+     <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+   {% else %}
+     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+   {% endif %}
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+     {% for field in inline_admin_formset.fields %}
+       {% if not field.widget.is_hidden %}
+       <th class="column-{{ field.name }}">{{ field.label|capfirst }}
+       {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+       </th>
+       {% endif %}
+     {% endfor %}
+     </tr></thead>
+
+     <tbody>
+     {% for inline_admin_form in inline_admin_formset %}
+        {% if inline_admin_form.form.non_field_errors %}
+        <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+        {% endif %}
+        <tr class="form-row" id="{{ inline_admin_formset.formset.prefix }}-{{ forloop.counter0 }}">
+        {% for fieldset in inline_admin_form %}
+          {% for line in fieldset %}
+            {% for field in line %}
+              {% if not field.field.is_hidden %}
+              <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}">
+              {% if field.is_readonly %}
+                  <p>{{ field.contents }}</p>
+              {% else %}
+                  {{ field.field }}
+              {% endif %}
+              </td>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        </tr>
+     {% endfor %}
+     </tbody>
+   </table>
+</fieldset>
+  </div>
+</div>


### PR DESCRIPTION
## Problem

Admin users need to view organization members when managing teams and projects in the Django admin interface. Currently, there's no easy way to see which users belong to an organization when viewing a team or project page, making it difficult to understand the relationship between projects/teams and their organization members.

## Changes

- Created a new `OrganizationMemberForRelatedInline` that displays organization members as a read-only inline on Team and Project admin pages
- Added custom formset logic to handle the indirect relationship between Team/Project and OrganizationMembership (both relate through Organization)
- Implemented pagination support for organization members with 20 members per page
- Added a custom read-only tabular template for displaying the inline data
- Integrated the new inline into both `ProjectAdmin` and `TeamAdmin` classes
- The inline displays user email (as a link), role, and join date for each organization member

## How did you test this code?

As an AI agent, I have not manually tested this code. The implementation includes:
- Proper Django admin inline structure with custom formset handling
- Template inheritance from Django's admin system
- Integration with existing admin classes
- Pagination support through django-admin-inline-paginator

Manual testing should verify:
- Organization members display correctly on Team and Project admin pages
- Pagination works when organizations have more than 20 members
- User links navigate to the correct user admin pages
- Read-only functionality prevents accidental modifications

## Publish to changelog?

No - this is an internal admin interface improvement that doesn't affect end users.