### PR TITLE
feat(funnels): use properties and dateRange for preview table

### DIFF
--- a/frontend/src/lib/components/TablePreview/DatabaseTablePreview.test.tsx
+++ b/frontend/src/lib/components/TablePreview/DatabaseTablePreview.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'kea'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+import { PropertyFilterType } from '~/types'
 
 import { DatabaseTablePreview } from './DatabaseTablePreview'
 import { TablePreviewExpressionColumn } from './types'
@@ -12,7 +13,15 @@ import { TablePreviewExpressionColumn } from './types'
 type QueryBody = {
     query?: {
         query?: string
+        filters?: Record<string, any>
+        modifiers?: Record<string, any>
     }
+}
+
+function queryNodeFromRequestBody(reqBody: unknown): NonNullable<QueryBody['query']> {
+    const body = typeof reqBody === 'string' ? (JSON.parse(reqBody) as QueryBody) : ((reqBody || {}) as QueryBody)
+
+    return body.query || {}
 }
 
 const eventsTable = {
@@ -32,9 +41,7 @@ const personsTable = {
 }
 
 function queryStringFromRequestBody(reqBody: unknown): string {
-    const body = typeof reqBody === 'string' ? (JSON.parse(reqBody) as QueryBody) : ((reqBody || {}) as QueryBody)
-
-    return body.query?.query || ''
+    return queryNodeFromRequestBody(reqBody).query || ''
 }
 
 describe('DatabaseTablePreview', () => {
@@ -237,5 +244,80 @@ describe('DatabaseTablePreview', () => {
         expect(executedQueries).toHaveLength(1)
         expect(executedQueries[0]).toContain('lower(event)')
         expect(executedQueries[0]).toContain('normalized_event')
+    })
+
+    it('uses {filters} with forwarded query filters and modifiers when provided', async () => {
+        const executedRequests: NonNullable<QueryBody['query']>[] = []
+
+        useMocks({
+            post: {
+                '/api/environments/:team/query': (req) => {
+                    executedRequests.push(queryNodeFromRequestBody(req.body))
+
+                    return [
+                        200,
+                        {
+                            columns: ['event', 'value'],
+                            results: [['$pageview', 1]],
+                        },
+                    ]
+                },
+            },
+        })
+
+        render(
+            <Provider>
+                <DatabaseTablePreview
+                    table={eventsTable as any}
+                    emptyMessage="No table selected"
+                    queryFilters={{
+                        dateRange: { date_from: '-7d' },
+                        properties: [
+                            {
+                                key: 'event',
+                                value: '$pageview',
+                                type: PropertyFilterType.Event,
+                                operator: 'exact',
+                            },
+                        ],
+                    }}
+                    queryModifiers={{
+                        dataWarehouseEventsModifiers: [
+                            {
+                                table_name: 'events',
+                                id_field: 'uuid',
+                                timestamp_field: 'timestamp',
+                                distinct_id_field: 'distinct_id',
+                            },
+                        ],
+                    }}
+                />
+            </Provider>
+        )
+
+        expect(await screen.findByText('$pageview')).toBeInTheDocument()
+        expect(executedRequests).toHaveLength(1)
+        expect(executedRequests[0].query).toContain('WHERE {filters}')
+        expect(executedRequests[0].filters).toEqual({
+            dateRange: { date_from: '-7d' },
+            properties: [
+                {
+                    key: 'event',
+                    value: '$pageview',
+                    type: PropertyFilterType.Event,
+                    operator: 'exact',
+                },
+            ],
+        })
+        expect(executedRequests[0].modifiers).toEqual({
+            dataWarehouseEventsModifiers: [
+                {
+                    table_name: 'events',
+                    id_field: 'uuid',
+                    timestamp_field: 'timestamp',
+                    distinct_id_field: 'distinct_id',
+                },
+            ],
+        })
     })
 })

--- a/frontend/src/lib/components/TablePreview/DatabaseTablePreview.tsx
+++ b/frontend/src/lib/components/TablePreview/DatabaseTablePreview.tsx
@@ -2,6 +2,7 @@ import { useValues } from 'kea'
 import { useRef } from 'react'
 
 import { databaseTablePreviewLogic } from './databaseTablePreviewLogic'
+import type { DatabaseTablePreviewLogicProps } from './databaseTablePreviewLogic'
 import { TablePreview, TablePreviewProps } from './TablePreview'
 import { TablePreviewExpressionColumn } from './types'
 
@@ -10,6 +11,8 @@ export interface DatabaseTablePreviewProps extends Omit<TablePreviewProps, 'load
     limit?: number
     whereClause?: string | null
     expressionColumns?: TablePreviewExpressionColumn[]
+    queryFilters?: DatabaseTablePreviewLogicProps['queryFilters']
+    queryModifiers?: DatabaseTablePreviewLogicProps['queryModifiers']
 }
 
 let uniqueMemoizedIndex = 0
@@ -20,6 +23,8 @@ export function DatabaseTablePreview({
     limit,
     whereClause,
     expressionColumns,
+    queryFilters,
+    queryModifiers,
     ...rest
 }: DatabaseTablePreviewProps): JSX.Element {
     const instanceLogicKey = useRef(logicKey || `database-table-preview-${uniqueMemoizedIndex++}`).current
@@ -30,6 +35,8 @@ export function DatabaseTablePreview({
         limit,
         whereClause,
         expressionColumns,
+        queryFilters,
+        queryModifiers,
     })
     const { previewData, previewDataLoading } = useValues(logic)
 

--- a/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
+++ b/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
@@ -2,7 +2,9 @@ import { afterMount, kea, key, path, props, propsChanged } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
-import { hogqlQuery } from '~/queries/query'
+import api from 'lib/api'
+
+import { HogQLFilters, HogQLQueryModifiers, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
 
 import type { databaseTablePreviewLogicType } from './databaseTablePreviewLogicType'
@@ -14,6 +16,8 @@ export interface DatabaseTablePreviewLogicProps {
     limit?: number
     whereClause?: string | null
     expressionColumns?: TablePreviewExpressionColumn[]
+    queryFilters?: HogQLFilters
+    queryModifiers?: HogQLQueryModifiers
 }
 
 const DEFAULT_LIMIT = 10
@@ -41,13 +45,29 @@ export const databaseTablePreviewLogic = kea<databaseTablePreviewLogicType>([
                                   )
                                   .join(', ')}`
                             : ''
+                    const hasFilterContext = Boolean(props.queryFilters || props.queryModifiers)
+                    const forwardedQueryFilters = props.queryFilters ?? {}
+                    const baseQuery = String(
+                        hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.identifier(props.tableName)}`
+                    )
+                    const previewQuery = hasFilterContext
+                        ? `${baseQuery}${
+                              trimmedWhereClause ? ` WHERE {filters} AND (${trimmedWhereClause})` : ' WHERE {filters}'
+                          } LIMIT ${previewLimit}`
+                        : String(
+                              trimmedWhereClause
+                                  ? hogql`${hogql.raw(baseQuery)} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
+                                  : hogql`${hogql.raw(baseQuery)} LIMIT ${previewLimit}`
+                          )
 
                     try {
-                        const response = await hogqlQuery(
-                            trimmedWhereClause
-                                ? hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.identifier(props.tableName)} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
-                                : hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.identifier(props.tableName)} LIMIT ${previewLimit}`
-                        )
+                        const response = (await api.query({
+                            kind: NodeKind.HogQLQuery,
+                            query: previewQuery,
+                            filters: hasFilterContext ? forwardedQueryFilters : undefined,
+                            modifiers: props.queryModifiers,
+                        })) as HogQLQueryResponse
+
                         return (response.results || []).map((row: any[]) =>
                             Object.fromEntries(
                                 (response.columns || []).map((column: string, index: number) => [column, row[index]])
@@ -71,12 +91,18 @@ export const databaseTablePreviewLogic = kea<databaseTablePreviewLogicType>([
         const nextLimit = props.limit || DEFAULT_LIMIT
         const previousExpressionColumns = JSON.stringify(oldProps.expressionColumns || [])
         const nextExpressionColumns = JSON.stringify(props.expressionColumns || [])
+        const previousQueryFilters = JSON.stringify(oldProps.queryFilters || null)
+        const nextQueryFilters = JSON.stringify(props.queryFilters || null)
+        const previousQueryModifiers = JSON.stringify(oldProps.queryModifiers || null)
+        const nextQueryModifiers = JSON.stringify(props.queryModifiers || null)
 
         if (
             props.tableName !== oldProps.tableName ||
             previousWhereClause !== nextWhereClause ||
             previousLimit !== nextLimit ||
-            previousExpressionColumns !== nextExpressionColumns
+            previousExpressionColumns !== nextExpressionColumns ||
+            previousQueryFilters !== nextQueryFilters ||
+            previousQueryModifiers !== nextQueryModifiers
         ) {
             actions.loadPreviewData()
         }

--- a/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
@@ -65,6 +65,8 @@ function FunnelDataWarehouseStepDefinitionPopoverContent({
         previewTable,
         previewExpressionColumns,
         previewSelectedKey,
+        previewQueryFilters,
+        previewQueryModifiers,
     } = useValues(logic)
     const { setActiveFieldKey, selectTable, setLocalDefinition } = useActions(logic)
 
@@ -77,6 +79,8 @@ function FunnelDataWarehouseStepDefinitionPopoverContent({
                 limit={25}
                 className="mt-2"
                 expressionColumns={previewExpressionColumns}
+                queryFilters={previewQueryFilters}
+                queryModifiers={previewQueryModifiers}
             />
             <LemonSegmentedButton
                 className="mt-4"

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
@@ -11,7 +11,12 @@ import type {
 import { DataWarehouseTableForInsight } from 'scenes/data-warehouse/types'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 
-import type { DatabaseSerializedFieldType } from '~/queries/schema/schema-general'
+import type {
+    DataWarehouseNode,
+    DatabaseSerializedFieldType,
+    HogQLFilters,
+    HogQLQueryModifiers,
+} from '~/queries/schema/schema-general'
 import { InsightLogicProps } from '~/types'
 
 import type { funnelDataWarehouseStepDefinitionPopoverLogicType } from './funnelDataWarehouseStepDefinitionPopoverLogicType'
@@ -148,6 +153,46 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
             (previewExpressionColumns, activeFieldKey, activeFieldValue) =>
                 previewExpressionColumns.find((column) => column.key.startsWith(`__${activeFieldKey}_hogql_expression`))
                     ?.key ?? activeFieldValue,
+        ],
+        previewQueryFilters: [
+            (s) => [s.localDefinition, s.querySource],
+            (localDefinition, querySource): HogQLFilters | undefined => {
+                const entityProperties =
+                    'properties' in localDefinition && Array.isArray(localDefinition.properties)
+                        ? localDefinition.properties
+                        : undefined
+                const dateRange = querySource?.dateRange
+
+                if (!entityProperties?.length && !dateRange) {
+                    return undefined
+                }
+
+                return {
+                    ...(dateRange ? { dateRange } : {}),
+                    ...(entityProperties?.length ? { properties: entityProperties } : {}),
+                }
+            },
+        ],
+        previewQueryModifiers: [
+            (s, p) => [s.localDefinition, p.table],
+            (localDefinition, table): HogQLQueryModifiers | undefined => {
+                const previewEntity = localDefinition as Partial<DataWarehouseNode>
+
+                if (!previewEntity.id_field || !previewEntity.timestamp_field || !previewEntity.distinct_id_field) {
+                    return undefined
+                }
+
+                return {
+                    dataWarehouseEventsModifiers: [
+                        {
+                            table_name: table.name,
+                            id_field: previewEntity.id_field,
+                            timestamp_field: previewEntity.timestamp_field,
+                            distinct_id_field: previewEntity.distinct_id_field,
+                        },
+                    ],
+                }
+            },
         ],
         activeFieldOptions: [
             (s) => [s.columnOptions, s.activeField, s.activeFieldKey],

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -62,21 +62,33 @@ class ReplaceFilters(CloningVisitor):
             found_sessions = False
             found_logs = False
             found_groups = False
+            found_persons = False
+            found_generic_table = False
             while last_join is not None:
                 if isinstance(last_join.table, ast.Field):
                     if last_join.table.chain == ["events"]:
                         found_events = True
-                    if last_join.table.chain == ["sessions"]:
+                    elif last_join.table.chain == ["sessions"]:
                         found_sessions = True
-                    if last_join.table.chain == ["logs"] or last_join.table.chain == ["log_attributes"]:
+                    elif last_join.table.chain == ["logs"] or last_join.table.chain == ["log_attributes"]:
                         found_logs = True
-                    if last_join.table.chain == ["groups"]:
+                    elif last_join.table.chain == ["groups"]:
                         found_groups = True
-                    if found_events and found_sessions or found_groups:
+                    elif last_join.table.chain == ["persons"]:
+                        found_persons = True
+                    else:
+                        found_generic_table = True
+
+                    if (found_events and found_sessions) or found_groups or found_generic_table:
                         break
                 last_join = last_join.next_join
 
-            if not any([found_events, found_sessions, found_logs, found_groups]):
+            if found_persons and not any([found_events, found_sessions, found_logs, found_groups, found_generic_table]):
+                raise QueryError(
+                    "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table."
+                )
+
+            if not any([found_events, found_sessions, found_logs, found_groups, found_generic_table]):
                 raise QueryError(
                     "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events, sessions, logs or groups table."
                 )
@@ -104,7 +116,9 @@ class ReplaceFilters(CloningVisitor):
                 else:
                     exprs.append(property_to_expr(self.filters.properties, self.team, scope="event"))
 
-            timestamp_field = ast.Field(chain=["$start_timestamp"])
+            timestamp_field = ast.Field(chain=["timestamp"])
+            if found_sessions and not any([found_events, found_logs, found_groups, found_generic_table]):
+                timestamp_field = ast.Field(chain=["$start_timestamp"])
             if found_events or found_logs:
                 timestamp_field = ast.Field(chain=["timestamp"])
             if found_groups:

--- a/posthog/hogql/test/test_filters.py
+++ b/posthog/hogql/test/test_filters.py
@@ -2,7 +2,14 @@ from typing import Any, Optional
 
 from posthog.test.base import BaseTest
 
-from posthog.schema import DateRange, EventPropertyFilter, GroupPropertyFilter, HogQLFilters, PersonPropertyFilter
+from posthog.schema import (
+    DataWarehousePropertyFilter,
+    DateRange,
+    EventPropertyFilter,
+    GroupPropertyFilter,
+    HogQLFilters,
+    PersonPropertyFilter,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
@@ -12,6 +19,8 @@ from posthog.hogql.filters import replace_filters
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.visitor import clear_locations
+
+from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
 
 
 class TestFilters(BaseTest):
@@ -139,6 +148,44 @@ class TestFilters(BaseTest):
             self._print_ast(select),
             "SELECT event FROM events WHERE "
             "and(less(timestamp, toDateTime('2020-02-03 18:59:59.000000')), "
+            f"greaterOrEquals(timestamp, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+        )
+
+    def test_replace_filters_generic_table_with_date_range_and_data_warehouse_properties(self):
+        credential = DataWarehouseCredential.objects.create(
+            team=self.team, access_key="_accesskey", access_secret="_secret"
+        )
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="paid_bills",
+            columns={
+                "id": {"hogql": "StringDatabaseField", "clickhouse": "String"},
+                "status": {"hogql": "StringDatabaseField", "clickhouse": "String"},
+                "timestamp": {"hogql": "DateTimeDatabaseField", "clickhouse": "DateTime64"},
+            },
+            credential=credential,
+            url_pattern="",
+        )
+
+        select = replace_filters(
+            self._parse_select("SELECT id FROM paid_bills WHERE {filters}"),
+            HogQLFilters(
+                dateRange=DateRange(date_from="2020-02-02"),
+                properties=[
+                    DataWarehousePropertyFilter(
+                        key="status",
+                        operator="exact",
+                        value="paid",
+                        type="data_warehouse",
+                    )
+                ],
+            ),
+            self.team,
+        )
+        self.assertEqual(
+            self._print_ast(select),
+            "SELECT id FROM paid_bills WHERE "
+            "and(equals(status, 'paid'), "
             f"greaterOrEquals(timestamp, toDateTime('2020-02-02 00:00:00.000000'))) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 


### PR DESCRIPTION
## Summary

Update the funnel insight data warehouse step preview to use `HogQLQuery` with `{filters}` instead of a raw `SELECT *` query.

This change makes the preview table respect:
- the funnel `dateRange`
- the selected data warehouse entity's property filters
- the selected table field mappings via `dataWarehouseEventsModifiers`

It also extends HogQL `{filters}` placeholder support so these preview queries work against data warehouse tables, not just events, sessions, logs, and groups.

## Changes

- pass preview `filters` and `modifiers` through the shared `DatabaseTablePreview`
- build funnel data warehouse preview queries as `HogQLQuery` requests with `WHERE {filters}`
- derive preview `dateRange` and entity properties from the current funnel query + selected step definition
- derive preview `dataWarehouseEventsModifiers` from the selected table mappings
- allow HogQL `{filters}` expansion for generic/data warehouse tables and use `timestamp` as the default date field there
- add frontend and backend test coverage for the new preview behavior

## Testing

- `pnpm --filter=@posthog/frontend jest src/lib/components/TablePreview/DatabaseTablePreview.test.tsx --runInBand`
- `.flox/cache/venv/bin/pytest posthog/hogql/test/test_filters.py`

## Notes

- `pnpm --filter=@posthog/frontend typescript:check` still reports unrelated pre-existing local type errors from other in-progress schema changes
