### PR TITLE
fix: restore feature flag filter in session replay UI

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -417,6 +417,7 @@ const ReplayFiltersTab = ({
         TaxonomicFilterGroupType.EventProperties,
         TaxonomicFilterGroupType.Actions,
         TaxonomicFilterGroupType.Cohorts,
+        TaxonomicFilterGroupType.EventFeatureFlags,
         TaxonomicFilterGroupType.PersonProperties,
         TaxonomicFilterGroupType.SessionProperties,
         ...groupsTaxonomicTypes,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Users can't filter session replays by feature flag directly from the filter UI.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Re-added `TaxonomicFilterGroupType.EventFeatureFlags` to the replay filter groups in `RecordingsUniversalFiltersEmbed.tsx`. All backend and filter logic support was already in place.
<img width="782" height="659" alt="Screenshot 2026-03-09 at 20 40 58" src="https://github.com/user-attachments/assets/b85bd31a-eb46-40cc-b4ab-53451b0b0e35" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
