### PR TITLE
fix(llma): add schedule_to_start_timeout for sentiment activity

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -24,6 +24,7 @@ QUERY_LOOKBACK_DAYS = 30  # timestamp filter to enable partition pruning
 # Temporal workflow/activity config
 WORKFLOW_NAME = "llma-sentiment-classify"
 ACTIVITY_TIMEOUT_SECONDS = 120  # start-to-close timeout for classify activity
+ACTIVITY_SCHEDULE_TO_START_TIMEOUT_SECONDS = 30  # fail fast if no worker picks up the activity
 WORKFLOW_TIMEOUT_BATCH_SECONDS = 120  # task timeout for sentiment workflow
 MAX_RETRY_ATTEMPTS = 2  # retry policy for both workflow and activity
 

--- a/posthog/temporal/llm_analytics/sentiment/workflow.py
+++ b/posthog/temporal/llm_analytics/sentiment/workflow.py
@@ -8,7 +8,11 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.sentiment.activities import classify_sentiment_activity
-from posthog.temporal.llm_analytics.sentiment.constants import ACTIVITY_TIMEOUT_SECONDS, MAX_RETRY_ATTEMPTS
+from posthog.temporal.llm_analytics.sentiment.constants import (
+    ACTIVITY_SCHEDULE_TO_START_TIMEOUT_SECONDS,
+    ACTIVITY_TIMEOUT_SECONDS,
+    MAX_RETRY_ATTEMPTS,
+)
 from posthog.temporal.llm_analytics.sentiment.schema import ClassifySentimentInput
 
 
@@ -28,5 +32,6 @@ class ClassifySentimentWorkflow(PostHogWorkflow):
             classify_sentiment_activity,
             input,
             start_to_close_timeout=timedelta(seconds=ACTIVITY_TIMEOUT_SECONDS),
+            schedule_to_start_timeout=timedelta(seconds=ACTIVITY_SCHEDULE_TO_START_TIMEOUT_SECONDS),
             retry_policy=RetryPolicy(maximum_attempts=MAX_RETRY_ATTEMPTS),
         )


### PR DESCRIPTION
## Summary
- Adds a 30s `schedule_to_start_timeout` to the sentiment classification activity
- When all workers are busy with CPU-intensive ONNX inference, new activities queue indefinitely — the API hangs until the 120s workflow timeout
- With this change, if no worker picks up the activity within 30s, it fails fast so the user gets an error promptly instead of waiting minutes

## Test plan
- [ ] Run sentiment workflow when cluster is idle — should work as before
- [ ] During high load, verify activities fail with schedule-to-start timeout instead of hanging