### PR TITLE
feat(logs): turn SeverityLevelsFilter into a controlled component and replace with LemonDropdown

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -49,17 +49,17 @@ export const LogsFilterBar = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
     const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
     const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
-    const { zoomDateRange } = useActions(logsViewerFiltersLogic)
+    const { zoomDateRange, setSeverityLevels } = useActions(logsViewerFiltersLogic)
     const { filters } = useValues(logsViewerFiltersLogic)
     const { setDateRange } = useActions(logsViewerFiltersLogic)
-    const { dateRange } = filters
+    const { dateRange, severityLevels } = filters
 
     return (
         <LogsFilterGroup>
             <div className="flex flex-col gap-2 w-full bg-primary">
                 <div className="flex gap-2 flex-wrap w-full justify-between">
                     <div className="flex shrink-0 flex-1 gap-1.5">
-                        <SeverityLevelsFilter />
+                        <SeverityLevelsFilter value={severityLevels} onChange={setSeverityLevels} />
                         <ServiceFilter />
                         <div className="min-w-[300px] max-w-[350px] w-full">
                             <LogsFilterSearch />

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -50,7 +50,7 @@ export const SeverityLevelsFilter = ({ value, onChange }: SeverityLevelsFilterPr
                 {value.length === 0 || value.length === SEVERITY_OPTIONS.length
                     ? 'All levels'
                     : value.length === 1
-                      ? SEVERITY_OPTIONS.find((o) => o.key === value[0])?.label
+                      ? (SEVERITY_OPTIONS.find((o) => o.key === value[0])?.label ?? value[0])
                       : `${value.length} levels`}
             </LemonButton>
         </LemonDropdown>

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -1,68 +1,58 @@
-import { useActions, useValues } from 'kea'
-
-import { IconFilter } from '@posthog/icons'
-import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
-
-import { capitalizeFirstLetter } from 'lib/utils'
+import { IconChevronDown } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonDropdown } from '@posthog/lemon-ui'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
-import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+const SEVERITY_OPTIONS: { key: LogMessage['severity_text']; label: string }[] = [
+    { key: 'trace', label: 'Trace' },
+    { key: 'debug', label: 'Debug' },
+    { key: 'info', label: 'Info' },
+    { key: 'warn', label: 'Warn' },
+    { key: 'error', label: 'Error' },
+    { key: 'fatal', label: 'Fatal' },
+]
 
-const options: Record<LogMessage['severity_text'], string> = {
-    trace: 'Trace',
-    debug: 'Debug',
-    info: 'Info',
-    warn: 'Warn',
-    error: 'Error',
-    fatal: 'Fatal',
+interface SeverityLevelsFilterProps {
+    value: LogMessage['severity_text'][]
+    onChange: (levels: LogMessage['severity_text'][]) => void
 }
 
-const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
-
-export const SeverityLevelsFilter = (): JSX.Element => {
-    const { filters } = useValues(logsViewerFiltersLogic)
-    const { severityLevels } = filters
-    const { setSeverityLevels } = useActions(logsViewerFiltersLogic)
-
-    const onClick = (level: LogMessage['severity_text']): void => {
-        const levels = [...severityLevels]
-
-        const index = levels.indexOf(level)
-
-        if (index > -1) {
-            levels.splice(index, 1)
-        } else {
-            levels.push(level)
-        }
-
-        setSeverityLevels(levels)
-    }
-
-    const displayLevels =
-        severityLevels.length !== ALL_LOG_LEVELS.length && severityLevels.length > 0
-            ? severityLevels.map((l) => capitalizeFirstLetter(l)).join(', ')
-            : 'All levels'
-
+export const SeverityLevelsFilter = ({ value, onChange }: SeverityLevelsFilterProps): JSX.Element => {
     return (
-        <LemonMenu
+        <LemonDropdown
             closeOnClickInside={false}
-            items={Object.entries(options).map(([key, label]) => ({
-                label,
-                onClick: () => onClick(key as LogMessage['severity_text']),
-                active: severityLevels.includes(key as LogMessage['severity_text']),
-                'data-attr': `logs-severity-option-${key}`,
-            }))}
+            overlay={
+                <div className="space-y-px p-1">
+                    {SEVERITY_OPTIONS.map((option) => (
+                        <LemonButton
+                            key={option.key}
+                            type="tertiary"
+                            size="small"
+                            fullWidth
+                            icon={
+                                <LemonCheckbox checked={value.includes(option.key)} className="pointer-events-none" />
+                            }
+                            onClick={() => {
+                                const newLevels = value.includes(option.key)
+                                    ? value.filter((l) => l !== option.key)
+                                    : [...value, option.key]
+                                onChange(newLevels)
+                            }}
+                            data-attr={`logs-severity-option-${option.key}`}
+                        >
+                            {option.label}
+                        </LemonButton>
+                    ))}
+                </div>
+            }
         >
-            <LemonButton
-                data-attr="logs-severity-filter"
-                icon={<IconFilter />}
-                size="small"
-                type="secondary"
-                className="whitespace-nowrap"
-            >
-                {displayLevels}
+            <LemonButton data-attr="logs-severity-filter" type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                {value.length === 0 || value.length === SEVERITY_OPTIONS.length
+                    ? 'All levels'
+                    : value.length === 1
+                      ? SEVERITY_OPTIONS.find((o) => o.key === value[0])?.label
+                      : `${value.length} levels`}
             </LemonButton>
-        </LemonMenu>
+        </LemonDropdown>
     )
 }


### PR DESCRIPTION
## Problem

The severity levels filter component was tightly coupled to the logs viewer filters logic, making it difficult to reuse and test independently. The component needed to be refactored to accept props for better separation of concerns.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/66eb8bef-373d-4c23-aeec-6d77dae3610d.png)

- Refactored `SeverityLevelsFilter` to accept `value` and `onChange` props instead of directly accessing the filters logic
- Replaced `LemonMenu` with `LemonDropdown` for a more modern dropdown interface
- Added checkboxes to clearly indicate selected severity levels
- Improved the button text logic to show "All levels", single level name, or count of selected levels
- Updated the parent component to pass the required props to the filter
- Replaced filter icon with chevron down icon for better UX consistency

## How did you test this code?

Local dev & playwright tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No