### PR TITLE
feat(journey-builder): Add templates page for journey builder

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -53,6 +53,8 @@ export const productScenes: Record<string, () => Promise<any>> = {
         import('../../products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/CustomerAnalyticsConfigurationScene'),
     CustomerJourneyBuilder: () =>
         import('../../products/customer_analytics/frontend/scenes/CustomerJourneyBuilderScene/CustomerJourneyBuilderScene'),
+    CustomerJourneyTemplates: () =>
+        import('../../products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene'),
     DataOps: () => import('../../products/data_warehouse/DataWarehouseScene'),
     Models: () => import('../../frontend/src/scenes/models/ModelsScene'),
     NodeDetail: () => import('../../frontend/src/scenes/models/NodeDetailScene'),
@@ -122,6 +124,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/support/settings': ['SupportSettings', 'supportSettings'],
     '/customer_analytics/dashboard': ['CustomerAnalytics', 'customerAnalyticsDashboard'],
     '/customer_analytics/journeys/new': ['CustomerJourneyBuilder', 'customerJourneyBuilder'],
+    '/customer_analytics/journeys/templates': ['CustomerJourneyTemplates', 'customerJourneyTemplates'],
     '/customer_analytics/journeys': ['CustomerAnalytics', 'customerAnalyticsJourneys'],
     '/customer_analytics/configuration': ['CustomerAnalyticsConfiguration', 'customerAnalyticsConfiguration'],
     '/data-ops': ['DataOps', 'dataOps'],
@@ -279,6 +282,7 @@ export const productConfiguration: Record<string, any> = {
         name: 'Customer analytics configuration',
     },
     CustomerJourneyBuilder: { projectBased: true, name: 'New journey' },
+    CustomerJourneyTemplates: { projectBased: true, name: 'New journey' },
     DataOps: {
         name: 'Data ops',
         projectBased: true,
@@ -565,6 +569,7 @@ export const productUrls = {
     customerAnalyticsJourneys: (): string => '/customer_analytics/journeys',
     customerAnalyticsConfiguration: (): string => '/customer_analytics/configuration',
     customerJourneyBuilder: (): string => '/customer_analytics/journeys/new',
+    customerJourneyTemplates: (): string => '/customer_analytics/journeys/templates',
     dashboards: (): string => '/dashboard',
     dashboard: (id: string | number, highlightInsightId?: string): string =>
         combineUrl(`/dashboard/${id}`, highlightInsightId ? { highlightInsightId } : {}).url,
@@ -1210,7 +1215,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         tags: ['beta'],
         flag: FEATURE_FLAGS.CUSTOMER_ANALYTICS,
         sceneKey: 'CustomerAnalytics',
-        sceneKeys: ['CustomerAnalytics', 'CustomerJourneyBuilder'],
+        sceneKeys: ['CustomerAnalytics', 'CustomerJourneyTemplates', 'CustomerJourneyBuilder'],
     },
     {
         path: 'Dashboards',

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -136,7 +136,6 @@ export enum Scene {
     SessionProfile = 'SessionProfile',
     Settings = 'Settings',
     Signup = 'Signup',
-
     Site = 'Site',
     Coupons = 'Coupons',
     Sources = 'Sources',
@@ -188,6 +187,7 @@ export enum Scene {
     TaskDetail = 'TaskDetail',
     TaskTracker = 'TaskTracker',
     OrganizationDeactivated = 'OrganizationDeactivated',
+    CustomerJourneyTemplates = 'CustomerJourneyTemplates',
 }
 
 export type SceneComponent<T> = (props: T) => JSX.Element | null

--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -129,7 +129,7 @@ export function CustomerAnalyticsScene({ tabId }: { tabId?: string }): JSX.Eleme
                                 <LemonButton
                                     type="primary"
                                     size="small"
-                                    to={urls.customerJourneyBuilder()}
+                                    to={urls.customerJourneyTemplates()}
                                     data-attr="new-journey"
                                 >
                                     New journey

--- a/products/customer_analytics/frontend/components/CustomerJourneys/CustomerJourneysEmptyState.tsx
+++ b/products/customer_analytics/frontend/components/CustomerJourneys/CustomerJourneysEmptyState.tsx
@@ -22,7 +22,7 @@ export function CustomerJourneysEmptyState({ embedded }: { embedded?: boolean })
             productName="Customer journeys"
             thingName="journey"
             description={description}
-            action={() => router.actions.push(urls.customerJourneyBuilder())}
+            action={() => router.actions.push(urls.customerJourneyTemplates())}
             customHog={ExplorerHog}
             className={embedded ? 'border-0' : undefined}
             isEmpty

--- a/products/customer_analytics/frontend/components/CustomerJourneys/journeyBuilderLogic.ts
+++ b/products/customer_analytics/frontend/components/CustomerJourneys/journeyBuilderLogic.ts
@@ -1,10 +1,12 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
-import { router } from 'kea-router'
+import { actions, afterMount, connect, isBreakpoint, kea, listeners, path, reducers, selectors } from 'kea'
+import { router, urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { isEmptyObject } from 'lib/utils'
 import { getDefaultEventName, getProjectEventExistence } from 'lib/utils/getAppContext'
 import { funnelPathsExpansionLogic } from 'scenes/funnels/FunnelFlowGraph/funnelPathsExpansionLogic'
 import { PathExpansion } from 'scenes/funnels/FunnelFlowGraph/pathFlowUtils'
@@ -23,14 +25,87 @@ import {
     NodeKind,
 } from '~/queries/schema/schema-general'
 import { insightsApi } from '~/scenes/insights/utils/api'
-import { Breadcrumb, FunnelPathType, FunnelVizType, InsightLogicProps } from '~/types'
+import {
+    BreakdownAttributionType,
+    Breadcrumb,
+    FunnelConversionWindowTimeUnit,
+    FunnelPathType,
+    FunnelStepReference,
+    FunnelVizType,
+    InsightLogicProps,
+    StepOrderValue,
+} from '~/types'
 
+import { customerAnalyticsConfigLogic } from '../../customerAnalyticsConfigLogic'
 import { customerJourneysLogic } from './customerJourneysLogic'
 import type { journeyBuilderLogicType } from './journeyBuilderLogicType'
 
 const JOURNEY_NAME_MAX_LENGTH = 64
 const INSIGHT_NAME_PREFIX = 'Journey: '
 export const JOURNEY_NAME_INPUT_MAX_LENGTH = JOURNEY_NAME_MAX_LENGTH - INSIGHT_NAME_PREFIX.length
+
+type JourneyTemplateKey = 'signup_conversion' | 'free_to_paid'
+
+function createTemplateQuery(
+    templateKey: JourneyTemplateKey,
+    signupPageviewEvent: AnyEntityNode,
+    signupEvent: AnyEntityNode,
+    paymentEvent: AnyEntityNode
+): InsightVizNode<FunnelsQuery> | null {
+    if (templateKey === 'signup_conversion') {
+        if (isEmptyObject(signupPageviewEvent) || isEmptyObject(signupEvent)) {
+            return null
+        }
+        const { custom_name: _a, ...pageviewNode } = signupPageviewEvent as AnyEntityNode & { custom_name?: string }
+        const { custom_name: _b, ...signupNode } = signupEvent as AnyEntityNode & { custom_name?: string }
+        return {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.FunnelsQuery,
+                series: [pageviewNode as EventsNode | ActionsNode, signupNode as EventsNode | ActionsNode],
+                funnelsFilter: {
+                    funnelVizType: FunnelVizType.Flow,
+                    funnelOrderType: StepOrderValue.ORDERED,
+                    funnelStepReference: FunnelStepReference.total,
+                    funnelWindowInterval: 14,
+                    breakdownAttributionType: BreakdownAttributionType.FirstTouch,
+                    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Day,
+                },
+                breakdownFilter: { breakdown_type: 'event' },
+            },
+            full: true,
+            showFilters: true,
+        }
+    }
+
+    if (templateKey === 'free_to_paid') {
+        if (isEmptyObject(signupEvent) || isEmptyObject(paymentEvent)) {
+            return null
+        }
+        const { custom_name: _a, ...signupNode } = signupEvent as AnyEntityNode & { custom_name?: string }
+        const { custom_name: _b, ...payNode } = paymentEvent as AnyEntityNode & { custom_name?: string }
+        return {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.FunnelsQuery,
+                series: [signupNode as EventsNode | ActionsNode, payNode as EventsNode | ActionsNode],
+                funnelsFilter: {
+                    funnelVizType: FunnelVizType.Flow,
+                    funnelOrderType: StepOrderValue.ORDERED,
+                    funnelStepReference: FunnelStepReference.total,
+                    funnelWindowInterval: 6,
+                    breakdownAttributionType: BreakdownAttributionType.FirstTouch,
+                    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Week,
+                },
+                breakdownFilter: { breakdown_type: 'event' },
+            },
+            full: true,
+            showFilters: true,
+        }
+    }
+
+    return null
+}
 
 export const JOURNEY_BUILDER_INSIGHT_PROPS: InsightLogicProps = {
     dashboardItemId: 'new-AdHoc.InsightViz.journey-builder',
@@ -71,7 +146,12 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
             customerJourneysLogic,
             ['addJourney', 'addJourneySuccess', 'addJourneyFailure'],
         ],
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [
+            featureFlagLogic,
+            ['featureFlags'],
+            customerAnalyticsConfigLogic,
+            ['signupEvent', 'signupPageviewEvent', 'paymentEvent'],
+        ],
     })),
 
     actions({
@@ -99,6 +179,9 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
         setJourneyDescription: (description: string) => ({ description }),
         saveJourney: true,
         saveJourneyFailure: (error: string) => ({ error }),
+        loadFromInsight: (insightId: number) => ({ insightId }),
+        applyTemplate: (templateKey: string) => ({ templateKey }),
+        resetBuilder: true,
     }),
 
     reducers({
@@ -151,6 +234,11 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
                     path: urls.customerAnalyticsJourneys(),
                 },
                 {
+                    key: Scene.CustomerJourneyTemplates,
+                    name: 'Templates',
+                    path: urls.customerJourneyTemplates(),
+                },
+                {
                     key: Scene.CustomerJourneyBuilder,
                     name: 'New journey',
                 },
@@ -190,10 +278,9 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
                 name: defaultEvent === null ? 'All events' : defaultEvent,
             }
             series.splice(insertAtIndex, 0, newStep)
-            actions.setQuery({
-                ...values.query,
-                source: { ...values.query.source, series },
-            })
+            const query = { ...values.query, source: { ...values.query.source, series } }
+            actions.setQuery(query)
+            actions.setInsightQuery(query)
         },
 
         removeStep: ({ stepIndex }) => {
@@ -201,10 +288,9 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
             if (series.length === 0) {
                 return
             }
-            actions.setQuery({
-                ...values.query,
-                source: { ...values.query.source, series },
-            })
+            const query = { ...values.query, source: { ...values.query.source, series } }
+            actions.setQuery(query)
+            actions.setInsightQuery(query)
         },
 
         updateStepEvent: ({ stepIndex, value, groupType, item }) => {
@@ -258,10 +344,62 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
             const newStep = eventNameToEventsNode(eventName)
             const series = [...values.query.source.series]
             series.splice(insertionIndex, 0, newStep)
-            actions.setQuery({
-                ...values.query,
-                source: { ...values.query.source, series },
-            })
+            const query = { ...values.query, source: { ...values.query.source, series } }
+            actions.setQuery(query)
+            actions.setInsightQuery(query)
+        },
+
+        applyTemplate: ({ templateKey }) => {
+            const { signupPageviewEvent, signupEvent, paymentEvent } = values
+            const query = createTemplateQuery(
+                templateKey as JourneyTemplateKey,
+                signupPageviewEvent,
+                signupEvent,
+                paymentEvent
+            )
+            if (query) {
+                const names: Record<string, string> = {
+                    signup_conversion: 'Signup conversion',
+                    free_to_paid: 'Free-to-paid conversion',
+                }
+                actions.setQuery(query)
+                actions.setJourneyName(names[templateKey] || '')
+                actions.setInsightQuery(query)
+            }
+        },
+
+        loadFromInsight: async ({ insightId }, breakpoint) => {
+            try {
+                const insight = await insightsApi.getByNumericId(insightId)
+                breakpoint()
+                if (!insight?.query) {
+                    lemonToast.error('Could not load funnel insight')
+                    return
+                }
+                const vizNode = insight.query as InsightVizNode<FunnelsQuery>
+                const modifiedQuery: InsightVizNode<FunnelsQuery> = {
+                    ...vizNode,
+                    source: {
+                        ...vizNode.source,
+                        funnelsFilter: {
+                            ...vizNode.source.funnelsFilter,
+                            funnelVizType: FunnelVizType.Flow,
+                        },
+                    },
+                    full: true,
+                    showFilters: true,
+                }
+                actions.setQuery(modifiedQuery)
+                actions.setJourneyName(insight.name || '')
+                actions.setJourneyDescription(insight.description || '')
+                actions.setInsightQuery(modifiedQuery)
+            } catch (e: any) {
+                if (isBreakpoint(e)) {
+                    return
+                }
+                posthog.captureException(e)
+                lemonToast.error('Failed to load insight')
+            }
         },
 
         saveJourney: async () => {
@@ -300,13 +438,29 @@ export const journeyBuilderLogic = kea<journeyBuilderLogicType>([
                 actions.addJourney({
                     insightId: insight.id,
                     name,
+                    description: journeyDescription.trim() || undefined,
                 })
 
+                actions.resetBuilder()
                 router.actions.push(urls.customerAnalyticsJourneys())
             } catch (e) {
                 const message = e instanceof Error ? e.message : 'Failed to save journey'
                 actions.saveJourneyFailure(message)
                 lemonToast.error(message)
+            }
+        },
+    })),
+
+    urlToAction(({ actions }) => ({
+        [urls.customerJourneyBuilder()]: (_, searchParams) => {
+            const template = searchParams.template
+            if (template && template !== 'scratch') {
+                actions.applyTemplate(template)
+                return
+            }
+            const fromInsight = searchParams.fromInsight
+            if (fromInsight) {
+                actions.loadFromInsight(Number(fromInsight))
             }
         },
     })),

--- a/products/customer_analytics/frontend/scenes/CustomerJourneyBuilderScene/CustomerJourneyBuilderScene.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerJourneyBuilderScene/CustomerJourneyBuilderScene.tsx
@@ -28,6 +28,7 @@ export function CustomerJourneyBuilderScene(): JSX.Element {
                 resourceType={{ type: 'funnel' }}
                 onNameChange={setJourneyName}
                 onDescriptionChange={setJourneyDescription}
+                descriptionMaxLength={400}
                 canEdit
                 forceEdit
                 renameDebounceMs={0}

--- a/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene.stories.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene.stories.tsx
@@ -1,0 +1,127 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { App } from 'scenes/App'
+import { JOURNEY_FEATURE_FLAGS } from 'scenes/funnels/FunnelFlowGraph/__mocks__/journeyMocks'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator, useStorybookMocks } from '~/mocks/browser'
+import { NodeKind } from '~/queries/schema/schema-general'
+
+const SAMPLE_FUNNELS = {
+    count: 2,
+    results: [
+        {
+            id: 101,
+            short_id: 'funnel-1',
+            name: 'Onboarding Funnel',
+            description: 'Tracks user onboarding steps',
+            saved: true,
+            query: {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.FunnelsQuery,
+                    series: [
+                        { kind: NodeKind.EventsNode, event: '$pageview', name: 'Pageview' },
+                        { kind: NodeKind.EventsNode, event: 'sign_up', name: 'Sign up' },
+                    ],
+                    funnelsFilter: { funnelVizType: 'steps' },
+                },
+            },
+            result: null,
+            created_at: '2024-01-01T00:00:00Z',
+            last_modified_at: '2024-01-10T00:00:00Z',
+            tags: ['onboarding'],
+            dashboards: [],
+        },
+        {
+            id: 102,
+            short_id: 'funnel-2',
+            name: 'Checkout Funnel',
+            description: 'Cart to payment flow',
+            saved: true,
+            query: {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.FunnelsQuery,
+                    series: [
+                        { kind: NodeKind.EventsNode, event: 'add_to_cart', name: 'Add to cart' },
+                        { kind: NodeKind.EventsNode, event: 'purchase', name: 'Purchase' },
+                    ],
+                    funnelsFilter: { funnelVizType: 'steps' },
+                },
+            },
+            result: null,
+            created_at: '2024-01-05T00:00:00Z',
+            last_modified_at: '2024-01-12T00:00:00Z',
+            tags: ['revenue'],
+            dashboards: [],
+        },
+    ],
+}
+
+const CONFIGURED_EVENTS = {
+    customer_analytics_config: {
+        signup_event: { kind: 'EventsNode', event: 'sign_up', name: 'Sign up' },
+        signup_pageview_event: { kind: 'EventsNode', event: '$pageview', name: 'Pageview' },
+        payment_event: { kind: 'EventsNode', event: 'purchase', name: 'Purchase' },
+        activity_event: { kind: 'EventsNode', event: '$pageview', name: 'Pageview' },
+        subscription_event: {},
+    },
+}
+
+const EMPTY_EVENTS = {
+    customer_analytics_config: {
+        signup_event: {},
+        signup_pageview_event: {},
+        payment_event: {},
+        activity_event: {},
+        subscription_event: {},
+    },
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/Customer Analytics/Journey Templates',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2024-01-15',
+        featureFlags: JOURNEY_FEATURE_FLAGS,
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                'api/environments/:team_id/customer_profile_configs/': { count: 0, results: [] },
+                'api/environments/:team_id/customer_journeys/': { count: 0, results: [] },
+                'api/environments/:team_id/insights/': SAMPLE_FUNNELS,
+            },
+        }),
+    ],
+}
+export default meta
+
+export const TemplatesWithEventsConfigured: StoryFn = () => {
+    useStorybookMocks({
+        get: {
+            'api/environments/:team_id/': { ...CONFIGURED_EVENTS },
+        },
+    })
+    return <App />
+}
+TemplatesWithEventsConfigured.parameters = {
+    pageUrl: urls.customerJourneyTemplates(),
+    testOptions: { waitForSelector: '[data-attr="journey-template-card-scratch"]' },
+}
+
+export const TemplatesWithoutEventsConfigured: StoryFn = () => {
+    useStorybookMocks({
+        get: {
+            'api/environments/:team_id/': { ...EMPTY_EVENTS },
+        },
+    })
+    return <App />
+}
+TemplatesWithoutEventsConfigured.parameters = {
+    pageUrl: urls.customerJourneyTemplates(),
+    testOptions: { waitForSelector: '[data-attr="journey-template-card-scratch"]' },
+}

--- a/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene.tsx
@@ -1,0 +1,29 @@
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { ProductKey } from '~/queries/schema/schema-general'
+import { SceneExport } from '~/scenes/sceneTypes'
+
+import { JourneyTemplatePicker } from './JourneyTemplatePicker'
+import { journeyTemplatePickerLogic } from './journeyTemplatePickerLogic'
+
+export const scene: SceneExport = {
+    component: CustomerJourneyTemplatesScene,
+    logic: journeyTemplatePickerLogic,
+    productKey: ProductKey.CUSTOMER_ANALYTICS,
+}
+
+export function CustomerJourneyTemplatesScene(): JSX.Element {
+    return (
+        <SceneContent>
+            <div className="flex items-center justify-start mb-4">
+                <LemonButton type="tertiary" size="small" to={urls.customerAnalyticsJourneys()}>
+                    ← Back to journeys
+                </LemonButton>
+            </div>
+            <JourneyTemplatePicker />
+        </SceneContent>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/JourneyTemplatePicker.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/JourneyTemplatePicker.tsx
@@ -1,0 +1,227 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import { useEffect, useRef } from 'react'
+
+import { IconPlus, IconTarget, IconTrending } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonInput, Link } from '@posthog/lemon-ui'
+
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { TZLabel } from 'lib/components/TZLabel'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
+import { InsightIcon } from 'scenes/saved-insights/SavedInsights'
+import { urls } from 'scenes/urls'
+
+import { QueryBasedInsightModel } from '~/types'
+
+import { JourneyTemplateKey, journeyTemplatePickerLogic } from './journeyTemplatePickerLogic'
+
+interface TemplateCardConfig {
+    key: JourneyTemplateKey
+    title: string
+    description: string
+    icon: React.ComponentType<{ className?: string }>
+    available: boolean
+    disabledReason?: string
+}
+
+function TemplateCard({ config, onClick }: { config: TemplateCardConfig; onClick: () => void }): JSX.Element {
+    const Icon = config.icon
+    const card = (
+        <button
+            type="button"
+            data-attr={`journey-template-card-${config.key}`}
+            onClick={config.available ? onClick : undefined}
+            disabled={!config.available}
+            className={clsx(
+                'group relative text-left rounded-lg border border-border bg-bg-light transition-all p-5 w-full',
+                config.available
+                    ? 'hover:border-border-bold hover:shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2'
+                    : 'opacity-50 cursor-not-allowed'
+            )}
+        >
+            <div className="flex flex-col gap-3">
+                <Icon className={clsx('text-2xl transition-colors', config.available && 'group-hover:text-link')} />
+                <div>
+                    <h3
+                        className={clsx(
+                            'font-semibold text-base mb-1 transition-colors',
+                            config.available && 'group-hover:text-link'
+                        )}
+                    >
+                        {config.title}
+                    </h3>
+                    <p className="text-sm text-muted m-0">{config.description}</p>
+                </div>
+            </div>
+        </button>
+    )
+
+    if (!config.available && config.disabledReason) {
+        return (
+            <Tooltip title={config.disabledReason}>
+                <div>{card}</div>
+            </Tooltip>
+        )
+    }
+    return card
+}
+
+export function JourneyTemplatePicker(): JSX.Element {
+    const {
+        isSignupConversionAvailable,
+        isFreeToPaidAvailable,
+        showExistingFunnels,
+        funnels,
+        funnelsLoading,
+        searchTerm,
+    } = useValues(journeyTemplatePickerLogic)
+    const { selectTemplate, selectExistingFunnel, toggleExistingFunnels, setSearchTerm } =
+        useActions(journeyTemplatePickerLogic)
+    const summarizeInsight = useSummarizeInsight()
+    const funnelsSectionRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (showExistingFunnels && funnelsSectionRef.current) {
+            funnelsSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        }
+    }, [showExistingFunnels])
+
+    const templates: TemplateCardConfig[] = [
+        {
+            key: 'signup_conversion',
+            title: 'Signup conversion',
+            description: 'Track how users convert from viewing your signup page to completing signup',
+            icon: IconTrending,
+            available: isSignupConversionAvailable,
+            disabledReason: `Configure signup pageview and signup events in Customer analytics settings to use this template`,
+        },
+        {
+            key: 'free_to_paid',
+            title: 'Free-to-paid conversion',
+            description: 'Track how users convert from signing up to making their first payment',
+            icon: IconTarget,
+            available: isFreeToPaidAvailable,
+            disabledReason: `Configure signup and payment events in Customer analytics settings to use this template`,
+        },
+        {
+            key: 'scratch',
+            title: 'Start from scratch',
+            description: 'Build a custom journey funnel from any events',
+            icon: IconPlus,
+            available: true,
+        },
+    ]
+
+    return (
+        <div className="space-y-6">
+            <div className="text-center max-w-xl mx-auto">
+                <h2 className="text-2xl font-semibold mb-4">Create a customer journey</h2>
+                <p className="text-muted text-sm">
+                    Choose a template to get started quickly, or build a custom journey from scratch.
+                    {(!isSignupConversionAvailable || !isFreeToPaidAvailable) && (
+                        <>
+                            {' '}
+                            <Link to={urls.customerAnalyticsConfiguration()}>Configure events</Link> to unlock more
+                            templates.
+                        </>
+                    )}
+                </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                {templates.map((template) => (
+                    <TemplateCard key={template.key} config={template} onClick={() => selectTemplate(template.key)} />
+                ))}
+            </div>
+
+            <LemonDivider />
+
+            <div ref={funnelsSectionRef}>
+                <span className="flex justify-center items-center">
+                    <LemonButton type="tertiary" onClick={toggleExistingFunnels}>
+                        {showExistingFunnels ? 'Hide existing funnels' : 'Start from an existing funnel'}
+                    </LemonButton>
+                </span>
+
+                {showExistingFunnels && (
+                    <div className="mt-4 space-y-3">
+                        <LemonInput
+                            type="search"
+                            placeholder="Search funnels..."
+                            value={searchTerm}
+                            onChange={(value) => setSearchTerm(value)}
+                            autoFocus
+                        />
+                        <LemonTable
+                            dataSource={funnels}
+                            columns={[
+                                {
+                                    key: 'id',
+                                    width: 32,
+                                    render: function renderType(_, insight) {
+                                        return <InsightIcon insight={insight} className="text-secondary text-2xl" />
+                                    },
+                                },
+                                {
+                                    title: 'Name',
+                                    dataIndex: 'name',
+                                    key: 'name',
+                                    render: function renderName(name: string, insight) {
+                                        const displayName = name || summarizeInsight(insight.query)
+                                        return (
+                                            <div className="flex flex-col gap-1 min-w-0">
+                                                <span className="block truncate">{name || <i>{displayName}</i>}</span>
+                                                {insight.description && (
+                                                    <div className="text-xs text-tertiary truncate">
+                                                        {insight.description}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )
+                                    },
+                                },
+                                {
+                                    title: 'Tags',
+                                    dataIndex: 'tags' as keyof QueryBasedInsightModel,
+                                    key: 'tags',
+                                    render: function renderTags(tags: string[]) {
+                                        return <ObjectTags tags={tags} staticOnly />
+                                    },
+                                },
+                                {
+                                    title: 'Last modified',
+                                    dataIndex: 'last_modified_at',
+                                    render: function renderLastModified(last_modified_at: string) {
+                                        return (
+                                            <div className="whitespace-nowrap">
+                                                {last_modified_at && <TZLabel time={last_modified_at} />}
+                                            </div>
+                                        )
+                                    },
+                                },
+                            ]}
+                            loading={funnelsLoading}
+                            rowKey="id"
+                            nouns={['funnel', 'funnels']}
+                            rowClassName="cursor-pointer hover:bg-primary-highlight/30"
+                            onRow={(insight) => ({
+                                onClick: () => selectExistingFunnel(insight.id),
+                            })}
+                            emptyState={
+                                searchTerm ? (
+                                    <div className="text-muted text-center p-4">
+                                        No funnels found matching your search
+                                    </div>
+                                ) : (
+                                    <div className="text-muted text-center p-4">No saved funnel insights found</div>
+                                )
+                            }
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/journeyTemplatePickerLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/journeyTemplatePickerLogic.ts
@@ -1,0 +1,108 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { lazyLoaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import api from 'lib/api'
+import { isEmptyObject } from 'lib/utils'
+import { urls } from 'scenes/urls'
+
+import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
+import { InsightType, QueryBasedInsightModel } from '~/types'
+
+import { customerAnalyticsConfigLogic } from '../../customerAnalyticsConfigLogic'
+import type { journeyTemplatePickerLogicType } from './journeyTemplatePickerLogicType'
+
+export type JourneyTemplateKey = 'signup_conversion' | 'free_to_paid' | 'scratch'
+
+export const journeyTemplatePickerLogic = kea<journeyTemplatePickerLogicType>([
+    path([
+        'products',
+        'customer_analytics',
+        'frontend',
+        'scenes',
+        'CustomerJourneyTemplatesScene',
+        'journeyTemplatePickerLogic',
+    ]),
+
+    connect(() => ({
+        values: [customerAnalyticsConfigLogic, ['signupEvent', 'signupPageviewEvent', 'paymentEvent']],
+    })),
+
+    actions({
+        toggleExistingFunnels: true,
+        selectTemplate: (templateKey: JourneyTemplateKey) => ({ templateKey }),
+        selectExistingFunnel: (insightId: number) => ({ insightId }),
+        setSearchTerm: (term: string) => ({ term }),
+        loadFunnels: true,
+        resetState: true,
+    }),
+
+    lazyLoaders(({ values }) => ({
+        funnels: {
+            __default: [] as QueryBasedInsightModel[],
+            loadFunnels: async (_, breakpoint) => {
+                await breakpoint(300)
+                const response = await api.insights.list({
+                    saved: true,
+                    insight: InsightType.FUNNELS,
+                    ...(values.searchTerm ? { search: values.searchTerm } : {}),
+                })
+                return response.results.map((insight) => getQueryBasedInsightModel(insight))
+            },
+        },
+    })),
+
+    reducers({
+        showExistingFunnels: [
+            false,
+            {
+                toggleExistingFunnels: (state) => !state,
+                resetState: () => false,
+            },
+        ],
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { term }) => term,
+                resetState: () => '',
+            },
+        ],
+    }),
+
+    selectors({
+        isSignupConversionAvailable: [
+            (s) => [s.signupPageviewEvent, s.signupEvent],
+            (signupPageviewEvent, signupEvent): boolean =>
+                !isEmptyObject(signupPageviewEvent) && !isEmptyObject(signupEvent),
+        ],
+        isFreeToPaidAvailable: [
+            (s) => [s.signupEvent, s.paymentEvent],
+            (signupEvent, paymentEvent): boolean => !isEmptyObject(signupEvent) && !isEmptyObject(paymentEvent),
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        selectTemplate: ({ templateKey }) => {
+            if (templateKey === 'scratch') {
+                router.actions.push(urls.customerJourneyBuilder())
+            } else {
+                router.actions.push(urls.customerJourneyBuilder() + '?template=' + templateKey)
+            }
+        },
+        selectExistingFunnel: ({ insightId }) => {
+            router.actions.push(urls.customerJourneyBuilder() + '?fromInsight=' + insightId)
+        },
+        toggleExistingFunnels: () => {
+            if (values.showExistingFunnels) {
+                actions.loadFunnels()
+            }
+        },
+        setSearchTerm: () => {
+            actions.loadFunnels()
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.resetState()
+    }),
+])

--- a/products/customer_analytics/manifest.tsx
+++ b/products/customer_analytics/manifest.tsx
@@ -29,10 +29,16 @@ export const manifest: ProductManifest = {
             projectBased: true,
             name: 'New journey',
         },
+        CustomerJourneyTemplates: {
+            import: () => import('./frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene'),
+            projectBased: true,
+            name: 'New journey',
+        },
     },
     routes: {
         '/customer_analytics/dashboard': ['CustomerAnalytics', 'customerAnalyticsDashboard'],
         '/customer_analytics/journeys/new': ['CustomerJourneyBuilder', 'customerJourneyBuilder'],
+        '/customer_analytics/journeys/templates': ['CustomerJourneyTemplates', 'customerJourneyTemplates'],
         '/customer_analytics/journeys': ['CustomerAnalytics', 'customerAnalyticsJourneys'],
         '/customer_analytics/configuration': ['CustomerAnalyticsConfiguration', 'customerAnalyticsConfiguration'],
     },
@@ -46,6 +52,7 @@ export const manifest: ProductManifest = {
         customerAnalyticsJourneys: (): string => '/customer_analytics/journeys',
         customerAnalyticsConfiguration: (): string => '/customer_analytics/configuration',
         customerJourneyBuilder: (): string => '/customer_analytics/journeys/new',
+        customerJourneyTemplates: (): string => '/customer_analytics/journeys/templates',
     },
     treeItemsProducts: [
         {
@@ -57,7 +64,7 @@ export const manifest: ProductManifest = {
             tags: ['beta'],
             flag: FEATURE_FLAGS.CUSTOMER_ANALYTICS,
             sceneKey: 'CustomerAnalytics',
-            sceneKeys: ['CustomerAnalytics', 'CustomerJourneyBuilder'],
+            sceneKeys: ['CustomerAnalytics', 'CustomerJourneyTemplates', 'CustomerJourneyBuilder'],
         },
     ],
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
@@ -4,7 +4,21 @@
         "assignee": {
             "properties": {
                 "id": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "type": {
                     "type": "string"


### PR DESCRIPTION
## Problem

A feedback we've received was that folks wanted to add more steps to the funnels in Customer analytics dashboard. Now, they kinda can do that by creating a customer journey using them as templates.

Closes https://github.com/PostHog/posthog/issues/48956
## Changes

Added a new journey templates selection screen that provides:

- **Template cards** for common journey patterns:
  - Signup conversion (pageview → signup)
  - Free-to-paid conversion (signup → payment)
  - Start from scratch option
- **Template availability** based on configured events in customer analytics settings
- **Existing funnel import** functionality with searchable table of saved funnel insights
- **Navigation flow** that routes through templates before reaching the journey builder
- **Pre-configured queries** for templates with appropriate funnel settings and time windows
- **URL parameter support** for template selection and insight loading

The templates integrate with the existing customer analytics configuration to determine availability and automatically populate funnel queries with the configured events.

## How did you test this code?

Manually and storybook tests

## Publish to changelog?

No, behind feature flag