### PR TITLE
perf(cohorts): optimize realtime cohort query building by passing team objects

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -111,6 +111,8 @@ class HogQLCohortQuery:
                     hogql_context=self.hogql_context,
                 ),
                 self.team.pk,
+                self.team,
+                cohort,
             )
             self.property_groups = filter.property_groups
         elif cohort_query is not None:

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -111,7 +111,6 @@ class HogQLCohortQuery:
                     hogql_context=self.hogql_context,
                 ),
                 self.team.pk,
-                self.team,
             )
             self.property_groups = filter.property_groups
         elif cohort_query is not None:

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -111,6 +111,7 @@ class HogQLCohortQuery:
                     hogql_context=self.hogql_context,
                 ),
                 self.team.pk,
+                self.team,
             )
             self.property_groups = filter.property_groups
         elif cohort_query is not None:

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -212,9 +212,7 @@ class FOSSCohortQuery(EventQuery):
                                     # Use passed team object if available, otherwise fetch from database
                                     if team is None:
                                         team = Team.objects.get(pk=team_id)
-                                    prop_cohort: Cohort = Cohort.objects.get(
-                                        pk=prop.value, team__project_id=team.project_id
-                                    )
+                                    prop_cohort = Cohort.objects.get(pk=prop.value, team__project_id=team.project_id)
                                 new_property_group_list.append(
                                     PropertyGroup(
                                         type=PropertyOperatorType.AND,

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -206,7 +206,7 @@ class FOSSCohortQuery(EventQuery):
                         if prop.type in ["cohort", "precalculated-cohort"]:
                             try:
                                 # Use passed cohort object if it matches the requested cohort ID
-                                if cohort is not None and cohort.pk == prop.value:
+                                if cohort is not None and cohort.pk == int(prop.value):
                                     prop_cohort = cohort
                                 else:
                                     # Use passed team object if available, otherwise fetch from database

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -149,7 +149,7 @@ class FOSSCohortQuery(EventQuery):
         self._cohort_pk = cohort_pk
 
         super().__init__(
-            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk),
+            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk, team),
             team=team,
             round_interval=round_interval,
             should_join_distinct_ids=should_join_distinct_ids,
@@ -169,8 +169,11 @@ class FOSSCohortQuery(EventQuery):
         self._outer_property_groups = property_groups.outer
 
     @staticmethod
-    def unwrap_cohort(filter: Filter, team_id: int) -> Filter:
+    def unwrap_cohort(
+        filter: Filter, team_id: int, team: Optional[Team] = None, cohort: Optional[Cohort] = None
+    ) -> Filter:
         def _unwrap(property_group: PropertyGroup, negate_group: bool = False) -> PropertyGroup:
+            nonlocal team
             if len(property_group.values):
                 if isinstance(property_group.values[0], PropertyGroup):
                     # dealing with a list of property groups, so unwrap each one
@@ -202,7 +205,16 @@ class FOSSCohortQuery(EventQuery):
                         negation_value = not current_negation if negate_group else current_negation
                         if prop.type in ["cohort", "precalculated-cohort"]:
                             try:
-                                prop_cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
+                                # Use passed cohort object if it matches the requested cohort ID
+                                if cohort is not None and cohort.pk == prop.value:
+                                    prop_cohort = cohort
+                                else:
+                                    # Use passed team object if available, otherwise fetch from database
+                                    if team is None:
+                                        team = Team.objects.get(pk=team_id)
+                                    prop_cohort: Cohort = Cohort.objects.get(
+                                        pk=prop.value, team__project_id=team.project_id
+                                    )
                                 new_property_group_list.append(
                                     PropertyGroup(
                                         type=PropertyOperatorType.AND,

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -206,7 +206,7 @@ class FOSSCohortQuery(EventQuery):
                         if prop.type in ["cohort", "precalculated-cohort"]:
                             try:
                                 # Use passed cohort object if it matches the requested cohort ID
-                                if cohort is not None and cohort.pk == int(prop.value):
+                                if cohort is not None and str(cohort.pk) == str(prop.value):
                                     prop_cohort = cohort
                                 else:
                                     # Use passed team object if available, otherwise fetch from database

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -149,7 +149,7 @@ class FOSSCohortQuery(EventQuery):
         self._cohort_pk = cohort_pk
 
         super().__init__(
-            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk, team),
+            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk),
             team=team,
             round_interval=round_interval,
             should_join_distinct_ids=should_join_distinct_ids,
@@ -169,9 +169,8 @@ class FOSSCohortQuery(EventQuery):
         self._outer_property_groups = property_groups.outer
 
     @staticmethod
-    def unwrap_cohort(filter: Filter, team_id: int, team: Optional[Team] = None) -> Filter:
+    def unwrap_cohort(filter: Filter, team_id: int) -> Filter:
         def _unwrap(property_group: PropertyGroup, negate_group: bool = False) -> PropertyGroup:
-            nonlocal team
             if len(property_group.values):
                 if isinstance(property_group.values[0], PropertyGroup):
                     # dealing with a list of property groups, so unwrap each one
@@ -203,9 +202,6 @@ class FOSSCohortQuery(EventQuery):
                         negation_value = not current_negation if negate_group else current_negation
                         if prop.type in ["cohort", "precalculated-cohort"]:
                             try:
-                                # Use passed team object if available, otherwise fetch from database
-                                if team is None:
-                                    team = Team.objects.get(pk=team_id)
                                 prop_cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
                                 new_property_group_list.append(
                                     PropertyGroup(

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -149,7 +149,7 @@ class FOSSCohortQuery(EventQuery):
         self._cohort_pk = cohort_pk
 
         super().__init__(
-            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk),
+            filter=FOSSCohortQuery.unwrap_cohort(filter, team.pk, team),
             team=team,
             round_interval=round_interval,
             should_join_distinct_ids=should_join_distinct_ids,
@@ -169,9 +169,7 @@ class FOSSCohortQuery(EventQuery):
         self._outer_property_groups = property_groups.outer
 
     @staticmethod
-    def unwrap_cohort(filter: Filter, team_id: int) -> Filter:
-        team: Optional[Team] = None
-
+    def unwrap_cohort(filter: Filter, team_id: int, team: Optional[Team] = None) -> Filter:
         def _unwrap(property_group: PropertyGroup, negate_group: bool = False) -> PropertyGroup:
             nonlocal team
             if len(property_group.values):
@@ -205,11 +203,10 @@ class FOSSCohortQuery(EventQuery):
                         negation_value = not current_negation if negate_group else current_negation
                         if prop.type in ["cohort", "precalculated-cohort"]:
                             try:
-                                if team is None:  # This ensures we only fetch team if needed, but never more than once
+                                # Use passed team object if available, otherwise fetch from database
+                                if team is None:
                                     team = Team.objects.get(pk=team_id)
-                                prop_cohort: Cohort = Cohort.objects.get(
-                                    pk=prop.value, team__project_id=team.project_id
-                                )
+                                prop_cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
                                 new_property_group_list.append(
                                     PropertyGroup(
                                         type=PropertyOperatorType.AND,

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -493,6 +493,19 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                 # Includes: query execution + Kafka message production + message flushing
                 cohort_end_time = time.monotonic()
                 duration_ms = int((cohort_end_time - cohort_start_time) * 1000)
+                duration_seconds = duration_ms / 1000
+
+                # Log slow cohorts for investigation
+                if duration_seconds > 10:
+                    logger.warning(
+                        f"Slow cohort detected: cohort {cohort.pk} took {duration_seconds:.1f}s to process",
+                        cohort_id=cohort.pk,
+                        duration_seconds=duration_seconds,
+                        duration_ms=duration_ms,
+                        team_id=cohort.team_id,
+                        cohort_name=cohort.name,
+                        is_slow_cohort=True,
+                    )
 
                 # Record total cohort calculation duration
                 COHORT_CALCULATION_TOTAL_DURATION_HISTOGRAM.labels(percentile_bucket=percentile_bucket).observe(
@@ -506,6 +519,7 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                     f"Cohort {cohort.pk} processing completed",
                     cohort_id=cohort.pk,
                     duration_ms=duration_ms,
+                    duration_seconds=duration_seconds,
                 )
 
                 get_cohort_calculation_success_metric().add(1)

--- a/posthog/temporal/messaging/schedule.py
+++ b/posthog/temporal/messaging/schedule.py
@@ -171,7 +171,7 @@ async def create_realtime_cohort_calculation_schedule_with_id(
             else None,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=interval_minutes))]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, schedule_id):


### PR DESCRIPTION
## Problem

Realtime cohort calculations were experiencing slow query building times (~800ms for p0-50 percentile). Additionally, overlapping temporal workflows were being queued instead of skipped, and there was no visibility into which specific cohorts were causing performance issues.

## Changes

- **Added optional `team` and `cohort` parameters** to `FOSSCohortQuery.unwrap_cohort()` to eliminate redundant database queries
- **Updated all callers** to pass preloaded team and cohort objects from `select_related("team")` queries
- **Maintained cross-team cohort access** by keeping `team__project_id` filtering for project-level cohort sharing
- **Changed temporal schedule overlap policy** from `BUFFER_ONE` to `SKIP` to prevent workflow queuing when one is already running
- **Added slow cohort logging** with warnings for cohorts taking longer than 10 seconds, including cohort ID, duration, team ID, and cohort name for identification