### PR TITLE
fix(surveys): preserve question IDs during ai edit

### DIFF
--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -47,6 +47,11 @@ QUESTION_TYPE_MAP: dict[str, dict[str, Any]] = {
 class SimpleSurveyQuestion(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
+    id: str | None = Field(
+        default=None,
+        description="Question number from the survey context (e.g. '1', '2', '3'). "
+        "Reuse to preserve question identity and historical response data. Omit for new questions.",
+    )
     type: SEMANTIC_QUESTION_TYPE
     question: str
     description: str | None = None
@@ -305,6 +310,11 @@ SURVEY_EDIT_TOOL_DESCRIPTION = dedent("""
     - Set stop=true to stop collecting responses
     - Set archive=true to archive the survey
 
+    # Question identity
+    - When updating questions, use read_data(kind="survey") first to see the current questions
+    - Each question is shown with a number (1, 2, 3, ...) — pass that number as the question's `id` to preserve its identity and historical response data
+    - Omit `id` for entirely new questions; they will be assigned a fresh ID automatically
+
     # Important
     - Only include fields you want to change
     - When updating questions, provide the complete list (it replaces existing)
@@ -414,7 +424,18 @@ class EditSurveyTool(MaxTool):
             if description is not None:
                 update_data["description"] = description
             if questions is not None:
-                update_data["questions"] = [_build_question(q) for q in questions]
+                new_questions = [_build_question(q) for q in questions]
+                existing_questions = survey.questions or []
+
+                # Build numeric label -> real UUID mapping (1-indexed, matching read_data output)
+                id_map = {str(i + 1): eq["id"] for i, eq in enumerate(existing_questions) if "id" in eq}
+
+                # Resolve numeric labels back to real UUIDs; unknown/missing id -> new question
+                for new_q, simple_q in zip(new_questions, questions):
+                    if simple_q.id and simple_q.id in id_map:
+                        new_q["id"] = id_map[simple_q.id]
+
+                update_data["questions"] = new_questions
             if linked_flag_id is not None:
                 update_data["linked_flag_id"] = linked_flag_id
             if responses_limit is not None:

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -569,6 +569,99 @@ class TestEditSurveyTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
+    async def test_edit_survey_questions_preserves_ids_with_numeric_labels(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey(
+            questions=[
+                {"type": "open", "question": "First?", "id": "uuid-first"},
+                {"type": "open", "question": "Second?", "id": "uuid-second"},
+            ]
+        )
+
+        _, _ = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(id="1", type="open", question="First (edited)?"),
+                SimpleSurveyQuestion(id="2", type="open", question="Second (edited)?"),
+            ],
+        )
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        assert updated_survey.questions[0]["id"] == "uuid-first"
+        assert updated_survey.questions[1]["id"] == "uuid-second"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_questions_reorder_preserves_ids(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey(
+            questions=[
+                {"type": "open", "question": "First?", "id": "uuid-first"},
+                {"type": "open", "question": "Second?", "id": "uuid-second"},
+            ]
+        )
+
+        _, _ = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(id="2", type="open", question="Second (now first)?"),
+                SimpleSurveyQuestion(id="1", type="open", question="First (now second)?"),
+            ],
+        )
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        assert updated_survey.questions[0]["id"] == "uuid-second"
+        assert updated_survey.questions[1]["id"] == "uuid-first"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_questions_new_question_gets_fresh_id(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey(
+            questions=[{"type": "open", "question": "Existing?", "id": "uuid-existing"}]
+        )
+
+        _, _ = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(id="1", type="open", question="Existing (kept)?"),
+                SimpleSurveyQuestion(type="open", question="Brand new?"),
+            ],
+        )
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        assert updated_survey.questions[0]["id"] == "uuid-existing"
+        assert updated_survey.questions[1]["id"] != "uuid-existing"
+        assert updated_survey.questions[1]["id"]  # non-empty fresh UUID
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_questions_remove_question_keeps_remaining_ids(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey(
+            questions=[
+                {"type": "open", "question": "First?", "id": "uuid-first"},
+                {"type": "open", "question": "Second?", "id": "uuid-second"},
+            ]
+        )
+
+        _, _ = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(id="1", type="open", question="First (kept)?"),
+            ],
+        )
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        assert len(updated_survey.questions) == 1
+        assert updated_survey.questions[0]["id"] == "uuid-first"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
     async def test_edit_survey_url_targeting(self):
         tool = self._setup_tool()
         survey = await self._create_test_survey()


### PR DESCRIPTION
## Problem

the survey edit ai tool does not preserve question IDs during edits

which then causes the UI to break since historic event data refereneces nonexistent question IDs

https://posthoghelp.zendesk.com/agent/tickets/52678 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56667)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

updates edit tool to preserve IDs by:

- explicitly instructing LLM to keep the numbers as "IDs"
- mapping the numbers back to their real question UUIDs before calling survey api

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing, unit tests

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->