### PR TITLE
fix(experiments): make service writes atomic

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -5,6 +5,8 @@ from datetime import date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from django.db import transaction
+
 import pydantic
 from rest_framework.exceptions import ValidationError
 
@@ -110,6 +112,7 @@ class ExperimentService:
                 except pydantic.ValidationError as e:
                     raise ValidationError(f"Invalid metric at index {i}: {e.errors()}")
 
+    @transaction.atomic
     def create_experiment(
         self,
         name: str,
@@ -437,6 +440,7 @@ class ExperimentService:
     # Update
     # ------------------------------------------------------------------
 
+    @transaction.atomic
     def update_experiment(
         self,
         experiment: Experiment,

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -455,11 +455,15 @@ class ExperimentService:
         validation (field types, metric schema, etc.) before calling this method.
         """
         context = serializer_context or self._build_serializer_context()
+        feature_flag = experiment.feature_flag
 
-        # --- saved metrics replacement (delete-all / re-create) -----------
+        self._validate_update_payload(experiment, update_data, feature_flag)
+
         update_saved_metrics = "saved_metrics_ids" in update_data
         saved_metrics_data: list[dict] = update_data.pop("saved_metrics_ids", []) or []
+        update_data.pop("get_feature_flag_key", None)
 
+        # --- saved metrics replacement (delete-all / re-create) -----------
         old_saved_metric_uuids: dict[str, set[str]] = {"primary": set(), "secondary": set()}
         if update_saved_metrics:
             for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
@@ -485,67 +489,6 @@ class ExperimentService:
                 saved_metric_serializer.is_valid(raise_exception=True)
                 saved_metric_serializer.save()
 
-        # --- restoration validation ----------------------------------------
-        feature_flag = experiment.feature_flag
-        if experiment.deleted and update_data.get("deleted") is False:
-            if feature_flag.deleted:
-                raise ValidationError(
-                    "Cannot restore experiment: the linked feature flag has been deleted. "
-                    "Restore the feature flag first, then restore the experiment."
-                )
-
-        # --- immutable / unexpected keys -----------------------------------
-        expected_keys = {
-            "name",
-            "description",
-            "start_date",
-            "end_date",
-            "filters",
-            "parameters",
-            "archived",
-            "deleted",
-            "secondary_metrics",
-            "holdout",
-            "exposure_criteria",
-            "metrics",
-            "metrics_secondary",
-            "stats_config",
-            "scheduling_config",
-            "conclusion",
-            "conclusion_comment",
-            "primary_metrics_ordered_uuids",
-            "secondary_metrics_ordered_uuids",
-        }
-        given_keys = set(update_data.keys())
-        extra_keys = given_keys - expected_keys
-
-        if feature_flag.key == update_data.get("get_feature_flag_key"):
-            extra_keys.discard("get_feature_flag_key")
-
-        if extra_keys:
-            raise ValidationError(f"Can't update keys: {', '.join(sorted(extra_keys))} on Experiment")
-
-        update_data.pop("get_feature_flag_key", None)
-
-        # --- draft-only restrictions (variants / holdout) ------------------
-        if not experiment.is_draft:
-            if "feature_flag_variants" in update_data.get("parameters", {}):
-                if len(update_data["parameters"]["feature_flag_variants"]) != len(feature_flag.variants):
-                    raise ValidationError("Can't update feature_flag_variants on Experiment")
-                for variant in update_data["parameters"]["feature_flag_variants"]:
-                    if (
-                        len([ff_variant for ff_variant in feature_flag.variants if ff_variant["key"] == variant["key"]])
-                        != 1
-                    ):
-                        raise ValidationError("Can't update feature_flag_variants on Experiment")
-            if "holdout" in update_data and update_data["holdout"] != experiment.holdout:
-                raise ValidationError("Can't update holdout on running Experiment")
-
-        # --- global filter properties rejection ----------------------------
-        properties = update_data.get("filters", {}).get("properties")
-        if properties:
-            raise ValidationError("Experiments do not support global filter properties")
-
         # --- feature flag variant sync for draft experiments ---------------
         if experiment.is_draft:
             holdout_groups = experiment.holdout.filters if experiment.holdout else None
@@ -555,12 +498,6 @@ class ExperimentService:
             if update_data.get("parameters"):
                 variants = update_data["parameters"].get("feature_flag_variants", [])
                 aggregation_group_type_index = update_data["parameters"].get("aggregation_group_type_index")
-
-                global_filters = update_data.get("filters")
-                if global_filters:
-                    filter_properties = global_filters.get("properties", [])
-                    if filter_properties:
-                        raise ValidationError("Experiments do not support global filter properties")
 
                 feature_flag_filters = feature_flag.filters
                 existing_groups = feature_flag.filters.get("groups", [])
@@ -634,6 +571,61 @@ class ExperimentService:
         experiment.save()
 
         return experiment
+
+    def _validate_update_payload(self, experiment: Experiment, update_data: dict, feature_flag: FeatureFlag) -> None:
+        """Validate update payload before any database mutations occur."""
+        if experiment.deleted and update_data.get("deleted") is False and feature_flag.deleted:
+            raise ValidationError(
+                "Cannot restore experiment: the linked feature flag has been deleted. "
+                "Restore the feature flag first, then restore the experiment."
+            )
+
+        expected_keys = {
+            "name",
+            "description",
+            "start_date",
+            "end_date",
+            "filters",
+            "parameters",
+            "archived",
+            "deleted",
+            "secondary_metrics",
+            "holdout",
+            "exposure_criteria",
+            "metrics",
+            "metrics_secondary",
+            "stats_config",
+            "scheduling_config",
+            "conclusion",
+            "conclusion_comment",
+            "primary_metrics_ordered_uuids",
+            "secondary_metrics_ordered_uuids",
+            "saved_metrics_ids",
+        }
+        extra_keys = set(update_data.keys()) - expected_keys
+
+        if feature_flag.key == update_data.get("get_feature_flag_key"):
+            extra_keys.discard("get_feature_flag_key")
+
+        if extra_keys:
+            raise ValidationError(f"Can't update keys: {', '.join(sorted(extra_keys))} on Experiment")
+
+        if not experiment.is_draft:
+            if "feature_flag_variants" in update_data.get("parameters", {}):
+                if len(update_data["parameters"]["feature_flag_variants"]) != len(feature_flag.variants):
+                    raise ValidationError("Can't update feature_flag_variants on Experiment")
+                for variant in update_data["parameters"]["feature_flag_variants"]:
+                    if (
+                        len([ff_variant for ff_variant in feature_flag.variants if ff_variant["key"] == variant["key"]])
+                        != 1
+                    ):
+                        raise ValidationError("Can't update feature_flag_variants on Experiment")
+            if "holdout" in update_data and update_data["holdout"] != experiment.holdout:
+                raise ValidationError("Can't update holdout on running Experiment")
+
+        properties = update_data.get("filters", {}).get("properties")
+        if properties:
+            raise ValidationError("Experiments do not support global filter properties")
 
     # ------------------------------------------------------------------
     # Duplication

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from decimal import Decimal
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -482,6 +483,25 @@ class TestExperimentService(APIBaseTest):
             "saved-secondary",
         }
 
+    def test_create_experiment_rolls_back_when_late_validation_fails(self):
+        service = self._service()
+
+        with (
+            patch.object(
+                ExperimentService,
+                "_validate_metric_ordering_on_create",
+                side_effect=ValidationError("ordering invalid"),
+            ),
+            self.assertRaises(ValidationError),
+        ):
+            service.create_experiment(
+                name="Rollback Create",
+                feature_flag_key="rollback-create-flag",
+            )
+
+        assert not Experiment.objects.filter(name="Rollback Create").exists()
+        assert not FeatureFlag.objects.filter(team=self.team, key="rollback-create-flag").exists()
+
     # ------------------------------------------------------------------
     # Status field
     # ------------------------------------------------------------------
@@ -777,6 +797,47 @@ class TestExperimentService(APIBaseTest):
         second_link = experiment.experimenttosavedmetric_set.first()
         assert second_link is not None
         assert second_link.saved_metric_id == sm2.id
+
+    def test_update_experiment_rolls_back_saved_metric_changes_on_validation_error(self):
+        self._create_flag(key="rollback-update")
+        sm1 = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="SM1",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "sm-1", "event": "$pageview"},
+        )
+        sm2 = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="SM2",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "sm-2", "event": "$pageleave"},
+        )
+        service = self._service()
+        experiment = service.create_experiment(
+            name="Rollback Update",
+            feature_flag_key="rollback-update",
+            saved_metrics_ids=[{"id": sm1.id, "metadata": {"type": "primary"}}],
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            service.update_experiment(
+                experiment,
+                {
+                    "saved_metrics_ids": [{"id": sm2.id, "metadata": {"type": "secondary"}}],
+                    "unknown_key": "value",
+                },
+            )
+
+        assert "Can't update keys" in str(ctx.exception)
+
+        link_ids = list(
+            Experiment.objects.get(id=experiment.id).experimenttosavedmetric_set.values_list(
+                "saved_metric_id", flat=True
+            )
+        )
+        assert link_ids == [sm1.id]
+
+        fresh_experiment = Experiment.objects.get(id=experiment.id)
+        assert fresh_experiment.primary_metrics_ordered_uuids == ["sm-1"]
+        assert fresh_experiment.secondary_metrics_ordered_uuids == []
 
     def test_update_experiment_restore_with_deleted_flag_raises(self):
         experiment = self._create_draft_experiment()

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -839,6 +839,40 @@ class TestExperimentService(APIBaseTest):
         assert fresh_experiment.primary_metrics_ordered_uuids == ["sm-1"]
         assert fresh_experiment.secondary_metrics_ordered_uuids == []
 
+    def test_update_experiment_validates_unknown_keys_before_saved_metric_mutation(self):
+        self._create_flag(key="validate-before-mutate")
+        sm1 = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="SM1",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "sm-1", "event": "$pageview"},
+        )
+        sm2 = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="SM2",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "sm-2", "event": "$pageleave"},
+        )
+        service = self._service()
+        experiment = service.create_experiment(
+            name="Validate Before Mutate",
+            feature_flag_key="validate-before-mutate",
+            saved_metrics_ids=[{"id": sm1.id, "metadata": {"type": "primary"}}],
+        )
+
+        with (
+            patch("django.db.models.query.QuerySet.delete") as delete_mock,
+            self.assertRaises(ValidationError) as ctx,
+        ):
+            service.update_experiment(
+                experiment,
+                {
+                    "saved_metrics_ids": [{"id": sm2.id, "metadata": {"type": "secondary"}}],
+                    "unknown_key": "value",
+                },
+            )
+
+        assert "Can't update keys" in str(ctx.exception)
+        delete_mock.assert_not_called()
+
     def test_update_experiment_restore_with_deleted_flag_raises(self):
         experiment = self._create_draft_experiment()
         service = self._service()


### PR DESCRIPTION
## Problem

Experiment create and update operations are not ran in a single atomic transaction. Thus, if it fails half-way, you can end up in a partial state where f.ex the feature flag is persisted where as the experiment is not.

## Changes

Wrap the service calls in an atomic transaction to make them "all or nothing". If anything fails, the whole transaction will be aborted.

## How did you test this code?

- Tests added
- Tested locally


## Publish to changelog?
No
