### PR TITLE
fix(llma): playground save fixes

### DIFF
--- a/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
@@ -352,9 +352,11 @@ function PromptCard({
                 <ModelConfigBar promptId={prompt.id} />
             </div>
 
-            <div className="min-h-0 overflow-y-auto pr-1">
+            <div className="min-h-0 flex-1 overflow-y-auto pr-1">
                 <MessagesSection promptId={prompt.id} />
             </div>
+
+            <MessageActions promptId={prompt.id} />
         </div>
     )
 }
@@ -628,8 +630,6 @@ function ModelConfigBar({ promptId }: { promptId: string }): JSX.Element {
 
 function MessagesSection({ promptId }: { promptId: string }): JSX.Element {
     const prompt = usePromptConfig(promptId)
-    const { submitting } = useValues(llmPlaygroundRunLogic)
-    const { addMessage } = useActions(llmPlaygroundPromptsLogic)
 
     if (!prompt) {
         return <LemonSkeleton className="h-16" />
@@ -641,18 +641,26 @@ function MessagesSection({ promptId }: { promptId: string }): JSX.Element {
             {prompt.messages.map((message, index) => (
                 <MessageDisplay key={`${promptId}-${index}`} promptId={promptId} index={index} message={message} />
             ))}
-            <div className="flex items-center gap-2">
-                <LemonButton
-                    type="secondary"
-                    size="small"
-                    icon={<IconPlus />}
-                    onClick={() => addMessage(undefined, promptId)}
-                    disabledReason={submitting ? 'Generating...' : undefined}
-                >
-                    Message
-                </LemonButton>
-                <ToolsButton promptId={promptId} />
-            </div>
+        </div>
+    )
+}
+
+function MessageActions({ promptId }: { promptId: string }): JSX.Element {
+    const { submitting } = useValues(llmPlaygroundRunLogic)
+    const { addMessage } = useActions(llmPlaygroundPromptsLogic)
+
+    return (
+        <div className="flex items-center gap-2 shrink-0 mt-3">
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconPlus />}
+                onClick={() => addMessage(undefined, promptId)}
+                disabledReason={submitting ? 'Generating...' : undefined}
+            >
+                Message
+            </LemonButton>
+            <ToolsButton promptId={promptId} />
         </div>
     )
 }

--- a/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/playground/LLMAnalyticsPlaygroundScene.tsx
@@ -319,6 +319,7 @@ function PromptCard({
 }): JSX.Element {
     const { submitting } = useValues(llmPlaygroundRunLogic)
     const showHeaderRow = promptCount > 1 || canRemove
+    const messagesRef = React.useRef<HTMLDivElement>(null)
 
     return (
         <div className="min-w-0 border rounded p-4 bg-transparent group/prompt ring-1 ring-primary/40 shadow-sm h-full flex flex-col min-h-0">
@@ -352,11 +353,11 @@ function PromptCard({
                 <ModelConfigBar promptId={prompt.id} />
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+            <div ref={messagesRef} className="min-h-0 flex-1 overflow-y-auto pr-1">
                 <MessagesSection promptId={prompt.id} />
             </div>
 
-            <MessageActions promptId={prompt.id} />
+            <MessageActions promptId={prompt.id} scrollContainerRef={messagesRef} />
         </div>
     )
 }
@@ -645,9 +646,25 @@ function MessagesSection({ promptId }: { promptId: string }): JSX.Element {
     )
 }
 
-function MessageActions({ promptId }: { promptId: string }): JSX.Element {
+function MessageActions({
+    promptId,
+    scrollContainerRef,
+}: {
+    promptId: string
+    scrollContainerRef: React.RefObject<HTMLDivElement | null>
+}): JSX.Element {
     const { submitting } = useValues(llmPlaygroundRunLogic)
     const { addMessage } = useActions(llmPlaygroundPromptsLogic)
+
+    const handleAddMessage = (): void => {
+        addMessage(undefined, promptId)
+        requestAnimationFrame(() => {
+            const el = scrollContainerRef.current
+            if (el) {
+                el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+            }
+        })
+    }
 
     return (
         <div className="flex items-center gap-2 shrink-0 mt-3">
@@ -655,7 +672,7 @@ function MessageActions({ promptId }: { promptId: string }): JSX.Element {
                 type="secondary"
                 size="small"
                 icon={<IconPlus />}
-                onClick={() => addMessage(undefined, promptId)}
+                onClick={handleAddMessage}
                 disabledReason={submitting ? 'Generating...' : undefined}
             >
                 Message

--- a/products/llm_analytics/frontend/playground/PlaygroundSaveMenu.tsx
+++ b/products/llm_analytics/frontend/playground/PlaygroundSaveMenu.tsx
@@ -55,7 +55,7 @@ export function PlaygroundSaveMenu({ prompt }: { prompt: PromptConfig }): JSX.El
                 </LemonField>
             ),
             errors: { name: (name) => (!name ? 'A name is required' : undefined) },
-            onSubmit: ({ name }) => saveAsNewPrompt(name),
+            onSubmit: ({ name }) => saveAsNewPrompt(prompt.id, name),
         })
     }
 
@@ -69,7 +69,7 @@ export function PlaygroundSaveMenu({ prompt }: { prompt: PromptConfig }): JSX.El
                 </LemonField>
             ),
             errors: { name: (name) => (!name ? 'A name is required' : undefined) },
-            onSubmit: ({ name }) => saveAsNewEvaluation(name, modelConfig),
+            onSubmit: ({ name }) => saveAsNewEvaluation(prompt.id, name, modelConfig),
         })
     }
 
@@ -86,7 +86,8 @@ export function PlaygroundSaveMenu({ prompt }: { prompt: PromptConfig }): JSX.El
             primaryButton: {
                 children: isPrompt ? 'Publish version' : 'Save',
                 type: 'primary',
-                onClick: () => (isPrompt ? saveToLinkedPrompt() : saveToLinkedEvaluation(modelConfig)),
+                onClick: () =>
+                    isPrompt ? saveToLinkedPrompt(prompt.id) : saveToLinkedEvaluation(prompt.id, modelConfig),
             },
             secondaryButton: { children: 'Cancel', type: 'secondary' },
         })

--- a/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
@@ -1214,7 +1214,8 @@ describe('llmPlaygroundLogic', () => {
             })
 
             llmPlaygroundPromptsLogic.actions.setSystemPrompt('My system prompt')
-            llmPlaygroundPromptsLogic.actions.saveAsNewPrompt('saved-prompt')
+            const promptId = llmPlaygroundPromptsLogic.values.promptConfigs[0].id
+            llmPlaygroundPromptsLogic.actions.saveAsNewPrompt(promptId, 'saved-prompt')
 
             await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
 
@@ -1235,7 +1236,8 @@ describe('llmPlaygroundLogic', () => {
             })
 
             llmPlaygroundPromptsLogic.actions.setSystemPrompt('Judge prompt')
-            llmPlaygroundPromptsLogic.actions.saveAsNewEvaluation('saved-eval', {
+            const promptId = llmPlaygroundPromptsLogic.values.promptConfigs[0].id
+            llmPlaygroundPromptsLogic.actions.saveAsNewEvaluation(promptId, 'saved-eval', {
                 model: 'gpt-5',
                 provider: 'openai',
                 provider_key_id: null,
@@ -1275,7 +1277,8 @@ describe('llmPlaygroundLogic', () => {
             await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
 
             llmPlaygroundPromptsLogic.actions.setSystemPrompt('Updated prompt.')
-            llmPlaygroundPromptsLogic.actions.saveToLinkedPrompt()
+            const promptId = llmPlaygroundPromptsLogic.values.promptConfigs[0].id
+            llmPlaygroundPromptsLogic.actions.saveToLinkedPrompt(promptId)
 
             await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
 
@@ -1309,7 +1312,8 @@ describe('llmPlaygroundLogic', () => {
             await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
 
             llmPlaygroundPromptsLogic.actions.setSystemPrompt('New eval prompt.')
-            llmPlaygroundPromptsLogic.actions.saveToLinkedEvaluation({
+            const promptId = llmPlaygroundPromptsLogic.values.promptConfigs[0].id
+            llmPlaygroundPromptsLogic.actions.saveToLinkedEvaluation(promptId, {
                 model: 'gpt-5',
                 provider: 'openai',
                 provider_key_id: null,

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -12,7 +12,7 @@ import { urls } from 'scenes/urls'
 
 import { llmEvaluationLogic } from '../evaluations/llmEvaluationLogic'
 import type { EvaluationConfig } from '../evaluations/types'
-import { llmPromptLogic } from '../prompts/llmPromptLogic'
+import { getApiErrorDetail, llmPromptLogic } from '../prompts/llmPromptLogic'
 import { normalizeLLMProvider } from '../settings/llmProviderKeysLogic'
 import { normalizeRole } from '../utils'
 import type { llmPlaygroundPromptsLogicType } from './llmPlaygroundPromptsLogicType'
@@ -823,8 +823,8 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                         logic.actions.loadPrompt()
                     }
                 }
-            } catch {
-                lemonToast.error('Failed to update prompt')
+            } catch (error: unknown) {
+                lemonToast.error(getApiErrorDetail(error) || 'Failed to update prompt')
             } finally {
                 actions.saveComplete()
             }
@@ -868,8 +868,8 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                         logic.actions.loadEvaluation()
                     }
                 }
-            } catch {
-                lemonToast.error('Failed to update evaluation')
+            } catch (error: unknown) {
+                lemonToast.error(getApiErrorDetail(error) || 'Failed to update evaluation')
             } finally {
                 actions.saveComplete()
             }
@@ -908,8 +908,8 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                         action: () => router.actions.push(urls.llmAnalyticsPrompt(name)),
                     },
                 })
-            } catch {
-                lemonToast.error('Failed to save prompt')
+            } catch (error: unknown) {
+                lemonToast.error(getApiErrorDetail(error) || 'Failed to save prompt')
             } finally {
                 actions.saveComplete()
             }
@@ -961,8 +961,8 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                         action: () => router.actions.push(urls.llmAnalyticsEvaluation(created.id)),
                     },
                 })
-            } catch {
-                lemonToast.error('Failed to save evaluation')
+            } catch (error: unknown) {
+                lemonToast.error(getApiErrorDetail(error) || 'Failed to save evaluation')
             } finally {
                 actions.saveComplete()
             }

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -256,15 +256,17 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         toggleCollapsed: (key: string) => ({ key }),
         setToolsJsonError: (promptId: string, error: string | null) => ({ promptId, error }),
         setSourceSetupLoading: (isLoading: boolean) => ({ isLoading }),
-        saveToLinkedPrompt: true,
+        saveToLinkedPrompt: (promptId: string) => ({ promptId }),
         saveToLinkedEvaluation: (
+            promptId: string,
             modelConfig: { model: string; provider: string; provider_key_id: string | null } | null
-        ) => ({ modelConfig }),
-        saveAsNewPrompt: (name: string) => ({ name }),
+        ) => ({ promptId, modelConfig }),
+        saveAsNewPrompt: (promptId: string, name: string) => ({ promptId, name }),
         saveAsNewEvaluation: (
+            promptId: string,
             name: string,
             modelConfig: { model: string; provider: string; provider_key_id: string | null } | null
-        ) => ({ name, modelConfig }),
+        ) => ({ promptId, name, modelConfig }),
         saveComplete: true,
         resetPlayground: true,
     }),
@@ -779,7 +781,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             }
         },
 
-        saveToLinkedPrompt: async () => {
+        saveToLinkedPrompt: async ({ promptId }) => {
             posthog.capture('llma playground saved to source', { action: 'save_to_linked_prompt' })
             const { linkedSource, promptConfigs } = values
             if (!linkedSource.promptName) {
@@ -787,7 +789,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                 actions.saveComplete()
                 return
             }
-            const prompt = promptConfigs[0]
+            const prompt = promptConfigs.find((p) => p.id === promptId)
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')
                 actions.saveComplete()
@@ -830,7 +832,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             }
         },
 
-        saveToLinkedEvaluation: async ({ modelConfig }) => {
+        saveToLinkedEvaluation: async ({ promptId, modelConfig }) => {
             posthog.capture('llma playground saved to source', { action: 'save_to_linked_evaluation' })
             const { linkedSource, promptConfigs } = values
             if (!linkedSource.evaluationId) {
@@ -838,7 +840,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                 actions.saveComplete()
                 return
             }
-            const prompt = promptConfigs[0]
+            const prompt = promptConfigs.find((p) => p.id === promptId)
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')
                 actions.saveComplete()
@@ -875,9 +877,9 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             }
         },
 
-        saveAsNewPrompt: async ({ name }) => {
+        saveAsNewPrompt: async ({ promptId, name }) => {
             posthog.capture('llma playground saved to source', { action: 'save_as_new_prompt' })
-            const prompt = values.promptConfigs[0]
+            const prompt = values.promptConfigs.find((p) => p.id === promptId)
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')
                 actions.saveComplete()
@@ -915,9 +917,9 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             }
         },
 
-        saveAsNewEvaluation: async ({ name, modelConfig }) => {
+        saveAsNewEvaluation: async ({ promptId, name, modelConfig }) => {
             posthog.capture('llma playground saved to source', { action: 'save_as_new_evaluation' })
-            const prompt = values.promptConfigs[0]
+            const prompt = values.promptConfigs.find((p) => p.id === promptId)
             if (!prompt) {
                 lemonToast.error('No prompt configuration to save')
                 actions.saveComplete()

--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -129,7 +129,7 @@ function buildPromptVersionSummary(prompt: LLMPrompt, isLatest: boolean): LLMPro
     }
 }
 
-function getApiErrorDetail(error: unknown): string | undefined {
+export function getApiErrorDetail(error: unknown): string | undefined {
     if (error !== null && typeof error === 'object' && 'detail' in error && typeof error.detail === 'string') {
         return error.detail
     }


### PR DESCRIPTION
## Problem

Two bugs in the playground save flow:

1. **Generic error messages**: When saving a prompt from the playground (e.g. "Save as new prompt"), backend validation errors (invalid name, duplicate name, etc.) were silently swallowed. The user only saw a generic "Failed to save prompt" toast with no indication of what went wrong.

2. **Wrong prompt saved**: When multiple prompts exist in the playground (e.g. duplicating a prompt for comparison), all save actions used `promptConfigs[0]` instead of the prompt the user clicked save on. This meant modifying the second prompt and saving would save the first prompt's content.

## Changes

- Export `getApiErrorDetail` from `llmPromptLogic` and use it in all four playground save catch blocks to surface actual API error details
- Add `promptId` parameter to all save actions (`saveToLinkedPrompt`, `saveToLinkedEvaluation`, `saveAsNewPrompt`, `saveAsNewEvaluation`) so the correct prompt config is used
- Extract `MessageActions` component outside the scrollable area so the add message button stays visible

## How did you test this code?

Tested locally.

## Publish to changelog?

no