### PR TITLE
feat(experiments): track experiment creation source

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import ClickhouseTestMixin, FuzzyInt, _create_event, _create_person, flush_persons_and_events
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from django.core.cache import cache
 
@@ -126,6 +126,47 @@ class TestExperimentCRUD(APILicensedTest):
         experiment = Experiment.objects.get(pk=id)
         self.assertEqual(experiment.description, "Bazinga")
         self.assertEqual(experiment.end_date.strftime("%Y-%m-%dT%H:%M"), end_date)
+
+    @patch("products.experiments.backend.experiment_service.report_user_action")
+    def test_creating_experiment_reports_user_action(self, mock_report_user_action):
+        ff_key = "tracked-experiment"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Tracked Experiment",
+                "description": "",
+                "feature_flag_key": ff_key,
+                "parameters": None,
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}],
+                    "properties": [],
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        mock_report_user_action.assert_called_once()
+        self.assertEqual(mock_report_user_action.call_args.args[0], self.user)
+        self.assertEqual(mock_report_user_action.call_args.args[1], "experiment created")
+        self.assertEqual(
+            mock_report_user_action.call_args.args[2],
+            {
+                "experiment_id": response.json()["id"],
+                "experiment_name": "Tracked Experiment",
+                "feature_flag_key": ff_key,
+                "type": "product",
+                "status": "draft",
+                "metrics_count": 0,
+                "secondary_metrics_count": 0,
+                "has_description": False,
+                "variant_count": 2,
+                "created_at": ANY,
+            },
+        )
+        self.assertEqual(mock_report_user_action.call_args.kwargs["team"], self.team)
+        self.assertIsNotNone(mock_report_user_action.call_args.kwargs["request"])
 
     def test_creating_experiment_with_ensure_experience_continuity(self):
         ff_key = "test-continuity-flag"

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -383,10 +383,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     // This ensures we have the full experiment data including feature_flag, etc.
                     actions.setExperiment(response)
 
-                    actions.reportExperimentCreated(response, {
-                        creation_source: 'wizard',
-                        has_linked_flag: !!response.feature_flag?.id,
-                    })
                     actions.addProductIntent({
                         product_type: ProductKey.EXPERIMENTS,
                         intent_context: ProductIntentContext.EXPERIMENT_CREATED,

--- a/frontend/src/scenes/experiments/ExperimentTabContent/createDraftExperimentFromFlagLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentTabContent/createDraftExperimentFromFlagLogic.ts
@@ -91,10 +91,6 @@ export const createDraftExperimentFromFlagLogic = kea<createDraftExperimentFromF
         },
 
         createDraftExperimentSuccess: ({ experiment }) => {
-            actions.reportExperimentCreated(experiment, {
-                creation_source: 'feature_flag_quick_create',
-                has_linked_flag: true,
-            })
             lemonToast.success('Draft experiment created')
             router.actions.push(urls.experiment(experiment.id))
         },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1318,9 +1318,6 @@ export const experimentLogic = kea<experimentLogicType>([
                     })
 
                     if (response) {
-                        actions.reportExperimentCreated(response, {
-                            creation_source: 'legacy',
-                        })
                         actions.addProductIntent({
                             product_type: ProductKey.EXPERIMENTS,
                             intent_context: ProductIntentContext.EXPERIMENT_CREATED,

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -77,6 +77,33 @@ class TestWebExperiment(APIBaseTest):
             request=ANY,
         )
 
+    @patch("posthog.api.web_experiment.report_user_action")
+    def test_web_experiment_creation_reports_experiment_created(self, mock_report_user_action):
+        response = self._create_web_experiment()
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+
+        web_experiment = WebExperiment.objects.get(id=response_data["id"])
+
+        mock_report_user_action.assert_called_once_with(
+            ANY,
+            "experiment created",
+            {
+                "experiment_id": web_experiment.id,
+                "experiment_name": web_experiment.name,
+                "feature_flag_key": web_experiment.feature_flag.key,
+                "type": "web",
+                "status": "draft",
+                "metrics_count": 0,
+                "secondary_metrics_count": 0,
+                "has_description": False,
+                "variant_count": 2,
+                "created_at": web_experiment.created_at,
+            },
+            team=ANY,
+            request=ANY,
+        )
+
     def test_can_list_active_web_experiments(self):
         response = self._create_web_experiment("active_web_experiment")
         response_data = response.json()

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import get_token
+from posthog.event_usage import report_user_action
 from posthog.exceptions import generate_exception_response
 from posthog.models import Experiment, Team, WebExperiment
 from posthog.utils_cors import cors_response
@@ -215,6 +216,15 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         experiment = WebExperiment.objects.create(
             team_id=self.context["team_id"], feature_flag=feature_flag, **create_params, stats_config=stats_config
         )
+
+        report_user_action(
+            self.context["request"].user,
+            "experiment created",
+            experiment.get_analytics_metadata(),
+            team=team,
+            request=self.context["request"],
+        )
+
         return experiment
 
     def update(self, instance: WebExperiment, validated_data: dict[str, Any]) -> WebExperiment:

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -117,6 +117,24 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
     def get_feature_flag_key(self):
         return self.feature_flag.key
 
+    def get_analytics_metadata(self) -> dict[str, Any]:
+        variants = (self.parameters or {}).get("feature_flag_variants")
+        if not variants:
+            variants = self.feature_flag.filters.get("multivariate", {}).get("variants", [])
+
+        return {
+            "experiment_id": self.id,
+            "experiment_name": self.name,
+            "feature_flag_key": self.get_feature_flag_key(),
+            "type": self.type,
+            "status": self.status or Experiment.compute_status(self.start_date, self.end_date),
+            "metrics_count": len(self.metrics or []),
+            "secondary_metrics_count": len(self.metrics_secondary or []),
+            "has_description": bool(self.description),
+            "variant_count": len(variants),
+            "created_at": self.created_at,
+        }
+
     def get_stats_config(self, key: str):
         return self.stats_config.get(key) if self.stats_config else None
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -14,6 +14,7 @@ from posthog.schema import ActionsNode, ExperimentEventExposureConfig, Experimen
 
 from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer
+from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.models.cohort import Cohort
 from posthog.models.experiment import (
@@ -141,6 +142,7 @@ class ExperimentService:
         conclusion: str | None = None,
         conclusion_comment: str | None = None,
         serializer_context: dict | None = None,
+        event_source: EventSource | None = None,
     ) -> Experiment:
         """Create experiment with full validation and defaults."""
         is_draft = start_date is None
@@ -220,12 +222,40 @@ class ExperimentService:
             self._sync_saved_metrics(experiment, saved_metrics_ids, serializer_context)
 
         self._validate_metric_ordering_on_create(experiment)
+        self._report_experiment_created(
+            experiment,
+            serializer_context=serializer_context,
+            event_source=event_source,
+        )
 
         return experiment
 
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _report_experiment_created(
+        self,
+        experiment: Experiment,
+        *,
+        serializer_context: dict | None,
+        event_source: EventSource | None,
+    ) -> None:
+        request = serializer_context.get("request") if serializer_context else None
+        if request is None and event_source is None:
+            return
+
+        analytics_metadata = experiment.get_analytics_metadata()
+        if event_source is not None:
+            analytics_metadata["source"] = event_source
+
+        report_user_action(
+            self.user,
+            "experiment created",
+            analytics_metadata,
+            team=experiment.team,
+            request=request,
+        )
 
     def _ensure_feature_flag(
         self,

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import MaxExperimentMetricResult
 
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models import Experiment, FeatureFlag
 from posthog.session_recordings.session_recording_api import list_recordings_from_query
@@ -168,6 +169,7 @@ class CreateExperimentTool(MaxTool):
                     "feature_flag_variants": feature_flag_variants,
                     "minimum_detectable_effect": 30,
                 },
+                event_source=EventSource.POSTHOG_AI,
             )
 
         try:

--- a/products/experiments/backend/test/test_max_tools.py
+++ b/products/experiments/backend/test/test_max_tools.py
@@ -1,5 +1,5 @@
 from posthog.test.base import APIBaseTest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from posthog.schema import (
     MaxExperimentMetricResult,
@@ -7,6 +7,7 @@ from posthog.schema import (
     MaxExperimentVariantResultFrequentist,
 )
 
+from posthog.event_usage import EventSource
 from posthog.models import Experiment, FeatureFlag
 
 from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool
@@ -138,6 +139,37 @@ class TestCreateExperimentTool(APIBaseTest):
 
         experiment = await Experiment.objects.select_related("feature_flag").aget(name="New Experiment", team=self.team)
         assert experiment.feature_flag.key == "existing-flag"
+
+    @patch("products.experiments.backend.experiment_service.report_user_action")
+    async def test_create_experiment_reports_posthog_ai_source(self, mock_report_user_action):
+        await self._create_multivariate_flag(key="tracked-experiment-flag")
+        tool = self._create_tool()
+
+        result, _artifact = await tool._arun_impl(
+            name="Tracked Experiment",
+            feature_flag_key="tracked-experiment-flag",
+        )
+
+        assert "Successfully created" in result
+
+        mock_report_user_action.assert_called_once()
+        assert mock_report_user_action.call_args.args[0] == self.user
+        assert mock_report_user_action.call_args.args[1] == "experiment created"
+        assert mock_report_user_action.call_args.args[2] == {
+            "experiment_id": ANY,
+            "experiment_name": "Tracked Experiment",
+            "feature_flag_key": "tracked-experiment-flag",
+            "type": "product",
+            "status": "draft",
+            "metrics_count": 0,
+            "secondary_metrics_count": 0,
+            "has_description": False,
+            "variant_count": 2,
+            "created_at": ANY,
+            "source": EventSource.POSTHOG_AI,
+        }
+        assert mock_report_user_action.call_args.kwargs["team"] == self.team
+        assert mock_report_user_action.call_args.kwargs["request"] is None
 
     async def test_create_experiment_flag_already_used(self):
         flag = await self._create_multivariate_flag(key="used-flag")


### PR DESCRIPTION
## Problem
Experiment creation is currently tracked from the frontend, which misses backend-triggered sources like MCP and PostHog AI and makes source attribution incomplete.

## Changes
- Track `experiment created` via backend `report_user_action` for shared experiment creation and web experiments.
- Pass explicit `posthog_ai` source for Max-created experiments and remove duplicate frontend captures.

Note: We will loose the current `creation_source: 'feature_flag_quick_create'` etc. This information can still be inferred from the `$current_url` / `$pathname` though, so we can still break it down in insights when we need this. 

## Testing
- Tested locally and verified that events are coming through