### PR TITLE
chore(signals): test CI trigger for product-only py change

### DIFF
--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -2,12 +2,19 @@
 
 // Discovers which products need testing and builds a GitHub Actions matrix.
 //
+// Isolation detection: products that declare a backend:contract-check script
+// (with narrowed inputs in their own turbo.json) are considered isolated —
+// they can be tested alone when only their non-contract files change.
+// Products without contract-check are non-isolated: any change in them
+// triggers the full test suite (all products + Django).
+//
 // Products under SMALL_THRESHOLD duration get grouped into one matrix entry
 // to avoid spinning up a full Docker stack for a handful of tests.
 // Durations come from .test_durations (maintained by pytest-split).
 //
 // Input:  LEGACY_CHANGED env var ("true"/"false")
-// Output: JSON matrix on stdout, diagnostics on stderr
+// Output: JSON on stdout: { matrix, run_legacy }
+//         Diagnostics on stderr
 
 const { execSync } = require('child_process')
 const fs = require('fs')
@@ -24,18 +31,17 @@ const DURATION_SAFETY_FACTOR = 2
 // and are handled by Django CI's dedicated segments — exclude from duration estimates
 const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 
-function getTurboTasks() {
+function turboDryRun(task) {
     try {
-        // Call turbo directly to avoid pnpm wrapper noise on stdout
-        // (pnpm can emit engine warnings like {"node":">=24"} that break JSON parsing)
-        const raw = execSync('./node_modules/.bin/turbo run backend:test --dry-run=json', {
+        const raw = execSync(`./node_modules/.bin/turbo run ${task} --dry-run=json`, {
             encoding: 'utf-8',
             stdio: ['pipe', 'pipe', 'pipe'],
+            maxBuffer: 50 * 1024 * 1024,
         })
         const parsed = JSON.parse(raw)
         return parsed.tasks.filter((t) => !/NONEXISTENT/.test(t.command))
     } catch (e) {
-        console.error(`turbo dry-run failed: ${e.message}`)
+        console.error(`turbo dry-run (${task}) failed: ${e.message}`)
         if (e.stderr) {
             console.error(e.stderr.toString().slice(0, 1000))
         }
@@ -43,17 +49,22 @@ function getTurboTasks() {
     }
 }
 
-function getProducts(tasks, legacyChanged) {
-    if (legacyChanged) {
-        // Legacy code changed — all products must be tested
-        return [...new Set(tasks.map((t) => t.package.replace('@posthog/products-', '')))].sort()
-    }
-    // Only product files changed — test only cache MISSes
+function packageToProduct(pkg) {
+    return pkg.replace('@posthog/products-', '')
+}
+
+function getIsolatedProducts(contractTasks) {
+    return new Set(contractTasks.map((t) => packageToProduct(t.package)))
+}
+
+function getMissProducts(testTasks) {
     return [
-        ...new Set(
-            tasks.filter((t) => t.cache?.status === 'MISS').map((t) => t.package.replace('@posthog/products-', ''))
-        ),
+        ...new Set(testTasks.filter((t) => t.cache?.status === 'MISS').map((t) => packageToProduct(t.package))),
     ].sort()
+}
+
+function getAllProducts(testTasks) {
+    return [...new Set(testTasks.map((t) => packageToProduct(t.package)))].sort()
 }
 
 function loadTestDurations() {
@@ -137,11 +148,61 @@ function buildMatrix(products, durations) {
     return matrix
 }
 
+// --- Main ---
+
 const legacyChanged = process.env.LEGACY_CHANGED === 'true'
-const tasks = getTurboTasks()
-const products = getProducts(tasks, legacyChanged)
+const testTasks = turboDryRun('backend:test')
+const contractTasks = turboDryRun('backend:contract-check')
+const isolatedProducts = getIsolatedProducts(contractTasks)
+const allProducts = getAllProducts(testTasks)
+
+console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
+
+let products
+let runLegacy
+
+if (legacyChanged) {
+    console.error('Legacy code changed — testing all products')
+    products = allProducts
+    runLegacy = true
+} else {
+    const missProducts = getMissProducts(testTasks)
+    const nonIsolatedMisses = missProducts.filter((p) => !isolatedProducts.has(p))
+
+    if (nonIsolatedMisses.length > 0) {
+        // Non-isolated product changed — must test everything
+        console.error(
+            `Non-isolated products changed: ${JSON.stringify(nonIsolatedMisses)} — testing all products + Django`
+        )
+        products = allProducts
+        runLegacy = true
+    } else if (missProducts.length > 0) {
+        // Only isolated products changed — check contract-check cache
+        const contractMisses = contractTasks
+            .filter((t) => t.cache?.status === 'MISS')
+            .map((t) => packageToProduct(t.package))
+        if (contractMisses.length > 0) {
+            console.error(`Isolated product contracts changed: ${JSON.stringify(contractMisses)} — Django will run`)
+            runLegacy = true
+        } else {
+            console.error('Only isolated product internals changed — Django can be skipped')
+            runLegacy = false
+        }
+        products = missProducts
+    } else {
+        console.error('No product changes detected')
+        products = []
+        runLegacy = false
+    }
+}
+
 console.error(`Products to test: ${JSON.stringify(products)}`)
+console.error(`Run legacy (Django): ${runLegacy}`)
 
 const durations = loadTestDurations()
+const result = {
+    matrix: buildMatrix(products, durations),
+    run_legacy: runLegacy,
+}
 // eslint-disable-next-line no-console
-process.stdout.write(JSON.stringify(buildMatrix(products, durations)) + '\n')
+process.stdout.write(JSON.stringify(result) + '\n')

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -31,22 +31,10 @@ const DURATION_SAFETY_FACTOR = 2
 // and are handled by Django CI's dedicated segments — exclude from duration estimates
 const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 
-function turboDryRun(task) {
-    try {
-        const raw = execSync(`./node_modules/.bin/turbo run ${task} --dry-run=json`, {
-            encoding: 'utf-8',
-            stdio: ['pipe', 'pipe', 'pipe'],
-            maxBuffer: 50 * 1024 * 1024,
-        })
-        const parsed = JSON.parse(raw)
-        return parsed.tasks.filter((t) => !/NONEXISTENT/.test(t.command))
-    } catch (e) {
-        console.error(`turbo dry-run (${task}) failed: ${e.message}`)
-        if (e.stderr) {
-            console.error(e.stderr.toString().slice(0, 1000))
-        }
-        process.exit(1)
-    }
+const TURBO_EXEC_OPTS = { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: 50 * 1024 * 1024 }
+
+function parseTurboTasks(raw) {
+    return JSON.parse(raw).tasks.filter((t) => !/NONEXISTENT/.test(t.command))
 }
 
 function packageToProduct(pkg) {
@@ -151,8 +139,22 @@ function buildMatrix(products, durations) {
 // --- Main ---
 
 const legacyChanged = process.env.LEGACY_CHANGED === 'true'
-const testTasks = turboDryRun('backend:test')
-const contractTasks = turboDryRun('backend:contract-check')
+
+let testTasks, contractTasks
+try {
+    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+    testTasks = parseTurboTasks(execSync('./node_modules/.bin/turbo run backend:test --dry-run=json', TURBO_EXEC_OPTS))
+    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+    contractTasks = parseTurboTasks(
+        execSync('./node_modules/.bin/turbo run backend:contract-check --dry-run=json', TURBO_EXEC_OPTS)
+    )
+} catch (e) {
+    console.error(`turbo dry-run failed: ${e.message}`)
+    if (e.stderr) {
+        console.error(e.stderr.toString().slice(0, 1000))
+    }
+    process.exit(1)
+}
 const isolatedProducts = getIsolatedProducts(contractTasks)
 const allProducts = getAllProducts(testTasks)
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -120,7 +120,8 @@ jobs:
                         - docker/clickhouse
                       legacy:
                         # Non-product backend code — when only products/ change,
-                        # turbo contract-check decides whether Django tests run.
+                        # turbo-discover diffs backend:test vs backend:contract-check
+                        # to detect isolated products and decide whether Django runs.
                         # Everything from backend: EXCEPT products/**/backend/**/*
                         - 'ee/**/*'
                         - 'common/**/*'
@@ -212,7 +213,7 @@ jobs:
         timeout-minutes: 5
         name: Discover product tests
         outputs:
-            run_legacy: ${{ steps.contract-check.outputs.run_legacy }}
+            run_legacy: ${{ steps.discover.outputs.run_legacy }}
             matrix: ${{ steps.discover.outputs.matrix }}
 
         steps:
@@ -233,58 +234,23 @@ jobs:
             - name: Install pnpm dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Check contract changes
-              id: contract-check
-              run: |
-                  # Determines if Django needs to run based on contract changes.
-                  #
-                  # Logic:
-                  # - Push to master: run Django (full CI)
-                  # - Legacy (posthog/ee/common) changed: run Django
-                  # - Any contract-check cache miss: run Django
-                  # - All cache hits: skip Django (isolated impl-only changes)
-                  #
-                  # Always runs contract-check at the end to keep the remote cache
-                  # warm as a baseline for future product-only PRs.
-
-                  if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-                    echo "Push to master - Django will run"
-                    echo "run_legacy=true" >> $GITHUB_OUTPUT
-                  elif [[ "${{ needs.changes.outputs.legacy }}" == "true" ]]; then
-                    echo "Legacy code changed - Django will run"
-                    echo "run_legacy=true" >> $GITHUB_OUTPUT
-                  else
-                    # Product-only change — check contract cache to decide
-                    CACHE_STATUS=$(./node_modules/.bin/turbo run backend:contract-check --dry-run=json 2>/dev/null | jq -r '
-                      [.tasks[] | select(.command | test("NONEXISTENT") | not) | .cache.status] |
-                      if length == 0 then "NO_TASKS"
-                      elif any(. == "MISS") then "MISS"
-                      else "HIT"
-                      end
-                    ' || echo "PARSE_ERROR")
-
-                    echo "Contract check cache status: $CACHE_STATUS"
-
-                    if [[ "$CACHE_STATUS" == "HIT" || "$CACHE_STATUS" == "NO_TASKS" ]]; then
-                      echo "Contracts unchanged (cache $CACHE_STATUS) - Django can be skipped"
-                      echo "run_legacy=false" >> $GITHUB_OUTPUT
-                    else
-                      echo "Contract files changed ($CACHE_STATUS) - Django will run"
-                      echo "run_legacy=true" >> $GITHUB_OUTPUT
-                    fi
-                  fi
-
-                  # Always run to keep remote cache warm as baseline
-                  ./node_modules/.bin/turbo run backend:contract-check --output-logs=errors-only 2>/dev/null || true
-
             - name: Discover products to test
               id: discover
               env:
-                  LEGACY_CHANGED: ${{ needs.changes.outputs.legacy }}
+                  # On pushes to master, always run everything.
+                  # On PRs, use the path filter to detect legacy changes.
+                  LEGACY_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.legacy }}
               run: |
-                  MATRIX=$(node .github/scripts/turbo-discover.js)
-                  echo "Matrix: $MATRIX"
-                  echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+                  # turbo-discover.js diffs backend:test vs backend:contract-check
+                  # to detect isolated products. Non-isolated product changes trigger
+                  # the full suite (all products + Django).
+                  RESULT=$(node .github/scripts/turbo-discover.js)
+                  echo "Result: $RESULT"
+                  echo "matrix=$(echo "$RESULT" | jq -c '.matrix')" >> $GITHUB_OUTPUT
+                  echo "run_legacy=$(echo "$RESULT" | jq -r '.run_legacy')" >> $GITHUB_OUTPUT
+
+                  # Keep contract-check remote cache warm for future runs
+                  ./node_modules/.bin/turbo run backend:contract-check --output-logs=errors-only 2>/dev/null || true
 
     # Runs product tests in parallel — one matrix job per group
     # Each job gets its own runner + Docker stack, so no shared DB conflicts

--- a/common/hogli/product.py
+++ b/common/hogli/product.py
@@ -280,7 +280,13 @@ def lint_product(name: str, verbose: bool = True) -> list[str]:
         else:
             scripts = {}
 
-        for script in ("backend:test", "backend:contract-check"):
+        # backend:test is required for all products with backend/
+        # backend:contract-check is only required for isolated products (have turbo.json)
+        required_scripts = ["backend:test"]
+        if is_isolated:
+            required_scripts.append("backend:contract-check")
+
+        for script in required_scripts:
             has_script = script in scripts
             if verbose:
                 click.echo(f"  {script} in package.json...")
@@ -418,7 +424,7 @@ def _lint_all_products() -> None:
 
     click.echo(f"Linting {len(product_dirs)} products ({len(strict)} strict, {len(lenient)} lenient)")
     click.echo(
-        "Checks: required root files, backend:test, backend:contract-check, misplaced files, file/folder conflicts\n"
+        "Checks: required root files, backend:test, backend:contract-check (isolated only), misplaced files, file/folder conflicts\n"
     )
 
     failed: list[str] = []

--- a/common/hogli/product_structure.yaml
+++ b/common/hogli/product_structure.yaml
@@ -53,8 +53,7 @@ root_files:
             {{
                 "name": "@posthog/products-{product}",
                 "scripts": {{
-                    "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
-                    "backend:contract-check": "echo 'Contract files unchanged'"
+                    "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
                 }}
             }}
 

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2932,7 +2932,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 41}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 59}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/products/actions/package.json
+++ b/products/actions/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-actions",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-forms": "catalog:",

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-alerts",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
     }
 }

--- a/products/analytics_platform/package.json
+++ b/products/analytics_platform/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-analytics-platform",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -52,7 +52,7 @@ We will begin by wiring up **one product** to:
 
 Focus:
 
-- One product = one Turbo package with `backend:test` and `backend:contract-check` tasks
+- One product = one Turbo package with `backend:test`; isolated products also declare `backend:contract-check`
 - Facade (`facade/api.py`) will define the **public interface**
 - Internal files will be private implementation details
 - Presentation layer (DRF) will sit above the facade but remain outside the contract surface initially

--- a/products/batch_exports/package.json
+++ b/products/batch_exports/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-batch-exports",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests --ignore=backend/tests/temporal -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests --ignore=backend/tests/temporal -v --tb=short"
     }
 }

--- a/products/cdp/package.json
+++ b/products/cdp/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-cdp",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
     }
 }

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-cohorts",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-conversations",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/core_events/package.json
+++ b/products/core_events/package.json
@@ -1,6 +1,3 @@
 {
-    "name": "@posthog/products-core-events",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    }
+    "name": "@posthog/products-core-events"
 }

--- a/products/customer_analytics/package.json
+++ b/products/customer_analytics/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-customer-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/dashboards/package.json
+++ b/products/dashboards/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-dashboards",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/data_modeling/package.json
+++ b/products/data_modeling/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-data-modeling",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/data_warehouse/package.json
+++ b/products/data_warehouse/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-data-warehouse",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/desktop_recordings/package.json
+++ b/products/desktop_recordings/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-desktop_recordings",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
     }
 }

--- a/products/early_access_features/package.json
+++ b/products/early_access_features/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-early-access-features",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/endpoints/package.json
+++ b/products/endpoints/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-endpoints",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-error-tracking",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/event_definitions/package.json
+++ b/products/event_definitions/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-event-definitions",
     "scripts": {
-        "backend:test": "echo 'No backend tests'",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "echo 'No backend tests'"
     }
 }

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-experiments",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/feature_flags/package.json
+++ b/products/feature_flags/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-feature-flags",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/games/package.json
+++ b/products/games/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-games",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/groups/package.json
+++ b/products/groups/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-groups",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/growth/package.json
+++ b/products/growth/package.json
@@ -1,6 +1,3 @@
 {
-    "name": "@posthog/products-growth",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    }
+    "name": "@posthog/products-growth"
 }

--- a/products/links/package.json
+++ b/products/links/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-links",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/live_debugger/package.json
+++ b/products/live_debugger/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-live-debugger",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "fuse.js": "catalog:"

--- a/products/llm_analytics/package.json
+++ b/products/llm_analytics/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-llm-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-logs",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/managed_migrations/package.json
+++ b/products/managed_migrations/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-managed-migrations",
     "scripts": {
-        "backend:test": "echo 'No backend tests'",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "echo 'No backend tests'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/marketing_analytics/package.json
+++ b/products/marketing_analytics/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-marketing-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/mcp_store/package.json
+++ b/products/mcp_store/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-mcp-store",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-notebooks",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/persons/package.json
+++ b/products/persons/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-persons",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/posthog_ai/package.json
+++ b/products/posthog_ai/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-posthog-ai",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-product-analytics",
     "scripts": {
-        "backend:test": "echo 'No backend tests'",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "echo 'No backend tests'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/product_tours/package.json
+++ b/products/product_tours/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-product-tours",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     }
 }

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-replay",
     "scripts": {
-        "backend:test": "echo 'No backend tests'",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "echo 'No backend tests'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/revenue_analytics/package.json
+++ b/products/revenue_analytics/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-revenue-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/session_summaries/package.json
+++ b/products/session_summaries/package.json
@@ -1,8 +1,5 @@
 {
     "name": "@posthog/products-session-summaries",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    },
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -36,7 +36,7 @@ class InvalidStatusTransition(Exception):
     def __init__(self, from_status: str, to_status: str):
         self.from_status = from_status
         self.to_status = to_status
-        super().__init__(f"Cannot transition from {from_status} to {to_status}")
+        super().__init__(f"Invalid status transition from {from_status} to {to_status}")
 
 
 class SignalReport(UUIDModel):

--- a/products/signals/package.json
+++ b/products/signals/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-signals",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
     }
 }

--- a/products/slack_app/package.json
+++ b/products/slack_app/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@posthog/products-slack-app",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
     }
 }

--- a/products/surveys/package.json
+++ b/products/surveys/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-surveys",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/tasks/package.json
+++ b/products/tasks/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-tasks",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests backend/services -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests backend/services -v --tb=short"
     },
     "dependencies": {
         "fast-deep-equal": "catalog:",

--- a/products/toolbar/package.json
+++ b/products/toolbar/package.json
@@ -1,6 +1,3 @@
 {
-    "name": "@posthog/products-toolbar",
-    "scripts": {
-        "backend:contract-check": "echo 'Contract files unchanged'"
-    }
+    "name": "@posthog/products-toolbar"
 }

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-user-interviews",
     "scripts": {
-        "backend:test": "echo 'No backend tests'",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "echo 'No backend tests'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/web_analytics/package.json
+++ b/products/web_analytics/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-web-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@posthog/products-workflows",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
-        "backend:contract-check": "echo 'Contract files unchanged'"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
         "kea": "catalog:",


### PR DESCRIPTION
Testing CI behavior when only a signals .py file changes — verifying which products get tested and whether Django matrix runs.

Throwaway PR, will close after observing CI.