### PR TITLE
fix(experiments): remove ExperimentProgressStatus

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -742,17 +742,15 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 )
 
 
-class ExperimentStatus(str, Enum):
+class ExperimentQueryStatus(str, Enum):
     """
-    Note: The frontend also uses a "ProgressStatus.Paused" status, but this is purely a
-    virtual status to have better UX for the user. Technically, paused experiments have
-    feature flags disabled while the experiment is still "running" in the backend, i.e.
-    they have start_date but no end_date).
+    Note: The frontend still treats paused experiments as a UI-only variant of "running"
+    when the linked flag is disabled, so the API only filters on stored experiment statuses.
     """
 
     DRAFT = "draft"
     RUNNING = "running"
-    COMPLETE = "complete"
+    STOPPED = "stopped"
     ALL = "all"
 
 
@@ -783,18 +781,29 @@ class EnterpriseExperimentsViewSet(
             # filtering by status
             status = self.request.query_params.get("status")
             if status:
+                normalized_status = status.lower()
+                if normalized_status == "complete":
+                    normalized_status = ExperimentQueryStatus.STOPPED.value
+
                 try:
-                    status_enum = ExperimentStatus(status.lower())
+                    status_enum = ExperimentQueryStatus(normalized_status)
                 except ValueError:
                     status_enum = None
 
-                if status_enum and status_enum != ExperimentStatus.ALL:
-                    if status_enum == ExperimentStatus.DRAFT:
-                        queryset = queryset.filter(start_date__isnull=True)
-                    elif status_enum == ExperimentStatus.RUNNING:
-                        queryset = queryset.filter(start_date__isnull=False, end_date__isnull=True)
-                    elif status_enum == ExperimentStatus.COMPLETE:
-                        queryset = queryset.filter(end_date__isnull=False)
+                if status_enum and status_enum != ExperimentQueryStatus.ALL:
+                    if status_enum == ExperimentQueryStatus.DRAFT:
+                        queryset = queryset.filter(
+                            Q(status=Experiment.Status.DRAFT) | Q(status__isnull=True, start_date__isnull=True)
+                        )
+                    elif status_enum == ExperimentQueryStatus.RUNNING:
+                        queryset = queryset.filter(
+                            Q(status=Experiment.Status.RUNNING)
+                            | Q(status__isnull=True, start_date__isnull=False, end_date__isnull=True)
+                        )
+                    elif status_enum == ExperimentQueryStatus.STOPPED:
+                        queryset = queryset.filter(
+                            Q(status=Experiment.Status.STOPPED) | Q(status__isnull=True, end_date__isnull=False)
+                        )
 
             # filtering by creator id
             created_by_id = self.request.query_params.get("created_by_id")

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -29,6 +29,49 @@ class TestExperimentCRUD(APILicensedTest):
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @parameterized.expand(
+        [
+            ("draft", "draft"),
+            ("running", "running"),
+            ("stopped", "stopped"),
+            ("complete", "stopped"),
+        ]
+    )
+    def test_can_filter_experiments_by_status(self, status_filter: str, expected_status: str) -> None:
+        self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Draft experiment",
+                "feature_flag_key": "draft-filter-flag",
+                "parameters": None,
+            },
+        )
+        self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Running experiment",
+                "feature_flag_key": "running-filter-flag",
+                "start_date": "2021-12-01T10:23",
+                "parameters": None,
+            },
+        )
+        self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Stopped experiment",
+                "feature_flag_key": "stopped-filter-flag",
+                "start_date": "2021-12-01T10:23",
+                "end_date": "2021-12-10T00:00",
+                "parameters": None,
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/?status={status_filter}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["status"], expected_status)
+
     def test_getting_experiments_is_not_nplus1(self) -> None:
         self.client.post(
             f"/api/projects/{self.team.id}/experiments/",

--- a/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
@@ -11,9 +11,14 @@ import stringWithWBR from 'lib/utils/stringWithWBR'
 import { urls } from 'scenes/urls'
 
 import type { Experiment, FeatureFlagType } from '~/types'
-import { ExperimentProgressStatus } from '~/types'
+import { ExperimentStatus } from '~/types'
 
-import { getExperimentStatus, getShippedVariantKey, isSingleVariantShipped } from '../experimentsLogic'
+import {
+    getExperimentStatus,
+    getShippedVariantKey,
+    isExperimentPaused,
+    isSingleVariantShipped,
+} from '../experimentsLogic'
 import { StatusTag } from '../ExperimentView/components'
 import { isLegacyExperiment } from '../utils'
 import { featureFlagRelatedExperimentsLogic } from './featureFlagRelatedExperimentsLogic'
@@ -176,18 +181,22 @@ export const RelatedExperimentsTable = ({
                         title: 'Status',
                         key: 'status',
                         render: function Render(_, experiment: Experiment) {
-                            return <StatusTag status={getExperimentStatus(experiment)} />
+                            return (
+                                <StatusTag
+                                    status={getExperimentStatus(experiment)}
+                                    isPaused={isExperimentPaused(experiment)}
+                                />
+                            )
                         },
                         align: 'center',
                         sorter: (a, b) => {
                             const statusA = getExperimentStatus(a)
                             const statusB = getExperimentStatus(b)
 
-                            const score: Record<ExperimentProgressStatus, number> = {
-                                [ExperimentProgressStatus.Draft]: 1,
-                                [ExperimentProgressStatus.Running]: 2,
-                                [ExperimentProgressStatus.Paused]: 2,
-                                [ExperimentProgressStatus.Complete]: 3,
+                            const score: Record<ExperimentStatus, number> = {
+                                [ExperimentStatus.Draft]: 1,
+                                [ExperimentStatus.Running]: 2,
+                                [ExperimentStatus.Stopped]: 3,
                             }
                             return score[statusA] > score[statusB] ? 1 : -1
                         },

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -7,7 +7,7 @@ import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { humanFriendlyNumber } from 'lib/utils'
 
-import { Experiment, ExperimentProgressStatus, InsightType } from '~/types'
+import { Experiment, ExperimentStatus, InsightType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatus } from '../experimentsLogic'
@@ -71,7 +71,7 @@ export function DataCollection(): JSX.Element {
             : (actualRunningTime / recommendedRunningTime) * 100
 
     const hasHighRunningTime = recommendedRunningTime > 62
-    const hasEnded = getExperimentStatus(experiment) === ExperimentProgressStatus.Complete
+    const hasEnded = getExperimentStatus(experiment) === ExperimentStatus.Stopped
 
     return (
         <div>

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -12,12 +12,12 @@ import { Label } from 'lib/ui/Label/Label'
 import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
-import { ExperimentProgressStatus, ExperimentStatsMethod } from '~/types'
+import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
-import { getExperimentStatus } from '../experimentsLogic'
+import { getExperimentStatus, isExperimentPaused } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { StatusTag } from './components'
 import { ExperimentDuration } from './ExperimentDuration'
@@ -65,6 +65,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
         secondaryMetricsResults?.[0]?.last_refresh
 
     const status = getExperimentStatus(experiment)
+    const isPaused = isExperimentPaused(experiment)
 
     return (
         <>
@@ -76,12 +77,12 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                         <div className="flex flex-col" data-attr="experiment-status">
                             <Label intent="menu">Status</Label>
                             <div className="flex gap-1">
-                                {status === ExperimentProgressStatus.Paused ? (
+                                {isPaused ? (
                                     <Tooltip
                                         placement="bottom"
                                         title="Your experiment is paused. The linked flag is disabled and no data is being collected."
                                     >
-                                        <StatusTag status={status} />
+                                        <StatusTag status={status} isPaused={isPaused} />
                                     </Tooltip>
                                 ) : (
                                     <StatusTag status={status} />
@@ -101,7 +102,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                             <div className="flex flex-col max-w-[500px]">
                                 <Label intent="menu">Feature flag</Label>
                                 <div className="flex gap-1 items-center">
-                                    {status === ExperimentProgressStatus.Paused && (
+                                    {isPaused && (
                                         <Tooltip
                                             placement="bottom"
                                             title="Your experiment is paused. The linked flag is disabled and no data is being collected."
@@ -211,7 +212,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                                     isExperimentDraft={isExperimentDraft}
                                 />
                             )}
-                            {status !== ExperimentProgressStatus.Draft && (
+                            {status !== ExperimentStatus.Draft && (
                                 <ExperimentReloadAction
                                     isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
                                     lastRefresh={lastRefresh}

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -55,14 +55,14 @@ import {
     ActionFilter,
     AnyPropertyFilter,
     ExperimentConclusion,
-    ExperimentProgressStatus,
+    ExperimentStatus,
     InsightShortId,
 } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG, EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
 import { DuplicateExperimentModal } from '../DuplicateExperimentModal'
 import { experimentLogic } from '../experimentLogic'
-import { getExperimentStatusColor } from '../experimentsLogic'
+import { getExperimentStatusColor, getExperimentStatusLabel } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { getVariantColor } from '../utils'
 
@@ -847,10 +847,10 @@ export const ResetButton = (): JSX.Element => {
     )
 }
 
-export function StatusTag({ status }: { status: ExperimentProgressStatus }): JSX.Element {
+export function StatusTag({ status, isPaused = false }: { status: ExperimentStatus; isPaused?: boolean }): JSX.Element {
     return (
-        <LemonTag type={getExperimentStatusColor(status)} className="cursor-default">
-            <b className="uppercase">{status}</b>
+        <LemonTag type={getExperimentStatusColor(status, isPaused)} className="cursor-default">
+            <b className="uppercase">{getExperimentStatusLabel(status, isPaused)}</b>
         </LemonTag>
     )
 }

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -39,7 +39,7 @@ import {
     AccessControlResourceType,
     ActivityScope,
     Experiment,
-    ExperimentProgressStatus,
+    ExperimentStatus,
     ExperimentsTabs,
 } from '~/types'
 
@@ -49,6 +49,7 @@ import {
     ExperimentsFilters,
     experimentsLogic,
     getExperimentStatus,
+    isExperimentPaused,
     getShippedVariantKey,
     isSingleVariantShipped,
 } from './experimentsLogic'
@@ -131,15 +132,15 @@ const ExperimentsTableFilters = ({
                                 const { status: _, ...restFilters } = filters
                                 onFiltersChange({ ...restFilters, page: 1 }, true)
                             } else {
-                                onFiltersChange({ status: status as ExperimentProgressStatus, page: 1 })
+                                onFiltersChange({ status: status as ExperimentStatus, page: 1 })
                             }
                         }}
                         options={
                             [
                                 { label: 'All', value: 'all' },
-                                { label: 'Draft', value: ExperimentProgressStatus.Draft },
-                                { label: 'Running / Paused', value: ExperimentProgressStatus.Running },
-                                { label: 'Complete', value: ExperimentProgressStatus.Complete },
+                                { label: 'Draft', value: ExperimentStatus.Draft },
+                                { label: 'Running / Paused', value: ExperimentStatus.Running },
+                                { label: 'Complete', value: ExperimentStatus.Stopped },
                             ] as { label: string; value: string }[]
                         }
                         value={filters.status ?? 'all'}
@@ -311,18 +312,17 @@ const ExperimentsTable = ({
             title: 'Status',
             key: 'status',
             render: function Render(_, experiment: Experiment) {
-                return <StatusTag status={getExperimentStatus(experiment)} />
+                return <StatusTag status={getExperimentStatus(experiment)} isPaused={isExperimentPaused(experiment)} />
             },
             align: 'center',
             sorter: (a, b) => {
                 const statusA = getExperimentStatus(a)
                 const statusB = getExperimentStatus(b)
 
-                const score = {
-                    draft: 1,
-                    paused: 2,
-                    running: 3,
-                    complete: 4,
+                const score: Record<ExperimentStatus, number> = {
+                    [ExperimentStatus.Draft]: 1,
+                    [ExperimentStatus.Running]: 2,
+                    [ExperimentStatus.Stopped]: 3,
                 }
                 return score[statusA] > score[statusB] ? 1 : -1
             },
@@ -352,7 +352,7 @@ const ExperimentsTable = ({
                                     }}
                                 />
                                 {!experiment.archived &&
-                                    getExperimentStatus(experiment) === ExperimentProgressStatus.Complete && (
+                                    getExperimentStatus(experiment) === ExperimentStatus.Stopped && (
                                         <AccessControlAction
                                             resourceType={AccessControlResourceType.Experiment}
                                             minAccessLevel={AccessControlLevel.Editor}

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -4,7 +4,7 @@ import { ActivityLogItem, HumanizedChange, userNameForLogItem } from 'lib/compon
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 
-import { ExperimentProgressStatus } from '~/types'
+import { ExperimentStatus } from '~/types'
 
 import {
     getExperimentChangeDescription,
@@ -21,7 +21,7 @@ export const ExperimentDetails = ({
     status,
 }: {
     logItem: ActivityLogItem
-    status: ExperimentProgressStatus
+    status: ExperimentStatus
 }): JSX.Element => {
     return (
         <LemonCard className="flex items-center justify-between gap-3 p-4">
@@ -169,7 +169,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                                 <span>created a new shared metric:</span>
                             ) : (
                                 <span>
-                                    created a new <StatusTag status={ExperimentProgressStatus.Draft} /> experiment:
+                                    created a new <StatusTag status={ExperimentStatus.Draft} /> experiment:
                                 </span>
                             ),
                         ]}

--- a/frontend/src/scenes/experiments/experimentsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.test.ts
@@ -6,9 +6,15 @@ import { expectLogic } from 'kea-test-utils'
 import { NEW_FLAG } from 'scenes/feature-flags/featureFlagLogic'
 
 import { initKeaTests } from '~/test/init'
-import { Experiment, ExperimentProgressStatus, ExperimentStatus, FeatureFlagType } from '~/types'
+import { Experiment, ExperimentStatus, FeatureFlagType } from '~/types'
 
-import { experimentsLogic, getExperimentStatus, getExperimentStatusColor, hasEnded } from './experimentsLogic'
+import {
+    experimentsLogic,
+    getExperimentStatus,
+    getExperimentStatusColor,
+    hasEnded,
+    isExperimentPaused,
+} from './experimentsLogic'
 
 const createMockExperiment = (overrides: any = {}): Experiment =>
     ({
@@ -268,13 +274,13 @@ describe('experimentsLogic', () => {
         it('constructs correct params from filters', () => {
             logic.actions.setExperimentsFilters({
                 search: 'test',
-                status: ExperimentProgressStatus.Running,
+                status: ExperimentStatus.Running,
                 page: 2,
             })
 
             expect(logic.values.paramsFromFilters).toEqual({
                 search: 'test',
-                status: ExperimentProgressStatus.Running,
+                status: ExperimentStatus.Running,
                 page: 2,
                 limit: 100,
                 offset: 100,
@@ -391,25 +397,15 @@ describe('experimentsLogic', () => {
 describe('utility functions', () => {
     describe('getExperimentStatus', () => {
         it('returns Draft for experiments without start date', () => {
-            expect(getExperimentStatus(mockDraftExperiment)).toBe(ExperimentProgressStatus.Draft)
+            expect(getExperimentStatus(mockDraftExperiment)).toBe(ExperimentStatus.Draft)
         })
 
         it('returns Running for experiments with start date but no end date', () => {
-            expect(getExperimentStatus(mockRunningExperiment)).toBe(ExperimentProgressStatus.Running)
+            expect(getExperimentStatus(mockRunningExperiment)).toBe(ExperimentStatus.Running)
         })
 
-        it('returns Complete for experiments with both start and end dates', () => {
-            expect(getExperimentStatus(mockExperiment)).toBe(ExperimentProgressStatus.Complete)
-        })
-
-        it('returns Paused when feature flag is inactive', () => {
-            const pausedExperiment = createMockExperiment({
-                start_date: '2024-01-01',
-                end_date: null,
-                status: ExperimentStatus.Running,
-                feature_flag: { active: false },
-            })
-            expect(getExperimentStatus(pausedExperiment)).toBe(ExperimentProgressStatus.Paused)
+        it('returns Stopped for experiments with both start and end dates', () => {
+            expect(getExperimentStatus(mockExperiment)).toBe(ExperimentStatus.Stopped)
         })
 
         it('returns Running when feature flag is active', () => {
@@ -419,16 +415,40 @@ describe('utility functions', () => {
                 status: ExperimentStatus.Running,
                 feature_flag: { active: true },
             })
-            expect(getExperimentStatus(runningExperiment)).toBe(ExperimentProgressStatus.Running)
+            expect(getExperimentStatus(runningExperiment)).toBe(ExperimentStatus.Running)
+        })
+    })
+
+    describe('isExperimentPaused', () => {
+        it('returns true when a running experiment has an inactive feature flag', () => {
+            const pausedExperiment = createMockExperiment({
+                start_date: '2024-01-01',
+                end_date: null,
+                status: ExperimentStatus.Running,
+                feature_flag: { active: false },
+            })
+
+            expect(isExperimentPaused(pausedExperiment)).toBe(true)
+        })
+
+        it('returns false when a running experiment has an active feature flag', () => {
+            const runningExperiment = createMockExperiment({
+                start_date: '2024-01-01',
+                end_date: null,
+                status: ExperimentStatus.Running,
+                feature_flag: { active: true },
+            })
+
+            expect(isExperimentPaused(runningExperiment)).toBe(false)
         })
     })
 
     describe('getExperimentStatusColor', () => {
         it('returns correct colors for each status', () => {
-            expect(getExperimentStatusColor(ExperimentProgressStatus.Draft)).toBe('default')
-            expect(getExperimentStatusColor(ExperimentProgressStatus.Running)).toBe('success')
-            expect(getExperimentStatusColor(ExperimentProgressStatus.Paused)).toBe('warning')
-            expect(getExperimentStatusColor(ExperimentProgressStatus.Complete)).toBe('completion')
+            expect(getExperimentStatusColor(ExperimentStatus.Draft)).toBe('default')
+            expect(getExperimentStatusColor(ExperimentStatus.Running)).toBe('success')
+            expect(getExperimentStatusColor(ExperimentStatus.Running, true)).toBe('warning')
+            expect(getExperimentStatusColor(ExperimentStatus.Stopped)).toBe('completion')
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -20,7 +20,6 @@ import {
     ActivityScope,
     Breadcrumb,
     Experiment,
-    ExperimentProgressStatus,
     ExperimentStatus,
     ExperimentVelocityStats,
     ExperimentsTabs,
@@ -38,7 +37,7 @@ export interface ExperimentsResult extends CountedPaginatedResponse<Experiment> 
 
 export interface ExperimentsFilters {
     search?: string
-    status?: ExperimentProgressStatus | 'all'
+    status?: ExperimentStatus | 'all'
     created_by_id?: number
     archived?: boolean
     page?: number
@@ -72,9 +71,13 @@ const DEFAULT_MODAL_FILTERS: FeatureFlagModalFilters = {
     evaluation_runtime: undefined,
 }
 
-type StoredExperimentStatusInput = Pick<Experiment, 'status' | 'start_date' | 'end_date'> | null | undefined
+type ExperimentStatusInput = Pick<Experiment, 'status' | 'start_date' | 'end_date'> | null | undefined
+type ExperimentStatusDisplayInput =
+    | Pick<Experiment, 'status' | 'start_date' | 'end_date' | 'feature_flag'>
+    | null
+    | undefined
 
-export function getStoredExperimentStatus(experiment: StoredExperimentStatusInput): ExperimentStatus {
+export function getExperimentStatus(experiment: ExperimentStatusInput): ExperimentStatus {
     if (!experiment) {
         return ExperimentStatus.Draft
     }
@@ -93,31 +96,20 @@ export function getStoredExperimentStatus(experiment: StoredExperimentStatusInpu
     return ExperimentStatus.Draft
 }
 
-export function isLaunched(experiment: StoredExperimentStatusInput): boolean {
-    return getStoredExperimentStatus(experiment) !== ExperimentStatus.Draft
+export function isExperimentPaused(experiment: ExperimentStatusDisplayInput): boolean {
+    return (
+        getExperimentStatus(experiment) === ExperimentStatus.Running &&
+        !!experiment?.feature_flag &&
+        !experiment.feature_flag.active
+    )
 }
 
-export function hasEnded(experiment: StoredExperimentStatusInput): boolean {
-    return getStoredExperimentStatus(experiment) === ExperimentStatus.Stopped
+export function isLaunched(experiment: ExperimentStatusInput): boolean {
+    return getExperimentStatus(experiment) !== ExperimentStatus.Draft
 }
 
-export function getExperimentStatus(experiment: Experiment | null | undefined): ExperimentProgressStatus {
-    const status = getStoredExperimentStatus(experiment)
-
-    if (status === ExperimentStatus.Draft) {
-        return ExperimentProgressStatus.Draft
-    }
-
-    if (status === ExperimentStatus.Running) {
-        // When the feature flag is disabled, we show "Paused" to the user for better UX.
-        // This is just a virtual status, the backend still considers the experiment "running".
-        if (experiment?.feature_flag && !experiment.feature_flag.active) {
-            return ExperimentProgressStatus.Paused
-        }
-        return ExperimentProgressStatus.Running
-    }
-
-    return ExperimentProgressStatus.Complete
+export function hasEnded(experiment: ExperimentStatusInput): boolean {
+    return getExperimentStatus(experiment) === ExperimentStatus.Stopped
 }
 
 export function isSingleVariantShipped(experiment: Experiment): boolean {
@@ -143,17 +135,56 @@ export function getShippedVariantKey(experiment: Experiment): string | null {
     )
 }
 
-export function getExperimentStatusColor(status: ExperimentProgressStatus): LemonTagType {
+export function getExperimentStatusLabel(status: ExperimentStatus, isPaused: boolean = false): string {
+    if (isPaused) {
+        return 'Paused'
+    }
+
     switch (status) {
-        case ExperimentProgressStatus.Draft:
+        case ExperimentStatus.Draft:
+            return 'Draft'
+        case ExperimentStatus.Running:
+            return 'Running'
+        case ExperimentStatus.Stopped:
+            return 'Complete'
+    }
+
+    return 'Draft'
+}
+
+export function getExperimentStatusColor(status: ExperimentStatus, isPaused: boolean = false): LemonTagType {
+    if (isPaused) {
+        return 'warning'
+    }
+
+    switch (status) {
+        case ExperimentStatus.Draft:
             return 'default'
-        case ExperimentProgressStatus.Running:
+        case ExperimentStatus.Running:
             return 'success'
-        case ExperimentProgressStatus.Paused:
-            return 'warning'
-        case ExperimentProgressStatus.Complete:
+        case ExperimentStatus.Stopped:
             return 'completion'
     }
+
+    return 'default'
+}
+
+function normalizeExperimentFilterStatus(status: string | undefined): ExperimentStatus | 'all' {
+    if (!status) {
+        return 'all'
+    }
+
+    const normalizedStatus = status.toLowerCase()
+
+    if (normalizedStatus === 'complete') {
+        return ExperimentStatus.Stopped
+    }
+
+    if (Object.values(ExperimentStatus).includes(normalizedStatus as ExperimentStatus)) {
+        return normalizedStatus as ExperimentStatus
+    }
+
+    return 'all'
 }
 
 export const experimentsLogic = kea<experimentsLogicType>([
@@ -528,7 +559,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 order,
             }
 
-            pageFiltersFromUrl.status = status || 'all'
+            pageFiltersFromUrl.status = normalizeExperimentFilterStatus(status)
             pageFiltersFromUrl.page = page !== undefined ? parseInt(page) : 1
             pageFiltersFromUrl.archived = String(archived) === 'true'
 

--- a/frontend/src/scenes/experiments/legacy/LegacyExperimentInfo.tsx
+++ b/frontend/src/scenes/experiments/legacy/LegacyExperimentInfo.tsx
@@ -15,11 +15,11 @@ import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { ExperimentProgressStatus, ExperimentStatsMethod } from '~/types'
+import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'
-import { getExperimentStatus } from '../experimentsLogic'
+import { getExperimentStatus, isExperimentPaused } from '../experimentsLogic'
 import { StatusTag } from '../ExperimentView/components'
 import { StatsMethodModal } from '../ExperimentView/StatsMethodModal'
 import { modalsLogic } from '../modalsLogic'
@@ -109,6 +109,7 @@ export function LegacyExperimentInfo(): JSX.Element | null {
         secondaryMetricsResults?.[0]?.last_refresh
 
     const status = getExperimentStatus(experiment)
+    const isPaused = isExperimentPaused(experiment)
 
     return (
         <SceneContent>
@@ -117,7 +118,7 @@ export function LegacyExperimentInfo(): JSX.Element | null {
                     <div className="flex flex-col" data-attr="experiment-status">
                         <Label intent="menu">Status</Label>
                         <div className="flex gap-1">
-                            <StatusTag status={status} />
+                            <StatusTag status={status} isPaused={isPaused} />
                             {isSingleVariantShipped && (
                                 <Tooltip title={`Variant "${shippedVariantKey}" has been rolled out to 100% of users`}>
                                     <LemonTag type="completion" className="cursor-default">
@@ -131,10 +132,10 @@ export function LegacyExperimentInfo(): JSX.Element | null {
                         <div className="flex flex-col">
                             <Label intent="menu">Feature flag</Label>
                             <div className="flex gap-1 items-center">
-                                {status === ExperimentProgressStatus.Running && !experiment.feature_flag.active && (
+                                {isPaused && (
                                     <Tooltip
                                         placement="bottom"
-                                        title="Your experiment is running, but the linked flag is disabled. No data is being collected."
+                                        title="Your experiment is paused. The linked flag is disabled and no data is being collected."
                                     >
                                         <IconWarning
                                             style={{ transform: 'translateY(2px)' }}
@@ -188,7 +189,7 @@ export function LegacyExperimentInfo(): JSX.Element | null {
 
                 <div className="flex flex-col">
                     <div className="inline-flex deprecated-space-x-8">
-                        {status !== ExperimentProgressStatus.Draft && (
+                        {status !== ExperimentStatus.Draft && (
                             <ExperimentLastRefresh
                                 isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
                                 lastRefresh={lastRefresh}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -7,7 +7,7 @@ import { LemonDivider } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { experimentLogic } from 'scenes/experiments/experimentLogic'
-import { getExperimentStatus } from 'scenes/experiments/experimentsLogic'
+import { getExperimentStatus, isExperimentPaused } from 'scenes/experiments/experimentsLogic'
 import { LegacyResultsQuery, ResultsTag, StatusTag } from 'scenes/experiments/ExperimentView/components'
 import { Info } from 'scenes/experiments/ExperimentView/Info'
 import { SummaryTable } from 'scenes/experiments/ExperimentView/SummaryTable'
@@ -59,7 +59,10 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
                     ) : (
                         <>
                             <span className="flex-1 font-semibold truncate">{experiment.name}</span>
-                            <StatusTag status={getExperimentStatus(experiment)} />
+                            <StatusTag
+                                status={getExperimentStatus(experiment)}
+                                isPaused={isExperimentPaused(experiment)}
+                            />
                             <ResultsTag />
                         </>
                     )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -896,13 +896,6 @@ export enum ProgressStatus {
     Complete = 'complete',
 }
 
-export enum ExperimentProgressStatus {
-    Draft = 'draft',
-    Running = 'running',
-    Paused = 'paused',
-    Complete = 'complete',
-}
-
 export enum ExperimentStatus {
     Draft = 'draft',
     Running = 'running',


### PR DESCRIPTION
## Problem
`ExperimentProgressStatus` was left over from when experiment state was derived on the frontend from `start_date` and `end_date`.
Since experiments now persist an explicit `status` field in the database, keeping a second status type in the frontend duplicated the source of truth and forced the app to translate between backend state and frontend-only state.
That made the code harder to follow and increased rollout risk, because the frontend and backend were not speaking the same status vocabulary.

## Changes
- remove frontend usage of `ExperimentProgressStatus` and use `ExperimentStatus` for experiment state instead
- keep `Paused` as a UI-only derived display state when a running experiment has an inactive feature flag
- keep `Complete` as a display label for backend `stopped`, rather than as a separate stored/frontend enum value (we can later rename the label to "stopped")
- align the experiments list filter backend with stored statuses, while keeping `status=complete` as a compatibility alias during rollout
- update experiment status helpers, tags, filters, and tests to reflect the simplified model

## Testing
- CI passes with new tests
- Tested locally, verified that filtering works and that status displays correctly on experiments