### PR TITLE
fix: Handle situations where shared experiments created via the API and aren't provided a UUID

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db.models.functions import Lower
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -108,6 +110,9 @@ class ExperimentSavedMetricSerializer(
                 ExperimentFunnelsQuery(**metric_query)
         except pydantic.ValidationError as e:
             raise ValidationError(str(e.errors())) from e
+
+        if metric_query.get("kind") == "ExperimentMetric" and not metric_query.get("uuid"):
+            value["uuid"] = str(uuid.uuid4())
 
         return value
 

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -239,6 +239,31 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         self.assertEqual(response.json()["description"], "Test description")
         self.assertEqual(response.json()["query"]["kind"], "ExperimentMetric")
         self.assertEqual(response.json()["query"]["metric_type"], "mean")
+        # uuid must be auto-generated when not provided so the metric renders correctly in the UI
+        self.assertIsNotNone(response.json()["query"]["uuid"])
+
+    def test_create_saved_metric_with_experiment_metric_preserves_provided_uuid(self):
+        provided_uuid = "e1882559-cda9-466d-9fe5-3f9d21015847"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": "Test Experiment saved metric",
+                "description": "Test description",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": provided_uuid,
+                    "source": {
+                        "kind": "EventsNode",
+                        "event": "$pageview",
+                    },
+                },
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["query"]["uuid"], provided_uuid)
 
     def test_create_saved_metric_with_experiment_metric_invalid_metric_type(self):
         response = self.client.post(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18166,6 +18166,8 @@ export namespace Schemas {
       /** @nullable */
       readonly next_delivery_date: string | null;
       /** @nullable */
+      integration_id?: number | null;
+      /** @nullable */
       invite_message?: string | null;
     }
 
@@ -21304,6 +21306,8 @@ export namespace Schemas {
       readonly summary?: string;
       /** @nullable */
       readonly next_delivery_date?: string | null;
+      /** @nullable */
+      integration_id?: number | null;
       /** @nullable */
       invite_message?: string | null;
     }


### PR DESCRIPTION
uuid is optional in the pydantic schema `(uuid: str | None = None)`, so API calls that omit it pass validation. But the frontend requires uuid to:

Build primary_metrics_ordered_uuids / secondary_metrics_ordered_uuids. Without it, the metric is filtered out (.filter(Boolean) at line 864/877 of utils.ts)

```
newExperiment.primary_metrics_ordered_uuids = allMetrics
      .map((metric: any) => metric.uuid || metric.query?.uuid)
      .filter(Boolean)
```

Map metrics to results. Metrics without a UUID are never rendered. 

```
  return orderedUuids
      .map((uuid) => metricsMap.get(uuid))
      .filter(Boolean)
```

It's possible the better solution is just to require the uuid via the API. If that's preferred let me know!

## Problem

Customer wrote in, the API doesn't require the UUID, they could create shared metrics via the API, and then add them to an experiment, but they would not display.

## Changes

Basically just checking if there's a uuid provided and if not, generate one.

## How did you test this code?

Checked locally

Updated tests (hopefully accurately, please double check!)

## Publish to changelog?

No

