### PR TITLE
Query request parsing

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -507,8 +507,12 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                             query={sourceQuery.source}
                             setQuery={(query) => {
                                 setSourceQuery({
+                                    kind: NodeKind.DataVisualizationNode,
                                     ...sourceQuery,
-                                    source: query,
+                                    source: {
+                                        kind: NodeKind.HogQLQuery,
+                                        ...query,
+                                    },
                                 })
                                 runQuery(query.query)
                             }}

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -714,7 +714,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     {
                         kind: NodeKind.HogQLQuery,
                         query: queryInput,
-                    },
+                    } as HogQLQuery,
                     viewId,
                     values.activeTab
                 )
@@ -726,7 +726,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         runQuery: ({ queryOverride, switchTab }) => {
             const query = (queryOverride || values.queryInput) ?? ''
 
-            const newSource = {
+            const newSource: HogQLQuery = {
+                kind: NodeKind.HogQLQuery,
                 ...values.sourceQuery.source,
                 query,
             }
@@ -1063,9 +1064,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     actions.setSourceQuery({
                         ...values.sourceQuery,
                         source: {
+                            kind: NodeKind.HogQLQuery,
                             ...values.sourceQuery.source,
                             filters: {},
-                        },
+                        } as HogQLQuery,
                     })
                 }
             } else {
@@ -1073,9 +1075,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     actions.setSourceQuery({
                         ...values.sourceQuery,
                         source: {
+                            kind: NodeKind.HogQLQuery,
                             ...values.sourceQuery.source,
                             filters: undefined,
-                        },
+                        } as HogQLQuery,
                     })
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users encountered a `JSON parse error - 1 validation error for QueryRequest query Unable to extract tag using discriminator 'kind'` when executing queries from the SQL editor. This Pydantic validation error occurred because the `kind` discriminator field was missing from query objects sent to the backend, preventing correct parsing of the query type.

## Changes

This PR explicitly sets the `kind` field in query objects within the SQL editor logic to ensure it's always present for backend validation.

Specifically, changes were made in:

1.  **`sqlEditorLogic.tsx` - `runQuery` function**: Explicitly set `kind: NodeKind.HogQLQuery` for `newSource`.
2.  **`sqlEditorLogic.tsx` - `showLegacyFilters` subscription**: Added `kind: NodeKind.HogQLQuery` when modifying query filters.
3.  **`OutputPane.tsx` - DateRange callback**: Set `kind: NodeKind.DataVisualizationNode` for the outer query and `kind: NodeKind.HogQLQuery` for the inner source query when updating date ranges.

## How did you test this code?

This fix addresses the identified root cause by ensuring the `kind` field is always present in the query object.
As an agent, I have not performed manual testing.

## Publish to changelog?

no

[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1773162025759349?thread_ts=1773162025.759349&cid=D0ACMC57HDE)

<div><a href="https://cursor.com/agents/bc-c70c2752-f471-5b50-ac2a-a162cf10fed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70c2752-f471-5b50-ac2a-a162cf10fed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->