### PR TITLE
feat(dashboard): Hover on dashboard cards to enter edit mode

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -19,13 +19,13 @@ describe('EditModeEdgeOverlay', () => {
         })
     })
 
-    it('calls onEnterEditMode when an edge is pressed', () => {
+    it.each([0, 1, 2, 3])('calls onEnterEditMode when edge %i is pressed', (edgeIndex) => {
         const onEnterEditMode = jest.fn()
 
         const { getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={onEnterEditMode} />)
-        const [firstEdge] = getAllByTitle('Click to edit layout')
+        const edges = getAllByTitle('Click to edit layout')
 
-        fireEvent.mouseDown(firstEdge)
-        expect(onEnterEditMode).toHaveBeenCalled()
+        fireEvent.mouseDown(edges[edgeIndex])
+        expect(onEnterEditMode).toHaveBeenCalledTimes(1)
     })
 })

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+
+import { EditModeEdgeOverlay } from './EditModeEdgeOverlay'
+
+describe('EditModeEdgeOverlay', () => {
+    beforeEach(() => {
+        cleanup()
+    })
+
+    it('renders four edge hit areas with data attr', () => {
+        const { getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={() => {}} />)
+
+        const edges = getAllByTitle('Click to edit layout')
+        expect(edges).toHaveLength(4)
+        edges.forEach((edge) => {
+            expect(edge).toHaveAttribute('data-attr', 'dashboard-edit-mode-from-card-edge')
+        })
+    })
+
+    it('calls onEnterEditMode when an edge is pressed', () => {
+        const onEnterEditMode = jest.fn()
+
+        const { getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={onEnterEditMode} />)
+        const [firstEdge] = getAllByTitle('Click to edit layout')
+
+        fireEvent.mouseDown(firstEdge)
+        expect(onEnterEditMode).toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -4,16 +4,16 @@ interface EditModeEdgeOverlayProps {
     onEnterEditMode: () => void
 }
 
-export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
-    const edgeOverlayBaseStyle: React.CSSProperties = {
-        position: 'absolute',
-        zIndex: 5,
-        padding: 0,
-        margin: 0,
-        border: 'none',
-        background: 'none',
-    }
+const edgeOverlayBaseStyle: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 5,
+    padding: 0,
+    margin: 0,
+    border: 'none',
+    background: 'none',
+}
 
+export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
     const handlePress = (event: React.MouseEvent<HTMLDivElement>): void => {
         // Treat any press (click or drag attempt) as intent to edit
         event.preventDefault()

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+interface EditModeEdgeOverlayProps {
+    onEnterEditMode: () => void
+}
+
+export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
+    const edgeOverlayBaseStyle: React.CSSProperties = {
+        position: 'absolute',
+        zIndex: 5,
+        padding: 0,
+        margin: 0,
+        border: 'none',
+        background: 'none',
+    }
+
+    const handlePress = (event: React.MouseEvent<HTMLDivElement>): void => {
+        // Treat any press (click or drag attempt) as intent to edit
+        event.preventDefault()
+        event.stopPropagation()
+        onEnterEditMode()
+    }
+
+    const edges: { style: React.CSSProperties; cursor: React.CSSProperties['cursor'] }[] = [
+        // top – vertical resize cursor
+        { style: { left: 0, right: 0, top: -6, height: 12 }, cursor: 'ns-resize' },
+        // bottom – vertical resize cursor
+        { style: { left: 0, right: 0, bottom: -6, height: 12 }, cursor: 'ns-resize' },
+        // left – horizontal resize cursor
+        { style: { top: 0, bottom: 0, left: -6, width: 12 }, cursor: 'ew-resize' },
+        // right – horizontal resize cursor
+        { style: { top: 0, bottom: 0, right: -6, width: 12 }, cursor: 'ew-resize' },
+    ]
+
+    return (
+        <>
+            {edges.map(({ style, cursor }, index) => (
+                <div
+                    key={index}
+                    onMouseDown={handlePress}
+                    aria-hidden="true"
+                    title="Click to edit layout"
+                    data-attr="dashboard-edit-mode-from-card-edge"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ ...edgeOverlayBaseStyle, ...style, cursor }}
+                />
+            ))}
+        </>
+    )
+}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -42,6 +42,7 @@ import {
 } from '~/types'
 
 import { ResizeHandle1D, ResizeHandle2D } from '../handles'
+import { EditModeEdgeOverlay } from './EditModeEdgeOverlay'
 import { InsightMeta } from './InsightMeta'
 
 const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
@@ -100,6 +101,10 @@ export interface InsightCardProps extends Resizeable {
     tile?: DashboardTile<QueryBasedInsightModel>
     /** survey opportunity for this insight */
     surveyOpportunity?: boolean
+    /** Whether hovering near the card edge should hint that edit mode is available. */
+    canEnterEditModeFromEdge?: boolean
+    /** Called when the user clicks an edge hint to enter edit mode. */
+    onEnterEditModeFromEdge?: () => void
 }
 
 function InsightCardInternal(
@@ -139,6 +144,8 @@ function InsightCardInternal(
         breakdownColorOverride: _breakdownColorOverride,
         dataColorThemeId: _dataColorThemeId,
         surveyOpportunity,
+        canEnterEditModeFromEdge,
+        onEnterEditModeFromEdge,
         ...divProps
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
@@ -297,6 +304,9 @@ function InsightCardInternal(
                         <ResizeHandle1D orientation="horizontal" />
                         {canResizeWidth ? <ResizeHandle2D /> : null}
                     </>
+                )}
+                {canEnterEditModeFromEdge && !showResizeHandles && onEnterEditModeFromEdge && (
+                    <EditModeEdgeOverlay onEnterEditMode={onEnterEditModeFromEdge} />
                 )}
                 {children /* Extras, specifically resize handles injected by ReactGridLayout */}
             </ErrorBoundary>

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -79,6 +79,7 @@ export enum DashboardEventSource {
     MainNavigation = 'main_nav',
     DashboardsList = 'dashboards_list',
     SceneCommonButtons = 'scene_common_buttons',
+    CardEdgeHover = 'card_edge_hover',
 }
 
 export enum InsightEventSource {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -219,7 +219,7 @@ export function DashboardItems(): JSX.Element {
                             canResizeWidth: canResizeWidth,
                             canEnterEditModeFromEdge,
                             onEnterEditModeFromEdge: canEnterEditModeFromEdge
-                                ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
+                                ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardEdgeHover)
                                 : undefined,
                             showEditingControls: isEditablePlacement,
                             moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -12,7 +12,7 @@ import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { BREAKPOINTS, BREAKPOINT_COLUMN_COUNTS } from 'scenes/dashboard/dashboardUtils'
 import { useSurveyLinkedInsights } from 'scenes/surveys/hooks/useSurveyLinkedInsights'
@@ -44,6 +44,7 @@ export function DashboardItems(): JSX.Element {
         effectiveDashboardVariableOverrides,
         temporaryBreakdownColors,
         dataColorThemeId,
+        canEditDashboard,
     } = useValues(dashboardLogic)
     const {
         updateLayouts,
@@ -55,6 +56,7 @@ export function DashboardItems(): JSX.Element {
         refreshDashboardItem,
         moveToDashboard,
         setTileOverride,
+        setDashboardMode,
     } = useActions(dashboardLogic)
     const { renameInsight } = useActions(insightsModel)
     const { reportDashboardTileRepositioned } = useActions(eventUsageLogic)
@@ -91,6 +93,14 @@ export function DashboardItems(): JSX.Element {
     const { width: gridWrapperWidth, ref: gridWrapperRef } = useResizeObserver()
     const canResizeWidth = !gridWrapperWidth || gridWrapperWidth > BREAKPOINTS['sm']
     const isMobileView = gridWrapperWidth && gridWrapperWidth <= BREAKPOINTS['sm']
+    const isEditablePlacement = [
+        DashboardPlacement.Dashboard,
+        DashboardPlacement.ProjectHomepage,
+        DashboardPlacement.Builtin,
+    ].includes(placement)
+
+    const canEnterEditModeFromEdge =
+        !!dashboard && canEditDashboard && dashboardMode !== DashboardMode.Edit && !isMobileView && isEditablePlacement
 
     return (
         <div className="dashboard-items-wrapper" ref={gridWrapperRef}>
@@ -207,11 +217,11 @@ export function DashboardItems(): JSX.Element {
                             dashboardId: dashboard?.id,
                             showResizeHandles: dashboardMode === DashboardMode.Edit && !isMobileView,
                             canResizeWidth: canResizeWidth,
-                            showEditingControls: [
-                                DashboardPlacement.Dashboard,
-                                DashboardPlacement.ProjectHomepage,
-                                DashboardPlacement.Builtin,
-                            ].includes(placement),
+                            canEnterEditModeFromEdge,
+                            onEnterEditModeFromEdge: canEnterEditModeFromEdge
+                                ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
+                                : undefined,
+                            showEditingControls: isEditablePlacement,
                             moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
                                 if (!dashboard) {
                                     throw new Error('must be on a dashboard to move this tile')


### PR DESCRIPTION
## Problem

When editing the layout for a dashboard, currently the way to enable editing of a layout is by clicking the "Edit Layout", button at the top, pressing the "E" key (which is hidden behind a tooltip), or going to the sidebar.

This makes the editing experience at sometimes feel hidden behind several clicks.

## Changes

(Unfortunately the cursor resize doesnt show up on the screen grab, but I swear its there.)

When not in editing state, makes the edges of the insight cards have a cursor interaction, that can quickly trigger entering edit mode.

https://github.com/user-attachments/assets/526ec70b-b5c7-442b-8e90-ec9b757c7afe


One option I do have is:
- should it only be the sides of the card that trigger the interaction, or all other parts of the card itself (not including things like the graph that have its own interactivity)

## How did you test this code?

Locally.

Added a test.
