### PR TITLE
fix(experiments): Tab isolation for validation errors and flag auto-linking

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -86,9 +86,9 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     props({} as CreateExperimentLogicProps),
     key((props) => `${props.tabId ?? 'global'}-create-experiment`),
     path((key) => ['scenes', 'experiments', 'create', 'createExperimentLogic', key]),
-    connect(() => ({
+    connect((props: CreateExperimentLogicProps) => ({
         values: [
-            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }),
+            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId }),
             ['featureFlagKeyValidation', 'featureFlagKeyValidationLoading'],
             featureFlagLogic,
             ['featureFlags'],
@@ -190,7 +190,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             },
         ],
     })),
-    selectors(() => ({
+    selectors(({ props }) => ({
         canSubmitExperiment: [
             (s) => [s.experiment, s.featureFlagKeyValidation, s.mode, s.experimentErrors],
             (
@@ -228,7 +228,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
         mode: [
             (s) => [s.experiment],
             (): 'create' | 'link' => {
-                return variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }).values.mode
+                return variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId })
+                    .values.mode
             },
         ],
     })),

--- a/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.ts
@@ -11,14 +11,16 @@ import type { Experiment, FeatureFlagType } from '~/types'
 import type { variantsPanelLogicType } from './variantsPanelLogicType'
 
 export const variantsPanelLogic = kea<variantsPanelLogicType>({
-    key: (props) => props.experiment?.id || 'new',
+    key: (props) => props.tabId || props.experiment?.id || 'new',
     path: (key) => ['scenes', 'experiments', 'create', 'panels', 'variantsPanelLogic', key],
     props: {
         experiment: {} as Experiment,
         disabled: false as boolean,
+        tabId: undefined as string | undefined,
     } as {
         experiment: Experiment
         disabled: boolean
+        tabId?: string
     },
     connect: {
         values: [featureFlagsLogic, ['featureFlags'], experimentsLogic, ['experiments']],

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
@@ -511,7 +511,7 @@ describe('experimentWizardLogic', () => {
         it('existing feature flag key shows error when validation fails', async () => {
             // Directly set the validation result on the variantsPanelLogic instance
             // (the same instance createExperimentLogic connects to)
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false })
+            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: TAB_ID })
             vpLogic.actions.validateFeatureFlagKeySuccess({
                 valid: false,
                 error: 'A feature flag with this key already exists.',

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
@@ -312,6 +312,13 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         afterMount: () => {
             actions.reportExperimentWizardStarted(values.showGuide)
             actions.loadFeatureFlagsForAutocomplete()
+            // Re-validate the feature flag key if one is already set.
+            // The per-tab variantsPanelLogic unmounts when switching tabs,
+            // so validation state is lost and needs to be re-checked.
+            const key = values.experiment?.feature_flag_key
+            if (key) {
+                actions.validateFeatureFlagKey(key)
+            }
         },
     })),
 ])

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
@@ -74,7 +74,7 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
                 'saveExperiment',
                 'saveExperimentSuccess',
             ],
-            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }),
+            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId }),
             ['validateFeatureFlagKey', 'clearFeatureFlagKeyValidation'],
             selectExistingFeatureFlagModalLogic,
             ['loadFeatureFlagsForAutocomplete', 'loadFeatureFlagsSuccess'],
@@ -97,7 +97,18 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         setLinkedFeatureFlag: (flag: FeatureFlagType | null) => ({ flag }),
     }),
 
-    reducers(({ props }) => ({
+    reducers(({ props }: { props: ExperimentWizardLogicProps }) => ({
+        // Tracks whether the initial flag auto-link check has been performed.
+        // Prevents repeated auto-linking when other tabs trigger loadFeatureFlagsSuccess
+        // on the shared selectExistingFeatureFlagModalLogic singleton.
+        initialFlagCheckDone: [
+            false,
+            {
+                loadFeatureFlagsSuccess: () => true,
+                resetWizard: () => false,
+                saveExperimentSuccess: () => false,
+            },
+        ],
         showGuide: [
             (() => {
                 try {
@@ -248,6 +259,12 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         }: {
             featureFlags: { results: FeatureFlagType[]; count: number }
         }) => {
+            // Only auto-link on the first load for this tab. The
+            // selectExistingFeatureFlagModalLogic is a singleton, so other
+            // tabs loading flags would otherwise trigger auto-linking here.
+            if (values.initialFlagCheckDone) {
+                return
+            }
             const key = values.experiment?.feature_flag_key
             if (key && !values.linkedFeatureFlag && featureFlags.results?.length) {
                 const match = featureFlags.results.find((f) => f.key === key)


### PR DESCRIPTION
## Problem

See video:
- Validation errors were not tab-isolated
- In case of an existing feature flag being entered, auto-linking was triggered through tab switching

https://github.com/user-attachments/assets/ab7bf4f8-f022-431f-8d25-204ad5708ae7

## Changes

Both cases fixed

https://github.com/user-attachments/assets/873a5808-fd0f-4c6b-b0fd-6888c89eb2db


## How did you test this code?

- Manually
- Will add a test case under https://github.com/PostHog/posthog/pull/50563 which is where I found the bug and would need to adjust the test case there anyway

## Publish to changelog?

No