### PR TITLE
fix: Make "Show enabled only" button persistent on refresh

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
@@ -197,6 +197,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
         ],
         showEnabledSchemasOnly: [
             false as boolean,
+            { persist: true },
             {
                 setShowEnabledSchemasOnly: (_, { showEnabledSchemasOnly }) => showEnabledSchemasOnly,
             },


### PR DESCRIPTION
## Problem

When refreshing a data warehouse source, the "Show enabled only" toggle resets to the off state. User has requested that his persist accross refreshes.

<img width="348" height="224" alt="image" src="https://github.com/user-attachments/assets/6f8f1673-e105-4881-8838-7e09d9915da0" />


## Changes

Adds the persist option as `true`.

## How did you test this code?

Tested locally, after setting up a source of data.

## Publish to changelog?

no
