### PR TITLE
feat(approvals): surface pending CR banners on FF list and experiment pages

### DIFF
--- a/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
+++ b/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
@@ -1,0 +1,31 @@
+import { useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { pluralize } from 'lib/utils'
+import { urls } from 'scenes/urls'
+
+import { pendingApprovalsLogic } from './pendingApprovalsLogic'
+
+export function PendingApprovalsBanner(): JSX.Element | null {
+    const { actionableCount, pendingChangeRequestsLoading } = useValues(pendingApprovalsLogic)
+
+    if (pendingChangeRequestsLoading || actionableCount === 0) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type="info"
+            className="mb-4"
+            action={
+                <LemonButton type="secondary" size="small" to={urls.approvals()}>
+                    Go to change requests
+                </LemonButton>
+            }
+        >
+            {actionableCount} {pluralize(actionableCount, 'change request', 'change requests', false)}{' '}
+            {actionableCount === 1 ? 'is' : 'are'} awaiting your decision
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
+++ b/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner } from '@posthog/lemon-ui'
 
 import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -23,11 +23,10 @@ export function PendingApprovalsBanner(): JSX.Element | null {
         <LemonBanner
             type="info"
             className="mb-4"
-            action={
-                <LemonButton type="secondary" size="small" to={urls.approvals()}>
-                    Go to change requests
-                </LemonButton>
-            }
+            action={{
+                children: 'Go to change requests',
+                to: urls.approvals(),
+            }}
         >
             {message}
         </LemonBanner>

--- a/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
+++ b/frontend/src/scenes/approvals/PendingApprovalsBanner.tsx
@@ -8,11 +8,16 @@ import { urls } from 'scenes/urls'
 import { pendingApprovalsLogic } from './pendingApprovalsLogic'
 
 export function PendingApprovalsBanner(): JSX.Element | null {
-    const { actionableCount, pendingChangeRequestsLoading } = useValues(pendingApprovalsLogic)
+    const { actionableCount, pendingCount, pendingChangeRequestsLoading } = useValues(pendingApprovalsLogic)
 
-    if (pendingChangeRequestsLoading || actionableCount === 0) {
+    if (pendingChangeRequestsLoading || pendingCount === 0) {
         return null
     }
+
+    const message =
+        actionableCount > 0
+            ? `${actionableCount} ${pluralize(actionableCount, 'change request', 'change requests', false)} ${actionableCount === 1 ? 'is' : 'are'} awaiting your decision`
+            : `${pendingCount} ${pluralize(pendingCount, 'change request', 'change requests', false)} ${pendingCount === 1 ? 'is' : 'are'} pending approval`
 
     return (
         <LemonBanner
@@ -24,8 +29,7 @@ export function PendingApprovalsBanner(): JSX.Element | null {
                 </LemonButton>
             }
         >
-            {actionableCount} {pluralize(actionableCount, 'change request', 'change requests', false)}{' '}
-            {actionableCount === 1 ? 'is' : 'are'} awaiting your decision
+            {message}
         </LemonBanner>
     )
 }

--- a/frontend/src/scenes/approvals/pendingApprovalsLogic.test.ts
+++ b/frontend/src/scenes/approvals/pendingApprovalsLogic.test.ts
@@ -97,4 +97,19 @@ describe('pendingApprovalsLogic', () => {
             await expectLogic(logic).toMatchValues({ actionableCount: expected })
         })
     })
+
+    describe('pendingCount', () => {
+        it('counts all pending CRs regardless of can_approve', async () => {
+            logic = pendingApprovalsLogic()
+            logic.mount()
+
+            logic.actions.loadPendingChangeRequestsSuccess([
+                makeChangeRequest({ id: 'cr-1', can_approve: true }),
+                makeChangeRequest({ id: 'cr-2', can_approve: false }),
+                makeChangeRequest({ id: 'cr-3', can_approve: false, user_decision: 'approved' }),
+            ])
+
+            await expectLogic(logic).toMatchValues({ pendingCount: 3, actionableCount: 1 })
+        })
+    })
 })

--- a/frontend/src/scenes/approvals/pendingApprovalsLogic.test.ts
+++ b/frontend/src/scenes/approvals/pendingApprovalsLogic.test.ts
@@ -1,0 +1,100 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { ChangeRequest, ChangeRequestState } from '~/types'
+
+import { pendingApprovalsLogic } from './pendingApprovalsLogic'
+
+const MOCK_USER = { id: 1, first_name: 'Test', email: 'test@posthog.com', uuid: 'abc' }
+
+function makeChangeRequest(overrides: Partial<ChangeRequest> = {}): ChangeRequest {
+    return {
+        id: 'cr-1',
+        action_key: 'toggle_feature_flag',
+        action_version: 1,
+        resource_type: 'feature_flag',
+        resource_id: '1',
+        intent: {},
+        intent_display: {},
+        policy_snapshot: {},
+        validation_status: 'valid' as any,
+        validation_errors: null,
+        validated_at: null,
+        state: ChangeRequestState.Pending,
+        created_by: MOCK_USER as any,
+        applied_by: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        expires_at: '2026-01-08T00:00:00Z',
+        applied_at: null,
+        apply_error: '',
+        result_data: null,
+        approvals: [],
+        can_approve: true,
+        can_cancel: false,
+        is_requester: false,
+        user_decision: null,
+        ...overrides,
+    }
+}
+
+describe('pendingApprovalsLogic', () => {
+    let logic: ReturnType<typeof pendingApprovalsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:teamId/change_requests': () => [200, { results: [] }],
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('actionableChangeRequests', () => {
+        it.each([
+            {
+                label: 'includes pending CRs where user can approve and has not decided',
+                changeRequests: [makeChangeRequest()],
+                expected: 1,
+            },
+            {
+                label: 'excludes CRs where user cannot approve',
+                changeRequests: [makeChangeRequest({ can_approve: false })],
+                expected: 0,
+            },
+            {
+                label: 'excludes CRs where user already decided',
+                changeRequests: [makeChangeRequest({ user_decision: 'approved' })],
+                expected: 0,
+            },
+            {
+                label: 'includes approved-state CRs that user can still act on',
+                changeRequests: [makeChangeRequest({ state: ChangeRequestState.Approved })],
+                expected: 1,
+            },
+            {
+                label: 'filters correctly across mixed CRs',
+                changeRequests: [
+                    makeChangeRequest({ id: 'cr-1' }),
+                    makeChangeRequest({ id: 'cr-2', can_approve: false }),
+                    makeChangeRequest({ id: 'cr-3', user_decision: 'rejected' }),
+                    makeChangeRequest({ id: 'cr-4', state: ChangeRequestState.Approved }),
+                ],
+                expected: 2,
+            },
+        ])('$label', async ({ changeRequests, expected }) => {
+            logic = pendingApprovalsLogic()
+            logic.mount()
+
+            // Directly set loaded data to test selector logic independently of API/auth
+            logic.actions.loadPendingChangeRequestsSuccess(changeRequests)
+
+            await expectLogic(logic).toMatchValues({ actionableCount: expected })
+        })
+    })
+})

--- a/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
+++ b/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
@@ -1,0 +1,52 @@
+import { afterMount, kea, path, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { AvailableFeature, ChangeRequest, ChangeRequestState } from '~/types'
+
+import type { pendingApprovalsLogicType } from './pendingApprovalsLogicType'
+
+export const pendingApprovalsLogic = kea<pendingApprovalsLogicType>([
+    path(['scenes', 'approvals', 'pendingApprovalsLogic']),
+
+    loaders(() => ({
+        pendingChangeRequests: [
+            [] as ChangeRequest[],
+            {
+                loadPendingChangeRequests: async () => {
+                    const currentTeamId = teamLogic.findMounted()?.values.currentTeamId
+                    const hasFeature = userLogic.findMounted()?.values.hasAvailableFeature(AvailableFeature.APPROVALS)
+                    if (!currentTeamId || !hasFeature) {
+                        return []
+                    }
+
+                    const response = await api.get(`api/environments/${currentTeamId}/change_requests`, {
+                        state: 'pending,approved',
+                    })
+                    return response.results || []
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        actionableChangeRequests: [
+            (s) => [s.pendingChangeRequests],
+            (changeRequests): ChangeRequest[] =>
+                changeRequests.filter(
+                    (cr) =>
+                        cr.can_approve &&
+                        !cr.user_decision &&
+                        (cr.state === ChangeRequestState.Pending || cr.state === ChangeRequestState.Approved)
+                ),
+        ],
+        actionableCount: [(s) => [s.actionableChangeRequests], (actionable): number => actionable.length],
+    }),
+
+    afterMount(({ actions }) => {
+        actions.loadPendingChangeRequests()
+    }),
+])

--- a/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
+++ b/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
@@ -40,6 +40,7 @@ export const pendingApprovalsLogic = kea<pendingApprovalsLogicType>([
             (changeRequests): ChangeRequest[] => changeRequests.filter((cr) => cr.can_approve && !cr.user_decision),
         ],
         actionableCount: [(s) => [s.actionableChangeRequests], (actionable): number => actionable.length],
+        pendingCount: [(s) => [s.pendingChangeRequests], (pending): number => pending.length],
     }),
 
     afterMount(({ actions }) => {

--- a/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
+++ b/frontend/src/scenes/approvals/pendingApprovalsLogic.ts
@@ -1,29 +1,31 @@
-import { afterMount, kea, path, selectors } from 'kea'
+import { afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { AvailableFeature, ChangeRequest, ChangeRequestState } from '~/types'
+import { AvailableFeature, ChangeRequest } from '~/types'
 
 import type { pendingApprovalsLogicType } from './pendingApprovalsLogicType'
 
 export const pendingApprovalsLogic = kea<pendingApprovalsLogicType>([
     path(['scenes', 'approvals', 'pendingApprovalsLogic']),
 
-    loaders(() => ({
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId'], userLogic, ['hasAvailableFeature']],
+    })),
+
+    loaders(({ values }) => ({
         pendingChangeRequests: [
             [] as ChangeRequest[],
             {
                 loadPendingChangeRequests: async () => {
-                    const currentTeamId = teamLogic.findMounted()?.values.currentTeamId
-                    const hasFeature = userLogic.findMounted()?.values.hasAvailableFeature(AvailableFeature.APPROVALS)
-                    if (!currentTeamId || !hasFeature) {
+                    if (!values.currentTeamId || !values.hasAvailableFeature(AvailableFeature.APPROVALS)) {
                         return []
                     }
 
-                    const response = await api.get(`api/environments/${currentTeamId}/change_requests`, {
+                    const response = await api.get(`api/environments/${values.currentTeamId}/change_requests`, {
                         state: 'pending,approved',
                     })
                     return response.results || []
@@ -35,13 +37,7 @@ export const pendingApprovalsLogic = kea<pendingApprovalsLogicType>([
     selectors({
         actionableChangeRequests: [
             (s) => [s.pendingChangeRequests],
-            (changeRequests): ChangeRequest[] =>
-                changeRequests.filter(
-                    (cr) =>
-                        cr.can_approve &&
-                        !cr.user_decision &&
-                        (cr.state === ChangeRequestState.Pending || cr.state === ChangeRequestState.Approved)
-                ),
+            (changeRequests): ChangeRequest[] => changeRequests.filter((cr) => cr.can_approve && !cr.user_decision),
         ],
         actionableCount: [(s) => [s.actionableChangeRequests], (actionable): number => actionable.length],
     }),

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -5,6 +5,7 @@ import { LemonTabs, LemonTag } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { PendingChangeRequestBanner } from 'scenes/approvals/PendingChangeRequestBanner'
 import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from 'scenes/experiments/constants'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
 
@@ -279,6 +280,12 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
             ) : (
                 <>
                     <ExperimentWarningBanner />
+                    {experiment.feature_flag?.id && (
+                        <PendingChangeRequestBanner
+                            resourceType="feature_flag"
+                            resourceId={experiment.feature_flag.id}
+                        />
+                    )}
                     {usesNewQueryRunner ? <Info tabId={tabId} /> : <LegacyExperimentInfo />}
                     {usesNewQueryRunner ? <ExperimentHeader /> : <LegacyExperimentHeader />}
                     <LemonTabs

--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 
 import { LemonBanner } from '@posthog/lemon-ui'
 
+import { approvalsGateLogic } from 'lib/approvals/approvalsGateLogic'
 import { JudgeHog } from 'lib/components/hedgehogs'
 import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -18,11 +19,17 @@ const DISMISS_KEY = 'feature-flags-approvals-promo'
 export function ApprovalsPromoBanner(): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
     const { isAdminOrOwner } = useValues(organizationLogic)
+    const { activePolicies, activePoliciesLoading } = useValues(approvalsGateLogic)
     const bannerLogic = lemonBannerLogic({ dismissKey: DISMISS_KEY })
     const { isDismissed } = useValues(bannerLogic)
     const { dismiss } = useActions(bannerLogic)
 
-    const shouldShow = isAdminOrOwner && hasAvailableFeature(AvailableFeature.APPROVALS)
+    const hasActivePolicies = activePolicies.length > 0
+    const shouldShow =
+        isAdminOrOwner &&
+        hasAvailableFeature(AvailableFeature.APPROVALS) &&
+        !hasActivePolicies &&
+        !activePoliciesLoading
 
     useEffect(() => {
         if (shouldShow && !isDismissed) {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -35,6 +35,7 @@ import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -347,6 +348,7 @@ export function OverViewTab({
     nouns?: [string, string]
 }): JSX.Element {
     const { aggregationLabel } = useValues(groupsModel)
+    const { user } = useValues(userLogic)
 
     const flagLogic = featureFlagsLogic({ flagPrefix })
     const { featureFlagsLoading, displayedFlags, pagination, filters, shouldShowEmptyState, filtersChanged } =
@@ -355,6 +357,7 @@ export function OverViewTab({
     const { featureFlags: enabledFeatureFlags } = useValues(enabledFeaturesLogic)
     const featureFlagsV2Enabled = !!enabledFeatureFlags[FEATURE_FLAGS.FEATURE_FLAGS_V2]
     const newFeatureFlagUrl = featureFlagsV2Enabled ? urls.featureFlagTemplates() : urls.featureFlag('new')
+    const isProductIntroVisible = shouldShowEmptyState || !user?.has_seen_product_intro_for?.[ProductKey.FEATURE_FLAGS]
 
     const {
         selectedCount,
@@ -551,7 +554,7 @@ export function OverViewTab({
                 customHog={FeatureFlagHog}
                 className={cn('my-0')}
             />
-            <ApprovalsPromoBanner />
+            {!isProductIntroVisible && <ApprovalsPromoBanner />}
             <PendingApprovalsBanner />
             <div>{filtersSection}</div>
             <LemonDivider className="my-0" />

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -28,6 +28,7 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { PendingApprovalsBanner } from 'scenes/approvals/PendingApprovalsBanner'
 import { projectLogic } from 'scenes/projectLogic'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
@@ -551,6 +552,7 @@ export function OverViewTab({
                 className={cn('my-0')}
             />
             <ApprovalsPromoBanner />
+            <PendingApprovalsBanner />
             <div>{filtersSection}</div>
             <LemonDivider className="my-0" />
             <div className="flex items-center justify-between min-h-9">

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -1,6 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import api from 'lib/api'
+import { showApprovalRequiredToast } from 'scenes/approvals/ApprovalRequiredBanner'
 import { NEW_FLAG } from 'scenes/feature-flags/featureFlagLogic'
 import {
     FeatureFlagsTab,
@@ -11,8 +13,13 @@ import {
 } from 'scenes/feature-flags/featureFlagsLogic'
 import { urls } from 'scenes/urls'
 
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { FeatureFlagType } from '~/types'
+
+jest.mock('scenes/approvals/ApprovalRequiredBanner', () => ({
+    showApprovalRequiredToast: jest.fn(),
+}))
 
 describe('flagMatchesSearch', () => {
     const flag = { ...NEW_FLAG, id: 1, key: 'my-feature', name: 'My Feature Flag' } as FeatureFlagType
@@ -112,5 +119,67 @@ describe('the feature flags logic', () => {
         }).toMatchValues({
             activeTab: FeatureFlagsTab.HISTORY,
         })
+    })
+})
+
+describe('updateFeatureFlag 409 handling', () => {
+    let logic: ReturnType<typeof featureFlagsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:projectId/feature_flags/': () => [
+                    200,
+                    {
+                        results: [{ id: 1, key: 'test-flag', active: false }],
+                        count: 1,
+                    },
+                ],
+            },
+        })
+        initKeaTests()
+        logic = featureFlagsLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it.each([
+        { active: true, expected: 'enable this feature flag' },
+        { active: false, expected: 'disable this feature flag' },
+    ])(
+        'shows approval toast with "$expected" when toggling active=$active gets a 409',
+        async ({ active, expected }) => {
+            const error = { status: 409, data: { change_request_id: 'cr-123' } }
+            jest.spyOn(api, 'update').mockRejectedValueOnce(error)
+
+            logic.actions.updateFeatureFlag({ id: 1, payload: { active } })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(showApprovalRequiredToast).toHaveBeenCalledWith('cr-123', expected)
+        }
+    )
+
+    it('does not show approval toast for non-409 errors', async () => {
+        const error = { status: 500, data: { detail: 'Internal server error' } }
+        jest.spyOn(api, 'update').mockRejectedValueOnce(error)
+
+        logic.actions.updateFeatureFlag({ id: 1, payload: { active: true } })
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(showApprovalRequiredToast).not.toHaveBeenCalled()
+    })
+
+    it('does not show approval toast for 409 without change_request_id', async () => {
+        const error = { status: 409, data: { detail: 'Conflict' } }
+        jest.spyOn(api, 'update').mockRejectedValueOnce(error)
+
+        logic.actions.updateFeatureFlag({ id: 1, payload: { active: true } })
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(showApprovalRequiredToast).not.toHaveBeenCalled()
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -7,6 +7,7 @@ import { PaginationManual } from '@posthog/lemon-ui'
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { objectsEqual, parseTagsFilter, toParams } from 'lib/utils'
+import { showApprovalRequiredToast } from 'scenes/approvals/ApprovalRequiredBanner'
 import { projectLogic } from 'scenes/projectLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -152,14 +153,27 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                     }
                 },
                 updateFeatureFlag: async ({ id, payload }: { id: number; payload: Partial<FeatureFlagType> }) => {
-                    const response = await api.update(
-                        `api/projects/${values.currentProjectId}/feature_flags/${id}`,
-                        payload
-                    )
-                    const updatedFlags = [...values.featureFlags.results].map((flag) =>
-                        flag.id === response.id ? response : flag
-                    )
-                    return { ...values.featureFlags, results: updatedFlags, lastUpdatedFlagId: id }
+                    try {
+                        const response = await api.update(
+                            `api/projects/${values.currentProjectId}/feature_flags/${id}`,
+                            payload
+                        )
+                        const updatedFlags = [...values.featureFlags.results].map((flag) =>
+                            flag.id === response.id ? response : flag
+                        )
+                        return { ...values.featureFlags, results: updatedFlags, lastUpdatedFlagId: id }
+                    } catch (e: any) {
+                        if (e.status === 409 && e.data?.change_request_id) {
+                            const actionDescription =
+                                payload.active === true
+                                    ? 'enable this feature flag'
+                                    : payload.active === false
+                                      ? 'disable this feature flag'
+                                      : 'update this feature flag'
+                            showApprovalRequiredToast(e.data.change_request_id, actionDescription)
+                        }
+                        throw e
+                    }
                 },
             },
         ],

--- a/posthog/approvals/permissions.py
+++ b/posthog/approvals/permissions.py
@@ -21,10 +21,11 @@ class CanApprove(permissions.BasePermission):
         allow_self_approve = policy_snapshot.get("allow_self_approve", False)
         is_requester = obj.created_by == request.user
 
-        # Check self-approval first - if requester and not allowed, deny immediately
-        if is_requester and not allow_self_approve:
-            self.message = "You cannot approve your own change request"
-            return False
+        # Check self-approval: if requester, self-approve flag determines access
+        if is_requester:
+            if not allow_self_approve:
+                self.message = "You cannot approve your own change request"
+            return allow_self_approve
 
         # Check if user is in explicit approver set (users/roles)
         if self._user_in_approver_set(request.user, policy_snapshot, obj):

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -78,11 +78,11 @@ class ChangeRequestSerializer(serializers.ModelSerializer):
         user = request.user
         policy = obj.policy_snapshot
 
-        # If user is the requester and self-approve is not allowed, they cannot approve
+        # If user is the requester, self-approve controls whether they can approve
         is_requester = obj.created_by_id == user.id
         allow_self_approve = policy.get("allow_self_approve", False)
-        if is_requester and not allow_self_approve:
-            return False
+        if is_requester:
+            return allow_self_approve
 
         # Check if user is in approver users list
         approver_users = policy.get("users", [])

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -173,6 +173,57 @@ class TestChangeRequestViewSet(APIBaseTest):
         assert response.json()["status"] == "applied"
         assert Approval.objects.filter(change_request=cr, decision=ApprovalDecision.APPROVED).exists()
 
+    def test_can_approve_true_for_requester_with_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": True},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/{cr.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["can_approve"] is True
+
+    def test_can_approve_false_for_requester_without_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": False},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/{cr.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["can_approve"] is False
+
+    @patch("posthog.approvals.services.apply_change_request")
+    def test_approve_success_for_requester_with_self_approve_not_in_approvers(self, mock_apply):
+        mock_apply.return_value = type("obj", (object,), {"id": 123, "version": 1})()
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": True},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/",
+            {"reason": "Self-approving"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "applied"
+
+    def test_approve_denied_for_requester_without_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": False},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/",
+            {"reason": "Trying to self-approve"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_approve_already_voted(self):
         cr = self._create_change_request()
         Approval.objects.create(change_request=cr, created_by=self.user, decision=ApprovalDecision.APPROVED)


### PR DESCRIPTION
## Summary
- Show "X change requests are awaiting your decision" banner on the **feature flags list page** for users who are approvers on pending CRs
- Handle **409 approval-required** responses when toggling enable/disable from the FF list (was silently failing)
- Show **pending change request banner** on the **experiment detail page** for the experiment's linked feature flag
- Hide the **approvals promo banner** when the team already has active approval policies configured
- Use `connect()` instead of `findMounted()` in `pendingApprovalsLogic` for reliability
- Remove redundant state filtering in selector (API already filters by state)
