### PR TITLE
fix(insights): stop double timezone conversion on x-axis labels

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -174,15 +174,15 @@ describe('createXAxisTickCallback', () => {
     })
 
     describe('non-UTC timezone', () => {
-        it('shifts hour labels according to timezone offset', () => {
+        it('does not shift hour labels because datetime strings are already in project timezone', () => {
             const callback = createXAxisTickCallback({
                 interval: 'hour',
                 allDays: ['2025-04-01 00:00:00', '2025-04-01 01:00:00', '2025-04-01 02:00:00'],
                 timezone: 'America/New_York',
             })
-            expect(callback('ignored', 0)).toBe('20:00')
-            expect(callback('ignored', 1)).toBe('21:00')
-            expect(callback('ignored', 2)).toBe('22:00')
+            expect(callback('ignored', 0)).toBe('00:00')
+            expect(callback('ignored', 1)).toBe('01:00')
+            expect(callback('ignored', 2)).toBe('02:00')
         })
 
         it.each([

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -1,5 +1,4 @@
 import { dayjs, Dayjs } from 'lib/dayjs'
-import { dayjsUtcToTimezone } from 'lib/dayjs'
 
 import { IntervalType } from '~/types'
 
@@ -25,14 +24,16 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    // Datetime strings (with time component) are UTC from ClickHouse — convert to project timezone.
-    // Date-only strings are calendar bucket labels — parse as midnight in the project timezone
-    // so that e.g. "2023-07-01" stays July and doesn't drift to June in behind-UTC timezones.
+    // Datetime strings (with time component) are already in the project timezone
+    // (ClickHouse applies toTimeZone before truncation), so parse them directly in
+    // that timezone. Date-only strings are calendar bucket labels — parse as midnight
+    // in the project timezone so that e.g. "2023-07-01" stays July and doesn't drift
+    // to June in behind-UTC timezones.
     const parsedDates = allDays.map((d) => {
         const s = String(d)
         const hasTime = s.includes(' ') || s.includes('T')
         if (hasTime) {
-            return dayjsUtcToTimezone(s, timezone, false)
+            return dayjs.tz(s, timezone)
         }
         try {
             return dayjs.tz(s + ' 00:00:00', timezone)


### PR DESCRIPTION
Datetime strings in the API response are already in the project timezone (ClickHouse applies toTimeZone before truncation), but the x-axis formatter was treating them as UTC and converting again. This caused hour labels to be offset by the project's UTC difference (e.g. 05:00 displayed as 13:00 for UTC+8).

Switch from dayjsUtcToTimezone() to dayjs.tz() to match the tooltip formatter, which already handles this correctly.

## Problem

Users in non-UTC timezones see inconsistent times between the x-axis labels and tooltips on hourly trend charts. For example, a UTC+8 user hovering over a data point sees "05:00 (UTC+8)" in the tooltip but the x-axis label at that position reads "13:00", an 8-hour offset matching their UTC difference.

## Changes

The x-axis formatter in `formatXAxisTick.ts` was treating datetime strings from the API as UTC and converting them to the project timezone using `dayjsUtcToTimezone()`. However, ClickHouse already applies `toTimeZone(e.timestamp, '<project_tz>')` before truncation, so the strings arrive **already in the project timezone**. This caused a double conversion (e.g. 05:00 + 8h = 13:00).

The fix replaces `dayjsUtcToTimezone(s, timezone, false)` with `dayjs.tz(s, timezone)`, which correctly interprets the string as already being in the target timezone — matching the tooltip formatter's existing behavior.

## How did you test this code?

I followed these testing steps:
1. Set your project timezone to something non-UTC (e.g. UTC+8 or America/New_York)
2. Create a trends insight with hourly interval (e.g. "Last 24 hours" grouped by hour)
3. Hover over data points and verify the x-axis label matches the time shown in the tooltip

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Opus 4.6 via Claude Code. 
