### PR TITLE
fix(ph-ai): release all modes

### DIFF
--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -26,16 +26,10 @@ from ee.hogai.core.agent_modes.presets.product_analytics import (
 )
 from ee.hogai.core.agent_modes.presets.session_replay import chat_agent_plan_session_replay_agent, session_replay_agent
 from ee.hogai.core.agent_modes.presets.sql import chat_agent_plan_sql_agent, sql_agent
-from ee.hogai.core.agent_modes.presets.survey import subagent_survey_agent, survey_agent
+from ee.hogai.core.agent_modes.presets.survey import chat_agent_plan_survey_agent, subagent_survey_agent, survey_agent
 from ee.hogai.core.agent_modes.prompt_builder import AgentPromptBuilder
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
-from ee.hogai.utils.feature_flags import (
-    has_error_tracking_mode_feature_flag,
-    has_flags_mode_feature_flag,
-    has_llm_analytics_mode_feature_flag,
-    has_plan_mode_feature_flag,
-    has_survey_mode_feature_flag,
-)
+from ee.hogai.utils.feature_flags import has_plan_mode_feature_flag
 from ee.hogai.utils.types.base import AssistantState, NodePath
 
 # Execution and plan mode definitions - fictitious modes used to trigger transition in and out of plan mode
@@ -56,6 +50,10 @@ DEFAULT_CHAT_AGENT_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
     AgentMode.PRODUCT_ANALYTICS: product_analytics_agent,
     AgentMode.SQL: sql_agent,
     AgentMode.SESSION_REPLAY: session_replay_agent,
+    AgentMode.ERROR_TRACKING: error_tracking_agent,
+    AgentMode.FLAGS: flags_agent,
+    AgentMode.SURVEY: survey_agent,
+    AgentMode.LLM_ANALYTICS: llm_analytics_agent,
 }
 
 DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
@@ -63,26 +61,25 @@ DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
     AgentMode.SQL: chat_agent_plan_sql_agent,
     AgentMode.SESSION_REPLAY: chat_agent_plan_session_replay_agent,
     AgentMode.EXECUTION: execution_agent,
+    AgentMode.ERROR_TRACKING: chat_agent_plan_error_tracking_agent,
+    AgentMode.FLAGS: chat_agent_plan_flags_agent,
+    AgentMode.SURVEY: chat_agent_plan_survey_agent,
+    AgentMode.LLM_ANALYTICS: chat_agent_plan_llm_analytics_agent,
 }
 
 SUBAGENT_CHAT_AGENT_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
     AgentMode.PRODUCT_ANALYTICS: subagent_product_analytics_agent,
     AgentMode.SQL: sql_agent,
     AgentMode.SESSION_REPLAY: session_replay_agent,
+    AgentMode.ERROR_TRACKING: error_tracking_agent,
+    AgentMode.FLAGS: chat_agent_plan_flags_agent,
+    AgentMode.SURVEY: subagent_survey_agent,
+    AgentMode.LLM_ANALYTICS: chat_agent_plan_llm_analytics_agent,
 }
 
 
 def get_plan_mode_registry(team: Team, user: User) -> dict[AgentMode, AgentModeDefinition]:
-    registry = dict(DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY)
-    if has_error_tracking_mode_feature_flag(team, user):
-        registry[AgentMode.ERROR_TRACKING] = chat_agent_plan_error_tracking_agent
-    if has_flags_mode_feature_flag(team, user):
-        registry[AgentMode.FLAGS] = chat_agent_plan_flags_agent
-    if has_survey_mode_feature_flag(team, user):
-        registry[AgentMode.SURVEY] = survey_agent
-    if has_llm_analytics_mode_feature_flag(team, user):
-        registry[AgentMode.LLM_ANALYTICS] = chat_agent_plan_llm_analytics_agent
-    return registry
+    return dict(DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY)
 
 
 def get_execution_mode_registry(team: Team, user: User) -> dict[AgentMode, AgentModeDefinition]:
@@ -90,16 +87,7 @@ def get_execution_mode_registry(team: Team, user: User) -> dict[AgentMode, Agent
 
     This is the registry that will be available after transitioning out of plan mode.
     """
-    registry = dict(DEFAULT_CHAT_AGENT_MODE_REGISTRY)
-    if has_error_tracking_mode_feature_flag(team, user):
-        registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
-    if has_survey_mode_feature_flag(team, user):
-        registry[AgentMode.SURVEY] = survey_agent
-    if has_flags_mode_feature_flag(team, user):
-        registry[AgentMode.FLAGS] = flags_agent
-    if has_llm_analytics_mode_feature_flag(team, user):
-        registry[AgentMode.LLM_ANALYTICS] = llm_analytics_agent
-    return registry
+    return dict(DEFAULT_CHAT_AGENT_MODE_REGISTRY)
 
 
 class ChatAgentModeManager(AgentModeManager):
@@ -152,14 +140,7 @@ class ChatAgentModeManager(AgentModeManager):
 
     @property
     def _subagent_mode_registry(self) -> dict[AgentMode, AgentModeDefinition]:
-        registry = dict(SUBAGENT_CHAT_AGENT_MODE_REGISTRY)
-        if has_error_tracking_mode_feature_flag(self._team, self._user):
-            registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
-        if has_survey_mode_feature_flag(self._team, self._user):
-            registry[AgentMode.SURVEY] = subagent_survey_agent
-        if has_llm_analytics_mode_feature_flag(self._team, self._user):
-            registry[AgentMode.LLM_ANALYTICS] = llm_analytics_agent
-        return registry
+        return dict(SUBAGENT_CHAT_AGENT_MODE_REGISTRY)
 
     @property
     def prompt_builder_class(self) -> type[AgentPromptBuilder]:

--- a/ee/hogai/chat_agent/test/test_mode_manager.py
+++ b/ee/hogai/chat_agent/test/test_mode_manager.py
@@ -43,7 +43,7 @@ from ee.hogai.chat_agent.prompts import (
 from ee.hogai.chat_agent.toolkit import ChatAgentPlanToolkit, ChatAgentToolkit, ChatAgentToolkitManager
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.agent_modes.presets.product_analytics import ReadOnlyProductAnalyticsAgentToolkit
-from ee.hogai.core.agent_modes.presets.survey import SubagentSurveyAgentToolkit
+from ee.hogai.core.agent_modes.presets.survey import ReadOnlySurveyAgentToolkit
 from ee.hogai.tools import CreateInsightTool, UpsertDashboardTool
 from ee.hogai.tools.replay.filter_session_recordings import FilterSessionRecordingsTool
 from ee.hogai.utils.tests import FakeChatAnthropic, FakeChatOpenAI
@@ -131,8 +131,8 @@ class TestAgentToolkit(BaseTest):
             # (tasks_flag, expected_tools, unexpected_tools)
             [
                 False,
-                ["read_taxonomy", "read_data", "search", "todo_write", "switch_mode"],
-                ["create_form", "create_task", "run_task", "list_tasks"],
+                ["read_taxonomy", "read_data", "search", "todo_write", "switch_mode", "create_form"],
+                ["create_task", "run_task", "list_tasks"],
             ],
             [
                 True,
@@ -142,6 +142,7 @@ class TestAgentToolkit(BaseTest):
                     "search",
                     "todo_write",
                     "switch_mode",
+                    "create_form",
                     "create_task",
                     "run_task",
                     "get_task_run",
@@ -149,7 +150,7 @@ class TestAgentToolkit(BaseTest):
                     "list_tasks",
                     "list_task_runs",
                 ],
-                ["create_form"],
+                [],
             ],
         ]
     )
@@ -180,42 +181,30 @@ class TestAgentToolkit(BaseTest):
         mock_get_tools.assert_awaited_once()
         self.assertIn({"type": "web_search_20250305", "name": "web_search", "max_uses": 5}, tools)
 
-    @parameterized.expand(
-        [
-            # (error_tracking_flag, flags_flag, expected_modes, unexpected_modes)
-            [False, False, ["product_analytics", "sql", "session_replay"], ["error_tracking", "flags"]],
-            [True, False, ["product_analytics", "sql", "session_replay", "error_tracking"], ["flags"]],
-            [False, True, ["product_analytics", "sql", "session_replay", "flags"], ["error_tracking"]],
-            [True, True, ["product_analytics", "sql", "session_replay", "error_tracking", "flags"], []],
-        ]
-    )
-    def test_mode_registry_based_on_feature_flags(
-        self, error_tracking_flag, flags_flag, expected_modes, unexpected_modes
-    ):
-        with (
-            patch(
-                "ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag",
-                return_value=error_tracking_flag,
-            ),
-            patch("ee.hogai.chat_agent.mode_manager.has_flags_mode_feature_flag", return_value=flags_flag),
-        ):
-            node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
-            context_manager = AssistantContextManager(
-                team=self.team, user=self.user, config=RunnableConfig(configurable={})
-            )
-            mode_manager = ChatAgentModeManager(
-                team=self.team,
-                user=self.user,
-                node_path=node_path,
-                context_manager=context_manager,
-                state=AssistantState(messages=[HumanMessage(content="Test")]),
-            )
-            mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
+    def test_mode_registry_includes_all_modes(self):
+        node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
+        context_manager = AssistantContextManager(
+            team=self.team, user=self.user, config=RunnableConfig(configurable={})
+        )
+        mode_manager = ChatAgentModeManager(
+            team=self.team,
+            user=self.user,
+            node_path=node_path,
+            context_manager=context_manager,
+            state=AssistantState(messages=[HumanMessage(content="Test")]),
+        )
+        mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
 
-            for expected in expected_modes:
-                self.assertIn(expected, mode_names)
-            for unexpected in unexpected_modes:
-                self.assertNotIn(unexpected, mode_names)
+        for expected in [
+            "product_analytics",
+            "sql",
+            "session_replay",
+            "error_tracking",
+            "flags",
+            "survey",
+            "llm_analytics",
+        ]:
+            self.assertIn(expected, mode_names)
 
     @parameterized.expand(
         [
@@ -660,118 +649,55 @@ class TestRootNodeTools(BaseTest):
 class TestChatAgentModeManagerModeFallback(BaseTest):
     @parameterized.expand(
         [
-            [AgentMode.LLM_ANALYTICS, "has_llm_analytics_mode_feature_flag"],
-            [AgentMode.ERROR_TRACKING, "has_error_tracking_mode_feature_flag"],
-            [AgentMode.SURVEY, "has_survey_mode_feature_flag"],
-            [AgentMode.FLAGS, "has_flags_mode_feature_flag"],
+            [AgentMode.LLM_ANALYTICS],
+            [AgentMode.ERROR_TRACKING],
+            [AgentMode.SURVEY],
+            [AgentMode.FLAGS],
         ]
     )
-    def test_falls_back_to_product_analytics_when_feature_flag_is_off(self, mode, flag_func_name):
+    def test_all_modes_are_always_available(self, mode):
         node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
         context_manager = AssistantContextManager(
             team=self.team, user=self.user, config=RunnableConfig(configurable={})
         )
         state = AssistantState(messages=[HumanMessage(content="Test")], agent_mode=mode)
 
-        with patch(f"ee.hogai.chat_agent.mode_manager.{flag_func_name}", return_value=False):
-            mode_manager = ChatAgentModeManager(
-                team=self.team,
-                user=self.user,
-                node_path=node_path,
-                context_manager=context_manager,
-                state=state,
-            )
-            self.assertEqual(mode_manager._mode, AgentMode.PRODUCT_ANALYTICS)
-            # Accessing .node should not raise KeyError
-            self.assertIn(mode_manager._mode, mode_manager.mode_registry)
-
-    @parameterized.expand(
-        [
-            [AgentMode.LLM_ANALYTICS, "has_llm_analytics_mode_feature_flag"],
-            [AgentMode.ERROR_TRACKING, "has_error_tracking_mode_feature_flag"],
-            [AgentMode.SURVEY, "has_survey_mode_feature_flag"],
-            [AgentMode.FLAGS, "has_flags_mode_feature_flag"],
-        ]
-    )
-    def test_keeps_mode_when_feature_flag_is_on(self, mode, flag_func_name):
-        node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
-        context_manager = AssistantContextManager(
-            team=self.team, user=self.user, config=RunnableConfig(configurable={})
+        mode_manager = ChatAgentModeManager(
+            team=self.team,
+            user=self.user,
+            node_path=node_path,
+            context_manager=context_manager,
+            state=state,
         )
-        state = AssistantState(messages=[HumanMessage(content="Test")], agent_mode=mode)
-
-        with patch(f"ee.hogai.chat_agent.mode_manager.{flag_func_name}", return_value=True):
-            mode_manager = ChatAgentModeManager(
-                team=self.team,
-                user=self.user,
-                node_path=node_path,
-                context_manager=context_manager,
-                state=state,
-            )
-            self.assertEqual(mode_manager._mode, mode)
-            self.assertIn(mode_manager._mode, mode_manager.mode_registry)
+        self.assertEqual(mode_manager._mode, mode)
+        self.assertIn(mode_manager._mode, mode_manager.mode_registry)
 
 
 class TestChatAgentModeManagerSubagent(BaseTest):
-    @parameterized.expand(
-        [
-            # (error_tracking_flag, plan_flag, survey_flag, expected_modes, unexpected_modes)
-            [
-                False,
-                False,
-                False,
-                ["product_analytics", "sql", "session_replay"],
-                ["plan", "error_tracking", "survey"],
-            ],
-            [
-                True,
-                False,
-                False,
-                ["product_analytics", "sql", "session_replay", "error_tracking"],
-                ["plan", "survey"],
-            ],
-            [
-                False,
-                False,
-                True,
-                ["product_analytics", "sql", "session_replay", "survey"],
-                ["plan", "error_tracking"],
-            ],
-            [
-                False,
-                True,
-                False,
-                ["product_analytics", "sql", "session_replay"],
-                ["plan", "error_tracking", "survey"],
-            ],
-        ]
-    )
-    def test_subagent_mode_registry(
-        self, error_tracking_flag, plan_flag, survey_flag, expected_modes, unexpected_modes
-    ):
+    def test_subagent_mode_registry_includes_all_modes(self):
         node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
         config = RunnableConfig(configurable={"is_subagent": True})
         context_manager = AssistantContextManager(team=self.team, user=self.user, config=config)
-        with (
-            patch(
-                "ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag",
-                return_value=error_tracking_flag,
-            ),
-            patch("ee.hogai.chat_agent.mode_manager.has_plan_mode_feature_flag", return_value=plan_flag),
-            patch("ee.hogai.chat_agent.mode_manager.has_survey_mode_feature_flag", return_value=survey_flag),
-        ):
-            mode_manager = ChatAgentModeManager(
-                team=self.team,
-                user=self.user,
-                node_path=node_path,
-                context_manager=context_manager,
-                state=AssistantState(messages=[HumanMessage(content="Test")]),
-            )
-            mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
-            for expected in expected_modes:
-                self.assertIn(expected, mode_names)
-            for unexpected in unexpected_modes:
-                self.assertNotIn(unexpected, mode_names)
+        mode_manager = ChatAgentModeManager(
+            team=self.team,
+            user=self.user,
+            node_path=node_path,
+            context_manager=context_manager,
+            state=AssistantState(messages=[HumanMessage(content="Test")]),
+        )
+        mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
+        for expected in [
+            "product_analytics",
+            "sql",
+            "session_replay",
+            "error_tracking",
+            "flags",
+            "survey",
+            "llm_analytics",
+        ]:
+            self.assertIn(expected, mode_names)
+        # Plan mode is never available for subagents
+        self.assertNotIn("plan", mode_names)
 
     def test_subagent_product_analytics_toolkit_excludes_dangerous_tools(self):
         context_manager = AssistantContextManager(
@@ -786,29 +712,25 @@ class TestChatAgentModeManagerSubagent(BaseTest):
         context_manager = AssistantContextManager(
             team=self.team, user=self.user, config=RunnableConfig(configurable={"is_subagent": True})
         )
-        toolkit = SubagentSurveyAgentToolkit(team=self.team, user=self.user, context_manager=context_manager)
+        toolkit = ReadOnlySurveyAgentToolkit(team=self.team, user=self.user, context_manager=context_manager)
         self.assertIn(SurveyAnalysisTool, toolkit.tools)
         self.assertNotIn(CreateSurveyTool, toolkit.tools)
         self.assertNotIn(EditSurveyTool, toolkit.tools)
 
-    def test_non_subagent_mode_registry_unchanged(self):
+    def test_non_subagent_mode_registry_includes_all_modes(self):
         node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
         config = RunnableConfig(configurable={})
         context_manager = AssistantContextManager(team=self.team, user=self.user, config=config)
-        with (
-            patch("ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag", return_value=True),
-            patch("ee.hogai.chat_agent.mode_manager.has_plan_mode_feature_flag", return_value=True),
-            patch("ee.hogai.chat_agent.mode_manager.has_survey_mode_feature_flag", return_value=True),
-        ):
-            mode_manager = ChatAgentModeManager(
-                team=self.team,
-                user=self.user,
-                node_path=node_path,
-                context_manager=context_manager,
-                state=AssistantState(messages=[HumanMessage(content="Test")]),
-            )
-            mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
-            self.assertIn("product_analytics", mode_names)
-            self.assertIn("plan", mode_names)
-            self.assertIn("survey", mode_names)
-            self.assertIn("error_tracking", mode_names)
+        mode_manager = ChatAgentModeManager(
+            team=self.team,
+            user=self.user,
+            node_path=node_path,
+            context_manager=context_manager,
+            state=AssistantState(messages=[HumanMessage(content="Test")]),
+        )
+        mode_names = [mode.value for mode in mode_manager.mode_registry.keys()]
+        self.assertIn("product_analytics", mode_names)
+        self.assertIn("survey", mode_names)
+        self.assertIn("error_tracking", mode_names)
+        self.assertIn("flags", mode_names)
+        self.assertIn("llm_analytics", mode_names)

--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -32,7 +32,6 @@ from ee.hogai.tools import (
 from ee.hogai.tools.call_mcp_server.tool import CallMCPServerTool
 from ee.hogai.tools.finalize_plan.tool import FinalizePlanTool
 from ee.hogai.utils.feature_flags import (
-    has_create_form_tool_feature_flag,
     has_mcp_servers_feature_flag,
     has_memory_tool_feature_flag,
     has_phai_tasks_feature_flag,
@@ -47,6 +46,7 @@ DEFAULT_TOOLS: list[type[MaxTool]] = [
     ListDataTool,
     TodoWriteTool,
     SwitchModeTool,
+    CreateFormTool,
     CreateNotebookTool,
 ]
 
@@ -90,8 +90,6 @@ class ChatAgentToolkit(AgentToolkit):
             tools.append(TaskTool)
         if has_memory_tool_feature_flag(self._team, self._user):
             tools.append(ManageMemoriesTool)
-        if has_create_form_tool_feature_flag(self._team, self._user):
-            tools.append(CreateFormTool)
         return tools
 
 

--- a/ee/hogai/core/agent_modes/presets/survey.py
+++ b/ee/hogai/core/agent_modes/presets/survey.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from posthog.schema import AgentMode
 
+from ee.hogai.chat_agent.executables import ChatAgentPlanExecutable, ChatAgentPlanToolsExecutable
 from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit
 from ee.hogai.tools.todo_write import TodoWriteExample
@@ -114,7 +115,7 @@ survey_agent = AgentModeDefinition(
 )
 
 
-class SubagentSurveyAgentToolkit(AgentToolkit):
+class ReadOnlySurveyAgentToolkit(AgentToolkit):
     """Survey toolkit for subagents — only includes SurveyAnalysisTool (read-only)."""
 
     @property
@@ -124,8 +125,16 @@ class SubagentSurveyAgentToolkit(AgentToolkit):
         return [SurveyAnalysisTool]
 
 
-SUBAGENT_MODE_DESCRIPTION = "Specialized mode for analyzing surveys. Analyze survey responses to extract themes, sentiment, and actionable insights."
+READ_ONLY_SURVEY_MODE_DESCRIPTION = "Specialized mode for analyzing surveys. Analyze survey responses to extract themes, sentiment, and actionable insights."
 
 subagent_survey_agent = replace(
-    survey_agent, toolkit_class=SubagentSurveyAgentToolkit, mode_description=SUBAGENT_MODE_DESCRIPTION
+    survey_agent, toolkit_class=ReadOnlySurveyAgentToolkit, mode_description=READ_ONLY_SURVEY_MODE_DESCRIPTION
+)
+
+chat_agent_plan_survey_agent = AgentModeDefinition(
+    mode=AgentMode.FLAGS,
+    mode_description=READ_ONLY_SURVEY_MODE_DESCRIPTION,
+    toolkit_class=ReadOnlySurveyAgentToolkit,
+    node_class=ChatAgentPlanExecutable,
+    tools_node_class=ChatAgentPlanToolsExecutable,
 )

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -36,16 +36,6 @@ def has_task_tool_feature_flag(team: Team, user: User) -> bool:
     )
 
 
-def has_error_tracking_mode_feature_flag(team: Team, user: User) -> bool:
-    return posthoganalytics.feature_enabled(
-        "posthog-ai-error-tracking-mode",
-        str(user.distinct_id),
-        groups={"organization": str(team.organization_id)},
-        group_properties={"organization": {"id": str(team.organization_id)}},
-        send_feature_flag_events=False,
-    )
-
-
 def has_memory_tool_feature_flag(team: Team, user: User) -> bool:
     return posthoganalytics.feature_enabled(
         "phai-memory-tool",
@@ -56,29 +46,9 @@ def has_memory_tool_feature_flag(team: Team, user: User) -> bool:
     )
 
 
-def has_create_form_tool_feature_flag(team: Team, user: User) -> bool:
-    return posthoganalytics.feature_enabled(
-        "phai-create-form-tool",
-        str(user.distinct_id),
-        groups={"organization": str(team.organization_id)},
-        group_properties={"organization": {"id": str(team.organization_id)}},
-        send_feature_flag_events=False,
-    )
-
-
 def has_plan_mode_feature_flag(team: Team, user: User) -> bool:
     return posthoganalytics.feature_enabled(
         "phai-plan-mode",
-        str(user.distinct_id),
-        groups={"organization": str(team.organization_id)},
-        group_properties={"organization": {"id": str(team.organization_id)}},
-        send_feature_flag_events=False,
-    )
-
-
-def has_survey_mode_feature_flag(team: Team, user: User) -> bool:
-    return posthoganalytics.feature_enabled(
-        "posthog-ai-survey-mode",
         str(user.distinct_id),
         groups={"organization": str(team.organization_id)},
         group_properties={"organization": {"id": str(team.organization_id)}},
@@ -109,26 +79,6 @@ def is_core_memory_disabled(team: Team, user: User) -> bool:
 def has_mcp_servers_feature_flag(team: Team, user: User) -> bool:
     return posthoganalytics.feature_enabled(
         "mcp-servers",
-        str(user.distinct_id),
-        groups={"organization": str(team.organization_id)},
-        group_properties={"organization": {"id": str(team.organization_id)}},
-        send_feature_flag_events=False,
-    )
-
-
-def has_flags_mode_feature_flag(team: Team, user: User) -> bool:
-    return posthoganalytics.feature_enabled(
-        "posthog-ai-flags-mode",
-        str(user.distinct_id),
-        groups={"organization": str(team.organization_id)},
-        group_properties={"organization": {"id": str(team.organization_id)}},
-        send_feature_flag_events=False,
-    )
-
-
-def has_llm_analytics_mode_feature_flag(team: Team, user: User) -> bool:
-    return posthoganalytics.feature_enabled(
-        "posthog-ai-llm-analytics-mode",
         str(user.distinct_id),
         groups={"organization": str(team.organization_id)},
         group_properties={"organization": {"id": str(team.organization_id)}},

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -335,10 +335,7 @@ export const FEATURE_FLAGS = {
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @benjackwhite
     NOTEBOOK_PYTHON: 'notebook-python', // owner: #team-data-tools
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
-    PHAI_ERROR_TRACKING_MODE: 'posthog-ai-error-tracking-mode', // owner: #team-posthog-ai
-    PHAI_LLM_ANALYTICS_MODE: 'posthog-ai-llm-analytics-mode', // owner: #team-posthog-ai
     PHAI_PLAN_MODE: 'phai-plan-mode', // owner: #team-posthog-ai
-    PHAI_SURVEY_MODE: 'posthog-ai-survey-mode', // owner: #team-posthog-ai
     PHAI_TASKS: 'phai-tasks', // owner: #team-array
     PRODUCT_ANALYTICS_AI_INSIGHT_ANALYSIS: 'product-analytics-ai-insight-analysis', // owner: #team-analytics-platform, used to show AI analysis section in insights
     PRODUCT_ANALYTICS_AUTONAME_INSIGHTS_WITH_AI: 'autoname-insights-with-ai', // owner: @gesh #team-product-analytics
@@ -375,7 +372,6 @@ export const FEATURE_FLAGS = {
     POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG: 'posthog-ai-conversation-feedback-config', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_LLMA_SESSIONS: 'posthog-ai-conversation-feedback-llma-sessions', // owner: #team-posthog-ai
     POSTHOG_AI_QUEUE_MESSAGES_SYSTEM: 'posthog-ai-queue-messages-system', // owner: #team-posthog-ai
-    POSTHOG_AI_FLAGS_MODE: 'posthog-ai-flags-mode', // owner: #team-posthog-ai
     RBAC_UI_REDESIGN: 'rbac-ui-redesign', // owner: @reece #team-platform-features
     RECORDINGS_PLAYER_EVENT_PROPERTY_EXPANSION: 'recordings-player-event-property-expansion', // owner: @pauldambra #team-replay
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1054,14 +1054,12 @@ export const MODE_DEFINITIONS: Record<
         description: 'Searches and analyzes error tracking issues to help you understand and fix bugs.',
         icon: iconForType('error_tracking'),
         scenes: new Set([Scene.ErrorTracking]),
-        flag: 'PHAI_ERROR_TRACKING_MODE',
     },
     [AgentMode.Survey]: {
         name: 'Surveys',
         description: 'Creates and analyzes surveys to collect user feedback.',
         icon: iconForType('survey'),
         scenes: new Set([Scene.Surveys, Scene.Survey]),
-        flag: 'PHAI_SURVEY_MODE',
     },
     [AgentMode.Onboarding]: {
         name: 'Onboarding',
@@ -1083,7 +1081,6 @@ export const MODE_DEFINITIONS: Record<
             Scene.ExperimentsSharedMetric,
             Scene.ExperimentsSharedMetrics,
         ]),
-        flag: 'POSTHOG_AI_FLAGS_MODE',
     },
     [AgentMode.LLMAnalytics]: {
         name: 'LLM analytics',
@@ -1099,7 +1096,6 @@ export const MODE_DEFINITIONS: Record<
             Scene.LLMAnalyticsPlayground,
             Scene.LLMAnalyticsUsers,
         ]),
-        flag: 'PHAI_LLM_ANALYTICS_MODE',
     },
 }
 


### PR DESCRIPTION
## Problem
The AI chat agent modes (error tracking, flags, survey, and LLM analytics) were previously gated behind feature flags. We want to release them all fully.

We also want to release the create form tool to the base agent.

Plan mode survey agent was also using the wrong executable.

## Changes
- Removed feature flag checks for AI agent modes (error tracking, flags, survey, LLM analytics) and made them available by default
- Added all agent modes directly to the default registries instead of conditionally adding them
- Removed unused feature flag functions: `has_error_tracking_mode_feature_flag`, `has_flags_mode_feature_flag`, `has_survey_mode_feature_flag`, `has_llm_analytics_mode_feature_flag`, `has_create_form_tool_feature_flag`
- Added `chat_agent_plan_survey_agent` import and definition for survey mode planning
- Renamed `SubagentSurveyAgentToolkit` to `ReadOnlySurveyAgentToolkit` for clarity
- Made `CreateFormTool` available by default instead of behind a feature flag
- Removed corresponding frontend feature flag constants

## How did you test this code?
Updated existing unit tests to reflect the renamed toolkit class.

## Publish to changelog?
Yes