### PR TITLE
fix: cast person display names to string in exports

### DIFF
--- a/frontend/src/queries/nodes/DataTable/exportTransformers.ts
+++ b/frontend/src/queries/nodes/DataTable/exportTransformers.ts
@@ -9,7 +9,7 @@ const PERSON_COLUMN = 'person'
  * Replaces the person column with a coalesce expression using personDisplayNameProperties for performance reasons
  */
 export function transformColumnsForExport(columns: string[], personDisplayNameProperties: string[]): string[] {
-    const props = personDisplayNameProperties.map((key) => `person.properties.${key}`)
+    const props = personDisplayNameProperties.map((key) => `toString(person.properties.${key})`)
     const expr = `coalesce(${[...props, 'distinct_id'].join(', ')})`
     return columns.map((column) => {
         const cleanColumn = removeExpressionComment(column)


### PR DESCRIPTION
## Problem

exports fail (for surveys, at least) when a person display name type is inferred as something other than a string

https://posthoghelp.zendesk.com/agent/tickets/52651 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53829)
https://github.com/PostHog/posthog/issues/47780

this issue has appeared in a customer account where all (or most) of the persons have number names like `123456`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds `toString` in the export transfomer

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->