### PR TITLE
feat(replay): add decompress and CORS support to recording-api

### DIFF
--- a/nodejs/src/session-replay/recording-api/metrics.ts
+++ b/nodejs/src/session-replay/recording-api/metrics.ts
@@ -3,8 +3,8 @@ import { Counter, Histogram } from 'prom-client'
 export class RecordingApiMetrics {
     private static readonly getBlockDuration = new Histogram({
         name: 'recording_api_get_block_duration_seconds',
-        help: 'Time taken to serve a getBlock request (S3 fetch + decrypt)',
-        labelNames: ['result', 'session_state'],
+        help: 'Time taken to serve a getBlock request (S3 fetch + decrypt + optional decompress)',
+        labelNames: ['result', 'session_state', 'decompress'],
         buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
     })
 
@@ -15,8 +15,15 @@ export class RecordingApiMetrics {
         buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
     })
 
-    public static observeGetBlock(result: string, seconds: number, sessionState: string): void {
-        this.getBlockDuration.labels({ result, session_state: sessionState }).observe(seconds)
+    public static observeGetBlock(
+        result: string,
+        seconds: number,
+        sessionState: string,
+        decompress: boolean = false
+    ): void {
+        this.getBlockDuration
+            .labels({ result, session_state: sessionState, decompress: String(decompress) })
+            .observe(seconds)
     }
 
     private static readonly recordingsDeleted = new Counter({

--- a/nodejs/src/session-replay/recording-api/recording-api.integration.test.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.integration.test.ts
@@ -961,6 +961,7 @@ describe('Recording API encryption integration', () => {
                 expect(res.status).toBe(204)
                 expect(res.headers['access-control-allow-origin']).toBe('https://us.posthog.com')
                 expect(res.headers['access-control-allow-methods']).toBe('GET')
+                expect(res.headers['access-control-allow-headers']).toBe('X-Internal-Api-Secret')
                 expect(res.headers['access-control-max-age']).toBe('86400')
             })
 

--- a/nodejs/src/session-replay/recording-api/recording-api.integration.test.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.integration.test.ts
@@ -775,7 +775,10 @@ describe('Recording API encryption integration', () => {
                 decryptor
             )
 
-            const recordingApi = new RecordingApi({} as RecordingApiConfig, {} as PostgresRouter)
+            const recordingApi = new RecordingApi(
+                { SITE_URL: 'https://us.posthog.com' } as RecordingApiConfig,
+                {} as PostgresRouter
+            )
             await recordingApi.start(recordingService)
 
             app = express()
@@ -854,6 +857,180 @@ describe('Recording API encryption integration', () => {
 
                 expect(res.status).toBe(404)
                 expect(res.body.error).toBe('Block not found')
+            })
+
+            it('should return decompressed JSONL when decompress=true', async () => {
+                const sessionId = 'http-decompress-1'
+                const teamId = 1
+                const originalEvents = [
+                    { type: 2, data: { content: 'hello' } },
+                    { type: 3, data: { content: 'world' } },
+                ]
+
+                const sessionKey = await keyStore.generateKey(sessionId, teamId)
+                const blockData = await createBlockData(originalEvents)
+                const { data: encrypted } = encryptor.encryptBlockWithKey(sessionId, teamId, blockData, sessionKey)
+
+                mockS3Send.mockResolvedValue({
+                    Body: { transformToByteArray: () => Promise.resolve(encrypted) },
+                })
+
+                const res = await supertest(app)
+                    .get(`/api/projects/${teamId}/recordings/${sessionId}/block`)
+                    .query({
+                        key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                        start: '0',
+                        end: String(encrypted.length - 1),
+                        decompress: 'true',
+                    })
+
+                expect(res.status).toBe(200)
+                expect(res.headers['content-type']).toContain('application/jsonl')
+                expect(res.headers['cache-control']).toBe('public, max-age=2592000, immutable')
+
+                const lines = res.text.trim().split('\n')
+                expect(lines).toHaveLength(2)
+                expect(parseJSON(lines[0])[1]).toEqual(originalEvents[0])
+                expect(parseJSON(lines[1])[1]).toEqual(originalEvents[1])
+            })
+
+            it('should return compressed data when decompress is not set', async () => {
+                const sessionId = 'http-no-decompress-1'
+                const teamId = 1
+                const originalEvents = [{ type: 2, data: { content: 'compressed' } }]
+
+                const sessionKey = await keyStore.generateKey(sessionId, teamId)
+                const blockData = await createBlockData(originalEvents)
+                const { data: encrypted } = encryptor.encryptBlockWithKey(sessionId, teamId, blockData, sessionKey)
+
+                mockS3Send.mockResolvedValue({
+                    Body: { transformToByteArray: () => Promise.resolve(encrypted) },
+                })
+
+                const res = await supertest(app)
+                    .get(`/api/projects/${teamId}/recordings/${sessionId}/block`)
+                    .query({
+                        key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                        start: '0',
+                        end: String(encrypted.length - 1),
+                    })
+
+                expect(res.status).toBe(200)
+                expect(res.headers['content-type']).toContain('application/octet-stream')
+                expect(Buffer.from(res.body).equals(blockData)).toBe(true)
+            })
+        })
+
+        describe('CORS', () => {
+            it('should set CORS headers for the matching deployment origin', async () => {
+                mockS3Send.mockResolvedValue({ Body: null })
+
+                const res = await supertest(app)
+                    .get('/api/projects/1/recordings/session-1/block')
+                    .set('Origin', 'https://us.posthog.com')
+                    .query({
+                        key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                        start: '0',
+                        end: '100',
+                    })
+
+                expect(res.headers['access-control-allow-origin']).toBe('https://us.posthog.com')
+                expect(res.headers['vary']).toContain('Origin')
+            })
+
+            it('should not set CORS headers for non-matching origins', async () => {
+                mockS3Send.mockResolvedValue({ Body: null })
+
+                const res = await supertest(app)
+                    .get('/api/projects/1/recordings/session-1/block')
+                    .set('Origin', 'https://evil.example.com')
+                    .query({
+                        key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                        start: '0',
+                        end: '100',
+                    })
+
+                expect(res.headers['access-control-allow-origin']).toBeUndefined()
+            })
+
+            it('should handle OPTIONS preflight', async () => {
+                const res = await supertest(app)
+                    .options('/api/projects/1/recordings/session-1/block')
+                    .set('Origin', 'https://us.posthog.com')
+
+                expect(res.status).toBe(204)
+                expect(res.headers['access-control-allow-origin']).toBe('https://us.posthog.com')
+                expect(res.headers['access-control-allow-methods']).toBe('GET')
+                expect(res.headers['access-control-max-age']).toBe('86400')
+            })
+
+            it('should not set CORS headers when SITE_URL is empty', async () => {
+                const noSiteUrlService = new RecordingService(
+                    { send: mockS3Send, destroy: jest.fn() } as unknown as S3Client,
+                    'test-bucket',
+                    'session_recordings',
+                    keyStore,
+                    decryptor
+                )
+                const noSiteUrlApi = new RecordingApi({ SITE_URL: '' } as RecordingApiConfig, {} as PostgresRouter)
+                await noSiteUrlApi.start(noSiteUrlService)
+
+                const noSiteUrlApp = express()
+                noSiteUrlApp.use('/', noSiteUrlApi.router())
+                const noSiteUrlServer = noSiteUrlApp.listen(0, () => {})
+
+                try {
+                    mockS3Send.mockResolvedValue({ Body: null })
+
+                    const res = await supertest(noSiteUrlApp)
+                        .get('/api/projects/1/recordings/session-1/block')
+                        .set('Origin', 'https://us.posthog.com')
+                        .query({
+                            key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                            start: '0',
+                            end: '100',
+                        })
+
+                    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+                } finally {
+                    noSiteUrlServer.close()
+                }
+            })
+
+            it('should allow localhost origin for local development', async () => {
+                const localService = new RecordingService(
+                    { send: mockS3Send, destroy: jest.fn() } as unknown as S3Client,
+                    'test-bucket',
+                    'session_recordings',
+                    keyStore,
+                    decryptor
+                )
+                const localApi = new RecordingApi(
+                    { SITE_URL: 'http://localhost:8000' } as RecordingApiConfig,
+                    {} as PostgresRouter
+                )
+                await localApi.start(localService)
+
+                const localApp = express()
+                localApp.use('/', localApi.router())
+                const localServer = localApp.listen(0, () => {})
+
+                try {
+                    mockS3Send.mockResolvedValue({ Body: null })
+
+                    const res = await supertest(localApp)
+                        .get('/api/projects/1/recordings/session-1/block')
+                        .set('Origin', 'http://localhost:8000')
+                        .query({
+                            key: 'session_recordings/30d/1764634738680-3cca0f5d3c7cc7ee',
+                            start: '0',
+                            end: '100',
+                        })
+
+                    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:8000')
+                } finally {
+                    localServer.close()
+                }
             })
         })
     })

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -1,5 +1,4 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
-import snappy from 'snappy'
 import express from 'ultimate-express'
 
 import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS } from '../../config/kafka-topics'
@@ -239,6 +238,7 @@ export class RecordingApi {
                 key,
                 startByte,
                 endByte,
+                decompress,
             })
 
             // Serialize response
@@ -255,18 +255,11 @@ export class RecordingApi {
                 return
             }
 
-            if (decompress) {
-                const decompressed = await snappy.uncompress(result.data, { asBuffer: false })
-                res.set('Content-Type', 'application/jsonl')
-                res.set('Content-Length', String(Buffer.byteLength(decompressed as string)))
-                res.set('Cache-Control', 'public, max-age=2592000, immutable')
-                res.send(decompressed)
-            } else {
-                res.set('Content-Type', 'application/octet-stream')
-                res.set('Content-Length', String(result.data.length))
-                res.set('Cache-Control', 'public, max-age=2592000, immutable')
-                res.send(result.data)
-            }
+            const contentType = decompress ? 'application/jsonl' : 'application/octet-stream'
+            res.set('Content-Type', contentType)
+            res.set('Content-Length', String(Buffer.byteLength(result.data)))
+            res.set('Cache-Control', 'public, max-age=2592000, immutable')
+            res.send(result.data)
         } catch (error) {
             logger.error('[RecordingApi] Error fetching block from S3', {
                 error: serializeError(error),

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -195,6 +195,7 @@ export class RecordingApi {
     private handleCorsPreflightForBlock = (req: express.Request, res: express.Response): void => {
         this.setCorsHeaders(req, res)
         res.set('Access-Control-Allow-Methods', 'GET')
+        res.set('Access-Control-Allow-Headers', 'X-Internal-Api-Secret')
         res.set('Access-Control-Max-Age', '86400')
         res.status(204).end()
     }

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -1,4 +1,5 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
+import snappy from 'snappy'
 import express from 'ultimate-express'
 
 import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS } from '../../config/kafka-topics'
@@ -25,6 +26,7 @@ import { DeleteRecordingsBodySchema, GetBlockQuerySchema, RecordingParamsSchema,
 import { KeyStore, RecordingApiConfig, RecordingDecryptor } from './types'
 
 export class RecordingApi {
+    private corsOrigin: string | null = null
     private s3Client: S3Client | null = null
     private s3Bucket: string | null = null
     private s3Prefix: string | null = null
@@ -48,6 +50,8 @@ export class RecordingApi {
     }
 
     async start(recordingService?: RecordingService): Promise<void> {
+        this.corsOrigin = this.config.SITE_URL || null
+
         if (recordingService) {
             this.recordingService = recordingService
             logger.info('[RecordingApi] Started with injected RecordingService')
@@ -173,13 +177,32 @@ export class RecordingApi {
             (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> =>
                 fn(req, res).catch(next)
 
-        router.get('/api/projects/:team_id/recordings/:session_id/block', asyncHandler(this.getBlock))
+        const blockPath = '/api/projects/:team_id/recordings/:session_id/block'
+
+        router.options(blockPath, this.handleCorsPreflightForBlock)
+        router.get(blockPath, asyncHandler(this.getBlock))
         router.post('/api/projects/:team_id/recordings/delete', asyncHandler(this.deleteRecordings))
 
         return router
     }
 
+    private setCorsHeaders(req: express.Request, res: express.Response): void {
+        if (this.corsOrigin && req.headers.origin === this.corsOrigin) {
+            res.set('Access-Control-Allow-Origin', this.corsOrigin)
+            res.set('Vary', 'Origin')
+        }
+    }
+
+    private handleCorsPreflightForBlock = (req: express.Request, res: express.Response): void => {
+        this.setCorsHeaders(req, res)
+        res.set('Access-Control-Allow-Methods', 'GET')
+        res.set('Access-Control-Max-Age', '86400')
+        res.status(204).end()
+    }
+
     private getBlock = async (req: express.Request, res: express.Response): Promise<void> => {
+        this.setCorsHeaders(req, res)
+
         // Parse and validate request
         const paramsResult = RecordingParamsSchema.safeParse(req.params)
         if (!paramsResult.success) {
@@ -200,7 +223,7 @@ export class RecordingApi {
         }
 
         const { team_id: teamId, session_id: sessionId } = paramsResult.data
-        const { key, start: startByte, end: endByte } = queryResult.data
+        const { key, start: startByte, end: endByte, decompress } = queryResult.data
 
         // Validate S3 key format
         if (!this.recordingService.validateS3Key(key)) {
@@ -232,10 +255,18 @@ export class RecordingApi {
                 return
             }
 
-            res.set('Content-Type', 'application/octet-stream')
-            res.set('Content-Length', String(result.data.length))
-            res.set('Cache-Control', 'public, max-age=2592000, immutable')
-            res.send(result.data)
+            if (decompress) {
+                const decompressed = await snappy.uncompress(result.data, { asBuffer: false })
+                res.set('Content-Type', 'application/jsonl')
+                res.set('Content-Length', String(Buffer.byteLength(decompressed as string)))
+                res.set('Cache-Control', 'public, max-age=2592000, immutable')
+                res.send(decompressed)
+            } else {
+                res.set('Content-Type', 'application/octet-stream')
+                res.set('Content-Length', String(result.data.length))
+                res.set('Cache-Control', 'public, max-age=2592000, immutable')
+                res.send(result.data)
+            }
         } catch (error) {
             logger.error('[RecordingApi] Error fetching block from S3', {
                 error: serializeError(error),

--- a/nodejs/src/session-replay/recording-api/recording-service.test.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.test.ts
@@ -1,4 +1,5 @@
 import { NoSuchKey, S3Client } from '@aws-sdk/client-s3'
+import snappy from 'snappy'
 
 import { PostgresRouter } from '../../utils/db/postgres'
 import { SessionMetadataStore } from '../shared/metadata/session-metadata-store'
@@ -111,6 +112,23 @@ describe('RecordingService', () => {
 
             expect(result).toEqual({ ok: true, data: Buffer.from('decrypted data') })
             expect(mockDecryptor.decryptBlock).toHaveBeenCalledWith('session-123', 1, expect.any(Buffer))
+        })
+
+        it('returns decompressed data when decompress is true', async () => {
+            const originalData = '{"type": 3, "data": {}}'
+            const compressed = await snappy.compress(Buffer.from(originalData))
+            const mockBody = {
+                transformToByteArray: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+            }
+            mockS3Send.mockResolvedValue({ Body: mockBody })
+            mockDecryptor.decryptBlock.mockResolvedValue({
+                data: Buffer.from(compressed),
+                sessionState: 'ciphertext',
+            })
+
+            const result = await service.getBlock({ ...validParams, decompress: true })
+
+            expect(result).toEqual({ ok: true, data: Buffer.from(originalData) })
         })
 
         it('returns not_found when S3 returns no body', async () => {

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -101,12 +101,10 @@ export class RecordingService {
                 sessionState,
             })
 
-            RecordingApiMetrics.observeGetBlock('success', (performance.now() - startTime) / 1000, sessionState)
-
+            let result = data
             if (decompress) {
                 try {
-                    const decompressed = (await snappy.uncompress(data, { asBuffer: true })) as Buffer
-                    return { ok: true, data: decompressed }
+                    result = (await snappy.uncompress(data, { asBuffer: true })) as Buffer
                 } catch (decompressError) {
                     logger.error('[RecordingService] Failed to decompress block', {
                         sessionId,
@@ -118,7 +116,14 @@ export class RecordingService {
                     throw decompressError
                 }
             }
-            return { ok: true, data }
+
+            RecordingApiMetrics.observeGetBlock(
+                'success',
+                (performance.now() - startTime) / 1000,
+                sessionState,
+                !!decompress
+            )
+            return { ok: true, data: result }
         } catch (error) {
             if (error instanceof NoSuchKey) {
                 logger.warn('[RecordingService] S3 object not found (NoSuchKey)', {

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -1,4 +1,5 @@
 import { GetObjectCommand, NoSuchKey, S3Client } from '@aws-sdk/client-s3'
+import snappy from 'snappy'
 
 import { PostgresRouter, PostgresUse } from '../../utils/db/postgres'
 import { logger, serializeError } from '../../utils/logger'
@@ -14,6 +15,7 @@ export interface GetBlockParams {
     key: string
     startByte: number
     endByte: number
+    decompress?: boolean
 }
 
 export type GetBlockResult =
@@ -47,7 +49,7 @@ export class RecordingService {
     }
 
     async getBlock(params: GetBlockParams): Promise<GetBlockResult> {
-        const { sessionId, teamId, key, startByte, endByte } = params
+        const { sessionId, teamId, key, startByte, endByte, decompress } = params
         const startTime = performance.now()
 
         logger.debug('[RecordingService] getBlock request', {
@@ -100,6 +102,11 @@ export class RecordingService {
             })
 
             RecordingApiMetrics.observeGetBlock('success', (performance.now() - startTime) / 1000, sessionState)
+
+            if (decompress) {
+                const decompressed = (await snappy.uncompress(data, { asBuffer: true })) as Buffer
+                return { ok: true, data: decompressed }
+            }
             return { ok: true, data }
         } catch (error) {
             if (error instanceof NoSuchKey) {

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -104,8 +104,19 @@ export class RecordingService {
             RecordingApiMetrics.observeGetBlock('success', (performance.now() - startTime) / 1000, sessionState)
 
             if (decompress) {
-                const decompressed = (await snappy.uncompress(data, { asBuffer: true })) as Buffer
-                return { ok: true, data: decompressed }
+                try {
+                    const decompressed = (await snappy.uncompress(data, { asBuffer: true })) as Buffer
+                    return { ok: true, data: decompressed }
+                } catch (decompressError) {
+                    logger.error('[RecordingService] Failed to decompress block', {
+                        sessionId,
+                        teamId,
+                        key,
+                        dataSize: data.length,
+                        error: serializeError(decompressError),
+                    })
+                    throw decompressError
+                }
             }
             return { ok: true, data }
         } catch (error) {

--- a/nodejs/src/session-replay/recording-api/schemas.ts
+++ b/nodejs/src/session-replay/recording-api/schemas.ts
@@ -44,6 +44,10 @@ export const GetBlockQuerySchema = z
         key: z.string({ required_error: 'Missing key query parameter' }).min(1, 'Invalid key query parameter'),
         start: nonNegativeIntString('start'),
         end: nonNegativeIntString('end'),
+        decompress: z
+            .enum(['true', 'false', '1', '0'])
+            .optional()
+            .transform((v) => v === 'true' || v === '1'),
     })
     .refine((data) => data.start <= data.end, {
         message: 'start must be less than or equal to end',

--- a/nodejs/src/session-replay/recording-api/types.ts
+++ b/nodejs/src/session-replay/recording-api/types.ts
@@ -26,6 +26,7 @@ export {
  */
 export type RecordingApiConfig = Pick<
     PluginsServerConfig,
+    | 'SITE_URL'
     | 'KAFKA_CLIENT_RACK'
     | 'REDIS_POOL_MIN_SIZE'
     | 'REDIS_POOL_MAX_SIZE'

--- a/posthog/session_recordings/recordings/recording_api_client.py
+++ b/posthog/session_recordings/recordings/recording_api_client.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 
-import snappy
 import aiohttp
 import structlog
 
@@ -42,21 +41,15 @@ class RecordingApiClient:
 
         return key, int(match.group(1)), int(match.group(2))
 
-    async def fetch_compressed_block(self, block_url: str, session_id: str, team_id: int) -> bytes:
-        """
-        Fetch a recording block via the Recording API.
-
-        Returns the decrypted but still snappy-compressed block bytes.
-
-        Raises:
-            RecordingDeletedError: If the recording has been deleted.
-            BlockFetchError: If the block is not found or other fetch errors occur.
-        """
+    async def fetch_block(self, block_url: str, session_id: str, team_id: int, *, decompress: bool = False) -> bytes:
         key, start, end = self._parse_block_url(block_url)
         url = f"{self.base_url}/api/projects/{team_id}/recordings/{session_id}/block"
+        params: dict[str, str | int] = {"key": key, "start": start, "end": end}
+        if decompress:
+            params["decompress"] = "true"
 
         try:
-            async with self.session.get(url, params={"key": key, "start": start, "end": end}) as response:
+            async with self.session.get(url, params=params) as response:
                 if response.status == 404:
                     raise BlockFetchError("Block not found")
                 if response.status == 410:
@@ -79,7 +72,7 @@ class RecordingApiClient:
             raise
         except aiohttp.ClientError as e:
             logger.exception(
-                "recording_api_client.fetch_compressed_block_failed",
+                "recording_api_client.fetch_block_failed",
                 url=url,
                 session_id=session_id,
                 team_id=team_id,
@@ -87,32 +80,6 @@ class RecordingApiClient:
                 exc_info=False,
             )
             raise BlockFetchError(f"Failed to fetch block from Recording API: {str(e)}")
-
-    async def fetch_decompressed_block(self, block_url: str, session_id: str, team_id: int) -> str:
-        """
-        Fetch and decompress a recording block via the Recording API.
-
-        Returns the decrypted and decompressed block content as a string.
-
-        Raises:
-            RecordingDeletedError: If the recording has been deleted.
-            BlockFetchError: If the block is not found or other fetch errors occur.
-        """
-        try:
-            compressed_block = await self.fetch_compressed_block(block_url, session_id, team_id)
-            decompressed_block = snappy.decompress(compressed_block).decode("utf-8")
-            return decompressed_block.rstrip("\n")
-        except (RecordingDeletedError, BlockFetchError):
-            raise
-        except Exception as e:
-            logger.exception(
-                "recording_api_client.fetch_block_failed",
-                session_id=session_id,
-                team_id=team_id,
-                error=str(e),
-                exc_info=False,
-            )
-            raise BlockFetchError(f"Failed to decompress block: {str(e)}")
 
     async def delete_recordings(self, session_ids: list[str], team_id: int, deleted_by: str) -> list[str]:
         """
@@ -146,7 +113,7 @@ async def recording_api_client() -> AsyncIterator[RecordingApiClient]:
 
     Usage:
         async with recording_api_client() as client:
-            content = await client.fetch_decompressed_block(block_url, session_id, team_id)
+            content = await client.fetch_block(block_url, session_id, team_id, decompress=True)
     """
     if not settings.RECORDING_API_URL:
         raise RuntimeError("RECORDING_API_URL is not configured")

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1444,7 +1444,7 @@ class SessionRecordingViewSet(
 
                 if decompress:
                     response = HttpResponse(
-                        content=b"\n".join(blocks_data),
+                        content=b"".join(blocks_data).rstrip(b"\n"),
                         content_type="application/jsonl",
                     )
                 else:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import json
+import struct
 import asyncio
 import builtins
 from collections.abc import Generator
@@ -478,6 +479,14 @@ class SnapshotsBurstRateThrottle(PersonalApiKeyRateThrottle):
 class SnapshotsSustainedRateThrottle(PersonalApiKeyRateThrottle):
     scope = "snapshots_sustained"
     rate = "600/hour"
+
+
+def _length_prefix_blocks(blocks: list[bytes]) -> bytes:
+    chunks = []
+    for block in blocks:
+        chunks.append(struct.pack(">I", len(block)))
+        chunks.append(block)
+    return b"".join(chunks)
 
 
 def clean_referer_url(current_url: str | None) -> str:
@@ -1361,14 +1370,12 @@ class SessionRecordingViewSet(
         api_client: RecordingApiClient,
         decompress: bool,
     ) -> BlockList:
-        async def fetch_single_block(block_index: int) -> tuple[int, str | bytes | None]:
+        async def fetch_single_block(block_index: int) -> tuple[int, bytes | None]:
             try:
                 block = blocks[block_index]
-                content: str | bytes
-                if decompress:
-                    content = await api_client.fetch_decompressed_block(block.url, recording.session_id, self.team.id)
-                else:
-                    content = await api_client.fetch_compressed_block(block.url, recording.session_id, self.team.id)
+                content = await api_client.fetch_block(
+                    block.url, recording.session_id, self.team.id, decompress=decompress
+                )
                 return block_index, content
             except RecordingDeletedError:
                 # Let this propagate up to return a 410 response
@@ -1385,7 +1392,7 @@ class SessionRecordingViewSet(
         tasks = [fetch_single_block(block_index) for block_index in range(min_blob_key, max_blob_key + 1)]
         results = await asyncio.gather(*tasks)
 
-        blocks_data: list[str | bytes] = []
+        blocks_data: list[bytes] = []
         block_errors = []
 
         for block_index, content in results:
@@ -1418,71 +1425,6 @@ class SessionRecordingViewSet(
                         blocks, min_blob_key, max_blob_key, recording, storage, decompress
                     )
 
-    @tracer.start_as_current_span("_stream_decompressed_blocks")
-    async def _stream_decompressed_blocks(
-        self,
-        recording: SessionRecording,
-        timer: ServerTimingsGathered,
-        min_blob_key: int,
-        max_blob_key: int,
-    ) -> HttpResponse:
-        blocks = await self._fetch_and_validate_blocks(recording, timer, min_blob_key, max_blob_key)
-
-        blocks_data = await self._fetch_blocks_with_storage(
-            blocks, min_blob_key, max_blob_key, recording, timer, decompress=True
-        )
-
-        response = HttpResponse(
-            content="\n".join(blocks_data),
-            content_type="application/jsonl",
-        )
-        response["Cache-Control"] = "max-age=3600"
-        response["Content-Disposition"] = "inline"
-        return response
-
-    @tracer.start_as_current_span("_stream_compressed_blocks")
-    async def _stream_compressed_blocks(
-        self,
-        recording: SessionRecording,
-        timer: ServerTimingsGathered,
-        min_blob_key: int,
-        max_blob_key: int,
-    ) -> HttpResponse:
-        import struct
-
-        blocks = await self._fetch_and_validate_blocks(recording, timer, min_blob_key, max_blob_key)
-
-        blocks_data = await self._fetch_blocks_with_storage(
-            blocks, min_blob_key, max_blob_key, recording, timer, decompress=False
-        )
-
-        payload_chunks = []
-        for block in blocks_data:
-            payload_chunks.append(struct.pack(">I", len(block)))
-            payload_chunks.append(block)
-
-        response = HttpResponse(
-            content=b"".join(payload_chunks),
-            content_type="application/octet-stream",
-        )
-        response["Cache-Control"] = "max-age=3600"
-        response["Content-Disposition"] = "inline"
-        return response
-
-    async def _stream_blob_v2_to_client_async(
-        self,
-        recording: SessionRecording,
-        timer: ServerTimingsGathered,
-        min_blob_key: int,
-        max_blob_key: int,
-        decompress: bool = True,
-    ) -> HttpResponse:
-        with STREAM_RESPONSE_TO_CLIENT_HISTOGRAM.labels(blob_version="v2", decompress=decompress).time():
-            if decompress:
-                return await self._stream_decompressed_blocks(recording, timer, min_blob_key, max_blob_key)
-            else:
-                return await self._stream_compressed_blocks(recording, timer, min_blob_key, max_blob_key)
-
     def _stream_blob_v2_to_client(
         self,
         recording: SessionRecording,
@@ -1491,9 +1433,30 @@ class SessionRecordingViewSet(
         max_blob_key: int,
         decompress: bool = True,
     ) -> HttpResponse:
-        return asyncio.run(
-            self._stream_blob_v2_to_client_async(recording, timer, min_blob_key, max_blob_key, decompress)
-        )
+        async def _run() -> HttpResponse:
+            with STREAM_RESPONSE_TO_CLIENT_HISTOGRAM.labels(blob_version="v2", decompress=decompress).time():
+                blocks = await self._fetch_and_validate_blocks(recording, timer, min_blob_key, max_blob_key)
+
+                blocks_data = await self._fetch_blocks_with_storage(
+                    blocks, min_blob_key, max_blob_key, recording, timer, decompress=decompress
+                )
+
+                if decompress:
+                    response = HttpResponse(
+                        content=b"\n".join(blocks_data),
+                        content_type="application/jsonl",
+                    )
+                else:
+                    response = HttpResponse(
+                        content=_length_prefix_blocks(blocks_data),
+                        content_type="application/octet-stream",
+                    )
+
+                response["Cache-Control"] = "max-age=3600"
+                response["Content-Disposition"] = "inline"
+                return response
+
+        return asyncio.run(_run())
 
     def _stream_lts_blob_v2_to_client(
         self,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1425,6 +1425,7 @@ class SessionRecordingViewSet(
                         blocks, min_blob_key, max_blob_key, recording, storage, decompress
                     )
 
+    @tracer.start_as_current_span("_stream_blob_v2_to_client")
     def _stream_blob_v2_to_client(
         self,
         recording: SessionRecording,

--- a/posthog/session_recordings/test/recordings/test_recording_api_client.py
+++ b/posthog/session_recordings/test/recordings/test_recording_api_client.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import snappy
 import aiohttp
 
 from posthog.session_recordings.recordings.errors import BlockFetchError, RecordingDeletedError
@@ -25,7 +24,7 @@ class TestRecordingApiClient:
         assert client_with_trailing_slash.base_url == "http://localhost:6740"
 
 
-class TestFetchBlockBytes:
+class TestFetchBlock:
     @pytest.fixture
     def mock_session(self):
         return MagicMock(spec=aiohttp.ClientSession)
@@ -35,7 +34,7 @@ class TestFetchBlockBytes:
         return RecordingApiClient(mock_session, "http://localhost:6740")
 
     @pytest.mark.asyncio
-    async def test_successful_fetch(self, client, mock_session):
+    async def test_returns_compressed_bytes_by_default(self, client, mock_session):
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.read = AsyncMock(return_value=b"compressed-data")
@@ -45,7 +44,7 @@ class TestFetchBlockBytes:
 
         mock_session.get = MagicMock(return_value=mock_response)
 
-        result = await client.fetch_compressed_block(
+        result = await client.fetch_block(
             "s3://bucket/key?range=bytes=0-100",
             "session-123",
             1,
@@ -58,6 +57,30 @@ class TestFetchBlockBytes:
         )
 
     @pytest.mark.asyncio
+    async def test_decompress_passes_param(self, client, mock_session):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.read = AsyncMock(return_value=b'{"type": 3, "data": {}}')
+        mock_response.raise_for_status = MagicMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        result = await client.fetch_block(
+            "s3://bucket/key?range=bytes=0-100",
+            "session-123",
+            1,
+            decompress=True,
+        )
+
+        assert result == b'{"type": 3, "data": {}}'
+        mock_session.get.assert_called_once_with(
+            "http://localhost:6740/api/projects/1/recordings/session-123/block",
+            params={"key": "key", "start": 0, "end": 100, "decompress": "true"},
+        )
+
+    @pytest.mark.asyncio
     async def test_404_raises_error(self, client, mock_session):
         mock_response = AsyncMock()
         mock_response.status = 404
@@ -67,7 +90,7 @@ class TestFetchBlockBytes:
         mock_session.get = MagicMock(return_value=mock_response)
 
         with pytest.raises(BlockFetchError, match="Block not found"):
-            await client.fetch_compressed_block(
+            await client.fetch_block(
                 "s3://bucket/key?range=bytes=0-100",
                 "session-123",
                 1,
@@ -85,7 +108,7 @@ class TestFetchBlockBytes:
         mock_session.get = MagicMock(return_value=mock_response)
 
         with pytest.raises(RecordingDeletedError, match="Recording has been deleted") as exc_info:
-            await client.fetch_compressed_block(
+            await client.fetch_block(
                 "s3://bucket/key?range=bytes=0-100",
                 "session-123",
                 1,
@@ -109,118 +132,11 @@ class TestFetchBlockBytes:
         mock_session.get = MagicMock(return_value=mock_response)
 
         with pytest.raises(BlockFetchError, match="Failed to fetch block from Recording API"):
-            await client.fetch_compressed_block(
+            await client.fetch_block(
                 "s3://bucket/key?range=bytes=0-100",
                 "session-123",
                 1,
             )
-
-
-class TestFetchBlock:
-    @pytest.fixture
-    def mock_session(self):
-        return MagicMock(spec=aiohttp.ClientSession)
-
-    @pytest.fixture
-    def client(self, mock_session):
-        return RecordingApiClient(mock_session, "http://localhost:6740")
-
-    @pytest.mark.asyncio
-    async def test_successful_fetch_and_decompress(self, client, mock_session):
-        original_content = '{"type": 3, "data": {}}'
-        compressed_content = snappy.compress(original_content.encode("utf-8"))
-
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.read = AsyncMock(return_value=compressed_content)
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        result = await client.fetch_decompressed_block(
-            "s3://bucket/key?range=bytes=0-100",
-            "session-123",
-            1,
-        )
-
-        assert result == original_content
-
-    @pytest.mark.asyncio
-    async def test_strips_trailing_newlines(self, client, mock_session):
-        original_content = '{"type": 3, "data": {}}\n\n'
-        compressed_content = snappy.compress(original_content.encode("utf-8"))
-
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.read = AsyncMock(return_value=compressed_content)
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        result = await client.fetch_decompressed_block(
-            "s3://bucket/key?range=bytes=0-100",
-            "session-123",
-            1,
-        )
-
-        assert result == '{"type": 3, "data": {}}'
-
-    @pytest.mark.asyncio
-    async def test_decompress_error_raises_error(self, client, mock_session):
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.read = AsyncMock(return_value=b"not-valid-snappy-data")
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        with pytest.raises(BlockFetchError, match="Failed to decompress block"):
-            await client.fetch_decompressed_block(
-                "s3://bucket/key?range=bytes=0-100",
-                "session-123",
-                1,
-            )
-
-    @pytest.mark.asyncio
-    async def test_propagates_fetch_error(self, client, mock_session):
-        mock_response = AsyncMock()
-        mock_response.status = 404
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        with pytest.raises(BlockFetchError, match="Block not found"):
-            await client.fetch_decompressed_block(
-                "s3://bucket/key?range=bytes=0-100",
-                "session-123",
-                1,
-            )
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("deleted_at", [1700000000, None])
-    async def test_410_raises_recording_deleted_error(self, client, mock_session, deleted_at):
-        mock_response = AsyncMock()
-        mock_response.status = 410
-        mock_response.json = AsyncMock(return_value={"error": "Recording has been deleted", "deleted_at": deleted_at})
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        with pytest.raises(RecordingDeletedError, match="Recording has been deleted") as exc_info:
-            await client.fetch_decompressed_block(
-                "s3://bucket/key?range=bytes=0-100",
-                "session-123",
-                1,
-            )
-        assert exc_info.value.deleted_at == deleted_at
 
 
 class TestDeleteRecordings:

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
@@ -121,7 +121,9 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         assert mock_storage.fetch_block.call_count == 2
         call_args_list = mock_storage.fetch_block.await_args_list
         assert call_args_list[0].args == ("s3://bucket/key0?range=bytes=0-100", session_id, self.team.pk)
+        assert call_args_list[0].kwargs.get("decompress") is True
         assert call_args_list[1].args == ("s3://bucket/key1?range=bytes=101-200", session_id, self.team.pk)
+        assert call_args_list[1].kwargs.get("decompress") is True
 
     @parameterized.expand(
         [
@@ -506,6 +508,44 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         return_value=True,
     )
     @patch("posthog.session_recordings.session_recording_api.SessionRecording.get_or_build")
+    def test_blob_v2_decompressed_blocks_with_trailing_newlines_concatenate_cleanly(
+        self,
+        mock_get_session_recording,
+        _mock_exists,
+        mock_list_blocks,
+        mock_recording_api_client,
+    ) -> None:
+        session_id = str(uuid7())
+        mock_get_session_recording.return_value = SessionRecording(session_id=session_id, team=self.team, deleted=False)
+
+        mock_blocks = [
+            MagicMock(url="s3://bucket/key0?range=bytes=0-100"),
+            MagicMock(url="s3://bucket/key1?range=bytes=101-200"),
+        ]
+        mock_list_blocks.return_value = mock_blocks
+
+        mock_storage = MagicMock()
+        mock_storage.fetch_block = AsyncMock(
+            side_effect=[
+                b'{"timestamp": 1000}\n{"timestamp": 2000}\n',
+                b'{"timestamp": 3000}\n{"timestamp": 4000}\n',
+            ]
+        )
+        mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
+
+        url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=0&end_blob_key=1"
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content == b'{"timestamp": 1000}\n{"timestamp": 2000}\n{"timestamp": 3000}\n{"timestamp": 4000}'
+
+    @patch("posthog.session_recordings.session_recording_api.recording_api_client")
+    @patch("posthog.session_recordings.session_recording_api.list_blocks")
+    @patch(
+        "posthog.session_recordings.queries.session_replay_events.SessionReplayEvents.exists",
+        return_value=True,
+    )
+    @patch("posthog.session_recordings.session_recording_api.SessionRecording.get_or_build")
     def test_blob_v2_decompress_false_returns_length_prefixed_format(
         self,
         mock_get_session_recording,
@@ -622,7 +662,9 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         assert mock_storage.fetch_block.call_count == 2
         call_args_list = mock_storage.fetch_block.await_args_list
         assert call_args_list[0].args == ("s3://bucket/key0?range=bytes=0-100", session_id, self.team.pk)
+        assert call_args_list[0].kwargs.get("decompress") is True
         assert call_args_list[1].args == ("s3://bucket/key1?range=bytes=101-200", session_id, self.team.pk)
+        assert call_args_list[1].kwargs.get("decompress") is True
 
     @parameterized.expand(
         [

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
@@ -104,10 +104,10 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         mock_list_blocks.return_value = mock_blocks
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(
+        mock_storage.fetch_block = AsyncMock(
             side_effect=[
-                '{"timestamp": 1000, "type": "snapshot1"}',
-                '{"timestamp": 2000, "type": "snapshot2"}',
+                b'{"timestamp": 1000, "type": "snapshot1"}',
+                b'{"timestamp": 2000, "type": "snapshot2"}',
             ]
         )
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
@@ -118,8 +118,8 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         assert response.status_code == status.HTTP_200_OK
         assert response.headers.get("content-type") == "application/jsonl"
 
-        assert mock_storage.fetch_decompressed_block.call_count == 2
-        call_args_list = mock_storage.fetch_decompressed_block.await_args_list
+        assert mock_storage.fetch_block.call_count == 2
+        call_args_list = mock_storage.fetch_block.await_args_list
         assert call_args_list[0].args == ("s3://bucket/key0?range=bytes=0-100", session_id, self.team.pk)
         assert call_args_list[1].args == ("s3://bucket/key1?range=bytes=101-200", session_id, self.team.pk)
 
@@ -412,8 +412,8 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
 
     @parameterized.expand(
         [
-            (True, "application/jsonl", 2, 0),
-            (False, "application/octet-stream", 0, 2),
+            (True, "application/jsonl"),
+            (False, "application/octet-stream"),
         ]
     )
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
@@ -427,8 +427,6 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         self,
         decompress,
         expected_content_type,
-        expected_fetch_decompressed_block_calls,
-        expected_fetch_compressed_block_calls,
         mock_get_session_recording,
         _mock_exists,
         mock_list_blocks,
@@ -452,8 +450,10 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         compressed_data_2 = snappy.compress(test_data_2.encode("utf-8"))
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(side_effect=[test_data_1, test_data_2])
-        mock_storage.fetch_compressed_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2])
+        if decompress:
+            mock_storage.fetch_block = AsyncMock(side_effect=[test_data_1.encode(), test_data_2.encode()])
+        else:
+            mock_storage.fetch_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2])
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         decompress_param = f"&decompress={str(decompress).lower()}"
@@ -462,8 +462,9 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.headers.get("content-type") == expected_content_type
-        assert mock_storage.fetch_decompressed_block.call_count == expected_fetch_decompressed_block_calls
-        assert mock_storage.fetch_compressed_block.call_count == expected_fetch_compressed_block_calls
+        assert mock_storage.fetch_block.call_count == 2
+        for call in mock_storage.fetch_block.await_args_list:
+            assert call.kwargs["decompress"] == decompress
 
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
     @patch("posthog.session_recordings.session_recording_api.list_blocks")
@@ -487,8 +488,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         mock_list_blocks.return_value = mock_blocks
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(return_value='{"timestamp": 1000, "type": "snapshot1"}')
-        mock_storage.fetch_compressed_block = AsyncMock()
+        mock_storage.fetch_block = AsyncMock(return_value=b'{"timestamp": 1000, "type": "snapshot1"}')
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=0&end_blob_key=0"
@@ -496,8 +496,8 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
-        assert mock_storage.fetch_decompressed_block.call_count == 1
-        assert mock_storage.fetch_compressed_block.call_count == 0
+        assert mock_storage.fetch_block.call_count == 1
+        assert mock_storage.fetch_block.await_args.kwargs["decompress"] is True
 
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
     @patch("posthog.session_recordings.session_recording_api.list_blocks")
@@ -536,9 +536,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         compressed_data_3 = snappy.compress(test_data_3.encode("utf-8"))
 
         mock_storage = MagicMock()
-        mock_storage.fetch_compressed_block = AsyncMock(
-            side_effect=[compressed_data_1, compressed_data_2, compressed_data_3]
-        )
+        mock_storage.fetch_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2, compressed_data_3])
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=0&end_blob_key=2&decompress=false"
@@ -607,10 +605,10 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         mock_list_blocks.return_value = mock_blocks
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(
+        mock_storage.fetch_block = AsyncMock(
             side_effect=[
-                '{"timestamp": 1000, "type": "snapshot1"}',
-                '{"timestamp": 2000, "type": "snapshot2"}',
+                b'{"timestamp": 1000, "type": "snapshot1"}',
+                b'{"timestamp": 2000, "type": "snapshot2"}',
             ]
         )
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
@@ -621,15 +619,15 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         assert response.status_code == status.HTTP_200_OK
         assert response.headers.get("content-type") == "application/jsonl"
 
-        assert mock_storage.fetch_decompressed_block.call_count == 2
-        call_args_list = mock_storage.fetch_decompressed_block.await_args_list
+        assert mock_storage.fetch_block.call_count == 2
+        call_args_list = mock_storage.fetch_block.await_args_list
         assert call_args_list[0].args == ("s3://bucket/key0?range=bytes=0-100", session_id, self.team.pk)
         assert call_args_list[1].args == ("s3://bucket/key1?range=bytes=101-200", session_id, self.team.pk)
 
     @parameterized.expand(
         [
-            (True, "application/jsonl", 2, 0),
-            (False, "application/octet-stream", 0, 2),
+            (True, "application/jsonl"),
+            (False, "application/octet-stream"),
         ]
     )
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
@@ -643,8 +641,6 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         self,
         decompress,
         expected_content_type,
-        expected_fetch_decompressed_block_calls,
-        expected_fetch_compressed_block_calls,
         mock_get_session_recording,
         _mock_exists,
         mock_list_blocks,
@@ -668,8 +664,10 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         compressed_data_2 = snappy.compress(test_data_2.encode("utf-8"))
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(side_effect=[test_data_1, test_data_2])
-        mock_storage.fetch_compressed_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2])
+        if decompress:
+            mock_storage.fetch_block = AsyncMock(side_effect=[test_data_1.encode(), test_data_2.encode()])
+        else:
+            mock_storage.fetch_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2])
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         decompress_param = f"&decompress={str(decompress).lower()}"
@@ -678,8 +676,9 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.headers.get("content-type") == expected_content_type
-        assert mock_storage.fetch_decompressed_block.call_count == expected_fetch_decompressed_block_calls
-        assert mock_storage.fetch_compressed_block.call_count == expected_fetch_compressed_block_calls
+        assert mock_storage.fetch_block.call_count == 2
+        for call in mock_storage.fetch_block.await_args_list:
+            assert call.kwargs["decompress"] == decompress
 
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
     @patch("posthog.session_recordings.session_recording_api.list_blocks")
@@ -703,8 +702,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         mock_list_blocks.return_value = mock_blocks
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(return_value='{"timestamp": 1000, "type": "snapshot1"}')
-        mock_storage.fetch_compressed_block = AsyncMock()
+        mock_storage.fetch_block = AsyncMock(return_value=b'{"timestamp": 1000, "type": "snapshot1"}')
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=0&end_blob_key=0"
@@ -712,8 +710,8 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
-        assert mock_storage.fetch_decompressed_block.call_count == 1
-        assert mock_storage.fetch_compressed_block.call_count == 0
+        assert mock_storage.fetch_block.call_count == 1
+        assert mock_storage.fetch_block.await_args.kwargs["decompress"] is True
 
     @patch("posthog.session_recordings.session_recording_api.recording_api_client")
     @patch("posthog.session_recordings.session_recording_api.list_blocks")
@@ -752,9 +750,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         compressed_data_3 = snappy.compress(test_data_3.encode("utf-8"))
 
         mock_storage = MagicMock()
-        mock_storage.fetch_compressed_block = AsyncMock(
-            side_effect=[compressed_data_1, compressed_data_2, compressed_data_3]
-        )
+        mock_storage.fetch_block = AsyncMock(side_effect=[compressed_data_1, compressed_data_2, compressed_data_3])
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage
 
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=0&end_blob_key=2&decompress=false"
@@ -818,7 +814,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
         mock_list_blocks.return_value = [MagicMock(url="s3://bucket/key0?range=bytes=0-100")]
 
         mock_storage = MagicMock()
-        mock_storage.fetch_decompressed_block = AsyncMock(
+        mock_storage.fetch_block = AsyncMock(
             side_effect=RecordingDeletedError("recording deleted", deleted_at=1700000000)
         )
         mock_recording_api_client.return_value.__aenter__.return_value = mock_storage

--- a/posthog/temporal/export_recording/activities.py
+++ b/posthog/temporal/export_recording/activities.py
@@ -190,7 +190,7 @@ async def export_recording_data(input: ExportContext) -> None:
             block_offset = int(match.group(1))
 
             try:
-                block_data = await storage.fetch_compressed_block(block.url, input.session_id, input.team_id)
+                block_data = await storage.fetch_block(block.url, input.session_id, input.team_id)
                 logger.info(f"Successfully fetched block data ({len(block_data)} bytes)")
             except RecordingDeletedError:
                 raise

--- a/posthog/temporal/tests/export_recording/test_activities.py
+++ b/posthog/temporal/tests/export_recording/test_activities.py
@@ -243,7 +243,7 @@ async def test_export_recording_data_success():
 
     mock_recording = MagicMock()
     mock_storage = AsyncMock()
-    mock_storage.fetch_compressed_block = AsyncMock(return_value=b"block data content")
+    mock_storage.fetch_block = AsyncMock(return_value=b"block data content")
     mock_redis = AsyncMock()
 
     with (
@@ -260,7 +260,7 @@ async def test_export_recording_data_success():
 
         await export_recording_data(export_context)
 
-        mock_storage.fetch_compressed_block.assert_called_once_with(
+        mock_storage.fetch_block.assert_called_once_with(
             mock_block.url, export_context.session_id, export_context.team_id
         )
         assert mock_redis.setex.call_count == 2
@@ -366,7 +366,7 @@ async def test_export_recording_data_block_fetch_error():
 
     mock_recording = MagicMock()
     mock_storage = AsyncMock()
-    mock_storage.fetch_compressed_block = AsyncMock(side_effect=BlockFetchError("Fetch failed"))
+    mock_storage.fetch_block = AsyncMock(side_effect=BlockFetchError("Fetch failed"))
     mock_redis = AsyncMock()
 
     with (


### PR DESCRIPTION
## Summary

- Add `?decompress=true` query parameter to the recording-api block endpoint, returning decompressed JSONL instead of snappy-compressed bytes
- Add CORS headers (using `SITE_URL`) and OPTIONS preflight handler to the block endpoint
- Simplify the Django `RecordingApiClient` to a single `fetch_block` method that passes `decompress` through to the recording-api instead of doing local snappy decompression
- Consolidate `_stream_decompressed_blocks` / `_stream_compressed_blocks` into `_stream_blob_v2_to_client`

No change to the Django API's external behavior — same bytes, headers, and status codes.

## Test plan

- [x] Recording-api integration tests pass (40 tests including localstack)
- [x] Django `RecordingApiClient` unit tests pass (16 tests)
- [x] Django blob_v2 snapshot API tests pass (27 tests)
- [x] Temporal export recording tests pass (17 tests)