### PR TITLE
fix: show date pickers for 'between' operator on date properties in cohorts

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDateBetween.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDateBetween.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+
+import { LemonCalendarSelectInput } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+
+import { PropertyFilterValue } from '~/types'
+
+interface PropertyFilterDateBetweenProps {
+    value: PropertyFilterValue
+    onSet: (newValue: PropertyFilterValue) => void
+}
+
+const dateFormat = 'YYYY-MM-DD'
+
+/**
+ * A "between" filter for date properties that renders two date pickers
+ * (min date and max date) instead of two number inputs.
+ */
+export function PropertyFilterDateBetween({ value, onSet }: PropertyFilterDateBetweenProps): JSX.Element {
+    // Value is stored as [min, max] array
+    const parsed = Array.isArray(value) ? value : []
+    const [minValue, setMinValue] = useState<dayjs.Dayjs | undefined>(
+        parsed[0] ? dayjs(String(parsed[0])) : undefined
+    )
+    const [maxValue, setMaxValue] = useState<dayjs.Dayjs | undefined>(
+        parsed[1] ? dayjs(String(parsed[1])) : undefined
+    )
+    const [minOpen, setMinOpen] = useState(false)
+    const [maxOpen, setMaxOpen] = useState(false)
+
+    const updateValue = (newMin: dayjs.Dayjs | undefined, newMax: dayjs.Dayjs | undefined): void => {
+        const minStr = newMin?.format(dateFormat) ?? ''
+        const maxStr = newMax?.format(dateFormat) ?? ''
+        onSet([minStr, maxStr])
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            <LemonCalendarSelectInput
+                value={minValue}
+                format={dateFormat}
+                visible={minOpen}
+                onClickOutside={() => setMinOpen(false)}
+                onChange={(selectedDate) => {
+                    setMinValue(selectedDate)
+                    updateValue(selectedDate, maxValue)
+                    setMinOpen(false)
+                }}
+                onClose={() => setMinOpen(false)}
+                granularity="day"
+                buttonProps={{
+                    'data-attr': 'prop-val-date-min',
+                    onClick: () => setMinOpen(true),
+                    children: minValue ? minValue.format(dateFormat) : 'Start date',
+                }}
+            />
+            <span className="font-medium">and</span>
+            <LemonCalendarSelectInput
+                value={maxValue}
+                format={dateFormat}
+                visible={maxOpen}
+                onClickOutside={() => setMaxOpen(false)}
+                onChange={(selectedDate) => {
+                    setMaxValue(selectedDate)
+                    updateValue(minValue, selectedDate)
+                    setMaxOpen(false)
+                }}
+                onClose={() => setMaxOpen(false)}
+                granularity="day"
+                buttonProps={{
+                    'data-attr': 'prop-val-date-max',
+                    onClick: () => setMaxOpen(true),
+                    children: maxValue ? maxValue.format(dateFormat) : 'End date',
+                }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -13,6 +13,7 @@ import { AssigneeSelect } from '@posthog/products-error-tracking/frontend/compon
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
 import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
+import { PropertyFilterDateBetween } from 'lib/components/PropertyFilters/components/PropertyFilterDateBetween'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { propertyValueLogic } from 'lib/components/PropertyFilters/components/propertyValueLogic'
 import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
@@ -89,6 +90,9 @@ export function PropertyValue({
 
     const isNumericProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
+
+    const isDateProperty =
+        propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.DateTime
 
     // TODO: Add semver input validation when a semver operator is selected.
     // This will require detecting isOperatorSemver(operator) and validating the input
@@ -247,6 +251,9 @@ export function PropertyValue({
     }
 
     if (isBetweenProperty) {
+        if (isDateProperty) {
+            return <PropertyFilterDateBetween value={value ?? null} onSet={setValue} />
+        }
         return <PropertyFilterBetween value={value ?? null} onSet={setValue} size={size} />
     }
 


### PR DESCRIPTION
## Problem

When a date property is selected in a cohort filter and the **between** operator is chosen, the form shows two **number inputs** instead of two **date pickers**. This happens because the `isBetweenProperty` check in `PropertyValue` takes precedence over the date type check, so the generic `PropertyFilterBetween` (numeric) component renders instead of a date-aware one.

Additionally, the `between` input only shows a single field (the same generic number input) instead of the expected min/max pair with date pickers.

## Solution

- **New component**: `PropertyFilterDateBetween` — renders two `LemonCalendarSelectInput` date pickers (start date / end date) and stores the value as a `[min, max]` array of date strings
- **Updated `PropertyValue`**: Added `isDateProperty` detection using `describeProperty`. When both `isBetweenProperty` and `isDateProperty` are true, renders `PropertyFilterDateBetween` instead of the numeric `PropertyFilterBetween`

## How to test

1. Go to Cohorts → Create/Edit a cohort
2. Add a criteria → "Have the property" 
3. Select a **date** property (e.g. `created_at`)
4. Choose `between` as the operator
5. ✅ Two date pickers should now appear (Start date / End date)
6. Previously: two number inputs appeared

Closes #20821