### PR TITLE
fix(dashboard): fixes some layout problems for dashboard on mobile

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -571,7 +571,9 @@ export function DashboardHeader(): JSX.Element | null {
                                                     tooltipPlacement="top"
                                                     icon={<IconPlusSmall />}
                                                 >
-                                                    Text card
+                                                    <div>
+                                                        Text <span className="hidden md:inline-flex"> card</span>
+                                                    </div>
                                                 </LemonButton>
                                             </AppShortcut>
                                         </AccessControlAction>
@@ -597,7 +599,9 @@ export function DashboardHeader(): JSX.Element | null {
                                                     tooltip="Edit layout"
                                                     tooltipPlacement="top"
                                                 >
-                                                    Edit layout
+                                                    <div>
+                                                        Edit <span className="hidden md:inline-flex"> layout</span>
+                                                    </div>
                                                 </LemonButton>
                                             </AppShortcut>
                                         )}

--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -18,7 +18,7 @@ export const DashboardOverridesBanner = (): JSX.Element | null => {
 
     return (
         <LemonBanner type="info" className="mt-4 mb-2">
-            <div className="flex flex-row items-center justify-between gap-2">
+            <div className="flex flex-row items-center justify-between gap-2 flex-wrap">
                 <span>You are viewing this dashboard with filter overrides.</span>
 
                 <div className="flex gap-2">


### PR DESCRIPTION
## Problem
Mobile views were hiding some buttons on smaller screen sizes. We should at least make them reachable.

## Changes

Before
<img width="446" height="804" alt="image" src="https://github.com/user-attachments/assets/e874c243-7dcf-4ecb-a30f-6b746417f0db" />


After:
<img width="449" height="808" alt="image" src="https://github.com/user-attachments/assets/afd9e5c6-c0d9-4ff0-9b08-051f7e0341af" />


## How did you test this code?
Locally.

## Publish to changelog?

No.