### PR TITLE
chore: improve source and type tracking for (insight|dashboard) (created|analyzed) events

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -223,7 +223,7 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
         // trends like
         payload.has_formula = !!getFormula(querySource)
         payload.display =
-            getDisplay(querySource) ?? (isTrendsQuery(querySource) ? ChartDisplayType.ActionsLineGraph : undefined)
+            getDisplay(querySource) ?? ((isTrendsQuery(querySource) || isStickinessQuery(querySource)) ? ChartDisplayType.ActionsLineGraph : undefined)
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -223,7 +223,6 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
         // trends like
         payload.has_formula = !!getFormula(querySource)
         payload.display = getDisplay(querySource) ?? (isTrendsQuery(querySource) ? ChartDisplayType.ActionsLineGraph : undefined)
-        payload.trend_type = isTrendsQuery(querySource) ? payload.display : undefined
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -39,6 +39,7 @@ import {
 } from '~/queries/utils'
 import { PROPERTY_KEYS } from '~/taxonomy/taxonomy'
 import {
+    ChartDisplayType,
     CohortType,
     DashboardMode,
     DashboardTile,
@@ -221,8 +222,8 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
 
         // trends like
         payload.has_formula = !!getFormula(querySource)
-        payload.display = getDisplay(querySource)
-        payload.trend_type = isTrendsQuery(querySource) ? getDisplay(querySource) : undefined
+        payload.display = getDisplay(querySource) ?? (isTrendsQuery(querySource) ? ChartDisplayType.ActionsLineGraph : undefined)
+        payload.trend_type = isTrendsQuery(querySource) ? payload.display : undefined
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -35,6 +35,7 @@ import {
     isInsightQueryNode,
     isInsightVizNode,
     isNodeWithSource,
+    isStickinessQuery,
     isTrendsQuery,
 } from '~/queries/utils'
 import { PROPERTY_KEYS } from '~/taxonomy/taxonomy'

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -224,7 +224,10 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
         // trends like
         payload.has_formula = !!getFormula(querySource)
         payload.display =
-            getDisplay(querySource) ?? ((isTrendsQuery(querySource) || isStickinessQuery(querySource)) ? ChartDisplayType.ActionsLineGraph : undefined)
+            getDisplay(querySource) ??
+            (isTrendsQuery(querySource) || isStickinessQuery(querySource)
+                ? ChartDisplayType.ActionsLineGraph
+                : undefined)
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -222,7 +222,8 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
 
         // trends like
         payload.has_formula = !!getFormula(querySource)
-        payload.display = getDisplay(querySource) ?? (isTrendsQuery(querySource) ? ChartDisplayType.ActionsLineGraph : undefined)
+        payload.display =
+            getDisplay(querySource) ?? (isTrendsQuery(querySource) ? ChartDisplayType.ActionsLineGraph : undefined)
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -35,6 +35,7 @@ import {
     isInsightQueryNode,
     isInsightVizNode,
     isNodeWithSource,
+    isTrendsQuery,
 } from '~/queries/utils'
 import { PROPERTY_KEYS } from '~/taxonomy/taxonomy'
 import {
@@ -221,6 +222,7 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
         // trends like
         payload.has_formula = !!getFormula(querySource)
         payload.display = getDisplay(querySource)
+        payload.trend_type = isTrendsQuery(querySource) ? getDisplay(querySource) : undefined
         payload.compare = getCompareFilter(querySource)?.compare
         payload.compare_to = getCompareFilter(querySource)?.compare_to
 
@@ -978,7 +980,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             // "insight created" essentially means that the user clicked "New insight"
             await breakpoint(500) // Debounce to avoid multiple quick "New insight" clicks being reported
 
-            posthog.capture('insight created', sanitizeQuery(query))
+            posthog.capture('insight created', { ...sanitizeQuery(query), source: 'web' })
         },
         reportInsightSaved: async ({ insight, query, isNewInsight }) => {
             // "insight saved" is a proxy for the new insight's results being valuable to the user
@@ -1006,7 +1008,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             }
 
             const eventName = delay ? 'insight analyzed' : 'insight viewed'
-            posthog.capture(eventName, objectClean(payload))
+            posthog.capture(eventName, objectClean({ ...payload, source: 'web' }))
         },
         reportPersonsModalViewed: async ({ params }) => {
             posthog.capture('insight person modal viewed', params)
@@ -1054,7 +1056,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             }
 
             const eventName = delay ? 'dashboard analyzed' : 'viewed dashboard' // `viewed dashboard` name is kept for backwards compatibility
-            posthog.capture(eventName, properties)
+            posthog.capture(eventName, { ...properties, source: 'web' })
         },
         reportProjectCreationSubmitted: async ({
             projectCount,


### PR DESCRIPTION
i wanted to make a graph but it was confusing for me

* type of trend is implied in the majority case
* we can't break down viewed/analyzed events by _where_ they are viewed / analyzed 

so i've improved the events we're capturing such that it wouldn't have been