### PR TITLE
fix(flox): ensure hogli symlink survives venv recreation

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -85,6 +85,12 @@ source "$FLOX_ENV_PROJECT/.flox/env/on-activate.sh"
 # taken to ensure compatibility with all shells, after which exactly one of
 # `profile.{bash,fish,tcsh,zsh}` is sourced by the corresponding shell.
 [profile]
+common = '''
+  # Ensure hogli symlink survives venv recreation (uv sync outside of on-activate)
+  if [ -d "$UV_PROJECT_ENVIRONMENT/bin" ] && [ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]; then
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  fi
+'''
 bash = '''
   if [ -f "$HOME/.bash_profile" ]; then
     source "$HOME/.bash_profile"

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -85,12 +85,6 @@ source "$FLOX_ENV_PROJECT/.flox/env/on-activate.sh"
 # taken to ensure compatibility with all shells, after which exactly one of
 # `profile.{bash,fish,tcsh,zsh}` is sourced by the corresponding shell.
 [profile]
-common = '''
-  # Ensure hogli symlink survives venv recreation (uv sync outside of on-activate)
-  if [ -d "$UV_PROJECT_ENVIRONMENT/bin" ] && [ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]; then
-    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
-  fi
-'''
 bash = '''
   if [ -f "$HOME/.bash_profile" ]; then
     source "$HOME/.bash_profile"
@@ -99,6 +93,13 @@ bash = '''
   fi
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
+  # Recreate venv if it was deleted (on-activate only runs on first activation)
+  if [ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]; then
+    uv sync
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  elif [ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]; then
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  fi
   source $UV_PROJECT_ENVIRONMENT/bin/activate
   # Source hogli bash completions
   [ -f "$FLOX_ENV_CACHE/completions/hogli.bash" ] && source "$FLOX_ENV_CACHE/completions/hogli.bash"
@@ -111,6 +112,13 @@ zsh = '''
   fi
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
+  # Recreate venv if it was deleted (on-activate only runs on first activation)
+  if [[ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]]; then
+    uv sync
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  elif [[ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]]; then
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  fi
   source $UV_PROJECT_ENVIRONMENT/bin/activate
   # Add hogli completions to zsh
   [[ -f "$FLOX_ENV_CACHE/completions/_hogli" ]] && fpath=("$FLOX_ENV_CACHE/completions" $fpath)
@@ -119,11 +127,25 @@ zsh = '''
 fish = '''
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   fish_add_path "$FLOX_ENV/bin"
+  # Recreate venv if it was deleted (on-activate only runs on first activation)
+  if not test -f "$UV_PROJECT_ENVIRONMENT/bin/activate.fish"
+    uv sync
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  else if not test -L "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  end
   source $UV_PROJECT_ENVIRONMENT/bin/activate.fish
 '''
 tcsh = '''
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   setenv PATH "$FLOX_ENV/bin:$PATH"
+  # Recreate venv if it was deleted (on-activate only runs on first activation)
+  if ( ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate.csh" ) then
+    uv sync
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  else if ( ! -l "$UV_PROJECT_ENVIRONMENT/bin/hogli" ) then
+    ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  endif
   source $UV_PROJECT_ENVIRONMENT/bin/activate.csh
 '''
 


### PR DESCRIPTION
The hogli symlink in the uv-managed venv gets wiped when `uv sync` runs outside of the on-activate hook. Add a profile.common check that recreates it on every shell init if missing.
