### PR TITLE
feat(logs): add tabbed view with configuration and viewer for logs scene

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -322,6 +322,7 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_RETENTION: 'logs-settings-retention', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
+    LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,10 +1,12 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { IconGear } from '@posthog/icons'
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
+import { Settings } from 'scenes/settings/Settings'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -15,7 +17,9 @@ import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPromp
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
 import { useOpenLogsSettingsPanel } from './hooks/useOpenLogsSettingsPanel'
-import { logsSceneLogic } from './logsSceneLogic'
+import { LogsSceneActiveTab, logsSceneLogic } from './logsSceneLogic'
+
+export const LOGS_LOGIC_KEY = 'logs'
 
 export const scene: SceneExport = {
     component: LogsScene,
@@ -24,9 +28,11 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
+    const useTabbedView = useFeatureFlag('LOGS_TABBED_VIEW')
+
     return (
         <SceneContent className="h-[calc(var(--scene-layout-rect-height,_100vh)_-_1rem)]">
-            <LogsSceneContent />
+            {useTabbedView ? <LogsSceneTabbedContent /> : <LogsSceneContent />}
         </SceneContent>
     )
 }
@@ -75,6 +81,64 @@ const LogsSceneContent = (): JSX.Element => {
                     <LogsViewer id={tabId} />
                 </div>
             </LogsSetupPrompt>
+        </>
+    )
+}
+
+const LogsSceneTabbedContent = (): JSX.Element => {
+    const { tabId, activeTab } = useValues(logsSceneLogic)
+    const { setActiveTab } = useActions(logsSceneLogic)
+    const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
+
+    return (
+        <>
+            <SceneTitleSection
+                name={sceneConfigurations[Scene.Logs].name}
+                resourceType={{
+                    type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
+                }}
+                actions={
+                    <>
+                        {hasLogs && (
+                            <LemonButton size="small" type="secondary" id="logs-feedback-button">
+                                Send feedback
+                            </LemonButton>
+                        )}
+                    </>
+                }
+            />
+            {teamHasLogsCheckFailed && (
+                <LemonBanner
+                    type="info"
+                    dismissKey="logs-setup-hint-banner"
+                    action={{
+                        to: 'https://posthog.com/docs/logs/',
+                        targetBlank: true,
+                        children: 'Setup guide',
+                    }}
+                >
+                    Unable to verify logs setup. If you haven't configured logging yet, check out our setup guide.
+                </LemonBanner>
+            )}
+            <LemonTabs<LogsSceneActiveTab>
+                activeKey={activeTab}
+                onChange={(key) => setActiveTab(key)}
+                tabs={[
+                    { key: 'viewer', label: 'Viewer' },
+                    { key: 'configuration', label: 'Configuration' },
+                ]}
+                sceneInset
+            />
+            {activeTab === 'viewer' && (
+                <LogsSetupPrompt>
+                    <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
+                        <LogsViewer id={tabId} />
+                    </div>
+                </LogsSetupPrompt>
+            )}
+            {activeTab === 'configuration' && (
+                <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
+            )}
         </>
     )
 }

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,9 +1,11 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 
 import { IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { IconFeedback } from 'lib/lemon-ui/icons'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { Settings } from 'scenes/settings/Settings'
@@ -52,11 +54,7 @@ const LogsSceneContent = (): JSX.Element => {
                 }}
                 actions={
                     <>
-                        {hasLogs && (
-                            <LemonButton size="small" type="secondary" id="logs-feedback-button">
-                                Send feedback
-                            </LemonButton>
-                        )}
+                        {hasLogs && <LogsSceneFeedbackButton />}
                         <LemonButton size="small" type="secondary" icon={<IconGear />} onClick={openLogsSettings}>
                             Settings
                         </LemonButton>
@@ -97,15 +95,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 resourceType={{
                     type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
                 }}
-                actions={
-                    <>
-                        {hasLogs && (
-                            <LemonButton size="small" type="secondary" id="logs-feedback-button">
-                                Send feedback
-                            </LemonButton>
-                        )}
-                    </>
-                }
+                actions={<>{hasLogs && <LogsSceneFeedbackButton />}</>}
             />
             {teamHasLogsCheckFailed && (
                 <LemonBanner
@@ -140,5 +130,18 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}
         </>
+    )
+}
+
+const LogsSceneFeedbackButton = (): JSX.Element => {
+    return (
+        <LemonButton
+            size="small"
+            type="secondary"
+            icon={<IconFeedback />}
+            onClick={() => posthog.displaySurvey('019a7d95-3810-0000-34dc-404a58075f17')}
+        >
+            Feedback
+        </LemonButton>
     )
 }

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -90,4 +90,58 @@ describe('logsSceneLogic', () => {
             expect(logic.values.filters.severityLevels).toEqual(expected)
         })
     })
+
+    describe('activeTab URL sync', () => {
+        it('defaults to viewer', () => {
+            expect(logic.values.activeTab).toEqual('viewer')
+        })
+
+        it.each([
+            ['viewer', 'viewer'],
+            ['configuration', 'configuration'],
+        ])('parses valid activeTab "%s" from URL', async (urlValue, expected) => {
+            await expectLogic(logic, () => {
+                router.actions.push('/logs', { activeTab: urlValue })
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual(expected)
+        })
+
+        it.each([
+            ['unknown string', 'invalid'],
+            ['array', ['viewer']],
+            ['object', { key: 'viewer' }],
+            ['number', 42],
+        ])('ignores invalid activeTab (%s)', async (_, urlValue) => {
+            await expectLogic(logic, () => {
+                router.actions.push('/logs', { activeTab: urlValue })
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('viewer')
+        })
+
+        it('syncs activeTab to URL on setActiveTab', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('configuration')
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('configuration')
+            expect(router.values.searchParams).toHaveProperty('activeTab', 'configuration')
+        })
+
+        it('removes activeTab from URL when set to default', async () => {
+            // First set to non-default
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('configuration')
+            }).toFinishAllListeners()
+
+            // Then set back to default
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('viewer')
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('viewer')
+            expect(router.values.searchParams).not.toHaveProperty('activeTab')
+        })
+    })
 })

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -36,6 +36,9 @@ import {
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
+export type LogsSceneActiveTab = 'viewer' | 'configuration'
+const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
+
 export interface LogsLogicProps {
     tabId: string
 }
@@ -68,6 +71,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     })),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
+            if (params.activeTab && params.activeTab !== values.activeTab) {
+                actions.setActiveTab(params.activeTab)
+            }
+
             const filtersFromUrl: Partial<LogsViewerFilters> = {}
             let hasFilterChanges = false
 
@@ -177,22 +184,37 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             })
         }
 
+        const syncActiveTab = (): ReturnType<typeof syncSearchParams> => {
+            return syncSearchParams(router, (params: Params) => {
+                updateSearchParams(params, 'activeTab', values.activeTab, DEFAULT_ACTIVE_TAB)
+                return params
+            })
+        }
+
         return {
             // initialLogsLimit is a one-shot override from "copy link to log" URLs.
             // It ensures the first fetch loads enough logs to include the linked log,
             // then resets to null so subsequent queries use the default page size.
             fetchLogsSuccess: () => clearInitialLogsLimit(),
             syncUrlAndRunQuery: () => buildUrlAndRunQuery(),
+            setActiveTab: () => syncActiveTab(),
         }
     }),
 
     actions({
+        setActiveTab: (activeTab: LogsSceneActiveTab) => ({ activeTab }),
         syncUrlAndRunQuery: true,
         toggleAttributeBreakdown: (key: string) => ({ key }),
         setExpandedAttributeBreaksdowns: (expandedAttributeBreaksdowns: string[]) => ({ expandedAttributeBreaksdowns }),
     }),
 
     reducers({
+        activeTab: [
+            DEFAULT_ACTIVE_TAB as LogsSceneActiveTab,
+            {
+                setActiveTab: (_, { activeTab }) => activeTab,
+            },
+        ],
         expandedAttributeBreaksdowns: [
             [] as string[],
             {

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -37,6 +37,7 @@ import {
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
 export type LogsSceneActiveTab = 'viewer' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'configuration']
 const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 export interface LogsLogicProps {
@@ -71,8 +72,12 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     })),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
-            if (params.activeTab && params.activeTab !== values.activeTab) {
-                actions.setActiveTab(params.activeTab)
+            if (
+                typeof params.activeTab === 'string' &&
+                VALID_ACTIVE_TABS.includes(params.activeTab as LogsSceneActiveTab) &&
+                params.activeTab !== values.activeTab
+            ) {
+                actions.setActiveTab(params.activeTab as LogsSceneActiveTab)
             }
 
             const filtersFromUrl: Partial<LogsViewerFilters> = {}


### PR DESCRIPTION
## Problem

Logs alerting needs a Configuration tab on the logs scene to host settings and (soon) the alert wizard. Currently the logs scene has no tab structure.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/4b5e5a04-6b1f-41fc-9d71-3c49f268fba1.png)

- Add `LOGS_TABBED_VIEW` feature flag to toggle between the original and tabbed logs scene layout
- Add `activeTab` state (`viewer` | `configuration`) to `logsSceneLogic` with URL sync via `activeTab` search param
- Render abstract `LemonTabs` (no `content` prop) to preserve the height-constrained layout for the virtualized logs viewer
- Show inline `<Settings sectionId="environment-logs" handleLocally />` on the Configuration tab

## How did you test this code?

unit tests

## Publish to changelog?

No