### PR TITLE
fix(replay): remove duplicate metric labels from Temporal interceptor

### DIFF
--- a/posthog/temporal/delete_recordings/metrics.py
+++ b/posthog/temporal/delete_recordings/metrics.py
@@ -109,7 +109,7 @@ class _DeleteRecordingsActivityInterceptor(ActivityInboundInterceptor):
         started_time = activity_info.started_time
         if scheduled_time and started_time:
             schedule_to_start_ms = int((started_time - scheduled_time).total_seconds() * 1000)
-            meter = get_metric_meter({"activity_type": activity_type})
+            meter = get_metric_meter()
             meter.create_histogram_timedelta(
                 name="delete_recordings_activity_schedule_to_start_latency",
                 description="Time between activity scheduling and start",
@@ -119,7 +119,6 @@ class _DeleteRecordingsActivityInterceptor(ActivityInboundInterceptor):
         with ExecutionTimeRecorder(
             "delete_recordings_activity_execution_latency",
             description="Execution latency for delete-recordings activities",
-            histogram_attributes={"activity_type": activity_type},
         ):
             return await super().execute_activity(input)
 
@@ -132,7 +131,7 @@ class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
         if workflow_type not in DELETE_RECORDINGS_WORKFLOW_TYPES:
             return await super().execute_workflow(input)
 
-        meter = get_metric_meter({"workflow_type": workflow_type})
+        meter = get_metric_meter()
         meter.create_counter(
             "delete_recordings_workflow_started",
             "Delete-recordings workflows started",
@@ -141,12 +140,11 @@ class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
         with ExecutionTimeRecorder(
             "delete_recordings_workflow_execution_latency",
             description="End-to-end workflow execution latency",
-            histogram_attributes={"workflow_type": workflow_type},
         ):
             status = "COMPLETED"
             try:
                 result = await super().execute_workflow(input)
-                meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
+                meter = get_metric_meter({"status": status})
                 meter.create_counter(
                     "delete_recordings_workflow_finished",
                     "Delete-recordings workflows finished",
@@ -154,7 +152,7 @@ class _DeleteRecordingsWorkflowInterceptor(WorkflowInboundInterceptor):
                 return result
             except Exception:
                 status = "FAILED"
-                meter = get_metric_meter({"workflow_type": workflow_type, "status": status})
+                meter = get_metric_meter({"status": status})
                 meter.create_counter(
                     "delete_recordings_workflow_finished",
                     "Delete-recordings workflows finished",


### PR DESCRIPTION
## Summary

- The Temporal SDK's `workflow.metric_meter()` and `activity.metric_meter()` already include `workflow_type`, `activity_type`, `namespace`, and `task_queue` as default attributes (see [`_workflow_instance.py:1218`](https://github.com/temporalio/sdk-python/blob/main/temporalio/worker/_workflow_instance.py#L1218) and [`activity.py:234`](https://github.com/temporalio/sdk-python/blob/main/temporalio/activity.py#L234))
- Our `DeleteRecordingsMetricsInterceptor` was passing these same attributes again via `get_metric_meter({"workflow_type": ...})`, causing Prometheus to concatenate duplicate label values with semicolons (e.g. `delete-recordings-with-person;delete-recordings-with-person`)
- Removed the redundant `workflow_type` and `activity_type` attributes; only truly additional attributes like `status` are still passed

Note: the same bug exists in the llm_analytics interceptors (`metrics.py`, `sentiment/metrics.py`, `trace_clustering/metrics.py`, `trace_summarization/metrics.py`) — will fix in a follow-up.

## Test plan

- [ ] Deploy and verify the Grafana "Workflow throughput by type" panel on the session-replay-recording-api dashboard no longer shows duplicated names like `delete-recordings-with-person;delete-recordings-with-person`
- [ ] Verify existing metric queries in Grafana still work (the `workflow_type` label is still present, just no longer duplicated)