### PR TITLE
fix: allow non-members to invite when members can invite is off

### DIFF
--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -141,7 +141,7 @@ export function Invites(): JSX.Element {
         scope: RestrictionScope.Organization,
     })
 
-    const userCannotInvite = restrictionReason || !currentOrganization?.members_can_invite
+    const userCannotInvite = restrictionReason && !currentOrganization?.members_can_invite
 
     return (
         <div className="deprecated-space-y-4">


### PR DESCRIPTION
## Problem

When "Members can invite" is turned off, no one (including admins and ownrers) can invite new members.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Fix logic so that non-members can still invite.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
