### PR TITLE
fix(approvals): allow self-approve to grant requester approval permission

### DIFF
--- a/posthog/approvals/permissions.py
+++ b/posthog/approvals/permissions.py
@@ -21,10 +21,11 @@ class CanApprove(permissions.BasePermission):
         allow_self_approve = policy_snapshot.get("allow_self_approve", False)
         is_requester = obj.created_by == request.user
 
-        # Check self-approval first - if requester and not allowed, deny immediately
-        if is_requester and not allow_self_approve:
-            self.message = "You cannot approve your own change request"
-            return False
+        # Check self-approval: if requester, self-approve flag determines access
+        if is_requester:
+            if not allow_self_approve:
+                self.message = "You cannot approve your own change request"
+            return allow_self_approve
 
         # Check if user is in explicit approver set (users/roles)
         if self._user_in_approver_set(request.user, policy_snapshot, obj):

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -78,11 +78,11 @@ class ChangeRequestSerializer(serializers.ModelSerializer):
         user = request.user
         policy = obj.policy_snapshot
 
-        # If user is the requester and self-approve is not allowed, they cannot approve
+        # If user is the requester, self-approve controls whether they can approve
         is_requester = obj.created_by_id == user.id
         allow_self_approve = policy.get("allow_self_approve", False)
-        if is_requester and not allow_self_approve:
-            return False
+        if is_requester:
+            return allow_self_approve
 
         # Check if user is in approver users list
         approver_users = policy.get("users", [])

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -173,6 +173,57 @@ class TestChangeRequestViewSet(APIBaseTest):
         assert response.json()["status"] == "applied"
         assert Approval.objects.filter(change_request=cr, decision=ApprovalDecision.APPROVED).exists()
 
+    def test_can_approve_true_for_requester_with_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": True},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/{cr.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["can_approve"] is True
+
+    def test_can_approve_false_for_requester_without_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": False},
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/change_requests/{cr.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["can_approve"] is False
+
+    @patch("posthog.approvals.services.apply_change_request")
+    def test_approve_success_for_requester_with_self_approve_not_in_approvers(self, mock_apply):
+        mock_apply.return_value = type("obj", (object,), {"id": 123, "version": 1})()
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": True},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/",
+            {"reason": "Self-approving"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "applied"
+
+    def test_approve_denied_for_requester_without_self_approve(self):
+        other_user = User.objects.create(email="other-approver@posthog.com")
+        cr = self._create_change_request(
+            policy_snapshot={"quorum": 1, "users": [other_user.id], "allow_self_approve": False},
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/",
+            {"reason": "Trying to self-approve"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_approve_already_voted(self):
         cr = self._create_change_request()
         Approval.objects.create(change_request=cr, created_by=self.user, decision=ApprovalDecision.APPROVED)


### PR DESCRIPTION
## Problem

When `allow_self_approve` was enabled on a policy, the requester still couldn't approve their own CR because of a recent additional condition introduced in the condition set.

## Changes

- `serializers.py` / `permissions.py`: when user is the requester, `allow_self_approve` directly controls the result
- 4 new backend tests covering self-approve grant/deny for both the serializer and permission

## How did you test this code?

- 55 backend tests pass (`test_approvals_api.py`)
- Manual testing via local dev with a policy that has `allow_self_approve=true` and requester not in approvers list

## Publish to changelog?

no