### PR TITLE
fix(flags): pass paired group identifiers instead of cartesian product

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1886,6 +1886,10 @@ impl FeatureFlagMatcher {
             .filter_map(|flag| flag.get_group_type_index())
             .collect();
 
+        if required_type_indexes.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let types_to_indexes = self.group_type_mapping_cache.get_group_types_to_indexes()?;
 
         let group_type_to_key: HashMap<GroupTypeIndex, String> = self

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1890,7 +1890,11 @@ impl FeatureFlagMatcher {
             return Ok(HashMap::new());
         }
 
-        let types_to_indexes = self.group_type_mapping_cache.get_group_types_to_indexes()?;
+        let types_to_indexes = match self.group_type_mapping_cache.get_group_types_to_indexes() {
+            Ok(map) => map,
+            Err(FlagError::NoGroupTypeMappings) => return Ok(HashMap::new()),
+            Err(e) => return Err(e),
+        };
 
         let group_type_to_key: HashMap<GroupTypeIndex, String> = self
             .groups

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -194,15 +194,6 @@ impl FlagEvaluationState {
     }
 }
 
-/// Represents the group-related data needed for feature flag evaluation
-#[derive(Debug)]
-struct GroupEvaluationData {
-    /// Set of group type indexes required for flag evaluation
-    type_indexes: HashSet<GroupTypeIndex>,
-    /// Set of group keys that need to be evaluated
-    keys: HashSet<String>,
-}
-
 /// Evaluates feature flags for a specific user/group context.
 ///
 /// This struct maintains the state and logic needed to evaluate feature flags, including:
@@ -1863,8 +1854,7 @@ impl FeatureFlagMatcher {
             self.router.get_persons_reader().clone(),
             self.distinct_id.clone(),
             self.team_id,
-            &group_data.type_indexes,
-            &group_data.keys,
+            &group_data,
             static_cohort_ids,
         )
         .await
@@ -1885,52 +1875,37 @@ impl FeatureFlagMatcher {
         }
     }
 
-    /// Analyzes flags and prepares required group type data for flag evaluation.
-    /// This includes:
-    /// - Extracting required group type indexes from flags
-    /// - Mapping group names to group_type_index and group_keys
+    /// Builds a paired mapping from group type index to group key for flag
+    /// evaluation, filtered to only the group types required by the given flags.
     fn prepare_group_data(
         &mut self,
         flags: &[&FeatureFlag],
-    ) -> Result<GroupEvaluationData, FlagError> {
-        // Extract required group type indexes from flags
-        let type_indexes: HashSet<GroupTypeIndex> = flags
+    ) -> Result<HashMap<GroupTypeIndex, String>, FlagError> {
+        let required_type_indexes: HashSet<GroupTypeIndex> = flags
             .iter()
             .filter_map(|flag| flag.get_group_type_index())
             .collect();
 
-        // Map group names to group_type_index and group_keys
-        let group_type_to_key_map: HashMap<GroupTypeIndex, String> = self
+        let types_to_indexes = self.group_type_mapping_cache.get_group_types_to_indexes()?;
+
+        let group_type_to_key: HashMap<GroupTypeIndex, String> = self
             .groups
             .iter()
             .filter_map(|(group_type, group_key_value)| {
                 let group_key = match group_key_value {
                     Value::String(s) => s.clone(),
                     Value::Number(n) => n.to_string(),
-                    _ => return None, // Skip non-string, non-number group keys
+                    _ => return None,
                 };
-                self.group_type_mapping_cache
-                    .get_group_types_to_indexes()
-                    .ok()?
+                types_to_indexes
                     .get(group_type)
                     .cloned()
+                    .filter(|idx| required_type_indexes.contains(idx))
                     .map(|group_type_index| (group_type_index, group_key))
             })
             .collect();
 
-        // Extract group_keys that are relevant to the required group_type_indexes
-        let keys: HashSet<String> = group_type_to_key_map
-            .iter()
-            .filter_map(|(group_type_index, group_key)| {
-                if type_indexes.contains(group_type_index) {
-                    Some(group_key.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        Ok(GroupEvaluationData { type_indexes, keys })
+        Ok(group_type_to_key)
     }
 
     /// Get person properties from the `FlagEvaluationState` only, returning empty HashMap if not found.

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -159,16 +159,14 @@ pub fn populate_missing_initial_properties(properties: &mut HashMap<String, Valu
     team_id = %team_id,
     distinct_id = %distinct_id,
     cohort_ids = ?static_cohort_ids,
-    group_type_indexes = ?group_type_indexes,
-    group_keys = ?group_keys
+    group_type_to_key = ?group_type_to_key
 ))]
 pub async fn fetch_and_locally_cache_all_relevant_properties(
     flag_evaluation_state: &mut FlagEvaluationState,
     reader: PostgresReader,
     distinct_id: String,
     team_id: TeamId,
-    group_type_indexes: &HashSet<GroupTypeIndex>,
-    group_keys: &HashSet<String>,
+    group_type_to_key: &HashMap<GroupTypeIndex, String>,
     static_cohort_ids: Vec<CohortId>,
 ) -> Result<(), FlagError> {
     // Add the test-specific counter increment
@@ -364,21 +362,22 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     person_processing_timer.fin();
 
     // Only fetch group property data if we have group types to look up
-    if !group_type_indexes.is_empty() {
+    if !group_type_to_key.is_empty() {
         let group_query = r#"
             SELECT
-                group_type_index,
-                group_key,
-                group_properties
-            FROM posthog_group
-            WHERE team_id = $1
-                AND group_type_index = ANY($2)
-                AND group_key = ANY($3)
+                g.group_type_index,
+                g.group_properties
+            FROM posthog_group g
+            INNER JOIN UNNEST($2::integer[], $3::text[]) AS t(group_type_index, group_key)
+                ON g.group_type_index = t.group_type_index AND g.group_key = t.group_key
+            WHERE g.team_id = $1
         "#;
 
-        let group_type_indexes_vec: Vec<GroupTypeIndex> =
-            group_type_indexes.iter().copied().collect();
-        let group_keys_vec: Vec<String> = group_keys.iter().cloned().collect();
+        let (group_type_indexes_vec, group_keys_vec): (Vec<GroupTypeIndex>, Vec<String>) =
+            group_type_to_key
+                .iter()
+                .map(|(&k, v)| (k, v.clone()))
+                .unzip();
 
         let group_query_start = Instant::now();
         let group_query_timer = common_metrics::timing_guard(FLAG_GROUP_QUERY_TIME, &query_labels);
@@ -399,8 +398,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             warn!(
                 duration_ms = group_query_duration.as_millis(),
                 team_id = team_id,
-                group_type_count = group_type_indexes_vec.len(),
-                group_key_count = group_keys_vec.len(),
+                group_pair_count = group_type_to_key.len(),
                 sql_summary =
                     "SELECT group properties with UNNEST for group_type_index, group_key pairs",
                 "Slow group query detected"
@@ -409,8 +407,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             info!(
                 duration_ms = group_query_duration.as_millis(),
                 team_id = team_id,
-                group_type_count = group_type_indexes_vec.len(),
-                group_key_count = group_keys_vec.len(),
+                group_pair_count = group_type_to_key.len(),
                 result_count = groups.len(),
                 "Group query completed"
             );

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -7746,4 +7746,156 @@ mod tests {
             "Match reason should be SuperConditionValue"
         );
     }
+
+    #[tokio::test]
+    async fn test_paired_group_identifiers_avoid_cartesian_product() {
+        use crate::utils::test_utils::create_group_in_pg;
+
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+
+        // Flag targeting "project" (group type index 0)
+        let project_flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "name".to_string(),
+                        value: Some(json!("Acme")),
+                        operator: Some(OperatorType::Exact),
+                        prop_type: PropertyType::Group,
+                        group_type_index: Some(0),
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: Some(0),
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // Flag targeting "organization" (group type index 1)
+        let org_flag = create_test_flag(
+            Some(2),
+            Some(team.id),
+            Some("org_flag".to_string()),
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "tier".to_string(),
+                        value: Some(json!("enterprise")),
+                        operator: Some(OperatorType::Exact),
+                        prop_type: PropertyType::Group,
+                        group_type_index: Some(1),
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: Some(1),
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // Insert correct group rows
+        create_group_in_pg(
+            context.persons_reader.clone(),
+            team.id,
+            "project",
+            "proj-456",
+            json!({"name": "Acme"}),
+        )
+        .await
+        .unwrap();
+
+        create_group_in_pg(
+            context.persons_reader.clone(),
+            team.id,
+            "organization",
+            "org-123",
+            json!({"tier": "enterprise"}),
+        )
+        .await
+        .unwrap();
+
+        // Insert a decoy row: project type (index 0) with org's key ("org-123").
+        // With the old cartesian-product query this row would be fetched and its
+        // properties would overwrite the correct project properties.
+        create_group_in_pg(
+            context.persons_reader.clone(),
+            team.id,
+            "project",
+            "org-123",
+            json!({"name": "DECOY"}),
+        )
+        .await
+        .unwrap();
+
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
+        group_type_mapping_cache
+            .init(context.persons_reader.clone())
+            .await
+            .unwrap();
+
+        let groups = HashMap::from([
+            ("project".to_string(), json!("proj-456")),
+            ("organization".to_string(), json!("org-123")),
+        ]);
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            Some(group_type_mapping_cache),
+            Some(groups),
+        );
+
+        matcher
+            .prepare_flag_evaluation_state(&[&project_flag, &org_flag])
+            .await
+            .unwrap();
+
+        let group_props = matcher.flag_evaluation_state.get_group_properties();
+
+        // Project (index 0) should have properties from (0, "proj-456"), not the decoy (0, "org-123")
+        let project_props = group_props
+            .get(&0)
+            .expect("project group properties should be loaded");
+        assert_eq!(
+            project_props.get("name"),
+            Some(&json!("Acme")),
+            "Project properties should come from the correct (type_index, key) pair, not the cartesian-product decoy"
+        );
+
+        // Organization (index 1) should have its own properties
+        let org_props = group_props
+            .get(&1)
+            .expect("organization group properties should be loaded");
+        assert_eq!(org_props.get("tier"), Some(&json!("enterprise")),);
+    }
 }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -306,6 +306,124 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mixed_person_and_group_flags_succeed_without_group_type_mappings() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+
+        let person_flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            Some("person_flag".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "email".to_string(),
+                        value: Some(json!("test@example.com")),
+                        operator: None,
+                        prop_type: PropertyType::Person,
+                        group_type_index: None,
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let group_flag = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("group_flag".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "name".to_string(),
+                        value: Some(json!("Acme")),
+                        operator: Some(OperatorType::Exact),
+                        prop_type: PropertyType::Group,
+                        group_type_index: Some(0),
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: Some(0),
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // No group type mappings initialized — person flags in a mixed batch
+        // should still evaluate successfully
+        let groups = HashMap::from([("project".to_string(), json!("proj-1"))]);
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            Some(groups),
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![person_flag.clone(), group_flag.clone()],
+            ..Default::default()
+        };
+        let result = matcher
+            .evaluate_all_feature_flags(
+                flags,
+                Some(HashMap::from([(
+                    "email".to_string(),
+                    json!("test@example.com"),
+                )])),
+                None,
+                None,
+                Uuid::new_v4(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !result.errors_while_computing_flags,
+            "Missing group type mappings should not cause errors for person flags in a mixed batch"
+        );
+        assert_eq!(
+            result.flags.get("person_flag").unwrap().to_value(),
+            FlagValue::Boolean(true),
+        );
+        // Group flag evaluates with empty group properties, so it won't match
+        assert_eq!(
+            result.flags.get("group_flag").unwrap().to_value(),
+            FlagValue::Boolean(false),
+        );
+    }
+
+    #[tokio::test]
     async fn test_group_property_overrides() {
         let context = TestContext::new(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(
@@ -7977,6 +8095,6 @@ mod tests {
         let org_props = group_props
             .get(&1)
             .expect("organization group properties should be loaded");
-        assert_eq!(org_props.get("tier"), Some(&json!("enterprise")),);
+        assert_eq!(org_props.get("tier"), Some(&json!("enterprise")));
     }
 }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -225,6 +225,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_person_only_flags_succeed_without_group_type_mappings() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+
+        let flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "email".to_string(),
+                        value: Some(json!("test@example.com")),
+                        operator: None,
+                        prop_type: PropertyType::Person,
+                        group_type_index: None,
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // No group type mappings initialized — this should not cause an error
+        // for person-only flags
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+            ..Default::default()
+        };
+        let result = matcher
+            .evaluate_all_feature_flags(
+                flags,
+                Some(HashMap::from([(
+                    "email".to_string(),
+                    json!("test@example.com"),
+                )])),
+                None,
+                None,
+                Uuid::new_v4(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.errors_while_computing_flags,
+            "Person-only flag evaluation should not error when group type mappings are uninitialized"
+        );
+        assert_eq!(
+            result.flags.get("test_flag").unwrap().to_value(),
+            FlagValue::Boolean(true)
+        );
+    }
+
+    #[tokio::test]
     async fn test_group_property_overrides() {
         let context = TestContext::new(None).await;
         let cohort_cache = Arc::new(CohortCacheManager::new(


### PR DESCRIPTION
## Problem

When evaluating feature flags that involve multiple group types, the Rust flag evaluation service fetched group properties using two independent `ANY` filters:

```sql
WHERE group_type_index = ANY($2) AND group_key = ANY($3)
```

The parameters came from separate `HashSet<GroupTypeIndex>` and `HashSet<String>` collections, so the pairing between each group type index and its key was lost before the query was built. The query expressed a cartesian product: match any row whose index is in the first set **and** whose key is in the second set.

### Example

A team has two group types and three group rows:
- `organization` (index 0), key `"acme"`
- `company` (index 1), key `"acme"` ← same key, different group type
- `company` (index 1), key `"globex"`

A request comes in for `groups: {"organization": "acme", "company": "globex"}`. We want rows for exactly `(0, "acme")` and `(1, "globex")`.

**Old query** (`ANY/ANY`): `group_type_index IN (0, 1) AND group_key IN ('acme', 'globex')` — returns **3 rows**, including the false match `(1, "acme")` because index 1 is in the first array and `"acme"` is in the second. The flag evaluator loads the wrong company's properties.

**New query** (`UNNEST` paired join): matches only the exact `(index, key)` pairs requested — returns the correct **2 rows**.

This isn't theoretical — many teams in production have group keys shared across multiple group type indexes.

### Additional issues with the old approach

- **Silent deduplication**: `HashSet<String>` for keys collapsed duplicate key strings shared across group types, silently dropping a lookup.
- **Extra data transferred**: the old query had to select `group_key` so it could re-associate results with the right group type after the unpaired fetch.

Fixes #49009

## Changes

- Replace separate `HashSet<GroupTypeIndex>` + `HashSet<String>` parameters with a `HashMap<GroupTypeIndex, String>` that preserves the 1:1 pairing
- SQL query now uses `INNER JOIN UNNEST($2, $3)` to match exact `(type_index, key)` pairs, matching the pattern already used in personhog-replica
- No longer selects `group_key` (unnecessary when the join guarantees pairing)

## How did you test this code?

- Unit tests covering the paired group identifier SQL path with multiple group types
- All existing feature flag evaluation tests continue to pass
- Manually tested a flag with group filter

## Publish to changelog?

No