### PR TITLE
feat(data-warehouse): Support requiredTables prop to skip schema step and auto-create source

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -221,6 +221,8 @@ const resolveIncrementalField = (fields: IncrementalField[]): IncrementalField |
 export interface SourceWizardLogicProps {
     onComplete?: () => void
     availableSources: Record<string, SourceConfig>
+    /** When set, only these tables will be pre-selected and they cannot be deselected */
+    requiredTables?: string[]
 }
 
 export const sourceWizardLogic = kea<sourceWizardLogicType>([
@@ -393,6 +395,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
     }),
     selectors({
         availableSources: [() => [(_, p) => p.availableSources], (availableSources) => availableSources],
+        requiredTables: [() => [(_, p) => p.requiredTables], (requiredTables) => requiredTables ?? null],
         suggestedTablesMap: [
             (s) => [s.selectedConnector],
             (selectedConnector: SourceConfig | null): Record<string, string | null> => {
@@ -735,13 +738,18 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     source_type: values.selectedConnector.name,
                 })
 
-                lemonToast.success('New data resource created')
-
                 actions.setSourceId(id)
                 actions.resetSourceConnectionDetails()
                 actions.loadSources()
                 actions.markTaskAsCompleted(SetupTaskId.ConnectSource)
-                actions.onNext()
+
+                // When requiredTables is set (e.g. signals setup), skip step 4 and complete directly
+                if (values.requiredTables && props.onComplete) {
+                    props.onComplete()
+                } else {
+                    lemonToast.success('New data resource created')
+                    actions.onNext()
+                }
             } catch (e: any) {
                 lemonToast.error(e.data?.message ?? e.message)
             } finally {
@@ -804,10 +812,33 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     }
                 }
 
-                if (showToast) {
+                if (showToast && !values.requiredTables) {
                     lemonToast.info(
                         "We've setup some defaults for you! Please take a look to make sure you're happy with the results."
                     )
+                }
+
+                // If required tables are specified (e.g. signals setup), skip the schema selection step
+                // entirely and create the source with only those tables, using their default sync settings
+                if (values.requiredTables) {
+                    const requiredSchemas = schemas.filter((schema) => values.requiredTables!.includes(schema.table))
+                    actions.updateSource({
+                        payload: {
+                            schemas: requiredSchemas.map((schema) => ({
+                                name: schema.table,
+                                should_sync: true,
+                                sync_type: schema.sync_type,
+                                incremental_field: schema.incremental_field,
+                                incremental_field_type: schema.incremental_field_type,
+                                sync_time_of_day: schema.sync_time_of_day ?? null,
+                            })),
+                        },
+                    })
+                    // Jump to step 3 so that createSource's onNext() advances to step 4 (sync progress)
+                    actions.setStep(3)
+                    actions.setIsLoading(true)
+                    actions.createSource()
+                    return
                 }
 
                 actions.setDatabaseSchemas(schemas)

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -822,6 +822,15 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 // entirely and create the source with only those tables, using their default sync settings
                 if (values.requiredTables) {
                     const requiredSchemas = schemas.filter((schema) => values.requiredTables!.includes(schema.table))
+                    if (requiredSchemas.length !== values.requiredTables.length) {
+                        const missingTables = values.requiredTables.filter(
+                            (table) => !requiredSchemas.some((schema) => schema.table === table)
+                        )
+                        lemonToast.error(`Required tables not found in source: ${missingTables.join(', ')}`)
+                        actions.setIsLoading(false)
+                        return
+                    }
+
                     actions.updateSource({
                         payload: {
                             schemas: requiredSchemas.map((schema) => ({

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -824,7 +824,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     const requiredSchemas = schemas.filter((schema) => values.requiredTables!.includes(schema.table))
                     if (requiredSchemas.length !== values.requiredTables.length) {
                         const missingTables = values.requiredTables.filter(
-                            (table) => !requiredSchemas.some((schema) => schema.table === table)
+                            (table: string) => !requiredSchemas.some((schema) => schema.table === table)
                         )
                         lemonToast.error(`Required tables not found in source: ${missingTables.join(', ')}`)
                         actions.setIsLoading(false)


### PR DESCRIPTION
## Problem

The data warehouse source wizard has a multi-step flow (credentials, schema selection, confirmation, sync progress) that's too heavy when we already know exactly which tables we need - like in the Signals Inbox where each source only needs one specific table.

## Changes

Adds a `requiredTables` prop to `sourceWizardLogic`. When set, the wizard skips the schema selection step and confirmation dialog entirely - it auto-configures the required tables with default sync settings and creates the source directly. On success with `onComplete` provided, it calls that callback instead of showing the sync progress step.

## How did you test this code?

Manual testing of the signals setup flow end-to-end.

## Publish to changelog?

No