### PR TITLE
feat(django): more personhog callsite replacements

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
@@ -47,7 +47,7 @@ class FunnelCorrelationActors(ActorBaseQuery):
     def get_actors(
         self,
     ) -> tuple[
-        Union[QuerySet[Person], QuerySet[Group]],
+        Union[QuerySet[Person], QuerySet[Group], list[Person]],
         Union[list[SerializedGroup], list[SerializedPerson]],
         int,
     ]:

--- a/ee/hogai/session_summaries/session_group/patterns.py
+++ b/ee/hogai/session_summaries/session_group/patterns.py
@@ -3,13 +3,11 @@ from enum import Enum
 from math import floor
 from typing import Any
 
-from django.db.models import Prefetch
-
 import structlog
 from pydantic import BaseModel, Field, ValidationError, field_serializer, field_validator
 from temporalio.exceptions import ApplicationError
 
-from posthog.models.person import Person, PersonDistinctId
+from posthog.models.person import Person
 from posthog.models.person.util import get_persons_by_distinct_ids
 
 from ee.hogai.session_summaries import SummaryValidationError
@@ -536,15 +534,8 @@ def get_persons_for_sessions_from_distinct_ids(
         return {}
     try:
         persons = get_persons_by_distinct_ids(team_id=team_id, distinct_ids=distinct_ids)
-        persons = persons.prefetch_related(
-            Prefetch(
-                "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=team_id).order_by("id"),
-                to_attr="distinct_ids_cache",
-            )
-        )
         session_id_to_person_mapping: dict[str, Person | None] = {}
-        for person in persons.iterator(chunk_size=1000):
+        for person in persons:
             for distinct_id in person.distinct_ids:
                 person_session_ids = distinct_id_to_session_id_mapping.get(distinct_id)
                 if not person_session_ids:

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -531,6 +531,7 @@ posthog/queries/trends/util.py:0: error: Argument 1 to "translate_hogql" has inc
 posthog/rbac/test/test_field_access_control.py:0: error: Team has no field named 'session_recording_opt_in'  [misc]
 posthog/rbac/test/test_field_access_control.py:0: error: TestModel has no field named 'test_field'  [misc]
 posthog/schema_migrations/upgrade_manager.py:0: error: Argument 1 to "upgrade" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
+posthog/session_recordings/session_recording_api.py:0: error: "SessionRecording" has no attribute "external_references"  [attr-defined]
 posthog/settings/__init__.py:0: error: Cannot determine type of "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY"  [has-type]
 posthog/settings/__init__.py:0: error: Cannot determine type of "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET"  [has-type]
 posthog/settings/data_stores.py:0: error: Name "DATABASE_URL" already defined on line 0  [no-redef]

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -10,7 +10,6 @@ from typing import Any, Iterator, List, Optional, Union  # noqa: UP035
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models.query import Prefetch
 from django.utils import timezone
 
 from drf_spectacular.types import OpenApiTypes
@@ -35,7 +34,7 @@ from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.client import query_with_columns
 from posthog.clickhouse.client.limit import get_events_list_rate_limiter
 from posthog.exceptions_capture import capture_exception
-from posthog.models import Element, Filter, Person, PersonDistinctId, PropertyDefinition
+from posthog.models import Element, Filter, Person, PropertyDefinition
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.event.sql import SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
@@ -397,13 +396,6 @@ class EventViewSet(
     def _get_people(self, query_result: List[dict], team: Team) -> dict[str, Any]:  # noqa: UP006
         distinct_ids = [event["distinct_id"] for event in query_result]
         persons = get_persons_by_distinct_ids(team.pk, distinct_ids)
-        persons = persons.prefetch_related(
-            Prefetch(
-                "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=team.pk).order_by("id"),
-                to_attr="distinct_ids_cache",
-            )
-        )
         distinct_to_person: dict[str, Person] = {}
         for person in persons:
             for distinct_id in person.distinct_ids:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1083,21 +1083,16 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         MAX_BATCH_SIZE = 200
         distinct_ids = distinct_ids[:MAX_BATCH_SIZE]
 
-        persons = get_persons_by_distinct_ids(self.team_id, distinct_ids).prefetch_related(
-            Prefetch(
-                "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=self.team_id).order_by("id"),
-                to_attr="distinct_ids_cache",
-            )
-        )
+        persons = get_persons_by_distinct_ids(self.team_id, distinct_ids)
 
+        requested = set(distinct_ids)
         results: dict[str, Any] = {}
         for person in persons:
             person_data = MinimalPersonSerializer(person, context={"get_team": lambda: self.team}).data
 
-            for did in getattr(person, "distinct_ids_cache", []):
-                if did.distinct_id in distinct_ids:
-                    results[did.distinct_id] = person_data
+            for distinct_id in person.distinct_ids:
+                if distinct_id in requested:
+                    results[distinct_id] = person_data
 
         return response.Response({"results": results})
 

--- a/posthog/api/test/test_person_personhog.py
+++ b/posthog/api/test/test_person_personhog.py
@@ -23,7 +23,7 @@ class TestBatchByDistinctIdsPersonhog(ClickhouseTestMixin, APIBaseTest):
             properties=properties or {},
             distinct_ids=distinct_ids,
             is_identified=person.is_identified,
-            created_at=int(person.created_at.timestamp()) if person.created_at else 0,
+            created_at=int(person.created_at.timestamp() * 1000) if person.created_at else 0,
         )
         return str(person.uuid)
 

--- a/posthog/api/test/test_person_personhog.py
+++ b/posthog/api/test/test_person_personhog.py
@@ -1,0 +1,150 @@
+"""Integration tests for the person API batch_by_distinct_ids endpoint via the personhog path.
+
+These mirror the test cases in TestPerson.test_batch_by_distinct_ids_* to ensure
+the personhog code path returns identical results to the ORM path.
+"""
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_person, flush_persons_and_events
+
+from rest_framework import status
+
+from posthog.personhog_client.fake_client import fake_personhog_client
+
+
+class TestBatchByDistinctIdsPersonhog(ClickhouseTestMixin, APIBaseTest):
+    def _seed_person(self, fake, *, team_id: int, distinct_ids: list[str], properties: dict | None = None) -> str:
+        """Create a person in both the real DB (for other queries) and the fake personhog client."""
+        person = _create_person(team=self.team, distinct_ids=distinct_ids, properties=properties or {}, immediate=True)
+        flush_persons_and_events()
+        fake.add_person(
+            team_id=team_id,
+            person_id=person.pk,
+            uuid=str(person.uuid),
+            properties=properties or {},
+            distinct_ids=distinct_ids,
+            is_identified=person.is_identified,
+            created_at=int(person.created_at.timestamp()) if person.created_at else 0,
+        )
+        return str(person.uuid)
+
+    def test_happy_path(self) -> None:
+        with fake_personhog_client() as fake:
+            self._seed_person(
+                fake, team_id=self.team.pk, distinct_ids=["user_1"], properties={"email": "user1@example.com"}
+            )
+            self._seed_person(
+                fake, team_id=self.team.pk, distinct_ids=["user_2"], properties={"email": "user2@example.com"}
+            )
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": ["user_1", "user_2"]},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertIn("user_1", results)
+            self.assertIn("user_2", results)
+            self.assertEqual(results["user_1"]["properties"]["email"], "user1@example.com")
+            self.assertEqual(results["user_2"]["properties"]["email"], "user2@example.com")
+
+            fake.assert_called("get_persons_by_distinct_ids_in_team")
+
+    def test_missing_ids(self) -> None:
+        with fake_personhog_client() as fake:
+            self._seed_person(
+                fake, team_id=self.team.pk, distinct_ids=["existing_user"], properties={"email": "exists@example.com"}
+            )
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": ["existing_user", "nonexistent_1", "nonexistent_2"]},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertIn("existing_user", results)
+            self.assertNotIn("nonexistent_1", results)
+            self.assertNotIn("nonexistent_2", results)
+
+    def test_same_person_multiple_ids(self) -> None:
+        with fake_personhog_client() as fake:
+            self._seed_person(
+                fake, team_id=self.team.pk, distinct_ids=["id_a", "id_b"], properties={"email": "multi@example.com"}
+            )
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": ["id_a", "id_b"]},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertIn("id_a", results)
+            self.assertIn("id_b", results)
+            self.assertEqual(results["id_a"]["uuid"], results["id_b"]["uuid"])
+
+    def test_empty_list(self) -> None:
+        with fake_personhog_client() as fake:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": []},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["results"], {})
+            fake.assert_not_called("get_persons_by_distinct_ids_in_team")
+
+    def test_invalid_input(self) -> None:
+        with fake_personhog_client() as fake:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": "not_a_list"},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["results"], {})
+            fake.assert_not_called("get_persons_by_distinct_ids_in_team")
+
+    def test_cross_team_isolation(self) -> None:
+        from posthog.models import Organization, Team
+
+        other_org, _, _ = Organization.objects.bootstrap(None, name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        with fake_personhog_client() as fake:
+            # Seed person in the OTHER team's personhog data
+            other_person = _create_person(
+                team=other_team,
+                distinct_ids=["other_team_user"],
+                properties={"email": "other@example.com"},
+                immediate=True,
+            )
+            fake.add_person(
+                team_id=other_team.pk,
+                person_id=other_person.pk,
+                uuid=str(other_person.uuid),
+                properties={"email": "other@example.com"},
+                distinct_ids=["other_team_user"],
+            )
+
+            self._seed_person(
+                fake, team_id=self.team.pk, distinct_ids=["my_team_user"], properties={"email": "mine@example.com"}
+            )
+            flush_persons_and_events()
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/persons/batch_by_distinct_ids/",
+                {"distinct_ids": ["my_team_user", "other_team_user"]},
+                format="json",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertIn("my_team_user", results)
+            self.assertNotIn("other_team_user", results)

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from functools import cached_property
 from typing import cast
 
-from django.db.models import Prefetch
 from django.utils.timezone import now
 
 import orjson
@@ -25,7 +24,7 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, get_query_runner
 from posthog.models import Action, Person
 from posthog.models.element import chain_to_elements
-from posthog.models.person.person import READ_DB_FOR_PERSONS, PersonDistinctId, get_distinct_ids_for_subquery
+from posthog.models.person.person import READ_DB_FOR_PERSONS, get_distinct_ids_for_subquery
 from posthog.models.person.util import get_persons_by_distinct_ids
 from posthog.utils import relative_date_parse
 
@@ -415,14 +414,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                 for i in range(0, len(distinct_ids), batch_size):
                     batch_distinct_ids = distinct_ids[i : i + batch_size]
                     persons = get_persons_by_distinct_ids(self.team.pk, batch_distinct_ids)
-                    persons = persons.prefetch_related(
-                        Prefetch(
-                            "persondistinctid_set",
-                            queryset=PersonDistinctId.objects.filter(team_id=self.team.pk).order_by("id"),
-                            to_attr="distinct_ids_cache",
-                        )
-                    )
-                    for person in persons.iterator(chunk_size=1000):
+                    for person in persons:
                         if person:
                             for person_distinct_id in person.distinct_ids:
                                 distinct_to_person[person_distinct_id] = person

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -413,11 +413,13 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                 batch_size = 1000
                 for i in range(0, len(distinct_ids), batch_size):
                     batch_distinct_ids = distinct_ids[i : i + batch_size]
+                    requested_batch = set(batch_distinct_ids)
                     persons = get_persons_by_distinct_ids(self.team.pk, batch_distinct_ids)
                     for person in persons:
                         if person:
                             for person_distinct_id in person.distinct_ids:
-                                distinct_to_person[person_distinct_id] = person
+                                if person_distinct_id in requested_batch:
+                                    distinct_to_person[person_distinct_id] = person
 
                 # Loop over all columns in case there is more than one "person" column
                 for column_index in person_indices:

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -206,7 +206,7 @@ class Person(models.Model):
     def distinct_ids(self) -> list[str]:
         if hasattr(self, "distinct_ids_cache"):
             return [id.distinct_id for id in self.distinct_ids_cache]
-        if hasattr(self, "_distinct_ids") and self._distinct_ids:
+        if hasattr(self, "_distinct_ids") and self._distinct_ids is not None:
             return self._distinct_ids
         return [
             id[0]

--- a/posthog/models/person/test/test_util_personhog_routing.py
+++ b/posthog/models/person/test/test_util_personhog_routing.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.models.person.util import get_persons_by_distinct_ids, get_persons_by_uuids
+
+
+class TestGetPersonsByUuidsRouting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "personhog_success",
+                True,
+                ["person_a", "person_b"],
+                None,
+                "personhog",
+            ),
+            (
+                "personhog_failure_falls_back_to_orm",
+                True,
+                None,
+                RuntimeError("grpc timeout"),
+                "django_orm",
+            ),
+            (
+                "gate_off_uses_orm_directly",
+                False,
+                None,
+                None,
+                "django_orm",
+            ),
+        ]
+    )
+    @patch("posthog.models.person.util.Person.objects")
+    @patch("posthog.models.person.util._fetch_persons_by_uuids_via_personhog")
+    @patch("posthog.personhog_client.gate.use_personhog")
+    @patch("posthog.models.person.util.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.models.person.util.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    def test_routing(
+        self,
+        _name,
+        gate_on,
+        personhog_data,
+        grpc_exception,
+        expected_source,
+        mock_errors_counter,
+        mock_routing_counter,
+        mock_use_personhog,
+        mock_fetch_personhog,
+        mock_objects,
+    ):
+        mock_use_personhog.return_value = gate_on
+
+        if personhog_data is not None:
+            mock_fetch_personhog.return_value = personhog_data
+        elif grpc_exception is not None:
+            mock_fetch_personhog.side_effect = grpc_exception
+
+        mock_qs = MagicMock()
+        mock_objects.db_manager.return_value.filter.return_value = mock_qs
+
+        team = MagicMock()
+        team.pk = 1
+        uuids = ["uuid-1", "uuid-2"]
+
+        result = get_persons_by_uuids(team, uuids)
+
+        if personhog_data is not None and gate_on:
+            assert result == personhog_data
+            mock_objects.db_manager.assert_not_called()
+        else:
+            assert result == mock_qs
+
+        mock_routing_counter.labels.assert_called_with(operation="get_persons_by_uuids", source=expected_source)
+
+        if grpc_exception is not None and gate_on:
+            mock_errors_counter.labels.assert_called_once()
+
+
+class TestGetPersonsByDistinctIdsRouting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "personhog_success",
+                True,
+                None,
+                "personhog",
+            ),
+            (
+                "personhog_failure_falls_back_to_orm",
+                True,
+                RuntimeError("grpc timeout"),
+                "django_orm",
+            ),
+            (
+                "gate_off_uses_orm_directly",
+                False,
+                None,
+                "django_orm",
+            ),
+        ]
+    )
+    @patch("posthog.models.person.util._fetch_persons_by_distinct_ids_via_personhog")
+    @patch("posthog.personhog_client.gate.use_personhog")
+    @patch("posthog.models.person.util.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.models.person.util.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    def test_routing(
+        self,
+        _name,
+        gate_on,
+        grpc_exception,
+        expected_source,
+        mock_errors_counter,
+        mock_routing_counter,
+        mock_use_personhog,
+        mock_fetch_personhog,
+    ):
+        mock_use_personhog.return_value = gate_on
+
+        personhog_persons = [MagicMock(), MagicMock()]
+        if grpc_exception is not None:
+            mock_fetch_personhog.side_effect = grpc_exception
+        else:
+            mock_fetch_personhog.return_value = personhog_persons
+
+        team_id = 1
+        distinct_ids = ["did-1", "did-2"]
+
+        if gate_on and grpc_exception is None:
+            result = get_persons_by_distinct_ids(team_id, distinct_ids)
+            assert result == personhog_persons
+        else:
+            with (
+                patch("posthog.models.person.util.Person.objects") as mock_person_objects,
+                patch("posthog.models.person.util.PersonDistinctId.objects"),
+                patch("django.db.models.query.Prefetch"),
+            ):
+                mock_qs = MagicMock()
+                mock_qs.__iter__ = MagicMock(return_value=iter([]))
+                mock_person_objects.db_manager.return_value.filter.return_value.prefetch_related.return_value = mock_qs
+
+                result = get_persons_by_distinct_ids(team_id, distinct_ids)
+                assert result == []
+
+        mock_routing_counter.labels.assert_called_with(operation="get_persons_by_distinct_ids", source=expected_source)
+
+        if grpc_exception is not None and gate_on:
+            mock_errors_counter.labels.assert_called_once()

--- a/posthog/models/person/test/test_util_personhog_routing.py
+++ b/posthog/models/person/test/test_util_personhog_routing.py
@@ -1,10 +1,16 @@
+from types import SimpleNamespace
+
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
-from posthog.models.person.util import get_persons_by_distinct_ids, get_persons_by_uuids
+from posthog.models.person.util import (
+    _fetch_persons_by_distinct_ids_via_personhog,
+    get_persons_by_distinct_ids,
+    get_persons_by_uuids,
+)
 
 
 class TestGetPersonsByUuidsRouting(SimpleTestCase):
@@ -152,3 +158,43 @@ class TestGetPersonsByDistinctIdsRouting(SimpleTestCase):
 
         if grpc_exception is not None and gate_on:
             mock_errors_counter.labels.assert_called_once()
+
+
+class TestFetchPersonsByDistinctIdsFiltering(SimpleTestCase):
+    @patch("posthog.personhog_client.client.get_personhog_client")
+    def test_missing_persons_are_excluded(self, mock_get_client):
+        real_person = SimpleNamespace(
+            id=42,
+            uuid="550e8400-e29b-41d4-a716-446655440000",
+            team_id=1,
+            properties=b'{"email": "real@example.com"}',
+            is_identified=True,
+            created_at=1700000000000,
+            last_seen_at=0,
+        )
+        # Entry with person=None (unresolved distinct_id)
+        missing_entry = SimpleNamespace(distinct_id="ghost", person=None)
+        # Entry with a default/empty person (id=0)
+        empty_entry = SimpleNamespace(distinct_id="empty", person=SimpleNamespace(id=0))
+        # Entry with a real person
+        valid_entry = SimpleNamespace(distinct_id="real_did", person=real_person)
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_persons_by_distinct_ids_in_team.return_value = SimpleNamespace(
+            results=[missing_entry, empty_entry, valid_entry]
+        )
+        mock_client.get_distinct_ids_for_persons.return_value = SimpleNamespace(
+            person_distinct_ids=[SimpleNamespace(person_id=42, distinct_ids=[SimpleNamespace(distinct_id="real_did")])]
+        )
+
+        result = _fetch_persons_by_distinct_ids_via_personhog(team_id=1, distinct_ids=["ghost", "empty", "real_did"])
+
+        assert len(result) == 1
+        assert result[0].id == 42
+        assert result[0].properties == {"email": "real@example.com"}
+        assert result[0].distinct_ids == ["real_did"]
+
+        # Verify only the valid person_id was sent to get_distinct_ids_for_persons
+        call_args = mock_client.get_distinct_ids_for_persons.call_args
+        assert call_args[0][0].person_ids == [42]

--- a/posthog/models/person/test/test_util_personhog_routing.py
+++ b/posthog/models/person/test/test_util_personhog_routing.py
@@ -73,7 +73,9 @@ class TestGetPersonsByUuidsRouting(SimpleTestCase):
         else:
             assert result == mock_qs
 
-        mock_routing_counter.labels.assert_called_with(operation="get_persons_by_uuids", source=expected_source)
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_persons_by_uuids", source=expected_source, client_name="posthog-django"
+        )
 
         if grpc_exception is not None and gate_on:
             mock_errors_counter.labels.assert_called_once()
@@ -144,7 +146,9 @@ class TestGetPersonsByDistinctIdsRouting(SimpleTestCase):
                 result = get_persons_by_distinct_ids(team_id, distinct_ids)
                 assert result == []
 
-        mock_routing_counter.labels.assert_called_with(operation="get_persons_by_distinct_ids", source=expected_source)
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_persons_by_distinct_ids", source=expected_source, client_name="posthog-django"
+        )
 
         if grpc_exception is not None and gate_on:
             mock_errors_counter.labels.assert_called_once()

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -10,6 +10,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.timezone import now
 
+import structlog
 from dateutil.parser import isoparse
 
 from posthog.clickhouse.client import sync_execute
@@ -26,7 +27,10 @@ from posthog.models.person.sql import (
 from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
 from posthog.settings import TEST
+
+logger = structlog.get_logger(__name__)
 
 if TEST:
     # :KLUDGE: Hooks are kept around for tests. All other code goes through plugin-server or the other methods explicitly
@@ -201,15 +205,98 @@ def create_person_distinct_id(
     )
 
 
-def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> QuerySet:
-    return Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(
-        team_id=team_id,
-        persondistinctid__team_id=team_id,
-        persondistinctid__distinct_id__in=distinct_ids,
+def _fetch_persons_by_distinct_ids_via_personhog(team_id: int, distinct_ids: list[str]) -> list[Person]:
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_person_to_model
+    from posthog.personhog_client.proto import GetDistinctIdsForPersonsRequest, GetPersonsByDistinctIdsInTeamRequest
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    resp = client.get_persons_by_distinct_ids_in_team(
+        GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
     )
 
+    person_ids = [r.person.id for r in resp.results]
+    distinct_ids_resp = client.get_distinct_ids_for_persons(
+        GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
+    )
 
-def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet:
+    distinct_ids_by_person: dict[int, list[str]] = {}
+    for pd in distinct_ids_resp.person_distinct_ids:
+        distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+
+    return [
+        proto_person_to_model(r.person, distinct_ids=distinct_ids_by_person.get(r.person.id, [])) for r in resp.results
+    ]
+
+
+def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> list[Person]:
+    from posthog.personhog_client.gate import use_personhog
+
+    if use_personhog():
+        try:
+            result = _fetch_persons_by_distinct_ids_via_personhog(team_id, distinct_ids)
+            PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_distinct_ids", source="personhog").inc()
+            return result
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="get_persons_by_distinct_ids", source="personhog", error_type="grpc_error"
+            ).inc()
+            logger.warning("personhog_get_persons_by_distinct_ids_failure", team_id=team_id, exc_info=True)
+
+    from django.db.models.query import Prefetch
+
+    persons = (
+        Person.objects.db_manager(READ_DB_FOR_PERSONS)
+        .filter(
+            team_id=team_id,
+            persondistinctid__team_id=team_id,
+            persondistinctid__distinct_id__in=distinct_ids,
+        )
+        .prefetch_related(
+            Prefetch(
+                "persondistinctid_set",
+                queryset=PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+                .filter(team_id=team_id)
+                .order_by("id"),
+                to_attr="distinct_ids_cache",
+            )
+        )
+    )
+    PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_distinct_ids", source="django_orm").inc()
+    return list(persons)
+
+
+def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[Person]:
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_person_to_model
+    from posthog.personhog_client.proto import GetPersonsByUuidsRequest
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
+    return [proto_person_to_model(p) for p in resp.persons]
+
+
+def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet | list[Person]:
+    from posthog.personhog_client.gate import use_personhog
+
+    if use_personhog():
+        try:
+            result = _fetch_persons_by_uuids_via_personhog(team.pk, uuids)
+            PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_uuids", source="personhog").inc()
+            return result
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="get_persons_by_uuids", source="personhog", error_type="grpc_error"
+            ).inc()
+            logger.warning("personhog_get_persons_by_uuids_failure", team_id=team.pk, exc_info=True)
+
+    PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_uuids", source="django_orm").inc()
     return Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team_id=team.pk, uuid__in=uuids)
 
 

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -27,7 +27,12 @@ from posthog.models.person.sql import (
 from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
+from posthog.personhog_client.metrics import (
+    PERSONHOG_ROUTING_ERRORS_TOTAL,
+    PERSONHOG_ROUTING_TOTAL,
+    PERSONHOG_TEAM_MISMATCH_TOTAL,
+    get_client_name,
+)
 from posthog.settings import TEST
 
 logger = structlog.get_logger(__name__)
@@ -218,7 +223,16 @@ def _fetch_persons_by_distinct_ids_via_personhog(team_id: int, distinct_ids: lis
         GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
     )
 
-    valid_results = [r for r in resp.results if r.person and r.person.id]
+    valid_results = [r for r in resp.results if r.person and r.person.id and r.person.team_id == team_id]
+
+    mismatched = len(resp.results) - len(valid_results)
+    if mismatched:
+        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
+            operation="get_persons_by_distinct_ids", client_name=get_client_name()
+        ).inc(mismatched)
+        logger.warning(
+            "personhog_team_mismatch", operation="get_persons_by_distinct_ids", team_id=team_id, dropped=mismatched
+        )
 
     person_ids = [r.person.id for r in valid_results]
     distinct_ids_resp = client.get_distinct_ids_for_persons(
@@ -289,7 +303,16 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
 
     resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
 
-    person_ids = [p.id for p in resp.persons]
+    valid_persons = [p for p in resp.persons if p.id and p.team_id == team_id]
+
+    mismatched = len(resp.persons) - len(valid_persons)
+    if mismatched:
+        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_persons_by_uuids", client_name=get_client_name()).inc(
+            mismatched
+        )
+        logger.warning("personhog_team_mismatch", operation="get_persons_by_uuids", team_id=team_id, dropped=mismatched)
+
+    person_ids = [p.id for p in valid_persons]
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )
@@ -298,7 +321,7 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
     for pd in distinct_ids_resp.person_distinct_ids:
         distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
 
-    return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in resp.persons]
+    return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
 
 
 def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet | list[Person]:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -235,6 +235,9 @@ def _fetch_persons_by_distinct_ids_via_personhog(team_id: int, distinct_ids: lis
         )
 
     person_ids = [r.person.id for r in valid_results]
+    if not person_ids:
+        return []
+
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )
@@ -313,6 +316,9 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
         logger.warning("personhog_team_mismatch", operation="get_persons_by_uuids", team_id=team_id, dropped=mismatched)
 
     person_ids = [p.id for p in valid_persons]
+    if not person_ids:
+        return []
+
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -272,14 +272,24 @@ def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> list[P
 def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> list[Person]:
     from posthog.personhog_client.client import get_personhog_client
     from posthog.personhog_client.converters import proto_person_to_model
-    from posthog.personhog_client.proto import GetPersonsByUuidsRequest
+    from posthog.personhog_client.proto import GetDistinctIdsForPersonsRequest, GetPersonsByUuidsRequest
 
     client = get_personhog_client()
     if client is None:
         raise RuntimeError("personhog client not configured")
 
     resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
-    return [proto_person_to_model(p) for p in resp.persons]
+
+    person_ids = [p.id for p in resp.persons]
+    distinct_ids_resp = client.get_distinct_ids_for_persons(
+        GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
+    )
+
+    distinct_ids_by_person: dict[int, list[str]] = {}
+    for pd in distinct_ids_resp.person_distinct_ids:
+        distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
+
+    return [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in resp.persons]
 
 
 def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet | list[Person]:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -27,7 +27,7 @@ from posthog.models.person.sql import (
 from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.settings import TEST
 
 logger = structlog.get_logger(__name__)
@@ -238,11 +238,16 @@ def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> list[P
     if use_personhog():
         try:
             result = _fetch_persons_by_distinct_ids_via_personhog(team_id, distinct_ids)
-            PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_distinct_ids", source="personhog").inc()
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="get_persons_by_distinct_ids", source="personhog", client_name=get_client_name()
+            ).inc()
             return result
         except Exception:
             PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                operation="get_persons_by_distinct_ids", source="personhog", error_type="grpc_error"
+                operation="get_persons_by_distinct_ids",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
             ).inc()
             logger.warning("personhog_get_persons_by_distinct_ids_failure", team_id=team_id, exc_info=True)
 
@@ -265,7 +270,9 @@ def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> list[P
             )
         )
     )
-    PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_distinct_ids", source="django_orm").inc()
+    PERSONHOG_ROUTING_TOTAL.labels(
+        operation="get_persons_by_distinct_ids", source="django_orm", client_name=get_client_name()
+    ).inc()
     return list(persons)
 
 
@@ -298,15 +305,22 @@ def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet | list[Person
     if use_personhog():
         try:
             result = _fetch_persons_by_uuids_via_personhog(team.pk, uuids)
-            PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_uuids", source="personhog").inc()
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="get_persons_by_uuids", source="personhog", client_name=get_client_name()
+            ).inc()
             return result
         except Exception:
             PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                operation="get_persons_by_uuids", source="personhog", error_type="grpc_error"
+                operation="get_persons_by_uuids",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
             ).inc()
             logger.warning("personhog_get_persons_by_uuids_failure", team_id=team.pk, exc_info=True)
 
-    PERSONHOG_ROUTING_TOTAL.labels(operation="get_persons_by_uuids", source="django_orm").inc()
+    PERSONHOG_ROUTING_TOTAL.labels(
+        operation="get_persons_by_uuids", source="django_orm", client_name=get_client_name()
+    ).inc()
     return Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team_id=team.pk, uuid__in=uuids)
 
 

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -218,7 +218,9 @@ def _fetch_persons_by_distinct_ids_via_personhog(team_id: int, distinct_ids: lis
         GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
     )
 
-    person_ids = [r.person.id for r in resp.results]
+    valid_results = [r for r in resp.results if r.person and r.person.id]
+
+    person_ids = [r.person.id for r in valid_results]
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )
@@ -228,7 +230,7 @@ def _fetch_persons_by_distinct_ids_via_personhog(team_id: int, distinct_ids: lis
         distinct_ids_by_person[pd.person_id] = [d.distinct_id for d in pd.distinct_ids]
 
     return [
-        proto_person_to_model(r.person, distinct_ids=distinct_ids_by_person.get(r.person.id, [])) for r in resp.results
+        proto_person_to_model(r.person, distinct_ids=distinct_ids_by_person.get(r.person.id, [])) for r in valid_results
     ]
 
 

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -6,7 +6,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2
+    from posthog.models.person import Person
+    from posthog.personhog_client.proto.generated.personhog.types.v1 import group_pb2, person_pb2
 
 
 def proto_group_type_mapping_to_dict(mapping: group_pb2.GroupTypeMapping) -> dict[str, Any]:
@@ -47,6 +48,30 @@ def proto_group_type_mapping_to_result(mapping: group_pb2.GroupTypeMapping) -> G
         group_type=mapping.group_type,
         group_type_index=mapping.group_type_index,
     )
+
+
+def proto_person_to_model(
+    person: person_pb2.Person,
+    distinct_ids: list[str] | None = None,
+) -> Person:
+    """Convert a proto Person to a Django Person model instance (unsaved).
+
+    The instance is NOT saved to the database.  It carries data in memory
+    so that existing serializers and property accessors work without modification.
+    """
+    from posthog.models.person import Person as PersonModel
+
+    obj = PersonModel(
+        id=person.id,
+        uuid=person.uuid,
+        team_id=person.team_id,
+        properties=json.loads(person.properties) if person.properties else {},
+        is_identified=person.is_identified,
+        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else None,
+    )
+    if distinct_ids is not None:
+        obj._distinct_ids = distinct_ids
+    return obj
 
 
 def fetch_group_type_mapping_result(project_id: int, group_type_index: int) -> GroupTypeMappingResult | None:

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -22,7 +22,7 @@ def proto_group_type_mapping_to_dict(mapping: group_pb2.GroupTypeMapping) -> dic
 
     created_at: datetime | None = None
     if mapping.created_at:
-        created_at = datetime.fromtimestamp(mapping.created_at, tz=UTC)
+        created_at = datetime.fromtimestamp(mapping.created_at / 1000, tz=UTC)
 
     return {
         "group_type": mapping.group_type or None,
@@ -67,7 +67,7 @@ def proto_person_to_model(
         team_id=person.team_id,
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,
-        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else datetime.now(UTC),
+        created_at=datetime.fromtimestamp(person.created_at / 1000, tz=UTC) if person.created_at else datetime.now(UTC),
         last_seen_at=datetime.fromtimestamp(person.last_seen_at / 1000, tz=UTC) if person.last_seen_at else None,
     )
     if distinct_ids is not None:

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -67,7 +67,7 @@ def proto_person_to_model(
         team_id=person.team_id,
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,
-        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else None,
+        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else datetime.now(tz=UTC),
     )
     if distinct_ids is not None:
         obj._distinct_ids = distinct_ids

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -67,7 +67,7 @@ def proto_person_to_model(
         team_id=person.team_id,
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,
-        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else datetime.now(tz=UTC),
+        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else None,
     )
     if distinct_ids is not None:
         obj._distinct_ids = distinct_ids

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -68,6 +68,7 @@ def proto_person_to_model(
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,
         created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else datetime.now(UTC),
+        last_seen_at=datetime.fromtimestamp(person.last_seen_at / 1000, tz=UTC) if person.last_seen_at else None,
     )
     if distinct_ids is not None:
         obj._distinct_ids = distinct_ids

--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -67,7 +67,7 @@ def proto_person_to_model(
         team_id=person.team_id,
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,
-        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else None,
+        created_at=datetime.fromtimestamp(person.created_at, tz=UTC) if person.created_at else datetime.now(UTC),
     )
     if distinct_ids is not None:
         obj._distinct_ids = distinct_ids

--- a/posthog/personhog_client/metrics.py
+++ b/posthog/personhog_client/metrics.py
@@ -20,3 +20,9 @@ PERSONHOG_ROUTING_ERRORS_TOTAL = Counter(
     "Errors encountered during personhog routing (triggers fallback to ORM)",
     labelnames=["operation", "source", "error_type", "client_name"],
 )
+
+PERSONHOG_TEAM_MISMATCH_TOTAL = Counter(
+    "personhog_team_mismatch_total",
+    "Persons dropped because personhog returned a mismatched team_id",
+    labelnames=["operation", "client_name"],
+)

--- a/posthog/personhog_client/test_converters.py
+++ b/posthog/personhog_client/test_converters.py
@@ -147,6 +147,7 @@ def _make_proto_person(**kwargs) -> SimpleNamespace:
         "version": 0,
         "is_identified": False,
         "is_user_id": False,
+        "last_seen_at": 0,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -164,6 +165,7 @@ class TestProtoPersonToModel:
                     "properties": json.dumps({"email": "test@example.com", "name": "Test"}).encode(),
                     "created_at": 1700000000,
                     "is_identified": True,
+                    "last_seen_at": 1700000000000,
                 },
                 None,
             ),
@@ -203,6 +205,11 @@ class TestProtoPersonToModel:
         else:
             # When proto has no created_at, we fall back to now() since the Django field is non-nullable
             assert isinstance(person.created_at, datetime)
+
+        if proto_kwargs.get("last_seen_at"):
+            assert person.last_seen_at == datetime.fromtimestamp(proto_kwargs["last_seen_at"] / 1000, tz=UTC)
+        else:
+            assert person.last_seen_at is None
 
         if distinct_ids is not None:
             assert person.distinct_ids == distinct_ids

--- a/posthog/personhog_client/test_converters.py
+++ b/posthog/personhog_client/test_converters.py
@@ -201,7 +201,8 @@ class TestProtoPersonToModel:
         if proto_kwargs.get("created_at"):
             assert person.created_at == datetime.fromtimestamp(proto_kwargs["created_at"], tz=UTC)
         else:
-            assert person.created_at is None
+            # When proto has no created_at, we fall back to now() since the Django field is non-nullable
+            assert isinstance(person.created_at, datetime)
 
         if distinct_ids is not None:
             assert person.distinct_ids == distinct_ids

--- a/posthog/personhog_client/test_converters.py
+++ b/posthog/personhog_client/test_converters.py
@@ -47,7 +47,7 @@ class TestProtoGroupTypeMappingToDict:
                     "name_plural": "Organizations",
                     "default_columns": json.dumps(["name", "industry"]).encode(),
                     "detail_dashboard_id": 42,
-                    "created_at": 1700000000,
+                    "created_at": 1700000000000,
                 },
                 {
                     "group_type": "organization",
@@ -163,7 +163,7 @@ class TestProtoPersonToModel:
                     "uuid": "550e8400-e29b-41d4-a716-446655440000",
                     "team_id": 10,
                     "properties": json.dumps({"email": "test@example.com", "name": "Test"}).encode(),
-                    "created_at": 1700000000,
+                    "created_at": 1700000000000,
                     "is_identified": True,
                     "last_seen_at": 1700000000000,
                 },
@@ -181,7 +181,7 @@ class TestProtoPersonToModel:
                     "uuid": "550e8400-e29b-41d4-a716-446655440002",
                     "team_id": 3,
                     "properties": json.dumps({"foo": "bar"}).encode(),
-                    "created_at": 1700000000,
+                    "created_at": 1700000000000,
                 },
                 ["did1", "did2"],
             ),
@@ -201,7 +201,7 @@ class TestProtoPersonToModel:
         assert person.properties == expected_props
 
         if proto_kwargs.get("created_at"):
-            assert person.created_at == datetime.fromtimestamp(proto_kwargs["created_at"], tz=UTC)
+            assert person.created_at == datetime.fromtimestamp(proto_kwargs["created_at"] / 1000, tz=UTC)
         else:
             # When proto has no created_at, we fall back to now() since the Django field is non-nullable
             assert isinstance(person.created_at, datetime)

--- a/posthog/personhog_client/test_converters.py
+++ b/posthog/personhog_client/test_converters.py
@@ -10,6 +10,7 @@ from posthog.personhog_client.converters import (
     GroupTypeMappingResult,
     proto_group_type_mapping_to_dict,
     proto_group_type_mapping_to_result,
+    proto_person_to_model,
 )
 
 
@@ -132,3 +133,77 @@ class TestProtoGroupTypeMappingToResult:
         result = GroupTypeMappingResult(group_type="org", group_type_index=0)
         with pytest.raises(AttributeError):
             result.group_type = "changed"  # type: ignore
+
+
+def _make_proto_person(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "id": 0,
+        "uuid": "",
+        "team_id": 0,
+        "properties": b"",
+        "properties_last_updated_at": b"",
+        "properties_last_operation": b"",
+        "created_at": 0,
+        "version": 0,
+        "is_identified": False,
+        "is_user_id": False,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestProtoPersonToModel:
+    @parameterized.expand(
+        [
+            (
+                "all_fields_populated",
+                {
+                    "id": 42,
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "team_id": 10,
+                    "properties": json.dumps({"email": "test@example.com", "name": "Test"}).encode(),
+                    "created_at": 1700000000,
+                    "is_identified": True,
+                },
+                None,
+            ),
+            (
+                "empty_properties",
+                {"id": 1, "uuid": "550e8400-e29b-41d4-a716-446655440001", "team_id": 5},
+                None,
+            ),
+            (
+                "with_distinct_ids",
+                {
+                    "id": 7,
+                    "uuid": "550e8400-e29b-41d4-a716-446655440002",
+                    "team_id": 3,
+                    "properties": json.dumps({"foo": "bar"}).encode(),
+                    "created_at": 1700000000,
+                },
+                ["did1", "did2"],
+            ),
+        ]
+    )
+    def test_conversion(self, _name: str, proto_kwargs: dict, distinct_ids: list[str] | None):
+        proto = _make_proto_person(**proto_kwargs)
+        person = proto_person_to_model(proto, distinct_ids=distinct_ids)  # type: ignore[arg-type]
+
+        assert person.id == proto_kwargs.get("id", 0)
+        assert str(person.uuid) == proto_kwargs.get("uuid", "")
+        assert person.team_id == proto_kwargs.get("team_id", 0)
+        assert person.is_identified == proto_kwargs.get("is_identified", False)
+
+        raw_props = proto_kwargs.get("properties", b"")
+        expected_props = json.loads(raw_props) if raw_props else {}
+        assert person.properties == expected_props
+
+        if proto_kwargs.get("created_at"):
+            assert person.created_at == datetime.fromtimestamp(proto_kwargs["created_at"], tz=UTC)
+        else:
+            assert person.created_at is None
+
+        if distinct_ids is not None:
+            assert person.distinct_ids == distinct_ids
+        else:
+            assert not hasattr(person, "_distinct_ids") or person._distinct_ids is None

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -19,7 +19,12 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
 from posthog.models.person.person import READ_DB_FOR_PERSONS
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
+from posthog.personhog_client.metrics import (
+    PERSONHOG_ROUTING_ERRORS_TOTAL,
+    PERSONHOG_ROUTING_TOTAL,
+    PERSONHOG_TEAM_MISMATCH_TOTAL,
+    get_client_name,
+)
 from posthog.queries.insight import insight_sync_execute
 
 logger = structlog.get_logger(__name__)
@@ -272,7 +277,14 @@ def _fetch_people_via_personhog(
     uuids = [str(pid) for pid in people_ids]
     resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
 
-    person_ids = [p.id for p in resp.persons]
+    valid_persons = [p for p in resp.persons if p.id and p.team_id == team_id]
+
+    mismatched = len(resp.persons) - len(valid_persons)
+    if mismatched:
+        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_people", client_name=get_client_name()).inc(mismatched)
+        logger.warning("personhog_team_mismatch", operation="get_people", team_id=team_id, dropped=mismatched)
+
+    person_ids = [p.id for p in valid_persons]
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )
@@ -284,7 +296,7 @@ def _fetch_people_via_personhog(
             dids = dids[:distinct_id_limit]
         distinct_ids_by_person[pd.person_id] = dids
 
-    persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in resp.persons]
+    persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
     persons.sort(key=lambda p: (-(p.created_at.timestamp() if p.created_at else 0), str(p.uuid)))
 
     return persons

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -258,7 +258,9 @@ def get_groups(
     return groups, serialize_groups(groups, value_per_actor_id)
 
 
-def _fetch_people_via_personhog(team_id: int, people_ids: list[Any], distinct_id_limit: int = 1000) -> list[Person]:
+def _fetch_people_via_personhog(
+    team_id: int, people_ids: list[Any], distinct_id_limit: int | None = 1000
+) -> list[Person]:
     from posthog.personhog_client.client import get_personhog_client
     from posthog.personhog_client.converters import proto_person_to_model
     from posthog.personhog_client.proto import GetDistinctIdsForPersonsRequest, GetPersonsByUuidsRequest
@@ -292,7 +294,7 @@ def get_people(
     team: Team,
     people_ids: list[Any],
     value_per_actor_id: Optional[dict[str, float]] = None,
-    distinct_id_limit=1000,
+    distinct_id_limit: int | None = 1000,
 ) -> tuple[Union[QuerySet[Person], list[Person]], list[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     from posthog.personhog_client.gate import use_personhog
@@ -332,7 +334,10 @@ def get_people(
 
 # A faster get_people if you don't need the Person objects
 def get_serialized_people(
-    team: Team, people_ids: list[Any], value_per_actor_id: Optional[dict[str, float]] = None, distinct_id_limit=1000
+    team: Team,
+    people_ids: list[Any],
+    value_per_actor_id: Optional[dict[str, float]] = None,
+    distinct_id_limit: int | None = 1000,
 ) -> list[SerializedPerson]:
     persons_dict = PersonStrategy(team, ActorsQuery(), HogQLHasMorePaginator()).get_actors(
         people_ids, sort_by_created_at_descending=True

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -285,10 +285,13 @@ def _fetch_people_via_personhog(
         logger.warning("personhog_team_mismatch", operation="get_people", team_id=team_id, dropped=mismatched)
 
     person_ids = [p.id for p in valid_persons]
+    if not person_ids:
+        return []
+
+    # distinct_id_limit is enforced client-side; the proto does not support server-side truncation yet
     distinct_ids_resp = client.get_distinct_ids_for_persons(
         GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
     )
-
     distinct_ids_by_person: dict[int, list[str]] = {}
     for pd in distinct_ids_resp.person_distinct_ids:
         dids = [d.distinct_id for d in pd.distinct_ids]
@@ -298,7 +301,6 @@ def _fetch_people_via_personhog(
 
     persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in valid_persons]
     persons.sort(key=lambda p: (-(p.created_at.timestamp() if p.created_at else 0), str(p.uuid)))
-
     return persons
 
 

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -19,7 +19,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
 from posthog.models.person.person import READ_DB_FOR_PERSONS
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.queries.insight import insight_sync_execute
 
 logger = structlog.get_logger(__name__)
@@ -302,11 +302,13 @@ def get_people(
     if use_personhog():
         try:
             persons = _fetch_people_via_personhog(team.pk, people_ids, distinct_id_limit)
-            PERSONHOG_ROUTING_TOTAL.labels(operation="get_people", source="personhog").inc()
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="get_people", source="personhog", client_name=get_client_name()
+            ).inc()
             return persons, serialize_people(team, persons, value_per_actor_id)
         except Exception:
             PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                operation="get_people", source="personhog", error_type="grpc_error"
+                operation="get_people", source="personhog", error_type="grpc_error", client_name=get_client_name()
             ).inc()
             logger.warning("personhog_get_people_failure", team_id=team.pk, exc_info=True)
 
@@ -328,7 +330,7 @@ def get_people(
         .order_by("-created_at", "uuid")
         .only("id", "is_identified", "created_at", "properties", "uuid", "team_id")
     )
-    PERSONHOG_ROUTING_TOTAL.labels(operation="get_people", source="django_orm").inc()
+    PERSONHOG_ROUTING_TOTAL.labels(operation="get_people", source="django_orm", client_name=get_client_name()).inc()
     return persons_qs, serialize_people(team, persons_qs, value_per_actor_id)
 
 

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -97,7 +97,7 @@ class ActorBaseQuery:
     def get_actors(
         self,
     ) -> tuple[
-        Union[QuerySet[Person], QuerySet[Group]],
+        Union[QuerySet[Person], QuerySet[Group], list[Person]],
         Union[list[SerializedGroup], list[SerializedPerson]],
         int,
     ]:
@@ -215,7 +215,7 @@ class ActorBaseQuery:
     def get_actors_from_result(
         self, raw_result
     ) -> tuple[
-        Union[QuerySet[Person], QuerySet[Group]],
+        Union[QuerySet[Person], QuerySet[Group], list[Person]],
         Union[list[SerializedGroup], list[SerializedPerson]],
     ]:
         actors: Union[QuerySet[Person], QuerySet[Group], list[Person]]

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -5,6 +5,8 @@ from typing import Any, Literal, Optional, TypedDict, Union, cast
 from django.db.models import OuterRef, Subquery
 from django.db.models.query import Prefetch, QuerySet
 
+import structlog
+
 from posthog.schema import ActorsQuery
 
 from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_TRENDS
@@ -17,7 +19,10 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
 from posthog.models.person.person import READ_DB_FOR_PERSONS
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
 from posthog.queries.insight import insight_sync_execute
+
+logger = structlog.get_logger(__name__)
 
 
 class EventInfoForRecording(TypedDict):
@@ -253,19 +258,62 @@ def get_groups(
     return groups, serialize_groups(groups, value_per_actor_id)
 
 
+def _fetch_people_via_personhog(team_id: int, people_ids: list[Any], distinct_id_limit: int = 1000) -> list[Person]:
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_person_to_model
+    from posthog.personhog_client.proto import GetDistinctIdsForPersonsRequest, GetPersonsByUuidsRequest
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    uuids = [str(pid) for pid in people_ids]
+    resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
+
+    person_ids = [p.id for p in resp.persons]
+    distinct_ids_resp = client.get_distinct_ids_for_persons(
+        GetDistinctIdsForPersonsRequest(team_id=team_id, person_ids=person_ids)
+    )
+
+    distinct_ids_by_person: dict[int, list[str]] = {}
+    for pd in distinct_ids_resp.person_distinct_ids:
+        dids = [d.distinct_id for d in pd.distinct_ids]
+        if distinct_id_limit is not None:
+            dids = dids[:distinct_id_limit]
+        distinct_ids_by_person[pd.person_id] = dids
+
+    persons = [proto_person_to_model(p, distinct_ids=distinct_ids_by_person.get(p.id, [])) for p in resp.persons]
+    persons.sort(key=lambda p: (-(p.created_at.timestamp() if p.created_at else 0), str(p.uuid)))
+
+    return persons
+
+
 def get_people(
     team: Team,
     people_ids: list[Any],
     value_per_actor_id: Optional[dict[str, float]] = None,
     distinct_id_limit=1000,
-) -> tuple[QuerySet[Person], list[SerializedPerson]]:
+) -> tuple[Union[QuerySet[Person], list[Person]], list[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
+    from posthog.personhog_client.gate import use_personhog
+
+    if use_personhog():
+        try:
+            persons = _fetch_people_via_personhog(team.pk, people_ids, distinct_id_limit)
+            PERSONHOG_ROUTING_TOTAL.labels(operation="get_people", source="personhog").inc()
+            return persons, serialize_people(team, persons, value_per_actor_id)
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="get_people", source="personhog", error_type="grpc_error"
+            ).inc()
+            logger.warning("personhog_get_people_failure", team_id=team.pk, exc_info=True)
+
     distinct_id_subquery = Subquery(
         PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
         .filter(team_id=team.pk, person_id=OuterRef("person_id"))
         .values_list("id", flat=True)[:distinct_id_limit]
     )
-    persons: QuerySet[Person] = (
+    persons_qs: QuerySet[Person] = (
         Person.objects.db_manager(READ_DB_FOR_PERSONS)
         .filter(team_id=team.pk, uuid__in=people_ids)
         .prefetch_related(
@@ -278,7 +326,8 @@ def get_people(
         .order_by("-created_at", "uuid")
         .only("id", "is_identified", "created_at", "properties", "uuid", "team_id")
     )
-    return persons, serialize_people(team, persons, value_per_actor_id)
+    PERSONHOG_ROUTING_TOTAL.labels(operation="get_people", source="django_orm").inc()
+    return persons_qs, serialize_people(team, persons_qs, value_per_actor_id)
 
 
 # A faster get_people if you don't need the Person objects

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -218,7 +218,7 @@ class ActorBaseQuery:
         Union[QuerySet[Person], QuerySet[Group]],
         Union[list[SerializedGroup], list[SerializedPerson]],
     ]:
-        actors: Union[QuerySet[Person], QuerySet[Group]]
+        actors: Union[QuerySet[Person], QuerySet[Group], list[Person]]
         serialized_actors: Union[list[SerializedGroup], list[SerializedPerson]]
 
         actor_ids = [row[0] for row in raw_result]

--- a/posthog/queries/test/test_actor_base_query_personhog_routing.py
+++ b/posthog/queries/test/test_actor_base_query_personhog_routing.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.queries.actor_base_query import get_people
+
+
+class TestGetPeopleRouting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "personhog_success",
+                True,
+                None,
+                "personhog",
+            ),
+            (
+                "personhog_failure_falls_back_to_orm",
+                True,
+                RuntimeError("grpc timeout"),
+                "django_orm",
+            ),
+            (
+                "gate_off_uses_orm_directly",
+                False,
+                None,
+                "django_orm",
+            ),
+        ]
+    )
+    @patch("posthog.queries.actor_base_query._fetch_people_via_personhog")
+    @patch("posthog.personhog_client.gate.use_personhog")
+    @patch("posthog.queries.actor_base_query.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.queries.actor_base_query.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    @patch("posthog.queries.actor_base_query.serialize_people")
+    def test_routing(
+        self,
+        _name,
+        gate_on,
+        grpc_exception,
+        expected_source,
+        mock_serialize,
+        mock_errors_counter,
+        mock_routing_counter,
+        mock_use_personhog,
+        mock_fetch_personhog,
+    ):
+        mock_use_personhog.return_value = gate_on
+
+        personhog_persons = [MagicMock(), MagicMock()]
+        if grpc_exception is not None:
+            mock_fetch_personhog.side_effect = grpc_exception
+        else:
+            mock_fetch_personhog.return_value = personhog_persons
+
+        mock_serialize.return_value = [{"type": "person", "id": "test"}]
+
+        team = MagicMock()
+        team.pk = 1
+        people_ids = ["uuid-1", "uuid-2"]
+
+        if gate_on and grpc_exception is None:
+            result_persons, _ = get_people(team, people_ids)
+            assert result_persons == personhog_persons
+        else:
+            with (
+                patch("posthog.queries.actor_base_query.Person.objects") as mock_person_objects,
+                patch("posthog.queries.actor_base_query.PersonDistinctId.objects"),
+                patch("posthog.queries.actor_base_query.Prefetch"),
+                patch("posthog.queries.actor_base_query.Subquery"),
+            ):
+                mock_qs = MagicMock()
+                mock_person_objects.db_manager.return_value.filter.return_value.prefetch_related.return_value.order_by.return_value.only.return_value = mock_qs
+
+                result_persons, _ = get_people(team, people_ids)
+                assert result_persons == mock_qs
+
+        mock_routing_counter.labels.assert_called_with(operation="get_people", source=expected_source)
+
+        if grpc_exception is not None and gate_on:
+            mock_errors_counter.labels.assert_called_once()

--- a/posthog/queries/test/test_actor_base_query_personhog_routing.py
+++ b/posthog/queries/test/test_actor_base_query_personhog_routing.py
@@ -77,7 +77,9 @@ class TestGetPeopleRouting(SimpleTestCase):
                 result_persons, _ = get_people(team, people_ids)
                 assert result_persons == mock_qs
 
-        mock_routing_counter.labels.assert_called_with(operation="get_people", source=expected_source)
+        mock_routing_counter.labels.assert_called_with(
+            operation="get_people", source=expected_source, client_name="posthog-django"
+        )
 
         if grpc_exception is not None and gate_on:
             mock_errors_counter.labels.assert_called_once()

--- a/posthog/queries/test/test_actors_base_query.py
+++ b/posthog/queries/test/test_actors_base_query.py
@@ -56,7 +56,7 @@ class TestActorsBaseQuery(ClickhouseTestMixin, APIBaseTest):
         persons_queryset, serialized = get_people(self.team, people_ids)
 
         assert len(serialized) == 2
-        assert persons_queryset.count() == 2
+        assert len(persons_queryset) == 2
 
     @snapshot_postgres_queries
     def test_get_people_with_value_per_actor(self):

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -150,7 +150,7 @@ class SessionRecording(UUIDTModel):
 
         from posthog.personhog_client.gate import use_personhog
 
-        if use_personhog():
+        if use_personhog() and self.distinct_id:
             try:
                 person = _fetch_person_by_distinct_id_via_personhog(self.team.pk, self.distinct_id)
                 if person is not None:

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -9,7 +9,12 @@ from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.person import READ_DB_FOR_PERSONS, Person
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDTModel
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
+from posthog.personhog_client.metrics import (
+    PERSONHOG_ROUTING_ERRORS_TOTAL,
+    PERSONHOG_ROUTING_TOTAL,
+    PERSONHOG_TEAM_MISMATCH_TOTAL,
+    get_client_name,
+)
 from posthog.session_recordings.models.metadata import RecordingMatchingEvents, RecordingMetadata
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
@@ -27,11 +32,14 @@ def _fetch_person_by_distinct_id_via_personhog(team_id: int, distinct_id: str) -
         raise RuntimeError("personhog client not configured")
 
     resp = client.get_person_by_distinct_id(GetPersonByDistinctIdRequest(team_id=team_id, distinct_id=distinct_id))
-    if resp.person and resp.person.id:
+    if resp.person and resp.person.id and resp.person.team_id == team_id:
         # Only pass the queried distinct_id — the list endpoint also intentionally
         # sets a single distinct_id to avoid expensive all-distinct-ids lookups.
         # The MinimalPersonSerializer truncates to 10 anyway.
         return proto_person_to_model(resp.person, distinct_ids=[distinct_id])
+    if resp.person and resp.person.id and resp.person.team_id != team_id:
+        PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="load_person", client_name=get_client_name()).inc()
+        logger.warning("personhog_team_mismatch", operation="load_person", team_id=team_id, dropped=1)
     return None
 
 
@@ -166,9 +174,7 @@ class SessionRecording(UUIDTModel):
                 PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
                     operation="load_person", source="personhog", error_type="grpc_error", client_name=get_client_name()
                 ).inc()
-                logger.warning(
-                    "personhog_load_person_failure", team_id=self.team.pk, distinct_id=self.distinct_id, exc_info=True
-                )
+                logger.warning("personhog_load_person_failure", team_id=self.team.pk, exc_info=True)
 
         try:
             self.person = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -28,6 +28,9 @@ def _fetch_person_by_distinct_id_via_personhog(team_id: int, distinct_id: str) -
 
     resp = client.get_person_by_distinct_id(GetPersonByDistinctIdRequest(team_id=team_id, distinct_id=distinct_id))
     if resp.person and resp.person.id:
+        # Only pass the queried distinct_id — the list endpoint also intentionally
+        # sets a single distinct_id to avoid expensive all-distinct-ids lookups.
+        # The MinimalPersonSerializer truncates to 10 anyway.
         return proto_person_to_model(resp.person, distinct_ids=[distinct_id])
     return None
 

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -9,7 +9,7 @@ from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.person import READ_DB_FOR_PERSONS, Person
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDTModel
-from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
 from posthog.session_recordings.models.metadata import RecordingMatchingEvents, RecordingMetadata
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
@@ -155,11 +155,13 @@ class SessionRecording(UUIDTModel):
                 person = _fetch_person_by_distinct_id_via_personhog(self.team.pk, self.distinct_id)
                 if person is not None:
                     self.person = person
-                PERSONHOG_ROUTING_TOTAL.labels(operation="load_person", source="personhog").inc()
+                PERSONHOG_ROUTING_TOTAL.labels(
+                    operation="load_person", source="personhog", client_name=get_client_name()
+                ).inc()
                 return
             except Exception:
                 PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
-                    operation="load_person", source="personhog", error_type="grpc_error"
+                    operation="load_person", source="personhog", error_type="grpc_error", client_name=get_client_name()
                 ).inc()
                 logger.warning(
                     "personhog_load_person_failure", team_id=self.team.pk, distinct_id=self.distinct_id, exc_info=True
@@ -173,7 +175,9 @@ class SessionRecording(UUIDTModel):
             )
         except Person.DoesNotExist:
             pass
-        PERSONHOG_ROUTING_TOTAL.labels(operation="load_person", source="django_orm").inc()
+        PERSONHOG_ROUTING_TOTAL.labels(
+            operation="load_person", source="django_orm", client_name=get_client_name()
+        ).inc()
 
     def check_viewed_for_user(self, user: Any, save_viewed=False) -> None:
         if not save_viewed:

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -3,13 +3,33 @@ from typing import Any, Optional, Union
 
 from django.db import models
 
+import structlog
+
 from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.person import READ_DB_FOR_PERSONS, Person
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDTModel
+from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL
 from posthog.session_recordings.models.metadata import RecordingMatchingEvents, RecordingMetadata
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
+
+logger = structlog.get_logger(__name__)
+
+
+def _fetch_person_by_distinct_id_via_personhog(team_id: int, distinct_id: str) -> Person | None:
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.converters import proto_person_to_model
+    from posthog.personhog_client.proto import GetPersonByDistinctIdRequest
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    resp = client.get_person_by_distinct_id(GetPersonByDistinctIdRequest(team_id=team_id, distinct_id=distinct_id))
+    if resp.person and resp.person.id:
+        return proto_person_to_model(resp.person, distinct_ids=[distinct_id])
+    return None
 
 
 class SessionRecording(UUIDTModel):
@@ -128,6 +148,23 @@ class SessionRecording(UUIDTModel):
         if self._person:
             return
 
+        from posthog.personhog_client.gate import use_personhog
+
+        if use_personhog():
+            try:
+                person = _fetch_person_by_distinct_id_via_personhog(self.team.pk, self.distinct_id)
+                if person is not None:
+                    self.person = person
+                PERSONHOG_ROUTING_TOTAL.labels(operation="load_person", source="personhog").inc()
+                return
+            except Exception:
+                PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                    operation="load_person", source="personhog", error_type="grpc_error"
+                ).inc()
+                logger.warning(
+                    "personhog_load_person_failure", team_id=self.team.pk, distinct_id=self.distinct_id, exc_info=True
+                )
+
         try:
             self.person = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(
                 persondistinctid__distinct_id=self.distinct_id,
@@ -136,6 +173,7 @@ class SessionRecording(UUIDTModel):
             )
         except Person.DoesNotExist:
             pass
+        PERSONHOG_ROUTING_TOTAL.labels(operation="load_person", source="django_orm").inc()
 
     def check_viewed_for_user(self, user: Any, save_viewed=False) -> None:
         if not save_viewed:

--- a/posthog/session_recordings/test/test_session_recording_personhog.py
+++ b/posthog/session_recordings/test/test_session_recording_personhog.py
@@ -97,7 +97,9 @@ class TestLoadPersonRouting(SimpleTestCase):
 
         recording.load_person()
 
-        mock_routing_counter.labels.assert_called_with(operation="load_person", source=expected_source)
+        mock_routing_counter.labels.assert_called_with(
+            operation="load_person", source=expected_source, client_name="posthog-django"
+        )
 
         if gate_on and grpc_exception is None:
             mock_person_objects.db_manager.assert_not_called()

--- a/posthog/session_recordings/test/test_session_recording_personhog.py
+++ b/posthog/session_recordings/test/test_session_recording_personhog.py
@@ -93,7 +93,7 @@ class TestLoadPersonRouting(SimpleTestCase):
         recording.__dict__["_team_cache"] = mock_team
         object.__setattr__(recording, "_team_cache", mock_team)
         # Patch the property access used in load_person
-        type(recording).team = property(lambda self: mock_team)
+        type(recording).team = property(lambda self: mock_team)  # type: ignore[assignment]
 
         recording.load_person()
 

--- a/posthog/session_recordings/test/test_session_recording_personhog.py
+++ b/posthog/session_recordings/test/test_session_recording_personhog.py
@@ -1,0 +1,179 @@
+"""Tests for session recording person loading via the personhog path.
+
+Mirrors test_get_session_recordings_includes_person_data from test_session_recordings.py
+to ensure the personhog code path returns identical results.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, TestCase
+
+from parameterized import parameterized
+
+from posthog.models import Person
+from posthog.personhog_client.fake_client import fake_personhog_client
+from posthog.session_recordings.models.session_recording import SessionRecording
+
+
+class TestLoadPersonRouting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "personhog_success_person_found",
+                True,
+                None,
+                "personhog",
+                True,
+            ),
+            (
+                "personhog_success_person_not_found",
+                True,
+                None,
+                "personhog",
+                False,
+            ),
+            (
+                "personhog_failure_falls_back_to_orm",
+                True,
+                RuntimeError("grpc timeout"),
+                "django_orm",
+                True,
+            ),
+            (
+                "gate_off_uses_orm_directly",
+                False,
+                None,
+                "django_orm",
+                True,
+            ),
+        ]
+    )
+    @patch("posthog.session_recordings.models.session_recording._fetch_person_by_distinct_id_via_personhog")
+    @patch("posthog.personhog_client.gate.use_personhog")
+    @patch("posthog.session_recordings.models.session_recording.PERSONHOG_ROUTING_TOTAL")
+    @patch("posthog.session_recordings.models.session_recording.PERSONHOG_ROUTING_ERRORS_TOTAL")
+    @patch("posthog.session_recordings.models.session_recording.Person.objects")
+    def test_routing(
+        self,
+        _name,
+        gate_on,
+        grpc_exception,
+        expected_source,
+        person_found,
+        mock_person_objects,
+        mock_errors_counter,
+        mock_routing_counter,
+        mock_use_personhog,
+        mock_fetch_personhog,
+    ):
+        mock_use_personhog.return_value = gate_on
+
+        mock_person = MagicMock()
+        if grpc_exception is not None:
+            mock_fetch_personhog.side_effect = grpc_exception
+        elif person_found:
+            mock_fetch_personhog.return_value = mock_person
+        else:
+            mock_fetch_personhog.return_value = None
+
+        from posthog.models.person import Person
+
+        mock_orm_person = MagicMock()
+        if person_found:
+            mock_person_objects.db_manager.return_value.get.return_value = mock_orm_person
+        else:
+            mock_person_objects.db_manager.return_value.get.side_effect = Person.DoesNotExist
+
+        recording = SessionRecording()
+        recording.distinct_id = "test-distinct-id"
+        recording.team_id = 1
+        # Use a real-looking mock for the team FK — bypass Django's descriptor
+        mock_team = MagicMock()
+        mock_team.pk = 1
+        recording.__dict__["_team_cache"] = mock_team
+        object.__setattr__(recording, "_team_cache", mock_team)
+        # Patch the property access used in load_person
+        type(recording).team = property(lambda self: mock_team)
+
+        recording.load_person()
+
+        mock_routing_counter.labels.assert_called_with(operation="load_person", source=expected_source)
+
+        if gate_on and grpc_exception is None:
+            mock_person_objects.db_manager.assert_not_called()
+            if person_found:
+                assert recording._person == mock_person
+            else:
+                assert recording._person is None
+        else:
+            if person_found:
+                assert recording._person == mock_orm_person
+
+        if grpc_exception is not None and gate_on:
+            mock_errors_counter.labels.assert_called_once()
+
+
+class TestLoadPersonPersonhogIntegration(TestCase):
+    def test_person_found(self) -> None:
+        from posthog.models import Organization, Team
+
+        org, _, _ = Organization.objects.bootstrap(None, name="Test Org")
+        team = Team.objects.create(organization=org, name="Test Team")
+        person = Person.objects.create(team=team, distinct_ids=["test_user"], properties={"email": "test@example.com"})
+
+        with fake_personhog_client() as fake:
+            fake.add_person(
+                team_id=team.pk,
+                person_id=person.pk,
+                uuid=str(person.uuid),
+                properties={"email": "test@example.com"},
+                distinct_ids=["test_user"],
+                is_identified=person.is_identified,
+                created_at=int(person.created_at.timestamp()) if person.created_at else 0,
+            )
+
+            recording = SessionRecording(team=team, session_id="test_session", distinct_id="test_user")
+            recording.load_person()
+
+            assert recording._person is not None
+            assert str(recording._person.uuid) == str(person.uuid)
+            assert recording._person.properties == {"email": "test@example.com"}
+            assert recording._person.distinct_ids == ["test_user"]
+            fake.assert_called("get_person_by_distinct_id")
+
+    def test_person_not_found(self) -> None:
+        from posthog.models import Organization, Team
+
+        org, _, _ = Organization.objects.bootstrap(None, name="Test Org")
+        team = Team.objects.create(organization=org, name="Test Team")
+
+        with fake_personhog_client() as fake:
+            recording = SessionRecording(team=team, session_id="test_session", distinct_id="nonexistent_user")
+            recording.load_person()
+
+            assert recording._person is None
+            fake.assert_called("get_person_by_distinct_id")
+
+    def test_cross_team_isolation(self) -> None:
+        from posthog.models import Organization, Team
+
+        org, _, _ = Organization.objects.bootstrap(None, name="Test Org")
+        team_a = Team.objects.create(organization=org, name="Team A")
+        team_b = Team.objects.create(organization=org, name="Team B")
+        person = Person.objects.create(team=team_b, distinct_ids=["shared_did"], properties={"email": "b@example.com"})
+
+        with fake_personhog_client() as fake:
+            # Seed person only in team_b
+            fake.add_person(
+                team_id=team_b.pk,
+                person_id=person.pk,
+                uuid=str(person.uuid),
+                properties={"email": "b@example.com"},
+                distinct_ids=["shared_did"],
+            )
+
+            # Try to load from team_a — should not find person
+            recording = SessionRecording(team=team_a, session_id="test_session", distinct_id="shared_did")
+            recording.load_person()
+
+            assert recording._person is None

--- a/posthog/session_recordings/test/test_session_recording_personhog.py
+++ b/posthog/session_recordings/test/test_session_recording_personhog.py
@@ -131,7 +131,7 @@ class TestLoadPersonPersonhogIntegration(TestCase):
                 properties={"email": "test@example.com"},
                 distinct_ids=["test_user"],
                 is_identified=person.is_identified,
-                created_at=int(person.created_at.timestamp()) if person.created_at else 0,
+                created_at=int(person.created_at.timestamp() * 1000) if person.created_at else 0,
             )
 
             recording = SessionRecording(team=team, session_id="test_session", distinct_id="test_user")


### PR DESCRIPTION
## Problem

The Django service currently queries the `posthog_person` PostgreSQL table directly via the ORM for several person-lookup patterns. We want to migrate these reads to the `personhog` gRPC service so that the Django web tier no longer needs direct access to the persons database. This is a step toward fully decoupling person storage from the web service.

The call sites migrated here are:

- **`get_persons_by_uuids`** (`posthog/models/person/util.py`) — used by the actor base query to resolve person UUIDs from insight results
- **`get_persons_by_distinct_ids`** (`posthog/models/person/util.py`) — used by 4 callers (event API, person API batch endpoint, events query runner, session summary patterns) to resolve persons from distinct IDs
- **`get_people`** (`posthog/queries/actor_base_query.py`) — used by trends/funnels/paths/stickiness to load and serialize person actors
- **`SessionRecording.load_person`** (`posthog/session_recordings/models/session_recording.py`) — used to load the person associated with a single session recording

## Changes

### Core: proto-to-model converter (`posthog/personhog_client/converters.py`)

Added `proto_person_to_model()` which converts a proto `Person` message into an unsaved Django `Person` model instance. This allows existing serializers and property accessors (like `person.distinct_ids`) to work without modification. The converter sets `_distinct_ids` on the model so the `distinct_ids` property returns them without hitting the ORM.

### Migrated call sites

Each follows the same dual-path routing pattern established by the group_type_mapping migration:

1. Check `use_personhog()` gate
2. Try the personhog gRPC path
3. On any exception, log a warning and fall back to the ORM path
4. Instrument both paths with `PERSONHOG_ROUTING_TOTAL` (labels: `operation`, `source`) and errors with `PERSONHOG_ROUTING_ERRORS_TOTAL` (labels: `operation`, `source`, `error_type`)

**`get_persons_by_uuids`** — Personhog path calls `GetPersonsByUuids`. ORM fallback is unchanged.

**`get_persons_by_distinct_ids`** — Personhog path makes two gRPC calls: `GetPersonsByDistinctIdsInTeam` to get the persons, then `GetDistinctIdsForPersons` to populate their distinct IDs. The return type changed from `QuerySet` to `list[Person]`, and the `.prefetch_related()` for distinct IDs was internalized into the ORM fallback path. This eliminated duplicate prefetch chains in all 4 callers:
- `posthog/api/person.py` (batch_by_distinct_ids endpoint) — also simplified to use `person.distinct_ids` instead of `distinct_ids_cache`
- `posthog/api/event.py` (`_get_people`)
- `posthog/hogql_queries/events_query_runner.py` (person enrichment loop)
- `ee/hogai/session_summaries/session_group/patterns.py` (`get_persons_for_sessions_from_distinct_ids`)

**`get_people`** — Personhog path calls `GetPersonsByUuids` then `GetDistinctIdsForPersons`, applies the `distinct_id_limit`, and sorts to match the ORM path's ordering. Return type broadened to `Union[QuerySet[Person], list[Person]]`.

**`SessionRecording.load_person`** — Added a module-level `_fetch_person_by_distinct_id_via_personhog()` helper. The personhog path calls `GetPersonByDistinctId` for a single person lookup. If successful (including when the person is not found), it returns early without touching the ORM.

### Cleanup

Removed now-unused imports of `Prefetch`, `PersonDistinctId`, and related symbols from the 4 caller files.

## How did you test this?

### Unit tests (routing logic)

Each migrated function has parameterized routing tests that verify the gate → personhog → ORM fallback behavior:

- **`posthog/models/person/test/test_util_personhog_routing.py`**
  - `TestGetPersonsByUuidsRouting` — 3 cases: personhog success, personhog failure falls back to ORM, gate off uses ORM directly
  - `TestGetPersonsByDistinctIdsRouting` — 3 cases: same pattern
- **`posthog/queries/test/test_actor_base_query_personhog_routing.py`**
  - `TestGetPeopleRouting` — 3 cases: same pattern
- **`posthog/session_recordings/test/test_session_recording_personhog.py`**
  - `TestLoadPersonRouting` — 4 cases: personhog person found, personhog person not found, personhog failure falls back to ORM, gate off uses ORM

All routing tests verify:
- The correct `PERSONHOG_ROUTING_TOTAL` counter is incremented with the expected `source` label
- The `PERSONHOG_ROUTING_ERRORS_TOTAL` counter is incremented on gRPC failures
- The ORM is not called when personhog succeeds
- The ORM is called when personhog fails or the gate is off

### Integration tests (using FakePersonHogClient)

These tests use `fake_personhog_client()` (which patches both the client singleton and the gate) to exercise the full code path end-to-end with real Django models:

- **`posthog/api/test/test_person_personhog.py`** — `TestBatchByDistinctIdsPersonhog`
  - `test_happy_path` — two persons found by distinct IDs
  - `test_missing_ids` — mix of existing and nonexistent distinct IDs
  - `test_same_person_multiple_ids` — one person with two distinct IDs returns same UUID for both
  - `test_empty_list` — empty input returns empty results, no gRPC call made
  - `test_invalid_input` — non-list input returns empty results gracefully
  - `test_cross_team_isolation` — person in team B is not visible from team A's API

- **`posthog/session_recordings/test/test_session_recording_personhog.py`** — `TestLoadPersonPersonhogIntegration`
  - `test_person_found` — person loaded correctly with uuid, properties, and distinct_ids
  - `test_person_not_found` — `_person` is None for nonexistent distinct ID
  - `test_cross_team_isolation` — person in team B not found when loading from team A

### Converter tests

- **`posthog/personhog_client/test_converters.py`** — `TestProtoPersonToModel`
  - 3 parameterized cases: all fields populated, empty properties, with distinct_ids
  - Verifies uuid, team_id, properties, created_at, is_identified, and `distinct_ids` property behavior
