### PR TITLE
refactor: use parent + component pricing for services catalog

### DIFF
--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -72,7 +72,6 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert "posthog" in service_ids
         assert "product_analytics" in service_ids
         assert "session_replay" in service_ids
-        assert "platform_and_support" not in service_ids
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache")

--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -49,53 +49,93 @@ def _mock_billing_response():
 class TestProvisioningServices(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache")
-    def test_returns_services_from_billing(self, mock_cache, mock_get):
+    def test_returns_parent_posthog_service(self, mock_cache, mock_get):
+        mock_cache.get.return_value = None
+        res = self._get_signed("/api/agentic/provisioning/services")
+        assert res.status_code == 200
+        data = res.json()
+        services = data["data"]
+        parent = services[0]
+        assert parent["id"] == "posthog"
+        assert parent["pricing"]["type"] == "free"
+        assert "analytics" in parent["categories"]
+        assert data["next_cursor"] == ""
+
+    @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache")
+    def test_returns_component_services_from_billing(self, mock_cache, mock_get):
         mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
         service_ids = {s["id"] for s in data["data"]}
+        assert "posthog" in service_ids
         assert "product_analytics" in service_ids
         assert "session_replay" in service_ids
         assert "platform_and_support" not in service_ids
-        assert data["next_cursor"] == ""
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache")
-    def test_each_service_has_stripe_price(self, mock_cache, mock_get):
+    def test_component_services_have_parent_and_stripe_price(self, mock_cache, mock_get):
         mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
-        for service in res.json()["data"]:
-            assert service["pricing"]["type"] == "paid"
-            assert service["pricing"]["paid"]["type"] == "stripe_price"
-            assert service["pricing"]["paid"]["stripe_price"].startswith("price_")
+        component_services = [s for s in res.json()["data"] if s["id"] != "posthog"]
+        assert len(component_services) > 0
+        for service in component_services:
+            assert service["pricing"]["type"] == "component"
+            options = service["pricing"]["component"]["options"]
+            assert len(options) == 1
+            assert options[0]["parent_service_ids"] == ["posthog"]
+            assert options[0]["type"] == "paid"
+            assert options[0]["paid"]["type"] == "stripe_price"
+            assert options[0]["paid"]["stripe_price"].startswith("price_")
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get")
     @patch("ee.api.agentic_provisioning.views.cache")
     def test_uses_cache(self, mock_cache, mock_get):
         cached = [
             {
+                "id": "posthog",
+                "description": "PostHog",
+                "categories": ["analytics"],
+                "pricing": {"type": "free"},
+            },
+            {
                 "id": "product_analytics",
                 "description": "cached",
                 "categories": ["analytics"],
-                "pricing": {"type": "paid", "paid": {"type": "stripe_price", "stripe_price": "price_cached"}},
-            }
+                "pricing": {
+                    "type": "component",
+                    "component": {
+                        "options": [
+                            {
+                                "parent_service_ids": ["posthog"],
+                                "type": "paid",
+                                "paid": {"type": "stripe_price", "stripe_price": "price_cached"},
+                            }
+                        ]
+                    },
+                },
+            },
         ]
         mock_cache.get.return_value = cached
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
-        assert res.json()["data"][0]["pricing"]["paid"]["stripe_price"] == "price_cached"
+        component = res.json()["data"][1]
+        assert component["pricing"]["component"]["options"][0]["paid"]["stripe_price"] == "price_cached"
         mock_get.assert_not_called()
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get")
     @patch("ee.api.agentic_provisioning.views.cache")
-    def test_billing_failure_returns_empty(self, mock_cache, mock_get):
+    def test_billing_failure_returns_parent_only(self, mock_cache, mock_get):
         mock_cache.get.return_value = None
         mock_get.side_effect = Exception("connection error")
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
-        assert res.json()["data"] == []
+        data = res.json()["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == "posthog"
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache")

--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -1,8 +1,11 @@
+import time
+
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
+from ee.api.agentic_provisioning.views import SERVICES_CACHE_EXPIRES_KEY, SERVICES_CACHE_KEY
 
 MOCK_BILLING_PRODUCTS = {
     "products": [
@@ -36,6 +39,32 @@ MOCK_BILLING_PRODUCTS = {
     ]
 }
 
+CACHED_SERVICES = [
+    {
+        "id": "posthog",
+        "description": "PostHog",
+        "categories": ["analytics"],
+        "pricing": {"type": "free"},
+    },
+    {
+        "id": "product_analytics",
+        "description": "cached",
+        "categories": ["analytics"],
+        "pricing": {
+            "type": "component",
+            "component": {
+                "options": [
+                    {
+                        "parent_service_ids": ["posthog"],
+                        "type": "paid",
+                        "paid": {"type": "stripe_price", "stripe_price": "price_cached"},
+                    }
+                ]
+            },
+        },
+    },
+]
+
 
 def _mock_billing_response():
     mock_resp = MagicMock()
@@ -45,12 +74,40 @@ def _mock_billing_response():
     return mock_resp
 
 
+def _mock_cache_expired():
+    """Cache with data but expired (expires_at in the past)."""
+    store = {
+        SERVICES_CACHE_KEY: CACHED_SERVICES,
+        SERVICES_CACHE_EXPIRES_KEY: time.time() - 10,
+    }
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    return mock
+
+
+def _mock_cache_fresh():
+    """Cache with data and still fresh."""
+    store = {
+        SERVICES_CACHE_KEY: CACHED_SERVICES,
+        SERVICES_CACHE_EXPIRES_KEY: time.time() + 3600,
+    }
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    return mock
+
+
+def _mock_cache_empty():
+    """No cached data at all."""
+    mock = MagicMock()
+    mock.get.return_value = None
+    return mock
+
+
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
 class TestProvisioningServices(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_returns_parent_posthog_service(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
@@ -62,9 +119,8 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert data["next_cursor"] == ""
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_returns_component_services_from_billing(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
@@ -74,9 +130,8 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert "session_replay" in service_ids
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_component_services_have_parent_and_stripe_price(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         component_services = [s for s in res.json()["data"] if s["id"] != "posthog"]
@@ -91,34 +146,8 @@ class TestProvisioningServices(StripeProvisioningTestBase):
             assert options[0]["paid"]["stripe_price"].startswith("price_")
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get")
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_uses_cache(self, mock_cache, mock_get):
-        cached = [
-            {
-                "id": "posthog",
-                "description": "PostHog",
-                "categories": ["analytics"],
-                "pricing": {"type": "free"},
-            },
-            {
-                "id": "product_analytics",
-                "description": "cached",
-                "categories": ["analytics"],
-                "pricing": {
-                    "type": "component",
-                    "component": {
-                        "options": [
-                            {
-                                "parent_service_ids": ["posthog"],
-                                "type": "paid",
-                                "paid": {"type": "stripe_price", "stripe_price": "price_cached"},
-                            }
-                        ]
-                    },
-                },
-            },
-        ]
-        mock_cache.get.return_value = cached
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_fresh)
+    def test_uses_fresh_cache(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         component = res.json()["data"][1]
@@ -126,9 +155,8 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         mock_get.assert_not_called()
 
     @patch("ee.api.agentic_provisioning.views.external_requests.get")
-    @patch("ee.api.agentic_provisioning.views.cache")
-    def test_billing_failure_returns_parent_only(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_billing_failure_no_cache_returns_parent_only(self, mock_cache, mock_get):
         mock_get.side_effect = Exception("connection error")
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
@@ -136,10 +164,20 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert len(data) == 1
         assert data[0]["id"] == "posthog"
 
+    @patch("ee.api.agentic_provisioning.views.external_requests.get")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_expired)
+    def test_billing_failure_serves_stale_cache(self, mock_cache, mock_get):
+        mock_get.side_effect = Exception("connection error")
+        res = self._get_signed("/api/agentic/provisioning/services")
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert len(data) == 2
+        assert data[0]["id"] == "posthog"
+        assert data[1]["id"] == "product_analytics"
+
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_excludes_inclusion_only_products(self, mock_cache, mock_get):
-        mock_cache.get.return_value = None
         res = self._get_signed("/api/agentic/provisioning/services")
         service_ids = {s["id"] for s in res.json()["data"]}
         assert "platform_and_support" not in service_ids

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from django.core.cache import cache
@@ -25,7 +26,8 @@ logger = structlog.get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 SERVICES_CACHE_KEY = "agentic_provisioning:services"
-SERVICES_CACHE_TTL = 300  # 5 minutes
+SERVICES_CACHE_TTL = 3600  # 1 hour
+SERVICES_CACHE_RETRY_TTL = 300  # 5 min retry window when billing is down
 
 # Products that shouldn't be listed as provisionable services
 _EXCLUDED_PRODUCT_TYPES = {"platform_and_support", "integrations"}
@@ -55,7 +57,8 @@ POSTHOG_PARENT_SERVICE: dict[str, Any] = {
 }
 
 
-def _fetch_services_from_billing() -> list[dict[str, Any]]:
+def _fetch_services_from_billing() -> list[dict[str, Any]] | None:
+    """Fetch product catalog from billing. Returns None on failure."""
     try:
         res = external_requests.get(
             f"{BILLING_SERVICE_URL}/api/products-v2",
@@ -65,7 +68,7 @@ def _fetch_services_from_billing() -> list[dict[str, Any]]:
         products = res.json().get("products", [])
     except Exception:
         logger.exception("agentic_provisioning.services.billing_fetch_failed")
-        return [POSTHOG_PARENT_SERVICE]
+        return None
 
     services: list[dict[str, Any]] = [POSTHOG_PARENT_SERVICE]
     for product in products:
@@ -105,15 +108,35 @@ def _fetch_services_from_billing() -> list[dict[str, Any]]:
     return services
 
 
+SERVICES_CACHE_EXPIRES_KEY = "agentic_provisioning:services:expires_at"
+SERVICES_CACHE_STORE_TTL = 86400  # store data for 24h so stale reads work
+
+
 def _get_services() -> list[dict[str, Any]]:
     cached = cache.get(SERVICES_CACHE_KEY)
-    if cached is not None:
+    expires_at = cache.get(SERVICES_CACHE_EXPIRES_KEY)
+
+    now = time.time()
+    if cached is not None and expires_at is not None and now < expires_at:
         return cached
 
     services = _fetch_services_from_billing()
-    if services:
-        cache.set(SERVICES_CACHE_KEY, services, SERVICES_CACHE_TTL)
-    return services
+    if services is not None:
+        cache.set(SERVICES_CACHE_KEY, services, SERVICES_CACHE_STORE_TTL)
+        cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_TTL, SERVICES_CACHE_STORE_TTL)
+        return services
+
+    # Billing failed — serve stale data, retry after SERVICES_CACHE_RETRY_TTL
+    if cached is not None:
+        logger.warning("agentic_provisioning.services.serving_stale_cache")
+        cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_RETRY_TTL, SERVICES_CACHE_STORE_TTL)
+        return cached
+
+    logger.warning("agentic_provisioning.services.no_cache_fallback")
+    fallback = [POSTHOG_PARENT_SERVICE]
+    cache.set(SERVICES_CACHE_KEY, fallback, SERVICES_CACHE_RETRY_TTL)
+    cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_RETRY_TTL, SERVICES_CACHE_RETRY_TTL)
+    return fallback
 
 
 VALID_SERVICE_IDS: set[str] = {POSTHOG_SERVICE_ID} | set(_CATEGORY_MAP.keys())

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -18,8 +18,10 @@ from .signature import SUPPORTED_VERSIONS, verify_stripe_signature
 logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Service catalog — fetched from the billing service and mapped to the
-# APP 0.1d services format with `stripe_price` pricing.
+# Service catalog — a parent "posthog" service with component children per
+# product. Users provision "posthog" and get all products; individual products
+# use component pricing with their Stripe price IDs so the orchestrator can
+# display pricing info.
 # ---------------------------------------------------------------------------
 
 SERVICES_CACHE_KEY = "agentic_provisioning:services"
@@ -43,6 +45,15 @@ _CATEGORY_MAP: dict[str, list[str]] = {
     "workflows_emails": ["email"],
 }
 
+POSTHOG_SERVICE_ID = "posthog"
+
+POSTHOG_PARENT_SERVICE: dict[str, Any] = {
+    "id": POSTHOG_SERVICE_ID,
+    "description": "PostHog — product analytics, session replay, feature flags, A/B testing, surveys, and more",
+    "categories": ["analytics", "observability", "feature_flags", "ai"],
+    "pricing": {"type": "free"},
+}
+
 
 def _fetch_services_from_billing() -> list[dict[str, Any]]:
     try:
@@ -54,9 +65,9 @@ def _fetch_services_from_billing() -> list[dict[str, Any]]:
         products = res.json().get("products", [])
     except Exception:
         logger.exception("agentic_provisioning.services.billing_fetch_failed")
-        return []
+        return [POSTHOG_PARENT_SERVICE]
 
-    services = []
+    services: list[dict[str, Any]] = [POSTHOG_PARENT_SERVICE]
     for product in products:
         product_type = product.get("type", "")
         if product_type in _EXCLUDED_PRODUCT_TYPES:
@@ -74,10 +85,18 @@ def _fetch_services_from_billing() -> list[dict[str, Any]]:
                 "description": product.get("headline") or product.get("description", ""),
                 "categories": _CATEGORY_MAP.get(product_type, ["analytics"]),
                 "pricing": {
-                    "type": "paid",
-                    "paid": {
-                        "type": "stripe_price",
-                        "stripe_price": paid_plan["price_id"],
+                    "type": "component",
+                    "component": {
+                        "options": [
+                            {
+                                "parent_service_ids": [POSTHOG_SERVICE_ID],
+                                "type": "paid",
+                                "paid": {
+                                    "type": "stripe_price",
+                                    "stripe_price": paid_plan["price_id"],
+                                },
+                            }
+                        ]
                     },
                 },
             }
@@ -97,7 +116,7 @@ def _get_services() -> list[dict[str, Any]]:
     return services
 
 
-VALID_SERVICE_IDS: set[str] = set(_CATEGORY_MAP.keys())
+VALID_SERVICE_IDS: set[str] = {POSTHOG_SERVICE_ID} | set(_CATEGORY_MAP.keys())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The services catalog listed each PostHog product as a separate top-level service with `paid` pricing. But PostHog projects include **all** products — you provision "PostHog" not "session_replay" individually. Rafa suggested using the APP spec's `component` pricing with `parent_service_ids` to model this hierarchy.

## Changes

- Added a parent `posthog` service with `pricing.type = "free"` — this is what users provision
- Changed each product service from `pricing.type = "paid"` to `pricing.type = "component"` with `parent_service_ids: ["posthog"]`
- Each component still carries its `stripe_price` ID so the orchestrator can display pricing info
- On billing fetch failure, returns just the parent service instead of empty list
- Updated `VALID_SERVICE_IDS` to include `"posthog"`

Context: [APP spec (v0.1d)](https://github.com/agentic-provisioning/posthog-spec), Slack: #project-posthog-stripe-apps

## How did you test this code?

- `pytest ee/api/agentic_provisioning/test/test_services.py -x -q` — 7 tests pass
- Tests cover: parent service present, component pricing structure, cache, billing failure fallback, exclusion of inclusion-only products

🤖 Generated with [Claude Code](https://claude.com/claude-code)