### PR TITLE
fix: handle API errors in taxonomic filter property values loading

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -441,5 +441,28 @@ describe('the property definitions model', () => {
 
             expect(logic.values.options['browser'].values).toEqual(expectedValues)
         })
+
+        it('handles API errors by setting error state and stopping loading', async () => {
+            useMocks({
+                get: {
+                    '/api/event/values/': () => [503, { detail: 'Service Unavailable' }],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.Event,
+                    propertyKey: 'browser',
+                    eventNames: [],
+                    newInput: undefined,
+                })
+            })
+                .toDispatchActions(['setOptionsLoading', 'setOptionsError'])
+                .toFinishAllListeners()
+
+            expect(logic.values.options['browser'].status).toEqual('error')
+            expect(logic.values.options['browser'].refreshing).toEqual(false)
+        })
     })
 })

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -4,6 +4,7 @@ import api, { ApiMethodOptions, CountedPaginatedResponse } from 'lib/api'
 import { TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
 import { captureTimeToSeeData } from 'lib/internalMetrics'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { colonDelimitedDuration, toString, isKeyOf } from 'lib/utils'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 import { teamLogic } from 'scenes/teamLogic'
@@ -100,7 +101,7 @@ export type PropValue = {
 export type Option = {
     label?: string
     name?: string
-    status?: 'loading' | 'loaded'
+    status?: 'loading' | 'loaded' | 'error'
     allowCustomValues?: boolean
     values?: PropValue[]
     refreshing?: boolean
@@ -223,6 +224,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             refreshing,
         }),
         setOptionsSearchInput: (key: string, searchInput: string) => ({ key, searchInput }),
+        setOptionsError: (key: string) => ({ key }),
         // internal
         fetchAllPendingDefinitions: true,
         abortAnyRunningQuery: true,
@@ -267,6 +269,10 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 setOptionsSearchInput: (state, { key, searchInput }) => ({
                     ...state,
                     [key]: { ...state[key], searchInput },
+                }),
+                setOptionsError: (state, { key }) => ({
+                    ...state,
+                    [key]: { ...state[key], status: 'error', refreshing: false },
                 }),
             },
         ],
@@ -432,50 +438,60 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
 
             actions.setOptionsSearchInput(propertyKey, newInput || '')
 
-            const responseData: { results: PropValue[]; refreshing: boolean } = await api.get(
-                constructValuesEndpoint(
-                    endpoint,
-                    values.currentTeamId,
-                    type,
-                    propertyKey,
-                    eventNames,
-                    newInput,
-                    properties,
-                    forceRefresh
-                ),
-                methodOptions
-            )
-            breakpoint()
+            try {
+                const responseData: { results: PropValue[]; refreshing: boolean } = await api.get(
+                    constructValuesEndpoint(
+                        endpoint,
+                        values.currentTeamId,
+                        type,
+                        propertyKey,
+                        eventNames,
+                        newInput,
+                        properties,
+                        forceRefresh
+                    ),
+                    methodOptions
+                )
+                breakpoint()
 
-            const propValues = Array.isArray(responseData.results) ? responseData.results : []
-            const refreshing = responseData.refreshing
+                const propValues = Array.isArray(responseData.results) ? responseData.results : []
+                const refreshing = responseData.refreshing
 
-            actions.setOptions(propertyKey, propValues, type !== PropertyDefinitionType.FlagValue, refreshing)
-            cache.abortController = null
+                actions.setOptions(propertyKey, propValues, type !== PropertyDefinitionType.FlagValue, refreshing)
+                cache.abortController = null
 
-            // Schedule a poll when the backend signals a background refresh is in progress
-            cache.pollingTimeouts = cache.pollingTimeouts || {}
-            if (refreshing) {
-                if (cache.pollingTimeouts[propertyKey]) {
+                // Schedule a poll when the backend signals a background refresh is in progress
+                cache.pollingTimeouts = cache.pollingTimeouts || {}
+                if (refreshing) {
+                    if (cache.pollingTimeouts[propertyKey]) {
+                        clearTimeout(cache.pollingTimeouts[propertyKey])
+                    }
+                    cache.pollingTimeouts[propertyKey] = setTimeout(() => {
+                        actions.loadPropertyValues({ endpoint, type, newInput, propertyKey, eventNames, properties })
+                    }, 2000)
+                } else if (cache.pollingTimeouts[propertyKey]) {
                     clearTimeout(cache.pollingTimeouts[propertyKey])
+                    delete cache.pollingTimeouts[propertyKey]
                 }
-                cache.pollingTimeouts[propertyKey] = setTimeout(() => {
-                    actions.loadPropertyValues({ endpoint, type, newInput, propertyKey, eventNames, properties })
-                }, 2000)
-            } else if (cache.pollingTimeouts[propertyKey]) {
-                clearTimeout(cache.pollingTimeouts[propertyKey])
-                delete cache.pollingTimeouts[propertyKey]
-            }
 
-            await captureTimeToSeeData(teamLogic.values.currentTeamId, {
-                type: 'property_values_load',
-                context: 'filters',
-                action: type,
-                primary_interaction_id: '',
-                status: 'success',
-                time_to_see_data_ms: Math.floor(performance.now() - start),
-                api_response_bytes: 0,
-            })
+                await captureTimeToSeeData(teamLogic.values.currentTeamId, {
+                    type: 'property_values_load',
+                    context: 'filters',
+                    action: type,
+                    primary_interaction_id: '',
+                    status: 'success',
+                    time_to_see_data_ms: Math.floor(performance.now() - start),
+                    api_response_bytes: 0,
+                })
+            } catch (e) {
+                // Don't show error for aborted requests (user typed new search query)
+                if (e instanceof DOMException && e.name === 'AbortError') {
+                    return
+                }
+                cache.abortController = null
+                actions.setOptionsError(propertyKey)
+                lemonToast.error('Failed to load property values')
+            }
         },
 
         abortAnyRunningQuery: () => {

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -484,8 +484,11 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                     api_response_bytes: 0,
                 })
             } catch (e) {
+                // Bail if a newer listener invocation has superseded this one
+                breakpoint()
+
                 // Don't show error for aborted requests (user typed new search query)
-                if (e instanceof DOMException && e.name === 'AbortError') {
+                if ((e as any)?.name === 'AbortError') {
                     return
                 }
                 cache.abortController = null


### PR DESCRIPTION
loading suggested values ignored API call errors

<img width="1982" height="776" alt="CleanShot 2026-03-10 at 21 19 10@2x" src="https://github.com/user-attachments/assets/37f4f7f6-c39a-470f-a7e3-67f315b7072d" />

When the API call to fetch property values (e.g., /api/event/values) fails (like a 503 error), the UI now properly:
- Stops the loading indicator by setting status to 'error'
- Shows a toast notification to inform the user

Previously, the loading indicator would remain spinning indefinitely when an API error occurred, with no feedback to the user.

https://claude.ai/code/session_01DvHW8dFTXf9tAex8z489HL
