### PR TITLE
feat(flags): add warn-then-enforce rate limiting with per-token overrides

### DIFF
--- a/docs/internal/feature-flags/rate-limiting.md
+++ b/docs/internal/feature-flags/rate-limiting.md
@@ -1,0 +1,87 @@
+# Rate limiting
+
+The Rust feature flags service uses three independent rate limiters, all implemented in-process using the `governor` crate (token bucket algorithm):
+
+| Limiter     | Scope         | Default config             | Purpose                            |
+| ----------- | ------------- | -------------------------- | ---------------------------------- |
+| IP-based    | Per source IP | 1000 burst / 50 per second | DDoS defense                       |
+| Token-based | Per API token | 500 burst / 10 per second  | Per-project limits                 |
+| Definitions | Per team ID   | 600 per minute             | `/flags/definitions` rate limiting |
+
+Rate limiting runs before body decoding and authentication in the `/flags` request pipeline. IP is checked first, then token. The definitions limiter is a simple allow/deny gate with no warn tier.
+
+## Warn-then-enforce model
+
+The `/flags` IP and token limiters use a three-outcome model: `Allowed`, `Warned`, or `Blocked`. The definitions limiter does not use this model.
+
+- **Allowed**: Request is below all thresholds — served normally.
+- **Warned**: Request exceeds the warn capacity but is below enforce. The request succeeds, but the response includes `X-PostHog-Rate-Limit-Warning: true` so callers can react proactively. A `rate_limit_warned` field is also set in the canonical request log.
+- **Blocked**: Request exceeds the enforce capacity — returns HTTP 429 with `{"type": "validation_error", "code": "rate_limit_exceeded"}`.
+
+The CORS layer exposes `x-posthog-rate-limit-warning` via `Access-Control-Expose-Headers` so browser SDKs can read the warning header on cross-origin requests.
+
+## Configuration modes
+
+By default, the warn tier is derived at 80% of the enforce capacity (`FLAGS_WARN_CAPACITY_RATIO=0.8`). Operators only need to set the enforce capacity (`FLAGS_BUCKET_CAPACITY` / `FLAGS_IP_BURST_SIZE`) and the warn tier follows automatically. The ratio applies to both token and IP limiters.
+
+Resolution logic lives in `resolve_rate_limit_capacities()` in `router.rs`. The mode is determined by `log_only` and the warn ratio:
+
+| Mode                | Condition                         | Behavior                                                                                                                      |
+| ------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Default**         | `log_only == false`, `ratio > 0`  | Warn tier is derived at `ratio` of enforce capacity. Operators get warning signals before hard 429s.                          |
+| **Warn disabled**   | `log_only == false`, `ratio == 0` | No warn tier. Hard block at enforce capacity with no prior warning.                                                           |
+| **Legacy log-only** | `log_only == true`                | Warn at enforce capacity, never block (`warn_only` mode). Preserves the legacy contract where rate limiting is observational. |
+
+### Migration path
+
+To move from legacy log-only to full enforcement:
+
+1. **Start** with the defaults: `FLAGS_RATE_LIMIT_LOG_ONLY=true` (observe via metrics)
+2. **Switch to enforce mode**: set `FLAGS_RATE_LIMIT_LOG_ONLY=false` — the warn tier is auto-derived at 80% of enforce capacity
+3. **Tune thresholds** using the `flags_rate_limit_exceeded_total` counter (labels: `mode="warned"` vs `mode="enforced"`)
+4. _(Optional)_ Adjust `FLAGS_WARN_CAPACITY_RATIO` if the default 80% doesn't fit your traffic pattern (0.0 disables the warn tier)
+5. **Remove** the deprecated `FLAGS_RATE_LIMIT_LOG_ONLY` env var once satisfied
+
+## Per-token overrides
+
+The `FLAGS_TOKEN_RATE_LIMIT_OVERRIDES` env var accepts a JSON map of token → rate string for per-token custom rate limits:
+
+```json
+{ "phc_abc123": "1200/minute", "phc_xyz789": "2400/hour" }
+```
+
+These create dedicated enforce-only limiters that take precedence over the default token limiter for matching tokens. Maximum 100 overrides. Token values are redacted in logs (prefix + suffix only).
+
+Rate strings follow the Django throttle format: `<count>/<period>` where period is one of `second`, `minute`, `hour`, or `day`.
+
+## Lifecycle
+
+A background task runs every 60 seconds (`RATE_LIMITER_CLEANUP_INTERVAL_SECS`) to call `retain_recent()` and `shrink_to_fit()` on all limiter stores, preventing unbounded memory growth from accumulated per-key entries.
+
+## Configuration reference
+
+| Variable                                   | Default | Purpose                                                            |
+| ------------------------------------------ | ------- | ------------------------------------------------------------------ |
+| `FLAGS_RATE_LIMIT_ENABLED`                 | `false` | Enable token-based rate limiting                                   |
+| `FLAGS_BUCKET_CAPACITY`                    | `500`   | Token bucket enforce capacity                                      |
+| `FLAGS_BUCKET_REPLENISH_RATE`              | `10.0`  | Tokens per second                                                  |
+| `FLAGS_IP_RATE_LIMIT_ENABLED`              | `false` | Enable IP-based rate limiting                                      |
+| `FLAGS_IP_BURST_SIZE`                      | `1000`  | IP bucket enforce capacity                                         |
+| `FLAGS_IP_REPLENISH_RATE`                  | `50.0`  | Requests per second per IP                                         |
+| `FLAGS_WARN_CAPACITY_RATIO`                | `0.8`   | Warn tier as fraction of enforce capacity (0.0 disables warn tier) |
+| `FLAGS_RATE_LIMIT_LOG_ONLY`                | `true`  | _(deprecated)_ Set to `false` and use `FLAGS_WARN_CAPACITY_RATIO`  |
+| `FLAGS_IP_RATE_LIMIT_LOG_ONLY`             | `true`  | _(deprecated)_ Set to `false` and use `FLAGS_WARN_CAPACITY_RATIO`  |
+| `FLAGS_TOKEN_RATE_LIMIT_OVERRIDES`         | (empty) | Per-token rate limit overrides as JSON (max 100)                   |
+| `RATE_LIMITER_CLEANUP_INTERVAL_SECS`       | `60`    | Stale entry cleanup interval                                       |
+| `FLAG_DEFINITIONS_DEFAULT_RATE_PER_MINUTE` | `600`   | Default rate for `/flags/definitions`                              |
+| `LOCAL_EVAL_RATE_LIMITS`                   | (empty) | Per-team overrides for `/flags/definitions` as JSON                |
+
+## Key files
+
+| File                                               | Purpose                                                                |
+| -------------------------------------------------- | ---------------------------------------------------------------------- |
+| `rust/feature-flags/src/api/flags_rate_limiter.rs` | `FlagsRateLimiter`, `IpRateLimiter`, `KeyedRateLimiter` implementation |
+| `rust/feature-flags/src/router.rs`                 | `resolve_rate_limit_capacities()`, limiter construction, cleanup task  |
+| `rust/feature-flags/src/api/endpoint.rs`           | Request-time rate limit checks, warning header insertion               |
+| `rust/feature-flags/src/config.rs`                 | Env var definitions, `FlagsTokenRateLimitOverrides` parsing            |
+| `rust/feature-flags/tests/test_rate_limiting.rs`   | Integration tests                                                      |

--- a/docs/internal/feature-flags/rate-limiting.md
+++ b/docs/internal/feature-flags/rate-limiting.md
@@ -4,8 +4,8 @@ The Rust feature flags service uses three independent rate limiters, all impleme
 
 | Limiter     | Scope         | Default config             | Purpose                            |
 | ----------- | ------------- | -------------------------- | ---------------------------------- |
-| IP-based    | Per source IP | 1000 burst / 50 per second | DDoS defense                       |
-| Token-based | Per API token | 500 burst / 10 per second  | Per-project limits                 |
+| IP-based    | Per source IP | 1250 burst / 50 per second | DDoS defense                       |
+| Token-based | Per API token | 625 burst / 10 per second  | Per-project limits                 |
 | Definitions | Per team ID   | 600 per minute             | `/flags/definitions` rate limiting |
 
 Rate limiting runs before body decoding and authentication in the `/flags` request pipeline. IP is checked first, then token. The definitions limiter is a simple allow/deny gate with no warn tier.
@@ -26,19 +26,22 @@ By default, the warn tier is derived at 80% of the enforce capacity (`FLAGS_WARN
 
 Resolution logic lives in `resolve_rate_limit_capacities()` in `router.rs`. The mode is determined by `log_only` and the warn ratio:
 
-| Mode                | Condition                         | Behavior                                                                                                                      |
-| ------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Default**         | `log_only == false`, `ratio > 0`  | Warn tier is derived at `ratio` of enforce capacity. Operators get warning signals before hard 429s.                          |
-| **Warn disabled**   | `log_only == false`, `ratio == 0` | No warn tier. Hard block at enforce capacity with no prior warning.                                                           |
-| **Legacy log-only** | `log_only == true`                | Warn at enforce capacity, never block (`warn_only` mode). Preserves the legacy contract where rate limiting is observational. |
+| Mode                | Condition                         | Behavior                                                                                                                  |
+| ------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Default**         | `log_only == false`, `ratio > 0`  | Warn tier is derived at `ratio` of enforce capacity. Operators get warning signals before hard 429s.                      |
+| **Warn disabled**   | `log_only == false`, `ratio == 0` | No warn tier. Hard block at enforce capacity with no prior warning.                                                       |
+| **Legacy log-only** | `log_only == true`                | Same thresholds as default mode, but never blocks (`warn_only` mode). Metrics show what _would_ happen under enforcement. |
 
 ### Migration path
 
 To move from legacy log-only to full enforcement:
 
 1. **Start** with the defaults: `FLAGS_RATE_LIMIT_LOG_ONLY=true` (observe via metrics)
-2. **Switch to enforce mode**: set `FLAGS_RATE_LIMIT_LOG_ONLY=false` — the warn tier is auto-derived at 80% of enforce capacity
-3. **Tune thresholds** using the `flags_rate_limit_exceeded_total` counter (labels: `mode="warned"` vs `mode="enforced"`)
+2. **Monitor** using the `flags_rate_limit_exceeded_total` counter — two orthogonal labels:
+   - `mode`: `log_only` (observe-only) or `enforcing` (actually blocking)
+   - `action`: `warned` (crossed warn tier) or `blocked` (crossed enforce tier)
+     In log-only mode, `action="blocked"` shows what _would_ be blocked without actually rejecting requests.
+3. **Switch to enforce mode**: set `FLAGS_RATE_LIMIT_LOG_ONLY=false` — thresholds stay the same, but requests are now actually blocked
 4. _(Optional)_ Adjust `FLAGS_WARN_CAPACITY_RATIO` if the default 80% doesn't fit your traffic pattern (0.0 disables the warn tier)
 5. **Remove** the deprecated `FLAGS_RATE_LIMIT_LOG_ONLY` env var once satisfied
 
@@ -63,10 +66,10 @@ A background task runs every 60 seconds (`RATE_LIMITER_CLEANUP_INTERVAL_SECS`) t
 | Variable                                   | Default | Purpose                                                            |
 | ------------------------------------------ | ------- | ------------------------------------------------------------------ |
 | `FLAGS_RATE_LIMIT_ENABLED`                 | `false` | Enable token-based rate limiting                                   |
-| `FLAGS_BUCKET_CAPACITY`                    | `500`   | Token bucket enforce capacity                                      |
+| `FLAGS_BUCKET_CAPACITY`                    | `625`   | Token bucket enforce capacity (warn at 80% = 500)                  |
 | `FLAGS_BUCKET_REPLENISH_RATE`              | `10.0`  | Tokens per second                                                  |
 | `FLAGS_IP_RATE_LIMIT_ENABLED`              | `false` | Enable IP-based rate limiting                                      |
-| `FLAGS_IP_BURST_SIZE`                      | `1000`  | IP bucket enforce capacity                                         |
+| `FLAGS_IP_BURST_SIZE`                      | `1250`  | IP bucket enforce capacity (warn at 80% = 1000)                    |
 | `FLAGS_IP_REPLENISH_RATE`                  | `50.0`  | Requests per second per IP                                         |
 | `FLAGS_WARN_CAPACITY_RATIO`                | `0.8`   | Warn tier as fraction of enforce capacity (0.0 disables warn tier) |
 | `FLAGS_RATE_LIMIT_LOG_ONLY`                | `true`  | _(deprecated)_ Set to `false` and use `FLAGS_WARN_CAPACITY_RATIO`  |

--- a/docs/internal/feature-flags/rust-service-overview.md
+++ b/docs/internal/feature-flags/rust-service-overview.md
@@ -173,17 +173,7 @@ pub struct FlagDetails {
 
 ## Rate limiting
 
-Three independent rate limiters, all implemented in-process using the `governor` crate (token bucket algorithm):
-
-| Limiter     | Scope         | Default config             | Purpose                            |
-| ----------- | ------------- | -------------------------- | ---------------------------------- |
-| IP-based    | Per source IP | 1000 burst / 50 per second | DDoS defense                       |
-| Token-based | Per API token | 500 burst / 10 per second  | Per-project limits                 |
-| Definitions | Per team ID   | 600 per minute             | `/flags/definitions` rate limiting |
-
-All three support a **log-only** mode (`*_LOG_ONLY=true`) for safe rollout -- violations are logged and metered but requests are not blocked.
-
-A background task runs every 60 seconds to clean up stale rate limiter entries.
+Three independent rate limiters (IP, token, definitions), all in-process using the `governor` crate. The `/flags` IP and token limiters support a warn-then-enforce model with `X-PostHog-Rate-Limit-Warning` headers and per-token custom overrides. See [rate-limiting.md](rate-limiting.md) for the full model, configuration modes, and migration path.
 
 ## Server initialization
 
@@ -248,17 +238,7 @@ All values come from environment variables via the `envconfig` crate. Defined in
 
 ### Rate limiting
 
-| Variable                                   | Default | Purpose                               |
-| ------------------------------------------ | ------- | ------------------------------------- |
-| `FLAGS_RATE_LIMIT_ENABLED`                 | `false` | Enable token-based rate limiting      |
-| `FLAGS_BUCKET_CAPACITY`                    | `500`   | Token bucket capacity                 |
-| `FLAGS_BUCKET_REPLENISH_RATE`              | `10.0`  | Tokens per second                     |
-| `FLAGS_IP_RATE_LIMIT_ENABLED`              | `false` | Enable IP-based rate limiting         |
-| `FLAGS_IP_BURST_SIZE`                      | `1000`  | IP bucket capacity                    |
-| `FLAGS_IP_REPLENISH_RATE`                  | `50.0`  | Tokens per second                     |
-| `FLAGS_RATE_LIMIT_LOG_ONLY`                | `true`  | Log violations without blocking       |
-| `FLAG_DEFINITIONS_DEFAULT_RATE_PER_MINUTE` | `600`   | Default rate for `/flags/definitions` |
-| `LOCAL_EVAL_RATE_LIMITS`                   | (empty) | Per-team overrides as JSON            |
+See [rate-limiting.md](rate-limiting.md) for the full configuration reference.
 
 ### Caching
 
@@ -308,7 +288,7 @@ Applied in order via Axum layers (defined in `router.rs`):
 
 1. **ConcurrencyLimitLayer**: Caps concurrent flag evaluation requests (default 1000)
 2. **TraceLayer**: HTTP request tracing with spans
-3. **CorsLayer**: Permissive CORS (mirrors request origin, allows credentials)
+3. **CorsLayer**: Permissive CORS (mirrors request origin, allows credentials, exposes `x-posthog-rate-limit-warning`)
 4. **track_metrics**: Prometheus HTTP request metrics
 
 ## Related files
@@ -327,6 +307,7 @@ Applied in order via Axum layers (defined in `router.rs`):
 
 ## See also
 
+- [Rate limiting](rate-limiting.md) - Warn-then-enforce model, configuration modes, per-token overrides
 - [Flag evaluation engine](flag-evaluation-engine.md) - How flags are matched and evaluated
 - [Database interaction patterns](database-interaction-patterns.md) - PostgreSQL connection pooling and query routing
 - [HyperCache system](hypercache-system.md) - Multi-tier caching with Redis, S3, and PostgreSQL

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::{
         errors::{ClientFacingError, FlagError},
+        flags_rate_limiter::RateLimitResult,
         types::{
             ConfigResponse, FlagsQueryParams, FlagsResponse, LegacyFlagsResponse, ServiceResponse,
         },
@@ -14,7 +15,7 @@ use crate::{
 };
 // TODO: stream this instead
 use axum::extract::{MatchedPath, Query, State};
-use axum::http::{HeaderMap, Method, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
@@ -328,21 +329,35 @@ pub async fn flags(
         // This order ensures that an attacker cannot bypass rate limiting by
         // simply rotating through fake tokens from the same IP address.
 
+        let mut rate_limit_warned = false;
+
         // Check IP-based rate limit first
-        if !state.ip_rate_limiter.allow_request(&ip_string) {
-            return Err(rate_limit_error(FlagError::ClientFacing(
-                ClientFacingError::IpRateLimited,
-            )));
+        match state.ip_rate_limiter.allow_request(&ip_string) {
+            RateLimitResult::Blocked => {
+                return Err(rate_limit_error(FlagError::ClientFacing(
+                    ClientFacingError::IpRateLimited,
+                )));
+            }
+            RateLimitResult::Warned => rate_limit_warned = true,
+            RateLimitResult::Allowed => {}
         }
 
         // Check token-based rate limit
         // Extract token from body, use IP as fallback if extraction fails
         let rate_limit_key =
             decoding::extract_token(&context.body).unwrap_or_else(|| ip_string.clone());
-        if !state.flags_rate_limiter.allow_request(&rate_limit_key) {
-            return Err(rate_limit_error(FlagError::ClientFacing(
-                ClientFacingError::TokenRateLimited,
-            )));
+        match state.flags_rate_limiter.allow_request(&rate_limit_key) {
+            RateLimitResult::Blocked => {
+                return Err(rate_limit_error(FlagError::ClientFacing(
+                    ClientFacingError::TokenRateLimited,
+                )));
+            }
+            RateLimitResult::Warned => rate_limit_warned = true,
+            RateLimitResult::Allowed => {}
+        }
+
+        if rate_limit_warned {
+            with_canonical_log(|l| l.rate_limit_warned = true);
         }
 
         process_request(context).await
@@ -360,7 +375,14 @@ pub async fn flags(
                 Ok((versioned_response, _response_format)) => {
                     log.http_status = 200;
                     log.emit();
-                    Ok(Json(versioned_response).into_response())
+                    let mut response = Json(versioned_response).into_response();
+                    if log.rate_limit_warned {
+                        response.headers_mut().insert(
+                            "X-PostHog-Rate-Limit-Warning",
+                            HeaderValue::from_static("true"),
+                        );
+                    }
+                    Ok(response)
                 }
                 Err(e) => {
                     log.emit_for_error(&e);

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -334,7 +334,8 @@ impl FlagsRateLimiter {
     /// Checks if a request should be allowed based on the rate limit.
     ///
     /// Custom per-token limiters take precedence over the default limiter.
-    /// Custom limiters are enforce-only (return `Allowed` or `Blocked`).
+    /// Custom limiters honor `warn_only` mode — when active, rejections
+    /// become warnings instead of blocks.
     pub fn allow_request(&self, bucket_key: &str) -> RateLimitResult {
         if !self.inner.enabled {
             return RateLimitResult::Allowed;
@@ -344,13 +345,23 @@ impl FlagsRateLimiter {
         if let Some(limiter) = self.custom_limiters.get(bucket_key) {
             let key_string = bucket_key.to_string();
             if limiter.check_key(&key_string).is_err() {
-                counter!(
-                    self.inner.config.metric_name,
-                    self.inner.config.key_label => key_string,
-                    "mode" => "enforced"
-                )
-                .increment(1);
-                return RateLimitResult::Blocked;
+                if self.inner.warn_only {
+                    counter!(
+                        self.inner.config.metric_name,
+                        self.inner.config.key_label => key_string,
+                        "mode" => "warned"
+                    )
+                    .increment(1);
+                    return RateLimitResult::Warned;
+                } else {
+                    counter!(
+                        self.inner.config.metric_name,
+                        self.inner.config.key_label => key_string,
+                        "mode" => "enforced"
+                    )
+                    .increment(1);
+                    return RateLimitResult::Blocked;
+                }
             }
             return RateLimitResult::Allowed;
         }
@@ -597,6 +608,30 @@ mod tests {
         // Request 6+: exceed enforce → still Warned (never Blocked in warn_only mode)
         assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
         assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+    }
+
+    #[test]
+    fn test_warn_only_mode_with_custom_limiter_never_blocks() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert("custom_token".to_string(), "1/second".to_string());
+
+        let limiter = FlagsRateLimiter::new(true, 0.1, Some(2), 5, true, custom_rates).unwrap();
+
+        // Custom token: capacity=1, so second request exceeds it
+        assert_eq!(
+            limiter.allow_request("custom_token"),
+            RateLimitResult::Allowed
+        );
+        // In warn_only mode, custom limiter rejection should produce Warned, not Blocked
+        assert_eq!(
+            limiter.allow_request("custom_token"),
+            RateLimitResult::Warned
+        );
+        // Subsequent requests should also be Warned, never Blocked
+        assert_eq!(
+            limiter.allow_request("custom_token"),
+            RateLimitResult::Warned
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -137,6 +137,34 @@ impl KeyedRateLimiter {
         })
     }
 
+    /// The metric `mode` label: `"log_only"` when warn-only, `"enforcing"` otherwise.
+    fn mode_label(&self) -> &'static str {
+        if self.warn_only {
+            "log_only"
+        } else {
+            "enforcing"
+        }
+    }
+
+    /// Emits a "blocked" metric and returns `Warned` (if warn_only) or `Blocked`.
+    ///
+    /// In log_only mode, `action="blocked"` is still emitted to show what _would_
+    /// happen if enforcement were enabled, but the request is not actually blocked.
+    fn record_block(&self, key_string: String) -> RateLimitResult {
+        counter!(
+            self.config.metric_name,
+            self.config.key_label => key_string,
+            "mode" => self.mode_label(),
+            "action" => "blocked"
+        )
+        .increment(1);
+        if self.warn_only {
+            RateLimitResult::Warned
+        } else {
+            RateLimitResult::Blocked
+        }
+    }
+
     /// Checks if a request should be allowed based on the rate limit.
     ///
     /// Always consumes tokens from both limiters to keep them in sync.
@@ -157,30 +185,15 @@ impl KeyedRateLimiter {
             .is_none_or(|wl| wl.check_key(&key_string).is_ok());
 
         if !enforce_ok {
-            if self.warn_only {
-                // Legacy log-only compat: never block, only warn
-                counter!(
-                    self.config.metric_name,
-                    self.config.key_label => key_string,
-                    "mode" => "warned"
-                )
-                .increment(1);
-                return RateLimitResult::Warned;
-            }
-            counter!(
-                self.config.metric_name,
-                self.config.key_label => key_string,
-                "mode" => "enforced"
-            )
-            .increment(1);
-            return RateLimitResult::Blocked;
+            return self.record_block(key_string);
         }
 
         if !warn_ok {
             counter!(
                 self.config.metric_name,
                 self.config.key_label => key_string.clone(),
-                "mode" => "warned"
+                "mode" => self.mode_label(),
+                "action" => "warned"
             )
             .increment(1);
             tracing::debug!(
@@ -345,23 +358,7 @@ impl FlagsRateLimiter {
         if let Some(limiter) = self.custom_limiters.get(bucket_key) {
             let key_string = bucket_key.to_string();
             if limiter.check_key(&key_string).is_err() {
-                if self.inner.warn_only {
-                    counter!(
-                        self.inner.config.metric_name,
-                        self.inner.config.key_label => key_string,
-                        "mode" => "warned"
-                    )
-                    .increment(1);
-                    return RateLimitResult::Warned;
-                } else {
-                    counter!(
-                        self.inner.config.metric_name,
-                        self.inner.config.key_label => key_string,
-                        "mode" => "enforced"
-                    )
-                    .increment(1);
-                    return RateLimitResult::Blocked;
-                }
+                return self.inner.record_block(key_string);
             }
             return RateLimitResult::Allowed;
         }

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -222,10 +222,10 @@ const MAX_CUSTOM_RATE_OVERRIDES: usize = crate::config::MAX_FLAGS_RATE_LIMIT_OVE
 
 /// Redacts a token for safe logging, showing only a prefix and suffix.
 fn redact_token(token: &str) -> String {
-    if token.len() <= 8 {
-        return "***".to_string();
+    match (token.get(..4), token.get(token.len().saturating_sub(4)..)) {
+        (Some(prefix), Some(suffix)) if token.len() > 8 => format!("{prefix}…{suffix}"),
+        _ => "***".to_string(),
     }
-    format!("{}…{}", &token[..4], &token[token.len() - 4..])
 }
 
 /// Token bucket rate limiter for feature flag requests.

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -3,12 +3,37 @@
 /// This module provides per-process, in-memory rate limiting for feature flag requests.
 /// It uses the governor crate's token bucket implementation to limit request rates per token.
 ///
+/// The rate limiter supports a two-tier warn-then-enforce model:
+/// - **Warn tier**: When a key exceeds the warn capacity, the request proceeds
+///   but the caller is informed via `RateLimitResult::Warned` so it can attach
+///   a warning header to the response.
+/// - **Enforce tier**: When a key exceeds the enforce capacity, the request is
+///   blocked with `RateLimitResult::Blocked`.
+///
 /// The rate limiter is designed to match the behavior of Python's DecideRateThrottle class,
 /// which uses the token-bucket library for the /decide endpoint.
+use crate::api::rate_parser::parse_rate_string;
 use governor::{clock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
 use metrics::counter;
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::sync::Arc;
+
+/// Type alias for the governor keyed rate limiter.
+type GovernorLimiter =
+    Arc<RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>>;
+
+/// Result of a rate limit check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitResult {
+    /// Request is within both warn and enforce thresholds.
+    Allowed,
+    /// Request exceeds the warn threshold but is below the enforce threshold.
+    /// The caller should attach a warning header to the response.
+    Warned,
+    /// Request exceeds the enforce threshold and should be rejected with 429.
+    Blocked,
+}
 
 /// Configuration for a keyed rate limiter's metrics and logging.
 #[derive(Clone, Debug)]
@@ -21,131 +46,150 @@ struct RateLimiterConfig {
     error_prefix: &'static str,
 }
 
-/// Generic keyed rate limiter using token bucket algorithm.
+/// Creates a governor limiter from a replenish rate and burst capacity.
+fn build_limiter(
+    replenish_rate: f64,
+    burst_capacity: u32,
+    error_prefix: &str,
+) -> anyhow::Result<GovernorLimiter> {
+    let burst = NonZeroU32::new(burst_capacity)
+        .ok_or_else(|| anyhow::anyhow!("{error_prefix} burst size must be greater than 0"))?;
+
+    let quota = if replenish_rate >= 1.0 {
+        let rate = NonZeroU32::new(replenish_rate.round() as u32).ok_or_else(|| {
+            anyhow::anyhow!("{error_prefix} replenish rate must be greater than 0")
+        })?;
+        Quota::per_second(rate).allow_burst(burst)
+    } else if replenish_rate > 0.0 {
+        let interval_ms = (1000.0 / replenish_rate).round() as u64;
+        Quota::with_period(std::time::Duration::from_millis(interval_ms))
+            .ok_or_else(|| anyhow::anyhow!("Invalid {error_prefix} rate limit period"))?
+            .allow_burst(burst)
+    } else {
+        return Err(anyhow::anyhow!(
+            "{error_prefix} replenish rate must be greater than 0"
+        ));
+    };
+
+    Ok(Arc::new(RateLimiter::dashmap(quota)))
+}
+
+/// Generic keyed rate limiter using token bucket algorithm with two-tier
+/// warn-then-enforce support.
 ///
 /// This is the core implementation shared by both FlagsRateLimiter and IpRateLimiter.
-/// It provides per-key rate limiting with support for log-only mode.
+/// It provides per-key rate limiting with optional warn and enforce thresholds.
+///
+/// Governor's `check_key` is all-or-nothing — there's no way to query remaining
+/// tokens without consuming one. Two limiters with the same replenish rate but
+/// different capacities (warn < enforce) give clean semantics: the warn bucket
+/// drains first.
 #[derive(Clone, Debug)]
 struct KeyedRateLimiter {
     /// Whether rate limiting is enabled
     enabled: bool,
-    /// Whether to log rate limit violations without blocking requests
-    log_only: bool,
-    /// The underlying token bucket rate limiter
-    limiter: Arc<RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>>,
+    /// The enforce-tier limiter (always present when enabled)
+    enforce_limiter: GovernorLimiter,
+    /// The warn-tier limiter (present only when warn capacity is configured)
+    warn_limiter: Option<GovernorLimiter>,
     /// Configuration for metrics and logging
     config: RateLimiterConfig,
 }
 
 impl KeyedRateLimiter {
     /// Creates a new KeyedRateLimiter with the specified configuration.
+    ///
+    /// - `warn_capacity`: If `Some`, a second limiter is created at this (lower) capacity.
+    ///   Requests that exceed it return `Warned`. If `None`, there is no warn tier.
+    /// - `enforce_capacity`: Hard limit. Requests that exceed it return `Blocked`.
     fn new(
         enabled: bool,
-        log_only: bool,
         replenish_rate: f64,
-        burst_size: u32,
+        warn_capacity: Option<u32>,
+        enforce_capacity: u32,
         config: RateLimiterConfig,
     ) -> anyhow::Result<Self> {
-        let burst = NonZeroU32::new(burst_size).ok_or_else(|| {
-            anyhow::anyhow!("{} burst size must be greater than 0", config.error_prefix)
-        })?;
+        let enforce_limiter = build_limiter(replenish_rate, enforce_capacity, config.error_prefix)?;
 
-        // Handle fractional replenish rates by using per-interval quotas
-        let quota = if replenish_rate >= 1.0 {
-            let rate = NonZeroU32::new(replenish_rate.round() as u32).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "{} replenish rate must be greater than 0",
-                    config.error_prefix
-                )
-            })?;
-            Quota::per_second(rate).allow_burst(burst)
-        } else if replenish_rate > 0.0 {
-            let interval_ms = (1000.0 / replenish_rate).round() as u64;
-            Quota::with_period(std::time::Duration::from_millis(interval_ms))
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Invalid {} rate limit period", config.error_prefix)
-                })?
-                .allow_burst(burst)
-        } else {
-            return Err(anyhow::anyhow!(
-                "{} replenish rate must be greater than 0",
-                config.error_prefix
-            ));
+        let warn_limiter = match warn_capacity {
+            Some(cap) if cap > 0 => Some(build_limiter(replenish_rate, cap, config.error_prefix)?),
+            _ => None,
         };
-
-        let limiter = Arc::new(RateLimiter::dashmap(quota));
 
         Ok(Self {
             enabled,
-            log_only,
-            limiter,
+            enforce_limiter,
+            warn_limiter,
             config,
         })
     }
 
     /// Checks if a request should be allowed based on the rate limit.
-    fn allow_request(&self, key: &str) -> bool {
-        // If rate limiting is disabled, always allow
+    ///
+    /// Always consumes tokens from both limiters to keep them in sync.
+    /// Returns `Blocked` if the enforce limiter rejects, `Warned` if the
+    /// warn limiter rejects but enforce allows, and `Allowed` otherwise.
+    fn allow_request(&self, key: &str) -> RateLimitResult {
         if !self.enabled {
-            return true;
+            return RateLimitResult::Allowed;
         }
 
-        // Check if this request is allowed by the token bucket
-        // Note: We allocate a String here since governor's check_key requires owned String
         let key_string = key.to_string();
-        let allowed = self.limiter.check_key(&key_string).is_ok();
 
-        // Track rate limit violations in metrics
-        if !allowed {
-            let mode = if self.log_only {
-                "log_only"
-            } else {
-                "enforced"
-            };
+        // Always consume from both limiters so they stay in sync.
+        let enforce_ok = self.enforce_limiter.check_key(&key_string).is_ok();
+        let warn_ok = self
+            .warn_limiter
+            .as_ref()
+            .is_none_or(|wl| wl.check_key(&key_string).is_ok());
+
+        if !enforce_ok {
+            counter!(
+                self.config.metric_name,
+                self.config.key_label => key_string,
+                "mode" => "enforced"
+            )
+            .increment(1);
+            return RateLimitResult::Blocked;
+        }
+
+        if !warn_ok {
             counter!(
                 self.config.metric_name,
                 self.config.key_label => key_string.clone(),
-                "mode" => mode
+                "mode" => "warned"
             )
             .increment(1);
-
-            // In log-only mode, log warning and allow the request to proceed
-            if self.log_only {
-                tracing::warn!(
-                    key = %key_string,
-                    limiter = %self.config.error_prefix,
-                    "Rate limit exceeded (log-only mode: request allowed)"
-                );
-                return true;
-            }
+            tracing::warn!(
+                key = %key_string,
+                limiter = %self.config.error_prefix,
+                "Rate limit warning threshold exceeded"
+            );
+            return RateLimitResult::Warned;
         }
 
-        allowed
+        RateLimitResult::Allowed
     }
 
     /// Removes stale entries from the rate limiter to prevent unbounded memory growth.
-    ///
-    /// Keys whose rate limiting state is indistinguishable from a fresh state
-    /// (i.e., the theoretical arrival time lies in the past) are removed.
-    /// This should be called periodically (e.g., every 60 seconds) to clean up
-    /// entries for keys that are no longer actively making requests.
     fn retain_recent(&self) {
-        self.limiter.retain_recent();
+        self.enforce_limiter.retain_recent();
+        if let Some(ref wl) = self.warn_limiter {
+            wl.retain_recent();
+        }
     }
 
     /// Shrinks the capacity of the rate limiter's state store if possible.
-    ///
-    /// Should be called after `retain_recent()` to reclaim memory from removed entries.
     fn shrink_to_fit(&self) {
-        self.limiter.shrink_to_fit();
+        self.enforce_limiter.shrink_to_fit();
+        if let Some(ref wl) = self.warn_limiter {
+            wl.shrink_to_fit();
+        }
     }
 
     /// Returns the number of keys currently tracked in the rate limiter.
-    ///
-    /// Note: This may return an approximate value depending on the underlying
-    /// state store implementation.
     fn len(&self) -> usize {
-        self.limiter.len()
+        self.enforce_limiter.len()
     }
 }
 
@@ -153,9 +197,13 @@ impl KeyedRateLimiter {
 ///
 /// Uses the governor crate to implement a per-key (token) rate limiter.
 /// This is a per-process limiter (not distributed across pods).
+///
+/// Supports optional per-token custom rate overrides via `custom_limiters`.
 #[derive(Clone, Debug)]
 pub struct FlagsRateLimiter {
     inner: KeyedRateLimiter,
+    /// Per-token custom rate limiters (enforce-only, no warn tier).
+    custom_limiters: HashMap<String, GovernorLimiter>,
 }
 
 impl FlagsRateLimiter {
@@ -164,27 +212,26 @@ impl FlagsRateLimiter {
     /// # Arguments
     ///
     /// * `enabled` - Whether rate limiting is enabled
-    /// * `log_only` - Whether to log violations without blocking (for safe rollout)
-    /// * `replenish_rate` - Tokens added per second (matches Python's replenish_rate)
-    /// * `capacity` - Maximum burst size (matches Python's bucket_capacity)
-    ///
-    /// # Returns
-    ///
-    /// Returns an error if the replenish rate or capacity are invalid (zero or negative).
+    /// * `replenish_rate` - Tokens added per second
+    /// * `warn_capacity` - Warn threshold bucket size (None = no warn tier)
+    /// * `enforce_capacity` - Hard limit bucket size
+    /// * `custom_rates` - Per-token rate overrides (e.g., `{"phc_abc": "1200/minute"}`)
     ///
     /// # Example
     ///
     /// ```
-    /// use feature_flags::api::flags_rate_limiter::FlagsRateLimiter;
+    /// use feature_flags::api::flags_rate_limiter::{FlagsRateLimiter, RateLimitResult};
+    /// use std::collections::HashMap;
     ///
-    /// let limiter = FlagsRateLimiter::new(true, false, 10.0, 500).unwrap();
-    /// assert!(limiter.allow_request("my_token"));
+    /// let limiter = FlagsRateLimiter::new(true, 10.0, None, 500, HashMap::new()).unwrap();
+    /// assert_eq!(limiter.allow_request("my_token"), RateLimitResult::Allowed);
     /// ```
     pub fn new(
         enabled: bool,
-        log_only: bool,
         replenish_rate: f64,
-        capacity: u32,
+        warn_capacity: Option<u32>,
+        enforce_capacity: u32,
+        custom_rates: HashMap<String, String>,
     ) -> anyhow::Result<Self> {
         let config = RateLimiterConfig {
             metric_name: "flags_rate_limit_exceeded_total",
@@ -192,138 +239,167 @@ impl FlagsRateLimiter {
             error_prefix: "Token rate limiter",
         };
 
-        let inner = KeyedRateLimiter::new(enabled, log_only, replenish_rate, capacity, config)?;
+        let inner = KeyedRateLimiter::new(
+            enabled,
+            replenish_rate,
+            warn_capacity,
+            enforce_capacity,
+            config,
+        )?;
 
-        Ok(Self { inner })
+        // Parse and create custom per-token limiters (enforce-only).
+        let mut custom_map = HashMap::new();
+        for (token, rate_string) in custom_rates {
+            match parse_rate_string(&rate_string) {
+                Ok(quota) => {
+                    let limiter = Arc::new(RateLimiter::dashmap(quota));
+                    custom_map.insert(token.clone(), limiter);
+                    tracing::info!(
+                        token = %token,
+                        rate = %rate_string,
+                        "Configured custom flags rate limit for token"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        token = %token,
+                        rate = %rate_string,
+                        error = %e,
+                        "Invalid rate string for token, ignoring custom rate"
+                    );
+                }
+            }
+        }
+
+        Ok(Self {
+            inner,
+            custom_limiters: custom_map,
+        })
     }
 
     /// Checks if a request should be allowed based on the rate limit.
     ///
-    /// Matches Python's DecideRateThrottle.allow_request() behavior with log-only mode support.
-    ///
-    /// # Arguments
-    ///
-    /// * `bucket_key` - The key to rate limit by (typically the token)
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if the request should be allowed, `false` if it should be rate limited.
-    ///
-    /// # Behavior
-    ///
-    /// - If rate limiting is disabled, always returns `true`
-    /// - Otherwise, checks the token bucket for the given key
-    /// - If rate limited and log-only mode:
-    ///   - Increments the `flags_rate_limit_exceeded_total` metric
-    ///   - Returns `true` (allows request to proceed)
-    /// - If rate limited and NOT log-only mode:
-    ///   - Increments the `flags_rate_limit_exceeded_total` metric
-    ///   - Returns `false` (blocks request)
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use feature_flags::api::flags_rate_limiter::FlagsRateLimiter;
-    ///
-    /// let limiter = FlagsRateLimiter::new(true, false, 1.0, 1).unwrap();
-    /// assert!(limiter.allow_request("token1"));  // First request allowed
-    /// assert!(!limiter.allow_request("token1")); // Second request blocked
-    /// assert!(limiter.allow_request("token2"));  // Different token allowed
-    /// ```
-    pub fn allow_request(&self, bucket_key: &str) -> bool {
+    /// Custom per-token limiters take precedence over the default limiter.
+    /// Custom limiters are enforce-only (return `Allowed` or `Blocked`).
+    pub fn allow_request(&self, bucket_key: &str) -> RateLimitResult {
+        if !self.inner.enabled {
+            return RateLimitResult::Allowed;
+        }
+
+        // Check for per-token custom limiter first
+        if let Some(limiter) = self.custom_limiters.get(bucket_key) {
+            let key_string = bucket_key.to_string();
+            if limiter.check_key(&key_string).is_err() {
+                counter!(
+                    self.inner.config.metric_name,
+                    self.inner.config.key_label => key_string,
+                    "mode" => "enforced"
+                )
+                .increment(1);
+                return RateLimitResult::Blocked;
+            }
+            return RateLimitResult::Allowed;
+        }
+
         self.inner.allow_request(bucket_key)
     }
 
     /// Removes stale entries and reclaims memory.
-    ///
-    /// This should be called periodically (e.g., every 60 seconds) by a background task.
-    /// Keys that haven't been used within the rate limit window are removed.
     pub fn cleanup(&self) {
         self.inner.retain_recent();
         self.inner.shrink_to_fit();
+
+        for limiter in self.custom_limiters.values() {
+            limiter.retain_recent();
+            limiter.shrink_to_fit();
+        }
     }
 
     /// Returns the approximate number of keys currently tracked.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        self.inner.len()
+        let mut total = self.inner.len();
+        for limiter in self.custom_limiters.values() {
+            total += limiter.len();
+        }
+        total
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::thread;
     use std::time::Duration;
 
+    fn default_limiter(
+        enabled: bool,
+        replenish_rate: f64,
+        warn_capacity: Option<u32>,
+        enforce_capacity: u32,
+    ) -> FlagsRateLimiter {
+        FlagsRateLimiter::new(
+            enabled,
+            replenish_rate,
+            warn_capacity,
+            enforce_capacity,
+            HashMap::new(),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn test_rate_limiter_disabled() {
-        let limiter = FlagsRateLimiter::new(false, false, 1.0, 1).unwrap();
+        let limiter = default_limiter(false, 1.0, None, 1);
 
-        // When disabled, all requests should be allowed
         for _ in 0..100 {
-            assert!(limiter.allow_request("test_token"));
+            assert_eq!(
+                limiter.allow_request("test_token"),
+                RateLimitResult::Allowed
+            );
         }
     }
 
     #[test]
     fn test_rate_limiter_basic_limiting() {
-        // Create limiter with capacity of 3
-        let limiter = FlagsRateLimiter::new(true, false, 0.1, 3).unwrap();
-
+        let limiter = default_limiter(true, 0.1, None, 3);
         let token = "test_token";
 
-        // First 3 requests should be allowed (burst capacity)
-        assert!(limiter.allow_request(token));
-        assert!(limiter.allow_request(token));
-        assert!(limiter.allow_request(token));
-
-        // 4th request should be blocked
-        assert!(!limiter.allow_request(token));
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
     }
 
     #[test]
     fn test_rate_limiter_replenishes_over_time() {
-        // Create limiter with 1 token/sec replenish rate and capacity of 1
-        let limiter = FlagsRateLimiter::new(true, false, 1.0, 1).unwrap();
-
+        let limiter = default_limiter(true, 1.0, None, 1);
         let token = "test_token";
 
-        // First request should be allowed
-        assert!(limiter.allow_request(token));
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
 
-        // Second request should be blocked
-        assert!(!limiter.allow_request(token));
-
-        // Wait for token to replenish (add buffer for timing)
         thread::sleep(Duration::from_millis(1100));
 
-        // Third request should be allowed after replenish
-        assert!(limiter.allow_request(token));
-
-        // Fourth request should be blocked again
-        assert!(!limiter.allow_request(token));
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
     }
 
     #[test]
     fn test_rate_limiter_per_token_isolation() {
-        // Create limiter with capacity of 1
-        let limiter = FlagsRateLimiter::new(true, false, 0.1, 1).unwrap();
+        let limiter = default_limiter(true, 0.1, None, 1);
 
-        // First token should be allowed
-        assert!(limiter.allow_request("token1"));
-        // First token second request should be blocked
-        assert!(!limiter.allow_request("token1"));
+        assert_eq!(limiter.allow_request("token1"), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request("token1"), RateLimitResult::Blocked);
 
-        // Second token should be allowed (different bucket)
-        assert!(limiter.allow_request("token2"));
-        // Second token second request should be blocked
-        assert!(!limiter.allow_request("token2"));
+        assert_eq!(limiter.allow_request("token2"), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request("token2"), RateLimitResult::Blocked);
     }
 
     #[test]
     fn test_rate_limiter_invalid_replenish_rate() {
-        let result = FlagsRateLimiter::new(true, false, 0.0, 500);
+        let result = FlagsRateLimiter::new(true, 0.0, None, 500, HashMap::new());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -333,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_rate_limiter_invalid_capacity() {
-        let result = FlagsRateLimiter::new(true, false, 10.0, 0);
+        let result = FlagsRateLimiter::new(true, 10.0, None, 0, HashMap::new());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -343,69 +419,110 @@ mod tests {
 
     #[test]
     fn test_rate_limiter_fractional_replenish_rate() {
-        // Test that fractional rates are properly rounded
-        let limiter = FlagsRateLimiter::new(true, false, 0.5, 1).unwrap();
+        let limiter = default_limiter(true, 0.5, None, 1);
 
-        // With 0.5 rounded to 1 token/sec, first request should be allowed
-        assert!(limiter.allow_request("test_token"));
-        // Second request should be blocked
-        assert!(!limiter.allow_request("test_token"));
+        assert_eq!(
+            limiter.allow_request("test_token"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("test_token"),
+            RateLimitResult::Blocked
+        );
     }
 
     #[test]
     fn test_rate_limiter_large_burst() {
-        // Test with larger burst capacity matching Python defaults
-        let limiter = FlagsRateLimiter::new(true, false, 10.0, 500).unwrap();
-
+        let limiter = default_limiter(true, 10.0, None, 500);
         let token = "test_token";
 
-        // Should allow up to 500 requests (burst capacity)
         for _ in 0..500 {
-            assert!(limiter.allow_request(token));
+            assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
         }
-
-        // 501st request should be blocked
-        assert!(!limiter.allow_request(token));
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
     }
 
     #[test]
-    fn test_rate_limiter_log_only_mode() {
-        // Create limiter with log-only mode enabled
-        let limiter = FlagsRateLimiter::new(true, true, 0.1, 2).unwrap();
-
+    fn test_warn_then_enforce() {
+        // warn_capacity=2, enforce_capacity=5
+        let limiter = default_limiter(true, 0.1, Some(2), 5);
         let token = "test_token";
 
-        // First 2 requests should be allowed (burst capacity)
-        assert!(limiter.allow_request(token));
-        assert!(limiter.allow_request(token));
+        // First 2 requests: within warn capacity → Allowed
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
 
-        // 3rd and 4th requests should also be allowed due to log-only mode
-        // (normally these would be blocked)
-        assert!(limiter.allow_request(token));
-        assert!(limiter.allow_request(token));
+        // Requests 3-5: exceed warn but within enforce → Warned
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+
+        // Request 6: exceeds enforce → Blocked
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
     }
 
     #[test]
-    fn test_rate_limiter_log_only_consumes_tokens() {
-        // Verify that log-only mode still consumes tokens from the bucket
-        let limiter = FlagsRateLimiter::new(true, true, 1.0, 1).unwrap();
-
+    fn test_no_warn_limiter_only_allowed_or_blocked() {
+        let limiter = default_limiter(true, 0.1, None, 2);
         let token = "test_token";
 
-        // First request consumes the token
-        assert!(limiter.allow_request(token));
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Blocked);
+    }
 
-        // Second request would be blocked normally, but log-only allows it
-        assert!(limiter.allow_request(token));
+    #[test]
+    fn test_custom_rate_overrides_default() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert("custom_token".to_string(), "1/second".to_string());
 
-        // Wait for replenishment
-        thread::sleep(Duration::from_millis(1100));
+        let limiter = FlagsRateLimiter::new(true, 0.1, Some(2), 5, custom_rates).unwrap();
 
-        // After replenishment, we have 1 token again
-        assert!(limiter.allow_request(token));
+        // Custom token uses its own limiter (capacity=1)
+        assert_eq!(
+            limiter.allow_request("custom_token"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("custom_token"),
+            RateLimitResult::Blocked
+        );
 
-        // This would be blocked normally, but log-only allows it
-        assert!(limiter.allow_request(token));
+        // Default token uses the default limiter (warn=2, enforce=5)
+        assert_eq!(
+            limiter.allow_request("default_token"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("default_token"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("default_token"),
+            RateLimitResult::Warned
+        );
+    }
+
+    #[test]
+    fn test_invalid_custom_rate_is_ignored() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert("bad_token".to_string(), "invalid".to_string());
+        custom_rates.insert("good_token".to_string(), "1/second".to_string());
+
+        let limiter = FlagsRateLimiter::new(true, 0.1, None, 5, custom_rates).unwrap();
+
+        // bad_token falls through to default limiter
+        assert_eq!(limiter.allow_request("bad_token"), RateLimitResult::Allowed);
+
+        // good_token uses custom limiter
+        assert_eq!(
+            limiter.allow_request("good_token"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("good_token"),
+            RateLimitResult::Blocked
+        );
     }
 }
 
@@ -424,27 +541,23 @@ impl IpRateLimiter {
     /// # Arguments
     ///
     /// * `enabled` - Whether IP rate limiting is enabled
-    /// * `log_only` - Whether to log violations without blocking (for safe rollout)
     /// * `replenish_rate` - Requests per second per IP
-    /// * `burst_size` - Maximum burst size per IP
-    ///
-    /// # Returns
-    ///
-    /// Returns an error if the replenish rate or burst size are invalid.
+    /// * `warn_capacity` - Warn threshold (None = no warn tier)
+    /// * `enforce_capacity` - Hard limit burst size per IP
     ///
     /// # Example
     ///
     /// ```
-    /// use feature_flags::api::flags_rate_limiter::IpRateLimiter;
+    /// use feature_flags::api::flags_rate_limiter::{IpRateLimiter, RateLimitResult};
     ///
-    /// let limiter = IpRateLimiter::new(true, false, 20.0, 100).unwrap();
-    /// assert!(limiter.allow_request("192.168.1.1"));
+    /// let limiter = IpRateLimiter::new(true, 20.0, None, 100).unwrap();
+    /// assert_eq!(limiter.allow_request("192.168.1.1"), RateLimitResult::Allowed);
     /// ```
     pub fn new(
         enabled: bool,
-        log_only: bool,
         replenish_rate: f64,
-        burst_size: u32,
+        warn_capacity: Option<u32>,
+        enforce_capacity: u32,
     ) -> anyhow::Result<Self> {
         let config = RateLimiterConfig {
             metric_name: "flags_ip_rate_limit_exceeded_total",
@@ -452,48 +565,23 @@ impl IpRateLimiter {
             error_prefix: "IP rate limiter",
         };
 
-        let inner = KeyedRateLimiter::new(enabled, log_only, replenish_rate, burst_size, config)?;
+        let inner = KeyedRateLimiter::new(
+            enabled,
+            replenish_rate,
+            warn_capacity,
+            enforce_capacity,
+            config,
+        )?;
 
         Ok(Self { inner })
     }
 
     /// Checks if a request from the given IP should be allowed.
-    ///
-    /// # Arguments
-    ///
-    /// * `ip` - The IP address to rate limit by
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if the request should be allowed, `false` if it should be rate limited.
-    ///
-    /// # Behavior
-    ///
-    /// - If IP rate limiting is disabled, always returns `true`
-    /// - Otherwise, checks the token bucket for the given IP
-    /// - If rate limited and log-only mode:
-    ///   - Increments the `flags_ip_rate_limit_exceeded_total` metric
-    ///   - Returns `true` (allows request to proceed)
-    /// - If rate limited and NOT log-only mode:
-    ///   - Increments the `flags_ip_rate_limit_exceeded_total` metric
-    ///   - Returns `false` (blocks request)
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use feature_flags::api::flags_rate_limiter::IpRateLimiter;
-    ///
-    /// let limiter = IpRateLimiter::new(true, false, 10.0, 5).unwrap();
-    /// assert!(limiter.allow_request("192.168.1.1"));
-    /// ```
-    pub fn allow_request(&self, ip: &str) -> bool {
+    pub fn allow_request(&self, ip: &str) -> RateLimitResult {
         self.inner.allow_request(ip)
     }
 
     /// Removes stale entries and reclaims memory.
-    ///
-    /// This should be called periodically (e.g., every 60 seconds) by a background task.
-    /// Keys that haven't been used within the rate limit window are removed.
     pub fn cleanup(&self) {
         self.inner.retain_recent();
         self.inner.shrink_to_fit();
@@ -514,78 +602,78 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_disabled() {
-        let limiter = IpRateLimiter::new(false, false, 1.0, 1).unwrap();
+        let limiter = IpRateLimiter::new(false, 1.0, None, 1).unwrap();
 
-        // When disabled, all requests should be allowed
         for _ in 0..100 {
-            assert!(limiter.allow_request("192.168.1.1"));
+            assert_eq!(
+                limiter.allow_request("192.168.1.1"),
+                RateLimitResult::Allowed
+            );
         }
     }
 
     #[test]
     fn test_ip_rate_limiter_basic_limiting() {
-        let limiter = IpRateLimiter::new(true, false, 0.1, 3).unwrap();
+        let limiter = IpRateLimiter::new(true, 0.1, None, 3).unwrap();
         let ip = "192.168.1.1";
 
-        // First 3 requests should be allowed (burst size)
-        assert!(limiter.allow_request(ip));
-        assert!(limiter.allow_request(ip));
-        assert!(limiter.allow_request(ip));
-
-        // 4th request should be blocked
-        assert!(!limiter.allow_request(ip));
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Blocked);
     }
 
     #[test]
     fn test_ip_rate_limiter_per_ip_isolation() {
-        let limiter = IpRateLimiter::new(true, false, 0.1, 1).unwrap();
+        let limiter = IpRateLimiter::new(true, 0.1, None, 1).unwrap();
 
-        // First IP should be allowed
-        assert!(limiter.allow_request("192.168.1.1"));
-        // First IP second request should be blocked
-        assert!(!limiter.allow_request("192.168.1.1"));
+        assert_eq!(
+            limiter.allow_request("192.168.1.1"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("192.168.1.1"),
+            RateLimitResult::Blocked
+        );
 
-        // Second IP should be allowed (different bucket)
-        assert!(limiter.allow_request("192.168.1.2"));
-        // Second IP second request should be blocked
-        assert!(!limiter.allow_request("192.168.1.2"));
+        assert_eq!(
+            limiter.allow_request("192.168.1.2"),
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.allow_request("192.168.1.2"),
+            RateLimitResult::Blocked
+        );
     }
 
     #[test]
     fn test_ip_rate_limiter_replenishes() {
-        let limiter = IpRateLimiter::new(true, false, 1.0, 1).unwrap();
+        let limiter = IpRateLimiter::new(true, 1.0, None, 1).unwrap();
         let ip = "192.168.1.1";
 
-        // First request allowed
-        assert!(limiter.allow_request(ip));
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Blocked);
 
-        // Second request blocked
-        assert!(!limiter.allow_request(ip));
-
-        // Wait for replenishment
         thread::sleep(Duration::from_millis(1100));
 
-        // Third request allowed after replenishment
-        assert!(limiter.allow_request(ip));
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
     }
 
     #[test]
-    fn test_ip_rate_limiter_log_only_mode() {
-        let limiter = IpRateLimiter::new(true, true, 0.1, 2).unwrap();
+    fn test_ip_rate_limiter_warn_then_enforce() {
+        let limiter = IpRateLimiter::new(true, 0.1, Some(2), 4).unwrap();
         let ip = "192.168.1.1";
 
-        // First 2 requests allowed (burst size)
-        assert!(limiter.allow_request(ip));
-        assert!(limiter.allow_request(ip));
-
-        // 3rd and 4th requests also allowed due to log-only mode
-        assert!(limiter.allow_request(ip));
-        assert!(limiter.allow_request(ip));
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(ip), RateLimitResult::Blocked);
     }
 
     #[test]
     fn test_ip_rate_limiter_invalid_burst_size() {
-        let result = IpRateLimiter::new(true, false, 10.0, 0);
+        let result = IpRateLimiter::new(true, 10.0, None, 0);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -595,7 +683,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_invalid_replenish_rate() {
-        let result = IpRateLimiter::new(true, false, 0.0, 100);
+        let result = IpRateLimiter::new(true, 0.0, None, 100);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -92,6 +92,9 @@ struct KeyedRateLimiter {
     enforce_limiter: GovernorLimiter,
     /// The warn-tier limiter (present only when warn capacity is configured)
     warn_limiter: Option<GovernorLimiter>,
+    /// When true, enforce rejections become warnings (never returns Blocked).
+    /// Used for legacy log-only backwards compatibility.
+    warn_only: bool,
     /// Configuration for metrics and logging
     config: RateLimiterConfig,
 }
@@ -102,24 +105,34 @@ impl KeyedRateLimiter {
     /// - `warn_capacity`: If `Some`, a second limiter is created at this (lower) capacity.
     ///   Requests that exceed it return `Warned`. If `None`, there is no warn tier.
     /// - `enforce_capacity`: Hard limit. Requests that exceed it return `Blocked`.
+    /// - `warn_only`: When true, enforce rejections become warnings (legacy log-only compat).
     fn new(
         enabled: bool,
         replenish_rate: f64,
         warn_capacity: Option<u32>,
         enforce_capacity: u32,
+        warn_only: bool,
         config: RateLimiterConfig,
     ) -> anyhow::Result<Self> {
         let enforce_limiter = build_limiter(replenish_rate, enforce_capacity, config.error_prefix)?;
 
         let warn_limiter = match warn_capacity {
-            Some(cap) if cap > 0 => Some(build_limiter(replenish_rate, cap, config.error_prefix)?),
-            _ => None,
+            Some(0) => {
+                tracing::warn!(
+                    limiter = %config.error_prefix,
+                    "Warn capacity is 0, which is equivalent to no warn tier"
+                );
+                None
+            }
+            Some(cap) => Some(build_limiter(replenish_rate, cap, config.error_prefix)?),
+            None => None,
         };
 
         Ok(Self {
             enabled,
             enforce_limiter,
             warn_limiter,
+            warn_only,
             config,
         })
     }
@@ -144,6 +157,16 @@ impl KeyedRateLimiter {
             .is_none_or(|wl| wl.check_key(&key_string).is_ok());
 
         if !enforce_ok {
+            if self.warn_only {
+                // Legacy log-only compat: never block, only warn
+                counter!(
+                    self.config.metric_name,
+                    self.config.key_label => key_string,
+                    "mode" => "warned"
+                )
+                .increment(1);
+                return RateLimitResult::Warned;
+            }
             counter!(
                 self.config.metric_name,
                 self.config.key_label => key_string,
@@ -160,7 +183,7 @@ impl KeyedRateLimiter {
                 "mode" => "warned"
             )
             .increment(1);
-            tracing::warn!(
+            tracing::debug!(
                 key = %key_string,
                 limiter = %self.config.error_prefix,
                 "Rate limit warning threshold exceeded"
@@ -193,6 +216,18 @@ impl KeyedRateLimiter {
     }
 }
 
+/// Maximum number of per-token rate limit overrides allowed.
+/// Prevents excessive memory usage and cleanup overhead from large configs.
+const MAX_CUSTOM_RATE_OVERRIDES: usize = 100;
+
+/// Redacts a token for safe logging, showing only a prefix and suffix.
+fn redact_token(token: &str) -> String {
+    if token.len() <= 8 {
+        return "***".to_string();
+    }
+    format!("{}…{}", &token[..4], &token[token.len() - 4..])
+}
+
 /// Token bucket rate limiter for feature flag requests.
 ///
 /// Uses the governor crate to implement a per-key (token) rate limiter.
@@ -203,7 +238,8 @@ impl KeyedRateLimiter {
 pub struct FlagsRateLimiter {
     inner: KeyedRateLimiter,
     /// Per-token custom rate limiters (enforce-only, no warn tier).
-    custom_limiters: HashMap<String, GovernorLimiter>,
+    /// Wrapped in Arc for O(1) clone since the map is immutable after construction.
+    custom_limiters: Arc<HashMap<String, GovernorLimiter>>,
 }
 
 impl FlagsRateLimiter {
@@ -215,6 +251,7 @@ impl FlagsRateLimiter {
     /// * `replenish_rate` - Tokens added per second
     /// * `warn_capacity` - Warn threshold bucket size (None = no warn tier)
     /// * `enforce_capacity` - Hard limit bucket size
+    /// * `warn_only` - When true, never returns Blocked (legacy log-only compat)
     /// * `custom_rates` - Per-token rate overrides (e.g., `{"phc_abc": "1200/minute"}`)
     ///
     /// # Example
@@ -223,7 +260,7 @@ impl FlagsRateLimiter {
     /// use feature_flags::api::flags_rate_limiter::{FlagsRateLimiter, RateLimitResult};
     /// use std::collections::HashMap;
     ///
-    /// let limiter = FlagsRateLimiter::new(true, 10.0, None, 500, HashMap::new()).unwrap();
+    /// let limiter = FlagsRateLimiter::new(true, 10.0, None, 500, false, HashMap::new()).unwrap();
     /// assert_eq!(limiter.allow_request("my_token"), RateLimitResult::Allowed);
     /// ```
     pub fn new(
@@ -231,8 +268,17 @@ impl FlagsRateLimiter {
         replenish_rate: f64,
         warn_capacity: Option<u32>,
         enforce_capacity: u32,
+        warn_only: bool,
         custom_rates: HashMap<String, String>,
     ) -> anyhow::Result<Self> {
+        if custom_rates.len() > MAX_CUSTOM_RATE_OVERRIDES {
+            return Err(anyhow::anyhow!(
+                "Too many custom rate overrides: {} (max {})",
+                custom_rates.len(),
+                MAX_CUSTOM_RATE_OVERRIDES
+            ));
+        }
+
         let config = RateLimiterConfig {
             metric_name: "flags_rate_limit_exceeded_total",
             key_label: "token",
@@ -244,25 +290,26 @@ impl FlagsRateLimiter {
             replenish_rate,
             warn_capacity,
             enforce_capacity,
+            warn_only,
             config,
         )?;
 
         // Parse and create custom per-token limiters (enforce-only).
         let mut custom_map = HashMap::new();
-        for (token, rate_string) in custom_rates {
-            match parse_rate_string(&rate_string) {
+        for (token, rate_string) in &custom_rates {
+            match parse_rate_string(rate_string) {
                 Ok(quota) => {
                     let limiter = Arc::new(RateLimiter::dashmap(quota));
                     custom_map.insert(token.clone(), limiter);
                     tracing::info!(
-                        token = %token,
+                        token = %redact_token(token),
                         rate = %rate_string,
                         "Configured custom flags rate limit for token"
                     );
                 }
                 Err(e) => {
                     tracing::warn!(
-                        token = %token,
+                        token = %redact_token(token),
                         rate = %rate_string,
                         error = %e,
                         "Invalid rate string for token, ignoring custom rate"
@@ -271,9 +318,16 @@ impl FlagsRateLimiter {
             }
         }
 
+        if !custom_map.is_empty() {
+            tracing::info!(
+                count = custom_map.len(),
+                "Loaded custom rate limit overrides"
+            );
+        }
+
         Ok(Self {
             inner,
-            custom_limiters: custom_map,
+            custom_limiters: Arc::new(custom_map),
         })
     }
 
@@ -344,6 +398,7 @@ mod tests {
             replenish_rate,
             warn_capacity,
             enforce_capacity,
+            false,
             HashMap::new(),
         )
         .unwrap()
@@ -399,7 +454,7 @@ mod tests {
 
     #[test]
     fn test_rate_limiter_invalid_replenish_rate() {
-        let result = FlagsRateLimiter::new(true, 0.0, None, 500, HashMap::new());
+        let result = FlagsRateLimiter::new(true, 0.0, None, 500, false, HashMap::new());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -409,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_rate_limiter_invalid_capacity() {
-        let result = FlagsRateLimiter::new(true, 10.0, None, 0, HashMap::new());
+        let result = FlagsRateLimiter::new(true, 10.0, None, 0, false, HashMap::new());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -476,7 +531,7 @@ mod tests {
         let mut custom_rates = HashMap::new();
         custom_rates.insert("custom_token".to_string(), "1/second".to_string());
 
-        let limiter = FlagsRateLimiter::new(true, 0.1, Some(2), 5, custom_rates).unwrap();
+        let limiter = FlagsRateLimiter::new(true, 0.1, Some(2), 5, false, custom_rates).unwrap();
 
         // Custom token uses its own limiter (capacity=1)
         assert_eq!(
@@ -509,7 +564,7 @@ mod tests {
         custom_rates.insert("bad_token".to_string(), "invalid".to_string());
         custom_rates.insert("good_token".to_string(), "1/second".to_string());
 
-        let limiter = FlagsRateLimiter::new(true, 0.1, None, 5, custom_rates).unwrap();
+        let limiter = FlagsRateLimiter::new(true, 0.1, None, 5, false, custom_rates).unwrap();
 
         // bad_token falls through to default limiter
         assert_eq!(limiter.allow_request("bad_token"), RateLimitResult::Allowed);
@@ -523,6 +578,44 @@ mod tests {
             limiter.allow_request("good_token"),
             RateLimitResult::Blocked
         );
+    }
+
+    #[test]
+    fn test_warn_only_mode_never_blocks() {
+        let limiter = FlagsRateLimiter::new(true, 0.1, Some(2), 5, true, HashMap::new()).unwrap();
+        let token = "test_token";
+
+        // First 2: within warn capacity → Allowed
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Allowed);
+
+        // 3-5: exceed warn → Warned
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+
+        // Request 6+: exceed enforce → still Warned (never Blocked in warn_only mode)
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+        assert_eq!(limiter.allow_request(token), RateLimitResult::Warned);
+    }
+
+    #[test]
+    fn test_too_many_custom_overrides_rejected() {
+        let mut custom_rates = HashMap::new();
+        for i in 0..=MAX_CUSTOM_RATE_OVERRIDES {
+            custom_rates.insert(format!("token_{i}"), "10/second".to_string());
+        }
+        let result = FlagsRateLimiter::new(true, 10.0, None, 500, false, custom_rates);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Too many"));
+    }
+
+    #[test]
+    fn test_redact_token() {
+        assert_eq!(redact_token("short"), "***");
+        assert_eq!(redact_token("phc_abcdefghijklmnop"), "phc_…mnop");
+        assert_eq!(redact_token("12345678"), "***");
+        assert_eq!(redact_token("123456789"), "1234…6789");
     }
 }
 
@@ -544,13 +637,14 @@ impl IpRateLimiter {
     /// * `replenish_rate` - Requests per second per IP
     /// * `warn_capacity` - Warn threshold (None = no warn tier)
     /// * `enforce_capacity` - Hard limit burst size per IP
+    /// * `warn_only` - When true, never returns Blocked (legacy log-only compat)
     ///
     /// # Example
     ///
     /// ```
     /// use feature_flags::api::flags_rate_limiter::{IpRateLimiter, RateLimitResult};
     ///
-    /// let limiter = IpRateLimiter::new(true, 20.0, None, 100).unwrap();
+    /// let limiter = IpRateLimiter::new(true, 20.0, None, 100, false).unwrap();
     /// assert_eq!(limiter.allow_request("192.168.1.1"), RateLimitResult::Allowed);
     /// ```
     pub fn new(
@@ -558,6 +652,7 @@ impl IpRateLimiter {
         replenish_rate: f64,
         warn_capacity: Option<u32>,
         enforce_capacity: u32,
+        warn_only: bool,
     ) -> anyhow::Result<Self> {
         let config = RateLimiterConfig {
             metric_name: "flags_ip_rate_limit_exceeded_total",
@@ -570,6 +665,7 @@ impl IpRateLimiter {
             replenish_rate,
             warn_capacity,
             enforce_capacity,
+            warn_only,
             config,
         )?;
 
@@ -602,7 +698,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_disabled() {
-        let limiter = IpRateLimiter::new(false, 1.0, None, 1).unwrap();
+        let limiter = IpRateLimiter::new(false, 1.0, None, 1, false).unwrap();
 
         for _ in 0..100 {
             assert_eq!(
@@ -614,7 +710,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_basic_limiting() {
-        let limiter = IpRateLimiter::new(true, 0.1, None, 3).unwrap();
+        let limiter = IpRateLimiter::new(true, 0.1, None, 3, false).unwrap();
         let ip = "192.168.1.1";
 
         assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
@@ -625,7 +721,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_per_ip_isolation() {
-        let limiter = IpRateLimiter::new(true, 0.1, None, 1).unwrap();
+        let limiter = IpRateLimiter::new(true, 0.1, None, 1, false).unwrap();
 
         assert_eq!(
             limiter.allow_request("192.168.1.1"),
@@ -648,7 +744,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_replenishes() {
-        let limiter = IpRateLimiter::new(true, 1.0, None, 1).unwrap();
+        let limiter = IpRateLimiter::new(true, 1.0, None, 1, false).unwrap();
         let ip = "192.168.1.1";
 
         assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
@@ -661,7 +757,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_warn_then_enforce() {
-        let limiter = IpRateLimiter::new(true, 0.1, Some(2), 4).unwrap();
+        let limiter = IpRateLimiter::new(true, 0.1, Some(2), 4, false).unwrap();
         let ip = "192.168.1.1";
 
         assert_eq!(limiter.allow_request(ip), RateLimitResult::Allowed);
@@ -673,7 +769,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_invalid_burst_size() {
-        let result = IpRateLimiter::new(true, 10.0, None, 0);
+        let result = IpRateLimiter::new(true, 10.0, None, 0, false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -683,7 +779,7 @@ mod ip_rate_limiter_tests {
 
     #[test]
     fn test_ip_rate_limiter_invalid_replenish_rate() {
-        let result = IpRateLimiter::new(true, 0.0, None, 100);
+        let result = IpRateLimiter::new(true, 0.0, None, 100, false);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -217,8 +217,8 @@ impl KeyedRateLimiter {
 }
 
 /// Maximum number of per-token rate limit overrides allowed.
-/// Prevents excessive memory usage and cleanup overhead from large configs.
-const MAX_CUSTOM_RATE_OVERRIDES: usize = 100;
+/// Reuses the config-level constant to keep both checks in sync.
+const MAX_CUSTOM_RATE_OVERRIDES: usize = crate::config::MAX_FLAGS_RATE_LIMIT_OVERRIDES;
 
 /// Redacts a token for safe logging, showing only a prefix and suffix.
 fn redact_token(token: &str) -> String {

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -163,8 +163,9 @@ impl FromStr for FlagsTokenRateLimitOverrides {
             return Ok(FlagsTokenRateLimitOverrides::default());
         }
 
-        let parsed: HashMap<String, String> = serde_json::from_str(s)
-            .map_err(|e| format!("Failed to parse FLAGS_TOKEN_RATE_LIMIT_OVERRIDES as JSON: {e}"))?;
+        let parsed: HashMap<String, String> = serde_json::from_str(s).map_err(|e| {
+            format!("Failed to parse FLAGS_TOKEN_RATE_LIMIT_OVERRIDES as JSON: {e}")
+        })?;
 
         if parsed.len() > MAX_FLAGS_RATE_LIMIT_OVERRIDES {
             return Err(format!(

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -164,11 +164,11 @@ impl FromStr for FlagsTokenRateLimitOverrides {
         }
 
         let parsed: HashMap<String, String> = serde_json::from_str(s)
-            .map_err(|e| format!("Failed to parse flags rate limits as JSON: {e}"))?;
+            .map_err(|e| format!("Failed to parse FLAGS_TOKEN_RATE_LIMIT_OVERRIDES as JSON: {e}"))?;
 
         if parsed.len() > MAX_FLAGS_RATE_LIMIT_OVERRIDES {
             return Err(format!(
-                "Too many flags rate limit overrides: {} (max {MAX_FLAGS_RATE_LIMIT_OVERRIDES})",
+                "Too many FLAGS_TOKEN_RATE_LIMIT_OVERRIDES entries: {} (max {MAX_FLAGS_RATE_LIMIT_OVERRIDES})",
                 parsed.len()
             ));
         }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -150,6 +150,9 @@ impl FromStr for FlagDefinitionsRateLimits {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FlagsRateLimits(pub HashMap<String, String>);
 
+/// Maximum number of per-token rate limit overrides allowed.
+const MAX_FLAGS_RATE_LIMIT_OVERRIDES: usize = 100;
+
 impl FromStr for FlagsRateLimits {
     type Err = String;
 
@@ -162,6 +165,13 @@ impl FromStr for FlagsRateLimits {
 
         let parsed: HashMap<String, String> = serde_json::from_str(s)
             .map_err(|e| format!("Failed to parse flags rate limits as JSON: {e}"))?;
+
+        if parsed.len() > MAX_FLAGS_RATE_LIMIT_OVERRIDES {
+            return Err(format!(
+                "Too many flags rate limit overrides: {} (max {MAX_FLAGS_RATE_LIMIT_OVERRIDES})",
+                parsed.len()
+            ));
+        }
 
         Ok(FlagsRateLimits(parsed))
     }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -151,7 +151,7 @@ impl FromStr for FlagDefinitionsRateLimits {
 pub struct FlagsRateLimits(pub HashMap<String, String>);
 
 /// Maximum number of per-token rate limit overrides allowed.
-const MAX_FLAGS_RATE_LIMIT_OVERRIDES: usize = 100;
+pub const MAX_FLAGS_RATE_LIMIT_OVERRIDES: usize = 100;
 
 impl FromStr for FlagsRateLimits {
     type Err = String;

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -144,23 +144,23 @@ impl FromStr for FlagDefinitionsRateLimits {
 }
 
 /// Per-token rate limit overrides for the /flags endpoint.
-/// Parses JSON from FLAGS_RATE_LIMITS_JSON environment variable.
+/// Parses JSON from FLAGS_TOKEN_RATE_LIMIT_OVERRIDES environment variable.
 /// Format: {"token_string": "rate_string", ...}
 /// Example: {"phc_abc123": "1200/minute", "phc_xyz789": "2400/hour"}
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct FlagsRateLimits(pub HashMap<String, String>);
+pub struct FlagsTokenRateLimitOverrides(pub HashMap<String, String>);
 
 /// Maximum number of per-token rate limit overrides allowed.
 pub const MAX_FLAGS_RATE_LIMIT_OVERRIDES: usize = 100;
 
-impl FromStr for FlagsRateLimits {
+impl FromStr for FlagsTokenRateLimitOverrides {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
 
         if s.is_empty() {
-            return Ok(FlagsRateLimits::default());
+            return Ok(FlagsTokenRateLimitOverrides::default());
         }
 
         let parsed: HashMap<String, String> = serde_json::from_str(s)
@@ -173,7 +173,7 @@ impl FromStr for FlagsRateLimits {
             ));
         }
 
-        Ok(FlagsRateLimits(parsed))
+        Ok(FlagsTokenRateLimitOverrides(parsed))
     }
 }
 
@@ -455,13 +455,6 @@ pub struct Config {
     #[envconfig(from = "FLAGS_BUCKET_REPLENISH_RATE", default = "10.0")]
     pub flags_bucket_replenish_rate: f64,
 
-    // Warn-tier bucket capacity for token-based rate limiting.
-    // When > 0, enables two-tier warn-then-enforce model. Requests that exceed this
-    // capacity (but are below FLAGS_BUCKET_CAPACITY) get a warning header.
-    // 0 = no warn tier (backwards-compatible behavior).
-    #[envconfig(from = "FLAGS_BUCKET_WARN_CAPACITY", default = "0")]
-    pub flags_bucket_warn_capacity: u32,
-
     // IP-based rate limiting configuration
     // Provides defense-in-depth against DDoS attacks with rotating fake tokens
     // This limits ALL requests per IP address, regardless of token validity
@@ -477,30 +470,29 @@ pub struct Config {
     #[envconfig(from = "FLAGS_IP_REPLENISH_RATE", default = "50.0")]
     pub flags_ip_replenish_rate: f64,
 
-    // Warn-tier burst size for IP-based rate limiting.
-    // When > 0, enables two-tier warn-then-enforce model. Requests that exceed this
-    // capacity (but are below FLAGS_IP_BURST_SIZE) get a warning header.
-    // 0 = no warn tier (backwards-compatible behavior).
-    #[envconfig(from = "FLAGS_IP_WARN_BURST_SIZE", default = "0")]
-    pub flags_ip_warn_burst_size: u32,
+    // Warn-tier ratio: the warn threshold is derived as this fraction of the enforce
+    // capacity for both token and IP limiters. E.g., 0.8 means warn at 80% of enforce.
+    // Set to 0.0 to disable the warn tier entirely.
+    #[envconfig(from = "FLAGS_WARN_CAPACITY_RATIO", default = "0.8")]
+    pub flags_warn_capacity_ratio: f64,
 
     // Log-only mode for rate limiting (defaults to true for safe rollout)
     // When true, rate limits are checked and violations logged, but requests are not blocked
     // This allows gathering metrics to tune limits before enforcing them
-    // DEPRECATED: use FLAGS_BUCKET_WARN_CAPACITY for the new warn-then-enforce model
+    // DEPRECATED: set FLAGS_RATE_LIMIT_LOG_ONLY=false and use FLAGS_WARN_CAPACITY_RATIO instead
     #[envconfig(from = "FLAGS_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_rate_limit_log_only: FlexBool,
 
     // Log-only mode for IP-based rate limiting (defaults to true for safe rollout)
-    // DEPRECATED: use FLAGS_IP_WARN_BURST_SIZE for the new warn-then-enforce model
+    // DEPRECATED: set FLAGS_IP_RATE_LIMIT_LOG_ONLY=false and use FLAGS_WARN_CAPACITY_RATIO instead
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_ip_rate_limit_log_only: FlexBool,
 
     // Per-token rate limit overrides for the /flags endpoint
     // JSON format: {"token_string": "rate_string", ...}
     // Example: {"phc_abc123": "1200/minute", "phc_xyz789": "2400/hour"}
-    #[envconfig(from = "FLAGS_RATE_LIMITS_JSON", default = "")]
-    pub flags_rate_limits: FlagsRateLimits,
+    #[envconfig(from = "FLAGS_TOKEN_RATE_LIMIT_OVERRIDES", default = "")]
+    pub flags_token_rate_limit_overrides: FlagsTokenRateLimitOverrides,
 
     // How often to clean up stale rate limiter entries (seconds)
     // The governor crate's keyed rate limiters accumulate entries for every unique key.
@@ -747,14 +739,13 @@ impl Config {
             flags_rate_limit_enabled: FlexBool(false),
             flags_bucket_capacity: 500,
             flags_bucket_replenish_rate: 10.0,
-            flags_bucket_warn_capacity: 0,
             flags_ip_rate_limit_enabled: FlexBool(false),
             flags_ip_burst_size: 500,
             flags_ip_replenish_rate: 100.0,
-            flags_ip_warn_burst_size: 0,
+            flags_warn_capacity_ratio: 0.8,
             flags_rate_limit_log_only: FlexBool(true),
             flags_ip_rate_limit_log_only: FlexBool(true),
-            flags_rate_limits: FlagsRateLimits::default(),
+            flags_token_rate_limit_overrides: FlagsTokenRateLimitOverrides::default(),
             rate_limiter_cleanup_interval_secs: 60,
             redis_compression_enabled: FlexBool(true),
             redis_client_retry_count: 3,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -143,6 +143,30 @@ impl FromStr for FlagDefinitionsRateLimits {
     }
 }
 
+/// Per-token rate limit overrides for the /flags endpoint.
+/// Parses JSON from FLAGS_RATE_LIMITS_JSON environment variable.
+/// Format: {"token_string": "rate_string", ...}
+/// Example: {"phc_abc123": "1200/minute", "phc_xyz789": "2400/hour"}
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FlagsRateLimits(pub HashMap<String, String>);
+
+impl FromStr for FlagsRateLimits {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
+        if s.is_empty() {
+            return Ok(FlagsRateLimits::default());
+        }
+
+        let parsed: HashMap<String, String> = serde_json::from_str(s)
+            .map_err(|e| format!("Failed to parse flags rate limits as JSON: {e}"))?;
+
+        Ok(FlagsRateLimits(parsed))
+    }
+}
+
 #[derive(Envconfig, Clone, Debug)]
 pub struct Config {
     #[envconfig(nested = true)]
@@ -411,7 +435,7 @@ pub struct Config {
     #[envconfig(from = "FLAGS_RATE_LIMIT_ENABLED", default = "false")]
     pub flags_rate_limit_enabled: FlexBool,
 
-    // Token bucket capacity (maximum burst size)
+    // Token bucket capacity (maximum burst size / enforce threshold)
     // Matches Python's DecideRateThrottle default of 500
     #[envconfig(from = "FLAGS_BUCKET_CAPACITY", default = "500")]
     pub flags_bucket_capacity: u32,
@@ -421,13 +445,20 @@ pub struct Config {
     #[envconfig(from = "FLAGS_BUCKET_REPLENISH_RATE", default = "10.0")]
     pub flags_bucket_replenish_rate: f64,
 
+    // Warn-tier bucket capacity for token-based rate limiting.
+    // When > 0, enables two-tier warn-then-enforce model. Requests that exceed this
+    // capacity (but are below FLAGS_BUCKET_CAPACITY) get a warning header.
+    // 0 = no warn tier (backwards-compatible behavior).
+    #[envconfig(from = "FLAGS_BUCKET_WARN_CAPACITY", default = "0")]
+    pub flags_bucket_warn_capacity: u32,
+
     // IP-based rate limiting configuration
     // Provides defense-in-depth against DDoS attacks with rotating fake tokens
     // This limits ALL requests per IP address, regardless of token validity
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_ENABLED", default = "false")]
     pub flags_ip_rate_limit_enabled: FlexBool,
 
-    // IP rate limit burst size (maximum requests per IP in a burst)
+    // IP rate limit burst size (maximum requests per IP / enforce threshold)
     #[envconfig(from = "FLAGS_IP_BURST_SIZE", default = "1000")]
     pub flags_ip_burst_size: u32,
 
@@ -436,15 +467,30 @@ pub struct Config {
     #[envconfig(from = "FLAGS_IP_REPLENISH_RATE", default = "50.0")]
     pub flags_ip_replenish_rate: f64,
 
+    // Warn-tier burst size for IP-based rate limiting.
+    // When > 0, enables two-tier warn-then-enforce model. Requests that exceed this
+    // capacity (but are below FLAGS_IP_BURST_SIZE) get a warning header.
+    // 0 = no warn tier (backwards-compatible behavior).
+    #[envconfig(from = "FLAGS_IP_WARN_BURST_SIZE", default = "0")]
+    pub flags_ip_warn_burst_size: u32,
+
     // Log-only mode for rate limiting (defaults to true for safe rollout)
     // When true, rate limits are checked and violations logged, but requests are not blocked
     // This allows gathering metrics to tune limits before enforcing them
+    // DEPRECATED: use FLAGS_BUCKET_WARN_CAPACITY for the new warn-then-enforce model
     #[envconfig(from = "FLAGS_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_rate_limit_log_only: FlexBool,
 
     // Log-only mode for IP-based rate limiting (defaults to true for safe rollout)
+    // DEPRECATED: use FLAGS_IP_WARN_BURST_SIZE for the new warn-then-enforce model
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_ip_rate_limit_log_only: FlexBool,
+
+    // Per-token rate limit overrides for the /flags endpoint
+    // JSON format: {"token_string": "rate_string", ...}
+    // Example: {"phc_abc123": "1200/minute", "phc_xyz789": "2400/hour"}
+    #[envconfig(from = "FLAGS_RATE_LIMITS_JSON", default = "")]
+    pub flags_rate_limits: FlagsRateLimits,
 
     // How often to clean up stale rate limiter entries (seconds)
     // The governor crate's keyed rate limiters accumulate entries for every unique key.
@@ -691,11 +737,14 @@ impl Config {
             flags_rate_limit_enabled: FlexBool(false),
             flags_bucket_capacity: 500,
             flags_bucket_replenish_rate: 10.0,
+            flags_bucket_warn_capacity: 0,
             flags_ip_rate_limit_enabled: FlexBool(false),
             flags_ip_burst_size: 500,
             flags_ip_replenish_rate: 100.0,
+            flags_ip_warn_burst_size: 0,
             flags_rate_limit_log_only: FlexBool(true),
             flags_ip_rate_limit_log_only: FlexBool(true),
+            flags_rate_limits: FlagsRateLimits::default(),
             rate_limiter_cleanup_interval_secs: 60,
             redis_compression_enabled: FlexBool(true),
             redis_client_retry_count: 3,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -445,9 +445,10 @@ pub struct Config {
     #[envconfig(from = "FLAGS_RATE_LIMIT_ENABLED", default = "false")]
     pub flags_rate_limit_enabled: FlexBool,
 
-    // Token bucket capacity (maximum burst size / enforce threshold)
-    // Matches Python's DecideRateThrottle default of 500
-    #[envconfig(from = "FLAGS_BUCKET_CAPACITY", default = "500")]
+    // Token bucket capacity (maximum burst size / enforce threshold).
+    // Set to 625 so the warn tier (80%) lands at 500, matching the legacy
+    // log-only threshold that operators' dashboards already track.
+    #[envconfig(from = "FLAGS_BUCKET_CAPACITY", default = "625")]
     pub flags_bucket_capacity: u32,
 
     // Token bucket replenish rate (tokens per second)
@@ -461,8 +462,10 @@ pub struct Config {
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_ENABLED", default = "false")]
     pub flags_ip_rate_limit_enabled: FlexBool,
 
-    // IP rate limit burst size (maximum requests per IP / enforce threshold)
-    #[envconfig(from = "FLAGS_IP_BURST_SIZE", default = "1000")]
+    // IP rate limit burst size (maximum requests per IP / enforce threshold).
+    // Set to 1250 so the warn tier (80%) lands at 1000, matching the legacy
+    // log-only threshold.
+    #[envconfig(from = "FLAGS_IP_BURST_SIZE", default = "1250")]
     pub flags_ip_burst_size: u32,
 
     // IP rate limit replenish rate (requests per second per IP)
@@ -737,10 +740,10 @@ impl Config {
             object_storage_region: "us-east-1".to_string(),
             object_storage_endpoint: "".to_string(),
             flags_rate_limit_enabled: FlexBool(false),
-            flags_bucket_capacity: 500,
+            flags_bucket_capacity: 625,
             flags_bucket_replenish_rate: 10.0,
             flags_ip_rate_limit_enabled: FlexBool(false),
-            flags_ip_burst_size: 500,
+            flags_ip_burst_size: 1250,
             flags_ip_replenish_rate: 100.0,
             flags_warn_capacity_ratio: 0.8,
             flags_rate_limit_log_only: FlexBool(true),

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -194,6 +194,8 @@ pub struct FlagsCanonicalLogLine {
 
     // Rate limiting
     pub rate_limited: bool,
+    /// True when a rate limit warn threshold was exceeded but the request was still allowed.
+    pub rate_limit_warned: bool,
 
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
@@ -242,6 +244,7 @@ impl Default for FlagsCanonicalLogLine {
             hash_key_override_status: None,
             evaluation_type: None,
             rate_limited: false,
+            rate_limit_warned: false,
             team_cache_source: None,
             http_status: 200,
             error_code: None,
@@ -302,6 +305,7 @@ impl FlagsCanonicalLogLine {
             hash_key_override_status = self.hash_key_override_status,
             evaluation_type = self.evaluation_type.map(|t| t.as_str()),
             rate_limited = self.rate_limited,
+            rate_limit_warned = self.rate_limit_warned,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"
@@ -430,6 +434,7 @@ mod tests {
         assert_eq!(log.dependency_graph_errors, 0);
         assert!(log.hash_key_override_status.is_none());
         assert!(!log.rate_limited);
+        assert!(!log.rate_limit_warned);
         assert!(log.team_cache_source.is_none());
         assert_eq!(log.http_status, 200);
         assert!(log.error_code.is_none());

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -117,12 +117,9 @@ pub fn router(
     )
     .expect("Failed to initialize flag definitions rate limiter");
 
-    // Initialize token-based rate limiter with backwards-compatible configuration.
-    //
-    // Priority logic:
-    // - If log_only == true: use enforce_capacity as warn capacity
-    //   with no hard enforce (warn-only, matches today's log-only behavior)
-    // - If log_only == false: derive warn tier from warn_ratio of enforce capacity
+    // Initialize token-based rate limiter.
+    // Both modes use the same thresholds (warn at ratio of enforce capacity).
+    // log_only=true sets warn_only, so requests are never blocked.
     let (flags_warn_cap, flags_enforce_cap, flags_warn_only) = resolve_rate_limit_capacities(
         config.flags_bucket_capacity,
         config.flags_warn_capacity_ratio,
@@ -281,33 +278,24 @@ pub fn router(
 /// Resolves warn/enforce capacities with backwards-compat logic for the old `log_only` flag.
 ///
 /// Returns `(warn_capacity, enforce_capacity, warn_only)`:
-/// - `log_only == true`: Treat enforce capacity as warn-only threshold. `warn_only` is
-///   true — requests are never blocked, only warned. This preserves the legacy log-only
-///   contract where rate limiting is observational.
-/// - `log_only == false`: Derive warn tier at `warn_ratio` of enforce capacity. Operators
-///   get warning signals before hard 429s. Set `warn_ratio` to 0.0 to disable the warn tier.
+/// - Both modes use the same threshold calculation: warn at `warn_ratio` of enforce capacity.
+/// - `log_only == true`: Sets `warn_only = true` so requests are never blocked, only warned.
+///   Thresholds are identical to enforcing mode, giving operators visibility into what
+///   _would_ happen when they flip `log_only` to `false`.
+/// - `log_only == false`: Same thresholds, but enforce tier actually blocks with 429s.
+/// - Set `warn_ratio` to 0.0 to disable the warn tier entirely.
 fn resolve_rate_limit_capacities(
     enforce_capacity: u32,
     warn_ratio: f64,
     log_only: bool,
 ) -> (Option<u32>, u32, bool) {
-    if log_only {
-        // Backwards compat: log-only mode → use enforce_capacity as warn capacity,
-        // set enforce very high so it effectively never triggers.
-        // warn_only=true ensures requests are never blocked even if the enforce
-        // bucket is somehow exhausted under extreme sustained traffic.
-        // Note: u32::MAX overflows governor's internal nanos arithmetic,
-        // so we use a large-but-safe value instead.
-        (Some(enforce_capacity), 1_000_000, true)
+    let derived_warn = (enforce_capacity as f64 * warn_ratio.clamp(0.0, 1.0)) as u32;
+    let warn_capacity = if derived_warn > 0 {
+        Some(derived_warn)
     } else {
-        // Derive warn tier from ratio
-        let derived_warn = (enforce_capacity as f64 * warn_ratio.clamp(0.0, 1.0)) as u32;
-        if derived_warn > 0 {
-            (Some(derived_warn), enforce_capacity, false)
-        } else {
-            (None, enforce_capacity, false)
-        }
-    }
+        None
+    };
+    (warn_capacity, enforce_capacity, log_only)
 }
 
 /// Spawns a background task to periodically clean up stale rate limiter entries.
@@ -580,10 +568,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_rate_limit_log_only_backwards_compat() {
+    fn test_resolve_rate_limit_log_only_uses_real_thresholds() {
+        // log_only uses the same thresholds as enforcing mode — only warn_only differs
         let (warn, enforce, warn_only) = resolve_rate_limit_capacities(200, 0.8, true);
-        assert_eq!(warn, Some(200));
-        assert_eq!(enforce, 1_000_000);
+        assert_eq!(warn, Some(160));
+        assert_eq!(enforce, 200);
         assert!(warn_only);
     }
 

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -124,7 +124,7 @@ pub fn router(
     // - If warn_capacity == 0 and log_only == true: use enforce_capacity as warn capacity
     //   with no hard enforce (warn-only, matches today's log-only behavior)
     // - If warn_capacity == 0 and log_only == false: no warn limiter, enforce at capacity
-    let (flags_warn_cap, flags_enforce_cap) = resolve_rate_limit_capacities(
+    let (flags_warn_cap, flags_enforce_cap, flags_warn_only) = resolve_rate_limit_capacities(
         config.flags_bucket_warn_capacity,
         config.flags_bucket_capacity,
         *config.flags_rate_limit_log_only,
@@ -134,6 +134,7 @@ pub fn router(
         config.flags_bucket_replenish_rate,
         flags_warn_cap,
         flags_enforce_cap,
+        flags_warn_only,
         config.flags_rate_limits.0.clone(),
     )
     .unwrap_or_else(|e| {
@@ -144,7 +145,7 @@ pub fn router(
     });
 
     // Initialize IP-based rate limiter with backwards-compatible configuration
-    let (ip_warn_cap, ip_enforce_cap) = resolve_rate_limit_capacities(
+    let (ip_warn_cap, ip_enforce_cap, ip_warn_only) = resolve_rate_limit_capacities(
         config.flags_ip_warn_burst_size,
         config.flags_ip_burst_size,
         *config.flags_ip_rate_limit_log_only,
@@ -154,6 +155,7 @@ pub fn router(
         config.flags_ip_replenish_rate,
         ip_warn_cap,
         ip_enforce_cap,
+        ip_warn_only,
     )
     .unwrap_or_else(|e| {
         panic!(
@@ -197,7 +199,10 @@ pub fn router(
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::HEAD])
         .allow_headers(AllowHeaders::mirror_request())
         .allow_credentials(true)
-        .allow_origin(AllowOrigin::mirror_request());
+        .allow_origin(AllowOrigin::mirror_request())
+        .expose_headers([axum::http::HeaderName::from_static(
+            "x-posthog-rate-limit-warning",
+        )]);
 
     // Clone database_pools for the startup route
     let db_pools_for_startup = state.database_pools.clone();
@@ -276,15 +281,18 @@ pub fn router(
 
 /// Resolves warn/enforce capacities with backwards-compat logic for the old `log_only` flag.
 ///
-/// - `warn_capacity > 0`: Use tiered model (warn + enforce), `log_only` is ignored
+/// Returns `(warn_capacity, enforce_capacity, warn_only)`:
+/// - `warn_capacity > 0`: Use tiered model (warn + enforce), `log_only` is ignored.
+///   `warn_only` is false — requests that exceed enforce are blocked.
 /// - `warn_capacity == 0` and `log_only == true`: Treat enforce capacity as warn-only
-///   (never blocks — identical to today's log-only behavior)
-/// - `warn_capacity == 0` and `log_only == false`: No warn tier, hard enforce
+///   threshold. `warn_only` is true — requests are never blocked, only warned.
+///   This preserves the legacy log-only contract where rate limiting is observational.
+/// - `warn_capacity == 0` and `log_only == false`: No warn tier, hard enforce.
 fn resolve_rate_limit_capacities(
     warn_capacity: u32,
     enforce_capacity: u32,
     log_only: bool,
-) -> (Option<u32>, u32) {
+) -> (Option<u32>, u32, bool) {
     if warn_capacity > 0 {
         // New tiered model takes precedence
         if warn_capacity >= enforce_capacity {
@@ -294,16 +302,18 @@ fn resolve_rate_limit_capacities(
                 "warn capacity >= enforce capacity; the warn tier will never trigger because requests will be blocked first"
             );
         }
-        (Some(warn_capacity), enforce_capacity)
+        (Some(warn_capacity), enforce_capacity, false)
     } else if log_only {
         // Backwards compat: log-only mode → use enforce_capacity as warn capacity,
-        // set enforce very high so it never blocks.
+        // set enforce very high so it effectively never triggers.
+        // warn_only=true ensures requests are never blocked even if the enforce
+        // bucket is somehow exhausted under extreme sustained traffic.
         // Note: u32::MAX overflows governor's internal nanos arithmetic,
         // so we use a large-but-safe value instead.
-        (Some(enforce_capacity), 1_000_000)
+        (Some(enforce_capacity), 1_000_000, true)
     } else {
         // Backwards compat: enforced mode → no warn tier
-        (None, enforce_capacity)
+        (None, enforce_capacity, false)
     }
 }
 
@@ -543,27 +553,31 @@ mod tests {
 
     #[test]
     fn test_resolve_rate_limit_tiered_model() {
-        let (warn, enforce) = resolve_rate_limit_capacities(100, 500, false);
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(100, 500, false);
         assert_eq!(warn, Some(100));
         assert_eq!(enforce, 500);
+        assert!(!warn_only);
 
         // log_only is ignored when warn_capacity > 0
-        let (warn, enforce) = resolve_rate_limit_capacities(100, 500, true);
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(100, 500, true);
         assert_eq!(warn, Some(100));
         assert_eq!(enforce, 500);
+        assert!(!warn_only);
     }
 
     #[test]
     fn test_resolve_rate_limit_log_only_backwards_compat() {
-        let (warn, enforce) = resolve_rate_limit_capacities(0, 200, true);
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(0, 200, true);
         assert_eq!(warn, Some(200));
         assert_eq!(enforce, 1_000_000);
+        assert!(warn_only);
     }
 
     #[test]
     fn test_resolve_rate_limit_enforce_backwards_compat() {
-        let (warn, enforce) = resolve_rate_limit_capacities(0, 200, false);
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(0, 200, false);
         assert_eq!(warn, None);
         assert_eq!(enforce, 200);
+        assert!(!warn_only);
     }
 }

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -120,13 +120,12 @@ pub fn router(
     // Initialize token-based rate limiter with backwards-compatible configuration.
     //
     // Priority logic:
-    // - If warn_capacity > 0: use tiered model (warn + enforce), ignore log_only
-    // - If warn_capacity == 0 and log_only == true: use enforce_capacity as warn capacity
+    // - If log_only == true: use enforce_capacity as warn capacity
     //   with no hard enforce (warn-only, matches today's log-only behavior)
-    // - If warn_capacity == 0 and log_only == false: no warn limiter, enforce at capacity
+    // - If log_only == false: derive warn tier from warn_ratio of enforce capacity
     let (flags_warn_cap, flags_enforce_cap, flags_warn_only) = resolve_rate_limit_capacities(
-        config.flags_bucket_warn_capacity,
         config.flags_bucket_capacity,
+        config.flags_warn_capacity_ratio,
         *config.flags_rate_limit_log_only,
     );
     let flags_rate_limiter = FlagsRateLimiter::new(
@@ -135,7 +134,7 @@ pub fn router(
         flags_warn_cap,
         flags_enforce_cap,
         flags_warn_only,
-        config.flags_rate_limits.0.clone(),
+        config.flags_token_rate_limit_overrides.0.clone(),
     )
     .unwrap_or_else(|e| {
         panic!(
@@ -146,8 +145,8 @@ pub fn router(
 
     // Initialize IP-based rate limiter with backwards-compatible configuration
     let (ip_warn_cap, ip_enforce_cap, ip_warn_only) = resolve_rate_limit_capacities(
-        config.flags_ip_warn_burst_size,
         config.flags_ip_burst_size,
+        config.flags_warn_capacity_ratio,
         *config.flags_ip_rate_limit_log_only,
     );
     let ip_rate_limiter = IpRateLimiter::new(
@@ -282,28 +281,17 @@ pub fn router(
 /// Resolves warn/enforce capacities with backwards-compat logic for the old `log_only` flag.
 ///
 /// Returns `(warn_capacity, enforce_capacity, warn_only)`:
-/// - `warn_capacity > 0`: Use tiered model (warn + enforce), `log_only` is ignored.
-///   `warn_only` is false — requests that exceed enforce are blocked.
-/// - `warn_capacity == 0` and `log_only == true`: Treat enforce capacity as warn-only
-///   threshold. `warn_only` is true — requests are never blocked, only warned.
-///   This preserves the legacy log-only contract where rate limiting is observational.
-/// - `warn_capacity == 0` and `log_only == false`: No warn tier, hard enforce.
+/// - `log_only == true`: Treat enforce capacity as warn-only threshold. `warn_only` is
+///   true — requests are never blocked, only warned. This preserves the legacy log-only
+///   contract where rate limiting is observational.
+/// - `log_only == false`: Derive warn tier at `warn_ratio` of enforce capacity. Operators
+///   get warning signals before hard 429s. Set `warn_ratio` to 0.0 to disable the warn tier.
 fn resolve_rate_limit_capacities(
-    warn_capacity: u32,
     enforce_capacity: u32,
+    warn_ratio: f64,
     log_only: bool,
 ) -> (Option<u32>, u32, bool) {
-    if warn_capacity > 0 {
-        // New tiered model takes precedence
-        if warn_capacity >= enforce_capacity {
-            tracing::warn!(
-                warn_capacity,
-                enforce_capacity,
-                "warn capacity >= enforce capacity; the warn tier will never trigger because requests will be blocked first"
-            );
-        }
-        (Some(warn_capacity), enforce_capacity, false)
-    } else if log_only {
+    if log_only {
         // Backwards compat: log-only mode → use enforce_capacity as warn capacity,
         // set enforce very high so it effectively never triggers.
         // warn_only=true ensures requests are never blocked even if the enforce
@@ -312,8 +300,13 @@ fn resolve_rate_limit_capacities(
         // so we use a large-but-safe value instead.
         (Some(enforce_capacity), 1_000_000, true)
     } else {
-        // Backwards compat: enforced mode → no warn tier
-        (None, enforce_capacity, false)
+        // Derive warn tier from ratio
+        let derived_warn = (enforce_capacity as f64 * warn_ratio.clamp(0.0, 1.0)) as u32;
+        if derived_warn > 0 {
+            (Some(derived_warn), enforce_capacity, false)
+        } else {
+            (None, enforce_capacity, false)
+        }
     }
 }
 
@@ -552,32 +545,62 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_rate_limit_tiered_model() {
-        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(100, 500, false);
-        assert_eq!(warn, Some(100));
-        assert_eq!(enforce, 500);
+    fn test_resolve_rate_limit_default_ratio() {
+        // 80% of 200 = 160
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(200, 0.8, false);
+        assert_eq!(warn, Some(160));
+        assert_eq!(enforce, 200);
         assert!(!warn_only);
+    }
 
-        // log_only is ignored when warn_capacity > 0
-        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(100, 500, true);
-        assert_eq!(warn, Some(100));
+    #[test]
+    fn test_resolve_rate_limit_custom_ratio() {
+        // 40% of 500 = 200
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(500, 0.4, false);
+        assert_eq!(warn, Some(200));
         assert_eq!(enforce, 500);
         assert!(!warn_only);
     }
 
     #[test]
+    fn test_resolve_rate_limit_zero_ratio_disables_warn() {
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(500, 0.0, false);
+        assert_eq!(warn, None);
+        assert_eq!(enforce, 500);
+        assert!(!warn_only);
+    }
+
+    #[test]
+    fn test_resolve_rate_limit_ratio_clamped_to_1() {
+        // ratio > 1.0 is clamped to 1.0, so warn == enforce
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(200, 1.5, false);
+        assert_eq!(warn, Some(200));
+        assert_eq!(enforce, 200);
+        assert!(!warn_only);
+    }
+
+    #[test]
     fn test_resolve_rate_limit_log_only_backwards_compat() {
-        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(0, 200, true);
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(200, 0.8, true);
         assert_eq!(warn, Some(200));
         assert_eq!(enforce, 1_000_000);
         assert!(warn_only);
     }
 
     #[test]
-    fn test_resolve_rate_limit_enforce_backwards_compat() {
-        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(0, 200, false);
+    fn test_resolve_rate_limit_tiny_capacity_no_warn() {
+        // enforce=1 → 80% rounds to 0, too small for warn tier
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(1, 0.8, false);
         assert_eq!(warn, None);
-        assert_eq!(enforce, 200);
+        assert_eq!(enforce, 1);
+        assert!(!warn_only);
+    }
+
+    #[test]
+    fn test_resolve_rate_limit_zero_capacity() {
+        let (warn, enforce, warn_only) = resolve_rate_limit_capacities(0, 0.8, false);
+        assert_eq!(warn, None);
+        assert_eq!(enforce, 0);
         assert!(!warn_only);
     }
 }

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -297,8 +297,10 @@ fn resolve_rate_limit_capacities(
         (Some(warn_capacity), enforce_capacity)
     } else if log_only {
         // Backwards compat: log-only mode → use enforce_capacity as warn capacity,
-        // set enforce very high so it never blocks
-        (Some(enforce_capacity), u32::MAX)
+        // set enforce very high so it never blocks.
+        // Note: u32::MAX overflows governor's internal nanos arithmetic,
+        // so we use a large-but-safe value instead.
+        (Some(enforce_capacity), 1_000_000)
     } else {
         // Backwards compat: enforced mode → no warn tier
         (None, enforce_capacity)
@@ -555,7 +557,7 @@ mod tests {
     fn test_resolve_rate_limit_log_only_backwards_compat() {
         let (warn, enforce) = resolve_rate_limit_capacities(0, 200, true);
         assert_eq!(warn, Some(200));
-        assert_eq!(enforce, u32::MAX);
+        assert_eq!(enforce, 1_000_000);
     }
 
     #[test]

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -117,12 +117,24 @@ pub fn router(
     )
     .expect("Failed to initialize flag definitions rate limiter");
 
-    // Initialize token-based rate limiter with configuration
+    // Initialize token-based rate limiter with backwards-compatible configuration.
+    //
+    // Priority logic:
+    // - If warn_capacity > 0: use tiered model (warn + enforce), ignore log_only
+    // - If warn_capacity == 0 and log_only == true: use enforce_capacity as warn capacity
+    //   with no hard enforce (warn-only, matches today's log-only behavior)
+    // - If warn_capacity == 0 and log_only == false: no warn limiter, enforce at capacity
+    let (flags_warn_cap, flags_enforce_cap) = resolve_rate_limit_capacities(
+        config.flags_bucket_warn_capacity,
+        config.flags_bucket_capacity,
+        *config.flags_rate_limit_log_only,
+    );
     let flags_rate_limiter = FlagsRateLimiter::new(
         *config.flags_rate_limit_enabled,
-        *config.flags_rate_limit_log_only,
         config.flags_bucket_replenish_rate,
-        config.flags_bucket_capacity,
+        flags_warn_cap,
+        flags_enforce_cap,
+        config.flags_rate_limits.0.clone(),
     )
     .unwrap_or_else(|e| {
         panic!(
@@ -131,12 +143,17 @@ pub fn router(
         )
     });
 
-    // Initialize IP-based rate limiter with configuration
+    // Initialize IP-based rate limiter with backwards-compatible configuration
+    let (ip_warn_cap, ip_enforce_cap) = resolve_rate_limit_capacities(
+        config.flags_ip_warn_burst_size,
+        config.flags_ip_burst_size,
+        *config.flags_ip_rate_limit_log_only,
+    );
     let ip_rate_limiter = IpRateLimiter::new(
         *config.flags_ip_rate_limit_enabled,
-        *config.flags_ip_rate_limit_log_only,
         config.flags_ip_replenish_rate,
-        config.flags_ip_burst_size,
+        ip_warn_cap,
+        ip_enforce_cap,
     )
     .unwrap_or_else(|e| {
         panic!(
@@ -254,6 +271,30 @@ pub fn router(
         router.route("/metrics", get(move || ready(recorder_handle.render())))
     } else {
         router
+    }
+}
+
+/// Resolves warn/enforce capacities with backwards-compat logic for the old `log_only` flag.
+///
+/// - `warn_capacity > 0`: Use tiered model (warn + enforce), `log_only` is ignored
+/// - `warn_capacity == 0` and `log_only == true`: Treat enforce capacity as warn-only
+///   (never blocks — identical to today's log-only behavior)
+/// - `warn_capacity == 0` and `log_only == false`: No warn tier, hard enforce
+fn resolve_rate_limit_capacities(
+    warn_capacity: u32,
+    enforce_capacity: u32,
+    log_only: bool,
+) -> (Option<u32>, u32) {
+    if warn_capacity > 0 {
+        // New tiered model takes precedence
+        (Some(warn_capacity), enforce_capacity)
+    } else if log_only {
+        // Backwards compat: log-only mode → use enforce_capacity as warn capacity,
+        // set enforce very high so it never blocks
+        (Some(enforce_capacity), u32::MAX)
+    } else {
+        // Backwards compat: enforced mode → no warn tier
+        (None, enforce_capacity)
     }
 }
 
@@ -489,5 +530,31 @@ mod tests {
 
         let result = startup(database_pools).await;
         assert_eq!(result, "started");
+    }
+
+    #[test]
+    fn test_resolve_rate_limit_tiered_model() {
+        let (warn, enforce) = resolve_rate_limit_capacities(100, 500, false);
+        assert_eq!(warn, Some(100));
+        assert_eq!(enforce, 500);
+
+        // log_only is ignored when warn_capacity > 0
+        let (warn, enforce) = resolve_rate_limit_capacities(100, 500, true);
+        assert_eq!(warn, Some(100));
+        assert_eq!(enforce, 500);
+    }
+
+    #[test]
+    fn test_resolve_rate_limit_log_only_backwards_compat() {
+        let (warn, enforce) = resolve_rate_limit_capacities(0, 200, true);
+        assert_eq!(warn, Some(200));
+        assert_eq!(enforce, u32::MAX);
+    }
+
+    #[test]
+    fn test_resolve_rate_limit_enforce_backwards_compat() {
+        let (warn, enforce) = resolve_rate_limit_capacities(0, 200, false);
+        assert_eq!(warn, None);
+        assert_eq!(enforce, 200);
     }
 }

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -287,6 +287,13 @@ fn resolve_rate_limit_capacities(
 ) -> (Option<u32>, u32) {
     if warn_capacity > 0 {
         // New tiered model takes precedence
+        if warn_capacity >= enforce_capacity {
+            tracing::warn!(
+                warn_capacity,
+                enforce_capacity,
+                "warn capacity >= enforce capacity; the warn tier will never trigger because requests will be blocked first"
+            );
+        }
         (Some(warn_capacity), enforce_capacity)
     } else if log_only {
         // Backwards compat: log-only mode → use enforce_capacity as warn capacity,

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1284,7 +1284,7 @@ async fn test_ip_rate_limit_warn_then_enforce() -> Result<()> {
 
 #[tokio::test]
 async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
-    // When log_only=true and no warn capacity configured, all requests should be allowed
+    // When log_only=true, all requests should be allowed regardless of warn/enforce thresholds
     // (matches today's behavior: log but don't block)
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1427,7 +1427,8 @@ async fn test_rate_limit_per_team_override() -> Result<()> {
     // Configure a very restrictive custom rate for this specific token
     let mut custom_rates = HashMap::new();
     custom_rates.insert(token.clone(), "1/hour".to_string());
-    config.flags_token_rate_limit_overrides = feature_flags::config::FlagsTokenRateLimitOverrides(custom_rates);
+    config.flags_token_rate_limit_overrides =
+        feature_flags::config::FlagsTokenRateLimitOverrides(custom_rates);
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1327,7 +1327,11 @@ async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
         .json(&payload)
         .send()
         .await?;
-    assert_eq!(response.status(), StatusCode::OK, "Request 1 should succeed");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Request 1 should succeed"
+    );
     assert!(
         response
             .headers()

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1426,7 +1426,7 @@ async fn test_rate_limit_per_team_override() -> Result<()> {
 
     // Configure a very restrictive custom rate for this specific token
     let mut custom_rates = HashMap::new();
-    custom_rates.insert(token.clone(), "1/second".to_string());
+    custom_rates.insert(token.clone(), "1/hour".to_string());
     config.flags_rate_limits = feature_flags::config::FlagsRateLimits(custom_rates);
 
     let context = TestContext::new(None).await;
@@ -1450,7 +1450,7 @@ async fn test_rate_limit_per_team_override() -> Result<()> {
         "distinct_id": "user123",
     });
 
-    // First request succeeds (custom rate: 1/second, so 1 burst)
+    // First request succeeds (custom rate: 1/hour, so 1 burst with no replenishment during test)
     let response = client
         .post(format!("http://{}/flags", server.addr))
         .header("content-type", "application/json")

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1319,8 +1319,26 @@ async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
         "distinct_id": "user123",
     });
 
-    // All requests should succeed (log_only mode never blocks)
-    for i in 1..=5 {
+    // With capacity=2 and default warn_ratio=0.8, warn capacity = floor(2*0.8) = 1.
+    // Request 1: within both thresholds → 200, no warning header
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK, "Request 1 should succeed");
+    assert!(
+        response
+            .headers()
+            .get("X-PostHog-Rate-Limit-Warning")
+            .is_none(),
+        "Request 1 should not have warning header"
+    );
+
+    // Requests 2-5: exceed warn or enforce thresholds → 200 with warning header
+    // (log_only mode converts all rejections to warnings)
+    for i in 2..=5 {
         let response = client
             .post(format!("http://{}/flags", server.addr))
             .header("content-type", "application/json")
@@ -1332,6 +1350,14 @@ async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
             response.status(),
             StatusCode::OK,
             "Request {i} should succeed in backwards-compat log-only mode"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .map(|v| v.to_str().unwrap()),
+            Some("true"),
+            "Request {i} should have warning header in log-only mode"
         );
     }
 

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1026,11 +1026,11 @@ async fn test_mixed_log_only_modes() -> Result<()> {
 
 #[tokio::test]
 async fn test_rate_limit_warn_then_enforce() -> Result<()> {
-    // Set warn_capacity=2, enforce_capacity=5
+    // warn at 40% of 5 = 2, enforce at 5
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);
     config.flags_rate_limit_log_only = FlexBool(false);
-    config.flags_bucket_warn_capacity = 2;
+    config.flags_warn_capacity_ratio = 0.4;
     config.flags_bucket_capacity = 5;
     config.flags_bucket_replenish_rate = 0.1;
 
@@ -1128,10 +1128,11 @@ async fn test_rate_limit_warn_then_enforce() -> Result<()> {
 #[tokio::test]
 async fn test_rate_limit_warn_header_absent_below_threshold() -> Result<()> {
     // Verify the warning header is absent on normal responses
+    // warn at 50% of 200 = 100
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);
     config.flags_rate_limit_log_only = FlexBool(false);
-    config.flags_bucket_warn_capacity = 100;
+    config.flags_warn_capacity_ratio = 0.5;
     config.flags_bucket_capacity = 200;
     config.flags_bucket_replenish_rate = 10.0;
 
@@ -1191,9 +1192,10 @@ async fn test_rate_limit_warn_header_absent_below_threshold() -> Result<()> {
 #[tokio::test]
 async fn test_ip_rate_limit_warn_then_enforce() -> Result<()> {
     let mut config = Config::default_test_config();
+    // warn at 50% of 4 = 2, enforce at 4
     config.flags_ip_rate_limit_enabled = FlexBool(true);
     config.flags_ip_rate_limit_log_only = FlexBool(false);
-    config.flags_ip_warn_burst_size = 2;
+    config.flags_warn_capacity_ratio = 0.5;
     config.flags_ip_burst_size = 4;
     config.flags_ip_replenish_rate = 0.1;
 
@@ -1287,7 +1289,6 @@ async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);
     config.flags_rate_limit_log_only = FlexBool(true);
-    config.flags_bucket_warn_capacity = 0; // no explicit warn tier
     config.flags_bucket_capacity = 2;
     config.flags_bucket_replenish_rate = 0.1;
 
@@ -1339,12 +1340,11 @@ async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
 
 #[tokio::test]
 async fn test_rate_limit_backwards_compat_enforce() -> Result<()> {
-    // When log_only=false and no warn capacity, should hard-block at enforce capacity
-    // (matches today's enforced behavior)
+    // When log_only=false and ratio=0, should hard-block at enforce capacity with no warn tier
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);
     config.flags_rate_limit_log_only = FlexBool(false);
-    config.flags_bucket_warn_capacity = 0; // no warn tier
+    config.flags_warn_capacity_ratio = 0.0; // disable warn tier
     config.flags_bucket_capacity = 2;
     config.flags_bucket_replenish_rate = 0.1;
 
@@ -1413,7 +1413,7 @@ async fn test_rate_limit_per_team_override() -> Result<()> {
     let mut config = Config::default_test_config();
     config.flags_rate_limit_enabled = FlexBool(true);
     config.flags_rate_limit_log_only = FlexBool(false);
-    config.flags_bucket_warn_capacity = 0;
+    config.flags_warn_capacity_ratio = 0.0; // disable warn tier, rely on per-token override
     config.flags_bucket_capacity = 100; // high default
     config.flags_bucket_replenish_rate = 0.1;
 
@@ -1427,7 +1427,7 @@ async fn test_rate_limit_per_team_override() -> Result<()> {
     // Configure a very restrictive custom rate for this specific token
     let mut custom_rates = HashMap::new();
     custom_rates.insert(token.clone(), "1/hour".to_string());
-    config.flags_rate_limits = feature_flags::config::FlagsRateLimits(custom_rates);
+    config.flags_token_rate_limit_overrides = feature_flags::config::FlagsTokenRateLimitOverrides(custom_rates);
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();

--- a/rust/feature-flags/tests/test_rate_limiting.rs
+++ b/rust/feature-flags/tests/test_rate_limiting.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use reqwest::StatusCode;
 use serde_json::json;
+use std::collections::HashMap;
 
 use crate::common::*;
 use feature_flags::config::{Config, FlexBool};
@@ -1018,6 +1019,463 @@ async fn test_mixed_log_only_modes() -> Result<()> {
         response.status(),
         StatusCode::TOO_MANY_REQUESTS,
         "4th request should be IP rate limited (enforced mode takes precedence)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limit_warn_then_enforce() -> Result<()> {
+    // Set warn_capacity=2, enforce_capacity=5
+    let mut config = Config::default_test_config();
+    config.flags_rate_limit_enabled = FlexBool(true);
+    config.flags_rate_limit_log_only = FlexBool(false);
+    config.flags_bucket_warn_capacity = 2;
+    config.flags_bucket_capacity = 5;
+    config.flags_bucket_replenish_rate = 0.1;
+
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // Requests 1-2: within warn capacity → 200, no warning header
+    for i in 1..=2 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Request {i} should succeed"
+        );
+        assert!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .is_none(),
+            "Request {i} should not have warning header"
+        );
+    }
+
+    // Requests 3-5: exceed warn but within enforce → 200 with warning header
+    for i in 3..=5 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Request {i} should succeed with warning"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .map(|v| v.to_str().unwrap()),
+            Some("true"),
+            "Request {i} should have warning header"
+        );
+    }
+
+    // Request 6: exceeds enforce → 429
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Request 6 should be blocked"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limit_warn_header_absent_below_threshold() -> Result<()> {
+    // Verify the warning header is absent on normal responses
+    let mut config = Config::default_test_config();
+    config.flags_rate_limit_enabled = FlexBool(true);
+    config.flags_rate_limit_log_only = FlexBool(false);
+    config.flags_bucket_warn_capacity = 100;
+    config.flags_bucket_capacity = 200;
+    config.flags_bucket_replenish_rate = 10.0;
+
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // A few requests well below the warn threshold
+    for i in 1..=3 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Request {i} should succeed"
+        );
+        assert!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .is_none(),
+            "Request {i} should NOT have warning header when below threshold"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ip_rate_limit_warn_then_enforce() -> Result<()> {
+    let mut config = Config::default_test_config();
+    config.flags_ip_rate_limit_enabled = FlexBool(true);
+    config.flags_ip_rate_limit_log_only = FlexBool(false);
+    config.flags_ip_warn_burst_size = 2;
+    config.flags_ip_burst_size = 4;
+    config.flags_ip_replenish_rate = 0.1;
+
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // Requests 1-2: within warn capacity → 200, no header
+    for i in 1..=2 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "Request {i}");
+        assert!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .is_none(),
+            "Request {i} should not have warning header"
+        );
+    }
+
+    // Requests 3-4: exceed warn, within enforce → 200 with warning header
+    for i in 3..=4 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "Request {i}");
+        assert_eq!(
+            response
+                .headers()
+                .get("X-PostHog-Rate-Limit-Warning")
+                .map(|v| v.to_str().unwrap()),
+            Some("true"),
+            "Request {i} should have warning header"
+        );
+    }
+
+    // Request 5: exceeds enforce → 429
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Request 5 should be blocked"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limit_backwards_compat_log_only() -> Result<()> {
+    // When log_only=true and no warn capacity configured, all requests should be allowed
+    // (matches today's behavior: log but don't block)
+    let mut config = Config::default_test_config();
+    config.flags_rate_limit_enabled = FlexBool(true);
+    config.flags_rate_limit_log_only = FlexBool(true);
+    config.flags_bucket_warn_capacity = 0; // no explicit warn tier
+    config.flags_bucket_capacity = 2;
+    config.flags_bucket_replenish_rate = 0.1;
+
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // All requests should succeed (log_only mode never blocks)
+    for i in 1..=5 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Request {i} should succeed in backwards-compat log-only mode"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limit_backwards_compat_enforce() -> Result<()> {
+    // When log_only=false and no warn capacity, should hard-block at enforce capacity
+    // (matches today's enforced behavior)
+    let mut config = Config::default_test_config();
+    config.flags_rate_limit_enabled = FlexBool(true);
+    config.flags_rate_limit_log_only = FlexBool(false);
+    config.flags_bucket_warn_capacity = 0; // no warn tier
+    config.flags_bucket_capacity = 2;
+    config.flags_bucket_replenish_rate = 0.1;
+
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // First 2 requests allowed
+    for i in 1..=2 {
+        let response = client
+            .post(format!("http://{}/flags", server.addr))
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Request {i} should succeed"
+        );
+    }
+
+    // 3rd request blocked
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Request 3 should be blocked in backwards-compat enforce mode"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rate_limit_per_team_override() -> Result<()> {
+    let mut config = Config::default_test_config();
+    config.flags_rate_limit_enabled = FlexBool(true);
+    config.flags_rate_limit_log_only = FlexBool(false);
+    config.flags_bucket_warn_capacity = 0;
+    config.flags_bucket_capacity = 100; // high default
+    config.flags_bucket_replenish_rate = 0.1;
+
+    // Set up team with a known token
+    let redis_client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let team = insert_new_team_in_redis(redis_client.clone())
+        .await
+        .unwrap();
+    let token = team.api_token.clone();
+
+    // Configure a very restrictive custom rate for this specific token
+    let mut custom_rates = HashMap::new();
+    custom_rates.insert(token.clone(), "1/second".to_string());
+    config.flags_rate_limits = feature_flags::config::FlagsRateLimits(custom_rates);
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+    context
+        .insert_person(team.id, "user123".to_string(), None)
+        .await
+        .unwrap();
+
+    let remote_config = json!({
+        "supportedCompression": ["gzip", "gzip-js"],
+        "config": {}
+    });
+    insert_config_in_hypercache(redis_client.clone(), &token, remote_config).await?;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": "user123",
+    });
+
+    // First request succeeds (custom rate: 1/second, so 1 burst)
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "First request should succeed"
+    );
+
+    // Second request should be rate limited by the custom per-token rate
+    let response = client
+        .post(format!("http://{}/flags", server.addr))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Second request should be blocked by per-token custom rate"
     );
 
     Ok(())


### PR DESCRIPTION
## Problem

The Rust feature flags service needs a gradual rollout path for rate limiting. Currently, rate limiting is binary (log-only or enforce), which makes it risky to enable in production. Operators need the ability to warn customers before hard-blocking, and specific high-traffic tokens need custom rate limits.

## Changes

- Add two-tier warn-then-enforce rate limiting model for the `/flags` IP and token limiters:
  - **Warn tier**: Requests exceeding the warn capacity proceed but include a warning header (`X-PostHog-Rate-Limit-Warning`) so callers can react proactively
  - **Enforce tier**: Requests exceeding the enforce capacity are blocked with 429
- Auto-derive the warn tier as a configurable percentage of enforce capacity via `FLAGS_WARN_CAPACITY_RATIO` (default 0.8), so operators only need to set the enforce capacity and get warnings for free
- Add per-token custom rate limit overrides via `FLAGS_TOKEN_RATE_LIMIT_OVERRIDES` env var (JSON map of token → rate string), allowing specific tokens to have custom limits
- Separate metric labels into two orthogonal dimensions:
  - `mode`: `log_only` (observe-only) or `enforcing` (actually blocking) — reflects how the limiter is configured
  - `action`: `warned` (crossed warn tier) or `blocked` (crossed enforce tier) — reflects which threshold was crossed
  - In log-only mode, `action="blocked"` shows what _would_ be blocked without actually rejecting requests
- Unify log_only and enforcing modes to use identical thresholds — both derive warn at 80% of enforce capacity. The only difference is `warn_only=true` prevents actual blocking. This gives operators full visibility into what will happen when they flip to enforcement.
- Bump default capacities (token: 500→625, IP: 1000→1250) so the warn tier at 80% matches the legacy log-only threshold (500 and 1000 respectively)
- Fix custom limiter path to honor `warn_only` mode — previously, per-token custom limiters would hard-block even when the system was in log-only mode
- Simplify `custom_limiters` from `Arc<RwLock<HashMap>>` to plain `HashMap` since the map is write-once/read-many
- Consolidate redundant config fields (`FLAGS_BUCKET_ENFORCE_CAPACITY`, `FLAGS_IP_ENFORCE_BURST_SIZE`) into the existing `FLAGS_BUCKET_CAPACITY` and `FLAGS_IP_BURST_SIZE`
- Extract `mode_label()` and `record_block()` helpers on `KeyedRateLimiter` to eliminate duplicated metric emission logic
- Extract rate limiting docs into standalone `docs/internal/feature-flags/rate-limiting.md`

### Configuration modes

| Mode | Condition | Behavior |
| --- | --- | --- |
| **Default** | `log_only=false`, `ratio > 0` | Warn at ratio of enforce capacity, block above enforce |
| **Warn disabled** | `log_only=false`, `ratio=0` | Hard block, no warning |
| **Legacy log-only** | `log_only=true` | Same thresholds, but never blocks. Metrics show what _would_ happen under enforcement. |

### Metric labels

| Label | Values | Meaning |
| --- | --- | --- |
| `mode` | `log_only`, `enforcing` | How the limiter is configured |
| `action` | `warned`, `blocked` | Which threshold was crossed |

### Client-visible change in log-only mode

In log-only mode (`FLAGS_RATE_LIMIT_LOG_ONLY=true`, the current production default), requests that exceed the warn tier will now receive the `X-PostHog-Rate-Limit-Warning: true` response header. Previously, log-only mode was purely server-side (metrics/logs only, no client-visible signal). This is intentional — it gives SDKs early visibility into approaching limits before enforcement is turned on, and the header is informational only (no behavioral change in any PostHog SDK today).

## How did you test this code?

- Unit tests for `resolve_rate_limit_capacities` covering default ratio, custom ratio, zero ratio, ratio clamping, log-only with real thresholds, tiny capacity, and zero capacity
- Integration tests for warn-then-enforce, warn header absent below threshold, IP rate limiting, backwards compat (log-only + enforce), and per-token overrides
- New test verifying custom per-token limiters respect `warn_only` mode (never return `Blocked`)
- All existing rate limiting tests updated and passing
- `cargo clippy` and `cargo fmt` clean

## Publish to changelog?

no