### PR TITLE
fix(hogql): remove double db call for group type mapping

### DIFF
--- a/posthog/caching/test/test_insight_cache.py
+++ b/posthog/caching/test/test_insight_cache.py
@@ -43,7 +43,9 @@ def create_insight_caching_state(
 
 # Reaching into the internals of LocMemCache
 def cache_keys(cache):
-    return {key.split(":", 2)[-1] for key in cache._cache.keys()}
+    # Filter to only insight cache keys (prefixed with "cache_") to avoid
+    # picking up unrelated cache entries (e.g. group_types_for_project_*)
+    return {key.split(":", 2)[-1] for key in cache._cache.keys() if key.split(":", 2)[-1].startswith("cache_")}
 
 
 @pytest.mark.django_db

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -122,9 +122,8 @@ from posthog.hogql.parser import parse_expr
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.exceptions_capture import capture_exception
-from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.team.team import WeekStartDay
-from posthog.person_db_router import PERSONS_DB_FOR_READ
 
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
@@ -781,12 +780,13 @@ class Database(BaseModel):
             _use_virtual_fields(database, modifiers, timings)
 
         with timings.measure("group_type_mapping"):
-            _setup_group_key_fields(database, team)
+            group_types = get_group_types_for_project(team.project_id)
+            _setup_group_key_fields(database, group_types)
             events_table = database.get_table("events")
-            for mapping in GroupTypeMapping.objects.using(PERSONS_DB_FOR_READ).filter(project_id=team.project_id):
-                if events_table.fields.get(mapping.group_type) is None:
-                    events_table.fields[mapping.group_type] = FieldTraverser(
-                        chain=[f"group_{mapping.group_type_index}"]
+            for mapping in group_types:
+                if events_table.fields.get(mapping["group_type"]) is None:
+                    events_table.fields[mapping["group_type"]] = FieldTraverser(
+                        chain=[f"group_{mapping['group_type_index']}"]
                     )
 
         warehouse_tables_dot_notation_mapping: dict[str, str] = {}
@@ -1201,17 +1201,14 @@ def _use_error_tracking_issue_id_from_error_tracking_issue_overrides(database: D
     )
 
 
-def _setup_group_key_fields(database: Database, team: "Team") -> None:
+def _setup_group_key_fields(database: Database, group_types: list[dict[str, Any]]) -> None:
     """
     Set up group key fields as ExpressionFields that handle filtering based on GroupTypeMapping.created_at.
     For $group_N fields, this returns:
     - Empty string if no GroupTypeMapping exists for that index
     - if(timestamp < mapping.created_at, '', $group_N) if GroupTypeMapping exists
     """
-    group_mappings = {
-        mapping.group_type_index: mapping
-        for mapping in GroupTypeMapping.objects.using(PERSONS_DB_FOR_READ).filter(team=team)
-    }
+    group_mappings = {mapping["group_type_index"]: mapping for mapping in group_types}
     table = database.get_table("events")
 
     for group_index in range(5):
@@ -1219,13 +1216,13 @@ def _setup_group_key_fields(database: Database, team: "Team") -> None:
 
         group_mapping = group_mappings.get(group_index, None)
         # If no mapping exists or the mapping predated this feature, leave the original field unchanged
-        if group_mapping and group_mapping.created_at:
+        if group_mapping and group_mapping["created_at"]:
             # Store the original field as a "raw" version before replacing
             original_field = table.fields[field_name]
             raw_field_name = f"_{field_name}_raw"
             table.fields[raw_field_name] = original_field.model_copy(update={"hidden": True})
 
-            created_at_str = group_mapping.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            created_at_str = group_mapping["created_at"].strftime("%Y-%m-%d %H:%M:%S")
 
             table.fields[field_name] = ExpressionField(
                 name=field_name,

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -35,6 +35,7 @@ from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_in_tests
 
+from posthog.models.group_type_mapping import invalidate_group_types_cache
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
@@ -377,7 +378,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
     @snapshot_postgres_queries
     @patch("posthog.hogql.query.sync_execute", return_value=([], []))
     def test_database_with_warehouse_tables_and_saved_queries_n_plus_1(self, patch_execute):
-        max_queries = FuzzyInt(7, 9)
+        max_queries = FuzzyInt(6, 8)
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="_accesskey", access_secret="_secret"
         )
@@ -433,7 +434,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             )
 
         # initialization team query doesn't run
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             modifiers = create_default_modifiers_for_team(
                 self.team, modifiers=HogQLQueryModifiers(useMaterializedViews=True)
             )
@@ -443,6 +444,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         create_group_type_mapping_without_created_at(
             team=self.team, project_id=self.team.project_id, group_type="test", group_type_index=0
         )
+        invalidate_group_types_cache(self.team.project_id)
         db = Database.create_for(team=self.team)
 
         assert db.get_table("events").fields["test"] == FieldTraverser(chain=["group_0"])
@@ -451,6 +453,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         create_group_type_mapping_without_created_at(
             team=self.team, project_id=self.team.project_id, group_type="event", group_type_index=0
         )
+        invalidate_group_types_cache(self.team.project_id)
         db = Database.create_for(team=self.team)
 
         assert db.get_table("events").fields["event"] == StringDatabaseField(name="event", nullable=False)
@@ -758,7 +761,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 },
             )
 
-            with self.assertNumQueries(FuzzyInt(6, 9)):
+            with self.assertNumQueries(FuzzyInt(5, 8)):
                 Database.create_for(team=self.team)
 
     # We keep adding sources, credentials and tables, number of queries should be stable

--- a/posthog/hogql/test/test_group_filtering.py
+++ b/posthog/hogql/test/test_group_filtering.py
@@ -12,6 +12,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 
 from posthog.models import GroupTypeMapping
+from posthog.models.group_type_mapping import invalidate_group_types_cache
 
 
 class TestGroupKeyFiltering(APIBaseTest):
@@ -22,17 +23,25 @@ class TestGroupKeyFiltering(APIBaseTest):
         self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
+    def _create_mapping_and_rebuild(self, **kwargs):
+        """Create a GroupTypeMapping, invalidate cache, and rebuild database."""
+        GroupTypeMapping.objects.create(**kwargs)
+
+    def _rebuild_database(self):
+        invalidate_group_types_cache(self.team.project_id)
+        self.database = Database.create_for(team=self.team)
+        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+
     def test_group_field_with_mapping_and_created_at(self):
         """Test that $group_0 gets filtering when GroupTypeMapping exists with created_at"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT $group_0 FROM events"
         parsed = parse_select(query)
@@ -46,8 +55,7 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_field_without_mapping(self):
         """Test that $group_0 falls back when no GroupTypeMapping exists"""
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT $group_0 FROM events"
         parsed = parse_select(query)
@@ -60,22 +68,21 @@ class TestGroupKeyFiltering(APIBaseTest):
     def test_multiple_group_fields(self):
         """Test filtering with multiple group type mappings"""
         # Create mappings for groups 0 and 1
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="team",
             group_type_index=1,
             created_at=datetime(2023, 2, 1, 10, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         # Parse a query that references multiple group fields
         query = "SELECT $group_0, $group_1, $group_2 FROM events"
@@ -91,15 +98,14 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_field_in_where_clause(self):
         """Test that group filtering works in WHERE clauses"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT event FROM events WHERE $group_0 = 'acme'"
         parsed = parse_select(query)
@@ -112,15 +118,14 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_join_with_filtering(self):
         """Test that group_1.properties access includes filtering for $group_1"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="team",
             group_type_index=1,
             created_at=datetime(2023, 2, 1, 10, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT group_1.properties FROM events"
         parsed = parse_select(query)
@@ -133,7 +138,7 @@ class TestGroupKeyFiltering(APIBaseTest):
     def test_multiple_group_joins_with_mixed_mappings(self):
         """Test joins to multiple groups with some having filtering and others not"""
         # Create mapping only for group_0
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
@@ -141,8 +146,7 @@ class TestGroupKeyFiltering(APIBaseTest):
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
         # No mapping for group_1
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT group_0.properties, group_1.properties FROM events"
         parsed = parse_select(query)
@@ -155,15 +159,14 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_non_clickhouse_dialect_no_filtering(self):
         """Test that non-ClickHouse dialects don't get filtering"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT $group_0 FROM events"
         parsed = parse_select(query)
@@ -174,15 +177,14 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_alias_with_filtering(self):
         """Test that group aliases (e.g., 'company' for $group_0) work with filtering"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT company.properties.name FROM events"
         parsed = parse_select(query)
@@ -196,15 +198,14 @@ class TestGroupKeyFiltering(APIBaseTest):
 
     def test_group_alias_in_where_clause(self):
         """Test that group aliases work with filtering in WHERE clauses"""
-        GroupTypeMapping.objects.create(
+        self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
             group_type="company",
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
-        self.database = Database.create_for(team=self.team)
-        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+        self._rebuild_database()
 
         query = "SELECT event FROM events WHERE company.properties.name = 'acme'"
         parsed = parse_select(query)

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -551,7 +551,7 @@ class TestExternalDataSource(APIBaseTest):
         self._create_external_data_source()
         self._create_external_data_source()
 
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(26):
             response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
         payload = response.json()
 


### PR DESCRIPTION
## Problem

`Database.create_for()` in the HogQL database initialization runs on every single query execution. It makes two uncached ORM queries to `posthog_grouptypemapping` per execution:

1. `GroupTypeMapping.objects.filter(team=team)` — loads all model fields, filtered by `team_id`
2. `GroupTypeMapping.objects.filter(project_id=team.project_id)` — loads all model fields

On the `posthog-query-django` deployment this generates ~830K queries/min (~1.66M total across both calls). Meanwhile, there is an existing Redis-cached function (`get_group_types_for_project`) with a 5-minute TTL that is already used elsewhere for the same data — but these two hot-path call sites bypass it entirely.


## Changes

- Replace both direct ORM queries in `posthog/hogql/database/database.py` with a single call to `get_group_types_for_project(team.project_id)`, which checks Redis cache first and only falls back to the database on cache miss.
- Update `_setup_group_key_fields()` to accept the cached `list[dict]` result instead of querying the ORM itself.
- Remove the now-unused `GroupTypeMapping` and `PERSONS_DB_FOR_READ` imports.


## How did you test this code?

- Ran existing HogQL database tests (`test_database_group_type_mappings`, `test_database_group_type_mappings_overwrite`) — both pass.
- Ran property types tests that exercise group type mapping through full HogQL query compilation (`test_group_boolean_property_types`, `test_group_property_types`, `test_group_types_are_the_same_in_persons_inlined_subselect`) — all pass.
- Ran group type mapping model tests (`test_group_type_mapping.py`) to confirm cache behavior is unchanged — all pass.
- Lint clean (`ruff check`).