### PR TITLE
feat(web-analytics): Allow users to zoom into web analytics graphs by clicking into a point

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -417,6 +417,7 @@ export const FEATURE_FLAGS = {
     UX_REMOVE_SIDEPANEL: 'ux-remove-sidepanel', // owner: #team-surveys
     WEB_ANALYTICS_CONVERSION_GOAL_PREAGG: 'web-analytics-conversion-goal-preagg', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_GRAPH_DATE_ZOOM: 'web-analytics-graph-date-zoom', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_METRICS: 'web-analytics-live-metrics', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -58,6 +58,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     ignoreActionsInSeriesLabels?: boolean
     /** Transform dataTableRows after they are created (e.g., to add date labels) */
     dataTableRowsTransformer?: (rows: DataTableRow[]) => DataTableRow[]
+    /** Custom label for the tooltip inspect hint (e.g. "Click to zoom in") */
+    inspectLabel?: string
     /** Compare filter for Web Analytics queries */
     compareFilter?: any
     /** Base currency for formatting monetary values */

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -842,7 +842,7 @@ export function LineGraph_({
                                                 )} (${percentageLabel}%)`
                                             })
                                         }
-                                        hideInspectActorsSection={!onClick || !showPersonsModal}
+                                        hideInspectActorsSection={!onClick || (!showPersonsModal && !inspectLabel)}
                                         inspectLabel={inspectLabel}
                                         {...tooltipProps}
                                         groupTypeLabel={

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -201,6 +201,7 @@ export function ActionsLineGraph({
                       }
                     : {
                           groupTypeLabel: context?.groupTypeLabel,
+                          inspectLabel: context?.inspectLabel,
                           filter: (s) => !s.hideTooltip,
                       }
             }

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -1,5 +1,6 @@
 import { BreakPointFunction } from 'kea'
 
+import { dayjs } from 'lib/dayjs'
 import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { UnexpectedNeverError, getDefaultInterval } from 'lib/utils'
 
@@ -14,7 +15,7 @@ import {
     WebStatsBreakdown,
 } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
-import { InsightLogicProps, PropertyFilterType, PropertyMathType } from '~/types'
+import { InsightLogicProps, IntervalType, PropertyFilterType, PropertyMathType } from '~/types'
 
 /** Matches BREAKDOWN_NULL_DISPLAY in posthog/hogql_queries/web_analytics/stats_table.py */
 export const BREAKDOWN_NULL_DISPLAY = '(none)'
@@ -586,5 +587,38 @@ export const parseWebAnalyticsURL = (urlString: string): ParsedURL => {
             pathname: null,
             isValid: false,
         }
+    }
+}
+
+export function getZoomDateRange(
+    day: string,
+    currentInterval: IntervalType
+): { dateFrom: string; dateTo: string; interval: IntervalType } | null {
+    const d = dayjs(day.slice(0, 10))
+    if (!d.isValid()) {
+        return null
+    }
+
+    switch (currentInterval) {
+        case 'month':
+            return {
+                dateFrom: d.startOf('month').format('YYYY-MM-DD'),
+                dateTo: d.endOf('month').format('YYYY-MM-DD'),
+                interval: 'day',
+            }
+        case 'week':
+            return {
+                dateFrom: d.format('YYYY-MM-DD'),
+                dateTo: d.add(6, 'day').format('YYYY-MM-DD'),
+                interval: 'day',
+            }
+        case 'day':
+            return {
+                dateFrom: d.format('YYYY-MM-DD'),
+                dateTo: d.add(1, 'day').format('YYYY-MM-DD'),
+                interval: 'hour',
+            }
+        default:
+            return null
     }
 }

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -693,6 +693,9 @@ export const WebStatsTrendTile = ({
                 ? {
                       inspectLabel: 'Click to zoom in',
                       onDataPointClick({ day }) {
+                          if (typeof day !== 'string') {
+                              return
+                          }
                           const zoomRange = getZoomDateRange(day, interval)
                           if (zoomRange) {
                               zoomIntoPeriod(zoomRange.dateFrom, zoomRange.dateTo, zoomRange.interval)

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { BuiltLogic, LogicWrapper, useActions, useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
-import { IconChevronDown, IconExternal, IconTrending, IconWarning } from '@posthog/icons'
+import { IconChevronDown, IconExternal, IconTrending, IconUndo, IconWarning } from '@posthog/icons'
 import { LemonSegmentedButton, LemonSelect, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { getColorVar } from 'lib/colors'
@@ -34,6 +34,7 @@ import {
     ProductTab,
     TileId,
     faviconUrl,
+    getZoomDateRange,
     webStatsBreakdownToPropertyName,
 } from 'scenes/web-analytics/common'
 import { webAnalyticsFilterLogic } from 'scenes/web-analytics/webAnalyticsFilterLogic'
@@ -601,10 +602,11 @@ export const WebStatsTrendTile = ({
     insightProps,
     attachTo,
 }: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean }): JSX.Element => {
-    const { togglePropertyFilter, setDateInterval } = useActions(webAnalyticsLogic)
+    const { togglePropertyFilter, setDateInterval, zoomIntoPeriod, resetZoom } = useActions(webAnalyticsLogic)
     const {
         hasCountryFilter,
         dateFilter: { interval },
+        preZoomDateFilter,
     } = useValues(webAnalyticsLogic)
     const worldMapPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Country)?.key
     const regionPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Region)?.key
@@ -682,16 +684,39 @@ export const WebStatsTrendTile = ({
             }
         }
 
-        return baseContext
-    }, [onWorldMapClick, onRegionMapClick, insightProps, query])
+        const canZoom = interval !== 'hour'
+        return {
+            ...baseContext,
+            ...(canZoom
+                ? {
+                      inspectLabel: 'Click to zoom in',
+                      onDataPointClick({ day }) {
+                          const zoomRange = getZoomDateRange(day, interval)
+                          if (zoomRange) {
+                              zoomIntoPeriod(zoomRange.dateFrom, zoomRange.dateTo, zoomRange.interval)
+                          }
+                      },
+                  }
+                : {}),
+        }
+    }, [onWorldMapClick, onRegionMapClick, insightProps, query, interval, zoomIntoPeriod])
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
-            {showIntervalTile && (
+            {(showIntervalTile || preZoomDateFilter) && (
                 <div className="flex flex-row items-center justify-end m-2 mr-4">
-                    <div className="flex flex-row items-center">
-                        <span className="mr-2">Group by</span>
-                        <IntervalFilterStandalone interval={interval} onIntervalChange={setDateInterval} />
+                    <div className="flex flex-row items-center gap-2">
+                        {showIntervalTile && (
+                            <>
+                                <span>Group by</span>
+                                <IntervalFilterStandalone interval={interval} onIntervalChange={setDateInterval} />
+                            </>
+                        )}
+                        {preZoomDateFilter && (
+                            <LemonButton type="secondary" size="small" icon={<IconUndo />} onClick={resetZoom}>
+                                Reset zoom
+                            </LemonButton>
+                        )}
                     </div>
                 </div>
             )}

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -608,6 +608,8 @@ export const WebStatsTrendTile = ({
         dateFilter: { interval },
         preZoomDateFilter,
     } = useValues(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const graphDateZoomEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_GRAPH_DATE_ZOOM]
     const worldMapPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Country)?.key
     const regionPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Region)?.key
 
@@ -684,7 +686,7 @@ export const WebStatsTrendTile = ({
             }
         }
 
-        const canZoom = interval !== 'hour'
+        const canZoom = graphDateZoomEnabled && interval !== 'hour'
         return {
             ...baseContext,
             ...(canZoom
@@ -699,11 +701,11 @@ export const WebStatsTrendTile = ({
                   }
                 : {}),
         }
-    }, [onWorldMapClick, onRegionMapClick, insightProps, query, interval, zoomIntoPeriod])
+    }, [onWorldMapClick, onRegionMapClick, insightProps, query, interval, zoomIntoPeriod, graphDateZoomEnabled])
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">
-            {(showIntervalTile || preZoomDateFilter) && (
+            {(showIntervalTile || (graphDateZoomEnabled && preZoomDateFilter)) && (
                 <div className="flex flex-row items-center justify-end m-2 mr-4">
                     <div className="flex flex-row items-center gap-2">
                         {showIntervalTile && (
@@ -712,7 +714,7 @@ export const WebStatsTrendTile = ({
                                 <IntervalFilterStandalone interval={interval} onIntervalChange={setDateInterval} />
                             </>
                         )}
-                        {preZoomDateFilter && (
+                        {graphDateZoomEnabled && preZoomDateFilter && (
                             <LemonButton type="secondary" size="small" icon={<IconUndo />} onClick={resetZoom}>
                                 Reset zoom
                             </LemonButton>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -219,6 +219,15 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setTileVisibility: (tileId: TileId, visible: boolean) => ({ tileId, visible }),
         resetTileVisibility: () => true,
         clearFilters: true,
+        zoomIntoPeriod: (dateFrom: string, dateTo: string, interval: IntervalType) => ({
+            dateFrom,
+            dateTo,
+            interval,
+        }),
+        resetZoom: true,
+        setPreZoomDateFilter: (
+            filter: { dateFrom: string | null; dateTo: string | null; interval: IntervalType } | null
+        ) => ({ filter }),
     }),
     loaders(({ values }) => ({
         shouldShowGeoIPQueries: {
@@ -418,6 +427,15 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             persistConfig,
             {
                 setConversionGoal: (_, { conversionGoal }) => conversionGoal,
+                clearFilters: () => null,
+            },
+        ],
+        preZoomDateFilter: [
+            null as { dateFrom: string | null; dateTo: string | null; interval: IntervalType } | null,
+            {
+                setPreZoomDateFilter: (_, { filter }) => filter,
+                setDates: () => null,
+                setDateInterval: () => null,
                 clearFilters: () => null,
             },
         ],
@@ -2270,6 +2288,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             togglePropertyFilter: stateToUrl,
             setConversionGoal: stateToUrl,
             setDates: stateToUrl,
+            setDatesAndInterval: stateToUrl,
             setDateInterval: stateToUrl,
             setDeviceTab: stateToUrl,
             setSourceTab: stateToUrl,
@@ -2344,6 +2363,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 (date_to && date_to !== values.dateFilter.dateTo) ||
                 (interval && interval !== values.dateFilter.interval)
             ) {
+                actions.setPreZoomDateFilter(null)
                 actions.setDatesAndInterval(date_from, date_to, interval)
             }
             if (device_tab && device_tab !== values._deviceTab) {
@@ -2440,6 +2460,23 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     interval,
                 })
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.FilterWebAnalytics)
+            },
+            zoomIntoPeriod: ({ dateFrom, dateTo, interval }) => {
+                if (values.preZoomDateFilter === null) {
+                    actions.setPreZoomDateFilter({
+                        dateFrom: values.dateFilter.dateFrom,
+                        dateTo: values.dateFilter.dateTo,
+                        interval: values.dateFilter.interval,
+                    })
+                }
+                actions.setDatesAndInterval(dateFrom, dateTo, interval)
+            },
+            resetZoom: () => {
+                const preZoom = values.preZoomDateFilter
+                if (preZoom) {
+                    actions.setPreZoomDateFilter(null)
+                    actions.setDatesAndInterval(preZoom.dateFrom, preZoom.dateTo, preZoom.interval)
+                }
             },
             setWebAnalyticsFilters: () => {
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.FilterWebAnalytics)


### PR DESCRIPTION
## Problem
It's somewhat clanky zooming in on a date range. It currently requires the user to change the group by and the date range manually.  This PR adds the ability to click into the date range by pressing a point on the graph.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

https://github.com/user-attachments/assets/b3253fb5-cabe-49a2-aa96-3b7a8216afea


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
