### PR TITLE
fix(mcp): Remove JSON stringification from MCP state tracking

### DIFF
--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -238,7 +238,7 @@ export class MCP extends McpAgent<Env> {
             const spanId = generateId()
             const spanName = `mcp/${tool.name}`
             const startTime = performance.now()
-            const inputState = JSON.stringify(params)
+            const inputState = params
             const validation = tool.schema.safeParse(params)
 
             if (!validation.success) {
@@ -249,12 +249,13 @@ export class MCP extends McpAgent<Env> {
                 })
                 const latency = (performance.now() - startTime) / 1000
                 const errorOutput = `Invalid input: ${validation.error.message}`
-                const outputState = JSON.stringify(errorOutput)
+                const outputState = { error: errorOutput }
                 await this.trackEvent(AnalyticsEvent.AI_TRACE, {
                     $ai_trace_id: traceId,
                     $ai_span_name: spanName,
                     $ai_latency: latency,
                     $ai_is_error: true,
+                    ai_product: 'mcp',
                 })
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
@@ -265,6 +266,7 @@ export class MCP extends McpAgent<Env> {
                     $ai_output_state: outputState,
                     $ai_latency: latency,
                     $ai_is_error: true,
+                    ai_product: 'mcp',
                 })
                 return [
                     {
@@ -282,7 +284,7 @@ export class MCP extends McpAgent<Env> {
             try {
                 const result = await handler(params)
                 const latency = (performance.now() - startTime) / 1000
-                const outputState = JSON.stringify(result)
+                const outputState = result
 
                 await this.trackEvent(AnalyticsEvent.MCP_TOOL_RESPONSE, {
                     tool: tool.name,
@@ -291,6 +293,7 @@ export class MCP extends McpAgent<Env> {
                     $ai_trace_id: traceId,
                     $ai_span_name: spanName,
                     $ai_latency: latency,
+                    ai_product: 'mcp',
                 })
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
@@ -300,6 +303,7 @@ export class MCP extends McpAgent<Env> {
                     $ai_input_state: inputState,
                     $ai_output_state: outputState,
                     $ai_latency: latency,
+                    ai_product: 'mcp',
                 })
 
                 // For tools with UI resources, include structuredContent for better UI rendering
@@ -334,12 +338,13 @@ export class MCP extends McpAgent<Env> {
             } catch (error: any) {
                 const latency = (performance.now() - startTime) / 1000
                 const errorMessage = error instanceof Error ? error.message : String(error)
-                const outputState = JSON.stringify({ error: errorMessage })
+                const outputState = { error: errorMessage }
                 await this.trackEvent(AnalyticsEvent.AI_TRACE, {
                     $ai_trace_id: traceId,
                     $ai_span_name: spanName,
                     $ai_latency: latency,
                     $ai_is_error: true,
+                    ai_product: 'mcp',
                 })
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
@@ -350,6 +355,7 @@ export class MCP extends McpAgent<Env> {
                     $ai_output_state: outputState,
                     $ai_latency: latency,
                     $ai_is_error: true,
+                    ai_product: 'mcp',
                 })
                 const distinctId = await this.getDistinctId()
                 return handleToolError(


### PR DESCRIPTION
## Problem

The MCP tool execution tracking is unnecessarily stringifying state objects before passing them to analytics events. This adds an extra serialization step and makes the data harder to work with downstream in analytics pipelines.

## Changes

- Removed `JSON.stringify()` calls on `inputState` and `outputState` variables in MCP tool execution tracking
- Changed error output state from stringified string to structured object format (`{ error: errorMessage }`)
- Added `ai_product: 'mcp'` field to all analytics event tracking calls for better product categorization

These changes ensure that state data is passed as native objects to the analytics layer, allowing for better data handling and filtering.

## How did you test this code?

The changes are straightforward refactoring of data serialization in analytics event tracking. Existing analytics infrastructure will handle the object format natively. No manual testing required as this is a data format change that maintains the same information while improving data structure.

## Publish to changelog?

no

https://claude.ai/code/session_01Mu3bECDj8AUE38g5L956oe