### PR TITLE
feat(onboarding): add adblocker detection to SDK onboarding verification

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
@@ -14,7 +14,7 @@ import { OnboardingStepKey, type SDK, SDKInstructionsMap, SDKTag, SDKTagOverride
 
 import { OnboardingStepComponentType, onboardingLogic } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
-import { useAdblockDetection } from './hooks/useAdblockDetection'
+import { type AdblockDetectionResult, useAdblockDetection } from './hooks/useAdblockDetection'
 import { useInstallationComplete } from './hooks/useInstallationComplete'
 import { AdblockWarning, RealtimeCheckIndicator } from './RealtimeCheckIndicator'
 import { sdksLogic } from './sdksLogic'
@@ -25,6 +25,7 @@ interface SDKInstructionsModalProps {
     onClose: () => void
     sdk?: SDK
     sdkInstructionMap: SDKInstructionsMap
+    adblockResult: AdblockDetectionResult
     verifyingProperty?: string
     verifyingName?: string
 }
@@ -34,6 +35,7 @@ export function SDKInstructionsModal({
     onClose,
     sdk,
     sdkInstructionMap,
+    adblockResult,
     verifyingProperty = 'ingested_event',
     verifyingName = 'event',
 }: SDKInstructionsModalProps): JSX.Element {
@@ -57,6 +59,11 @@ export function SDKInstructionsModal({
                     <div className="flex-grow overflow-y-auto px-4 py-2">
                         <SDKSnippet sdk={sdk} sdkInstructions={sdkInstructions} />
                     </div>
+                    {!installationComplete && (
+                        <div className="px-4 py-2">
+                            <AdblockWarning adblockResult={adblockResult} />
+                        </div>
+                    )}
                     <footer className="sticky bottom-0 w-full bg-bg-light dark:bg-bg-depth rounded-b-sm p-2 flex justify-between items-center gap-2 px-4">
                         <RealtimeCheckIndicator
                             teamPropertyToVerify={verifyingProperty}
@@ -214,6 +221,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
                     onClose={() => setInstructionsModalOpen(false)}
                     sdk={selectedSDK}
                     sdkInstructionMap={sdkInstructionMap}
+                    adblockResult={adblockResult}
                     verifyingProperty={teamPropertyToVerify}
                     verifyingName={listeningForName}
                 />

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
@@ -14,8 +14,9 @@ import { OnboardingStepKey, type SDK, SDKInstructionsMap, SDKTag, SDKTagOverride
 
 import { OnboardingStepComponentType, onboardingLogic } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
+import { useAdblockDetection } from './hooks/useAdblockDetection'
 import { useInstallationComplete } from './hooks/useInstallationComplete'
-import { RealtimeCheckIndicator } from './RealtimeCheckIndicator'
+import { AdblockWarning, RealtimeCheckIndicator } from './RealtimeCheckIndicator'
 import { sdksLogic } from './sdksLogic'
 import { SDKSnippet } from './SDKSnippet'
 
@@ -91,6 +92,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
     const { currentTeam } = useValues(teamLogic)
 
     const installationComplete = useInstallationComplete(teamPropertyToVerify)
+    const adblockResult = useAdblockDetection()
     const isSkipButtonExperiment = useFeatureFlag('ONBOARDING_SKIP_INSTALL_STEP', 'test')
 
     useEffect(() => {
@@ -119,6 +121,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             }
         >
             {header}
+            {!installationComplete && <AdblockWarning adblockResult={adblockResult} />}
             <div className="flex flex-col gap-y-4 mt-6">
                 <div className="flex flex-col gap-y-2">
                     <div className="flex flex-col-reverse md:flex-row justify-between gap-4">

--- a/frontend/src/scenes/onboarding/sdks/RealtimeCheckIndicator.tsx
+++ b/frontend/src/scenes/onboarding/sdks/RealtimeCheckIndicator.tsx
@@ -1,8 +1,6 @@
 import { IconCheck, IconWarning } from '@posthog/icons'
 
-import { Link } from 'lib/lemon-ui/Link'
-
-import { useAdblockDetection } from './hooks/useAdblockDetection'
+import { type AdblockDetectionResult } from './hooks/useAdblockDetection'
 import { useInstallationComplete } from './hooks/useInstallationComplete'
 import { OnboardingLiveEvents } from './OnboardingLiveEvents'
 
@@ -16,47 +14,46 @@ export function RealtimeCheckIndicator({
     listeningForName = 'event',
 }: RealtimeCheckIndicatorProps): JSX.Element {
     const installationComplete = useInstallationComplete(teamPropertyToVerify)
-    const adblockResult = useAdblockDetection()
-
-    const showAdblockWarning = !installationComplete && adblockResult === 'blocked'
 
     return (
-        <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-3">
-                {installationComplete ? (
-                    <div className="flex flex-row gap-2">
-                        <div className="flex items-center gap-2 px-2 py-1 font-medium">
-                            <IconCheck className="text-success" />
-                            <span className="text-success text-sm">Installation Complete</span>
-                        </div>
-                        <OnboardingLiveEvents />
+        <div className="flex items-center gap-3">
+            {installationComplete ? (
+                <div className="flex flex-row gap-2">
+                    <div className="flex items-center gap-2 px-2 py-1 font-medium">
+                        <IconCheck className="text-success" />
+                        <span className="text-success text-sm">Installation complete</span>
                     </div>
-                ) : (
-                    <div className="flex flex-row gap-3 items-center">
-                        <div className="font-medium">Verify Installation</div>
-                        <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
-                            <div className="relative flex items-center justify-center">
-                                <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
-                                <div className="w-2 h-2 bg-accent rounded-full" />
-                            </div>
-                            <span className="text-sm text-accent">Waiting for {listeningForName}s</span>
+                    <OnboardingLiveEvents />
+                </div>
+            ) : (
+                <div className="flex flex-row gap-3 items-center">
+                    <div className="font-medium">Verify installation</div>
+                    <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
+                        <div className="relative flex items-center justify-center">
+                            <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
+                            <div className="w-2 h-2 bg-accent rounded-full" />
                         </div>
+                        <span className="text-sm text-accent">Waiting for {listeningForName}s</span>
                     </div>
-                )}
-            </div>
-            {showAdblockWarning && (
-                <div className="flex items-start gap-2 px-3 py-2 rounded border border-warning bg-warning-highlight text-sm">
-                    <IconWarning className="text-warning mt-0.5 shrink-0" />
-                    <span>
-                        Your install might be working fine, but it looks like this browser may be blocking PostHog
-                        requests. Try disabling your adblocker and refreshing the page to verify.{' '}
-                        <Link to="https://posthog.com/docs/advanced/proxy" target="_blank">
-                            Set up a reverse proxy
-                        </Link>{' '}
-                        to ensure events aren't blocked for your users.
-                    </span>
                 </div>
             )}
+        </div>
+    )
+}
+
+export function AdblockWarning({ adblockResult }: { adblockResult: AdblockDetectionResult }): JSX.Element | null {
+    if (adblockResult !== 'blocked') {
+        return null
+    }
+
+    return (
+        <div className="flex items-start gap-2 px-3 py-2 rounded border border-warning bg-warning-highlight text-sm">
+            <IconWarning className="text-warning mt-0.5 shrink-0" />
+            <span>
+                Your install might be working fine, but it looks like this browser may be blocking PostHog requests. Try
+                disabling your adblocker and refreshing the page to verify. You can set up a reverse proxy later to
+                ensure events aren't blocked for your users.
+            </span>
         </div>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/RealtimeCheckIndicator.tsx
+++ b/frontend/src/scenes/onboarding/sdks/RealtimeCheckIndicator.tsx
@@ -1,5 +1,8 @@
-import { IconCheck } from '@posthog/icons'
+import { IconCheck, IconWarning } from '@posthog/icons'
 
+import { Link } from 'lib/lemon-ui/Link'
+
+import { useAdblockDetection } from './hooks/useAdblockDetection'
 import { useInstallationComplete } from './hooks/useInstallationComplete'
 import { OnboardingLiveEvents } from './OnboardingLiveEvents'
 
@@ -13,27 +16,45 @@ export function RealtimeCheckIndicator({
     listeningForName = 'event',
 }: RealtimeCheckIndicatorProps): JSX.Element {
     const installationComplete = useInstallationComplete(teamPropertyToVerify)
+    const adblockResult = useAdblockDetection()
+
+    const showAdblockWarning = !installationComplete && adblockResult === 'blocked'
 
     return (
-        <div className="flex items-center gap-3">
-            {installationComplete ? (
-                <div className="flex flex-row gap-2">
-                    <div className="flex items-center gap-2 px-2 py-1 font-medium">
-                        <IconCheck className="text-success" />
-                        <span className="text-success text-sm">Installation Complete</span>
-                    </div>
-                    <OnboardingLiveEvents />
-                </div>
-            ) : (
-                <div className="flex flex-row gap-3 items-center">
-                    <div className="font-medium">Verify Installation</div>
-                    <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
-                        <div className="relative flex items-center justify-center">
-                            <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
-                            <div className="w-2 h-2 bg-accent rounded-full" />
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-3">
+                {installationComplete ? (
+                    <div className="flex flex-row gap-2">
+                        <div className="flex items-center gap-2 px-2 py-1 font-medium">
+                            <IconCheck className="text-success" />
+                            <span className="text-success text-sm">Installation Complete</span>
                         </div>
-                        <span className="text-sm text-accent">Waiting for {listeningForName}s</span>
+                        <OnboardingLiveEvents />
                     </div>
+                ) : (
+                    <div className="flex flex-row gap-3 items-center">
+                        <div className="font-medium">Verify Installation</div>
+                        <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
+                            <div className="relative flex items-center justify-center">
+                                <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
+                                <div className="w-2 h-2 bg-accent rounded-full" />
+                            </div>
+                            <span className="text-sm text-accent">Waiting for {listeningForName}s</span>
+                        </div>
+                    </div>
+                )}
+            </div>
+            {showAdblockWarning && (
+                <div className="flex items-start gap-2 px-3 py-2 rounded border border-warning bg-warning-highlight text-sm">
+                    <IconWarning className="text-warning mt-0.5 shrink-0" />
+                    <span>
+                        Your install might be working fine, but it looks like this browser may be blocking PostHog
+                        requests. Try disabling your adblocker and refreshing the page to verify.{' '}
+                        <Link to="https://posthog.com/docs/advanced/proxy" target="_blank">
+                            Set up a reverse proxy
+                        </Link>{' '}
+                        to ensure events aren't blocked for your users.
+                    </span>
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/onboarding/sdks/hooks/useAdblockDetection.ts
+++ b/frontend/src/scenes/onboarding/sdks/hooks/useAdblockDetection.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react'
+
+export type AdblockDetectionResult = 'unknown' | 'blocked' | 'ok'
+
+/**
+ * Detects whether PostHog requests are being blocked (e.g. by an adblocker).
+ *
+ * Two checks are performed:
+ *  1. `window.posthog?.__loaded` – if posthog-js failed to initialize the
+ *     property will be falsy.
+ *  2. A lightweight fetch to the PostHog ingestion `/decide/` endpoint – a
+ *     network error (not an HTTP error) strongly suggests the request was
+ *     blocked.
+ *
+ * The result is only surfaced after `delayMs` (default 20 s) so we don't
+ * flash a warning before the user has had time to wait.
+ */
+export function useAdblockDetection(delayMs: number = 20_000): AdblockDetectionResult {
+    const [result, setResult] = useState<AdblockDetectionResult>('unknown')
+    const detectionDone = useRef(false)
+
+    useEffect(() => {
+        let cancelled = false
+
+        const detect = async (): Promise<AdblockDetectionResult> => {
+            // Check 1 – posthog-js loaded flag
+            const ph = (window as any).posthog
+            if (ph && !ph.__loaded) {
+                return 'blocked'
+            }
+
+            // Check 2 – attempt a fetch to the ingestion endpoint
+            try {
+                await fetch('https://us.i.posthog.com/decide/?v=3', {
+                    method: 'POST',
+                    mode: 'no-cors',
+                    body: JSON.stringify({}),
+                })
+                // If fetch resolves (even opaque response) → not blocked
+                return 'ok'
+            } catch {
+                // Network error → blocked
+                return 'blocked'
+            }
+        }
+
+        const timer = setTimeout(() => {
+            if (cancelled || detectionDone.current) {
+                return
+            }
+            detect()
+                .then((r) => {
+                    if (!cancelled) {
+                        detectionDone.current = true
+                        setResult(r)
+                    }
+                })
+                .catch(() => {
+                    if (!cancelled) {
+                        detectionDone.current = true
+                        setResult('blocked')
+                    }
+                })
+        }, delayMs)
+
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+        }
+    }, [delayMs])
+
+    return result
+}

--- a/frontend/src/scenes/onboarding/sdks/hooks/useAdblockDetection.ts
+++ b/frontend/src/scenes/onboarding/sdks/hooks/useAdblockDetection.ts
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { useEffect, useRef, useState } from 'react'
 
 export type AdblockDetectionResult = 'unknown' | 'blocked' | 'ok'
@@ -53,12 +54,14 @@ export function useAdblockDetection(delayMs: number = 20_000): AdblockDetectionR
                     if (!cancelled) {
                         detectionDone.current = true
                         setResult(r)
+                        posthog.capture('onboarding adblock detection completed', { status: r })
                     }
                 })
                 .catch(() => {
                     if (!cancelled) {
                         detectionDone.current = true
                         setResult('blocked')
+                        posthog.capture('onboarding adblock detection completed', { status: 'blocked' })
                     }
                 })
         }, delayMs)


### PR DESCRIPTION
## Problem

Users setting up PostHog SDKs during onboarding may have adblockers enabled that silently block PostHog requests. This results in a confusing experience where the "Verify Installation" check appears to hang indefinitely, with no indication that requests are being blocked rather than the SDK failing to initialize.

## Changes

Added adblocker detection to the SDK onboarding flow:

1. **New hook: `useAdblockDetection`** – Detects whether PostHog requests are being blocked by checking:
   - Whether `posthog-js` successfully initialized (`window.posthog.__loaded`)
   - Whether a test fetch to the PostHog `/decide/` endpoint succeeds
   - Results are delayed by 20 seconds to avoid false positives during normal initialization

2. **Updated `RealtimeCheckIndicator`** – Now displays a warning banner when:
   - Installation verification is still pending AND
   - Adblocker detection indicates requests are being blocked
   - The banner includes helpful guidance on disabling adblockers and setting up a reverse proxy

<img width="840" height="382" alt="Screenshot 2026-03-09 at 17 43 31" src="https://github.com/user-attachments/assets/927a2d43-9b35-4753-9b6a-978be491e334" />

## How did you test this code?

Code review of the implementation:
- `useAdblockDetection` properly handles async detection with cleanup on unmount
- Detection is delayed to avoid premature warnings
- `RealtimeCheckIndicator` correctly integrates the hook and conditionally renders the warning
- Warning only shows when both conditions are met (pending verification + blocked detection)

## Publish to changelog?

Yes – This improves the onboarding experience by helping users diagnose adblocker-related issues.

https://claude.ai/code/session_01V2YpYguNpwtSfwUXeYVw9J