### PR TITLE
feat(data-warehouse): add optional names filter to get_schemas

### DIFF
--- a/posthog/temporal/data_imports/sources/ashby/source.py
+++ b/posthog/temporal/data_imports/sources/ashby/source.py
@@ -42,7 +42,9 @@ class AshbySource(SimpleSource[AshbySourceConfig]):
         # and if not, returns an error message to return to the user
         raise NotImplementedError()
 
-    def get_schemas(self, config: AshbySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: AshbySourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         raise NotImplementedError()
 
     def source_for_pipeline(self, config: AshbySourceConfig, inputs: SourceInputs) -> SourceResponse:

--- a/posthog/temporal/data_imports/sources/attio/source.py
+++ b/posthog/temporal/data_imports/sources/attio/source.py
@@ -67,9 +67,11 @@ You can generate an API key in your Attio workspace settings. Check out [this gu
             featureFlag="dwh_attio",
         )
 
-    def get_schemas(self, config: AttioSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: AttioSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         # Attio API doesn't support updatedAt filtering, so only full refresh is supported
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint_config.name,
                 supports_incremental=False,
@@ -78,6 +80,10 @@ You can generate an API key in your Attio workspace settings. Check out [this gu
             )
             for endpoint_config in ATTIO_ENDPOINTS.values()
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: AttioSourceConfig, team_id: int, schema_name: str | None = None

--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -26,6 +26,7 @@ from products.data_warehouse.backend.types import IncrementalFieldType, Partitio
 def get_schemas(
     config: BigQuerySourceConfig,
     logger: FilteringBoundLogger | None = None,
+    names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     schema_list: dict[str, list[tuple[str, str, bool]]] = collections.defaultdict(list)
 
@@ -64,6 +65,10 @@ def get_schemas(
 
         for row in rows:
             schema_list[row.table_name].append((row.column_name, row.data_type, row.is_nullable == "YES"))
+
+    if names is not None:
+        names_set = set(names)
+        schema_list = {k: v for k, v in schema_list.items() if k in names_set}
 
     return schema_list
 

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -44,10 +44,13 @@ class BigQuerySource(SimpleSource[BigQuerySourceConfig]):
             "NotFound: 404": "BigQuery dataset or table not found. Please verify your project, dataset, and table names.",
         }
 
-    def get_schemas(self, config: BigQuerySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: BigQuerySourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         bq_schemas = get_bigquery_schemas(
             config,
             logger=None,
+            names=names,
         )
 
         filtered_results = [

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -70,11 +70,13 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate Bing Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: BingAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: BingAdsSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         bing_ads_schemas = get_schemas()
         ads_incremental_fields = get_incremental_fields()
 
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=ads_incremental_fields.get(endpoint, None) is not None,
@@ -86,6 +88,11 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             )
             for endpoint in bing_ads_schemas.keys()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: BingAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         integration = self.get_oauth_integration(config.bing_ads_integration_id, inputs.team_id)

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -90,7 +90,8 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -35,9 +35,9 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
         }
 
     def get_schemas(
-        self, config: BuildBetterSourceConfig, team_id: int, with_counts: bool = False
+        self, config: BuildBetterSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -46,6 +46,10 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
             )
             for endpoint in list(ENDPOINTS)
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: BuildBetterSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -35,8 +35,10 @@ class ChargebeeSource(SimpleSource[ChargebeeSourceConfig]):
             "Unauthorized for url": "Chargebee authentication failed. Please check your API key and site name.",
         }
 
-    def get_schemas(self, config: ChargebeeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: ChargebeeSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -45,6 +47,11 @@ class ChargebeeSource(SimpleSource[ChargebeeSourceConfig]):
             )
             for endpoint in list(ENDPOINTS)
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def validate_credentials(
         self, config: ChargebeeSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -49,7 +49,8 @@ class ChargebeeSource(SimpleSource[ChargebeeSourceConfig]):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -54,9 +54,11 @@ The secret key starts with `sk_live_`.
             ),
         )
 
-    def get_schemas(self, config: ClerkSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: ClerkSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         # Clerk only supports full refresh - the API doesn't support filtering by updated_at
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=False,
@@ -65,6 +67,11 @@ The secret key starts with `sk_live_`.
             )
             for endpoint in list(ENDPOINTS)
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def validate_credentials(
         self, config: ClerkSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -69,7 +69,8 @@ The secret key starts with `sk_live_`.
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -67,7 +67,9 @@ class _BaseSource(ABC, Generic[ConfigType]):
 
         return {}
 
-    def get_schemas(self, config: ConfigType, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: ConfigType, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         raise NotImplementedError()
 
     @property

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -43,7 +43,7 @@ class CustomerIOSource(SimpleSource[CustomerIOSourceConfig]):
         raise NotImplementedError()
 
     def get_schemas(
-        self, config: CustomerIOSourceConfig, team_id: int, with_counts: bool = False
+        self, config: CustomerIOSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
     ) -> list[SourceSchema]:
         raise NotImplementedError()
 

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -23,10 +23,12 @@ class DoItSource(SimpleSource[DoItSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DOIT
 
-    def get_schemas(self, config: DoItSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: DoItSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         reports = doit_list_reports(config)
 
-        return [
+        schemas = [
             SourceSchema(
                 name=name,
                 supports_incremental=True,
@@ -35,6 +37,11 @@ class DoItSource(SimpleSource[DoItSourceConfig]):
             )
             for name, _id in reports
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: DoItSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return doit_source(

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -39,7 +39,8 @@ class DoItSource(SimpleSource[DoItSourceConfig]):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -121,8 +121,10 @@ class GithubSource(SimpleSource[GithubSourceConfig], OAuthMixin):
             raise ValueError("GitHub access token not found")
         return integration.access_token
 
-    def get_schemas(self, config: GithubSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: GithubSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
@@ -131,6 +133,10 @@ class GithubSource(SimpleSource[GithubSourceConfig], OAuthMixin):
             )
             for endpoint in list(ENDPOINTS)
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: GithubSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -78,7 +78,8 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -55,6 +55,7 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
         config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig,
         team_id: int,
         with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
         google_ads_schemas = get_google_ads_schemas(
             config,
@@ -63,7 +64,7 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
 
         ads_incremental_fields = get_google_ads_incremental_fields()
 
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=ads_incremental_fields.get(endpoint, None) is not None,
@@ -75,6 +76,11 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
             )
             for endpoint in google_ads_schemas.keys()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(
         self, config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig, inputs: SourceInputs

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -47,6 +47,10 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
     ) -> list[SourceSchema]:
         sheets = get_google_sheets_schemas(config)
 
+        if names is not None:
+            names_set = set(names)
+            sheets = [(name, row_count) for name, row_count in sheets if name in names_set]
+
         schemas: list[SourceSchema] = []
         for name, _ in sheets:
             incremental_fields = get_google_sheets_schema_incremental_fields(config, name)
@@ -59,9 +63,6 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
                     incremental_fields=incremental_fields,
                 )
             )
-
-        if names is not None:
-            schemas = [s for s in schemas if s.name in names]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -39,7 +39,11 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         }
 
     def get_schemas(
-        self, config: GoogleSheetsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: GoogleSheetsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
         sheets = get_google_sheets_schemas(config)
 
@@ -55,6 +59,9 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
                     incremental_fields=incremental_fields,
                 )
             )
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -65,9 +65,13 @@ class HubspotSource(SimpleSource[HubspotSourceConfig | HubspotSourceOldConfig], 
         return HubspotSourceOldConfig.from_dict(job_inputs)
 
     def get_schemas(
-        self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int, with_counts: bool = False
+        self,
+        config: HubspotSourceConfig | HubspotSourceOldConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=False,
@@ -76,6 +80,11 @@ class HubspotSource(SimpleSource[HubspotSourceConfig | HubspotSourceOldConfig], 
             )
             for endpoint in HUBSPOT_ENDPOINTS
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(
         self, config: HubspotSourceConfig | HubspotSourceOldConfig, inputs: SourceInputs

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -82,7 +82,8 @@ class HubspotSource(SimpleSource[HubspotSourceConfig | HubspotSourceOldConfig], 
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -63,11 +63,13 @@ Make sure to grant the following read permissions:
             featureFlag="dwh_klaviyo",
         )
 
-    def get_schemas(self, config: KlaviyoSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: KlaviyoSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         # Events are immutable - append-only is the only sync mode
         append_only_endpoints = {"events"}
 
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None
@@ -77,6 +79,10 @@ Make sure to grant the following read permissions:
             )
             for endpoint in list(ENDPOINTS)
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: KlaviyoSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -66,8 +66,10 @@ class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
             raise ValueError("Linear access token not found")
         return integration.access_token
 
-    def get_schemas(self, config: LinearSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: LinearSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
@@ -76,6 +78,10 @@ class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
             )
             for endpoint in list(ENDPOINTS)
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: LinearSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -105,7 +105,8 @@ class LinkedInAdsSource(SimpleSource[LinkedinAdsSourceConfig]):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -82,12 +82,16 @@ class LinkedInAdsSource(SimpleSource[LinkedinAdsSourceConfig]):
             return False, f"Failed to validate LinkedIn Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: LinkedinAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: LinkedinAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
         linkedin_ads_schemas = get_linkedin_ads_schemas()
         ads_incremental_fields = get_linkedin_ads_incremental_fields()
 
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=ads_incremental_fields.get(endpoint, None) is not None,
@@ -99,6 +103,11 @@ class LinkedInAdsSource(SimpleSource[LinkedinAdsSourceConfig]):
             )
             for endpoint in linkedin_ads_schemas.keys()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: LinkedinAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return linkedin_ads_source(

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -62,8 +62,10 @@ The API key format is: `key-dc` (e.g., `abc123def456-us6`), where `dc` is the da
             "Invalid Mailchimp API key format": "Invalid API key format. Expected format: key-dc (e.g., abc123-us6)",
         }
 
-    def get_schemas(self, config: MailchimpSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: MailchimpSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
@@ -72,6 +74,10 @@ The API key format is: `key-dc` (e.g., `abc123def456-us6`), where `dc` is the da
             )
             for endpoint in list(ENDPOINTS)
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: MailchimpSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -32,8 +32,10 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
             "cannot be loaded due to missing permissions": None,
         }
 
-    def get_schemas(self, config: MetaAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: MetaAdsSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -42,6 +44,11 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
             )
             for endpoint in ENDPOINTS
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: MetaAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return meta_ads_source(

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -46,7 +46,8 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -291,7 +291,9 @@ def _determine_field_type_from_bson_types(bson_types: list[str]) -> str:
     return "string"
 
 
-def get_schemas(config: MongoDBSourceConfig, team_id: int) -> dict[str, list[tuple[str, str]]]:
+def get_schemas(
+    config: MongoDBSourceConfig, team_id: int, names: list[str] | None = None
+) -> dict[str, list[tuple[str, str]]]:
     """Get all collections from MongoDB source database to sync."""
 
     connection_params = _parse_connection_string(config.connection_string)
@@ -305,6 +307,10 @@ def get_schemas(config: MongoDBSourceConfig, team_id: int) -> dict[str, list[tup
 
         # Get collection names
         collection_names = db.list_collection_names(authorizedCollections=True)
+
+        if names is not None:
+            names_set = set(names)
+            collection_names = [n for n in collection_names if n in names_set]
 
         if not collection_names:
             return schema_list

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -35,8 +35,10 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {"The DNS query name does not exist": None, "authentication failed": None, "SSL handshake failed": None}
 
-    def get_schemas(self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        mongo_schemas = get_mongo_schemas(config, team_id=team_id)
+    def get_schemas(
+        self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        mongo_schemas = get_mongo_schemas(config, team_id=team_id, names=names)
 
         connection_params = _parse_connection_string(config.connection_string)
         with mongo_client(config.connection_string, team_id=team_id) as client:

--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -47,7 +47,7 @@ def filter_mssql_incremental_fields(
 
 
 def get_schemas(
-    host: str, user: str, password: str, database: str, schema: str, port: int
+    host: str, user: str, password: str, database: str, schema: str, port: int, names: list[str] | None = None
 ) -> dict[str, list[tuple[str, str, bool]]]:
     # Importing pymssql requires mssql drivers to be installed locally - see posthog/warehouse/README.md
     import pymssql
@@ -63,9 +63,18 @@ def get_schemas(
     )
 
     with connection.cursor(as_dict=False) as cursor:
+        params: dict = {"schema": schema}
+        names_filter = ""
+        if names is not None:
+            params["names"] = tuple(names)
+            names_filter = "AND table_name IN %(names)s"
+
         cursor.execute(
-            "SELECT table_name, column_name, data_type, is_nullable FROM information_schema.columns WHERE table_schema = %(schema)s ORDER BY table_name ASC",
-            {"schema": schema},
+            "SELECT table_name, column_name, data_type, is_nullable"
+            " FROM information_schema.columns"
+            f" WHERE table_schema = %(schema)s {names_filter}"
+            " ORDER BY table_name ASC",
+            params,
         )
 
         schema_list: dict[str, list[tuple[str, str, bool]]] = collections.defaultdict(list)

--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -66,6 +66,8 @@ def get_schemas(
         params: dict = {"schema": schema}
         names_filter = ""
         if names is not None:
+            if not names:
+                return {}
             params["names"] = tuple(names)
             names_filter = "AND table_name IN %(names)s"
 

--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -65,9 +65,7 @@ def get_schemas(
     with connection.cursor(as_dict=False) as cursor:
         params: dict = {"schema": schema}
         names_filter = ""
-        if names is not None:
-            if not names:
-                return {}
+        if names:
             params["names"] = tuple(names)
             names_filter = "AND table_name IN %(names)s"
 

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -99,7 +99,9 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
             ),
         )
 
-    def get_schemas(self, config: MSSQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: MSSQLSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -110,6 +112,7 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                names=names,
             )
 
         for table_name, columns in db_schemas.items():

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -51,7 +51,14 @@ def filter_mysql_incremental_fields(
 
 
 def get_schemas(
-    host: str, user: str, password: str, database: str, schema: str, port: int, using_ssl: bool = True
+    host: str,
+    user: str,
+    password: str,
+    database: str,
+    schema: str,
+    port: int,
+    using_ssl: bool = True,
+    names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Get all tables from MySQL source schemas to sync."""
 
@@ -71,9 +78,18 @@ def get_schemas(
     )
 
     with connection.cursor() as cursor:
+        params: dict = {"schema": schema}
+        names_filter = ""
+        if names is not None:
+            params["names"] = tuple(names)
+            names_filter = "AND table_name IN %(names)s"
+
         cursor.execute(
-            "SELECT table_name, column_name, data_type, is_nullable FROM information_schema.columns WHERE table_schema = %(schema)s ORDER BY table_name ASC",
-            {"schema": schema},
+            "SELECT table_name, column_name, data_type, is_nullable"
+            " FROM information_schema.columns"
+            f" WHERE table_schema = %(schema)s {names_filter}"
+            " ORDER BY table_name ASC",
+            params,
         )
         result = cursor.fetchall()
 

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -80,10 +80,7 @@ def get_schemas(
     with connection.cursor() as cursor:
         params: dict = {"schema": schema}
         names_filter = ""
-        if names is not None:
-            if not names:
-                connection.close()
-                return {}
+        if names:
             params["names"] = tuple(names)
             names_filter = "AND table_name IN %(names)s"
 

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -81,6 +81,9 @@ def get_schemas(
         params: dict = {"schema": schema}
         names_filter = ""
         if names is not None:
+            if not names:
+                connection.close()
+                return {}
             params["names"] = tuple(names)
             names_filter = "AND table_name IN %(names)s"
 

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -111,7 +111,9 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
             "Bad handshake": None,
         }
 
-    def get_schemas(self, config: MySQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: MySQLSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -123,6 +125,7 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
                 database=config.database,
                 using_ssl=config.using_ssl,
                 schema=config.schema,
+                names=names,
             )
 
         for table_name, columns in db_schemas.items():

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -97,7 +97,8 @@ class PinterestAdsSource(SimpleSource[PinterestAdsSourceConfig], OAuthMixin):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -80,9 +80,13 @@ class PinterestAdsSource(SimpleSource[PinterestAdsSourceConfig], OAuthMixin):
             return False, f"Failed to validate Pinterest Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: PinterestAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: PinterestAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint_config.name,
                 supports_incremental=endpoint_config.incremental_fields is not None,
@@ -91,6 +95,11 @@ class PinterestAdsSource(SimpleSource[PinterestAdsSourceConfig], OAuthMixin):
             )
             for endpoint_config in PINTEREST_ADS_CONFIG.values()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: PinterestAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         integration = self.get_oauth_integration(config.pinterest_ads_integration_id, inputs.team_id)

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -118,7 +118,7 @@ def get_postgres_row_count(
             params: dict = {"schema": schema}
             names_filter_tables = ""
             names_filter_matviews = ""
-            if names is not None:
+            if names:
                 params["names"] = names
                 names_filter_tables = "AND tablename = ANY(%(names)s)"
                 names_filter_matviews = "AND matviewname = ANY(%(names)s)"
@@ -192,7 +192,7 @@ def get_schemas(
         params: dict = {"schema": schema}
         names_filter = ""
         names_filter_pg = ""
-        if names is not None:
+        if names:
             params["names"] = names
             names_filter = "AND table_name = ANY(%(names)s)"
             names_filter_pg = "AND c.relname = ANY(%(names)s)"
@@ -268,7 +268,7 @@ def get_foreign_keys(
     with connection.cursor() as cursor:
         params: dict = {"schema": schema}
         names_filter = ""
-        if names is not None:
+        if names:
             params["names"] = names
             names_filter = "AND tc.table_name = ANY(%(names)s)"
 

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -76,7 +76,14 @@ def filter_postgres_incremental_fields(
 
 
 def get_postgres_row_count(
-    host: str, port: int, database: str, user: str, password: str, schema: str, require_ssl: bool = False
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    password: str,
+    schema: str,
+    require_ssl: bool = False,
+    names: list[str] | None = None,
 ) -> dict[str, int]:
     sslmode = _get_sslmode(require_ssl)
     try:
@@ -108,13 +115,21 @@ def get_postgres_row_count(
                 )
             )
 
+            params: dict = {"schema": schema}
+            names_filter_tables = ""
+            names_filter_matviews = ""
+            if names is not None:
+                params["names"] = names
+                names_filter_tables = "AND tablename = ANY(%(names)s)"
+                names_filter_matviews = "AND matviewname = ANY(%(names)s)"
+
             cursor.execute(
-                """
-                SELECT tablename as table_name FROM pg_tables WHERE schemaname = %(schema)s
+                f"""
+                SELECT tablename as table_name FROM pg_tables WHERE schemaname = %(schema)s {names_filter_tables}
                 UNION ALL
-                SELECT matviewname as table_name FROM pg_matviews WHERE schemaname = %(schema)s
+                SELECT matviewname as table_name FROM pg_matviews WHERE schemaname = %(schema)s {names_filter_matviews}
                 """,
-                {"schema": schema},
+                params,
             )
             tables = cursor.fetchall()
 
@@ -140,7 +155,14 @@ def get_postgres_row_count(
 
 
 def get_schemas(
-    host: str, database: str, user: str, password: str, schema: str, port: int, require_ssl: bool = False
+    host: str,
+    database: str,
+    user: str,
+    password: str,
+    schema: str,
+    port: int,
+    require_ssl: bool = False,
+    names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Get all tables from PostgreSQL source schemas to sync."""
 
@@ -167,11 +189,19 @@ def get_schemas(
         raise
 
     with connection.cursor() as cursor:
+        params: dict = {"schema": schema}
+        names_filter = ""
+        names_filter_pg = ""
+        if names is not None:
+            params["names"] = names
+            names_filter = "AND table_name = ANY(%(names)s)"
+            names_filter_pg = "AND c.relname = ANY(%(names)s)"
+
         cursor.execute(
-            """
+            f"""
             SELECT * FROM (
                 SELECT table_name, column_name, data_type, is_nullable FROM information_schema.columns
-                WHERE table_schema = %(schema)s
+                WHERE table_schema = %(schema)s {names_filter}
                 UNION ALL
                 SELECT
                     c.relname AS table_name,
@@ -185,9 +215,10 @@ def get_schemas(
                 AND n.nspname = %(schema)s
                 AND a.attnum > 0
                 AND NOT a.attisdropped
+                {names_filter_pg}
             ) t
             ORDER BY table_name ASC""",
-            {"schema": schema},
+            params,
         )
         result = cursor.fetchall()
 
@@ -201,7 +232,14 @@ def get_schemas(
 
 
 def get_foreign_keys(
-    host: str, database: str, user: str, password: str, schema: str, port: int, require_ssl: bool = False
+    host: str,
+    database: str,
+    user: str,
+    password: str,
+    schema: str,
+    port: int,
+    require_ssl: bool = False,
+    names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, str]]]:
     """Get foreign keys for tables in the selected PostgreSQL schema."""
 
@@ -228,8 +266,14 @@ def get_foreign_keys(
         raise
 
     with connection.cursor() as cursor:
+        params: dict = {"schema": schema}
+        names_filter = ""
+        if names is not None:
+            params["names"] = names
+            names_filter = "AND tc.table_name = ANY(%(names)s)"
+
         cursor.execute(
-            """
+            f"""
             SELECT
                 tc.table_name AS table_name,
                 kcu.column_name AS column_name,
@@ -245,9 +289,10 @@ def get_foreign_keys(
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_schema = %(schema)s
               AND ccu.table_schema = %(schema)s
+              {names_filter}
             ORDER BY tc.table_name, kcu.ordinal_position
             """,
-            {"schema": schema},
+            params,
         )
         result = cursor.fetchall()
 

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -146,7 +146,9 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
             "No space left on device": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
         }
 
-    def get_schemas(self, config: PostgresSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: PostgresSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -157,6 +159,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                names=names,
             )
             db_foreign_keys = get_postgres_foreign_keys(
                 host=host,
@@ -165,6 +168,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                names=names,
             )
 
             if with_counts:
@@ -175,6 +179,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                     password=config.password,
                     database=config.database,
                     schema=config.schema,
+                    names=names,
                 )
             else:
                 row_counts = {}

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -72,8 +72,10 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate Reddit Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: RedditAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: RedditAdsSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),
                 supports_incremental=endpoint_config.incremental_fields is not None,
@@ -82,6 +84,11 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             )
             for endpoint_config in REDDIT_ADS_CONFIG.values()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: RedditAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         integration = self.get_oauth_integration(config.reddit_integration_id, inputs.team_id)

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -86,7 +86,8 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -85,7 +85,7 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             for endpoint_config in REDDIT_ADS_CONFIG.values()
         ]
 
-        if names is not None:
+        if names:
             names_set = set(names)
             schemas = [s for s in schemas if s.name in names_set]
 

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -49,7 +49,7 @@ def filter_redshift_incremental_fields(
 
 
 def get_redshift_row_count(
-    host: str, port: int, database: str, user: str, password: str, schema: str
+    host: str, port: int, database: str, user: str, password: str, schema: str, names: list[str] | None = None
 ) -> dict[str, int]:
     """Get row counts for all tables in a Redshift schema."""
     connection = psycopg.connect(
@@ -72,20 +72,32 @@ def get_redshift_row_count(
                 sql.SQL("SET statement_timeout = {timeout}").format(timeout=sql.Literal(1000 * 30))  # 30 secs
             )
 
+            params: dict = {"schema": schema}
+            names_filter = ""
+            if names is not None:
+                params["names"] = names
+                names_filter = 'AND "table" = ANY(%(names)s)'
+
             cursor.execute(
-                """
+                f"""
                 SELECT "table" AS table_name, tbl_rows AS row_count
                 FROM svv_table_info
-                WHERE schema = %(schema)s
+                WHERE schema = %(schema)s {names_filter}
                 """,
-                {"schema": schema},
+                params,
             )
             row_count_result = cursor.fetchall()
             row_counts = {row[0]: int(row[1]) for row in row_count_result}
 
+            views_params: dict = {"schema": schema}
+            views_names_filter = ""
+            if names is not None:
+                views_params["names"] = names
+                views_names_filter = "AND viewname = ANY(%(names)s)"
+
             cursor.execute(
-                "SELECT viewname FROM pg_views WHERE schemaname = %(schema)s",
-                {"schema": schema},
+                f"SELECT viewname FROM pg_views WHERE schemaname = %(schema)s {views_names_filter}",
+                views_params,
             )
             views = cursor.fetchall()
 
@@ -110,7 +122,7 @@ def get_redshift_row_count(
 
 
 def get_schemas(
-    host: str, database: str, user: str, password: str, schema: str, port: int
+    host: str, database: str, user: str, password: str, schema: str, port: int, names: list[str] | None = None
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Get all tables from Redshift source schemas to sync."""
     connection = psycopg.connect(
@@ -128,14 +140,20 @@ def get_schemas(
     )
 
     with connection.cursor() as cursor:
+        params: dict = {"schema": schema}
+        names_filter = ""
+        if names is not None:
+            params["names"] = names
+            names_filter = "AND table_name = ANY(%(names)s)"
+
         cursor.execute(
-            """
+            f"""
             SELECT table_name, column_name, data_type, is_nullable
             FROM information_schema.columns
-            WHERE table_schema = %(schema)s
+            WHERE table_schema = %(schema)s {names_filter}
             ORDER BY table_name ASC
             """,
-            {"schema": schema},
+            params,
         )
         result = cursor.fetchall()
 

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -74,7 +74,7 @@ def get_redshift_row_count(
 
             params: dict = {"schema": schema}
             names_filter = ""
-            if names is not None:
+            if names:
                 params["names"] = names
                 names_filter = 'AND "table" = ANY(%(names)s)'
 
@@ -142,7 +142,7 @@ def get_schemas(
     with connection.cursor() as cursor:
         params: dict = {"schema": schema}
         names_filter = ""
-        if names is not None:
+        if names:
             params["names"] = names
             names_filter = "AND table_name = ANY(%(names)s)"
 

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -135,7 +135,9 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
             "Connection refused": None,
         }
 
-    def get_schemas(self, config: RedshiftSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: RedshiftSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -146,6 +148,7 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                names=names,
             )
 
             if with_counts:
@@ -156,6 +159,7 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
                     password=config.password,
                     database=config.database,
                     schema=config.schema,
+                    names=names,
                 )
             else:
                 row_counts = {}

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -35,9 +35,9 @@ class SalesforceSource(SimpleSource[SalesforceSourceConfig], OAuthMixin):
         }
 
     def get_schemas(
-        self, config: SalesforceSourceConfig, team_id: int, with_counts: bool = False
+        self, config: SalesforceSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -46,6 +46,10 @@ class SalesforceSource(SimpleSource[SalesforceSourceConfig], OAuthMixin):
             )
             for endpoint in ENDPOINTS
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -46,7 +46,7 @@ class SalesforceSource(SimpleSource[SalesforceSourceConfig], OAuthMixin):
             )
             for endpoint in ENDPOINTS
         ]
-        if names is not None:
+        if names:
             names_set = set(names)
             schemas = [s for s in schemas if s.name in names_set]
         return schemas

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -81,7 +81,9 @@ class ShopifySource(SimpleSource[ShopifySourceConfig]):
         except Exception as e:
             return False, str(e)
 
-    def get_schemas(self, config: ShopifySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: ShopifySourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
         for obj in SHOPIFY_GRAPHQL_OBJECTS.values():
             endpoint_config = ENDPOINT_CONFIGS.get(obj.name)
@@ -95,6 +97,9 @@ class ShopifySource(SimpleSource[ShopifySourceConfig]):
                     incremental_fields=endpoint_config.fields,
                 )
             )
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
         return schemas
 
     def source_for_pipeline(self, config: ShopifySourceConfig, inputs: SourceInputs) -> SourceResponse:

--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -89,7 +89,8 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
         ]
 
         if names is not None:
-            schemas = [s for s in schemas if s.name in names]
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
 
         return schemas
 

--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -72,9 +72,13 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             return False, f"Failed to validate Snapchat Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: SnapchatAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: SnapchatAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),
                 supports_incremental=endpoint_config.incremental_fields is not None,
@@ -83,6 +87,11 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             )
             for endpoint_config in SNAPCHAT_ADS_CONFIG.values()
         ]
+
+        if names is not None:
+            schemas = [s for s in schemas if s.name in names]
+
+        return schemas
 
     def source_for_pipeline(self, config: SnapchatAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         integration = self.get_oauth_integration(config.snapchat_integration_id, inputs.team_id)

--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -37,7 +37,9 @@ def filter_snowflake_incremental_fields(
     return results
 
 
-def get_schemas(config: SnowflakeSourceConfig) -> dict[str, list[tuple[str, str, bool]]]:
+def get_schemas(
+    config: SnowflakeSourceConfig, names: list[str] | None = None
+) -> dict[str, list[tuple[str, str, bool]]]:
     auth_connect_args: dict[str, str | None] = {}
     file_name: str | None = None
 
@@ -83,6 +85,10 @@ def get_schemas(config: SnowflakeSourceConfig) -> dict[str, list[tuple[str, str,
 
     if file_name is not None:
         os.unlink(file_name)
+
+    if names is not None:
+        names_set = set(names)
+        schema_list = {k: v for k, v in schema_list.items() if k in names_set}
 
     return schema_list
 

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -162,10 +162,12 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",
         }
 
-    def get_schemas(self, config: SnowflakeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: SnowflakeSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
-        db_schemas = get_snowflake_schemas(config)
+        db_schemas = get_snowflake_schemas(config, names=names)
 
         for table_name, columns in db_schemas.items():
             incremental_field_tuples = filter_snowflake_incremental_fields(columns)

--- a/posthog/temporal/data_imports/sources/source.template
+++ b/posthog/temporal/data_imports/sources/source.template
@@ -73,7 +73,7 @@ class TemplateSource(SimpleSource[Config]):  # rename this class and replace `Co
         )  # implement logic to validate the credentials of your source, e.g. check the validity of API keys. return a tuple of whether the credentials are valid, and if not, return an error message to return to the user
 
     def get_schemas(
-        self, config: Config, team_id: int, with_counts: bool = False
+        self, config: Config, team_id: int, with_counts: bool = False, names: list[str] | None = None
     ) -> list[SourceSchema]:  # replace `Config` with the generated class
         return []  # implement your source logic
 

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -143,8 +143,10 @@ These permissions are automatically pre-filled in the API key creation form if y
             "PermissionError": "Your API key does not have permissions to access endpoint. Please check your API key configuration and permissions in Stripe, then try again.",
         }
 
-    def get_schemas(self, config: StripeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: StripeSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=False,
@@ -154,6 +156,10 @@ These permissions are automatically pre-filled in the API key creation form if y
             )
             for endpoint in STRIPE_ENDPOINTS
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: StripeSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -31,9 +31,9 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
         return ExternalDataSourceType.TEMPORALIO
 
     def get_schemas(
-        self, config: TemporalIOSourceConfig, team_id: int, with_counts: bool = False
+        self, config: TemporalIOSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
     ) -> list[SourceSchema]:
-        return [
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -42,6 +42,10 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
             )
             for endpoint in ENDPOINTS
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[TemporalIOResumeConfig]:
         return ResumableSourceManager[TemporalIOResumeConfig](inputs, TemporalIOResumeConfig)

--- a/posthog/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/source.py
@@ -69,8 +69,10 @@ class TikTokAdsSource(SimpleSource[TikTokAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate TikTok Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: TikTokAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: TikTokAdsSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),
                 supports_incremental=endpoint_config.incremental_fields is not None,
@@ -79,6 +81,10 @@ class TikTokAdsSource(SimpleSource[TikTokAdsSourceConfig], OAuthMixin):
             )
             for endpoint_config in TIKTOK_ADS_CONFIG.values()
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def source_for_pipeline(self, config: TikTokAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
         integration = self.get_oauth_integration(config.tiktok_integration_id, inputs.team_id)

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -33,8 +33,10 @@ class VitallySource(SimpleSource[VitallySourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.VITALLY
 
-    def get_schemas(self, config: VitallySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: VitallySourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=VITALLY_INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -43,6 +45,10 @@ class VitallySource(SimpleSource[VitallySourceConfig]):
             )
             for endpoint in VITALLY_ENDPOINTS
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: VitallySourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -38,8 +38,10 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             "401 Client Error": "Zendesk authentication failed. Please check your API token and subdomain.",
         }
 
-    def get_schemas(self, config: ZendeskSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
-        return [
+    def get_schemas(
+        self, config: ZendeskSourceConfig, team_id: int, with_counts: bool = False, names: list[str] | None = None
+    ) -> list[SourceSchema]:
+        schemas = [
             SourceSchema(
                 name=endpoint,
                 supports_incremental=ZENDESK_INCREMENTAL_FIELDS.get(endpoint, None) is not None,
@@ -49,6 +51,10 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             for endpoint in list(BASE_ENDPOINTS)
             + [resource for resource, endpoint_url, data_key, cursor_paginated in SUPPORT_ENDPOINTS]
         ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
 
     def validate_credentials(
         self, config: ZendeskSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -17,8 +17,6 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.temporal.data_imports.sources import SourceRegistry
-from posthog.temporal.data_imports.sources.common.schema import SourceSchema
-
 from products.data_warehouse.backend.data_load.service import (
     cancel_external_data_workflow,
     external_data_workflow_exists,

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -359,7 +359,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         try:
-            schemas = new_source.get_schemas(config, self.team_id)
+            schemas = new_source.get_schemas(config, self.team_id, names=[instance.name])
         except Exception as e:
             capture_exception(e)
             return Response(
@@ -367,17 +367,12 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": str(e)},
             )
 
-        schema: SourceSchema | None = None
-
-        for s in schemas:
-            if s.name == instance.name:
-                schema = s
-                break
-
-        if schema is None:
+        if not schemas:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data={"message": f"Schema with name {instance.name} not found"}
             )
+
+        schema = schemas[0]
 
         data = {
             "incremental_fields": schema.incremental_fields,

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -17,6 +17,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.temporal.data_imports.sources import SourceRegistry
+
 from products.data_warehouse.backend.data_load.service import (
     cancel_external_data_workflow,
     external_data_workflow_exists,


### PR DESCRIPTION
## Problem

`get_schemas` on every data import source fetches metadata for **all** tables/endpoints, even when a caller only needs a subset. For SQL-backed sources this means running `information_schema` queries (and `COUNT(*)` for row counts) against every table in the database schema — wasteful when only a few specific tables are needed.

## Changes

Adds `names: list[str] | None = None` to `_BaseSource.get_schemas` and all 43 source implementations:

- **SQL database sources** (postgres, redshift, mysql, mssql) — filter pushed directly into the SQL query with `AND table_name = ANY(%(names)s)` / `AND table_name IN %(names)s`. For postgres/redshift row count queries, the initial table listing is filtered so `COUNT(*)` only runs on requested tables. Foreign key queries are similarly filtered.
- **Snowflake, BigQuery, MongoDB** — filter applied after fetching (driver/API limitations make in-query filtering less ergonomic).
- **Static/API endpoint sources** (stripe, hubspot, shopify, salesforce, etc.) — filter applied in Python on the result list; no change to fetch logic since these are cheap hardcoded lists or lightweight API calls.
- **Stubs** (ashby, customer_io) — signature updated only.

All existing callers omit `names` and get unchanged behaviour (all schemas returned).

## How did you test this code?

I am an agent and have not tested this manually. The change is additive (new optional parameter defaulting to `None` which preserves existing behaviour). Existing tests pass — the only test failures in the suite are a pre-existing `initial_sync_complete` not-null constraint issue unrelated to this change.

Do not publish to changelog.