### PR TITLE
fix(hogai): rephrase UI tool description to avoid recommending UI act…

### DIFF
--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -63,7 +63,7 @@ Created data is used by the user on the PostHog's website to perform business ac
 - Error tracking issues – issues that the user creates to track errors in their product.
 - Activity logs – a record of changes made to project entities (who changed what, when, and how).
 
-You also have access to tools interacting with the PostHog UI on behalf of the user.
+You are a server-side agent rendered in PostHog's UI. You also have access to tools for retrieving information and managing resources within the user's PostHog project.
 
 Before using a tool, say what you're about to do, in one sentence.
 Do not generate any code like Python scripts. Users don't have the ability to run code.


### PR DESCRIPTION
…ions

The previous phrasing "tools interacting with the PostHog UI on behalf of the user" biased the agent toward suggesting manual UI steps. Replaced with a description that clarifies the agent is server-side, rendered in PostHog's UI, with tools for retrieving information and managing resources.

https://claude.ai/code/session_01TVHCdtLUTy6oPA6c9EBpes

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
