### PR TITLE
fix(approvals): hide promo banner when product intro is visible or policies exist

### DIFF
--- a/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
+++ b/frontend/src/scenes/feature-flags/ApprovalsPromoBanner.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 
 import { LemonBanner } from '@posthog/lemon-ui'
 
+import { approvalsGateLogic } from 'lib/approvals/approvalsGateLogic'
 import { JudgeHog } from 'lib/components/hedgehogs'
 import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -18,11 +19,17 @@ const DISMISS_KEY = 'feature-flags-approvals-promo'
 export function ApprovalsPromoBanner(): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
     const { isAdminOrOwner } = useValues(organizationLogic)
+    const { activePolicies, activePoliciesLoading } = useValues(approvalsGateLogic)
     const bannerLogic = lemonBannerLogic({ dismissKey: DISMISS_KEY })
     const { isDismissed } = useValues(bannerLogic)
     const { dismiss } = useActions(bannerLogic)
 
-    const shouldShow = isAdminOrOwner && hasAvailableFeature(AvailableFeature.APPROVALS)
+    const hasActivePolicies = activePolicies.length > 0
+    const shouldShow =
+        isAdminOrOwner &&
+        hasAvailableFeature(AvailableFeature.APPROVALS) &&
+        !hasActivePolicies &&
+        !activePoliciesLoading
 
     useEffect(() => {
         if (shouldShow && !isDismissed) {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -34,6 +34,7 @@ import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -346,6 +347,7 @@ export function OverViewTab({
     nouns?: [string, string]
 }): JSX.Element {
     const { aggregationLabel } = useValues(groupsModel)
+    const { user } = useValues(userLogic)
 
     const flagLogic = featureFlagsLogic({ flagPrefix })
     const { featureFlagsLoading, displayedFlags, pagination, filters, shouldShowEmptyState, filtersChanged } =
@@ -354,6 +356,7 @@ export function OverViewTab({
     const { featureFlags: enabledFeatureFlags } = useValues(enabledFeaturesLogic)
     const featureFlagsV2Enabled = !!enabledFeatureFlags[FEATURE_FLAGS.FEATURE_FLAGS_V2]
     const newFeatureFlagUrl = featureFlagsV2Enabled ? urls.featureFlagTemplates() : urls.featureFlag('new')
+    const isProductIntroVisible = shouldShowEmptyState || !user?.has_seen_product_intro_for?.[ProductKey.FEATURE_FLAGS]
 
     const {
         selectedCount,
@@ -550,7 +553,7 @@ export function OverViewTab({
                 customHog={FeatureFlagHog}
                 className={cn('my-0')}
             />
-            <ApprovalsPromoBanner />
+            {!isProductIntroVisible && <ApprovalsPromoBanner />}
             <div>{filtersSection}</div>
             <LemonDivider className="my-0" />
             <div className="flex items-center justify-between min-h-9">


### PR DESCRIPTION
## Problem

The approvals promo banner showed on top of the "Welcome to Feature flags!" intro banner, and kept showing after the team already had active policies.

<img width="1289" height="695" alt="image" src="https://github.com/user-attachments/assets/6a1f09d7-e53e-4155-835e-b5497ebe1233" />


## Changes

- Hide `ApprovalsPromoBanner` when `ProductIntroduction` welcome banner is visible
- Hide `ApprovalsPromoBanner` when team has active approval policies (via `approvalsGateLogic`)

## How did you test this code?

- Manual testing via Playwright MCP browser

## Publish to changelog?

no