### PR TITLE
fix(experiments): Fix non-deterministic pagination on experiments list

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -855,6 +855,8 @@ class EnterpriseExperimentsViewSet(
                     queryset = queryset.order_by(F("computed_status").asc())
             else:
                 queryset = queryset.order_by(order)
+        else:
+            queryset = queryset.order_by("-created_at")
 
         return queryset
 

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -215,12 +215,19 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 setExperimentsTab: (state, { tabKey }) => tabKey ?? state,
             },
         ],
+        hasLoadedExperiments: [
+            false,
+            {
+                loadExperimentsSuccess: () => true,
+                loadExperimentsFailure: () => true,
+            },
+        ],
     }),
     listeners(({ actions, values }) => ({
         setExperimentsFilters: async (_, breakpoint) => {
             // Only debounce after the first load — the debounce is for search input,
             // but the initial load from urlToAction should fire immediately.
-            if (values.experiments.results.length > 0 || values.experimentsLoading) {
+            if (values.hasLoadedExperiments || values.experimentsLoading) {
                 await breakpoint(300)
             }
             actions.loadExperiments()

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -218,10 +218,11 @@ export const experimentsLogic = kea<experimentsLogicType>([
     }),
     listeners(({ actions, values }) => ({
         setExperimentsFilters: async (_, breakpoint) => {
-            /**
-             * this debounces the search input. Yeah, I know.
-             */
-            await breakpoint(300)
+            // Only debounce after the first load — the debounce is for search input,
+            // but the initial load from urlToAction should fire immediately.
+            if (values.experiments.results.length > 0 || values.experimentsLoading) {
+                await breakpoint(300)
+            }
             actions.loadExperiments()
         },
         setFeatureFlagModalFilters: async (_, breakpoint) => {
@@ -443,7 +444,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
         ],
     }),
     afterMount(({ actions, values }) => {
-        actions.loadExperiments()
         actions.loadExperimentsStats()
         // Sync modal page with URL on mount
         const urlPage = values.featureFlagModalPageFromURL


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0A27HCTE2H/p1773068570670329

The experiments list can show inconsistent results across pages - experiments appearing/disappearing on refresh, and pagination counts not adding up.

Two issues:

1. On page load, afterMount fires loadExperiments() before urlToAction processes the URL. This is a leftover from before server-side pagination was added - urlToAction already triggers the load with the correct filters, making the afterMount call redundant and introducing a race between two loads with potentially different filters.
2. The backend doesn't apply a default sort order when no explicit sort is requested. Postgres doesn't guarantee row order without ORDER BY, so LIMIT/OFFSET pagination can theoretically return inconsistent results. In practice the order should be usually stable, but worth being defensive here.

## Changes

- Add default `ORDER BY -created_at` when no explicit sort is requested.
- Remove redundant `loadExperiments()` from `afterMount`. The initial load now goes through `urlToAction` → `setExperimentsFilters` → `loadExperiments()`, same pattern as feature flags UI uses.
- Skip the 300ms debounce on the initial load so the page doesn't briefly flash an empty state.

## How did you test this code?
I wasn't able to replicate the bug locally, but tested that these changes preserve current functionality.