### PR TITLE
feat(logs): add initial scaffolding for alert configuration UI

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -40,6 +40,7 @@ import { AccessControlLevel, AccessControlResourceType, Realm } from '~/types'
 import { CustomerAnalyticsDashboardEvents } from 'products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/events/CustomerAnalyticsDashboardEvents'
 import { ExceptionAutocaptureToggle } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/ExceptionAutocaptureSettings'
 import { SuppressionRules } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRules'
+import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
 
 import { IntegrationsList } from '../../lib/integrations/IntegrationsList'
 import {
@@ -1089,6 +1090,14 @@ export const SETTINGS_MAP: SettingSection[] = [
                 component: <LogsRetentionSettings />,
                 flag: 'LOGS_SETTINGS_RETENTION',
                 keywords: ['retention', 'storage', 'delete', 'ttl'],
+            },
+            {
+                id: 'logs-alerting',
+                title: 'Alerting',
+                description: 'Configure alerts to get notified when log volumes breach thresholds.',
+                component: <LogsAlertingSection />,
+                flag: 'LOGS_ALERTING',
+                keywords: ['notification', 'alert', 'threshold', 'logs'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -200,6 +200,7 @@ export type SettingId =
     | 'logs'
     | 'logs-json-parse'
     | 'logs-retention'
+    | 'logs-alerting'
     | 'organization-ip-anonymization-default'
     | 'allow-impersonation'
     | 'approval-policies'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2483,6 +2483,9 @@ importers:
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
+      kea-forms:
+        specifier: 'catalog:'
+        version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       kea-loaders:
         specifier: 'catalog:'
         version: 3.1.1(kea@4.0.0-pre.5(react@18.3.1))

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -33,12 +33,14 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
     evaluation_periods = serializers.IntegerField(
         default=1,
         min_value=1,
-        help_text="Total number of check periods in the sliding evaluation window (M in N-of-M).",
+        max_value=10,
+        help_text="Total number of check periods in the sliding evaluation window for firing (M in N-of-M).",
     )
     datapoints_to_alarm = serializers.IntegerField(
         default=1,
         min_value=1,
-        help_text="How many periods within the evaluation window must breach the threshold to trigger (N in N-of-M).",
+        max_value=10,
+        help_text="How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).",
     )
 
     class Meta:

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -56,8 +56,7 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
     )
 
     # N-of-M evaluation (AWS CloudWatch naming convention).
-    # evaluation_periods = M (total checks in sliding window)
-    # datapoints_to_alarm = N (how many must breach to trigger)
+    # evaluation_periods = M, datapoints_to_alarm = N
     evaluation_periods = models.PositiveIntegerField(default=1)
     datapoints_to_alarm = models.PositiveIntegerField(default=1)
 

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -1,0 +1,397 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonCollapse, LemonDropdown, LemonInput, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
+
+import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
+import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
+import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
+import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
+import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
+import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
+
+import { ServiceFilter } from 'products/logs/frontend/components/LogsViewer/Filters/ServiceFilter'
+import { SeverityLevelsFilter } from 'products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter'
+import { ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+import { logsAlertFormLogic } from './logsAlertFormLogic'
+
+const WINDOW_OPTIONS = [
+    { value: 5, label: '5 minutes' },
+    { value: 10, label: '10 minutes' },
+    { value: 15, label: '15 minutes' },
+    { value: 30, label: '30 minutes' },
+    { value: 60, label: '60 minutes' },
+]
+
+const taxonomicFilterLogicKey = 'logs-alert'
+const taxonomicGroupTypes = [
+    TaxonomicFilterGroupType.Logs,
+    TaxonomicFilterGroupType.LogResourceAttributes,
+    TaxonomicFilterGroupType.LogAttributes,
+]
+
+function buildCheckPattern(datapoints: number, periods: number): boolean[] {
+    // Last check is always matched — it's the one that tips the alert over.
+    // Distribute OK checks evenly across the remaining positions.
+    const result: boolean[] = Array(periods).fill(true)
+    const okCount = periods - datapoints
+    for (let i = 0; i < okCount; i++) {
+        const pos = Math.round((i * (periods - 2)) / Math.max(okCount - 1, 1))
+        result[pos] = false
+    }
+    return result
+}
+
+function CheckDots({ checks }: { checks: boolean[] }): JSX.Element {
+    return (
+        <>
+            {checks.map((matched, i) => (
+                <div
+                    key={i}
+                    className={`w-3 h-3 rounded-full border ${
+                        matched ? 'bg-danger-highlight border-danger' : 'bg-success-highlight border-success'
+                    }`}
+                    title={`Check ${i + 1}: ${matched ? 'matched' : 'ok'}`}
+                />
+            ))}
+        </>
+    )
+}
+
+function CheckDotsTooltip({ datapoints, periods }: { datapoints: number; periods: number }): JSX.Element {
+    const checks = useMemo(() => buildCheckPattern(datapoints, periods), [datapoints, periods])
+
+    return (
+        <Tooltip
+            title={
+                <div className="space-y-1 py-0.5">
+                    <div className="text-xs">
+                        {datapoints} of {periods} checks must match to fire
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                        <CheckDots checks={checks} />
+                        <span className="text-xs">→</span>
+                        <span className="text-xs font-semibold text-danger">fires</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-secondary">
+                        <span className="inline-flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-full bg-danger-highlight border border-danger" />
+                            matched
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-full bg-success-highlight border border-success" />
+                            OK
+                        </span>
+                    </div>
+                </div>
+            }
+        >
+            <IconInfo className="text-base text-secondary" />
+        </Tooltip>
+    )
+}
+
+export function LogsAlertForm(): JSX.Element {
+    const { alertForm } = useValues(logsAlertFormLogic)
+    const { setAlertFormValue } = useActions(logsAlertFormLogic)
+
+    const handleFilterGroupChange = useCallback(
+        (group: UniversalFiltersGroup) => setAlertFormValue('filterGroup', group),
+        [setAlertFormValue]
+    )
+
+    return (
+        <div className="space-y-4">
+            <LemonField name="name" label="Name">
+                <LemonInput placeholder="e.g. API 5xx errors" fullWidth />
+            </LemonField>
+
+            <LemonCollapse
+                multiple
+                defaultActiveKeys={['filters', 'rules']}
+                panels={[
+                    {
+                        key: 'filters',
+                        header: 'Filters',
+                        content: (
+                            <div className="space-y-2">
+                                <p className="text-xs text-secondary m-0">
+                                    Every minute, query for logs matching these filters.
+                                </p>
+
+                                <LemonField name="severityLevels" label="Severity">
+                                    <SeverityLevelsFilter
+                                        value={alertForm.severityLevels}
+                                        onChange={(levels) => setAlertFormValue('severityLevels', levels)}
+                                    />
+                                </LemonField>
+
+                                <LemonField.Pure label="Service">
+                                    <ServiceFilter
+                                        value={alertForm.serviceNames}
+                                        onChange={(names) => setAlertFormValue('serviceNames', names)}
+                                    />
+                                </LemonField.Pure>
+
+                                <LemonField name="filterGroup" label="Attributes">
+                                    <AlertFilterGroup
+                                        filterGroup={alertForm.filterGroup}
+                                        onChange={handleFilterGroupChange}
+                                    />
+                                </LemonField>
+                            </div>
+                        ),
+                    },
+                    {
+                        key: 'rules',
+                        header: 'Rules',
+                        content: (
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <span className="text-sm">Alert if count goes</span>
+                                <LemonSegmentedButton
+                                    value={alertForm.thresholdOperator}
+                                    onChange={(value) => setAlertFormValue('thresholdOperator', value)}
+                                    options={[
+                                        {
+                                            value: ThresholdOperatorEnumApi.Above,
+                                            label: 'above',
+                                        },
+                                        {
+                                            value: ThresholdOperatorEnumApi.Below,
+                                            label: 'below',
+                                        },
+                                    ]}
+                                    size="small"
+                                />
+                                <LemonInput
+                                    type="number"
+                                    min={1}
+                                    value={alertForm.thresholdCount}
+                                    onChange={(val) => setAlertFormValue('thresholdCount', val ?? 1)}
+                                    className="w-24"
+                                    size="small"
+                                />
+                                <span className="text-sm">in the last</span>
+                                <LemonSelect
+                                    value={alertForm.windowMinutes}
+                                    onChange={(val) => setAlertFormValue('windowMinutes', val ?? 10)}
+                                    options={WINDOW_OPTIONS}
+                                    size="small"
+                                />
+                            </div>
+                        ),
+                    },
+                    {
+                        key: 'advanced',
+                        header: 'Advanced',
+                        content: (
+                            <div className="space-y-4">
+                                <LemonField.Pure
+                                    label={
+                                        <span className="inline-flex items-center gap-1">
+                                            Reduce noise
+                                            <Tooltip title="Require the condition to be met multiple times before the alert fires. This prevents notifications on brief, one-off spikes.">
+                                                <IconInfo className="text-base text-secondary" />
+                                            </Tooltip>
+                                        </span>
+                                    }
+                                >
+                                    <div className="space-y-2">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <LemonInput
+                                                type="number"
+                                                min={1}
+                                                max={alertForm.evaluationPeriods}
+                                                value={alertForm.datapointsToAlarm}
+                                                onChange={(val) => setAlertFormValue('datapointsToAlarm', val ?? 1)}
+                                                className="w-16"
+                                                size="small"
+                                            />
+                                            <span className="text-sm">of</span>
+                                            <LemonInput
+                                                type="number"
+                                                min={alertForm.datapointsToAlarm}
+                                                max={10}
+                                                value={alertForm.evaluationPeriods}
+                                                onChange={(val) => {
+                                                    const newPeriods = val ?? alertForm.datapointsToAlarm
+                                                    setAlertFormValue('evaluationPeriods', newPeriods)
+                                                    if (alertForm.datapointsToAlarm > newPeriods) {
+                                                        setAlertFormValue('datapointsToAlarm', newPeriods)
+                                                    }
+                                                }}
+                                                className="w-16"
+                                                size="small"
+                                            />
+                                            <span className="text-sm">checks must match to fire</span>
+                                            <CheckDotsTooltip
+                                                datapoints={alertForm.datapointsToAlarm}
+                                                periods={alertForm.evaluationPeriods}
+                                            />
+                                        </div>
+                                        <p className="text-xs text-secondary m-0">
+                                            The alert auto-resolves once the condition is no longer met.
+                                        </p>
+                                    </div>
+                                </LemonField.Pure>
+
+                                <LemonField.Pure
+                                    label="Notification cooldown"
+                                    help="After firing, wait this long before sending another notification. Set to 0 to notify on every check."
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <LemonInput
+                                            type="number"
+                                            min={0}
+                                            value={alertForm.cooldownMinutes}
+                                            onChange={(val) => setAlertFormValue('cooldownMinutes', val ?? 0)}
+                                            className="w-24"
+                                            size="small"
+                                        />
+                                        <span className="text-sm">minutes</span>
+                                    </div>
+                                </LemonField.Pure>
+                            </div>
+                        ),
+                    },
+                ]}
+            />
+        </div>
+    )
+}
+
+const AlertFilterGroup = memo(function AlertFilterGroup({
+    filterGroup,
+    onChange,
+}: {
+    filterGroup: UniversalFiltersGroup
+    onChange: (group: UniversalFiltersGroup) => void
+}): JSX.Element {
+    return (
+        <UniversalFilters
+            rootKey={taxonomicFilterLogicKey}
+            group={filterGroup}
+            taxonomicGroupTypes={taxonomicGroupTypes}
+            onChange={onChange}
+        >
+            <div className="space-y-2">
+                <AlertFilterSearch />
+                <AlertAppliedFilters />
+            </div>
+        </UniversalFilters>
+    )
+})
+
+function AlertFilterSearch(): JSX.Element {
+    const [visible, setVisible] = useState<boolean>(false)
+    const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
+    const { filterGroup } = useValues(universalFiltersLogic)
+
+    const searchInputRef = useRef<HTMLInputElement | null>(null)
+    const floatingRef = useRef<HTMLDivElement | null>(null)
+    const filterGroupRef = useRef(filterGroup)
+    filterGroupRef.current = filterGroup
+
+    const onClose = useCallback((): void => {
+        searchInputRef.current?.blur()
+        setVisible(false)
+    }, [])
+
+    const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = useMemo(
+        () => ({
+            taxonomicFilterLogicKey,
+            taxonomicGroupTypes,
+            onChange: (taxonomicGroup, value, item) => {
+                if (item.value === undefined) {
+                    addGroupFilter(taxonomicGroup, value, item)
+                    setVisible(false)
+                    return
+                }
+
+                const newValues = [...filterGroupRef.current.values]
+                const newPropertyFilter = {
+                    key: item.key,
+                    value: item.value,
+                    operator: PropertyOperator.IContains,
+                    type: item.propertyFilterType,
+                } as AnyPropertyFilter
+                newValues.push(newPropertyFilter)
+                setGroupValues(newValues)
+                setVisible(false)
+            },
+            onEnter: () => {
+                searchInputRef.current?.blur()
+                setVisible(false)
+            },
+            autoSelectItem: true,
+        }),
+        [addGroupFilter, setGroupValues]
+    )
+
+    const showDropdown = useCallback(() => setVisible(true), [])
+
+    return (
+        <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
+            <LemonDropdown
+                overlay={
+                    <div className="w-[400px]">
+                        <InfiniteSelectResults
+                            focusInput={() => searchInputRef.current?.focus()}
+                            taxonomicFilterLogicProps={taxonomicFilterLogicProps}
+                            popupAnchorElement={floatingRef.current}
+                            useVerticalLayout={true}
+                        />
+                    </div>
+                }
+                visible={visible}
+                closeOnClickInside={false}
+                floatingRef={floatingRef}
+                onClickOutside={onClose}
+            >
+                <TaxonomicFilterSearchInput
+                    onClick={showDropdown}
+                    searchInputRef={searchInputRef}
+                    onClose={onClose}
+                    onChange={showDropdown}
+                />
+            </LemonDropdown>
+        </BindLogic>
+    )
+}
+
+function AlertAppliedFilters(): JSX.Element | null {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
+
+    if (filterGroup.values.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex gap-1 items-center flex-wrap">
+            {filterGroup.values.map((filterOrGroup, index) => {
+                return isUniversalGroupFilterLike(filterOrGroup) ? (
+                    <UniversalFilters.Group index={index} key={index} group={filterOrGroup}>
+                        <AlertAppliedFilters />
+                    </UniversalFilters.Group>
+                ) : (
+                    <UniversalFilters.Value
+                        key={index}
+                        index={index}
+                        filter={filterOrGroup}
+                        onRemove={() => removeGroupValue(index)}
+                        onChange={(value) => replaceGroupValue(index, value)}
+                        initiallyOpen={filterOrGroup.type !== PropertyFilterType.HogQL}
+                    />
+                )
+            })}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -1,0 +1,107 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonDialog, LemonSwitch, LemonTable, LemonTableColumns, SpinnerOverlay } from '@posthog/lemon-ui'
+
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+
+import { LogsAlertConfigurationApi, ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+import { logsAlertingLogic } from './logsAlertingLogic'
+import { LogsAlertStateIndicator } from './LogsAlertStateIndicator'
+
+function formatThreshold(alert: LogsAlertConfigurationApi): string {
+    const operator = alert.threshold_operator === ThresholdOperatorEnumApi.Below ? '<' : '>'
+    return `${operator} ${alert.threshold_count} in ${alert.window_minutes}m`
+}
+
+export function LogsAlertList(): JSX.Element {
+    const { alerts, alertsLoading } = useValues(logsAlertingLogic)
+    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled } = useActions(logsAlertingLogic)
+
+    const columns: LemonTableColumns<LogsAlertConfigurationApi> = [
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            render: (_, alert) => (
+                <LemonButton type="tertiary" size="small" onClick={() => setEditingAlert(alert)}>
+                    {alert.name}
+                </LemonButton>
+            ),
+        },
+        {
+            title: 'Status',
+            dataIndex: 'state',
+            render: (_, alert) => <LogsAlertStateIndicator state={alert.state} />,
+        },
+        {
+            title: 'Threshold',
+            render: (_, alert) => <span className="text-muted text-xs">{formatThreshold(alert)}</span>,
+        },
+        {
+            title: 'Enabled',
+            dataIndex: 'enabled',
+            render: (_, alert) => (
+                <LemonSwitch checked={alert.enabled ?? true} onChange={() => toggleAlertEnabled(alert)} />
+            ),
+        },
+        {
+            title: '',
+            render: (_, alert) => (
+                <More
+                    overlay={
+                        <LemonMenuOverlay
+                            items={[
+                                {
+                                    label: 'Edit',
+                                    onClick: () => setEditingAlert(alert),
+                                },
+                                {
+                                    label: 'Delete',
+                                    status: 'danger',
+                                    onClick: () => {
+                                        LemonDialog.open({
+                                            title: `Delete "${alert.name}"?`,
+                                            description:
+                                                'This alert will be permanently deleted. This action cannot be undone.',
+                                            primaryButton: {
+                                                children: 'Delete',
+                                                type: 'primary',
+                                                status: 'danger',
+                                                onClick: () => deleteAlert(alert.id),
+                                            },
+                                            secondaryButton: {
+                                                children: 'Cancel',
+                                            },
+                                        })
+                                    },
+                                },
+                            ]}
+                        />
+                    }
+                />
+            ),
+        },
+    ]
+
+    if (alertsLoading) {
+        return <SpinnerOverlay />
+    }
+
+    return (
+        <div className="space-y-2">
+            <div className="flex justify-end">
+                <LemonButton type="primary" size="small" onClick={() => setIsCreating(true)}>
+                    New alert
+                </LemonButton>
+            </div>
+            <LemonTable
+                columns={columns}
+                dataSource={alerts}
+                rowKey="id"
+                emptyState="No alerts configured yet."
+                size="small"
+            />
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
@@ -1,0 +1,16 @@
+import { LemonTag, LemonTagType } from '@posthog/lemon-ui'
+
+import { LogsAlertConfigurationStateEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+const STATE_CONFIG: Record<LogsAlertConfigurationStateEnumApi, { label: string; type: LemonTagType }> = {
+    [LogsAlertConfigurationStateEnumApi.NotFiring]: { label: 'OK', type: 'success' },
+    [LogsAlertConfigurationStateEnumApi.Firing]: { label: 'Firing', type: 'danger' },
+    [LogsAlertConfigurationStateEnumApi.PendingResolve]: { label: 'Resolving', type: 'warning' },
+    [LogsAlertConfigurationStateEnumApi.Errored]: { label: 'Errored', type: 'danger' },
+    [LogsAlertConfigurationStateEnumApi.Snoozed]: { label: 'Snoozed', type: 'muted' },
+}
+
+export function LogsAlertStateIndicator({ state }: { state: LogsAlertConfigurationStateEnumApi }): JSX.Element {
+    const config = STATE_CONFIG[state] ?? { label: state, type: 'default' as LemonTagType }
+    return <LemonTag type={config.type}>{config.label}</LemonTag>
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -1,0 +1,75 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+
+import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+
+import { LogsAlertForm } from './LogsAlertForm'
+import { logsAlertFormLogic } from './logsAlertFormLogic'
+import { logsAlertingLogic } from './logsAlertingLogic'
+import { LogsAlertList } from './LogsAlertList'
+
+export function LogsAlertingSection(): JSX.Element {
+    return (
+        <BindLogic logic={logsAlertingLogic} props={{}}>
+            <LogsAlertingSectionInner />
+        </BindLogic>
+    )
+}
+
+function LogsAlertingSectionInner(): JSX.Element {
+    const { isCreating, editingAlert } = useValues(logsAlertingLogic)
+    const { setIsCreating, setEditingAlert } = useActions(logsAlertingLogic)
+
+    const isModalOpen = isCreating || editingAlert !== null
+
+    return (
+        <>
+            <LogsAlertList />
+            <LemonModal
+                isOpen={isModalOpen}
+                onClose={() => {
+                    setIsCreating(false)
+                    setEditingAlert(null)
+                }}
+                title=""
+                simple
+                width={720}
+            >
+                {isModalOpen && <LogsAlertModalContent editingAlert={editingAlert} />}
+            </LemonModal>
+        </>
+    )
+}
+
+function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfigurationApi | null }): JSX.Element {
+    const formLogicProps = { alert: editingAlert }
+    const { isAlertFormSubmitting } = useValues(logsAlertFormLogic(formLogicProps))
+
+    return (
+        <Form
+            logic={logsAlertFormLogic}
+            props={formLogicProps}
+            formKey="alertForm"
+            enableFormOnSubmit
+            className="LemonModal__layout"
+        >
+            <LemonModal.Header>
+                <h3>{editingAlert ? 'Edit alert' : 'New alert'}</h3>
+                <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
+            </LemonModal.Header>
+            <LemonModal.Content>
+                <LogsAlertForm />
+            </LemonModal.Content>
+            <LemonModal.Footer>
+                <div className="flex-1" />
+                <LemonButton type="primary" htmlType="submit" loading={isAlertFormSubmitting}>
+                    {editingAlert ? 'Save' : 'Create alert'}
+                </LemonButton>
+            </LemonModal.Footer>
+        </Form>
+    )
+}

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
@@ -1,0 +1,541 @@
+import { MOCK_TEAM_ID } from '~/lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { initKeaTests } from '~/test/init'
+import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
+
+import { logsAlertsCreate, logsAlertsPartialUpdate } from 'products/logs/frontend/generated/api'
+import {
+    LogsAlertConfigurationApi,
+    LogsAlertConfigurationStateEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
+
+import { LogsAlertFormType, logsAlertFormLogic } from '../logsAlertFormLogic'
+import { logsAlertingLogic } from '../logsAlertingLogic'
+
+jest.mock('products/logs/frontend/generated/api', () => ({
+    logsAlertsCreate: jest.fn(),
+    logsAlertsPartialUpdate: jest.fn(),
+    logsAlertsList: jest.fn(),
+    logsAlertsDestroy: jest.fn(),
+}))
+
+jest.mock('@posthog/lemon-ui', () => ({
+    lemonToast: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+const mockLogsAlertsCreate = logsAlertsCreate as jest.MockedFunction<typeof logsAlertsCreate>
+const mockLogsAlertsPartialUpdate = logsAlertsPartialUpdate as jest.MockedFunction<typeof logsAlertsPartialUpdate>
+
+const MOCK_PROJECT_ID = String(MOCK_TEAM_ID)
+
+const MOCK_ALERT: LogsAlertConfigurationApi = {
+    id: 'alert-uuid-1',
+    name: 'Test Alert',
+    enabled: true,
+    filters: { severityLevels: ['error'] },
+    threshold_count: 50,
+    threshold_operator: 'above',
+    window_minutes: 5,
+    evaluation_periods: 2,
+    datapoints_to_alarm: 1,
+    cooldown_minutes: 10,
+    state: LogsAlertConfigurationStateEnumApi.NotFiring,
+    check_interval_minutes: 1,
+    next_check_at: null,
+    last_notified_at: null,
+    last_checked_at: null,
+    consecutive_failures: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: {
+        id: 1,
+        uuid: 'user-uuid',
+        distinct_id: 'user-distinct-id',
+        first_name: 'Test',
+        email: 'test@example.com',
+        hedgehog_config: null,
+    },
+    updated_at: null,
+}
+
+const MOCK_CREATED_ALERT: LogsAlertConfigurationApi = {
+    ...MOCK_ALERT,
+    id: 'newly-created-uuid',
+}
+
+const VALID_FORM_VALUES: LogsAlertFormType = {
+    name: 'My Alert',
+    severityLevels: ['error'],
+    serviceNames: [],
+    filterGroup: { type: FilterLogicalOperator.And, values: [] },
+    thresholdOperator: 'above',
+    thresholdCount: 100,
+    windowMinutes: 10,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    cooldownMinutes: 0,
+}
+
+describe('logsAlertFormLogic', () => {
+    let alertingLogic: ReturnType<typeof logsAlertingLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+
+        alertingLogic = logsAlertingLogic.build()
+        alertingLogic.mount()
+        // Prevent afterMount loadAlerts from throwing
+        ;(require('products/logs/frontend/generated/api').logsAlertsList as jest.Mock).mockResolvedValue({
+            results: [],
+            count: 0,
+        })
+    })
+
+    afterEach(() => {
+        alertingLogic?.unmount()
+    })
+
+    describe('errors validation', () => {
+        // kea-forms exposes alertFormValidationErrors which always returns
+        // the raw computed errors, regardless of touched/submit state.
+        // alertFormErrors only surfaces them after the form is submitted or touched.
+
+        it('reports name error when name is empty', () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({ name: '', severityLevels: ['error'] })
+
+            expect(logic.values.alertFormValidationErrors.name).toBe('Name is required')
+
+            logic.unmount()
+        })
+
+        it('reports name error when name is only whitespace', () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({ name: '   ', severityLevels: ['error'] })
+
+            expect(logic.values.alertFormValidationErrors.name).toBe('Name is required')
+
+            logic.unmount()
+        })
+
+        it('clears name error when name has non-whitespace content', () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({ name: 'Valid name', severityLevels: ['error'] })
+
+            expect(logic.values.alertFormValidationErrors.name).toBeUndefined()
+
+            logic.unmount()
+        })
+
+        it('shows error toast on submit when no filter criteria are set', async () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({
+                name: 'My Alert',
+                severityLevels: [],
+                serviceNames: [],
+                filterGroup: { type: FilterLogicalOperator.And, values: [] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('At least one filter is required')
+            expect(mockLogsAlertsCreate).not.toHaveBeenCalled()
+
+            logic.unmount()
+        })
+
+        it.each<[string, Partial<LogsAlertFormType>]>([
+            [
+                'severityLevels populated',
+                {
+                    severityLevels: ['error'],
+                    serviceNames: [],
+                    filterGroup: { type: FilterLogicalOperator.And, values: [] },
+                },
+            ],
+            [
+                'serviceNames populated',
+                {
+                    severityLevels: [],
+                    serviceNames: ['my-service'],
+                    filterGroup: { type: FilterLogicalOperator.And, values: [] },
+                },
+            ],
+            [
+                'filterGroup has values',
+                {
+                    severityLevels: [],
+                    serviceNames: [],
+                    filterGroup: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                key: 'env',
+                                value: 'prod',
+                                operator: 'exact',
+                                type: 'event',
+                            } as AnyPropertyFilter,
+                        ],
+                    },
+                },
+            ],
+        ])('submits successfully when %s', async (_, filters) => {
+            mockLogsAlertsCreate.mockResolvedValue(MOCK_CREATED_ALERT)
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({ name: 'My Alert', ...filters })
+
+            await expectLogic(logic, () => {
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).toHaveBeenCalled()
+
+            logic.unmount()
+        })
+
+        it('alertFormErrors surfaces name error after submit attempt with validation failures', async () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            logic.actions.setAlertFormValues({
+                name: '',
+                severityLevels: ['error'],
+                serviceNames: [],
+                filterGroup: { type: FilterLogicalOperator.And, values: [] },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(logic.values.alertFormErrors.name).toBe('Name is required')
+
+            logic.unmount()
+        })
+    })
+
+    describe('create path (props.alert is null)', () => {
+        let logic: ReturnType<typeof logsAlertFormLogic.build>
+
+        beforeEach(() => {
+            mockLogsAlertsCreate.mockResolvedValue(MOCK_CREATED_ALERT)
+            logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+        })
+
+        afterEach(() => {
+            logic?.unmount()
+        })
+
+        it('calls logsAlertsCreate with correct payload on submit', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).toHaveBeenCalledTimes(1)
+            expect(mockLogsAlertsCreate).toHaveBeenCalledWith(
+                MOCK_PROJECT_ID,
+                expect.objectContaining({
+                    name: 'My Alert',
+                    filters: { severityLevels: ['error'] },
+                    threshold_count: 100,
+                    threshold_operator: 'above',
+                    window_minutes: 10,
+                    evaluation_periods: 1,
+                    datapoints_to_alarm: 1,
+                    cooldown_minutes: 0,
+                })
+            )
+        })
+
+        it('does not call logsAlertsPartialUpdate on create path', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsPartialUpdate).not.toHaveBeenCalled()
+        })
+
+        it('shows success toast after create', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.success).toHaveBeenCalledWith('Alert created')
+        })
+
+        it('trims whitespace from name in create payload', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues({ ...VALID_FORM_VALUES, name: '  trimmed  ' })
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).toHaveBeenCalledWith(
+                MOCK_PROJECT_ID,
+                expect.objectContaining({ name: 'trimmed' })
+            )
+        })
+
+        it('builds filters with only serviceNames when only serviceNames are provided', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues({
+                    ...VALID_FORM_VALUES,
+                    severityLevels: [],
+                    serviceNames: ['svc-a', 'svc-b'],
+                    filterGroup: { type: FilterLogicalOperator.And, values: [] },
+                })
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).toHaveBeenCalledWith(
+                MOCK_PROJECT_ID,
+                expect.objectContaining({
+                    filters: { serviceNames: ['svc-a', 'svc-b'] },
+                })
+            )
+        })
+
+        it('wraps filterGroup values in outer And group in payload', async () => {
+            const innerGroup: UniversalFiltersGroup = {
+                type: FilterLogicalOperator.And,
+                values: [{ key: 'env', value: 'prod', operator: 'exact', type: 'event' } as AnyPropertyFilter],
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues({
+                    ...VALID_FORM_VALUES,
+                    severityLevels: [],
+                    serviceNames: [],
+                    filterGroup: innerGroup,
+                })
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).toHaveBeenCalledWith(
+                MOCK_PROJECT_ID,
+                expect.objectContaining({
+                    filters: {
+                        filterGroup: {
+                            type: FilterLogicalOperator.And,
+                            values: [innerGroup],
+                        },
+                    },
+                })
+            )
+        })
+
+        it('excludes empty filter keys from payload filters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues({
+                    ...VALID_FORM_VALUES,
+                    severityLevels: ['info'],
+                    serviceNames: [],
+                    filterGroup: { type: FilterLogicalOperator.And, values: [] },
+                })
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            const calledWith = mockLogsAlertsCreate.mock.calls[0][1]
+            expect((calledWith.filters as Record<string, unknown>).serviceNames).toBeUndefined()
+            expect((calledWith.filters as Record<string, unknown>).filterGroup).toBeUndefined()
+        })
+
+        it('dispatches setEditingAlert(null) and setIsCreating(false) after create', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(alertingLogic.values.editingAlert).toBeNull()
+            expect(alertingLogic.values.isCreating).toBe(false)
+        })
+
+        it('shows error toast when create API throws with detail', async () => {
+            mockLogsAlertsCreate.mockRejectedValue({ detail: 'Quota exceeded' })
+
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Quota exceeded')
+        })
+
+        it('shows error toast from message field when detail is absent', async () => {
+            mockLogsAlertsCreate.mockRejectedValue(new Error('Network failure'))
+
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Network failure')
+        })
+
+        it('shows fallback error toast when neither detail nor message is present', async () => {
+            mockLogsAlertsCreate.mockRejectedValue({})
+
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Failed to save alert')
+        })
+    })
+
+    describe('edit path (props.alert is set)', () => {
+        let logic: ReturnType<typeof logsAlertFormLogic.build>
+
+        beforeEach(() => {
+            mockLogsAlertsPartialUpdate.mockResolvedValue(MOCK_ALERT)
+            logic = logsAlertFormLogic({ alert: MOCK_ALERT })
+            logic.mount()
+        })
+
+        afterEach(() => {
+            logic?.unmount()
+        })
+
+        it('calls logsAlertsPartialUpdate with correct alert id and payload on submit', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsPartialUpdate).toHaveBeenCalledTimes(1)
+            expect(mockLogsAlertsPartialUpdate).toHaveBeenCalledWith(
+                MOCK_PROJECT_ID,
+                MOCK_ALERT.id,
+                expect.objectContaining({
+                    name: 'My Alert',
+                    filters: { severityLevels: ['error'] },
+                    threshold_count: 100,
+                    threshold_operator: 'above',
+                    window_minutes: 10,
+                    evaluation_periods: 1,
+                    datapoints_to_alarm: 1,
+                    cooldown_minutes: 0,
+                })
+            )
+        })
+
+        it('does not call logsAlertsCreate on edit path', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(mockLogsAlertsCreate).not.toHaveBeenCalled()
+        })
+
+        it('shows success toast after update', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.success).toHaveBeenCalledWith('Alert updated')
+        })
+
+        it('pre-populates name from existing alert', () => {
+            expect(logic.values.alertForm.name).toBe(MOCK_ALERT.name)
+        })
+
+        it('pre-populates severityLevels from existing alert filters', () => {
+            expect(logic.values.alertForm.severityLevels).toEqual(['error'])
+        })
+
+        it('pre-populates numeric fields from existing alert', () => {
+            expect(logic.values.alertForm.thresholdCount).toBe(MOCK_ALERT.threshold_count)
+            expect(logic.values.alertForm.windowMinutes).toBe(MOCK_ALERT.window_minutes)
+            expect(logic.values.alertForm.evaluationPeriods).toBe(MOCK_ALERT.evaluation_periods)
+            expect(logic.values.alertForm.datapointsToAlarm).toBe(MOCK_ALERT.datapoints_to_alarm)
+            expect(logic.values.alertForm.cooldownMinutes).toBe(MOCK_ALERT.cooldown_minutes)
+        })
+
+        it('shows error toast when partial update API throws', async () => {
+            mockLogsAlertsPartialUpdate.mockRejectedValue({ detail: 'Permission denied' })
+
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Permission denied')
+        })
+
+        it('dispatches setEditingAlert(null) and setIsCreating(false) after update', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAlertFormValues(VALID_FORM_VALUES)
+                logic.actions.submitAlertForm()
+            }).toFinishAllListeners()
+
+            expect(alertingLogic.values.editingAlert).toBeNull()
+            expect(alertingLogic.values.isCreating).toBe(false)
+        })
+    })
+
+    describe('isEditing selector', () => {
+        it('is false when props.alert is null', () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            expect(logic.values.isEditing).toBe(false)
+
+            logic.unmount()
+        })
+
+        it('is true when props.alert is provided', () => {
+            const logic = logsAlertFormLogic({ alert: MOCK_ALERT })
+            logic.mount()
+
+            expect(logic.values.isEditing).toBe(true)
+
+            logic.unmount()
+        })
+    })
+
+    describe('form defaults', () => {
+        it('uses sensible defaults when creating a new alert', () => {
+            const logic = logsAlertFormLogic({ alert: null })
+            logic.mount()
+
+            expect(logic.values.alertForm).toMatchObject({
+                name: '',
+                severityLevels: [],
+                serviceNames: [],
+                thresholdOperator: 'above',
+                thresholdCount: 100,
+                windowMinutes: 10,
+                evaluationPeriods: 1,
+                datapointsToAlarm: 1,
+                cooldownMinutes: 0,
+            })
+
+            logic.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -1,0 +1,154 @@
+import { connect, kea, key, path, props, selectors } from 'kea'
+import { forms } from 'kea-forms'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { LogMessage } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
+
+import { logsAlertsCreate, logsAlertsPartialUpdate } from 'products/logs/frontend/generated/api'
+import {
+    LogsAlertConfigurationApi,
+    PatchedLogsAlertConfigurationApi,
+    ThresholdOperatorEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsAlertFormLogicType } from './logsAlertFormLogicType'
+import { logsAlertingLogic } from './logsAlertingLogic'
+
+const EMPTY_FILTER_GROUP: UniversalFiltersGroup = {
+    type: FilterLogicalOperator.And,
+    values: [],
+}
+
+export interface LogsAlertFormType {
+    name: string
+    severityLevels: LogMessage['severity_text'][]
+    serviceNames: string[]
+    filterGroup: UniversalFiltersGroup
+    thresholdOperator: ThresholdOperatorEnumApi
+    thresholdCount: number
+    windowMinutes: number
+    evaluationPeriods: number
+    datapointsToAlarm: number
+    cooldownMinutes: number
+}
+
+export interface LogsAlertFormLogicProps {
+    alert: LogsAlertConfigurationApi | null
+}
+
+function extractFilterGroup(alert: LogsAlertConfigurationApi | null): UniversalFiltersGroup {
+    const filters = (alert?.filters ?? {}) as Record<string, unknown>
+    const stored = filters.filterGroup as { type: string; values: unknown[] } | undefined
+    if (stored?.values) {
+        const innerGroup = stored.values[0] as UniversalFiltersGroup | undefined
+        if (innerGroup?.values) {
+            return innerGroup
+        }
+    }
+    return EMPTY_FILTER_GROUP
+}
+
+function buildFilters(
+    severityLevels: string[],
+    serviceNames: string[],
+    filterGroup: UniversalFiltersGroup
+): Record<string, unknown> {
+    const filters: Record<string, unknown> = {}
+    if (severityLevels.length > 0) {
+        filters.severityLevels = severityLevels
+    }
+    if (serviceNames.length > 0) {
+        filters.serviceNames = serviceNames
+    }
+    if (filterGroup.values.length > 0) {
+        filters.filterGroup = {
+            type: FilterLogicalOperator.And,
+            values: [filterGroup],
+        }
+    }
+    return filters
+}
+
+function hasAnyFilter(severityLevels: string[], serviceNames: string[], filterGroup: UniversalFiltersGroup): boolean {
+    return severityLevels.length > 0 || serviceNames.length > 0 || filterGroup.values.length > 0
+}
+
+export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertFormLogic']),
+    props({} as LogsAlertFormLogicProps),
+    key(({ alert }) => alert?.id ?? 'new'),
+
+    connect({
+        values: [teamLogic, ['currentTeamId']],
+        actions: [logsAlertingLogic, ['loadAlerts', 'setEditingAlert', 'setIsCreating']],
+    }),
+
+    selectors({
+        isEditing: [() => [(_, props) => props.alert], (alert: LogsAlertConfigurationApi | null) => alert !== null],
+    }),
+
+    forms(({ props, actions, values }) => ({
+        alertForm: {
+            defaults: {
+                name: props.alert?.name ?? '',
+                severityLevels: ((props.alert?.filters as Record<string, unknown>)?.severityLevels as string[]) ?? [],
+                serviceNames: ((props.alert?.filters as Record<string, unknown>)?.serviceNames as string[]) ?? [],
+                filterGroup: extractFilterGroup(props.alert),
+                thresholdOperator: props.alert?.threshold_operator ?? ThresholdOperatorEnumApi.Above,
+                thresholdCount: props.alert?.threshold_count ?? 100,
+                windowMinutes: props.alert?.window_minutes ?? 10,
+                evaluationPeriods: props.alert?.evaluation_periods ?? 1,
+                datapointsToAlarm: props.alert?.datapoints_to_alarm ?? 1,
+                cooldownMinutes: props.alert?.cooldown_minutes ?? 0,
+            } as LogsAlertFormType,
+            errors: ({ name }) => ({
+                name: !name?.trim() ? 'Name is required' : undefined,
+            }),
+            submit: async (form) => {
+                if (!hasAnyFilter(form.severityLevels, form.serviceNames, form.filterGroup)) {
+                    lemonToast.error('At least one filter is required')
+                    throw new Error('At least one filter is required')
+                }
+                const projectId = String(values.currentTeamId)
+                const payload = {
+                    name: form.name.trim(),
+                    filters: buildFilters(form.severityLevels, form.serviceNames, form.filterGroup),
+                    threshold_count: form.thresholdCount,
+                    threshold_operator: form.thresholdOperator,
+                    window_minutes: form.windowMinutes,
+                    evaluation_periods: form.evaluationPeriods,
+                    datapoints_to_alarm: form.datapointsToAlarm,
+                    cooldown_minutes: form.cooldownMinutes,
+                }
+
+                try {
+                    if (props.alert) {
+                        const patch: PatchedLogsAlertConfigurationApi = { ...payload }
+                        await logsAlertsPartialUpdate(projectId, props.alert.id, patch)
+                        lemonToast.success('Alert updated')
+                    } else {
+                        await logsAlertsCreate(projectId, payload)
+                        lemonToast.success('Alert created')
+                    }
+                    actions.setEditingAlert(null)
+                    actions.setIsCreating(false)
+                    actions.loadAlerts()
+                } catch (e: any) {
+                    const message =
+                        typeof e?.detail === 'string'
+                            ? e.detail
+                            : typeof e?.message === 'string'
+                              ? e.message
+                              : 'Failed to save alert'
+                    lemonToast.error(message)
+                    throw e
+                }
+                return form
+            },
+        },
+    })),
+])

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -1,0 +1,84 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { logsAlertsDestroy, logsAlertsList, logsAlertsPartialUpdate } from 'products/logs/frontend/generated/api'
+import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsAlertingLogicType } from './logsAlertingLogicType'
+
+export const logsAlertingLogic = kea<logsAlertingLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertingLogic']),
+
+    connect({
+        values: [teamLogic, ['currentTeamId']],
+    }),
+
+    actions({
+        setEditingAlert: (alert: LogsAlertConfigurationApi | null) => ({ alert }),
+        setIsCreating: (isCreating: boolean) => ({ isCreating }),
+        deleteAlert: (id: string) => ({ id }),
+        toggleAlertEnabled: (alert: LogsAlertConfigurationApi) => ({ alert }),
+    }),
+
+    reducers({
+        editingAlert: [
+            null as LogsAlertConfigurationApi | null,
+            {
+                setEditingAlert: (_, { alert }) => alert,
+                setIsCreating: () => null,
+            },
+        ],
+        isCreating: [
+            false,
+            {
+                setIsCreating: (_, { isCreating }) => isCreating,
+                setEditingAlert: () => false,
+            },
+        ],
+    }),
+
+    loaders(({ values }) => ({
+        alerts: [
+            [] as LogsAlertConfigurationApi[],
+            {
+                loadAlerts: async () => {
+                    const projectId = String(values.currentTeamId)
+                    const response = await logsAlertsList(projectId)
+                    return response.results
+                },
+            },
+        ],
+    })),
+
+    listeners(({ actions, values }) => ({
+        deleteAlert: async ({ id }) => {
+            const projectId = String(values.currentTeamId)
+            try {
+                await logsAlertsDestroy(projectId, id)
+                lemonToast.success('Alert deleted')
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to delete alert')
+            }
+        },
+        toggleAlertEnabled: async ({ alert }) => {
+            const projectId = String(values.currentTeamId)
+            try {
+                await logsAlertsPartialUpdate(projectId, alert.id, {
+                    enabled: !(alert.enabled ?? true),
+                })
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to update alert')
+            }
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadAlerts()
+    }),
+])

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -129,13 +129,15 @@ export interface LogsAlertConfigurationApi {
     readonly check_interval_minutes: number
     readonly state: LogsAlertConfigurationStateEnumApi
     /**
-     * Total number of check periods in the sliding evaluation window (M in N-of-M).
+     * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
      * @minimum 1
+     * @maximum 10
      */
     evaluation_periods?: number
     /**
-     * How many periods within the evaluation window must breach the threshold to trigger (N in N-of-M).
+     * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
      * @minimum 1
+     * @maximum 10
      */
     datapoints_to_alarm?: number
     /**
@@ -192,13 +194,15 @@ export interface PatchedLogsAlertConfigurationApi {
     readonly check_interval_minutes?: number
     readonly state?: LogsAlertConfigurationStateEnumApi
     /**
-     * Total number of check periods in the sliding evaluation window (M in N-of-M).
+     * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
      * @minimum 1
+     * @maximum 10
      */
     evaluation_periods?: number
     /**
-     * How many periods within the evaluation window must breach the threshold to trigger (N in N-of-M).
+     * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
      * @minimum 1
+     * @maximum 10
      */
     datapoints_to_alarm?: number
     /**

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -5,6 +5,7 @@
     },
     "dependencies": {
         "kea": "catalog:",
+        "kea-forms": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16887,13 +16887,15 @@ export namespace Schemas {
       readonly check_interval_minutes: number;
       readonly state: LogsAlertConfigurationStateEnum;
       /**
-       * Total number of check periods in the sliding evaluation window (M in N-of-M).
+       * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
        * @minimum 1
+       * @maximum 10
        */
       evaluation_periods?: number;
       /**
-       * How many periods within the evaluation window must breach the threshold to trigger (N in N-of-M).
+       * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
        * @minimum 1
+       * @maximum 10
        */
       datapoints_to_alarm?: number;
       /**
@@ -21488,13 +21490,15 @@ export namespace Schemas {
       readonly check_interval_minutes?: number;
       readonly state?: LogsAlertConfigurationStateEnum;
       /**
-       * Total number of check periods in the sliding evaluation window (M in N-of-M).
+       * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
        * @minimum 1
+       * @maximum 10
        */
       evaluation_periods?: number;
       /**
-       * How many periods within the evaluation window must breach the threshold to trigger (N in N-of-M).
+       * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
        * @minimum 1
+       * @maximum 10
        */
       datapoints_to_alarm?: number;
       /**


### PR DESCRIPTION
## Problem

Logs alerting has a backend API (models, migrations, CRUD endpoints) but no UI to manage alert rules. Users need a way to create, edit, delete, and toggle log alerts from the settings page.

## Changes

- Add `LogsAlertList` — table with name, state indicator, threshold summary, enabled toggle, edit/delete actions
- Add `LogsAlertForm` — modal form with severity, service, attribute filters (via `UniversalFilters`), threshold config, and advanced options (consecutive trigger, cooldown)
- Add `logsAlertingLogic` — kea logic for list CRUD, toggle enabled, delete with confirmation
- Add `logsAlertFormLogic` — kea-forms logic for create/edit with validation
- Add `LogsAlertStateIndicator` — state badge (OK, Firing, Errored, etc.)
- Register `logs-alerting` setting in `SettingsMap` under environment-logs section
- Add `kea-forms` dependency to logs product package.json

![image.png](https://app.graphite.com/user-attachments/assets/ff85b786-2953-4f3b-86c6-6577fd62a878.png)

## How did you test this code?

- Existing Playwright logs tests pass
- Manual testing of create, edit, delete, toggle flows against local API

## Publish to changelog?

No
