### PR TITLE
feat: add 'Not on any dashboard' filter for insights

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -17,8 +17,8 @@ import { membersLogic } from 'scenes/organization/membersLogic'
 import { INSIGHT_TYPE_OPTIONS } from 'scenes/saved-insights/SavedInsights'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 
-export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags'
-const ALL_QUICK_FILTERS: QuickFilterKind[] = ['insightType', 'tags', 'createdBy', 'favorites', 'featureFlags']
+export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags' | 'noDashboard'
+const ALL_QUICK_FILTERS: QuickFilterKind[] = ['insightType', 'tags', 'createdBy', 'favorites', 'featureFlags', 'noDashboard']
 
 export function SavedInsightsFilters({
     filters,
@@ -33,7 +33,7 @@ export function SavedInsightsFilters({
     borderless?: boolean
 }): JSX.Element {
     const isAIFirst = useFeatureFlag('AI_FIRST')
-    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy } = filters
+    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy, noDashboard } = filters
     const { meFirstMembers, filteredMembers, membersLoading, search: memberSearch } = useValues(membersLogic)
     const { setSearch: setMemberSearch, ensureAllMembersLoaded } = useActions(membersLogic)
     const quickFilterSet = new Set(quickFilters)
@@ -215,6 +215,23 @@ export function SavedInsightsFilters({
                             hideFeatureFlagInsights={hideFeatureFlagInsights ?? undefined}
                             onToggle={(checked) => setFilters({ hideFeatureFlagInsights: checked })}
                         />
+                    )}
+                    {quickFilterSet.has('noDashboard') && (
+                        <LemonButton
+                            type="secondary"
+                            status={borderless && !noDashboard ? 'alt' : 'default'}
+                            active={noDashboard || false}
+                            onClick={() => {
+                                setFilters({ noDashboard: !noDashboard })
+                                posthog.capture('saved insights filtered', {
+                                    filter_type: 'no_dashboard',
+                                    value: !noDashboard,
+                                })
+                            }}
+                            size="small"
+                        >
+                            Not on any dashboard
+                        </LemonButton>
                     )}
                 </div>
             )}

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -56,6 +56,7 @@ export interface SavedInsightFilters {
     events: string[] | undefined | null
     hideFeatureFlagInsights: boolean | undefined | null
     favorited: boolean | undefined | null
+    noDashboard: boolean | undefined | null
 }
 
 export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
@@ -77,6 +78,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         events: values.events,
         hideFeatureFlagInsights: values.hideFeatureFlagInsights || false,
         favorited: values.favorited || false,
+        noDashboard: values.noDashboard || false,
     }
 }
 
@@ -277,6 +279,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                     dashboards: [filters.dashboardId],
                 }),
                 ...(filters.hideFeatureFlagInsights && { hide_feature_flag_insights: true }),
+                ...(filters.noDashboard && { no_dashboard: true }),
             }),
         ],
         pagination: [

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1254,6 +1254,13 @@ class InsightViewSet(
                             .values_list("insight__id", flat=True)
                             .all()
                         )
+            elif key == "no_dashboard":
+                if str_to_bool(request.GET["no_dashboard"]):
+                    # Only show insights that are not on any dashboard
+                    queryset = queryset.exclude(
+                        id__in=DashboardTile.objects.filter(dashboard__deleted=False)
+                        .values_list("insight__id", flat=True)
+                    )
             elif key == "tags":
                 tags_filter = request.GET["tags"]
                 if tags_filter:


### PR DESCRIPTION
## Changes

Adds a new filter to the saved insights list that allows users to find insights that are **not included in any dashboard**. This makes it easy to identify and clean up orphaned insights.

### Backend
- Added `no_dashboard` query parameter to the insights API endpoint
- When `no_dashboard=true`, excludes insights present on any non-deleted dashboard via `DashboardTile` lookup

### Frontend
- Added `noDashboard` field to `SavedInsightFilters` interface
- Added `no_dashboard` parameter to API request params
- Added "Not on any dashboard" toggle button to the `SavedInsightsFilters` component

### How to test
1. Go to Product Analytics → All Insights
2. Click the "Not on any dashboard" button
3. Verify only insights not attached to any dashboard are shown

Closes #26621
Closes #17176