### PR TITLE
fix: address rafa's review feedback on agentic provisioning

### DIFF
--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -81,4 +81,4 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             f"/api/agentic/provisioning/resources/{self.team.id}",
             token=token,
         )
-        assert res.json()["service_id"] == "product_analytics"
+        assert res.json()["service_id"] == "posthog"

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -82,3 +82,13 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             token=token,
         )
         assert res.json()["service_id"] == "posthog"
+
+    def test_create_resource_defaults_service_id_to_posthog(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={},
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["service_id"] == "posthog"

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import override_settings
 
 from posthog.models.oauth import OAuthAccessToken
@@ -72,3 +74,22 @@ class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
             token=token,
         )
         assert res.json()["service_id"] == "session_replay"
+
+    def test_rotate_defaults_service_id_to_posthog(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["service_id"] == "posthog"
+
+    @patch("posthog.models.team.team.Team.reset_token_and_save", side_effect=Exception("db error"))
+    def test_rotate_returns_500_when_reset_token_fails(self, _mock_reset):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
+            token=token,
+        )
+        assert res.status_code == 500
+        assert res.json()["error"]["code"] == "credential_rotation_failed"

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken, find_oauth_refresh_token
 from posthog.models.team.team import Team
@@ -637,7 +638,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
     try:
         team.reset_token_and_save(user=user, is_impersonated_session=False)
     except Exception:
-        logger.exception("agentic_provisioning.rotate_credentials.reset_token_failed", team_id=team_id)
+        capture_exception(additional_properties={"team_id": team_id})
         return _error_response(
             "credential_rotation_failed", "Failed to rotate credentials", resource_id=resource_id, status=500
         )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -567,7 +567,7 @@ def provisioning_resources_create(request: Request) -> Response:
     except Team.DoesNotExist:
         return _error_response("team_not_found", "Team not found", resource_id=str(team_id), status=404)
 
-    resolved_service_id = service_id or "product_analytics"
+    resolved_service_id = service_id or POSTHOG_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
 
     region = get_instance_region() or "US"
@@ -634,9 +634,15 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
     except Team.DoesNotExist:
         return _error_response("not_found", "Resource not found", resource_id=resource_id, status=404)
 
-    team.reset_token_and_save(user=user, is_impersonated_session=False)
+    try:
+        team.reset_token_and_save(user=user, is_impersonated_session=False)
+    except Exception:
+        logger.exception("agentic_provisioning.rotate_credentials.reset_token_failed", team_id=team_id)
+        return _error_response(
+            "credential_rotation_failed", "Failed to rotate credentials", resource_id=resource_id, status=500
+        )
 
-    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or "product_analytics"
+    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or POSTHOG_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
@@ -696,7 +702,7 @@ def _resolve_resource_response(request: Request, resource_id: str) -> Response:
             status=404,
         )
 
-    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or "product_analytics"
+    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or POSTHOG_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 


### PR DESCRIPTION
## Problem

Addressing review feedback from @rafaeelaudiworker on #49897.

## Changes

- Default `service_id` to `"posthog"` instead of `"product_analytics"` when none is provided (aligns with the parent service ID)
- Wrap `team.reset_token_and_save()` in a try/except block in `rotate_credentials` to handle potential failures gracefully

## How did you test this code

- All 98 agentic provisioning tests pass
- `ruff check` and `ruff format` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)