### PR TITLE
fix(llm-gateway): always throttle against auth user

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/base.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/base.py
@@ -16,54 +16,21 @@ class InstrumentedCallback(CustomLogger):
     callback_name: str = "unknown"
 
     def _extract_end_user_id(self, kwargs: dict[str, Any]) -> str | None:
-        """Extract end_user_id from request data.
+        """Extract end_user_id from the authenticated user.
 
-        - OAuth: returns user_id (token holder)
-        - Personal API key: returns 'user' param from request
-        - Anthropic: falls back to metadata.user_id
-
-        The client can pass anything here, so it's up to them to ensure that it's actually an end user ID, and it should not be trusted.
+        Always returns the authenticated user's ID to prevent rate limit
+        poisoning via client-provided fields (e.g. the 'user' param).
         """
         auth_user = get_auth_user()
-        if auth_user and auth_user.auth_method == "oauth_access_token":
+        if auth_user:
             logger.debug(
-                "end_user_id_from_oauth",
+                "end_user_id_from_auth",
                 user_id=auth_user.user_id,
                 auth_method=auth_user.auth_method,
             )
             return str(auth_user.user_id)
 
-        # OpenAI 'user' param is stored directly in kwargs by litellm
-        if user := kwargs.get("user"):
-            logger.debug(
-                "end_user_id_from_kwargs",
-                user=user,
-                source="kwargs.user",
-            )
-            return user
-
-        # Fallback: check standard_logging_object.end_user (may be populated by some providers)
-        standard_logging_object = kwargs.get("standard_logging_object", {})
-        if end_user := standard_logging_object.get("end_user"):
-            logger.debug(
-                "end_user_id_from_slo",
-                end_user=end_user,
-                source="standard_logging_object.end_user",
-            )
-            return end_user
-
-        # Fallback: Anthropic stores user in metadata.user_id
-        litellm_params = kwargs.get("litellm_params") or {}
-        metadata = litellm_params.get("metadata") or {}
-        if user_id := metadata.get("user_id"):
-            logger.debug(
-                "end_user_id_from_metadata",
-                user_id=user_id,
-                source="litellm_params.metadata.user_id",
-            )
-            return user_id
-
-        logger.debug("end_user_id_not_found", auth_method=auth_user.auth_method if auth_user else None)
+        logger.debug("end_user_id_not_found")
         return None
 
     async def async_log_success_event(

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -95,9 +95,9 @@ async def enforce_throttles(
     ensure_costs_fresh()
     product = get_product_from_request(request)
 
-    # For OAuth, end_user_id is the token holder (user_id)
-    # For personal API key, it will be set later from the request's 'user' param
-    end_user_id = str(user.user_id) if user.auth_method == "oauth_access_token" else None
+    # Always use the authenticated user's ID for rate limiting.
+    # The client-provided 'user' param must NOT be used for quota enforcement.
+    end_user_id = str(user.user_id)
 
     context = ThrottleContext(
         user=user,

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -131,8 +131,7 @@ class ProductCostThrottle(CostThrottle):
 class _UserCostThrottleBase(CostThrottle):
     """Base for per-product user cost throttles (burst/sustained pattern).
 
-    - OAuth: end_user_id is the token holder (set at context creation)
-    - Personal API key: end_user_id is the 'user' param from the request (set in callback)
+    end_user_id is always the authenticated user's ID, set at context creation.
 
     If no end_user_id is set, user rate limiting is skipped.
     If a product is not in user_cost_limits config, default limits are used ($100/24h burst, $1000/30d sustained).

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -111,6 +111,6 @@ async def record_cost(cost: float, end_user_id: str | None = None) -> None:
     runner = throttle_runner_var.get()
     context = throttle_context_var.get()
     if runner and context:
-        if end_user_id:
+        if end_user_id and not context.end_user_id:
             context.end_user_id = end_user_id
         await runner.record_cost(context, cost)

--- a/services/llm-gateway/tests/callbacks/test_base.py
+++ b/services/llm-gateway/tests/callbacks/test_base.py
@@ -168,47 +168,95 @@ class TestExtractEndUserId:
             result = callback._extract_end_user_id(kwargs)
         assert result == "123"
 
-    def test_api_key_uses_end_user_from_request(
+    def test_api_key_returns_auth_user_id(
         self, callback: InstrumentedCallback, api_key_user: AuthenticatedUser
     ) -> None:
-        kwargs = {"standard_logging_object": {"end_user": "request-user"}}
+        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=api_key_user):
+            result = callback._extract_end_user_id({})
+        assert result == "123"
+
+    def test_api_key_ignores_client_provided_user(
+        self, callback: InstrumentedCallback, api_key_user: AuthenticatedUser
+    ) -> None:
+        kwargs = {"user": "attacker-supplied-id", "standard_logging_object": {"end_user": "request-user"}}
         with patch("llm_gateway.callbacks.base.get_auth_user", return_value=api_key_user):
             result = callback._extract_end_user_id(kwargs)
-        assert result == "request-user"
+        assert result == "123"
 
-    def test_api_key_falls_back_to_metadata_user_id(
+    def test_api_key_ignores_metadata_user_id(
         self, callback: InstrumentedCallback, api_key_user: AuthenticatedUser
     ) -> None:
         kwargs = {"litellm_params": {"metadata": {"user_id": "anthropic-user"}}}
         with patch("llm_gateway.callbacks.base.get_auth_user", return_value=api_key_user):
             result = callback._extract_end_user_id(kwargs)
-        assert result == "anthropic-user"
+        assert result == "123"
 
-    def test_api_key_prefers_end_user_over_metadata(
-        self, callback: InstrumentedCallback, api_key_user: AuthenticatedUser
-    ) -> None:
-        kwargs = {
-            "standard_logging_object": {"end_user": "openai-user"},
-            "litellm_params": {"metadata": {"user_id": "anthropic-user"}},
-        }
-        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=api_key_user):
-            result = callback._extract_end_user_id(kwargs)
-        assert result == "openai-user"
-
-    def test_api_key_returns_none_without_end_user(
-        self, callback: InstrumentedCallback, api_key_user: AuthenticatedUser
-    ) -> None:
-        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=api_key_user):
-            result = callback._extract_end_user_id({})
-        assert result is None
-
-    def test_no_auth_user_uses_end_user(self, callback: InstrumentedCallback) -> None:
-        kwargs = {"standard_logging_object": {"end_user": "request-user"}}
-        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=None):
-            result = callback._extract_end_user_id(kwargs)
-        assert result == "request-user"
-
-    def test_no_auth_user_returns_none_without_end_user(self, callback: InstrumentedCallback) -> None:
+    def test_no_auth_user_returns_none(self, callback: InstrumentedCallback) -> None:
         with patch("llm_gateway.callbacks.base.get_auth_user", return_value=None):
             result = callback._extract_end_user_id({})
         assert result is None
+
+    def test_no_auth_user_returns_none_even_with_kwargs(self, callback: InstrumentedCallback) -> None:
+        kwargs = {"user": "some-user", "standard_logging_object": {"end_user": "request-user"}}
+        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=None):
+            result = callback._extract_end_user_id(kwargs)
+        assert result is None
+
+
+class TestExtractEndUserIdPoisoningPrevention:
+    """Verify that client-provided user fields cannot poison rate limit buckets.
+
+    An attacker could supply another user's ID in the 'user' request param,
+    'standard_logging_object.end_user', or 'litellm_params.metadata.user_id'
+    to bill costs against the victim's quota.
+    """
+
+    @pytest.fixture
+    def callback(self) -> InstrumentedCallback:
+        return MockCallback()
+
+    @pytest.fixture
+    def attacker_user(self) -> AuthenticatedUser:
+        return AuthenticatedUser(
+            user_id=999,
+            team_id=1,
+            auth_method="personal_api_key",
+            distinct_id="attacker-distinct-id",
+        )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"user": "42"}, id="openai_user_param_with_victim_id"),
+            pytest.param({"user": "victim-user-id"}, id="openai_user_param_with_victim_string"),
+            pytest.param(
+                {"standard_logging_object": {"end_user": "42"}},
+                id="standard_logging_object_end_user",
+            ),
+            pytest.param(
+                {"litellm_params": {"metadata": {"user_id": "42"}}},
+                id="anthropic_metadata_user_id",
+            ),
+            pytest.param(
+                {
+                    "user": "42",
+                    "standard_logging_object": {"end_user": "42"},
+                    "litellm_params": {"metadata": {"user_id": "42"}},
+                },
+                id="all_injection_vectors_combined",
+            ),
+        ],
+    )
+    def test_attacker_cannot_poison_victim_rate_limit_bucket(
+        self, callback: InstrumentedCallback, attacker_user: AuthenticatedUser, kwargs: dict
+    ) -> None:
+        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=attacker_user):
+            result = callback._extract_end_user_id(kwargs)
+        assert result == "999", "Must return attacker's own authenticated ID, not the injected victim ID"
+
+    def test_attacker_cannot_evade_rate_limiting_by_omitting_user(
+        self, callback: InstrumentedCallback, attacker_user: AuthenticatedUser
+    ) -> None:
+        with patch("llm_gateway.callbacks.base.get_auth_user", return_value=attacker_user):
+            result = callback._extract_end_user_id({})
+        assert result == "999", "Must return authenticated ID even when no user param is provided"

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -896,6 +896,71 @@ class TestUserCostDisabledSustained:
         get_settings.cache_clear()
 
 
+class TestRateLimitPoisoningPrevention:
+    """Verify that cost is always recorded against the authenticated user's own bucket.
+
+    An attacker must not be able to:
+    1. Poison a victim's rate limit bucket by injecting their user ID
+    2. Bypass rate limiting entirely by omitting user identification
+    """
+
+    @pytest.mark.asyncio
+    async def test_cost_recorded_against_own_bucket_not_victim(self) -> None:
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+
+        attacker = make_user(user_id=999, auth_method="personal_api_key")
+        victim = make_user(user_id=42, auth_method="oauth_access_token")
+
+        attacker_ctx = make_context(user=attacker, product="posthog_code", end_user_id="999")
+        victim_ctx = make_context(user=victim, product="posthog_code")
+
+        await throttle.record_cost(attacker_ctx, 100.0)
+
+        assert (await throttle.allow_request(attacker_ctx)).allowed is False, (
+            "Attacker's own bucket should be exhausted"
+        )
+        assert (await throttle.allow_request(victim_ctx)).allowed is True, (
+            "Victim's bucket must not be affected by attacker's usage"
+        )
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_api_key_user_with_end_user_id_is_rate_limited(self) -> None:
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        user = make_user(user_id=999, auth_method="personal_api_key")
+        context = make_context(user=user, product="posthog_code", end_user_id="999")
+
+        await throttle.record_cost(context, 100.0)
+        result = await throttle.allow_request(context)
+
+        assert result.allowed is False, "Personal API key users must be rate limited when end_user_id is set"
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_injected_victim_id_does_not_affect_victim_cache_key(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+
+        attacker = make_user(user_id=999, auth_method="personal_api_key")
+        attacker_ctx = make_context(user=attacker, product="posthog_code", end_user_id="999")
+        attacker_key = throttle._get_cache_key(attacker_ctx)
+
+        victim = make_user(user_id=42, auth_method="oauth_access_token")
+        victim_ctx = make_context(user=victim, product="posthog_code")
+        victim_key = throttle._get_cache_key(victim_ctx)
+
+        assert attacker_key != victim_key
+        assert ":999" in attacker_key
+        assert ":42" in victim_key
+
+
 class TestCostAccumulatorTTL:
     def test_cost_expires_after_window(self) -> None:
         from unittest.mock import patch

--- a/services/llm-gateway/tests/test_request_context.py
+++ b/services/llm-gateway/tests/test_request_context.py
@@ -51,3 +51,36 @@ class TestRecordCost:
         await record_cost(0.0015)
 
         mock_runner.record_cost.assert_not_called()
+
+    async def test_record_cost_does_not_override_existing_end_user_id(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.record_cost = AsyncMock()
+
+        context = ThrottleContext(
+            user=make_mock_user(),
+            product="llm_gateway",
+            end_user_id="authenticated-user-42",
+        )
+
+        set_throttle_context(mock_runner, context)
+
+        await record_cost(0.0015, end_user_id="attacker-supplied-id")
+
+        assert context.end_user_id == "authenticated-user-42"
+        mock_runner.record_cost.assert_called_once_with(context, 0.0015)
+
+    async def test_record_cost_sets_end_user_id_when_not_already_set(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.record_cost = AsyncMock()
+
+        context = ThrottleContext(
+            user=make_mock_user(),
+            product="llm_gateway",
+            end_user_id=None,
+        )
+
+        set_throttle_context(mock_runner, context)
+
+        await record_cost(0.0015, end_user_id="fallback-id")
+
+        assert context.end_user_id == "fallback-id"


### PR DESCRIPTION
## Problem

The LLM gateway was vulnerable to rate limit poisoning attacks where malicious users could inject victim user IDs through client-provided fields (`user` param, `standard_logging_object.end_user`, or `litellm_params.metadata.user_id`) to bill costs against other users' quotas or bypass rate limiting entirely.

## Changes

- Modified `_extract_end_user_id()` to always return the authenticated user's ID instead of trusting client-provided user identification
- Updated rate limiting logic to consistently use the authenticated user's ID for quota enforcement across both OAuth and API key authentication methods
- Added safeguard in `record_cost()` to prevent overriding existing end_user_id with client-supplied values
- Removed fallback logic that previously checked multiple client-controlled sources for user identification

## How did you test this code?

Added test coverage including:
- Unit tests verifying that all client-provided user fields are ignored in favor of authenticated user ID
- Poisoning prevention tests confirming attackers cannot bill costs to victim accounts
- Rate limiting tests ensuring users are properly limited by their own authenticated identity
- Context tests verifying end_user_id cannot be overridden once set from authentication

## Publish to changelog?
No