### PR TITLE
fix: stable groups presented in suggested filters

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -17,7 +17,8 @@ import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFi
 import {
     DataWarehousePopoverField,
     DefinitionPopoverRenderer,
-    ListStorage,
+    isSkeletonItem,
+    SkeletonItem,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -209,7 +210,7 @@ const canSelectItem = (
 }
 
 interface InfiniteListRowProps {
-    results: TaxonomicDefinitionTypes[]
+    results: (TaxonomicDefinitionTypes | SkeletonItem)[]
     taxonomicGroups: TaxonomicFilterGroup[]
     group: TaxonomicFilterGroup
     listGroupType: TaxonomicFilterGroupType
@@ -226,7 +227,6 @@ interface InfiniteListRowProps {
     expandedCount: number
     isExpandable: boolean
     isLoading: boolean
-    items: ListStorage
     showNonCapturedEventOption: boolean
     trimmedSearchQuery: string
     dataWarehousePopoverFields: DataWarehousePopoverField[] | undefined
@@ -239,6 +239,33 @@ interface InfiniteListRowProps {
         item: TaxonomicDefinitionTypes | { name: string; isNonCaptured: true }
     ) => void
     setHighlightedItemElement: (element: HTMLDivElement | null) => void
+}
+
+function InfiniteListSkeletonItem({
+    style,
+    listGroupType,
+    rowIndex,
+    groupName,
+}: {
+    style: CSSProperties
+    listGroupType: TaxonomicFilterGroupType
+    rowIndex: number
+    groupName: string
+}): JSX.Element {
+    return (
+        <div
+            className={clsx('taxonomic-list-row', 'skeleton-row')}
+            style={style}
+            data-attr={`prop-skeleton-${listGroupType}-${rowIndex}`}
+        >
+            <div className="taxonomic-list-row-contents w-full">
+                <LemonSkeleton className="h-4 flex-1" />
+                <LemonTag size="small" type="highlight" className="ml-2 shrink-0">
+                    {groupName}
+                </LemonTag>
+            </div>
+        </div>
+    )
 }
 
 const InfiniteListRow = ({
@@ -275,6 +302,18 @@ const InfiniteListRow = ({
     style: CSSProperties
 } & InfiniteListRowProps): JSX.Element | null => {
     const item = results[rowIndex]
+
+    if (isSkeletonItem(item)) {
+        return (
+            <InfiniteListSkeletonItem
+                style={style}
+                listGroupType={listGroupType}
+                rowIndex={rowIndex}
+                groupName={item.groupName}
+            />
+        )
+    }
+
     const itemGroup = getItemGroup(item, taxonomicGroups, group)
     const itemValue = item ? itemGroup?.getValue?.(item) : null
 
@@ -487,7 +526,6 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         totalListCount,
         expandedCount,
         showPopover,
-        items,
         showNonCapturedEventOption,
         showEmptyState,
         showLoadingState,
@@ -555,7 +593,6 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                                     expandedCount,
                                     isExpandable,
                                     isLoading,
-                                    items,
                                     showNonCapturedEventOption,
                                     trimmedSearchQuery,
                                     dataWarehousePopoverFields,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -4,10 +4,11 @@ import { loaders } from 'kea-loaders'
 import { combineUrl } from 'kea-router'
 
 import api from 'lib/api'
-import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import { MAX_TOP_MATCHES_PER_GROUP, taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { taxonomicFilterPreferencesLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterPreferencesLogic'
 import {
     InfiniteListLogicProps,
+    isSkeletonItem,
     ListFuse,
     ListStorage,
     LoaderOptions,
@@ -84,7 +85,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
     connect((props: InfiniteListLogicProps) => ({
         values: [
             taxonomicFilterLogic(props),
-            ['searchQuery', 'value', 'groupType', 'taxonomicGroups', 'topMatchItems', 'anyGroupLoading'],
+            ['searchQuery', 'value', 'groupType', 'taxonomicGroups', 'topMatchItemsWithSkeletons', 'anyGroupLoading'],
             teamLogic,
             ['currentTeamId'],
         ],
@@ -463,16 +464,20 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 }
                 const remoteIsFresh = remoteItems.searchQuery === searchQuery
                 const results = hasRemoteDataSource ? (remoteIsFresh ? remoteItems.results : []) : localItems.results
-                return results.slice(0, 3)
+                return results.slice(0, MAX_TOP_MATCHES_PER_GROUP)
             },
         ],
         items: [
-            (s) => [s.remoteItems, s.localItems, s.listGroupType, s.topMatchItems],
-            (remoteItems, localItems, listGroupType, topMatchItems) => {
-                const topMatches = listGroupType === TaxonomicFilterGroupType.SuggestedFilters ? topMatchItems : []
+            (s) => [s.remoteItems, s.localItems, s.listGroupType, s.topMatchItemsWithSkeletons],
+            (remoteItems, localItems, listGroupType, topMatchItemsWithSkeletons) => {
+                const topMatches =
+                    listGroupType === TaxonomicFilterGroupType.SuggestedFilters ? topMatchItemsWithSkeletons : []
                 return {
                     results: [...localItems.results, ...remoteItems.results, ...topMatches],
-                    count: localItems.count + remoteItems.count + topMatches.length,
+                    count:
+                        localItems.count +
+                        remoteItems.count +
+                        topMatches.filter((item) => !isSkeletonItem(item)).length,
                     searchQuery: remoteItems.searchQuery || localItems.searchQuery,
                     expandedCount: remoteItems.expandedCount,
                     queryChanged: remoteItems.queryChanged,
@@ -493,7 +498,16 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         results: [(s) => [s.items], (items) => items.results],
         selectedItem: [
             (s) => [s.index, s.items],
-            (index, items): TaxonomicDefinitionTypes | undefined => (index >= 0 ? items.results[index] : undefined),
+            (index, items): TaxonomicDefinitionTypes | undefined => {
+                if (index < 0) {
+                    return undefined
+                }
+                const item = items.results[index]
+                if (!item || isSkeletonItem(item)) {
+                    return undefined
+                }
+                return item
+            },
         ],
         selectedItemValue: [
             (s) => [s.selectedItem, s.group],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -2,7 +2,12 @@ import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
-import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import {
+    isSkeletonItem,
+    redistributeTopMatches,
+    SKELETON_ROWS_PER_GROUP,
+    taxonomicFilterLogic,
+} from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
@@ -277,7 +282,7 @@ describe('taxonomicFilterLogic', () => {
                 })
         })
 
-        it('promotes up to 3 top matches from other groups', async () => {
+        it('collects top matches and redistributes via redistributedTopMatchItems', async () => {
             await expectLogic(quickLogic, () => {
                 quickLogic.actions.setSearchQuery('event')
             })
@@ -286,6 +291,11 @@ describe('taxonomicFilterLogic', () => {
                 .toMatchValues({
                     activeTab: TaxonomicFilterGroupType.SuggestedFilters,
                     topMatchItems: [
+                        expect.objectContaining({ name: 'event1', group: TaxonomicFilterGroupType.Events }),
+                        expect.objectContaining({ name: 'test event', group: TaxonomicFilterGroupType.Events }),
+                        expect.objectContaining({ name: 'other event', group: TaxonomicFilterGroupType.Events }),
+                    ],
+                    redistributedTopMatchItems: [
                         expect.objectContaining({ name: 'event1', group: TaxonomicFilterGroupType.Events }),
                         expect.objectContaining({ name: 'test event', group: TaxonomicFilterGroupType.Events }),
                         expect.objectContaining({ name: 'other event', group: TaxonomicFilterGroupType.Events }),
@@ -377,6 +387,53 @@ describe('taxonomicFilterLogic', () => {
                     payload.group.type === TaxonomicFilterGroupType.Events,
             ])
         })
+
+        it.each([
+            {
+                description: 'inserts skeleton placeholders for loading groups during search',
+                query: 'zzz-will-not-match',
+            },
+            {
+                description: 'inserts skeleton placeholders that are replaced by real results',
+                query: 'event',
+            },
+        ])('$description (query=$query)', async ({ query }) => {
+            const eventsListLogic = infiniteListLogic({
+                ...quickLogic.props,
+                listGroupType: TaxonomicFilterGroupType.Events,
+            })
+
+            await expectLogic(eventsListLogic).toDispatchActions(['loadRemoteItemsSuccess'])
+            await expectLogic(quickLogic).delay(1)
+
+            await expectLogic(quickLogic, () => {
+                quickLogic.actions.setSearchQuery(query)
+            }).toDispatchActions(['setSearchQuery'])
+
+            const duringLoading = quickLogic.values.topMatchItemsWithSkeletons
+            const skeletons = duringLoading.filter(isSkeletonItem)
+            expect(skeletons).toHaveLength(SKELETON_ROWS_PER_GROUP)
+            expect(skeletons.every((s) => s.group === TaxonomicFilterGroupType.Events)).toBe(true)
+            expect(skeletons[0].groupName).toBe('Events')
+
+            await expectLogic(eventsListLogic).toDispatchActions(['loadRemoteItemsSuccess'])
+            await expectLogic(quickLogic).delay(1)
+
+            const afterLoading = quickLogic.values.topMatchItemsWithSkeletons
+            expect(afterLoading.filter(isSkeletonItem)).toHaveLength(0)
+        })
+
+        it('does not insert skeletons when search query is empty', async () => {
+            const eventsListLogic = infiniteListLogic({
+                ...quickLogic.props,
+                listGroupType: TaxonomicFilterGroupType.Events,
+            })
+            await expectLogic(eventsListLogic).toDispatchActions(['loadRemoteItemsSuccess'])
+            await expectLogic(quickLogic).delay(1)
+
+            expect(quickLogic.values.searchQuery).toBe('')
+            expect(quickLogic.values.topMatchItemsWithSkeletons).toEqual([])
+        })
     })
 
     describe('SuggestedFilters presence', () => {
@@ -447,5 +504,138 @@ describe('taxonomicFilterLogic', () => {
                 { id: 'context3', name: 'Another Context', value: 'context3', icon: expect.anything() },
             ])
         })
+    })
+})
+
+describe('redistributeTopMatches', () => {
+    const makeItem = (name: string, group: TaxonomicFilterGroupType): any => ({ name, group })
+
+    it.each([
+        {
+            description: 'returns empty output for empty input',
+            items: [],
+            activeGroupCount: 3,
+            expected: [],
+        },
+        {
+            description: 'no redistribution needed when all groups are within default slots',
+            items: [
+                ...Array.from({ length: 4 }, (_, i) => makeItem(`e${i + 1}`, TaxonomicFilterGroupType.Events)),
+                makeItem('a1', TaxonomicFilterGroupType.Actions),
+            ],
+            activeGroupCount: 3,
+            expected: [
+                ...['e1', 'e2', 'e3', 'e4'].map((n) => expect.objectContaining({ name: n })),
+                expect.objectContaining({ name: 'a1' }),
+            ],
+        },
+        {
+            description: 'empty groups give surplus slots to groups with extra items',
+            items: Array.from({ length: 8 }, (_, i) => makeItem(`e${i + 1}`, TaxonomicFilterGroupType.Events)),
+            activeGroupCount: 3,
+            expected: Array.from({ length: 8 }, (_, i) => expect.objectContaining({ name: `e${i + 1}` })),
+        },
+        {
+            description: '3+ groups with results caps each at DEFAULT_SLOTS_PER_GROUP without redistribution',
+            items: [
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`ce${i + 1}`, TaxonomicFilterGroupType.CustomEvents)),
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`pu${i + 1}`, TaxonomicFilterGroupType.PageviewUrls)),
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`sc${i + 1}`, TaxonomicFilterGroupType.Screens)),
+            ],
+            activeGroupCount: 4,
+            expected: [
+                ...Array.from({ length: 5 }, (_, i) => expect.objectContaining({ name: `ce${i + 1}` })),
+                ...Array.from({ length: 5 }, (_, i) => expect.objectContaining({ name: `pu${i + 1}` })),
+                ...Array.from({ length: 5 }, (_, i) => expect.objectContaining({ name: `sc${i + 1}` })),
+            ],
+        },
+        {
+            description: 'fewer than 3 groups redistributes surplus with priority ordering',
+            items: [
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`ce${i + 1}`, TaxonomicFilterGroupType.CustomEvents)),
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`pu${i + 1}`, TaxonomicFilterGroupType.PageviewUrls)),
+            ],
+            activeGroupCount: 4,
+            expected: [
+                ...Array.from({ length: 8 }, (_, i) => expect.objectContaining({ name: `ce${i + 1}` })),
+                ...Array.from({ length: 8 }, (_, i) => expect.objectContaining({ name: `pu${i + 1}` })),
+            ],
+        },
+        {
+            description: 'surplus capped by available items in priority groups',
+            items: [
+                makeItem('ce1', TaxonomicFilterGroupType.CustomEvents),
+                ...Array.from({ length: 8 }, (_, i) => makeItem(`e${i + 1}`, TaxonomicFilterGroupType.Events)),
+            ],
+            activeGroupCount: 5,
+            expected: [
+                expect.objectContaining({ name: 'ce1' }),
+                ...Array.from({ length: 8 }, (_, i) => expect.objectContaining({ name: `e${i + 1}` })),
+            ],
+        },
+        {
+            description: 'without groupTypeOrder, preserves arrival order',
+            items: [makeItem('a1', TaxonomicFilterGroupType.Actions), makeItem('e1', TaxonomicFilterGroupType.Events)],
+            activeGroupCount: 2,
+            expected: [
+                expect.objectContaining({ name: 'a1', group: TaxonomicFilterGroupType.Actions }),
+                expect.objectContaining({ name: 'e1', group: TaxonomicFilterGroupType.Events }),
+            ],
+        },
+        {
+            description: 'with groupTypeOrder, sorts groups by category order regardless of arrival order',
+            items: [
+                makeItem('a1', TaxonomicFilterGroupType.Actions),
+                makeItem('dw1', TaxonomicFilterGroupType.DataWarehouse),
+                makeItem('e1', TaxonomicFilterGroupType.Events),
+            ],
+            activeGroupCount: 3,
+            groupTypeOrder: [
+                TaxonomicFilterGroupType.Events,
+                TaxonomicFilterGroupType.Actions,
+                TaxonomicFilterGroupType.DataWarehouse,
+            ],
+            expected: [
+                expect.objectContaining({ name: 'e1', group: TaxonomicFilterGroupType.Events }),
+                expect.objectContaining({ name: 'a1', group: TaxonomicFilterGroupType.Actions }),
+                expect.objectContaining({ name: 'dw1', group: TaxonomicFilterGroupType.DataWarehouse }),
+            ],
+        },
+        {
+            description: 'groupTypeOrder omits groups with no results',
+            items: [makeItem('e1', TaxonomicFilterGroupType.Events)],
+            activeGroupCount: 3,
+            groupTypeOrder: [TaxonomicFilterGroupType.Actions, TaxonomicFilterGroupType.Events],
+            expected: [expect.objectContaining({ name: 'e1', group: TaxonomicFilterGroupType.Events })],
+        },
+    ])('$description', ({ items, activeGroupCount, expected, groupTypeOrder }) => {
+        expect(redistributeTopMatches(items, activeGroupCount, groupTypeOrder)).toEqual(expected)
+    })
+})
+
+describe('isSkeletonItem', () => {
+    it.each([
+        {
+            description: 'returns true for skeleton items',
+            item: { _skeleton: true, group: TaxonomicFilterGroupType.Events, groupName: 'Events' },
+            expected: true,
+        },
+        {
+            description: 'returns false for regular items',
+            item: { name: 'event1', group: TaxonomicFilterGroupType.Events },
+            expected: false,
+        },
+        {
+            description: 'returns false for null',
+            item: null,
+            expected: false,
+        },
+        {
+            description: 'returns false for undefined',
+            item: undefined,
+            expected: false,
+        },
+    ])('$description', ({ item, expected }) => {
+        expect(isSkeletonItem(item)).toBe(expected)
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -15,6 +15,7 @@ import {
     ListStorage,
     SelectedProperties,
     SimpleOption,
+    SkeletonItem,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -79,6 +80,86 @@ import { HogFlowTaxonomicFilters } from 'products/workflows/frontend/Workflows/h
 
 import { InlineHogQLEditor } from './InlineHogQLEditor'
 import type { taxonomicFilterLogicType } from './taxonomicFilterLogicType'
+
+export const DEFAULT_SLOTS_PER_GROUP = 5
+export const MAX_TOP_MATCHES_PER_GROUP = 10
+
+const REDISTRIBUTION_PRIORITY_GROUPS: TaxonomicFilterGroupType[] = [
+    TaxonomicFilterGroupType.CustomEvents,
+    TaxonomicFilterGroupType.PageviewUrls,
+    TaxonomicFilterGroupType.Screens,
+]
+
+export type TopMatchItem = TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType }
+
+export const SKELETON_ROWS_PER_GROUP = 3
+
+export { isSkeletonItem, type SkeletonItem } from 'lib/components/TaxonomicFilter/types'
+
+export function redistributeTopMatches(
+    items: TopMatchItem[],
+    activeGroupCount: number,
+    groupTypeOrder: TaxonomicFilterGroupType[] = []
+): TopMatchItem[] {
+    if (items.length === 0) {
+        return []
+    }
+
+    const byGroup = new Map<TaxonomicFilterGroupType, TopMatchItem[]>()
+    for (const item of items) {
+        if (!byGroup.has(item.group)) {
+            byGroup.set(item.group, [])
+        }
+        byGroup.get(item.group)!.push(item)
+    }
+
+    const allocated = new Map<TaxonomicFilterGroupType, TopMatchItem[]>()
+    let usedSlots = 0
+    for (const [groupType, groupItems] of byGroup) {
+        const take = Math.min(groupItems.length, DEFAULT_SLOTS_PER_GROUP)
+        allocated.set(groupType, groupItems.slice(0, take))
+        usedSlots += take
+    }
+
+    if (byGroup.size < 3) {
+        const totalSlots = DEFAULT_SLOTS_PER_GROUP * activeGroupCount
+        let surplus = totalSlots - usedSlots
+        if (surplus > 0) {
+            const presentGroups = Array.from(byGroup.keys())
+            const priorityOrder = [
+                ...REDISTRIBUTION_PRIORITY_GROUPS.filter((g) => presentGroups.includes(g)),
+                ...presentGroups.filter((g) => !REDISTRIBUTION_PRIORITY_GROUPS.includes(g)),
+            ]
+
+            for (const groupType of priorityOrder) {
+                if (surplus <= 0) {
+                    break
+                }
+                const groupItems = byGroup.get(groupType)!
+                const currentlyAllocated = allocated.get(groupType) || []
+                const remaining = groupItems.slice(currentlyAllocated.length, MAX_TOP_MATCHES_PER_GROUP)
+                const extra = Math.min(remaining.length, surplus)
+                if (extra > 0) {
+                    allocated.set(groupType, [...currentlyAllocated, ...remaining.slice(0, extra)])
+                    surplus -= extra
+                }
+            }
+        }
+    }
+
+    const displayOrder =
+        groupTypeOrder.length > 0 ? groupTypeOrder.filter((g) => allocated.has(g)) : Array.from(allocated.keys())
+
+    const result: TopMatchItem[] = []
+    for (const groupType of displayOrder) {
+        const groupItems = allocated.get(groupType)
+        if (groupItems) {
+            result.push(...groupItems)
+        }
+    }
+
+    return result
+}
 
 export const eventTaxonomicGroupProps: Pick<TaxonomicFilterGroup, 'getPopoverHeader' | 'getIcon'> = {
     getPopoverHeader: (eventDefinition: EventDefinition): string => {
@@ -1136,6 +1217,24 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ],
             (anyGroupLoading: boolean) => anyGroupLoading,
         ],
+        loadingGroupTypes: [
+            (s) => [
+                (state, props) => {
+                    const logics = s.infiniteListLogics(state, props)
+                    return Object.entries(logics)
+                        .filter(
+                            ([type, logic]) =>
+                                type !== TaxonomicFilterGroupType.SuggestedFilters &&
+                                logic.isMounted() &&
+                                logic.selectors.isLoading(state, logic.props)
+                        )
+                        .map(([type]) => type)
+                        .join(',')
+                },
+            ],
+            (loadingGroupTypesString: string): TaxonomicFilterGroupType[] =>
+                loadingGroupTypesString ? (loadingGroupTypesString.split(',') as TaxonomicFilterGroupType[]) : [],
+        ],
         infiniteListCounts: [
             (s) => [
                 (state, props) =>
@@ -1179,6 +1278,54 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             `${index !== 0 ? (index === searchGroupTypes.length - 1 ? ' or ' : ', ') : ''}${name}`
                     )
                     .join('')
+            },
+        ],
+        redistributedTopMatchItems: [
+            (s) => [s.topMatchItems, s.taxonomicGroupTypes],
+            (topMatchItems: TopMatchItem[], taxonomicGroupTypes: TaxonomicFilterGroupType[]): TopMatchItem[] => {
+                const nonSuggestedGroups = taxonomicGroupTypes.filter(
+                    (t) => t !== TaxonomicFilterGroupType.SuggestedFilters
+                )
+                return redistributeTopMatches(topMatchItems, nonSuggestedGroups.length, nonSuggestedGroups)
+            },
+        ],
+        topMatchItemsWithSkeletons: [
+            (s) => [
+                s.redistributedTopMatchItems,
+                s.taxonomicGroupTypes,
+                s.loadingGroupTypes,
+                s.taxonomicGroups,
+                s.searchQuery,
+            ],
+            (
+                redistributed: TopMatchItem[],
+                taxonomicGroupTypes: TaxonomicFilterGroupType[],
+                loadingGroupTypes: TaxonomicFilterGroupType[],
+                taxonomicGroups: TaxonomicFilterGroup[],
+                searchQuery: string
+            ): (TopMatchItem | SkeletonItem)[] => {
+                if (!searchQuery) {
+                    return redistributed
+                }
+
+                const nonSuggestedGroups = taxonomicGroupTypes.filter(
+                    (t) => t !== TaxonomicFilterGroupType.SuggestedFilters
+                )
+
+                const result: (TopMatchItem | SkeletonItem)[] = []
+                for (const groupType of nonSuggestedGroups) {
+                    const groupItems = redistributed.filter((item) => item.group === groupType)
+                    if (groupItems.length > 0) {
+                        result.push(...groupItems)
+                    } else if (loadingGroupTypes.includes(groupType)) {
+                        const groupDef = taxonomicGroups.find((g) => g.type === groupType)
+                        const groupName = groupDef?.name ?? groupType
+                        for (let i = 0; i < SKELETON_ROWS_PER_GROUP; i++) {
+                            result.push({ _skeleton: true, group: groupType, groupName })
+                        }
+                    }
+                }
+                return result
             },
         ],
     }),

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -254,6 +254,16 @@ export type ListFuse = Fuse<{
     item: EventDefinition | CohortType
 }> // local alias for typegen
 
+export interface SkeletonItem {
+    _skeleton: true
+    group: TaxonomicFilterGroupType
+    groupName: string
+}
+
+export function isSkeletonItem(item: unknown): item is SkeletonItem {
+    return typeof item === 'object' && item !== null && '_skeleton' in item
+}
+
 export type TaxonomicDefinitionTypes =
     | EventDefinition
     | PropertyDefinition

--- a/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
@@ -7,11 +7,7 @@ import { LemonButton, Popover, Tooltip } from '@posthog/lemon-ui'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
-import {
-    TaxonomicDefinitionTypes,
-    TaxonomicFilterGroupType,
-    TaxonomicFilterRenderProps,
-} from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicFilterGroupType, TaxonomicFilterRenderProps } from 'lib/components/TaxonomicFilter/types'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 
 import { getFilterLabel } from '~/taxonomy/helpers'
@@ -19,8 +15,8 @@ import { PropertyFilterType } from '~/types'
 
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
 
-export const isReplayTaxonomicFilterProperty = (x: TaxonomicDefinitionTypes): x is ReplayTaxonomicFilterProperty => {
-    return (x as ReplayTaxonomicFilterProperty).taxonomicFilterGroup !== undefined
+export const isReplayTaxonomicFilterProperty = (x: unknown): x is ReplayTaxonomicFilterProperty => {
+    return typeof x === 'object' && x !== null && 'taxonomicFilterGroup' in x
 }
 
 export type ReplayTaxonomicFiltersProps = Pick<TaxonomicFilterRenderProps, 'onChange' | 'infiniteListLogicProps'>


### PR DESCRIPTION
the order of results in the suggested filters tab is determined by network speed not importance to the user

boo!

this adds skeleton rows for the groups we're searching only removing them when there are no results
the order of groups presented in the categories side bar determines the order of groups in the suggested filters tab

![CleanShot 2026-03-10 at 14.30.51.gif](https://app.graphite.com/user-attachments/assets/79a7dd01-002b-4056-918c-f47171f060d5.gif)

![CleanShot 2026-03-10 at 14.30.09.gif](https://app.graphite.com/user-attachments/assets/4d4fb3ae-131e-4e4e-9cf8-d5bab07a85e7.gif)

