### PR TITLE
chore(flags): add billing to rust endpoint for local_evaluation

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -350,7 +350,15 @@ impl IntoResponse for FlagError {
             FlagError::ClientFacing(err) => match err {
                 ClientFacingError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
                 ClientFacingError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-                ClientFacingError::BillingLimit => (StatusCode::PAYMENT_REQUIRED, "Billing limit reached. Please upgrade your plan.".to_string()),
+                ClientFacingError::BillingLimit => {
+                    let response = AuthenticationErrorResponse {
+                        error_type: "quota_limited".to_string(),
+                        code: "payment_required".to_string(),
+                        detail: "You have exceeded your feature flag request quota".to_string(),
+                        attr: None,
+                    };
+                    return (StatusCode::PAYMENT_REQUIRED, Json(response)).into_response();
+                }
                 ClientFacingError::RateLimited
                 | ClientFacingError::IpRateLimited
                 | ClientFacingError::TokenRateLimited => {

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -4,10 +4,7 @@ use crate::{
         errors::{ClientFacingError, FlagError},
     },
     flags::{
-        flag_analytics::{
-            increment_request_count, PRODUCT_TOUR_TARGETING_FLAG_PREFIX,
-            SURVEY_TARGETING_FLAG_PREFIX,
-        },
+        flag_analytics::{increment_request_count, is_billable_flag_key},
         flag_request::FlagRequestType,
         flag_service::FlagService,
     },
@@ -390,8 +387,7 @@ fn has_billable_flags(response: &Value) -> bool {
 
     flags.iter().any(|flag| {
         let key = flag.get("key").and_then(|k| k.as_str()).unwrap_or("");
-        !key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
-            && !key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+        is_billable_flag_key(key)
     })
 }
 

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -1,7 +1,14 @@
 use crate::{
-    api::{auth, errors::FlagError},
+    api::{
+        auth,
+        errors::{ClientFacingError, FlagError},
+    },
     flags::{
-        flag_analytics::increment_request_count, flag_request::FlagRequestType,
+        flag_analytics::{
+            increment_request_count, PRODUCT_TOUR_TARGETING_FLAG_PREFIX,
+            SURVEY_TARGETING_FLAG_PREFIX,
+        },
+        flag_request::FlagRequestType,
         flag_service::FlagService,
     },
     handler::types::Library,
@@ -87,24 +94,13 @@ pub async fn flags_definitions(
     // Check rate limit for this team
     state.flag_definitions_limiter.check_rate_limit(team.id)?;
 
-    // Record usage for billing with library tracking
-    if !*state.config.skip_writes {
-        let library = Library::from_headers(&headers);
-        if let Err(e) = increment_request_count(
-            state.redis_client.clone(),
-            team.id,
-            1,
-            FlagRequestType::FlagDefinitions,
-            Some(library),
-        )
+    // Check billing quota — matches Django's DECIDE_FEATURE_FLAG_QUOTA_CHECK behavior
+    if state
+        .feature_flags_billing_limiter
+        .is_limited(&params.token)
         .await
-        {
-            inc(
-                "flag_request_redis_error",
-                &[("error".to_string(), e.to_string())],
-                1,
-            );
-        }
+    {
+        return Err(FlagError::ClientFacing(ClientFacingError::BillingLimit));
     }
 
     let client_etag = extract_etag_from_header(headers.get("if-none-match"));
@@ -136,6 +132,26 @@ pub async fn flags_definitions(
 
     // Retrieve cached response from HyperCache (always with cohorts)
     let cached_response = get_from_cache(&state, &team_key, team.id).await?;
+
+    // Record usage for billing, filtering out non-billable flags (surveys, product tours)
+    if !*state.config.skip_writes && has_billable_flags(&cached_response) {
+        let library = Library::from_headers(&headers);
+        if let Err(e) = increment_request_count(
+            state.redis_client.clone(),
+            team.id,
+            1,
+            FlagRequestType::FlagDefinitions,
+            Some(library),
+        )
+        .await
+        {
+            inc(
+                "flag_request_redis_error",
+                &[("error".to_string(), e.to_string())],
+                1,
+            );
+        }
+    }
 
     Ok(ok_response_with_etag(
         cached_response,
@@ -362,9 +378,81 @@ async fn authenticate_flag_definitions(
     Err(FlagError::NoAuthenticationProvided)
 }
 
+/// Checks whether the cached flag definitions contain any billable flags.
+///
+/// Returns false if all flags are survey or product tour targeting flags,
+/// matching Django's `local_evaluation` billing filter. The cached response
+/// has a `"flags"` array where each entry has a `"key"` field.
+fn has_billable_flags(response: &Value) -> bool {
+    let Some(flags) = response.get("flags").and_then(|f| f.as_array()) else {
+        return false;
+    };
+
+    flags.iter().any(|flag| {
+        let key = flag.get("key").and_then(|k| k.as_str()).unwrap_or("");
+        !key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+            && !key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_has_billable_flags_regular_flags() {
+        let response = json!({"flags": [{"key": "my-feature"}, {"key": "another-flag"}]});
+        assert!(has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_only_survey_flags() {
+        let response = json!({"flags": [
+            {"key": "survey-targeting-abc"},
+            {"key": "survey-targeting-xyz"},
+        ]});
+        assert!(!has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_only_product_tour_flags() {
+        let response = json!({"flags": [
+            {"key": "product-tour-targeting-abc"},
+            {"key": "product-tour-targeting-xyz"},
+        ]});
+        assert!(!has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_mixed_survey_and_regular() {
+        let response = json!({"flags": [
+            {"key": "survey-targeting-abc"},
+            {"key": "my-feature"},
+        ]});
+        assert!(has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_empty_flags_array() {
+        let response = json!({"flags": []});
+        assert!(!has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_no_flags_key() {
+        let response = json!({"cohorts": {}});
+        assert!(!has_billable_flags(&response));
+    }
+
+    #[test]
+    fn test_has_billable_flags_only_survey_and_tour_flags() {
+        let response = json!({"flags": [
+            {"key": "survey-targeting-abc"},
+            {"key": "product-tour-targeting-xyz"},
+        ]});
+        assert!(!has_billable_flags(&response));
+    }
 
     #[test]
     fn test_extract_etag_from_header_weak() {

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -130,7 +130,9 @@ pub async fn flags_definitions(
     // Retrieve cached response from HyperCache (always with cohorts)
     let cached_response = get_from_cache(&state, &team_key, team.id).await?;
 
-    // Record usage for billing, filtering out non-billable flags (surveys, product tours)
+    // Record usage for billing, filtering out non-billable flags (surveys, product tours).
+    // Placed after the ETag/304 path intentionally: 304 responses skip billing,
+    // matching Django's /local_evaluation behavior.
     if !*state.config.skip_writes && has_billable_flags(&cached_response) {
         let library = Library::from_headers(&headers);
         if let Err(e) = increment_request_count(

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -398,60 +398,19 @@ fn has_billable_flags(response: &Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use serde_json::json;
 
-    #[test]
-    fn test_has_billable_flags_regular_flags() {
-        let response = json!({"flags": [{"key": "my-feature"}, {"key": "another-flag"}]});
-        assert!(has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_only_survey_flags() {
-        let response = json!({"flags": [
-            {"key": "survey-targeting-abc"},
-            {"key": "survey-targeting-xyz"},
-        ]});
-        assert!(!has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_only_product_tour_flags() {
-        let response = json!({"flags": [
-            {"key": "product-tour-targeting-abc"},
-            {"key": "product-tour-targeting-xyz"},
-        ]});
-        assert!(!has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_mixed_survey_and_regular() {
-        let response = json!({"flags": [
-            {"key": "survey-targeting-abc"},
-            {"key": "my-feature"},
-        ]});
-        assert!(has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_empty_flags_array() {
-        let response = json!({"flags": []});
-        assert!(!has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_no_flags_key() {
-        let response = json!({"cohorts": {}});
-        assert!(!has_billable_flags(&response));
-    }
-
-    #[test]
-    fn test_has_billable_flags_only_survey_and_tour_flags() {
-        let response = json!({"flags": [
-            {"key": "survey-targeting-abc"},
-            {"key": "product-tour-targeting-xyz"},
-        ]});
-        assert!(!has_billable_flags(&response));
+    #[rstest]
+    #[case::regular_flags(json!({"flags": [{"key": "my-feature"}, {"key": "another-flag"}]}), true)]
+    #[case::only_survey_flags(json!({"flags": [{"key": "survey-targeting-abc"}, {"key": "survey-targeting-xyz"}]}), false)]
+    #[case::only_product_tour_flags(json!({"flags": [{"key": "product-tour-targeting-abc"}]}), false)]
+    #[case::mixed_survey_and_regular(json!({"flags": [{"key": "survey-targeting-abc"}, {"key": "my-feature"}]}), true)]
+    #[case::empty_flags_array(json!({"flags": []}), false)]
+    #[case::no_flags_key(json!({"cohorts": {}}), false)]
+    #[case::only_survey_and_tour_flags(json!({"flags": [{"key": "survey-targeting-abc"}, {"key": "product-tour-targeting-xyz"}]}), false)]
+    fn test_has_billable_flags(#[case] response: Value, #[case] expected: bool) {
+        assert_eq!(has_billable_flags(&response), expected);
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -8,6 +8,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub const SURVEY_TARGETING_FLAG_PREFIX: &str = "survey-targeting-";
 pub const PRODUCT_TOUR_TARGETING_FLAG_PREFIX: &str = "product-tour-targeting-";
 
+pub fn is_billable_flag_key(key: &str) -> bool {
+    !key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+        && !key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+}
+
 const CACHE_BUCKET_SIZE: u64 = 60 * 2; // duration in seconds
 
 pub fn get_team_request_key(team_id: i32, request_type: FlagRequestType) -> String {

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -1,10 +1,7 @@
 use crate::{
     api::{errors::FlagError, types::FlagsResponse},
     flags::{
-        flag_analytics::{
-            increment_request_count, PRODUCT_TOUR_TARGETING_FLAG_PREFIX,
-            SURVEY_TARGETING_FLAG_PREFIX,
-        },
+        flag_analytics::{increment_request_count, is_billable_flag_key},
         flag_models::FeatureFlagList,
         flag_request::FlagRequestType,
     },
@@ -81,9 +78,7 @@ pub async fn record_usage(
 /// `filtered_out_flag_ids`, so no separate check is needed.
 fn contains_billable_flags(filtered_flags: &FeatureFlagList) -> bool {
     filtered_flags.flags.iter().any(|flag| {
-        !filtered_flags.filtered_out_flag_ids.contains(&flag.id)
-            && !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
-            && !flag.key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+        !filtered_flags.filtered_out_flag_ids.contains(&flag.id) && is_billable_flag_key(&flag.key)
     })
 }
 
@@ -96,6 +91,9 @@ pub fn should_record_usage(filtered_flags: &FeatureFlagList) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flags::flag_analytics::{
+        PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX,
+    };
     use crate::flags::flag_models::{FeatureFlag, FlagFilters, FlagPropertyGroup};
 
     use std::collections::HashSet;

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1716,8 +1716,8 @@ async fn test_flag_definitions_billing_limited_returns_402() {
         status, 402,
         "Should return 402 when billing quota is exceeded. Body: {body_text}"
     );
-    assert_eq!(
-        body_text,
-        "Billing limit reached. Please upgrade your plan."
-    );
+    // Response body matches Django's JSON format for SDK compatibility
+    let body: serde_json::Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(body["type"], "quota_limited");
+    assert_eq!(body["code"], "payment_required");
 }

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1674,3 +1674,50 @@ async fn test_etag_graceful_degradation_without_stored_etag() {
         "Should not include ETag header when no ETag is stored"
     );
 }
+
+#[tokio::test]
+async fn test_flag_definitions_billing_limited_returns_402() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // Create team with secret token in real PG (needed for auth)
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // Start server with mock Redis where the team's token is billing-limited
+    let server = common::ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![team.api_token.clone()],            // billing-limited
+        vec![(team.api_token.clone(), team.id)], // valid for team lookup
+    )
+    .await;
+
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+
+    assert_eq!(
+        status, 402,
+        "Should return 402 when billing quota is exceeded. Body: {body_text}"
+    );
+    assert_eq!(
+        body_text,
+        "Billing limit reached. Please upgrade your plan."
+    );
+}


### PR DESCRIPTION
# Summary

- Add billing quota enforcement to the Rust `/flags/definitions` endpoint, returning 402 when the team exceeds their feature flag request quota (matching Django's `/local_evaluation` behavior)
- Filter non-billable flags (survey and product tour targeting flags) from usage tracking, so only requests with actual feature flags count toward billing
- This is Task 5 of the `/local_evaluation` → Rust migration #49564 
- 
## Changes

**Quota limiting** (`flag_definitions.rs`):
- Check `FeatureFlagsLimiter.is_limited(token)` after rate limiting, before fetching cache
- Returns `FlagError::ClientFacing(ClientFacingError::BillingLimit)` → HTTP 402
- Uses the same `FeatureFlagsLimiter` already wired up for `/flags`

**Billable flag filtering** (`flag_definitions.rs`):
- Moved usage tracking (`increment_request_count`) to after cache fetch so we can inspect the response
- Added `has_billable_flags()` helper that checks if the cached response contains any flags whose key doesn't start with `survey-targeting-` or `product-tour-targeting-`
- Matches Django's filtering logic in `local_evaluation`

> **Note on billable flag filtering:** `/local_evaluation` returns ALL flag definitions in a single request, always counted as 1. The filtering only skips counting if a team has *exclusively* survey/product tour targeting flags and zero real feature flags, an edge case that's unlikely in practice. We match Django's behavior for parity.

**Tests**:
- 7 unit tests for `has_billable_flags`: regular flags, only surveys, only product tours, mixed, empty array, missing key, combined survey+tour
- 1 integration test: creates a billing-limited team via mock Redis, verifies `/flags/definitions` returns 402

## How Django `/local_evaluation` compares

| Aspect | Django | Rust (after this PR) |
|--------|--------|---------------------|
| Quota check | `list_limited_team_attributes` → 402 | `FeatureFlagsLimiter.is_limited` → 402 |
| Usage tracking | `increment_request_count` with `LOCAL_EVALUATION` type | Same function, same Redis keys |
| Billable filtering | Skips count if all flags are survey/tour | Same logic via `has_billable_flags()` |

## Test plan

- [x] Unit tests for `has_billable_flags` pass
- [x] Integration test for billing-limited 402 response passes
- [x] `cargo fmt`, `cargo clippy` clean