### PR TITLE
feat(logs): make feedback button more prominent and match error tracking

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,9 +1,11 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 
 import { IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { IconFeedback } from 'lib/lemon-ui/icons'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { Settings } from 'scenes/settings/Settings'
@@ -52,11 +54,7 @@ const LogsSceneContent = (): JSX.Element => {
                 }}
                 actions={
                     <>
-                        {hasLogs && (
-                            <LemonButton size="small" type="secondary" id="logs-feedback-button">
-                                Send feedback
-                            </LemonButton>
-                        )}
+                        {hasLogs && <LogsSceneFeedbackButton />}
                         <LemonButton size="small" type="secondary" icon={<IconGear />} onClick={openLogsSettings}>
                             Settings
                         </LemonButton>
@@ -97,15 +95,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 resourceType={{
                     type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
                 }}
-                actions={
-                    <>
-                        {hasLogs && (
-                            <LemonButton size="small" type="secondary" id="logs-feedback-button">
-                                Send feedback
-                            </LemonButton>
-                        )}
-                    </>
-                }
+                actions={<>{hasLogs && <LogsSceneFeedbackButton />}</>}
             />
             {teamHasLogsCheckFailed && (
                 <LemonBanner
@@ -140,5 +130,18 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}
         </>
+    )
+}
+
+const LogsSceneFeedbackButton = (): JSX.Element => {
+    return (
+        <LemonButton
+            size="small"
+            type="secondary"
+            icon={<IconFeedback />}
+            onClick={() => posthog.displaySurvey('019a7d95-3810-0000-34dc-404a58075f17')}
+        >
+            Feedback
+        </LemonButton>
     )
 }

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -90,4 +90,58 @@ describe('logsSceneLogic', () => {
             expect(logic.values.filters.severityLevels).toEqual(expected)
         })
     })
+
+    describe('activeTab URL sync', () => {
+        it('defaults to viewer', () => {
+            expect(logic.values.activeTab).toEqual('viewer')
+        })
+
+        it.each([
+            ['viewer', 'viewer'],
+            ['configuration', 'configuration'],
+        ])('parses valid activeTab "%s" from URL', async (urlValue, expected) => {
+            await expectLogic(logic, () => {
+                router.actions.push('/logs', { activeTab: urlValue })
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual(expected)
+        })
+
+        it.each([
+            ['unknown string', 'invalid'],
+            ['array', ['viewer']],
+            ['object', { key: 'viewer' }],
+            ['number', 42],
+        ])('ignores invalid activeTab (%s)', async (_, urlValue) => {
+            await expectLogic(logic, () => {
+                router.actions.push('/logs', { activeTab: urlValue })
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('viewer')
+        })
+
+        it('syncs activeTab to URL on setActiveTab', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('configuration')
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('configuration')
+            expect(router.values.searchParams).toHaveProperty('activeTab', 'configuration')
+        })
+
+        it('removes activeTab from URL when set to default', async () => {
+            // First set to non-default
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('configuration')
+            }).toFinishAllListeners()
+
+            // Then set back to default
+            await expectLogic(logic, () => {
+                logic.actions.setActiveTab('viewer')
+            }).toFinishAllListeners()
+
+            expect(logic.values.activeTab).toEqual('viewer')
+            expect(router.values.searchParams).not.toHaveProperty('activeTab')
+        })
+    })
 })

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -37,6 +37,7 @@ import {
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
 export type LogsSceneActiveTab = 'viewer' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'configuration']
 const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 export interface LogsLogicProps {
@@ -71,8 +72,12 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     })),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
-            if (params.activeTab && params.activeTab !== values.activeTab) {
-                actions.setActiveTab(params.activeTab)
+            if (
+                typeof params.activeTab === 'string' &&
+                VALID_ACTIVE_TABS.includes(params.activeTab as LogsSceneActiveTab) &&
+                params.activeTab !== values.activeTab
+            ) {
+                actions.setActiveTab(params.activeTab as LogsSceneActiveTab)
             }
 
             const filtersFromUrl: Partial<LogsViewerFilters> = {}


### PR DESCRIPTION
## Problem

Feedback button wasn't prominent enough and not explicitly linked to the survey id  
![image.png](https://app.graphite.com/user-attachments/assets/617f765b-ee39-496c-ab96-b786ba0784c2.png)

## Changes

- Added a dedicated `LogsSceneFeedbackButton` component that triggers a PostHog survey when clicked
- Added feedback icon to improve visual recognition of the feedback action
- Integrated PostHog survey display functionality with survey ID `019a7d95-3810-0000-34dc-404a58075f17`

## How did you test this code?

local dev

## Publish to changelog?

No