### PR TITLE
Fix timezone parsing issues during DST transitions

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.test.ts
@@ -460,6 +460,49 @@ describe('selectExistingFeatureFlagModalLogic', () => {
         })
     })
 
+    describe('race condition handling', () => {
+        it('discards stale response when a newer loadFeatureFlags is dispatched', async () => {
+            let callIndex = 0
+            useMocks({
+                get: {
+                    '/api/projects/@current/experiments/eligible_feature_flags/': async (req) => {
+                        const thisCall = ++callIndex
+                        const url = new URL(req.url, 'http://localhost')
+                        const search = url.searchParams.get('search') || 'none'
+                        // First call is slow (500ms), second call is fast (0ms).
+                        // Without breakpoint() in the loader, the slow first response
+                        // arrives after the fast second one and overwrites it.
+                        if (thisCall === 1) {
+                            await new Promise((r) => setTimeout(r, 500))
+                        }
+                        return [
+                            200,
+                            {
+                                results: [{ ...mockFeatureFlags[0], key: `result-${search}` }],
+                                count: 1,
+                            },
+                        ]
+                    },
+                },
+            })
+
+            // Dispatch two loads directly to simulate the race:
+            // e.g. openModal fires load #1, then a quick search fires load #2
+            logic.actions.loadFeatureFlags()
+
+            // Small delay so both are in-flight but load #2 starts after load #1
+            await expectLogic(logic).delay(50)
+            logic.actions.setFilters({ search: 'latest' })
+            await expectLogic(logic).delay(350) // wait for debounce to fire load #2
+
+            // Wait for slow first response to also resolve
+            await expectLogic(logic).delay(500)
+
+            // The final value must be the latest search, not the stale slow one
+            expect(logic.values.featureFlags.results[0].key).toBe('result-latest')
+        }, 10000)
+    })
+
     describe('paramsFromFilters selector', () => {
         it('converts filters to API params with limit and offset', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.ts
@@ -105,7 +105,7 @@ export const selectExistingFeatureFlagModalLogic = kea<selectExistingFeatureFlag
         featureFlags: [
             { results: [], count: 0 } as { results: FeatureFlagType[]; count: number },
             {
-                loadFeatureFlags: async (_, breakpoint) => {
+                loadFeatureFlags: async (_: void, breakpoint) => {
                     const url = `api/projects/@current/experiments/eligible_feature_flags/?${toParams({
                         ...values.paramsFromFilters,
                     })}`

--- a/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/selectExistingFeatureFlagModalLogic.ts
@@ -105,11 +105,12 @@ export const selectExistingFeatureFlagModalLogic = kea<selectExistingFeatureFlag
         featureFlags: [
             { results: [], count: 0 } as { results: FeatureFlagType[]; count: number },
             {
-                loadFeatureFlags: async () => {
+                loadFeatureFlags: async (_, breakpoint) => {
                     const url = `api/projects/@current/experiments/eligible_feature_flags/?${toParams({
                         ...values.paramsFromFilters,
                     })}`
                     const response = await api.get(url)
+                    breakpoint()
                     return response
                 },
             },

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.test.ts
@@ -199,6 +199,20 @@ describe('createXAxisTickCallback', () => {
             expect(callback('ignored', 1)).toBe('July')
             expect(callback('ignored', 2)).toBe('August')
         })
+
+        it('does not shift dates around US DST spring-forward transition', () => {
+            // US DST spring-forward is March 8, 2026. When the browser timezone
+            // differs from the project timezone, dayjs.tz() can mis-parse dates
+            // near the transition, causing e.g. Mar 8 to show as Mar 7.
+            const callback = createXAxisTickCallback({
+                interval: 'day',
+                allDays: ['2026-03-07', '2026-03-08', '2026-03-09'],
+                timezone: 'US/Pacific',
+            })
+            expect(callback('ignored', 0)).toBe('Mar 7')
+            expect(callback('ignored', 1)).toBe('Mar 8')
+            expect(callback('ignored', 2)).toBe('Mar 9')
+        })
     })
 
     describe('fallbacks', () => {

--- a/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/formatXAxisTick.ts
@@ -24,19 +24,18 @@ export function createXAxisTickCallback({
         return (value) => String(value)
     }
 
-    // Datetime strings (with time component) are already in the project timezone
-    // (ClickHouse applies toTimeZone before truncation), so parse them directly in
-    // that timezone. Date-only strings are calendar bucket labels — parse as midnight
-    // in the project timezone so that e.g. "2023-07-01" stays July and doesn't drift
-    // to June in behind-UTC timezones.
+    // Both datetime and date-only strings represent wall-clock times in the project
+    // timezone. We must avoid `dayjs.tz(string, tz)` because it internally parses the
+    // string in the *browser's* local timezone first, then converts — during DST
+    // transitions this intermediate step can shift the date by a day.
+    // Instead, parse as UTC (browser-independent) then reinterpret in the target
+    // timezone with `keepLocalTime: true` so the wall-clock time stays unchanged.
     const parsedDates = allDays.map((d) => {
         const s = String(d)
         const hasTime = s.includes(' ') || s.includes('T')
-        if (hasTime) {
-            return dayjs.tz(s, timezone)
-        }
         try {
-            return dayjs.tz(s + ' 00:00:00', timezone)
+            const utc = hasTime ? dayjs.utc(s) : dayjs.utc(s + ' 00:00:00')
+            return utc.isValid() ? utc.tz(timezone, true) : dayjs(null)
         } catch {
             return dayjs(null)
         }


### PR DESCRIPTION
## Changes

### Insights: formatXAxisTick
- **Fix DST transition bug**: Avoid `dayjs.tz(string, tz)` which parses strings in the browser's local timezone first, causing date shifts during DST transitions (e.g., spring-forward)
- **Solution**: Parse all dates as UTC first, then reinterpret in target timezone with `keepLocalTime: true` to preserve wall-clock time
- **Added test**: Verify dates don't shift around US DST spring-forward transition (March 8, 2026)

### Experiments: selectExistingFeatureFlagModalLogic
- **Fix race condition**: Add `breakpoint()` call after API response to discard stale responses when newer requests are dispatched
- **Added test**: Verify that slow first response doesn't overwrite faster second response with newer data

## Testing
- New test cases cover both DST edge case and race condition handling
- 4 files changed: 2 test files added/updated, 2 logic files fixed