### PR TITLE
feat(signals): Wire up GitHub, Linear, and Zendesk sources in Inbox UI

### DIFF
--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -32,9 +32,11 @@ type SourceProps =
           /** Whether enabling requires going through a setup flow (shows an arrow icon on the enable button) */
           requiresSetup?: boolean
           onToggle: () => void
-          configSection?: React.ReactNode
-          configButtonLabel?: string
-          onConfigClick?: () => void
+          config?: {
+              display: React.ReactNode
+              buttonLabel: string
+              onClick: () => void
+          }
           onClearClick?: () => void
           statusSection?: React.ReactNode
       }
@@ -94,7 +96,7 @@ function Source(props: SourceProps): JSX.Element {
                     )}
                 </div>
                 <p className="text-xs text-secondary mt-0.25 mb-0">{props.description}</p>
-                {!isComingSoon && props.checked && props.configSection !== undefined && (
+                {!isComingSoon && props.checked && props.config !== undefined && (
                     <>
                         <div className="mt-2 border rounded">
                             <div className="flex items-center justify-between px-2 pt-2">
@@ -105,14 +107,12 @@ function Source(props: SourceProps): JSX.Element {
                                             Clear
                                         </LemonButton>
                                     )}
-                                    {props.onConfigClick && (
-                                        <LemonButton type="secondary" size="xsmall" onClick={props.onConfigClick}>
-                                            {props.configButtonLabel}
-                                        </LemonButton>
-                                    )}
+                                    <LemonButton type="secondary" size="xsmall" onClick={props.config.onClick}>
+                                        {props.config.buttonLabel}
+                                    </LemonButton>
                                 </div>
                             </div>
-                            {props.configSection}
+                            {props.config.display}
                         </div>
                         {props.statusSection}
                     </>
@@ -173,19 +173,19 @@ export function SourcesList(): JSX.Element {
                 checked={!!sessionAnalysisConfig?.enabled}
                 loading={isSessionAnalysisToggling}
                 onToggle={() => toggleSessionAnalysis()}
-                configButtonLabel={recordingFilters ? 'Edit' : 'Configure'}
-                onConfigClick={openSessionAnalysisSetup}
-                onClearClick={hasNonEmptyFilters ? clearSessionAnalysisFilters : undefined}
-                statusSection={<ClusteringStatusIndicator status={sessionAnalysisConfig?.status ?? null} />}
-                configSection={
-                    recordingFilters ? (
+                config={{
+                    buttonLabel: recordingFilters ? 'Edit' : 'Configure',
+                    onClick: openSessionAnalysisSetup,
+                    display: recordingFilters ? (
                         <RecordingsUniversalFiltersDisplay filters={recordingFilters} />
                     ) : (
                         <div className="px-2 pb-2">
                             <span className="text-xs text-secondary">All sessions</span>
                         </div>
-                    )
-                }
+                    ),
+                }}
+                onClearClick={hasNonEmptyFilters ? clearSessionAnalysisFilters : undefined}
+                statusSection={<ClusteringStatusIndicator status={sessionAnalysisConfig?.status ?? null} />}
             />
 
             <Source

--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -2,8 +2,8 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useState } from 'react'
 
-import { IconGithub, IconLinear } from '@posthog/icons'
-import { LemonButton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
+import { IconArrowRight, IconBell, IconGithub, IconLinear } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { RecordingsUniversalFiltersDisplay } from 'lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay'
 import { IconSlack } from 'lib/lemon-ui/icons'
@@ -28,10 +28,13 @@ type SourceProps =
           description: string
           variant: 'available'
           checked: boolean
+          loading?: boolean
+          /** Whether enabling requires going through a setup flow (shows an arrow icon on the enable button) */
+          requiresSetup?: boolean
           onToggle: () => void
-          configSection: React.ReactNode
-          configButtonLabel: string
-          onConfigClick: () => void
+          configSection?: React.ReactNode
+          configButtonLabel?: string
+          onConfigClick?: () => void
           onClearClick?: () => void
           statusSection?: React.ReactNode
       }
@@ -48,6 +51,7 @@ function NotifyMeButton({ source }: { source: string }): JSX.Element {
                 posthog.capture('signals source interest', { source })
                 setNotified(true)
             }}
+            icon={<IconBell />}
             className="-my-4" // Prevent the button's height from affecting the row's height
         >
             {notified ? "We'll notify you!" : 'Notify me when available'}
@@ -66,12 +70,31 @@ function Source(props: SourceProps): JSX.Element {
                     <div className="font-medium text-sm">{props.title}</div>
                     {isComingSoon ? (
                         <NotifyMeButton source={props.title} />
+                    ) : props.checked ? (
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            loading={props.loading}
+                            onClick={props.onToggle}
+                            className="-my-4"
+                        >
+                            Disable
+                        </LemonButton>
                     ) : (
-                        <LemonSwitch checked={props.checked} onChange={props.onToggle} />
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            loading={props.loading}
+                            icon={props.requiresSetup ? <IconArrowRight /> : undefined}
+                            onClick={props.onToggle}
+                            className="-my-4"
+                        >
+                            Enable
+                        </LemonButton>
                     )}
                 </div>
                 <p className="text-xs text-secondary mt-0.25 mb-0">{props.description}</p>
-                {!isComingSoon && props.checked && (
+                {!isComingSoon && props.checked && props.configSection !== undefined && (
                     <>
                         <div className="mt-2 border rounded">
                             <div className="flex items-center justify-between px-2 pt-2">
@@ -82,9 +105,11 @@ function Source(props: SourceProps): JSX.Element {
                                             Clear
                                         </LemonButton>
                                     )}
-                                    <LemonButton type="secondary" size="xsmall" onClick={props.onConfigClick}>
-                                        {props.configButtonLabel}
-                                    </LemonButton>
+                                    {props.onConfigClick && (
+                                        <LemonButton type="secondary" size="xsmall" onClick={props.onConfigClick}>
+                                            {props.configButtonLabel}
+                                        </LemonButton>
+                                    )}
                                 </div>
                             </div>
                             {props.configSection}
@@ -114,9 +139,24 @@ function ClusteringStatusIndicator({ status }: { status: SignalSourceConfigStatu
 }
 
 export function SourcesList(): JSX.Element {
-    const { sessionAnalysisConfig } = useValues(signalSourcesLogic)
-    const { toggleSessionAnalysis, openSessionAnalysisSetup, clearSessionAnalysisFilters } =
-        useActions(signalSourcesLogic)
+    const {
+        sessionAnalysisConfig,
+        githubIssuesConfig,
+        linearIssuesConfig,
+        zendeskTicketsConfig,
+        isSessionAnalysisToggling,
+        isGithubIssuesToggling,
+        isLinearIssuesToggling,
+        isZendeskTicketsToggling,
+    } = useValues(signalSourcesLogic)
+    const {
+        toggleSessionAnalysis,
+        openSessionAnalysisSetup,
+        clearSessionAnalysisFilters,
+        initiateGithubIssuesToggle,
+        initiateLinearIssuesToggle,
+        initiateZendeskTicketsToggle,
+    } = useActions(signalSourcesLogic)
 
     const recordingFilters = sessionAnalysisConfig?.config?.recording_filters
     const hasNonEmptyFilters = isNonEmptyFilters(recordingFilters)
@@ -133,6 +173,7 @@ export function SourcesList(): JSX.Element {
                 description="Session recordings + event data → Signals"
                 variant="available"
                 checked={!!sessionAnalysisConfig?.enabled}
+                loading={isSessionAnalysisToggling}
                 onToggle={() => toggleSessionAnalysis()}
                 configButtonLabel={recordingFilters ? 'Edit' : 'Configure'}
                 onConfigClick={openSessionAnalysisSetup}
@@ -153,21 +194,33 @@ export function SourcesList(): JSX.Element {
                 icon={<img className="size-5" src={iconZendesk} />}
                 title="Zendesk"
                 description="Incoming support tickets → Signals"
-                variant="coming-soon"
+                variant="available"
+                checked={!!zendeskTicketsConfig?.enabled}
+                loading={isZendeskTicketsToggling}
+                requiresSetup
+                onToggle={() => initiateZendeskTicketsToggle()}
             />
 
             <Source
                 icon={<IconLinear className="size-5" />}
                 title="Linear"
                 description="New issues and updates → Signals"
-                variant="coming-soon"
+                variant="available"
+                checked={!!linearIssuesConfig?.enabled}
+                loading={isLinearIssuesToggling}
+                requiresSetup
+                onToggle={() => initiateLinearIssuesToggle()}
             />
 
             <Source
                 icon={<IconGithub className="size-5" />}
                 title="GitHub Issues"
                 description="New issues and updates → Signals"
-                variant="coming-soon"
+                variant="available"
+                checked={!!githubIssuesConfig?.enabled}
+                loading={isGithubIssuesToggling}
+                requiresSetup
+                onToggle={() => initiateGithubIssuesToggle()}
             />
 
             <Source

--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -153,9 +153,7 @@ export function SourcesList(): JSX.Element {
         toggleSessionAnalysis,
         openSessionAnalysisSetup,
         clearSessionAnalysisFilters,
-        initiateGithubIssuesToggle,
-        initiateLinearIssuesToggle,
-        initiateZendeskTicketsToggle,
+        initiateDataWarehouseSourceToggle,
     } = useActions(signalSourcesLogic)
 
     const recordingFilters = sessionAnalysisConfig?.config?.recording_filters
@@ -198,7 +196,7 @@ export function SourcesList(): JSX.Element {
                 checked={!!zendeskTicketsConfig?.enabled}
                 loading={isZendeskTicketsToggling}
                 requiresSetup
-                onToggle={() => initiateZendeskTicketsToggle()}
+                onToggle={() => initiateDataWarehouseSourceToggle('Zendesk')}
             />
 
             <Source
@@ -209,7 +207,7 @@ export function SourcesList(): JSX.Element {
                 checked={!!linearIssuesConfig?.enabled}
                 loading={isLinearIssuesToggling}
                 requiresSetup
-                onToggle={() => initiateLinearIssuesToggle()}
+                onToggle={() => initiateDataWarehouseSourceToggle('Linear')}
             />
 
             <Source
@@ -220,7 +218,7 @@ export function SourcesList(): JSX.Element {
                 checked={!!githubIssuesConfig?.enabled}
                 loading={isGithubIssuesToggling}
                 requiresSetup
-                onToggle={() => initiateGithubIssuesToggle()}
+                onToggle={() => initiateDataWarehouseSourceToggle('Github')}
             />
 
             <Source

--- a/frontend/src/scenes/inbox/SourcesModal.tsx
+++ b/frontend/src/scenes/inbox/SourcesModal.tsx
@@ -1,44 +1,158 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 
 import { IconArrowLeft } from '@posthog/icons'
-import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
+import SourceForm from 'scenes/data-warehouse/external/forms/SourceForm'
+import { availableSourcesDataLogic } from 'scenes/data-warehouse/new/availableSourcesDataLogic'
+import { sourceWizardLogic } from 'scenes/data-warehouse/new/sourceWizardLogic'
+import { DataWarehouseSourceIcon } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
+
+import { ExternalDataSourceType, SourceConfig } from '~/queries/schema/schema-general'
 
 import { SessionAnalysisSetup } from './SessionAnalysisSetup'
 import { signalSourcesLogic } from './signalSourcesLogic'
 import { SourcesList } from './SourcesList'
 
+// Each signal source reads from specific tables — pre-select them and make them required
+const SIGNAL_SOURCE_REQUIRED_TABLES: Partial<Record<ExternalDataSourceType, string[]>> = {
+    Github: ['issues'],
+    Linear: ['issues'],
+    Zendesk: ['tickets'],
+}
+
 export function SourcesModal(): JSX.Element {
-    const { sourcesModalOpen, sessionAnalysisSetupOpen } = useValues(signalSourcesLogic)
-    const { closeSourcesModal, closeSessionAnalysisSetup } = useActions(signalSourcesLogic)
+    const { sourcesModalOpen, sessionAnalysisSetupOpen, dataSourceSetupProduct } = useValues(signalSourcesLogic)
+    const { closeSourcesModal, closeSessionAnalysisSetup, closeDataSourceSetup, onDataSourceSetupComplete } =
+        useActions(signalSourcesLogic)
+    const { trigger: triggerHogfetti, HogfettiComponent } = useHogfetti({ count: 30, duration: 3000 })
+
+    const isDataSourceSetupOpen = dataSourceSetupProduct !== null
+
+    const handleDataSourceComplete = (): void => {
+        triggerHogfetti()
+        setTimeout(() => {
+            triggerHogfetti()
+        }, 200)
+        setTimeout(() => {
+            triggerHogfetti()
+        }, 400)
+        onDataSourceSetupComplete(dataSourceSetupProduct!)
+    }
 
     return (
-        <LemonModal
-            isOpen={sourcesModalOpen}
-            onClose={closeSourcesModal}
-            simple
-            width={sessionAnalysisSetupOpen ? '48rem' : '32rem'}
-        >
-            <LemonModal.Header>
-                <div className="flex items-center gap-2">
-                    {sessionAnalysisSetupOpen && (
-                        <LemonButton
-                            type="tertiary"
-                            size="small"
-                            icon={<IconArrowLeft />}
-                            onClick={closeSessionAnalysisSetup}
-                        />
+        <>
+            <LemonModal
+                isOpen={sourcesModalOpen}
+                onClose={closeSourcesModal}
+                simple
+                width={sessionAnalysisSetupOpen || isDataSourceSetupOpen ? '48rem' : '32rem'}
+            >
+                <LemonModal.Header>
+                    <div className="flex items-center gap-2">
+                        {(sessionAnalysisSetupOpen || isDataSourceSetupOpen) && (
+                            <LemonButton
+                                type="tertiary"
+                                size="small"
+                                icon={<IconArrowLeft />}
+                                onClick={isDataSourceSetupOpen ? closeDataSourceSetup : closeSessionAnalysisSetup}
+                            />
+                        )}
+                        <h3 className="font-semibold mb-0">
+                            {isDataSourceSetupOpen
+                                ? `Connect ${dataSourceSetupProduct}`
+                                : sessionAnalysisSetupOpen
+                                  ? 'Session analysis filters'
+                                  : 'Signal sources'}
+                        </h3>
+                    </div>
+                    {!sessionAnalysisSetupOpen && !isDataSourceSetupOpen && (
+                        <p className="text-xs text-secondary mt-1 mb-0">Set up sources feeding the Inbox.</p>
                     )}
-                    <h3 className="font-semibold mb-0">
-                        {sessionAnalysisSetupOpen ? 'Session analysis filters' : 'Signal sources'}
-                    </h3>
-                </div>
-                {!sessionAnalysisSetupOpen && (
-                    <p className="text-xs text-secondary mt-1 mb-0">Set up sources feeding the Inbox.</p>
-                )}
-            </LemonModal.Header>
-            <LemonModal.Content className={sessionAnalysisSetupOpen ? 'p-0 rounded-b' : ''}>
-                {sessionAnalysisSetupOpen ? <SessionAnalysisSetup /> : <SourcesList />}
-            </LemonModal.Content>
-        </LemonModal>
+                </LemonModal.Header>
+                <LemonModal.Content className={sessionAnalysisSetupOpen ? 'p-0 rounded-b' : ''}>
+                    {isDataSourceSetupOpen ? (
+                        <DataSourceSetup product={dataSourceSetupProduct} onComplete={handleDataSourceComplete} />
+                    ) : sessionAnalysisSetupOpen ? (
+                        <SessionAnalysisSetup />
+                    ) : (
+                        <SourcesList />
+                    )}
+                </LemonModal.Content>
+            </LemonModal>
+            {createPortal(
+                <HogfettiComponent />,
+                document.body /* Needs to be in portal to be above ReactModalPortal */
+            )}
+        </>
+    )
+}
+
+function DataSourceSetup({
+    product,
+    onComplete,
+}: {
+    product: ExternalDataSourceType
+    onComplete: () => void
+}): JSX.Element {
+    const { availableSources, availableSourcesLoading } = useValues(availableSourcesDataLogic)
+
+    if (availableSourcesLoading || availableSources === null) {
+        return <LemonSkeleton />
+    }
+
+    const sourceConfig = Object.values(availableSources).find((s: SourceConfig) => s.name === product)
+    if (!sourceConfig) {
+        return <div>Source not found</div>
+    }
+
+    return (
+        <BindLogic
+            logic={sourceWizardLogic}
+            props={{
+                availableSources,
+                requiredTables: SIGNAL_SOURCE_REQUIRED_TABLES[product],
+                onComplete,
+            }}
+        >
+            <DataSourceSetupForm sourceConfig={sourceConfig} />
+        </BindLogic>
+    )
+}
+
+function DataSourceSetupForm({ sourceConfig }: { sourceConfig: SourceConfig }): JSX.Element {
+    const { isLoading, canGoNext } = useValues(sourceWizardLogic)
+    const { setInitialConnector, onSubmit } = useActions(sourceWizardLogic)
+
+    // Set up the connector so sourceWizardLogic knows what source type we're connecting
+    useEffect(() => {
+        setInitialConnector(sourceConfig)
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center gap-3">
+                <DataWarehouseSourceIcon type={sourceConfig.name} size="small" disableTooltip />
+                <p className="text-sm text-muted-alt mb-0">
+                    Connect {sourceConfig.label ?? sourceConfig.name} as a data source to enable this signal.
+                </p>
+            </div>
+
+            <SourceForm sourceConfig={sourceConfig} showPrefix={false} />
+
+            <div className="flex justify-end">
+                <LemonButton
+                    type="primary"
+                    loading={isLoading}
+                    disabledReason={!canGoNext ? 'Fill in the required fields' : undefined}
+                    onClick={() => onSubmit()}
+                >
+                    Connect
+                </LemonButton>
+            </div>
+        </div>
     )
 }

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -20,6 +20,50 @@ import {
     ToggleSignalSourceParams,
 } from './types'
 
+export type DataWarehouseSource = 'Linear' | 'Zendesk' | 'Github'
+
+const DATA_WAREHOUSE_SOURCE_CONFIG: Record<
+    DataWarehouseSource,
+    {
+        sourceProduct: SignalSourceProduct
+        sourceType: SignalSourceType
+        requiredTable: 'issues' | 'tickets'
+        enableErrorMessage: string
+    }
+> = {
+    Github: {
+        sourceProduct: SignalSourceProduct.GITHUB,
+        sourceType: SignalSourceType.ISSUE,
+        requiredTable: 'issues',
+        enableErrorMessage: 'Failed to enable GitHub Issues',
+    },
+    Linear: {
+        sourceProduct: SignalSourceProduct.LINEAR,
+        sourceType: SignalSourceType.ISSUE,
+        requiredTable: 'issues',
+        enableErrorMessage: 'Failed to enable Linear Issues',
+    },
+    Zendesk: {
+        sourceProduct: SignalSourceProduct.ZENDESK,
+        sourceType: SignalSourceType.TICKET,
+        requiredTable: 'tickets',
+        enableErrorMessage: 'Failed to enable Zendesk Tickets',
+    },
+}
+
+function getDataWarehouseSourceConfig(
+    values: signalSourcesLogicType['values'],
+    dwSource: DataWarehouseSource
+): SignalSourceConfig | null {
+    if (dwSource === 'Github') {
+        return values.githubIssuesConfig
+    }
+    if (dwSource === 'Linear') {
+        return values.linearIssuesConfig
+    }
+    return values.zendeskTicketsConfig
+}
+
 function toggleSourceConfigState(
     state: SignalSourceConfig[] | null,
     sourceProduct: SignalSourceProduct,
@@ -63,12 +107,8 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         openSessionAnalysisSetup: true,
         closeSessionAnalysisSetup: true,
         toggleSessionAnalysis: true,
-        toggleGithubIssues: true,
-        toggleLinearIssues: true,
-        toggleZendeskTickets: true,
-        initiateGithubIssuesToggle: true,
-        initiateLinearIssuesToggle: true,
-        initiateZendeskTicketsToggle: true,
+        toggleDataWarehouseSource: (dwSource: DataWarehouseSource) => ({ dwSource }),
+        initiateDataWarehouseSourceToggle: (dwSource: DataWarehouseSource) => ({ dwSource }),
         openDataSourceSetup: (product: ExternalDataSourceType) => ({ product }),
         closeDataSourceSetup: true,
         onDataSourceSetupComplete: (product: ExternalDataSourceType) => ({ product }),
@@ -122,12 +162,10 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                     SignalSourceProduct.SESSION_REPLAY,
                     SignalSourceType.SESSION_ANALYSIS_CLUSTER
                 ),
-            toggleGithubIssues: (state: SignalSourceConfig[] | null) =>
-                toggleSourceConfigState(state, SignalSourceProduct.GITHUB, SignalSourceType.ISSUE),
-            toggleLinearIssues: (state: SignalSourceConfig[] | null) =>
-                toggleSourceConfigState(state, SignalSourceProduct.LINEAR, SignalSourceType.ISSUE),
-            toggleZendeskTickets: (state: SignalSourceConfig[] | null) =>
-                toggleSourceConfigState(state, SignalSourceProduct.ZENDESK, SignalSourceType.TICKET),
+            toggleDataWarehouseSource: (state: SignalSourceConfig[] | null, { dwSource }) => {
+                const { sourceProduct, sourceType } = DATA_WAREHOUSE_SOURCE_CONFIG[dwSource]
+                return toggleSourceConfigState(state, sourceProduct, sourceType)
+            },
         },
         togglingSourceKeys: [
             new Set<string>(),
@@ -235,65 +273,27 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 // Load external data sources so we can check connectivity when user toggles a source
                 actions.loadSources()
             },
-            initiateGithubIssuesToggle: async () => {
-                const isCurrentlyEnabled = values.githubIssuesConfig?.enabled === true
+            initiateDataWarehouseSourceToggle: async ({ dwSource }) => {
+                const { requiredTable, enableErrorMessage } = DATA_WAREHOUSE_SOURCE_CONFIG[dwSource]
+                const sourceConfig = getDataWarehouseSourceConfig(values, dwSource)
+                const isCurrentlyEnabled = sourceConfig?.enabled === true
                 if (!isCurrentlyEnabled) {
                     const hasSource =
                         values.dataWarehouseSources?.results?.some(
-                            (s: ExternalDataSource) => s.source_type === 'Github'
+                            (s: ExternalDataSource) => s.source_type === dwSource
                         ) ?? false
                     if (!hasSource) {
-                        actions.openDataSourceSetup('Github')
+                        actions.openDataSourceSetup(dwSource)
                         return
                     }
                     try {
-                        await ensureRequiredTableSyncing('Github', 'issues')
+                        await ensureRequiredTableSyncing(dwSource, requiredTable)
                     } catch (error: any) {
-                        lemonToast.error(error?.detail || error?.message || 'Failed to enable GitHub Issues')
+                        lemonToast.error(error?.detail || error?.message || enableErrorMessage)
                         return
                     }
                 }
-                actions.toggleGithubIssues()
-            },
-            initiateLinearIssuesToggle: async () => {
-                const isCurrentlyEnabled = values.linearIssuesConfig?.enabled === true
-                if (!isCurrentlyEnabled) {
-                    const hasSource =
-                        values.dataWarehouseSources?.results?.some(
-                            (s: ExternalDataSource) => s.source_type === 'Linear'
-                        ) ?? false
-                    if (!hasSource) {
-                        actions.openDataSourceSetup('Linear')
-                        return
-                    }
-                    try {
-                        await ensureRequiredTableSyncing('Linear', 'issues')
-                    } catch (error: any) {
-                        lemonToast.error(error?.detail || error?.message || 'Failed to enable Linear Issues')
-                        return
-                    }
-                }
-                actions.toggleLinearIssues()
-            },
-            initiateZendeskTicketsToggle: async () => {
-                const isCurrentlyEnabled = values.zendeskTicketsConfig?.enabled === true
-                if (!isCurrentlyEnabled) {
-                    const hasSource =
-                        values.dataWarehouseSources?.results?.some(
-                            (s: ExternalDataSource) => s.source_type === 'Zendesk'
-                        ) ?? false
-                    if (!hasSource) {
-                        actions.openDataSourceSetup('Zendesk')
-                        return
-                    }
-                    try {
-                        await ensureRequiredTableSyncing('Zendesk', 'tickets')
-                    } catch (error: any) {
-                        lemonToast.error(error?.detail || error?.message || 'Failed to enable Zendesk Tickets')
-                        return
-                    }
-                }
-                actions.toggleZendeskTickets()
+                actions.toggleDataWarehouseSource(dwSource)
             },
             onDataSourceSetupComplete: ({ product }: { product: ExternalDataSourceType }) => {
                 const mapping: Partial<
@@ -351,30 +351,13 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                     enabled: desiredEnabled,
                 })
             },
-            toggleGithubIssues: () => {
-                const config = values.githubIssuesConfig
+            toggleDataWarehouseSource: ({ dwSource }) => {
+                const { sourceProduct, sourceType } = DATA_WAREHOUSE_SOURCE_CONFIG[dwSource]
+                const config = getDataWarehouseSourceConfig(values, dwSource)
                 const desiredEnabled = config?.enabled ?? true
                 actions.toggleSignalSource({
-                    sourceProduct: SignalSourceProduct.GITHUB,
-                    sourceType: SignalSourceType.ISSUE,
-                    enabled: desiredEnabled,
-                })
-            },
-            toggleLinearIssues: () => {
-                const config = values.linearIssuesConfig
-                const desiredEnabled = config?.enabled ?? true
-                actions.toggleSignalSource({
-                    sourceProduct: SignalSourceProduct.LINEAR,
-                    sourceType: SignalSourceType.ISSUE,
-                    enabled: desiredEnabled,
-                })
-            },
-            toggleZendeskTickets: () => {
-                const config = values.zendeskTicketsConfig
-                const desiredEnabled = config?.enabled ?? true
-                actions.toggleSignalSource({
-                    sourceProduct: SignalSourceProduct.ZENDESK,
-                    sourceType: SignalSourceType.TICKET,
+                    sourceProduct,
+                    sourceType,
                     enabled: desiredEnabled,
                 })
             },

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -246,7 +246,12 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         actions.openDataSourceSetup('Github')
                         return
                     }
-                    await ensureRequiredTableSyncing('Github', 'issues')
+                    try {
+                        await ensureRequiredTableSyncing('Github', 'issues')
+                    } catch (error: any) {
+                        lemonToast.error(error?.detail || error?.message || 'Failed to enable GitHub Issues')
+                        return
+                    }
                 }
                 actions.toggleGithubIssues()
             },
@@ -261,7 +266,12 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         actions.openDataSourceSetup('Linear')
                         return
                     }
-                    await ensureRequiredTableSyncing('Linear', 'issues')
+                    try {
+                        await ensureRequiredTableSyncing('Linear', 'issues')
+                    } catch (error: any) {
+                        lemonToast.error(error?.detail || error?.message || 'Failed to enable Linear Issues')
+                        return
+                    }
                 }
                 actions.toggleLinearIssues()
             },
@@ -276,7 +286,12 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         actions.openDataSourceSetup('Zendesk')
                         return
                     }
-                    await ensureRequiredTableSyncing('Zendesk', 'tickets')
+                    try {
+                        await ensureRequiredTableSyncing('Zendesk', 'tickets')
+                    } catch (error: any) {
+                        lemonToast.error(error?.detail || error?.message || 'Failed to enable Zendesk Tickets')
+                        return
+                    }
                 }
                 actions.toggleZendeskTickets()
             },

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -1,4 +1,4 @@
-import { actions, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -6,8 +6,10 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { externalDataSourcesLogic } from 'scenes/data-warehouse/externalDataSourcesLogic'
 
-import { RecordingUniversalFilters } from '~/types'
+import { ExternalDataSourceType } from '~/queries/schema/schema-general'
+import { ExternalDataSource, ExternalDataSourceSchema, RecordingUniversalFilters } from '~/types'
 
 import type { signalSourcesLogicType } from './signalSourcesLogicType'
 import {
@@ -18,8 +20,42 @@ import {
     ToggleSignalSourceParams,
 } from './types'
 
+function toggleSourceConfigState(
+    state: SignalSourceConfig[] | null,
+    sourceProduct: SignalSourceProduct,
+    sourceType: SignalSourceType
+): SignalSourceConfig[] | null {
+    if (!state) {
+        return state
+    }
+    const existing = state.find((c) => c.source_product === sourceProduct && c.source_type === sourceType)
+    if (existing) {
+        return state.map((c) =>
+            c.source_product === sourceProduct && c.source_type === sourceType ? { ...c, enabled: !c.enabled } : c
+        )
+    }
+    return [
+        ...state,
+        {
+            id: `new_${sourceProduct}_${sourceType}`,
+            source_product: sourceProduct,
+            source_type: sourceType,
+            enabled: true,
+            config: {},
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            status: null,
+        },
+    ]
+}
+
 export const signalSourcesLogic = kea<signalSourcesLogicType>([
     path(['scenes', 'inbox', 'signalSourcesLogic']),
+
+    connect(() => ({
+        values: [externalDataSourcesLogic, ['dataWarehouseSources', 'dataWarehouseSourcesLoading']],
+        actions: [externalDataSourcesLogic, ['loadSources']],
+    })),
 
     actions({
         openSourcesModal: true,
@@ -27,6 +63,15 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         openSessionAnalysisSetup: true,
         closeSessionAnalysisSetup: true,
         toggleSessionAnalysis: true,
+        toggleGithubIssues: true,
+        toggleLinearIssues: true,
+        toggleZendeskTickets: true,
+        initiateGithubIssuesToggle: true,
+        initiateLinearIssuesToggle: true,
+        initiateZendeskTicketsToggle: true,
+        openDataSourceSetup: (product: ExternalDataSourceType) => ({ product }),
+        closeDataSourceSetup: true,
+        onDataSourceSetupComplete: (product: ExternalDataSourceType) => ({ product }),
         toggleSignalSource: (params: ToggleSignalSourceParams) => ({ params }),
         toggleSignalSourceSuccess: (params: ToggleSignalSourceParams) => ({ params }),
         toggleSignalSourceFailure: (params: ToggleSignalSourceParams, error: string) => ({ params, error }),
@@ -62,39 +107,48 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 closeSessionAnalysisSetup: () => false,
             },
         ],
-        sourceConfigs: {
-            toggleSessionAnalysis: (state: SignalSourceConfig[] | null) => {
-                if (!state) {
-                    return state
-                }
-                const existing = state.find(
-                    (c) =>
-                        c.source_product === SignalSourceProduct.SESSION_REPLAY &&
-                        c.source_type === SignalSourceType.SESSION_ANALYSIS_CLUSTER
-                )
-                if (existing) {
-                    return state.map((c) =>
-                        c.source_product === SignalSourceProduct.SESSION_REPLAY &&
-                        c.source_type === SignalSourceType.SESSION_ANALYSIS_CLUSTER
-                            ? { ...c, enabled: !c.enabled }
-                            : c
-                    )
-                }
-                return [
-                    ...state,
-                    {
-                        id: `new_${SignalSourceProduct.SESSION_REPLAY}_${SignalSourceType.SESSION_ANALYSIS_CLUSTER}`,
-                        source_product: SignalSourceProduct.SESSION_REPLAY,
-                        source_type: SignalSourceType.SESSION_ANALYSIS_CLUSTER,
-                        enabled: true,
-                        config: {},
-                        created_at: new Date().toISOString(),
-                        updated_at: new Date().toISOString(),
-                        status: null,
-                    },
-                ]
+        dataSourceSetupProduct: [
+            null as ExternalDataSourceType | null,
+            {
+                openDataSourceSetup: (_, { product }) => product,
+                closeDataSourceSetup: () => null,
+                closeSourcesModal: () => null,
             },
+        ],
+        sourceConfigs: {
+            toggleSessionAnalysis: (state: SignalSourceConfig[] | null) =>
+                toggleSourceConfigState(
+                    state,
+                    SignalSourceProduct.SESSION_REPLAY,
+                    SignalSourceType.SESSION_ANALYSIS_CLUSTER
+                ),
+            toggleGithubIssues: (state: SignalSourceConfig[] | null) =>
+                toggleSourceConfigState(state, SignalSourceProduct.GITHUB, SignalSourceType.ISSUE),
+            toggleLinearIssues: (state: SignalSourceConfig[] | null) =>
+                toggleSourceConfigState(state, SignalSourceProduct.LINEAR, SignalSourceType.ISSUE),
+            toggleZendeskTickets: (state: SignalSourceConfig[] | null) =>
+                toggleSourceConfigState(state, SignalSourceProduct.ZENDESK, SignalSourceType.TICKET),
         },
+        togglingSourceKeys: [
+            new Set<string>(),
+            {
+                toggleSignalSource: (state, { params }) => {
+                    const next = new Set(state)
+                    next.add(`${params.sourceProduct}_${params.sourceType}`)
+                    return next
+                },
+                toggleSignalSourceSuccess: (state, { params }) => {
+                    const next = new Set(state)
+                    next.delete(`${params.sourceProduct}_${params.sourceType}`)
+                    return next
+                },
+                toggleSignalSourceFailure: (state, { params }) => {
+                    const next = new Set(state)
+                    next.delete(`${params.sourceProduct}_${params.sourceType}`)
+                    return next
+                },
+            },
+        ],
     }),
 
     selectors({
@@ -106,6 +160,44 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                         c.source_product === SignalSourceProduct.SESSION_REPLAY &&
                         c.source_type === SignalSourceType.SESSION_ANALYSIS_CLUSTER
                 ) ?? null,
+        ],
+        githubIssuesConfig: [
+            (s) => [s.sourceConfigs],
+            (sourceConfigs: SignalSourceConfig[] | null): SignalSourceConfig | null =>
+                sourceConfigs?.find(
+                    (c) => c.source_product === SignalSourceProduct.GITHUB && c.source_type === SignalSourceType.ISSUE
+                ) ?? null,
+        ],
+        linearIssuesConfig: [
+            (s) => [s.sourceConfigs],
+            (sourceConfigs: SignalSourceConfig[] | null): SignalSourceConfig | null =>
+                sourceConfigs?.find(
+                    (c) => c.source_product === SignalSourceProduct.LINEAR && c.source_type === SignalSourceType.ISSUE
+                ) ?? null,
+        ],
+        zendeskTicketsConfig: [
+            (s) => [s.sourceConfigs],
+            (sourceConfigs: SignalSourceConfig[] | null): SignalSourceConfig | null =>
+                sourceConfigs?.find(
+                    (c) => c.source_product === SignalSourceProduct.ZENDESK && c.source_type === SignalSourceType.TICKET
+                ) ?? null,
+        ],
+        isSessionAnalysisToggling: [
+            (s) => [s.togglingSourceKeys],
+            (keys: Set<string>): boolean =>
+                keys.has(`${SignalSourceProduct.SESSION_REPLAY}_${SignalSourceType.SESSION_ANALYSIS_CLUSTER}`),
+        ],
+        isGithubIssuesToggling: [
+            (s) => [s.togglingSourceKeys],
+            (keys: Set<string>): boolean => keys.has(`${SignalSourceProduct.GITHUB}_${SignalSourceType.ISSUE}`),
+        ],
+        isLinearIssuesToggling: [
+            (s) => [s.togglingSourceKeys],
+            (keys: Set<string>): boolean => keys.has(`${SignalSourceProduct.LINEAR}_${SignalSourceType.ISSUE}`),
+        ],
+        isZendeskTicketsToggling: [
+            (s) => [s.togglingSourceKeys],
+            (keys: Set<string>): boolean => keys.has(`${SignalSourceProduct.ZENDESK}_${SignalSourceType.TICKET}`),
         ],
         isClusteringRunning: [
             (s) => [s.sessionAnalysisConfig],
@@ -122,89 +214,198 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
-        toggleSignalSource: async ({ params }, breakpoint) => {
-            const { sourceProduct, sourceType, enabled, config } = params
-            try {
-                const configs = values.sourceConfigs ?? []
-                const existing = configs.find((c) => c.source_product === sourceProduct && c.source_type === sourceType)
+    listeners(({ actions, values }) => {
+        // If the required table for a signal source is not yet syncing on the existing DW source,
+        // enable it so the signals workflow has data to process.
+        async function ensureRequiredTableSyncing(dwSourceType: string, tableName: string): Promise<void> {
+            const source = values.dataWarehouseSources?.results?.find(
+                (s: ExternalDataSource) => s.source_type === dwSourceType
+            )
+            if (!source) {
+                return
+            }
+            const schema = source.schemas?.find((s: ExternalDataSourceSchema) => s.name === tableName)
+            if (schema && !schema.should_sync) {
+                await api.externalDataSchemas.update(schema.id, { should_sync: true })
+            }
+        }
 
-                if (existing && !existing.id.startsWith('new_')) {
-                    const updateData: Partial<SignalSourceConfig> = { enabled }
-                    if (config !== undefined) {
-                        updateData.config = config
+        return {
+            openSourcesModal: () => {
+                // Load external data sources so we can check connectivity when user toggles a source
+                actions.loadSources()
+            },
+            initiateGithubIssuesToggle: async () => {
+                const isCurrentlyEnabled = values.githubIssuesConfig?.enabled === true
+                if (!isCurrentlyEnabled) {
+                    const hasSource =
+                        values.dataWarehouseSources?.results?.some(
+                            (s: ExternalDataSource) => s.source_type === 'Github'
+                        ) ?? false
+                    if (!hasSource) {
+                        actions.openDataSourceSetup('Github')
+                        return
                     }
-                    await api.signalSourceConfigs.update(existing.id, updateData)
-                } else if (enabled) {
-                    await api.signalSourceConfigs.create({
-                        source_product: sourceProduct,
-                        source_type: sourceType,
-                        enabled,
-                        config: config ?? {},
-                    })
+                    await ensureRequiredTableSyncing('Github', 'issues')
                 }
-                breakpoint()
-                actions.toggleSignalSourceSuccess(params)
-                actions.loadSourceConfigs()
-            } catch (error: any) {
-                breakpoint()
-                const errorMessage = error?.detail || error?.message || 'Failed to toggle signal source'
-                actions.toggleSignalSourceFailure(params, errorMessage)
-                actions.loadSourceConfigs()
-                lemonToast.error(errorMessage)
-            }
-        },
-        toggleSessionAnalysis: () => {
-            const config = values.sessionAnalysisConfig
-            const desiredEnabled = config?.enabled ?? true
-            actions.toggleSignalSource({
-                sourceProduct: SignalSourceProduct.SESSION_REPLAY,
-                sourceType: SignalSourceType.SESSION_ANALYSIS_CLUSTER,
-                enabled: desiredEnabled,
-            })
-        },
-        saveSessionAnalysisFilters: async ({ filters }) => {
-            try {
-                const existing = values.sessionAnalysisConfig
-                if (existing) {
-                    await api.signalSourceConfigs.update(existing.id, {
-                        config: { recording_filters: filters },
-                        enabled: true,
-                    })
-                } else {
-                    await api.signalSourceConfigs.create({
-                        source_product: SignalSourceProduct.SESSION_REPLAY,
-                        source_type: SignalSourceType.SESSION_ANALYSIS_CLUSTER,
-                        config: { recording_filters: filters },
-                        enabled: true,
-                    })
+                actions.toggleGithubIssues()
+            },
+            initiateLinearIssuesToggle: async () => {
+                const isCurrentlyEnabled = values.linearIssuesConfig?.enabled === true
+                if (!isCurrentlyEnabled) {
+                    const hasSource =
+                        values.dataWarehouseSources?.results?.some(
+                            (s: ExternalDataSource) => s.source_type === 'Linear'
+                        ) ?? false
+                    if (!hasSource) {
+                        actions.openDataSourceSetup('Linear')
+                        return
+                    }
+                    await ensureRequiredTableSyncing('Linear', 'issues')
                 }
-                lemonToast.success('Session analysis filters saved')
-                actions.loadSourceConfigs()
-                actions.closeSessionAnalysisSetup()
-            } catch (error: any) {
-                const errorMessage = error?.detail || error?.message || 'Failed to save filters'
-                lemonToast.error(errorMessage)
-            }
-        },
-        clearSessionAnalysisFilters: async () => {
-            try {
-                const existing = values.sessionAnalysisConfig
-                if (
-                    existing &&
-                    existing.id !==
-                        `new_${SignalSourceProduct.SESSION_REPLAY}_${SignalSourceType.SESSION_ANALYSIS_CLUSTER}`
-                ) {
-                    await api.signalSourceConfigs.update(existing.id, { config: {}, enabled: true })
-                    lemonToast.success('Session analysis filters cleared')
+                actions.toggleLinearIssues()
+            },
+            initiateZendeskTicketsToggle: async () => {
+                const isCurrentlyEnabled = values.zendeskTicketsConfig?.enabled === true
+                if (!isCurrentlyEnabled) {
+                    const hasSource =
+                        values.dataWarehouseSources?.results?.some(
+                            (s: ExternalDataSource) => s.source_type === 'Zendesk'
+                        ) ?? false
+                    if (!hasSource) {
+                        actions.openDataSourceSetup('Zendesk')
+                        return
+                    }
+                    await ensureRequiredTableSyncing('Zendesk', 'tickets')
                 }
-                actions.loadSourceConfigs()
-            } catch (error: any) {
-                const errorMessage = error?.detail || error?.message || 'Failed to clear filters'
-                lemonToast.error(errorMessage)
-            }
-        },
-    })),
+                actions.toggleZendeskTickets()
+            },
+            onDataSourceSetupComplete: ({ product }: { product: ExternalDataSourceType }) => {
+                const mapping: Partial<
+                    Record<ExternalDataSourceType, { sourceProduct: SignalSourceProduct; sourceType: SignalSourceType }>
+                > = {
+                    Github: { sourceProduct: SignalSourceProduct.GITHUB, sourceType: SignalSourceType.ISSUE },
+                    Linear: { sourceProduct: SignalSourceProduct.LINEAR, sourceType: SignalSourceType.ISSUE },
+                    Zendesk: { sourceProduct: SignalSourceProduct.ZENDESK, sourceType: SignalSourceType.TICKET },
+                }
+                const mapped = mapping[product]
+                if (mapped) {
+                    actions.toggleSignalSource({ ...mapped, enabled: true })
+                }
+                actions.closeDataSourceSetup()
+            },
+            toggleSignalSource: async ({ params }, breakpoint) => {
+                const { sourceProduct, sourceType, enabled, config } = params
+                try {
+                    const configs = values.sourceConfigs ?? []
+                    const existing = configs.find(
+                        (c: SignalSourceConfig) => c.source_product === sourceProduct && c.source_type === sourceType
+                    )
+
+                    if (existing && !existing.id.startsWith('new_')) {
+                        const updateData: Partial<SignalSourceConfig> = { enabled }
+                        if (config !== undefined) {
+                            updateData.config = config
+                        }
+                        await api.signalSourceConfigs.update(existing.id, updateData)
+                    } else if (enabled) {
+                        await api.signalSourceConfigs.create({
+                            source_product: sourceProduct,
+                            source_type: sourceType,
+                            enabled,
+                            config: config ?? {},
+                        })
+                    }
+                    breakpoint()
+                    actions.toggleSignalSourceSuccess(params)
+                    actions.loadSourceConfigs()
+                } catch (error: any) {
+                    breakpoint()
+                    const errorMessage = error?.detail || error?.message || 'Failed to toggle signal source'
+                    actions.toggleSignalSourceFailure(params, errorMessage)
+                    actions.loadSourceConfigs()
+                    lemonToast.error(errorMessage)
+                }
+            },
+            toggleSessionAnalysis: () => {
+                const config = values.sessionAnalysisConfig
+                const desiredEnabled = config?.enabled ?? true
+                actions.toggleSignalSource({
+                    sourceProduct: SignalSourceProduct.SESSION_REPLAY,
+                    sourceType: SignalSourceType.SESSION_ANALYSIS_CLUSTER,
+                    enabled: desiredEnabled,
+                })
+            },
+            toggleGithubIssues: () => {
+                const config = values.githubIssuesConfig
+                const desiredEnabled = config?.enabled ?? true
+                actions.toggleSignalSource({
+                    sourceProduct: SignalSourceProduct.GITHUB,
+                    sourceType: SignalSourceType.ISSUE,
+                    enabled: desiredEnabled,
+                })
+            },
+            toggleLinearIssues: () => {
+                const config = values.linearIssuesConfig
+                const desiredEnabled = config?.enabled ?? true
+                actions.toggleSignalSource({
+                    sourceProduct: SignalSourceProduct.LINEAR,
+                    sourceType: SignalSourceType.ISSUE,
+                    enabled: desiredEnabled,
+                })
+            },
+            toggleZendeskTickets: () => {
+                const config = values.zendeskTicketsConfig
+                const desiredEnabled = config?.enabled ?? true
+                actions.toggleSignalSource({
+                    sourceProduct: SignalSourceProduct.ZENDESK,
+                    sourceType: SignalSourceType.TICKET,
+                    enabled: desiredEnabled,
+                })
+            },
+            saveSessionAnalysisFilters: async ({ filters }) => {
+                try {
+                    const existing = values.sessionAnalysisConfig
+                    if (existing) {
+                        await api.signalSourceConfigs.update(existing.id, {
+                            config: { recording_filters: filters },
+                            enabled: true,
+                        })
+                    } else {
+                        await api.signalSourceConfigs.create({
+                            source_product: SignalSourceProduct.SESSION_REPLAY,
+                            source_type: SignalSourceType.SESSION_ANALYSIS_CLUSTER,
+                            config: { recording_filters: filters },
+                            enabled: true,
+                        })
+                    }
+                    lemonToast.success('Session analysis filters saved')
+                    actions.loadSourceConfigs()
+                    actions.closeSessionAnalysisSetup()
+                } catch (error: any) {
+                    const errorMessage = error?.detail || error?.message || 'Failed to save filters'
+                    lemonToast.error(errorMessage)
+                }
+            },
+            clearSessionAnalysisFilters: async () => {
+                try {
+                    const existing = values.sessionAnalysisConfig
+                    if (
+                        existing &&
+                        existing.id !==
+                            `new_${SignalSourceProduct.SESSION_REPLAY}_${SignalSourceType.SESSION_ANALYSIS_CLUSTER}`
+                    ) {
+                        await api.signalSourceConfigs.update(existing.id, { config: {}, enabled: true })
+                        lemonToast.success('Session analysis filters cleared')
+                    }
+                    actions.loadSourceConfigs()
+                } catch (error: any) {
+                    const errorMessage = error?.detail || error?.message || 'Failed to clear filters'
+                    lemonToast.error(errorMessage)
+                }
+            },
+        }
+    }),
 
     events(({ actions }) => ({
         afterMount: () => {

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -46,11 +46,16 @@ export interface SignalSourceConfig {
 export enum SignalSourceProduct {
     SESSION_REPLAY = 'session_replay',
     LLM_ANALYTICS = 'llm_analytics',
+    GITHUB = 'github',
+    LINEAR = 'linear',
+    ZENDESK = 'zendesk',
 }
 
 export enum SignalSourceType {
     SESSION_ANALYSIS_CLUSTER = 'session_analysis_cluster',
     EVALUATION = 'evaluation',
+    ISSUE = 'issue',
+    TICKET = 'ticket',
 }
 
 export interface ToggleSignalSourceParams {


### PR DESCRIPTION
## Problem

The Inbox Sources modal listed Zendesk, Linear, and GitHub as signal sources, but users couldn't actually connect the integrations from there - they had to set up data warehouse sources separately first.

## Changes

![2026-03-10 23 30 59](https://github.com/user-attachments/assets/3a0f165d-db35-4f6b-961f-6e29a9b95f64)

The three data-import sources are now fully wirable from the Inbox. When a user clicks Enable:

1. If no data warehouse connection exists for that service, the modal shows a `SourceForm` inline for entering credentials. On successful connection, Hogfetti celebrates and the signal source is enabled.
2. If a connection already exists but the required table isn't syncing, it's auto-enabled via API.
3. A `SignalSourceConfig` is created/toggled server-side.

The `SourcesList` UX also got a refresh: `LemonSwitch` replaced with Enable/Disable buttons, with an arrow icon on sources that require setup.

## How did you test this code?

Manual testing of all toggle flows: fresh setup, existing source without table syncing, enable/disable round-trips.

## Publish to changelog?

No