### PR TITLE
fix(experiments): Avoid using "current" in api call but rather be explicit to avoid inconsistent state

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.test.tsx
@@ -1,3 +1,5 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
@@ -18,7 +20,7 @@ describe('ExperimentForm Integration', () => {
 
         useMocks({
             post: {
-                '/api/projects/@current/experiments': async (req) => {
+                [`/api/projects/${MOCK_TEAM_ID}/experiments`]: async (req) => {
                     const body = (await req.json()) as Experiment
                     return [
                         200,

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.test.ts
@@ -1,3 +1,5 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
@@ -32,7 +34,7 @@ describe('createExperimentLogic', () => {
 
         useMocks({
             post: {
-                '/api/projects/@current/experiments': async (req) => {
+                [`/api/projects/${MOCK_TEAM_ID}/experiments`]: async (req) => {
                     const body = (await req.json()) as Experiment
                     if (!body.name || !body.description) {
                         return [400, { detail: 'Validation error' }]

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -8,6 +8,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -91,6 +92,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             ['featureFlagKeyValidation', 'featureFlagKeyValidationLoading'],
             featureFlagLogic,
             ['featureFlags'],
+            projectLogic,
+            ['currentProjectId'],
         ],
         actions: [
             eventUsageLogic,
@@ -368,7 +371,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 }
 
                 const response = (await api.create(
-                    `api/projects/@current/experiments`,
+                    `api/projects/${values.currentProjectId}/experiments`,
                     experimentPayload
                 )) as Experiment
 

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
@@ -1,3 +1,5 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
 import '@testing-library/jest-dom'
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
@@ -551,7 +553,7 @@ describe('experimentWizardLogic', () => {
             useMocks({
                 ...apiMocks,
                 post: {
-                    '/api/projects/@current/experiments/': async (req: any) => {
+                    [`/api/projects/${MOCK_TEAM_ID}/experiments/`]: async (req: any) => {
                         capturedPayload = await req.json()
                         return [
                             200,


### PR DESCRIPTION
## Problem

A user created an experiment, linked an existing feature flag, and clicked "Save as draft". The experiment was successfully created in the database, but the UI briefly showed the experiment view page and then switched to a "Not found" page. A toast displayed "Load feature flag failed: Not found". The user believed the creation had failed, but it did in fact work.

The issue ultimately was caused by the user temporarily switching projects. The Frontend used an implicit `@current` in the creation API call, which in this case was misaligned between Frontend and Backend.

## Changes

- Was tricky to debug, but the fix is a one liner: use `currentProjectId`
- Now the ID is set explicitly, which is also consistent with other experiment API calls

## How did you test this code?

- Manually: Creation works, uses the current project ID