### PR TITLE
fix: validate toolbar UI host scheme

### DIFF
--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -167,6 +167,38 @@ describe('toolbar toolbarConfigLogic', () => {
             logic.mount()
             expect(logic.values.uiHost).toBe('https://selfhosted.example.com')
         })
+
+        it.each(['javascript:alert(1)//', 'data:text/html,<script>alert(1)</script>', 'vbscript:msgbox'])(
+            'rejects uiHost with dangerous scheme: %s',
+            (maliciousHost) => {
+                const logic = toolbarConfigLogic.build({
+                    uiHost: maliciousHost,
+                    apiURL: 'https://fallback.example.com',
+                    posthog: { config: {} } as any,
+                } as any)
+                logic.mount()
+                // Should fall through to apiURL instead of using the malicious value
+                expect(logic.values.uiHost).toBe('https://fallback.example.com')
+            }
+        )
+
+        it('accepts valid https uiHost', () => {
+            const logic = toolbarConfigLogic.build({
+                uiHost: 'https://app.posthog.com',
+                apiURL: 'https://fallback.example.com',
+            } as any)
+            logic.mount()
+            expect(logic.values.uiHost).toBe('https://app.posthog.com')
+        })
+
+        it('accepts valid http uiHost', () => {
+            const logic = toolbarConfigLogic.build({
+                uiHost: 'http://localhost:8000',
+                apiURL: 'https://fallback.example.com',
+            } as any)
+            logic.mount()
+            expect(logic.values.uiHost).toBe('http://localhost:8000')
+        })
     })
 
     describe('OAuth localStorage restoration', () => {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -81,7 +81,15 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
                 // it's window.location.origin of the app itself, so it's always correct even
                 // for reverse-proxy customers who haven't set ui_host in posthog.init().
                 if (props.uiHost) {
-                    return props.uiHost.replace(/\/+$/, '')
+                    // Validate scheme to prevent javascript:/data: XSS via crafted hash params
+                    try {
+                        const parsed = new URL(props.uiHost)
+                        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+                            return props.uiHost.replace(/\/+$/, '')
+                        }
+                    } catch {
+                        // invalid URL, fall through to other sources
+                    }
                 }
 
                 // requestRouter.uiHost honours explicit ui_host config and derives from


### PR DESCRIPTION
Only accept `http` and `https` URLs.