### PR TITLE
fix(surveys): do not count skipped responses as other

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -541,7 +541,7 @@ export function buildAggregateQuery(
                 ${responseExpr} AS label,
                 count() AS cnt
             FROM events
-            WHERE ${baseWhere} AND ${responseExpr} != ''
+            WHERE ${baseWhere} AND isNotNull(${responseExpr})
             GROUP BY label`)
         } else if (question.type === SurveyQuestionType.MultipleChoice) {
             branches.push(`SELECT '${question.id}' AS question_id,
@@ -549,7 +549,7 @@ export function buildAggregateQuery(
                 count() AS cnt
             FROM events
             WHERE ${baseWhere}
-            GROUP BY label HAVING label != ''`)
+            GROUP BY label HAVING isNotNull(label) AND label != ''`)
 
             branches.push(`SELECT '${question.id}' AS question_id,
                 '__total__' AS label,
@@ -561,7 +561,7 @@ export function buildAggregateQuery(
                 '__total__' AS label,
                 count() AS cnt
             FROM events
-            WHERE ${baseWhere} AND ${responseExpr} != ''`)
+            WHERE ${baseWhere} AND isNotNull(${responseExpr})`)
         }
     }
 


### PR DESCRIPTION
## Problem

surveys response visualization accidentally shows "other (open-ended)" for null (skipped) questions

https://posthoghelp.zendesk.com/agent/tickets/52644 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53920)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

swaps `!= ''` for `isNotNull` to avoid this

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

```
select ifNull(notEquals(null, ''), 1) as test

> test = 1
```

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->