### PR TITLE
chore: remove replay share to linear or github

### DIFF
--- a/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
@@ -1,24 +1,16 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { IconCopy } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
 
 import { SharingModalContent } from 'lib/components/Sharing/SharingModal'
-import { integrationsLogic } from 'lib/integrations/integrationsLogic'
-import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { urls } from 'scenes/urls'
 
-import { SessionRecordingSidebarTab } from '~/types'
-
-import { playerSidebarLogic } from '../sidebar/playerSidebarLogic'
 import { PlayerShareLogicProps, playerShareLogic } from './playerShareLogic'
 
 function TimestampForm(props: PlayerShareLogicProps): JSX.Element {
@@ -100,257 +92,7 @@ function PrivateLink(props: PlayerShareLogicProps): JSX.Element {
     )
 }
 
-function IntegrationNudgeBanner({
-    kind,
-    onCloseDialog,
-}: {
-    kind: 'linear' | 'github'
-    onCloseDialog?: () => void
-}): JSX.Element | null {
-    const { getIntegrationsByKind, integrationsLoading } = useValues(integrationsLogic)
-    const { setTab } = useActions(playerSidebarLogic)
-
-    if (integrationsLoading) {
-        return null
-    }
-
-    const hasIntegration = getIntegrationsByKind([kind]).length > 0
-    const displayName = kind === 'linear' ? 'Linear' : 'GitHub'
-
-    if (hasIntegration) {
-        return (
-            <LemonBanner
-                type="info"
-                dismissKey={`share-integration-nudge-${kind}-configured`}
-                action={{
-                    children: <span className="w-full text-center">Use linked issues</span>,
-                    onClick: () => {
-                        posthog.capture('session_replay_share_integration_nudge_clicked', {
-                            kind,
-                            has_integration: true,
-                            action: 'switch_to_linked_issues',
-                        })
-                        setTab(SessionRecordingSidebarTab.LINKED_ISSUES)
-                        onCloseDialog?.()
-                    },
-                }}
-            >
-                Your {displayName} integration is connected. Use the <strong>Linked issues</strong> tab in the sidebar
-                to create tracked issues directly from PostHog.
-            </LemonBanner>
-        )
-    }
-
-    return (
-        <LemonBanner
-            type="info"
-            dismissKey={`share-integration-nudge-${kind}-not-configured`}
-            action={{
-                children: <span className="w-full text-center">Set up integration</span>,
-                onClick: () => {
-                    posthog.capture('session_replay_share_integration_nudge_clicked', {
-                        kind,
-                        has_integration: false,
-                        action: 'go_to_settings',
-                    })
-                    router.actions.push(urls.replaySettings('replay-integrations'))
-                },
-            }}
-        >
-            Set up a {displayName} integration to create issues that are tracked and linked to this recording.
-        </LemonBanner>
-    )
-}
-
-function LinearLink({ onCloseDialog, ...props }: PlayerShareLogicProps & { onCloseDialog?: () => void }): JSX.Element {
-    const logic = playerShareLogic(props)
-
-    const { linearLinkForm, linearUrl, linearLinkFormHasErrors } = useValues(logic)
-    const { setLinearLinkFormValue } = useActions(logic)
-
-    return (
-        <>
-            <IntegrationNudgeBanner kind="linear" onCloseDialog={onCloseDialog} />
-            <p className="mt-2">Add an issue to your Linear workspace with a link to this recording.</p>
-
-            <Form logic={playerShareLogic} props={props} formKey="linearLinkForm" className="flex flex-col gap-2">
-                <LemonField className="gap-1" name="issueTitle" label="Issue title">
-                    <LemonInput fullWidth />
-                </LemonField>
-                <LemonField
-                    className="gap-1"
-                    name="issueDescription"
-                    label="Issue description"
-                    help={<span>We'll include a link to the recording in the description.</span>}
-                >
-                    <LemonTextArea />
-                </LemonField>
-                <div className="flex gap-1 items-center">
-                    <LemonField name="includeTime">
-                        <LemonCheckbox label="Start at" checked={linearLinkForm.includeTime} />
-                    </LemonField>
-                    <LemonField name="time" inline>
-                        <LemonInput
-                            className={clsx('w-20', { 'opacity-50': !linearLinkForm.includeTime })}
-                            onFocus={() => setLinearLinkFormValue('includeTime', true)}
-                            placeholder="00:00"
-                            fullWidth={false}
-                            size="small"
-                        />
-                    </LemonField>
-                </div>
-                <LemonCollapse
-                    panels={[
-                        {
-                            key: 'more-options',
-                            header: 'More options',
-                            content: (
-                                <div className="flex flex-col gap-2">
-                                    <LemonField
-                                        className="gap-1"
-                                        name="assignee"
-                                        label="Assignee"
-                                        help={<span>Linear username or 'me' to assign to yourself</span>}
-                                    >
-                                        <LemonInput
-                                            fullWidth
-                                            placeholder="username or me"
-                                            data-attr="linear-share-assignee"
-                                        />
-                                    </LemonField>
-                                    <LemonField className="gap-1" name="labels" label="Label">
-                                        <LemonInput
-                                            fullWidth
-                                            placeholder="bug or feature"
-                                            data-attr="linear-share-labels"
-                                        />
-                                    </LemonField>
-                                </div>
-                            ),
-                        },
-                    ]}
-                    defaultActiveKey={props.expandMoreOptions ? 'more-options' : undefined}
-                />
-                <div className="flex justify-end">
-                    <LemonButton
-                        type="primary"
-                        to={linearUrl}
-                        targetBlank={true}
-                        disabledReason={linearLinkFormHasErrors ? 'Fix all errors before continuing' : undefined}
-                    >
-                        Create issue
-                    </LemonButton>
-                </div>
-            </Form>
-        </>
-    )
-}
-
-function GithubIssueLink({
-    onCloseDialog,
-    ...props
-}: PlayerShareLogicProps & { onCloseDialog?: () => void }): JSX.Element {
-    const logic = playerShareLogic(props)
-
-    const { githubLinkForm, githubUrl, githubLinkFormHasErrors } = useValues(logic)
-    const { setGithubLinkFormValue } = useActions(logic)
-
-    return (
-        <>
-            <IntegrationNudgeBanner kind="github" onCloseDialog={onCloseDialog} />
-            <p className="mt-2">Add an issue to your Github repository with a link to this recording.</p>
-
-            <Form logic={playerShareLogic} props={props} formKey="githubLinkForm" className="flex flex-col gap-2">
-                <LemonField className="gap-1" name="githubUsername" label="Username or Organization Name">
-                    <LemonInput fullWidth data-attr="github-share-username" />
-                </LemonField>
-                <LemonField className="gap-1" name="githubRepoName" label="Repository Name">
-                    <LemonInput fullWidth data-attr="github-share-repo-name" />
-                </LemonField>
-                <LemonField className="gap-1" name="githubIssueTitle" label="Issue Title">
-                    <LemonInput fullWidth data-attr="github-share-issue-title" />
-                </LemonField>
-                <LemonField
-                    className="gap-1"
-                    name="githubIssueDescription"
-                    label="Issue description"
-                    help={<span>We'll include a link to the recording in the description.</span>}
-                >
-                    <LemonTextArea />
-                </LemonField>
-                <div className="flex gap-1 items-center">
-                    <LemonField name="includeTime">
-                        <LemonCheckbox label="Start at" checked={githubLinkForm.includeTime} />
-                    </LemonField>
-                    <LemonField name="time" inline>
-                        <LemonInput
-                            className={clsx('w-20', { 'opacity-50': !githubLinkForm.includeTime })}
-                            onFocus={() => setGithubLinkFormValue('includeTime', true)}
-                            placeholder="00:00"
-                            fullWidth={false}
-                            size="small"
-                        />
-                    </LemonField>
-                </div>
-                <LemonCollapse
-                    panels={[
-                        {
-                            key: 'more-options',
-                            header: 'More options',
-                            content: (
-                                <div className="flex flex-col gap-2">
-                                    <LemonField
-                                        className="gap-1"
-                                        name="githubAssignees"
-                                        label="Assignees"
-                                        help={<span>Comma-separated GitHub usernames to assign</span>}
-                                    >
-                                        <LemonInput
-                                            fullWidth
-                                            placeholder="user1, user2"
-                                            data-attr="github-share-assignees"
-                                        />
-                                    </LemonField>
-                                    <LemonField
-                                        className="gap-1"
-                                        name="githubLabels"
-                                        label="Labels"
-                                        help={<span>Comma-separated labels to add to the issue</span>}
-                                    >
-                                        <LemonInput
-                                            fullWidth
-                                            placeholder="bug, enhancement"
-                                            data-attr="github-share-labels"
-                                        />
-                                    </LemonField>
-                                </div>
-                            ),
-                        },
-                    ]}
-                />
-                <div className="flex justify-end">
-                    <LemonButton
-                        type="primary"
-                        to={githubUrl}
-                        targetBlank={true}
-                        disabledReason={
-                            !githubUrl
-                                ? 'Please fill in Username or Organization Name and Repository Name'
-                                : githubLinkFormHasErrors
-                                  ? 'Fix all errors before continuing'
-                                  : undefined
-                        }
-                    >
-                        Create issue
-                    </LemonButton>
-                </div>
-            </Form>
-        </>
-    )
-}
-
 export function PlayerShareRecording({
-    onCloseDialog,
     ...props
 }: PlayerShareLogicProps & { onCloseDialog?: () => void }): JSX.Element {
     return (
@@ -358,10 +100,6 @@ export function PlayerShareRecording({
             {props.shareType === 'private' && <PrivateLink {...props} />}
 
             {props.shareType === 'public' && <PublicLink {...props} />}
-
-            {props.shareType === 'linear' && <LinearLink {...props} onCloseDialog={onCloseDialog} />}
-
-            {props.shareType === 'github' && <GithubIssueLink {...props} onCloseDialog={onCloseDialog} />}
         </div>
     )
 }
@@ -369,8 +107,6 @@ export function PlayerShareRecording({
 const shareTitleMapping = {
     private: 'Share private link',
     public: 'Share public link',
-    linear: 'Share to Linear',
-    github: 'Share to Github Issues',
 }
 
 export function openPlayerShareDialog(props: PlayerShareLogicProps): void {

--- a/frontend/src/scenes/session-recordings/player/share/PlayerShareDialog.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShareDialog.stories.tsx
@@ -49,18 +49,3 @@ PublicLink.args = {
     id: '1',
     shareType: 'public',
 }
-
-export const LinearLink: Story = Template.bind({})
-LinearLink.args = {
-    seconds: 120,
-    id: '1',
-    shareType: 'linear',
-}
-
-export const LinearLinkWithMoreOptionsExpanded: Story = Template.bind({})
-LinearLinkWithMoreOptionsExpanded.args = {
-    seconds: 120,
-    id: '1',
-    shareType: 'linear',
-    expandMoreOptions: true,
-}

--- a/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
@@ -63,18 +63,6 @@ export function PlayerShareMenu(): JSX.Element {
                     onClick: () => onShare('public'),
                     'data-attr': 'share-public-link',
                 },
-                {
-                    label: 'Share to Linear',
-                    icon: <IconExternal />,
-                    onClick: () => onShare('linear'),
-                    'data-attr': 'share-to-linear',
-                },
-                {
-                    label: 'Share to Github Issues',
-                    icon: <IconExternal />,
-                    onClick: () => onShare('github'),
-                    'data-attr': 'share-to-github',
-                },
             ]}
             buttonSize="xsmall"
         >

--- a/frontend/src/scenes/session-recordings/player/share/playerShareLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/share/playerShareLogic.ts
@@ -28,8 +28,7 @@ export function makePrivateLink(id: string, formWithTime: FormWithTime): string 
 export type PlayerShareLogicProps = {
     seconds: number | null
     id: string
-    shareType?: 'private' | 'public' | 'linear' | 'github'
-    expandMoreOptions?: boolean
+    shareType?: 'private' | 'public'
 }
 
 export const playerShareLogic = kea<playerShareLogicType>([
@@ -40,66 +39,6 @@ export const playerShareLogic = kea<playerShareLogicType>([
     forms(({ props }) => ({
         privateLinkForm: {
             defaults: { includeTime: true, time: colonDelimitedDuration(props.seconds, null) } as FormWithTime,
-            errors: ({ time, includeTime }) => ({
-                time:
-                    time && includeTime && reverseColonDelimitedDuration(time || undefined) === null
-                        ? 'Set a valid time like 02:30 (minutes:seconds)'
-                        : undefined,
-            }),
-            options: {
-                // whether we show errors after touch (true) or submit (false)
-                showErrorsOnTouch: true,
-
-                // show errors even without submitting first
-                alwaysShowErrors: true,
-            },
-        },
-        linearLinkForm: {
-            defaults: {
-                includeTime: true,
-                time: colonDelimitedDuration(props.seconds, null),
-                issueTitle: '',
-                issueDescription: '',
-                assignee: '',
-                labels: '',
-            } as FormWithTime & {
-                issueTitle: string
-                issueDescription: string
-                assignee: string
-                labels: string
-            },
-            errors: ({ time, includeTime }) => ({
-                time:
-                    time && includeTime && reverseColonDelimitedDuration(time || undefined) === null
-                        ? 'Set a valid time like 02:30 (minutes:seconds)'
-                        : undefined,
-            }),
-            options: {
-                // whether we show errors after touch (true) or submit (false)
-                showErrorsOnTouch: true,
-
-                // show errors even without submitting first
-                alwaysShowErrors: true,
-            },
-        },
-        githubLinkForm: {
-            defaults: {
-                includeTime: true,
-                time: colonDelimitedDuration(props.seconds, null),
-                githubIssueTitle: '',
-                githubIssueDescription: '',
-                githubUsername: '',
-                githubRepoName: '',
-                githubAssignees: '',
-                githubLabels: '',
-            } as FormWithTime & {
-                githubIssueTitle: string
-                githubIssueDescription: string
-                githubUsername: string
-                githubRepoName: string
-                githubAssignees: string
-                githubLabels: string
-            },
             errors: ({ time, includeTime }) => ({
                 time:
                     time && includeTime && reverseColonDelimitedDuration(time || undefined) === null
@@ -127,54 +66,6 @@ export const playerShareLogic = kea<playerShareLogicType>([
             (s) => [s.privateLinkForm],
             (privateLinkForm) => {
                 return makePrivateLink(props.id, privateLinkForm)
-            },
-        ],
-        linearQueryParams: [
-            (s) => [s.linearLinkForm],
-            (linearLinkForm) => {
-                return {
-                    title: linearLinkForm.issueTitle,
-                    description:
-                        linearLinkForm.issueDescription +
-                        `\n\nPostHog recording: ${makePrivateLink(props.id, linearLinkForm)}`,
-                    assignee: linearLinkForm.assignee,
-                    labels: linearLinkForm.labels,
-                }
-            },
-        ],
-        linearUrl: [
-            (s) => [s.linearQueryParams],
-            (linearQueryParams) => {
-                return combineUrl('https://linear.app/new', linearQueryParams).url
-            },
-        ],
-        githubQueryParams: [
-            (s) => [s.githubLinkForm],
-            (githubLinkForm) => {
-                return {
-                    title: githubLinkForm.githubIssueTitle,
-                    description:
-                        githubLinkForm.githubIssueDescription +
-                        `\n\nPostHog recording: ${makePrivateLink(props.id, githubLinkForm)}`,
-                    username: githubLinkForm.githubUsername,
-                    repoName: githubLinkForm.githubRepoName,
-                }
-            },
-        ],
-        githubUrl: [
-            (s) => [s.githubQueryParams, s.githubLinkForm],
-            (githubQueryParams, githubLinkForm) => {
-                const { username, repoName, title, description } = githubQueryParams
-                if (!username || !repoName) {
-                    return ''
-                }
-                const params = {
-                    title,
-                    body: description,
-                    assignees: githubLinkForm.githubAssignees,
-                    labels: githubLinkForm.githubLabels,
-                }
-                return combineUrl(`https://github.com/${username}/${repoName}/issues/new`, params).url
             },
         ],
     })),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
We have the integrations now set up on replay, we should remove the old share to linear/github that essentially did the same thing.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- removing share to linear/github parts from frontend

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
