### PR TITLE
chore(flags): update local-only dependencies in feature-flags crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3225,7 +3225,7 @@ dependencies = [
  "opentelemetry_sdk 0.22.1",
  "pbkdf2",
  "percent-encoding",
- "petgraph 0.6.5",
+ "petgraph 0.8.3",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -3239,7 +3239,7 @@ dependencies = [
  "sha1",
  "sha2",
  "sqlx",
- "strum 0.26.3",
+ "strum 0.28.0",
  "test-case",
  "thiserror 2.0.18",
  "tokio",
@@ -4642,13 +4642,12 @@ dependencies = [
 
 [[package]]
 name = "json5"
-version = "0.4.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
 dependencies = [
- "pest",
- "pest_derive",
  "serde",
+ "ucd-trie",
 ]
 
 [[package]]
@@ -5141,9 +5140,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -6184,6 +6183,7 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
+ "serde",
 ]
 
 [[package]]
@@ -7565,21 +7565,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -8637,6 +8636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8654,6 +8662,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.18.0"
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-json5 = "0.4"
+json5 = "1.3"
 thiserror = { workspace = true }
 sha1 = "0.10.6"
 sha2 = "0.10.8"
@@ -44,19 +44,19 @@ common-compression = { path = "../common/compression" }
 common-hypercache = { path = "../common/hypercache" }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 health = { path = "../common/health" }
 common-metrics = { path = "../common/metrics" }
 common-geoip = { path = "../common/geoip" }
 tower = { workspace = true }
 tower-http = { workspace = true }
-petgraph = "0.6.5"
+petgraph = "0.8"
 moka = { workspace = true }
 dateparser = "0.2.1"
 rust_decimal = "1.37.1"
 rayon = "1.10.0"
 percent-encoding = "2.3.1"
-md5 = "0.7.0"
+md5 = "0.8"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
@@ -69,7 +69,7 @@ semver = "1.0.27"
 workspace = true
 
 [dev-dependencies]
-rstest = "0.25.0"
+rstest = "0.26"
 assert-json-diff = { workspace = true }
 reqwest = { workspace = true }
 futures = "0.3.30"


### PR DESCRIPTION
## Problem

The `feature-flags` Rust crate has several local-only dependencies that are multiple major versions behind. Keeping dependencies current reduces future upgrade burden and picks up bug fixes, performance improvements, and security patches.

## Changes

Updates five dependencies that are **scoped entirely to the `feature-flags` crate** — no other workspace crates are affected:

| Dependency | Old | New | Notable improvements |
|---|---|---|---|
| `json5` | 0.4 | **1.3** | Complete rewrite with UTF-16 surrogate pair fix, u128/i128 support |
| `petgraph` | 0.6.5 | **0.8** | `no_std` support, new algorithms (Dinic's max flow, bidirectional Dijkstra, Bron-Kerbosch cliques), dot file parsing |
| `strum` | 0.26 | **0.28** | `no_std` compatibility, automatic `#[default]` propagation for `EnumDiscriminants`, `#[automatically_derived]` on generated impls |
| `md5` | 0.7 | **0.8** | Patch-level update, same `compute()` API |
| `rstest` | 0.25 | **0.26** | Windows `#[files]` reliability, new `#[test_attr]` and `#[dirs]` attributes (dev-dependency only) |

These are all **local dependencies** declared directly in `rust/feature-flags/Cargo.toml`, not workspace-level deps. No other crates in the Rust workspace reference these versions, so there is no risk to other services.

## How did you test this code?

- `cargo check -p feature-flags` — compiles cleanly with zero warnings
- `cargo test -p feature-flags` — 911 tests pass. 8 pre-existing failures unrelated to this change (missing GeoIP database in worktree environment + flaky timing test)

## Publish to changelog?

No