### PR TITLE
chore: Add PR description guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ Examples:
 - `chore(ci): update GitHub Actions workflow`
 - `chore: update AGENTS.md instructions`
 
+### PR descriptions
+
+Follow the PR description template in `.github/pull_request_template.md` when creating or updating PR descriptions. Keep the descriptions of changes higher-level, focusing on key details for the human reviewer to evaluate the rationale for the approach, and the overall architecture.
+
 ### Rules
 
 - Scope is optional but encouraged when the change is specific to a feature area


### PR DESCRIPTION
## Problem

Agents creating PRs don't consistently follow the repo's PR description template, leading to meh descriptions that miss key long-term context.

## Changes

Adds a "PR descriptions" subsection under "Commits and Pull Requests" in AGENTS.md, instructing agents to follow the `.github/pull_request_template.md` template and keep descriptions higher-level.

## Publish to changelog?

No