### PR TITLE
feat(experiments): Add significance notification UI

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -275,6 +275,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_ALERTS_WIZARD: 'error-tracking-alerts-wizard', // owner: @aleks #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_AI_ANALYSIS_TAB: 'experiment-ai-analysis-tab', // owner: @rodrigoi #team-experiments
+    EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -3,12 +3,12 @@ import { useActions, useValues } from 'kea'
 import { IconPencil } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 
 import { ExperimentStatsMethod } from '~/types'
 
-import { FEATURE_FLAGS } from '../../../lib/constants'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 import { StatsMethodModal } from './StatsMethodModal'

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -3,8 +3,12 @@ import { useActions, useValues } from 'kea'
 import { IconPencil } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
+
 import { ExperimentStatsMethod } from '~/types'
 
+import { FEATURE_FLAGS } from '../../../lib/constants'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 import { StatsMethodModal } from './StatsMethodModal'
@@ -12,6 +16,7 @@ import { StatsMethodModal } from './StatsMethodModal'
 export function SettingsTab(): JSX.Element {
     const { experiment, statsMethod } = useValues(experimentLogic)
     const { openStatsEngineModal } = useActions(modalsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
 
@@ -31,6 +36,13 @@ export function SettingsTab(): JSX.Element {
                 </div>
                 <StatsMethodModal />
             </div>
+            {featureFlags[FEATURE_FLAGS.EXPERIMENT_SIGNIFICANCE_ALERTS] && (
+                <div>
+                    <h2 className="font-semibold text-lg">Notifications</h2>
+                    <p>Get notified when a metric reaches significance.</p>
+                    <LinkedHogFunctions type="internal_destination" subTemplateIds={['experiment-significant']} />
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -51,6 +51,7 @@ const INTERNAL_DESTINATION_CONTEXT: Partial<
         url: urls.errorTrackingConfiguration() + '#selectedSetting=error-tracking-alerting',
     },
     'insight-alerts': { label: 'Insight alerts' },
+    'experiment-alerts': { label: 'Experiment alerts' },
 }
 
 function NotificationContextTag({ hogFunction }: { hogFunction: HogFunctionType }): JSX.Element | null {

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -80,6 +80,12 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         context_id: 'insight-alerts',
         filters: { events: [{ id: '$insight_alert_firing', type: 'events' }] },
     },
+    'experiment-significant': {
+        sub_template_id: 'experiment-significant',
+        type: 'internal_destination',
+        context_id: 'experiment-alerts',
+        filters: { events: [{ id: '$experiment_metric_significant', type: 'events' }] },
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -593,6 +599,58 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'experiment-significant': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['experiment-significant'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on experiment significance',
+            description: 'Send a webhook when an experiment metric reaches significance',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['experiment-significant'],
+            template_id: 'template-slack',
+            name: 'Post to Slack on experiment significance',
+            description: 'Post to a Slack channel when an experiment metric reaches significance',
+            inputs: {
+                blocks: {
+                    value: [
+                        {
+                            type: 'header',
+                            text: {
+                                type: 'plain_text',
+                                text: "Experiment '{event.properties.experiment_name}' has reached significance",
+                            },
+                        },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: 'Metric: *{event.properties.metric_name}* ({event.properties.variant_key} variant)',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}{event.properties.experiment_url}',
+                                    text: { text: 'View Experiment', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: "Experiment '{event.properties.experiment_name}' has reached significance",
+                },
+            },
+        },
+    ],
     [INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID]: [
         {
             ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES[INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID],
@@ -667,6 +725,8 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
             return 'error-tracking'
         case '$insight_alert_firing':
             return 'insight-alerts'
+        case '$experiment_metric_significant':
+            return 'experiment-alerts'
         case '$activity_log_entry_created':
             return 'activity-log'
         case '$discussion_mention_created':

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6197,6 +6197,7 @@ export type HogFunctionConfigurationContextId =
     | 'activity-log'
     | 'discussion-mention'
     | 'insight-alerts'
+    | 'experiment-alerts'
 
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
@@ -6207,6 +6208,7 @@ export type HogFunctionSubTemplateIdType =
     | 'error-tracking-issue-spiking'
     | 'discussion-mention'
     | 'insight-alert-firing'
+    | 'experiment-significant'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,


### PR DESCRIPTION
_Feature flag `experiment-significance-alerts`_

Implement the UI for subscribing to experiment metric notifications. For now went with generic alerting UI used elsewhere to test things and get feedback. I'll probably switch this to something less technical later.

<img width="993" height="399" alt="image" src="https://github.com/user-attachments/assets/ce40b418-bb67-4513-95e5-b61401553f8e" />

## Changes

- Register `experiment-significant` sub-template listening to `$experiment_metric_significant` events, with webhook and Slack destinations
- Add "Notifications" section to the experiment Settings tab using `LinkedHogFunctions`.

## How did you test this code?
Tested the webhook. Will test the Slack integration once deployed in prod.