### PR TITLE
refactor: simplify Stripe APP services catalog to single posthog service

### DIFF
--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -1,109 +1,20 @@
-from unittest.mock import MagicMock, patch
-
 from django.test import override_settings
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
-MOCK_BILLING_PRODUCTS = {
-    "products": [
-        {
-            "type": "product_analytics",
-            "name": "Product analytics",
-            "headline": "Product analytics with autocapture",
-            "description": "A comprehensive product analytics platform.",
-            "plans": [
-                {"plan_key": "free-20230117", "price_id": None},
-                {"plan_key": "paid-20240404", "price_id": "price_1PMG1IEuIatRXSdzht4rGlho"},
-            ],
-        },
-        {
-            "type": "session_replay",
-            "name": "Session replay",
-            "headline": "Watch how users experience your app",
-            "description": "Session replay helps you diagnose issues.",
-            "plans": [
-                {"plan_key": "free-20231218", "price_id": None},
-                {"plan_key": "paid-20240402-5k-free", "price_id": "price_1P1EZoEuIatRXSdzakl5PcUF"},
-            ],
-        },
-        {
-            "type": "platform_and_support",
-            "name": "Platform and support",
-            "description": "SSO, permission management, and support.",
-            "inclusion_only": True,
-            "plans": [{"plan_key": "free-20230117", "price_id": None}],
-        },
-    ]
-}
-
-
-def _mock_billing_response():
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = MOCK_BILLING_PRODUCTS
-    mock_resp.raise_for_status.return_value = None
-    return mock_resp
-
 
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
 class TestProvisioningServices(StripeProvisioningTestBase):
-    @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_returns_services_from_billing(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
+    def test_returns_single_posthog_service(self):
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
-        service_ids = {s["id"] for s in data["data"]}
-        assert "product_analytics" in service_ids
-        assert "session_replay" in service_ids
-        assert "platform_and_support" not in service_ids
+        assert len(data["data"]) == 1
+        service = data["data"][0]
+        assert service["id"] == "posthog"
+        assert service["pricing"]["type"] == "free"
+        assert "analytics" in service["categories"]
         assert data["next_cursor"] == ""
-
-    @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_each_service_has_stripe_price(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
-        res = self._get_signed("/api/agentic/provisioning/services")
-        assert res.status_code == 200
-        for service in res.json()["data"]:
-            assert service["pricing"]["type"] == "paid"
-            assert service["pricing"]["paid"]["type"] == "stripe_price"
-            assert service["pricing"]["paid"]["stripe_price"].startswith("price_")
-
-    @patch("ee.api.agentic_provisioning.views.external_requests.get")
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_uses_cache(self, mock_cache, mock_get):
-        cached = [
-            {
-                "id": "product_analytics",
-                "description": "cached",
-                "categories": ["analytics"],
-                "pricing": {"type": "paid", "paid": {"type": "stripe_price", "stripe_price": "price_cached"}},
-            }
-        ]
-        mock_cache.get.return_value = cached
-        res = self._get_signed("/api/agentic/provisioning/services")
-        assert res.status_code == 200
-        assert res.json()["data"][0]["pricing"]["paid"]["stripe_price"] == "price_cached"
-        mock_get.assert_not_called()
-
-    @patch("ee.api.agentic_provisioning.views.external_requests.get")
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_billing_failure_returns_empty(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
-        mock_get.side_effect = Exception("connection error")
-        res = self._get_signed("/api/agentic/provisioning/services")
-        assert res.status_code == 200
-        assert res.json()["data"] == []
-
-    @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_excludes_inclusion_only_products(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
-        res = self._get_signed("/api/agentic/provisioning/services")
-        service_ids = {s["id"] for s in res.json()["data"]}
-        assert "platform_and_support" not in service_ids
 
     def test_missing_signature_returns_401(self):
         res = self.client.get("/api/agentic/provisioning/services", HTTP_API_VERSION="0.1d")

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2,102 +2,33 @@ from __future__ import annotations
 
 from typing import Any
 
-from django.core.cache import cache
-
-import structlog
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.security.outbound_proxy import external_requests
-
-from ee.settings import BILLING_SERVICE_URL
-
 from .signature import SUPPORTED_VERSIONS, verify_stripe_signature
 
-logger = structlog.get_logger(__name__)
-
 # ---------------------------------------------------------------------------
-# Service catalog — fetched from the billing service and mapped to the
-# APP 0.1d services format with `stripe_price` pricing.
+# Service catalog — a single "posthog" service. PostHog projects include all
+# products (analytics, session replay, feature flags, etc.) so there's one
+# provisionable service. PostHog handles billing itself (payment_credentials:
+# "provider"), so pricing is "free" from Stripe's perspective.
 # ---------------------------------------------------------------------------
 
-SERVICES_CACHE_KEY = "agentic_provisioning:services"
-SERVICES_CACHE_TTL = 300  # 5 minutes
+POSTHOG_SERVICE_ID = "posthog"
 
-# Products that shouldn't be listed as provisionable services
-_EXCLUDED_PRODUCT_TYPES = {"platform_and_support", "integrations"}
-
-# Billing product type -> APP service categories
-_CATEGORY_MAP: dict[str, list[str]] = {
-    "product_analytics": ["analytics"],
-    "session_replay": ["observability"],
-    "feature_flags": ["feature_flags"],
-    "surveys": ["analytics"],
-    "data_warehouse": ["database"],
-    "error_tracking": ["observability"],
-    "llm_analytics": ["analytics", "ai"],
-    "logs": ["observability"],
-    "posthog_ai": ["ai"],
-    "realtime_destinations": ["messaging"],
-    "workflows_emails": ["email"],
+POSTHOG_SERVICE: dict[str, Any] = {
+    "id": POSTHOG_SERVICE_ID,
+    "description": "PostHog — product analytics, session replay, feature flags, A/B testing, surveys, and more",
+    "categories": ["analytics", "observability", "feature_flags", "ai"],
+    "pricing": {
+        "type": "free",
+    },
 }
 
 
-def _fetch_services_from_billing() -> list[dict[str, Any]]:
-    try:
-        res = external_requests.get(
-            f"{BILLING_SERVICE_URL}/api/products-v2",
-            params={"plan": "standard"},
-        )
-        res.raise_for_status()
-        products = res.json().get("products", [])
-    except Exception:
-        logger.exception("agentic_provisioning.services.billing_fetch_failed")
-        return []
-
-    services = []
-    for product in products:
-        product_type = product.get("type", "")
-        if product_type in _EXCLUDED_PRODUCT_TYPES:
-            continue
-        if product.get("inclusion_only"):
-            continue
-
-        paid_plan = next((p for p in product.get("plans", []) if p.get("price_id")), None)
-        if not paid_plan:
-            continue
-
-        services.append(
-            {
-                "id": product_type,
-                "description": product.get("headline") or product.get("description", ""),
-                "categories": _CATEGORY_MAP.get(product_type, ["analytics"]),
-                "pricing": {
-                    "type": "paid",
-                    "paid": {
-                        "type": "stripe_price",
-                        "stripe_price": paid_plan["price_id"],
-                    },
-                },
-            }
-        )
-
-    return services
-
-
 def _get_services() -> list[dict[str, Any]]:
-    cached = cache.get(SERVICES_CACHE_KEY)
-    if cached is not None:
-        return cached
-
-    services = _fetch_services_from_billing()
-    if services:
-        cache.set(SERVICES_CACHE_KEY, services, SERVICES_CACHE_TTL)
-    return services
-
-
-VALID_SERVICE_IDS: set[str] = set(_CATEGORY_MAP.keys())
+    return [POSTHOG_SERVICE]
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2931,7 +2931,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 63}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 65}'::jsonb)
   LIMIT 1
   '''
 # ---


### PR DESCRIPTION
## Problem

The services catalog listed each PostHog product (product_analytics, session_replay, feature_flags, etc.) as a separate APP service. But PostHog projects include **all** products — you don't provision "a session_replay instance" separately. This caused issues downstream:
- `service_id` in resource lifecycle responses was meaningless (hardcoded to `"product_analytics"`)
- The `stripe_price` IDs per product were informational only since PostHog handles billing itself (`payment_credentials: "provider"`)
- Resource create/detail/rotate responses had inconsistent service_ids

## Changes

- Replace multi-product services catalog with a single `"posthog"` service
- Set `pricing.type = "free"` (signup is free; PostHog handles usage-based billing)
- Categories cover all capabilities: `["analytics", "observability", "feature_flags", "ai"]`
- Remove billing service fetch, cache, and category map (no longer needed)
- Simplify tests accordingly

## How did you test this code?

- `pytest ee/api/agentic_provisioning/test/test_services.py -x -q` — 2 tests pass
- `pytest ee/api/agentic_provisioning/test/ -x -q` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)