### PR TITLE
fix(endpoints): allow selecting back the default 6h cache age

### DIFF
--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -76,7 +76,8 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
     const freshMaterialization = loadedMaterializationStatus ?? versionMaterialization
 
     const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
-    const effectiveCacheAge = cacheAge ?? viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds
+    const effectiveCacheAge =
+        cacheAge !== undefined ? cacheAge : (viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds)
     const effectiveIsMaterialized = localIsMaterialized ?? baseIsMaterialized
     const effectiveMaterializationStatus = freshMaterialization?.status
     const effectiveLastMaterializedAt = freshMaterialization?.last_materialized_at

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -156,7 +156,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             },
         ],
         cacheAge: [
-            null as number | null,
+            undefined as number | null | undefined,
             {
                 setCacheAge: (_, { cacheAge }) => cacheAge,
             },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
if an endpoint has a non-default cache age, trying to go back to 6h does not work because 6h is null.
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- distinguish undefined vs null
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
