### PR TITLE
chore(toolbar): cors allow credentials

### DIFF
--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2932,7 +2932,7 @@
   SELECT 1 AS "a"
   FROM "posthog_team"
   WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 41}'::jsonb)
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 46}'::jsonb)
   LIMIT 1
   '''
 # ---

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -90,4 +90,6 @@ if os.getenv("CORS_ALLOWED_ORIGINS", False):
 else:
     CORS_ORIGIN_ALLOW_ALL = True
 
+CORS_ALLOW_CREDENTIALS = True
+
 BLOCKED_GEOIP_REGIONS = get_list(os.getenv("BLOCKED_GEOIP_REGIONS", ""))


### PR DESCRIPTION
## Problem

by default, django-cors-headers uses `Access-Control-Allow-Origin: *`, which fails when requests include `credentials: "include"`

tools like datadog patch requests with `credentials: "include"`

therefore toolbar api requests always fail for customers with datadog or a similar tool enabled

sample request from the toolbar on a customer site that fails:

```javascript
await fetch("https://eu.posthog.com/api/projects/@current/product_tours/", {
  "headers": {
    "authorization": "Bearer [redacted]",
    "sec-ch-ua": "\"Not(A:Brand\";v=\"8\", \"Chromium\";v=\"144\", \"Google Chrome\";v=\"144\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"macOS\"",
    "traceparent": "[redacted]",
    "tracestate": "dd=s:1;o:rum",
    "x-datadog-origin": "rum",
    "x-datadog-parent-id": "[redacted]",
    "x-datadog-sampling-priority": "1",
    "x-datadog-trace-id": "[redacted]"
  },
  "referrer": "[customer domain - redacted]",
  "body": null,
  "method": "GET",
  "mode": "cors",
  "credentials": "include"
});
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

sorta-related, previously merged PR to allow datadog headers: https://github.com/PostHog/posthog/pull/49396

## Changes

sets `CORS_ALLOW_CREDENTIALS = True` so requests with `credentials: "include"` are no longer blocked

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->