### PR TITLE
fix: Allow users to reselect the default cache age for endpoints

### DIFF
--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -15,14 +15,15 @@ interface EndpointConfigurationProps {
     tabId: string
 }
 
-type CacheAgeOption = number | null
-const CACHE_AGE_OPTIONS: { value: CacheAgeOption; label: string }[] = [
+const DEFAULT_CACHE_AGE_SECONDS = 21600
+
+const CACHE_AGE_OPTIONS: { value: number; label: string }[] = [
     { value: 300, label: '5 minutes' },
     { value: 900, label: '15 minutes' },
     { value: 1800, label: '30 minutes' },
     { value: 3600, label: '1 hour' },
     { value: 10800, label: '3 hours' },
-    { value: null, label: '6 hours (default)' },
+    { value: DEFAULT_CACHE_AGE_SECONDS, label: '6 hours (default)' },
     { value: 86400, label: '1 day' },
     { value: 259200, label: '3 days' },
 ]
@@ -76,7 +77,8 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
     const freshMaterialization = loadedMaterializationStatus ?? versionMaterialization
 
     const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
-    const effectiveCacheAge = cacheAge ?? viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds
+    const effectiveCacheAge =
+        cacheAge ?? viewingVersion?.cache_age_seconds ?? endpoint.cache_age_seconds ?? DEFAULT_CACHE_AGE_SECONDS
     const effectiveIsMaterialized = localIsMaterialized ?? baseIsMaterialized
     const effectiveMaterializationStatus = freshMaterialization?.status
     const effectiveLastMaterializedAt = freshMaterialization?.last_materialized_at


### PR DESCRIPTION
## Problem

Users weren't able to select the default/6 hour cache age for endpoints once they'd selected another option

https://posthoghelp.zendesk.com/agent/tickets/52603 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56567)

## Changes

Use `DEFAULT_CACHE_AGE_SECONDS` as the fallback if the user hasn't explicitly selected an option.

## How did you test this code?

Tested locally