### PR TITLE
Add tagging support to annotations

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3527,21 +3527,30 @@ const api = {
         },
         async update(
             annotationId: RawAnnotationType['id'],
-            data: Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item' | 'dashboard_id'>
+            data: Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item' | 'dashboard_id'> & {
+                tags?: string[]
+            }
         ): Promise<RawAnnotationType> {
             return await new ApiRequest().annotation(annotationId).update({ data })
         },
-        async list(params?: { limit?: number; offset?: number }): Promise<PaginatedResponse<RawAnnotationType>> {
+        async list(params?: {
+            limit?: number
+            offset?: number
+            search?: string
+        }): Promise<PaginatedResponse<RawAnnotationType>> {
             return await new ApiRequest()
                 .annotations()
                 .withQueryString({
                     limit: params?.limit,
                     offset: params?.offset,
+                    search: params?.search,
                 })
                 .get()
         },
         async create(
-            data: Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item' | 'dashboard_id'>
+            data: Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item' | 'dashboard_id'> & {
+                tags?: string[]
+            }
         ): Promise<RawAnnotationType> {
             return await new ApiRequest().annotations().create({ data })
         },

--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -5,9 +5,11 @@ import posthog from 'posthog-js'
 import React, { useEffect, useRef, useState } from 'react'
 
 import { IconPencil, IconPlusSmall, IconTrash } from '@posthog/icons'
+import { LemonSelect } from '@posthog/lemon-ui'
 
 import { Chart } from 'lib/Chart'
 import { TextContent } from 'lib/components/Cards/TextCard/TextCard'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { dayjs } from 'lib/dayjs'
 import { LemonBadge } from 'lib/lemon-ui/LemonBadge/LemonBadge'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -232,8 +234,10 @@ function AnnotationsPopover({
         insightId,
         isPopoverShown,
         annotationsOverlayProps,
+        availableTags,
+        tagFilter,
     } = useValues(annotationsOverlayLogic)
-    const { closePopover } = useActions(annotationsOverlayLogic)
+    const { closePopover, setTagFilter } = useActions(annotationsOverlayLogic)
     const { openModalToCreateAnnotation } = useActions(annotationModalLogic)
 
     // Capture event when popup is shown with a system annotation
@@ -248,6 +252,11 @@ function AnnotationsPopover({
             })
         }
     }, [isPopoverShown, popoverAnnotations])
+
+    const tagFilterOptions = [
+        { value: null, label: 'All tags' },
+        ...availableTags.map((tag) => ({ value: tag, label: tag })),
+    ]
 
     return (
         <Popover
@@ -267,15 +276,31 @@ function AnnotationsPopover({
                         INTERVAL_UNIT_TO_HUMAN_DAYJS_FORMAT[intervalUnit]
                     )}`}
                     footer={
-                        <LemonButton
-                            type="primary"
-                            onClick={() =>
-                                openModalToCreateAnnotation(activeDate, insightId, annotationsOverlayProps.dashboardId)
-                            }
-                            disabled={!isDateLocked}
-                        >
-                            Add annotation
-                        </LemonButton>
+                        <div className="flex items-center justify-between w-full gap-2">
+                            {availableTags.length > 0 ? (
+                                <LemonSelect
+                                    options={tagFilterOptions}
+                                    value={tagFilter}
+                                    onSelect={setTagFilter}
+                                    size="small"
+                                />
+                            ) : (
+                                <div />
+                            )}
+                            <LemonButton
+                                type="primary"
+                                onClick={() =>
+                                    openModalToCreateAnnotation(
+                                        activeDate,
+                                        insightId,
+                                        annotationsOverlayProps.dashboardId
+                                    )
+                                }
+                                disabled={!isDateLocked}
+                            >
+                                Add annotation
+                            </LemonButton>
+                        </div>
                     }
                     closable={isDateLocked}
                     onClose={closePopover}
@@ -342,6 +367,11 @@ function AnnotationCard({ annotation }: { annotation: AnnotationType }): JSX.Ele
                 )}
                 <TextContent text={annotation.content ?? ''} data-attr="annotation-overlay-rendered-content" />
             </div>
+            {!isSystemAnnotation && annotation.tags && annotation.tags.length > 0 && (
+                <div className="mt-1">
+                    <ObjectTags tags={annotation.tags} staticOnly />
+                </div>
+            )}
             {!isSystemAnnotation && (
                 <div className="leading-6 mt-2 flex flex-row items-center justify-between">
                     <div>

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -99,6 +99,7 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
         lockDate: true,
         unlockDate: true,
         closePopover: true,
+        setTagFilter: (tag: string | null) => ({ tag }),
     }),
     reducers({
         isPopoverShown: [
@@ -123,6 +124,12 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
                 lockDate: () => true,
                 unlockDate: () => false,
                 closePopover: () => false,
+            },
+        ],
+        tagFilter: [
+            null as string | null,
+            {
+                setTagFilter: (_, { tag }) => tag,
             },
         ],
     }),
@@ -256,10 +263,33 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
                 return filteredAnnotations as DatedAnnotationType[]
             },
         ],
+        availableTags: [
+            (s) => [s.relevantAnnotations],
+            (relevantAnnotations): string[] => {
+                const tagSet = new Set<string>()
+                for (const annotation of relevantAnnotations) {
+                    for (const tag of annotation.tags || []) {
+                        tagSet.add(tag)
+                    }
+                }
+                return Array.from(tagSet).sort()
+            },
+        ],
+        filteredRelevantAnnotations: [
+            (s) => [s.relevantAnnotations, s.tagFilter],
+            (relevantAnnotations, tagFilter): DatedAnnotationType[] => {
+                if (!tagFilter) {
+                    return relevantAnnotations
+                }
+                return relevantAnnotations.filter(
+                    (annotation) => annotation.tags && annotation.tags.includes(tagFilter)
+                )
+            },
+        ],
         groupedAnnotations: [
-            (s) => [s.relevantAnnotations, s.intervalUnit, s.dateRange, s.pointsPerTick],
-            (relevantAnnotations, intervalUnit, dateRange, pointsPerTick) => {
-                return groupBy(relevantAnnotations, (annotation) => {
+            (s) => [s.filteredRelevantAnnotations, s.intervalUnit, s.dateRange, s.pointsPerTick],
+            (filteredRelevantAnnotations, intervalUnit, dateRange, pointsPerTick) => {
+                return groupBy(filteredRelevantAnnotations, (annotation) => {
                     return determineAnnotationsDateGroup(annotation.date_marker, intervalUnit, dateRange, pointsPerTick)
                 })
             },

--- a/frontend/src/models/annotationsModel.ts
+++ b/frontend/src/models/annotationsModel.ts
@@ -11,7 +11,9 @@ import { AnnotationType, RawAnnotationType } from '~/types'
 
 import type { annotationsModelType } from './annotationsModelType'
 
-export type AnnotationData = Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item'>
+export type AnnotationData = Pick<RawAnnotationType, 'date_marker' | 'scope' | 'content' | 'dashboard_item'> & {
+    tags?: string[]
+}
 export type AnnotationDataWithoutInsight = Omit<AnnotationData, 'dashboard_item'>
 
 export function deserializeAnnotation(annotation: RawAnnotationType, projectTimezone: string): AnnotationType {

--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -4,6 +4,7 @@ import { Form } from 'kea-forms'
 import {
     LemonButton,
     LemonCalendarSelectInput,
+    LemonInputSelect,
     LemonModal,
     LemonModalProps,
     LemonSelect,
@@ -174,6 +175,14 @@ export function AnnotationModal({
                         onPressCmdEnter={submitAnnotationModal}
                         data-attr="create-annotation-input"
                         maxLength={400}
+                    />
+                </LemonField>
+                <LemonField name="tags" label="Tags">
+                    <LemonInputSelect
+                        mode="multiple"
+                        allowCustomValues
+                        placeholder='Add tags (e.g. "release", "incident")'
+                        data-attr="annotation-tags-input"
                     />
                 </LemonField>
             </Form>

--- a/frontend/src/scenes/annotations/Annotations.tsx
+++ b/frontend/src/scenes/annotations/Annotations.tsx
@@ -7,9 +7,11 @@ import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { TextContent } from 'lib/components/Cards/TextCard/TextCard'
 import { MicrophoneHog } from 'lib/components/hedgehogs'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
@@ -45,11 +47,14 @@ export function Annotations(): JSX.Element {
 
     const { openModalToCreateAnnotation } = useActions(annotationModalLogic)
 
-    const { filteredAnnotations, shouldShowEmptyState, annotationsLoading, scope } = useValues(annotationsLogic)
-    const { setScope } = useActions(annotationsLogic)
+    const { filteredAnnotations, shouldShowEmptyState, annotationsLoading, scope, searchTerm, allTags, filterByTag } =
+        useValues(annotationsLogic)
+    const { setScope, setSearchTerm, setFilterByTag } = useActions(annotationsLogic)
 
     const { loadingNext, next } = useValues(annotationsModel)
     const { loadAnnotationsNext } = useActions(annotationsModel)
+
+    const tagOptions = [{ value: null, label: 'Any' }, ...allTags.map((tag) => ({ value: tag, label: tag }))]
 
     const columns: LemonTableColumns<AnnotationType> = [
         {
@@ -57,20 +62,27 @@ export function Annotations(): JSX.Element {
             key: 'annotation',
             render: function RenderAnnotation(_, annotation: AnnotationType): JSX.Element {
                 return (
-                    <Tooltip
-                        title={
-                            <TextContent
-                                text={annotation.content ?? ''}
-                                data-attr="annotation-scene-comment-title-rendered-content"
-                            />
-                        }
-                    >
-                        <div className="font-semibold line-clamp-2">
-                            <Link subtle to={urls.annotation(annotation.id)}>
-                                {annotation.content ?? ''}
-                            </Link>
-                        </div>
-                    </Tooltip>
+                    <div>
+                        <Tooltip
+                            title={
+                                <TextContent
+                                    text={annotation.content ?? ''}
+                                    data-attr="annotation-scene-comment-title-rendered-content"
+                                />
+                            }
+                        >
+                            <div className="font-semibold line-clamp-2">
+                                <Link subtle to={urls.annotation(annotation.id)}>
+                                    {annotation.content ?? ''}
+                                </Link>
+                            </div>
+                        </Tooltip>
+                        {annotation.tags && annotation.tags.length > 0 && (
+                            <div className="mt-1">
+                                <ObjectTags tags={annotation.tags} staticOnly />
+                            </div>
+                        )}
+                    </div>
                 )
             },
         },
@@ -117,7 +129,7 @@ export function Annotations(): JSX.Element {
             sorter: (a, b) => annotationScopeToLevel[a.scope] - annotationScopeToLevel[b.scope],
         },
         {
-            title: 'Created by',
+            title: 'Created by',
             dataIndex: 'created_by',
             render: function Render(_: any, item) {
                 const { created_by, creation_type } = item
@@ -175,9 +187,24 @@ export function Annotations(): JSX.Element {
                     </AppShortcut>
                 }
             />
-            <div className="flex flex-row items-center gap-2 justify-end">
-                <div>Scope:</div>
-                <LemonSelect options={annotationScopesMenuOptions()} value={scope} onSelect={setScope} />
+            <div className="flex flex-row items-center gap-2 justify-between">
+                <LemonInput
+                    type="search"
+                    placeholder="Search annotations..."
+                    onChange={setSearchTerm}
+                    value={searchTerm}
+                    className="min-w-64"
+                />
+                <div className="flex flex-row items-center gap-2">
+                    {allTags.length > 0 && (
+                        <>
+                            <div>Tag:</div>
+                            <LemonSelect options={tagOptions} value={filterByTag} onSelect={setFilterByTag} />
+                        </>
+                    )}
+                    <div>Scope:</div>
+                    <LemonSelect options={annotationScopesMenuOptions()} value={scope} onSelect={setScope} />
+                </div>
             </div>
             <div data-attr="annotations-content">
                 <div className={cn('mt-4 mb-0 empty:hidden')}>

--- a/frontend/src/scenes/annotations/annotationModalLogic.ts
+++ b/frontend/src/scenes/annotations/annotationModalLogic.ts
@@ -37,6 +37,7 @@ export interface AnnotationModalForm {
     content: AnnotationType['content']
     dashboardItemId: AnnotationType['dashboard_item'] | null
     dashboardId: AnnotationType['dashboard_id'] | null
+    tags: string[]
 }
 
 export const annotationModalLogic = kea<annotationModalLogicType>([
@@ -96,11 +97,12 @@ export const annotationModalLogic = kea<annotationModalLogicType>([
         ],
     })),
     listeners(({ cache, actions, values }) => ({
-        openModalToEditAnnotation: ({ annotation: { date_marker, scope, content }, insightId, dashboardId }) => {
+        openModalToEditAnnotation: ({ annotation: { date_marker, scope, content, tags }, insightId, dashboardId }) => {
             actions.setAnnotationModalValues({
                 dateMarker: dayjs(date_marker).tz(values.timezone),
                 scope,
                 content,
+                tags: tags || [],
             })
             if (insightId) {
                 actions.setAnnotationModalValue('dashboardItemId', insightId)
@@ -148,12 +150,13 @@ export const annotationModalLogic = kea<annotationModalLogicType>([
                 scope: AnnotationScope.Project,
                 dashboardItemId: null,
                 dashboardId: null,
+                tags: [],
             } as AnnotationModalForm,
             errors: ({ content }) => ({
                 content: !content?.trim() ? 'An annotation must have text content.' : null,
             }),
             submit: async (data) => {
-                const { dateMarker, content, scope, dashboardItemId, dashboardId } = data
+                const { dateMarker, content, scope, dashboardItemId, dashboardId, tags } = data
 
                 if (values.existingModalAnnotation) {
                     // annotationsModel's updateAnnotation inlined so that isAnnotationModalSubmitting works
@@ -165,6 +168,7 @@ export const annotationModalLogic = kea<annotationModalLogicType>([
                         dashboard_item: dashboardItemId,
                         // preserve existing dashboard id
                         dashboard_id: values.existingModalAnnotation.dashboard_id,
+                        tags,
                     })
                     actions.replaceAnnotation(updatedAnnotation)
                 } else {
@@ -175,6 +179,7 @@ export const annotationModalLogic = kea<annotationModalLogicType>([
                         scope,
                         dashboard_item: dashboardItemId,
                         dashboard_id: dashboardId,
+                        tags,
                     })
                     actions.appendAnnotations([createdAnnotation])
                 }

--- a/frontend/src/scenes/annotations/annotationsLogic.ts
+++ b/frontend/src/scenes/annotations/annotationsLogic.ts
@@ -43,9 +43,13 @@ export const annotationsLogic = kea<annotationsLogicType>([
     })),
     actions({
         setScope: (scope: AnnotationType['scope'] | null) => ({ scope }),
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
+        setFilterByTag: (tag: string | null) => ({ tag }),
     }),
     reducers(() => ({
         scope: [null as AnnotationType['scope'] | null, { setScope: (_, { scope }) => scope }],
+        searchTerm: ['' as string, { setSearchTerm: (_, { searchTerm }) => searchTerm }],
+        filterByTag: [null as string | null, { setFilterByTag: (_, { tag }) => tag }],
     })),
     selectors(() => ({
         shouldShowEmptyState: [
@@ -54,14 +58,35 @@ export const annotationsLogic = kea<annotationsLogicType>([
                 return annotations.length === 0 && !annotationsLoading
             },
         ],
+        allTags: [
+            (s) => [s.annotations],
+            (annotations): string[] => {
+                const tagSet = new Set<string>()
+                for (const annotation of annotations) {
+                    for (const tag of annotation.tags || []) {
+                        tagSet.add(tag)
+                    }
+                }
+                return Array.from(tagSet).sort()
+            },
+        ],
         filteredAnnotations: [
-            (s) => [s.annotations, s.scope],
-            (annotations, scope): AnnotationType[] => {
-                return scope
-                    ? annotations.filter((annotation) => {
-                          return annotation.scope === scope
-                      })
-                    : annotations
+            (s) => [s.annotations, s.scope, s.searchTerm, s.filterByTag],
+            (annotations, scope, searchTerm, filterByTag): AnnotationType[] => {
+                let result = annotations
+                if (scope) {
+                    result = result.filter((annotation) => annotation.scope === scope)
+                }
+                if (searchTerm.trim()) {
+                    const term = searchTerm.trim().toLowerCase()
+                    result = result.filter(
+                        (annotation) => annotation.content && annotation.content.toLowerCase().includes(term)
+                    )
+                }
+                if (filterByTag) {
+                    result = result.filter((annotation) => annotation.tags && annotation.tags.includes(filterByTag))
+                }
+                return result
             },
         ],
     })),
@@ -77,6 +102,28 @@ export const annotationsLogic = kea<annotationsLogicType>([
                 { replace: true },
             ]
         },
+        setSearchTerm: ({ searchTerm }) => {
+            return [
+                router.values.location.pathname,
+                {
+                    ...router.values.searchParams,
+                    q: searchTerm ? searchTerm : undefined,
+                },
+                router.values.hashParams,
+                { replace: true },
+            ]
+        },
+        setFilterByTag: ({ tag }) => {
+            return [
+                router.values.location.pathname,
+                {
+                    ...router.values.searchParams,
+                    tag: tag ? tag : undefined,
+                },
+                router.values.hashParams,
+                { replace: true },
+            ]
+        },
     })),
     urlToAction(({ actions, values }) => ({
         [urls.annotations()]: (_, searchParams) => {
@@ -86,6 +133,20 @@ export const annotationsLogic = kea<annotationsLogicType>([
             }
             if (!scope && values.scope) {
                 actions.setScope(null)
+            }
+            const q = searchParams.q
+            if (q !== undefined && q !== values.searchTerm) {
+                actions.setSearchTerm(q)
+            }
+            if (!q && values.searchTerm) {
+                actions.setSearchTerm('')
+            }
+            const tag = searchParams.tag
+            if (tag !== undefined && tag !== values.filterByTag) {
+                actions.setFilterByTag(tag)
+            }
+            if (!tag && values.filterByTag) {
+                actions.setFilterByTag(null)
             }
         },
     })),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2554,6 +2554,7 @@ export interface RawAnnotationType {
     dashboard_name?: DashboardBasicType['name'] | null
     deleted?: boolean
     creation_type?: 'USR' | 'GIT'
+    tags?: string[]
 }
 
 export interface AnnotationType extends Omit<RawAnnotationType, 'created_at' | 'date_marker'> {

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -13,6 +13,7 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
+from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.event_usage import report_user_action
 from posthog.models import Annotation, Dashboard, Insight
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
@@ -30,10 +31,11 @@ class AnnotationContext(ActivityContextBase):
     recording_id: Optional[str] = None
 
 
-class AnnotationSerializer(serializers.ModelSerializer):
+class AnnotationSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     dashboard_id = serializers.IntegerField(required=False, allow_null=True)
     dashboard_item = TeamScopedPrimaryKeyRelatedField(queryset=Insight.objects.all(), required=False, allow_null=True)
+    tags = serializers.ListField(required=False)
 
     class Meta:
         model = Annotation
@@ -53,6 +55,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
             "updated_at",
             "deleted",
             "scope",
+            "tags",
         ]
         read_only_fields = [
             "id",
@@ -67,7 +70,10 @@ class AnnotationSerializer(serializers.ModelSerializer):
 
     def update(self, instance: Annotation, validated_data: dict[str, Any]) -> Annotation:
         instance.team_id = self.context["team_id"]
-        return super().update(instance, validated_data)
+        validated_data.pop("tags", None)
+        instance = super().update(instance, validated_data)
+        self._attempt_set_tags(self.initial_data.get("tags"), instance)
+        return instance
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         team = self.context["get_team"]()
@@ -87,12 +93,14 @@ class AnnotationSerializer(serializers.ModelSerializer):
         request = self.context["request"]
         team = self.context["get_team"]()
 
+        validated_data.pop("tags", None)
         annotation = Annotation.objects.create(
             organization_id=team.organization_id,
             team_id=team.id,
             created_by=request.user,
             **validated_data,
         )
+        self._attempt_set_tags(self.initial_data.get("tags"), annotation)
         return annotation
 
 
@@ -101,7 +109,7 @@ class AnnotationsLimitOffsetPagination(pagination.LimitOffsetPagination):
 
 
 @extend_schema(tags=["core"])
-class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
+class AnnotationsViewSet(TeamAndOrgViewSetMixin, TaggedItemViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     """
     Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
     """

--- a/posthog/migrations/1000_add_annotation_to_tagged_item.py
+++ b/posthog/migrations/1000_add_annotation_to_tagged_item.py
@@ -1,0 +1,79 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+from posthog.models.utils import build_partial_uniqueness_constraint, build_unique_relationship_check
+
+RELATED_OBJECTS_OLD = (
+    "dashboard",
+    "insight",
+    "event_definition",
+    "property_definition",
+    "action",
+    "feature_flag",
+    "experiment_saved_metric",
+    "ticket",
+)
+
+RELATED_OBJECTS_NEW = (*RELATED_OBJECTS_OLD, "annotation")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0999_remove_presorted_events_modifier"),
+    ]
+
+    operations = [
+        # Add annotation FK
+        migrations.AddField(
+            model_name="taggeditem",
+            name="annotation",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="tagged_items",
+                to="posthog.annotation",
+            ),
+        ),
+        # Remove old check constraint
+        migrations.RemoveConstraint(
+            model_name="taggeditem",
+            name="exactly_one_related_object",
+        ),
+        # Remove old partial uniqueness constraints
+        *[
+            migrations.RemoveConstraint(
+                model_name="taggeditem",
+                name=f"unique_{field}_tagged_item",
+            )
+            for field in RELATED_OBJECTS_OLD
+        ],
+        # Remove old unique_together
+        migrations.AlterUniqueTogether(
+            name="taggeditem",
+            unique_together=set(),
+        ),
+        # Add new unique_together including annotation
+        migrations.AlterUniqueTogether(
+            name="taggeditem",
+            unique_together={("tag", *RELATED_OBJECTS_NEW)},
+        ),
+        # Add new partial uniqueness constraints
+        *[
+            migrations.AddConstraint(
+                model_name="taggeditem",
+                constraint=build_partial_uniqueness_constraint(
+                    field="tag", related_field=field, constraint_name=f"unique_{field}_tagged_item"
+                ),
+            )
+            for field in RELATED_OBJECTS_NEW
+        ],
+        # Add new check constraint
+        migrations.AddConstraint(
+            model_name="taggeditem",
+            constraint=models.CheckConstraint(
+                check=build_unique_relationship_check(RELATED_OBJECTS_NEW),
+                name="exactly_one_related_object",
+            ),
+        ),
+    ]

--- a/posthog/models/tagged_item.py
+++ b/posthog/models/tagged_item.py
@@ -13,6 +13,7 @@ RELATED_OBJECTS = (
     "feature_flag",
     "experiment_saved_metric",
     "ticket",
+    "annotation",
 )
 
 
@@ -86,6 +87,13 @@ class TaggedItem(ModelActivityMixin, UUIDTModel):
     )
     ticket = models.ForeignKey(
         "conversations.Ticket",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="tagged_items",
+    )
+    annotation = models.ForeignKey(
+        "Annotation",
         on_delete=models.CASCADE,
         null=True,
         blank=True,


### PR DESCRIPTION
## Problem

Annotations need to be taggable to allow users to organize and filter annotations by custom tags (e.g., "release", "incident"). This enables better organization and discovery of annotations across the platform.

## Changes

### Backend
- Added `annotation` foreign key to `TaggedItem` model to support tagging annotations
- Created migration `1000_add_annotation_to_tagged_item.py` that:
  - Adds the annotation FK field
  - Updates uniqueness constraints to include annotation
  - Updates check constraints to enforce exactly one related object
- Updated `AnnotationSerializer` to include `TaggedItemSerializerMixin` for tag handling
- Added `tags` field to annotation serialization and API endpoints

### Frontend
- **Annotations scene**: 
  - Added search functionality to filter annotations by content
  - Added tag filter dropdown to filter by specific tags
  - Display tags on annotation rows in the table
  - Updated logic to sync search and tag filters with URL parameters
  
- **Annotations overlay**:
  - Added tag filter dropdown in the popover footer
  - Display tags on annotation cards
  - Filter annotations by selected tag
  
- **Annotation modal**:
  - Added `LemonInputSelect` field for managing annotation tags
  - Support for multiple tags with custom values
  
- **Type definitions**: Added `tags` field to `RawAnnotationType` and related types
- **API client**: Updated annotation create/update methods to accept tags parameter

## How did you test this code?

This change includes database migrations and API schema updates. The implementation follows existing patterns in the codebase for tagged items (used with dashboards, insights, etc.). The frontend changes are straightforward UI additions that integrate with existing filtering and state management patterns already used for scope filtering.

## Publish to changelog?

Yes - this adds tagging capability to annotations, a user-facing feature for better organization and discovery.

https://claude.ai/code/session_01R86LVFmsYFdpvMF7pwKKZ5