### PR TITLE
chore(flags): refactor FlagsCanonicalLogLine and split evaluation counters

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -602,7 +602,7 @@ impl FeatureFlagMatcher {
         cohorts: Vec<Cohort>,
     ) -> Result<bool, FlagError> {
         // Track cohort evaluations in canonical log
-        with_canonical_log(|log| log.cohorts_evaluated += cohort_property_filters.len());
+        with_canonical_log(|log| log.eval.cohorts_evaluated += cohort_property_filters.len());
 
         // Get cached static cohort results or evaluate them if not cached
         let static_cohort_matches = match self.flag_evaluation_state.get_static_cohort_matches() {
@@ -1215,7 +1215,7 @@ impl FeatureFlagMatcher {
                     .as_ref()
                     .is_some_and(|device_id| !device_id.is_empty())
                 {
-                    with_canonical_log(|log| log.flags_device_id_bucketing += 1);
+                    with_canonical_log(|log| log.eval.flags_device_id_bucketing += 1);
                 } else {
                     with_canonical_log(|log| {
                         tracing::warn!(
@@ -1943,7 +1943,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "person_properties".to_string())],
                 1,
             );
-            with_canonical_log(|log| log.property_cache_hits += 1);
+            with_canonical_log(|log| log.eval.property_cache_hits += 1);
             let mut result = HashMap::new();
             result.clone_from(properties);
             Ok(result)
@@ -1954,8 +1954,8 @@ impl FeatureFlagMatcher {
                 1,
             );
             with_canonical_log(|log| {
-                log.property_cache_misses += 1;
-                log.person_properties_not_cached = true;
+                log.eval.property_cache_misses += 1;
+                log.eval.person_properties_not_cached = true;
             });
             // Return empty HashMap instead of error - no properties is a valid state
             // TODO probably worth error modeling empty cache vs error.
@@ -1981,7 +1981,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "group_properties".to_string())],
                 1,
             );
-            with_canonical_log(|log| log.property_cache_hits += 1);
+            with_canonical_log(|log| log.eval.property_cache_hits += 1);
             let mut result = HashMap::new();
             result.clone_from(properties);
             Ok(result)
@@ -1992,8 +1992,8 @@ impl FeatureFlagMatcher {
                 1,
             );
             with_canonical_log(|log| {
-                log.property_cache_misses += 1;
-                log.group_properties_not_cached = true;
+                log.eval.property_cache_misses += 1;
+                log.eval.group_properties_not_cached = true;
             });
             // Return empty HashMap instead of error - no properties is a valid state
             Ok(HashMap::new())

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -114,6 +114,51 @@ fn truncate_chars(s: &str, max_chars: usize) -> &str {
     }
 }
 
+/// Per-flag evaluation counters accumulated during `evaluate_single_flag` and its callees.
+///
+/// These counters are the fields written via `with_canonical_log` on rayon worker threads.
+/// Extracting them into a sub-struct ensures that `merge` covers every field: the
+/// exhaustive destructuring pattern in `merge` causes a compile error when a new field
+/// is added without a corresponding merge rule.
+#[derive(Debug, Clone, Default)]
+pub struct EvalCounters {
+    /// Number of flags that used device_id for bucketing (instead of distinct_id).
+    pub flags_device_id_bucketing: usize,
+    pub cohorts_evaluated: usize,
+    pub property_cache_hits: usize,
+    pub property_cache_misses: usize,
+    /// True if person properties were not found in evaluation state cache.
+    pub person_properties_not_cached: bool,
+    /// True if group properties were not found in evaluation state cache.
+    pub group_properties_not_cached: bool,
+}
+
+impl EvalCounters {
+    /// Merge another set of counters into this one.
+    ///
+    /// Numeric counters are summed; boolean flags are OR'd.
+    ///
+    /// The exhaustive destructuring pattern ensures that adding a new field to
+    /// `EvalCounters` without handling it here is a compile error.
+    pub fn merge(&mut self, other: &EvalCounters) {
+        let EvalCounters {
+            flags_device_id_bucketing,
+            cohorts_evaluated,
+            property_cache_hits,
+            property_cache_misses,
+            person_properties_not_cached,
+            group_properties_not_cached,
+        } = other;
+
+        self.flags_device_id_bucketing += flags_device_id_bucketing;
+        self.cohorts_evaluated += cohorts_evaluated;
+        self.property_cache_hits += property_cache_hits;
+        self.property_cache_misses += property_cache_misses;
+        self.person_properties_not_cached |= person_properties_not_cached;
+        self.group_properties_not_cached |= group_properties_not_cached;
+    }
+}
+
 /// Accumulates data throughout a /flags request lifecycle for canonical logging.
 ///
 /// A canonical log line is a single comprehensive log entry emitted at request
@@ -144,12 +189,14 @@ pub struct FlagsCanonicalLogLine {
     // Populated during flag evaluation
     pub flags_evaluated: usize,
     pub flags_experience_continuity: usize,
-    /// Number of flags that used device_id for bucketing (instead of distinct_id).
-    pub flags_device_id_bucketing: usize,
     pub flags_disabled: bool,
     pub quota_limited: bool,
     /// Source of the flags data: "Redis", "S3", or "Fallback" (PostgreSQL).
     pub flags_cache_source: Option<&'static str>,
+
+    /// Per-flag evaluation counters accumulated on rayon threads.
+    /// See [`EvalCounters::merge`] for the merge strategy.
+    pub eval: EvalCounters,
 
     // Deep evaluation metrics (populated via task_local from flag_matching.rs)
     /// Total number of database property fetch operations (aggregate counter).
@@ -166,13 +213,6 @@ pub struct FlagsCanonicalLogLine {
     pub group_query_time_ms: u64,
     /// Time spent on static cohort membership queries in milliseconds.
     pub cohort_query_time_ms: u64,
-    pub property_cache_hits: usize,
-    pub property_cache_misses: usize,
-    /// True if person properties were not found in evaluation state cache.
-    pub person_properties_not_cached: bool,
-    /// True if group properties were not found in evaluation state cache.
-    pub group_properties_not_cached: bool,
-    pub cohorts_evaluated: usize,
     pub flags_errored: usize,
     /// Number of errors encountered during dependency graph construction.
     /// These errors (like missing dependencies or cycles) set errors_while_computing_flags=true
@@ -221,10 +261,10 @@ impl Default for FlagsCanonicalLogLine {
             anon_distinct_id: None,
             flags_evaluated: 0,
             flags_experience_continuity: 0,
-            flags_device_id_bucketing: 0,
             flags_disabled: false,
             quota_limited: false,
             flags_cache_source: None,
+            eval: EvalCounters::default(),
             db_property_fetches: 0,
             person_queries: 0,
             group_queries: 0,
@@ -232,11 +272,6 @@ impl Default for FlagsCanonicalLogLine {
             person_query_time_ms: 0,
             group_query_time_ms: 0,
             cohort_query_time_ms: 0,
-            property_cache_hits: 0,
-            property_cache_misses: 0,
-            person_properties_not_cached: false,
-            group_properties_not_cached: false,
-            cohorts_evaluated: 0,
             flags_errored: 0,
             dependency_graph_errors: 0,
             hash_key_override_status: None,
@@ -281,7 +316,7 @@ impl FlagsCanonicalLogLine {
             http_status = self.http_status,
             flags_evaluated = self.flags_evaluated,
             flags_experience_continuity = self.flags_experience_continuity,
-            flags_device_id_bucketing = self.flags_device_id_bucketing,
+            flags_device_id_bucketing = self.eval.flags_device_id_bucketing,
             flags_disabled = self.flags_disabled,
             quota_limited = self.quota_limited,
             flags_cache_source = self.flags_cache_source,
@@ -292,11 +327,11 @@ impl FlagsCanonicalLogLine {
             person_query_time_ms = self.person_query_time_ms,
             group_query_time_ms = self.group_query_time_ms,
             cohort_query_time_ms = self.cohort_query_time_ms,
-            property_cache_hits = self.property_cache_hits,
-            property_cache_misses = self.property_cache_misses,
-            person_properties_not_cached = self.person_properties_not_cached,
-            group_properties_not_cached = self.group_properties_not_cached,
-            cohorts_evaluated = self.cohorts_evaluated,
+            property_cache_hits = self.eval.property_cache_hits,
+            property_cache_misses = self.eval.property_cache_misses,
+            person_properties_not_cached = self.eval.person_properties_not_cached,
+            group_properties_not_cached = self.eval.group_properties_not_cached,
+            cohorts_evaluated = self.eval.cohorts_evaluated,
             flags_errored = self.flags_errored,
             dependency_graph_errors = self.dependency_graph_errors,
             hash_key_override_status = self.hash_key_override_status,
@@ -356,25 +391,14 @@ impl FlagsCanonicalLogLine {
 
     /// Merge evaluation counters accumulated on a rayon thread back into this log.
     ///
+    /// Delegates to [`EvalCounters::merge`], which uses an exhaustive destructuring
+    /// pattern so that adding a new counter field without a merge rule is a compile error.
+    ///
     /// Only merges fields that are written during per-flag evaluation inside
     /// `evaluate_single_flag` and its callees. Request-level metadata (request_id,
-    /// team_id, ip, etc.) is intentionally not merged.
-    ///
-    /// `flags_errored` is excluded because it is incremented in `process_flag_result`,
-    /// which runs on the tokio task after rayon returns.
-    ///
-    /// Numeric counters are summed; boolean flags are OR'd.
-    ///
-    // TODO: consider splitting these eval counters into an `EvalCounters` sub-struct
-    // so that new counters are merged automatically and this field list doesn't drift.
-    // See https://github.com/PostHog/posthog/issues/49255
+    /// team_id, ip, etc.) lives outside `EvalCounters` and is intentionally not merged.
     pub fn merge_rayon_delta(&mut self, delta: &FlagsCanonicalLogLine) {
-        self.flags_device_id_bucketing += delta.flags_device_id_bucketing;
-        self.cohorts_evaluated += delta.cohorts_evaluated;
-        self.property_cache_hits += delta.property_cache_hits;
-        self.property_cache_misses += delta.property_cache_misses;
-        self.person_properties_not_cached |= delta.person_properties_not_cached;
-        self.group_properties_not_cached |= delta.group_properties_not_cached;
+        self.eval.merge(&delta.eval);
     }
 
     /// Populate error fields from a FlagError without emitting.
@@ -413,7 +437,7 @@ mod tests {
         assert!(log.anon_distinct_id.is_none());
         assert_eq!(log.flags_evaluated, 0);
         assert_eq!(log.flags_experience_continuity, 0);
-        assert_eq!(log.flags_device_id_bucketing, 0);
+        assert_eq!(log.eval.flags_device_id_bucketing, 0);
         assert!(!log.flags_disabled);
         assert!(!log.quota_limited);
         assert!(log.flags_cache_source.is_none());
@@ -421,11 +445,11 @@ mod tests {
         assert_eq!(log.person_queries, 0);
         assert_eq!(log.group_queries, 0);
         assert_eq!(log.static_cohort_queries, 0);
-        assert_eq!(log.property_cache_hits, 0);
-        assert_eq!(log.property_cache_misses, 0);
-        assert!(!log.person_properties_not_cached);
-        assert!(!log.group_properties_not_cached);
-        assert_eq!(log.cohorts_evaluated, 0);
+        assert_eq!(log.eval.property_cache_hits, 0);
+        assert_eq!(log.eval.property_cache_misses, 0);
+        assert!(!log.eval.person_properties_not_cached);
+        assert!(!log.eval.group_properties_not_cached);
+        assert_eq!(log.eval.cohorts_evaluated, 0);
         assert_eq!(log.flags_errored, 0);
         assert_eq!(log.dependency_graph_errors, 0);
         assert!(log.hash_key_override_status.is_none());
@@ -453,14 +477,14 @@ mod tests {
         log.device_id = Some("device_123".to_string());
         log.flags_evaluated = 10;
         log.flags_experience_continuity = 2;
-        log.flags_device_id_bucketing = 3;
+        log.eval.flags_device_id_bucketing = 3;
         log.flags_disabled = false;
         log.quota_limited = true;
         log.flags_cache_source = Some("redis");
         log.db_property_fetches = 3;
-        log.property_cache_hits = 5;
-        log.property_cache_misses = 2;
-        log.cohorts_evaluated = 4;
+        log.eval.property_cache_hits = 5;
+        log.eval.property_cache_misses = 2;
+        log.eval.cohorts_evaluated = 4;
         log.flags_errored = 1;
         log.hash_key_override_status = Some("found");
         log.rate_limited = false;
@@ -491,8 +515,8 @@ mod tests {
         let (result, final_log) = run_with_canonical_log(log, async {
             with_canonical_log(|l| l.team_id = Some(456));
             with_canonical_log(|l| l.flags_evaluated = 10);
-            with_canonical_log(|l| l.property_cache_hits += 1);
-            with_canonical_log(|l| l.property_cache_hits += 1);
+            with_canonical_log(|l| l.eval.property_cache_hits += 1);
+            with_canonical_log(|l| l.eval.property_cache_hits += 1);
             "done"
         })
         .await;
@@ -500,7 +524,7 @@ mod tests {
         assert_eq!(result, "done");
         assert_eq!(final_log.team_id, Some(456));
         assert_eq!(final_log.flags_evaluated, 10);
-        assert_eq!(final_log.property_cache_hits, 2);
+        assert_eq!(final_log.eval.property_cache_hits, 2);
     }
 
     #[tokio::test]
@@ -510,14 +534,14 @@ mod tests {
         let (_, final_log) = run_with_canonical_log(log, async {
             with_canonical_log(|l| {
                 l.db_property_fetches = 3;
-                l.cohorts_evaluated = 5;
+                l.eval.cohorts_evaluated = 5;
                 l.hash_key_override_status = Some("found");
             });
         })
         .await;
 
         assert_eq!(final_log.db_property_fetches, 3);
-        assert_eq!(final_log.cohorts_evaluated, 5);
+        assert_eq!(final_log.eval.cohorts_evaluated, 5);
         assert_eq!(final_log.hash_key_override_status, Some("found"));
     }
 
@@ -573,7 +597,7 @@ mod tests {
                             tokio::task::yield_now().await;
 
                             // Update more fields after yield
-                            with_canonical_log(|l| l.property_cache_hits = i * 2);
+                            with_canonical_log(|l| l.eval.property_cache_hits = i * 2);
                         })
                         .await;
 
@@ -582,7 +606,7 @@ mod tests {
                             i,
                             final_log.team_id,
                             final_log.flags_evaluated,
-                            final_log.property_cache_hits,
+                            final_log.eval.property_cache_hits,
                         )
                     })
                 })
@@ -864,55 +888,67 @@ mod tests {
 
             for &(device_id, cohorts, hits, misses, person, group) in deltas {
                 let delta = FlagsCanonicalLogLine {
-                    flags_device_id_bucketing: device_id,
-                    cohorts_evaluated: cohorts,
-                    property_cache_hits: hits,
-                    property_cache_misses: misses,
-                    person_properties_not_cached: person,
-                    group_properties_not_cached: group,
+                    eval: EvalCounters {
+                        flags_device_id_bucketing: device_id,
+                        cohorts_evaluated: cohorts,
+                        property_cache_hits: hits,
+                        property_cache_misses: misses,
+                        person_properties_not_cached: person,
+                        group_properties_not_cached: group,
+                    },
                     ..Default::default()
                 };
                 log.merge_rayon_delta(&delta);
             }
 
-            assert_eq!(log.flags_device_id_bucketing, expected_device_id);
-            assert_eq!(log.cohorts_evaluated, expected_cohorts);
-            assert_eq!(log.property_cache_hits, expected_cache_hits);
-            assert_eq!(log.property_cache_misses, expected_cache_misses);
-            assert_eq!(log.person_properties_not_cached, expected_person_not_cached);
-            assert_eq!(log.group_properties_not_cached, expected_group_not_cached);
+            assert_eq!(log.eval.flags_device_id_bucketing, expected_device_id);
+            assert_eq!(log.eval.cohorts_evaluated, expected_cohorts);
+            assert_eq!(log.eval.property_cache_hits, expected_cache_hits);
+            assert_eq!(log.eval.property_cache_misses, expected_cache_misses);
+            assert_eq!(
+                log.eval.person_properties_not_cached,
+                expected_person_not_cached
+            );
+            assert_eq!(
+                log.eval.group_properties_not_cached,
+                expected_group_not_cached
+            );
         }
 
         #[test]
         fn test_merge_into_preexisting_counters() {
             let mut log = FlagsCanonicalLogLine {
-                property_cache_hits: 10,
-                property_cache_misses: 5,
-                cohorts_evaluated: 3,
-                flags_device_id_bucketing: 2,
-                person_properties_not_cached: true,
-                group_properties_not_cached: false,
+                eval: EvalCounters {
+                    property_cache_hits: 10,
+                    property_cache_misses: 5,
+                    cohorts_evaluated: 3,
+                    flags_device_id_bucketing: 2,
+                    person_properties_not_cached: true,
+                    group_properties_not_cached: false,
+                },
                 ..Default::default()
             };
 
             let delta = FlagsCanonicalLogLine {
-                property_cache_hits: 7,
-                property_cache_misses: 3,
-                cohorts_evaluated: 2,
-                flags_device_id_bucketing: 1,
-                person_properties_not_cached: false,
-                group_properties_not_cached: true,
+                eval: EvalCounters {
+                    property_cache_hits: 7,
+                    property_cache_misses: 3,
+                    cohorts_evaluated: 2,
+                    flags_device_id_bucketing: 1,
+                    person_properties_not_cached: false,
+                    group_properties_not_cached: true,
+                },
                 ..Default::default()
             };
 
             log.merge_rayon_delta(&delta);
 
-            assert_eq!(log.property_cache_hits, 17);
-            assert_eq!(log.property_cache_misses, 8);
-            assert_eq!(log.cohorts_evaluated, 5);
-            assert_eq!(log.flags_device_id_bucketing, 3);
-            assert!(log.person_properties_not_cached);
-            assert!(log.group_properties_not_cached);
+            assert_eq!(log.eval.property_cache_hits, 17);
+            assert_eq!(log.eval.property_cache_misses, 8);
+            assert_eq!(log.eval.cohorts_evaluated, 5);
+            assert_eq!(log.eval.flags_device_id_bucketing, 3);
+            assert!(log.eval.person_properties_not_cached);
+            assert!(log.eval.group_properties_not_cached);
         }
 
         #[test]
@@ -924,7 +960,10 @@ mod tests {
             let delta = FlagsCanonicalLogLine {
                 team_id: Some(999),
                 flags_evaluated: 42,
-                property_cache_hits: 5,
+                eval: EvalCounters {
+                    property_cache_hits: 5,
+                    ..Default::default()
+                },
                 ..Default::default()
             };
 
@@ -934,7 +973,7 @@ mod tests {
             assert_eq!(log.team_id, Some(123));
             assert_eq!(log.flags_evaluated, 50);
             // Evaluation counter is merged
-            assert_eq!(log.property_cache_hits, 5);
+            assert_eq!(log.eval.property_cache_hits, 5);
         }
     }
 
@@ -947,15 +986,15 @@ mod tests {
 
             // Modify via with_canonical_log (outside tokio scope, falls back to thread-local)
             with_canonical_log(|log| {
-                log.property_cache_hits = 7;
-                log.cohorts_evaluated = 3;
+                log.eval.property_cache_hits = 7;
+                log.eval.cohorts_evaluated = 3;
             });
 
             let delta = take_rayon_canonical_log();
             assert!(delta.is_some());
             let delta = delta.unwrap();
-            assert_eq!(delta.property_cache_hits, 7);
-            assert_eq!(delta.cohorts_evaluated, 3);
+            assert_eq!(delta.eval.property_cache_hits, 7);
+            assert_eq!(delta.eval.cohorts_evaluated, 3);
         }
 
         #[test]
@@ -968,7 +1007,7 @@ mod tests {
         #[test]
         fn test_take_clears_the_thread_local() {
             let _guard = install_rayon_canonical_log();
-            with_canonical_log(|log| log.property_cache_hits = 1);
+            with_canonical_log(|log| log.eval.property_cache_hits = 1);
 
             let first = take_rayon_canonical_log();
             assert!(first.is_some());
@@ -980,12 +1019,12 @@ mod tests {
         #[test]
         fn test_install_replaces_previous() {
             let _guard = install_rayon_canonical_log();
-            with_canonical_log(|log| log.property_cache_hits = 99);
+            with_canonical_log(|log| log.eval.property_cache_hits = 99);
 
             // Re-install should reset
             let _guard = install_rayon_canonical_log();
             let delta = take_rayon_canonical_log().unwrap();
-            assert_eq!(delta.property_cache_hits, 0);
+            assert_eq!(delta.eval.property_cache_hits, 0);
         }
 
         #[test]
@@ -997,7 +1036,7 @@ mod tests {
 
             let result = catch_unwind(|| {
                 let _guard = install_rayon_canonical_log();
-                with_canonical_log(|log| log.property_cache_hits = 42);
+                with_canonical_log(|log| log.eval.property_cache_hits = 42);
                 panic!("simulated evaluation panic");
             });
 
@@ -1026,16 +1065,16 @@ mod tests {
             // Run inside a tokio canonical log scope
             let log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
             let (_, final_log) = run_with_canonical_log(log, async {
-                with_canonical_log(|l| l.property_cache_hits = 42);
+                with_canonical_log(|l| l.eval.property_cache_hits = 42);
             })
             .await;
 
             // The tokio scope should have received the update
-            assert_eq!(final_log.property_cache_hits, 42);
+            assert_eq!(final_log.eval.property_cache_hits, 42);
 
             // The rayon thread-local should be untouched
             let rayon_delta = take_rayon_canonical_log().unwrap();
-            assert_eq!(rayon_delta.property_cache_hits, 0);
+            assert_eq!(rayon_delta.eval.property_cache_hits, 0);
         }
 
         #[test]
@@ -1049,19 +1088,19 @@ mod tests {
             let b1 = barrier.clone();
             rayon::spawn(move || {
                 let _guard = install_rayon_canonical_log();
-                with_canonical_log(|log| log.property_cache_hits = 111);
+                with_canonical_log(|log| log.eval.property_cache_hits = 111);
                 b1.wait(); // sync so both threads are alive simultaneously
                 let delta = take_rayon_canonical_log().unwrap();
-                tx1.send(delta.property_cache_hits).unwrap();
+                tx1.send(delta.eval.property_cache_hits).unwrap();
             });
 
             let b2 = barrier.clone();
             rayon::spawn(move || {
                 let _guard = install_rayon_canonical_log();
-                with_canonical_log(|log| log.property_cache_hits = 222);
+                with_canonical_log(|log| log.eval.property_cache_hits = 222);
                 b2.wait();
                 let delta = take_rayon_canonical_log().unwrap();
-                tx2.send(delta.property_cache_hits).unwrap();
+                tx2.send(delta.eval.property_cache_hits).unwrap();
             });
 
             assert_eq!(rx1.recv().unwrap(), 111);

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -31,7 +31,7 @@ std::thread_local! {
 /// # Example
 /// ```ignore
 /// with_canonical_log(|log| log.team_id = Some(123));
-/// with_canonical_log(|log| log.property_cache_hits += 1);
+/// with_canonical_log(|log| log.eval.property_cache_hits += 1);
 /// ```
 pub fn with_canonical_log(f: impl FnOnce(&mut FlagsCanonicalLogLine)) {
     // Probe whether the tokio task-local is accessible without consuming `f`.
@@ -124,8 +124,11 @@ fn truncate_chars(s: &str, max_chars: usize) -> &str {
 pub struct EvalCounters {
     /// Number of flags that used device_id for bucketing (instead of distinct_id).
     pub flags_device_id_bucketing: usize,
+    /// Number of cohort property filters evaluated across all flags.
     pub cohorts_evaluated: usize,
+    /// Number of property lookups served from the evaluation state cache.
     pub property_cache_hits: usize,
+    /// Number of property lookups that missed the evaluation state cache.
     pub property_cache_misses: usize,
     /// True if person properties were not found in evaluation state cache.
     pub person_properties_not_cached: bool,
@@ -213,6 +216,8 @@ pub struct FlagsCanonicalLogLine {
     pub group_query_time_ms: u64,
     /// Time spent on static cohort membership queries in milliseconds.
     pub cohort_query_time_ms: u64,
+    /// Number of flags whose evaluation returned an error. Not in `EvalCounters` because it is
+    /// incremented in `process_flag_result`, which runs on the tokio task after rayon returns.
     pub flags_errored: usize,
     /// Number of errors encountered during dependency graph construction.
     /// These errors (like missing dependencies or cycles) set errors_while_computing_flags=true
@@ -847,6 +852,71 @@ mod tests {
             .await;
 
             assert_eq!(final_log.hash_key_override_status, Some("empty"));
+        }
+    }
+
+    mod eval_counters_tests {
+        use super::*;
+
+        #[test]
+        fn test_merge_sums_counters_and_ors_booleans() {
+            let mut base = EvalCounters {
+                flags_device_id_bucketing: 1,
+                cohorts_evaluated: 2,
+                property_cache_hits: 3,
+                property_cache_misses: 4,
+                person_properties_not_cached: false,
+                group_properties_not_cached: true,
+            };
+
+            let other = EvalCounters {
+                flags_device_id_bucketing: 10,
+                cohorts_evaluated: 20,
+                property_cache_hits: 30,
+                property_cache_misses: 40,
+                person_properties_not_cached: true,
+                group_properties_not_cached: false,
+            };
+
+            base.merge(&other);
+
+            assert_eq!(base.flags_device_id_bucketing, 11);
+            assert_eq!(base.cohorts_evaluated, 22);
+            assert_eq!(base.property_cache_hits, 33);
+            assert_eq!(base.property_cache_misses, 44);
+            assert!(base.person_properties_not_cached);
+            assert!(base.group_properties_not_cached);
+        }
+
+        #[test]
+        fn test_merge_default_is_identity() {
+            let mut base = EvalCounters {
+                flags_device_id_bucketing: 5,
+                cohorts_evaluated: 3,
+                property_cache_hits: 7,
+                property_cache_misses: 2,
+                person_properties_not_cached: true,
+                group_properties_not_cached: false,
+            };
+            let snapshot = base.clone();
+
+            base.merge(&EvalCounters::default());
+
+            assert_eq!(
+                base.flags_device_id_bucketing,
+                snapshot.flags_device_id_bucketing
+            );
+            assert_eq!(base.cohorts_evaluated, snapshot.cohorts_evaluated);
+            assert_eq!(base.property_cache_hits, snapshot.property_cache_hits);
+            assert_eq!(base.property_cache_misses, snapshot.property_cache_misses);
+            assert_eq!(
+                base.person_properties_not_cached,
+                snapshot.person_properties_not_cached
+            );
+            assert_eq!(
+                base.group_properties_not_cached,
+                snapshot.group_properties_not_cached
+            );
         }
     }
 

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -11,7 +11,9 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
-pub use canonical_log::{run_with_canonical_log, with_canonical_log, FlagsCanonicalLogLine};
+pub use canonical_log::{
+    run_with_canonical_log, with_canonical_log, EvalCounters, FlagsCanonicalLogLine,
+};
 pub use types::*;
 
 use crate::{


### PR DESCRIPTION
## Problem

`FlagsCanonicalLogLine` mixes request-level metadata with per-flag evaluation counters in a single flat struct. `merge_rayon_delta` must explicitly list every evaluation counter field to merge rayon thread-local deltas back into the request log. If someone adds a new eval counter and writes it via `with_canonical_log` inside `evaluate_single_flag` but forgets to add it to `merge_rayon_delta`, the counter silently stays at zero, re-introducing a silent data loss bug for that field.

Closes https://github.com/PostHog/posthog/issues/49255

## Solution

Extract the 6 evaluation counter fields into an `EvalCounters` sub-struct embedded in `FlagsCanonicalLogLine` as `pub eval: EvalCounters`. The `merge` method on `EvalCounters` uses an exhaustive destructuring pattern (no `..`), so adding a new field to `EvalCounters` without a corresponding merge rule is a **compile error**.

`merge_rayon_delta` becomes a one-liner that delegates to `self.eval.merge(&delta.eval)`.

## Changes

**`handler/canonical_log.rs`**
- New `EvalCounters` struct with `flags_device_id_bucketing`, `cohorts_evaluated`, `property_cache_hits`, `property_cache_misses`, `person_properties_not_cached`, `group_properties_not_cached`.
- `EvalCounters::merge()` with exhaustive destructuring for compile-time safety.
- `FlagsCanonicalLogLine` embeds `pub eval: EvalCounters` replacing the 6 flat fields.
- `merge_rayon_delta` delegates to `self.eval.merge(&delta.eval)`.
- `emit()` references `self.eval.*` fields (log output field names unchanged).
- All tests updated to use `log.eval.*` paths and construct `EvalCounters` directly.

**`handler/mod.rs`**
- Re-export `EvalCounters` alongside `FlagsCanonicalLogLine`.

**`flags/flag_matching.rs`**
- All 6 `with_canonical_log` call sites updated from `log.field` to `log.eval.field`.

## How did you test this code?

- All 80 `canonical_log` unit tests pass (merge, isolation, rayon fallback, emit, error mapping, truncation).
- `cargo check` and `cargo clippy` clean.
- `cargo fmt` clean.
- No behavioral changes, log output field names are decoupled from struct field paths.

## Publish to changelog?

No
