### PR TITLE
fix(mcp): use x-explicit-tags for scaffold operation discovery

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -11,10 +11,9 @@ Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-
 
 ```sh
 # 1. Scaffold a starter YAML with all operations disabled.
-#    --product is a substring match on URL paths: it selects every endpoint
-#    whose path contains /<name>/ (hyphens normalized to underscores).
-#    The value can be a product name or any path-segment needle
-#    (e.g. --product actions matches /api/projects/{project_id}/actions/).
+#    --product discovers endpoints via x-explicit-tags (priority 1) then
+#    URL substring match (fallback). ViewSets in products/<name>/backend/
+#    are auto-tagged. ViewSets elsewhere need @extend_schema(tags=["<product>"]).
 pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product \
     --output ../../products/your_product/mcp/tools.yaml
 
@@ -82,8 +81,8 @@ The build pipeline discovers YAML files from both paths.
 
 ```yaml
 category: Human readable name
-feature: snake_case_name
-url_prefix: /path
+feature: snake_case_name # must match the product folder name
+url_prefix: /path # frontend app route, used for enrich_url links
 tools:
   your-tool-name: # kebab-case
     operation: operationId_from_openapi

--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -81,7 +81,7 @@ The build pipeline discovers YAML files from both paths.
 
 ```yaml
 category: Human readable name
-feature: snake_case_name # must match the product folder name
+feature: snake_case_name # should match the product folder name (used for runtime filtering)
 url_prefix: /path # frontend app route, used for enrich_url links
 tools:
   your-tool-name: # kebab-case

--- a/.agents/skills/improving-drf-endpoints/SKILL.md
+++ b/.agents/skills/improving-drf-endpoints/SKILL.md
@@ -64,6 +64,7 @@ See [serializer-fields.md](references/serializer-fields.md) for patterns and exa
 11. **Error responses are typed** — use `OpenApiResponse(response=ErrorSerializer)`, not `OpenApiTypes.OBJECT`
 12. **List endpoints declare pagination** — reset with `pagination_class=None` on custom actions that don't paginate
 13. **Prefer `@validated_request`** over manual `serializer.is_valid()` + `@extend_schema` — it handles both in one decorator
+14. **ViewSets outside `products/` need `@extend_schema(tags=["<product>"])`** — ViewSets in `products/<name>/backend/` are auto-tagged via module path, but ViewSets in `posthog/api/` or `ee/` are not. Without the tag, the MCP scaffold and frontend type generator can't route the endpoint to the right product
 
 **Streaming endpoints:** For SSE or streaming responses, use `@extend_schema(request=InputSerializer, responses={(200, "text/event-stream"): OpenApiTypes.STR})` to document the request schema even though the response can't be fully typed.
 

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -167,12 +167,16 @@ Product teams own their definitions and control which operations are exposed as 
 **Workflow: scaffold, configure, generate.**
 
 1. **Scaffold** a starter YAML with all operations disabled.
-   `--product` is a **substring match** on URL paths —
-   it selects every endpoint whose path contains `/<name>/`
-   (hyphens are normalized to underscores before matching).
-   The value doesn't have to be an exact product name;
-   any string that appears as a path segment will work
-   (e.g., `--product actions` matches `/api/projects/{project_id}/actions/`).
+   `--product` discovers endpoints in two ways (same priority as frontend type generation):
+   1. **`x-explicit-tags`** — matches endpoints whose OpenAPI tag equals the product name.
+      ViewSets in `products/<name>/backend/` are auto-tagged.
+      ViewSets elsewhere (e.g. `posthog/api/`) need `@extend_schema(tags=["<product>"])`.
+   2. **URL substring fallback** — selects endpoints whose path contains `/<name>/`
+      (hyphens normalized to underscores).
+
+   If your product's API routes use a different slug than the product folder name
+   (e.g. `workflows` product with `/hog_flows/` routes),
+   add `@extend_schema(tags=["workflows"])` to the ViewSet so the scaffold can find them.
 
    ```sh
    pnpm --filter=@posthog/mcp run scaffold-yaml -- --product your_product

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -8,6 +8,7 @@ import structlog
 import posthoganalytics
 from django_filters import BaseInFilter, CharFilter, FilterSet
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -336,6 +337,7 @@ class HogFlowFilterSet(FilterSet):
         fields = ["id", "created_by", "created_at", "updated_at"]
 
 
+@extend_schema(tags=["workflows"])
 class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, viewsets.ModelViewSet):
     scope_object = "hog_flow"
     queryset = HogFlow.objects.all()

--- a/posthog/api/hog_flow_template.py
+++ b/posthog/api/hog_flow_template.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 import structlog
 import posthoganalytics
+from drf_spectacular.utils import extend_schema
 from loginas.utils import is_impersonated_session
 from rest_framework import mixins, permissions, serializers, status, viewsets
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -213,6 +214,7 @@ class HogFlowTemplateSerializer(serializers.ModelSerializer):
         return super().create(validated_data=validated_data)
 
 
+@extend_schema(tags=["workflows"])
 class HogFlowTemplateViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelViewSet):
     scope_object = "INTERNAL"
     queryset = HogFlowTemplate.objects.all()

--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -8,9 +8,6 @@ category: Cohorts
 feature: cohorts
 url_prefix: /cohorts
 tools:
-    environments-persons-cohorts-retrieve:
-        operation: environments_persons_cohorts_retrieve
-        enabled: false
     cohorts-list:
         operation: cohorts_list
         enabled: true

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -14,18 +14,6 @@ tools:
     error-tracking-assignment-rules-create:
         operation: error_tracking_assignment_rules_create
         enabled: false
-    error-tracking-assignment-rules-retrieve:
-        operation: error_tracking_assignment_rules_retrieve
-        enabled: false
-    error-tracking-assignment-rules-update:
-        operation: error_tracking_assignment_rules_update
-        enabled: false
-    error-tracking-assignment-rules-partial-update:
-        operation: error_tracking_assignment_rules_partial_update
-        enabled: false
-    error-tracking-assignment-rules-destroy:
-        operation: error_tracking_assignment_rules_destroy
-        enabled: false
     error-tracking-assignment-rules-reorder-partial-update:
         operation: error_tracking_assignment_rules_reorder_partial_update
         enabled: false
@@ -34,18 +22,6 @@ tools:
         enabled: false
     error-tracking-external-references-create:
         operation: error_tracking_external_references_create
-        enabled: false
-    error-tracking-external-references-retrieve:
-        operation: error_tracking_external_references_retrieve
-        enabled: false
-    error-tracking-external-references-update:
-        operation: error_tracking_external_references_update
-        enabled: false
-    error-tracking-external-references-partial-update:
-        operation: error_tracking_external_references_partial_update
-        enabled: false
-    error-tracking-external-references-destroy:
-        operation: error_tracking_external_references_destroy
         enabled: false
     error-tracking-fingerprints-list:
         operation: error_tracking_fingerprints_list
@@ -67,18 +43,6 @@ tools:
         enabled: false
     error-tracking-grouping-rules-create:
         operation: error_tracking_grouping_rules_create
-        enabled: false
-    error-tracking-grouping-rules-retrieve:
-        operation: error_tracking_grouping_rules_retrieve
-        enabled: false
-    error-tracking-grouping-rules-update:
-        operation: error_tracking_grouping_rules_update
-        enabled: false
-    error-tracking-grouping-rules-partial-update:
-        operation: error_tracking_grouping_rules_partial_update
-        enabled: false
-    error-tracking-grouping-rules-destroy:
-        operation: error_tracking_grouping_rules_destroy
         enabled: false
     error-tracking-grouping-rules-reorder-partial-update:
         operation: error_tracking_grouping_rules_reorder_partial_update
@@ -206,18 +170,6 @@ tools:
     error-tracking-suppression-rules-create:
         operation: error_tracking_suppression_rules_create
         enabled: false
-    error-tracking-suppression-rules-retrieve:
-        operation: error_tracking_suppression_rules_retrieve
-        enabled: false
-    error-tracking-suppression-rules-update:
-        operation: error_tracking_suppression_rules_update
-        enabled: false
-    error-tracking-suppression-rules-partial-update:
-        operation: error_tracking_suppression_rules_partial_update
-        enabled: false
-    error-tracking-suppression-rules-destroy:
-        operation: error_tracking_suppression_rules_destroy
-        enabled: false
     error-tracking-suppression-rules-reorder-partial-update:
         operation: error_tracking_suppression_rules_reorder_partial_update
         enabled: false
@@ -250,4 +202,52 @@ tools:
         enabled: false
     error-tracking-symbol-sets-start-upload-create:
         operation: error_tracking_symbol_sets_start_upload_create
+        enabled: false
+    error-tracking-assignment-rules-retrieve:
+        operation: error_tracking_assignment_rules_retrieve
+        enabled: false
+    error-tracking-assignment-rules-update:
+        operation: error_tracking_assignment_rules_update
+        enabled: false
+    error-tracking-assignment-rules-partial-update:
+        operation: error_tracking_assignment_rules_partial_update
+        enabled: false
+    error-tracking-assignment-rules-destroy:
+        operation: error_tracking_assignment_rules_destroy
+        enabled: false
+    error-tracking-external-references-retrieve:
+        operation: error_tracking_external_references_retrieve
+        enabled: false
+    error-tracking-external-references-update:
+        operation: error_tracking_external_references_update
+        enabled: false
+    error-tracking-external-references-partial-update:
+        operation: error_tracking_external_references_partial_update
+        enabled: false
+    error-tracking-external-references-destroy:
+        operation: error_tracking_external_references_destroy
+        enabled: false
+    error-tracking-grouping-rules-retrieve:
+        operation: error_tracking_grouping_rules_retrieve
+        enabled: false
+    error-tracking-grouping-rules-update:
+        operation: error_tracking_grouping_rules_update
+        enabled: false
+    error-tracking-grouping-rules-partial-update:
+        operation: error_tracking_grouping_rules_partial_update
+        enabled: false
+    error-tracking-grouping-rules-destroy:
+        operation: error_tracking_grouping_rules_destroy
+        enabled: false
+    error-tracking-suppression-rules-retrieve:
+        operation: error_tracking_suppression_rules_retrieve
+        enabled: false
+    error-tracking-suppression-rules-update:
+        operation: error_tracking_suppression_rules_update
+        enabled: false
+    error-tracking-suppression-rules-partial-update:
+        operation: error_tracking_suppression_rules_partial_update
+        enabled: false
+    error-tracking-suppression-rules-destroy:
+        operation: error_tracking_suppression_rules_destroy
         enabled: false

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -57,32 +57,6 @@ export const logsExplainLogWithAICreate = async (
     })
 }
 
-export const getHogFlowTemplatesLogsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/hog_flow_templates/${id}/logs/`
-}
-
-export const hogFlowTemplatesLogsRetrieve = async (
-    projectId: string,
-    id: string,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getHogFlowTemplatesLogsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getHogFlowsLogsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/hog_flows/${id}/logs/`
-}
-
-export const hogFlowsLogsRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getHogFlowsLogsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
 export const getHogFunctionsLogsRetrieveUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/hog_functions/${id}/logs/`
 }

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -150,6 +150,307 @@ export interface PaginatedMessageTemplateListApi {
     results: MessageTemplateApi[]
 }
 
+/**
+ * * `team` - Only team
+ * `organization` - Organization
+ * `global` - Global
+ */
+export type HogFlowTemplateScopeEnumApi = (typeof HogFlowTemplateScopeEnumApi)[keyof typeof HogFlowTemplateScopeEnumApi]
+
+export const HogFlowTemplateScopeEnumApi = {
+    Team: 'team',
+    Organization: 'organization',
+    Global: 'global',
+} as const
+
+export interface HogFlowMaskingApi {
+    /**
+     * @minimum 60
+     * @maximum 94608000
+     * @nullable
+     */
+    ttl?: number | null
+    /** @nullable */
+    threshold?: number | null
+    hash: string
+    bytecode?: unknown | null
+}
+
+/**
+ * * `exit_on_conversion` - Conversion
+ * `exit_on_trigger_not_matched` - Trigger Not Matched
+ * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+ * `exit_only_at_end` - Only At End
+ */
+export type ExitConditionEnumApi = (typeof ExitConditionEnumApi)[keyof typeof ExitConditionEnumApi]
+
+export const ExitConditionEnumApi = {
+    ExitOnConversion: 'exit_on_conversion',
+    ExitOnTriggerNotMatched: 'exit_on_trigger_not_matched',
+    ExitOnTriggerNotMatchedOrConversion: 'exit_on_trigger_not_matched_or_conversion',
+    ExitOnlyAtEnd: 'exit_only_at_end',
+} as const
+
+/**
+ * * `continue` - continue
+ * `abort` - abort
+ * `complete` - complete
+ * `branch` - branch
+ */
+export type OnErrorEnumApi = (typeof OnErrorEnumApi)[keyof typeof OnErrorEnumApi]
+
+export const OnErrorEnumApi = {
+    Continue: 'continue',
+    Abort: 'abort',
+    Complete: 'complete',
+    Branch: 'branch',
+} as const
+
+/**
+ * * `events` - events
+ * `person-updates` - person-updates
+ * `data-warehouse-table` - data-warehouse-table
+ */
+export type HogFunctionFiltersSourceEnumApi =
+    (typeof HogFunctionFiltersSourceEnumApi)[keyof typeof HogFunctionFiltersSourceEnumApi]
+
+export const HogFunctionFiltersSourceEnumApi = {
+    Events: 'events',
+    PersonUpdates: 'person-updates',
+    DataWarehouseTable: 'data-warehouse-table',
+} as const
+
+export type HogFunctionFiltersApiActionsItem = { [key: string]: unknown }
+
+export type HogFunctionFiltersApiEventsItem = { [key: string]: unknown }
+
+export type HogFunctionFiltersApiDataWarehouseItem = { [key: string]: unknown }
+
+export type HogFunctionFiltersApiPropertiesItem = { [key: string]: unknown }
+
+export interface HogFunctionFiltersApi {
+    source?: HogFunctionFiltersSourceEnumApi
+    actions?: HogFunctionFiltersApiActionsItem[]
+    events?: HogFunctionFiltersApiEventsItem[]
+    data_warehouse?: HogFunctionFiltersApiDataWarehouseItem[]
+    properties?: HogFunctionFiltersApiPropertiesItem[]
+    bytecode?: unknown | null
+    transpiled?: unknown
+    filter_test_accounts?: boolean
+    bytecode_error?: string
+}
+
+/**
+ * Custom action serializer for templates that skips input validation
+(since templates should have default/empty values).
+ */
+export interface HogFlowTemplateActionApi {
+    id: string
+    /** @maxLength 400 */
+    name: string
+    description?: string
+    on_error?: OnErrorEnumApi | NullEnumApi | null
+    created_at?: number
+    updated_at?: number
+    filters?: HogFunctionFiltersApi | null
+    /** @maxLength 100 */
+    type: string
+    config: unknown
+    output_variable?: unknown | null
+}
+
+export type HogFlowTemplateApiVariablesItem = { [key: string]: string }
+
+/**
+ * Serializer for creating hog flow templates.
+Validates and sanitizes the workflow before creating it as a template.
+ */
+export interface HogFlowTemplateApi {
+    readonly id: string
+    /** @maxLength 400 */
+    name: string
+    description?: string
+    /**
+     * @maxLength 8201
+     * @nullable
+     */
+    image_url?: string | null
+    tags?: string[]
+    scope: HogFlowTemplateScopeEnumApi
+    readonly created_at: string
+    readonly created_by: string
+    readonly updated_at: string
+    trigger?: unknown
+    trigger_masking?: HogFlowMaskingApi | null
+    conversion?: unknown | null
+    exit_condition?: ExitConditionEnumApi
+    edges?: unknown
+    actions: HogFlowTemplateActionApi[]
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    abort_action?: string | null
+    variables?: HogFlowTemplateApiVariablesItem[]
+}
+
+export interface PaginatedHogFlowTemplateListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: HogFlowTemplateApi[]
+}
+
+export type PatchedHogFlowTemplateApiVariablesItem = { [key: string]: string }
+
+/**
+ * Serializer for creating hog flow templates.
+Validates and sanitizes the workflow before creating it as a template.
+ */
+export interface PatchedHogFlowTemplateApi {
+    readonly id?: string
+    /** @maxLength 400 */
+    name?: string
+    description?: string
+    /**
+     * @maxLength 8201
+     * @nullable
+     */
+    image_url?: string | null
+    tags?: string[]
+    scope?: HogFlowTemplateScopeEnumApi
+    readonly created_at?: string
+    readonly created_by?: string
+    readonly updated_at?: string
+    trigger?: unknown
+    trigger_masking?: HogFlowMaskingApi | null
+    conversion?: unknown | null
+    exit_condition?: ExitConditionEnumApi
+    edges?: unknown
+    actions?: HogFlowTemplateActionApi[]
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    abort_action?: string | null
+    variables?: PatchedHogFlowTemplateApiVariablesItem[]
+}
+
+/**
+ * * `draft` - Draft
+ * `active` - Active
+ * `archived` - Archived
+ */
+export type StatusA5eEnumApi = (typeof StatusA5eEnumApi)[keyof typeof StatusA5eEnumApi]
+
+export const StatusA5eEnumApi = {
+    Draft: 'draft',
+    Active: 'active',
+    Archived: 'archived',
+} as const
+
+export interface HogFlowMinimalApi {
+    readonly id: string
+    /** @nullable */
+    readonly name: string | null
+    readonly description: string
+    readonly version: number
+    readonly status: StatusA5eEnumApi
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    readonly updated_at: string
+    readonly trigger: unknown
+    readonly trigger_masking: unknown | null
+    readonly conversion: unknown | null
+    readonly exit_condition: ExitConditionEnumApi
+    readonly edges: unknown
+    readonly actions: unknown
+    /** @nullable */
+    readonly abort_action: string | null
+    readonly variables: unknown | null
+    readonly billable_action_types: unknown | null
+}
+
+export interface PaginatedHogFlowMinimalListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: HogFlowMinimalApi[]
+}
+
+export type HogFlowApiVariablesItem = { [key: string]: string }
+
+export interface HogFlowActionApi {
+    id: string
+    /** @maxLength 400 */
+    name: string
+    description?: string
+    on_error?: OnErrorEnumApi | NullEnumApi | null
+    created_at?: number
+    updated_at?: number
+    filters?: HogFunctionFiltersApi | null
+    /** @maxLength 100 */
+    type: string
+    config: unknown
+    output_variable?: unknown | null
+}
+
+export interface HogFlowApi {
+    readonly id: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    name?: string | null
+    description?: string
+    readonly version: number
+    status?: StatusA5eEnumApi
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    readonly updated_at: string
+    trigger?: unknown
+    trigger_masking?: HogFlowMaskingApi | null
+    conversion?: unknown | null
+    exit_condition?: ExitConditionEnumApi
+    edges?: unknown
+    actions: HogFlowActionApi[]
+    /** @nullable */
+    readonly abort_action: string | null
+    variables?: HogFlowApiVariablesItem[]
+    readonly billable_action_types: unknown | null
+}
+
+export type PatchedHogFlowApiVariablesItem = { [key: string]: string }
+
+export interface PatchedHogFlowApi {
+    readonly id?: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    name?: string | null
+    description?: string
+    readonly version?: number
+    status?: StatusA5eEnumApi
+    readonly created_at?: string
+    readonly created_by?: UserBasicApi
+    readonly updated_at?: string
+    trigger?: unknown
+    trigger_masking?: HogFlowMaskingApi | null
+    conversion?: unknown | null
+    exit_condition?: ExitConditionEnumApi
+    edges?: unknown
+    actions?: HogFlowActionApi[]
+    /** @nullable */
+    readonly abort_action?: string | null
+    variables?: PatchedHogFlowApiVariablesItem[]
+    readonly billable_action_types?: unknown | null
+}
+
 export type MessagingCategoriesListParams = {
     /**
      * Number of results to return per page.
@@ -170,4 +471,30 @@ export type MessagingTemplatesListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+}
+
+export type HogFlowTemplatesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type HogFlowsListParams = {
+    created_at?: string
+    created_by?: number
+    id?: string
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    updated_at?: string
 }

--- a/products/workflows/frontend/generated/api.ts
+++ b/products/workflows/frontend/generated/api.ts
@@ -9,12 +9,20 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    HogFlowApi,
+    HogFlowTemplateApi,
+    HogFlowTemplatesListParams,
+    HogFlowsListParams,
     MessageCategoryApi,
     MessageTemplateApi,
     MessagingCategoriesListParams,
     MessagingTemplatesListParams,
+    PaginatedHogFlowMinimalListApi,
+    PaginatedHogFlowTemplateListApi,
     PaginatedMessageCategoryListApi,
     PaginatedMessageTemplateListApi,
+    PatchedHogFlowApi,
+    PatchedHogFlowTemplateApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -206,5 +214,357 @@ export const messagingTemplatesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(messageTemplateApi),
+    })
+}
+
+/**
+ * Override list to include global templates from files alongside team templates from DB.
+ */
+export const getHogFlowTemplatesListUrl = (projectId: string, params?: HogFlowTemplatesListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/hog_flow_templates/?${stringifiedParams}`
+        : `/api/projects/${projectId}/hog_flow_templates/`
+}
+
+export const hogFlowTemplatesList = async (
+    projectId: string,
+    params?: HogFlowTemplatesListParams,
+    options?: RequestInit
+): Promise<PaginatedHogFlowTemplateListApi> => {
+    return apiMutator<PaginatedHogFlowTemplateListApi>(getHogFlowTemplatesListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowTemplatesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/`
+}
+
+export const hogFlowTemplatesCreate = async (
+    projectId: string,
+    hogFlowTemplateApi: NonReadonly<HogFlowTemplateApi>,
+    options?: RequestInit
+): Promise<HogFlowTemplateApi> => {
+    return apiMutator<HogFlowTemplateApi>(getHogFlowTemplatesCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowTemplateApi),
+    })
+}
+
+/**
+ * Check file-based global templates first, then DB team templates.
+The queryset excludes all global templates from DB, so this only returns team templates from DB.
+ */
+export const getHogFlowTemplatesRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/${id}/`
+}
+
+export const hogFlowTemplatesRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<HogFlowTemplateApi> => {
+    return apiMutator<HogFlowTemplateApi>(getHogFlowTemplatesRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowTemplatesUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/${id}/`
+}
+
+export const hogFlowTemplatesUpdate = async (
+    projectId: string,
+    id: string,
+    hogFlowTemplateApi: NonReadonly<HogFlowTemplateApi>,
+    options?: RequestInit
+): Promise<HogFlowTemplateApi> => {
+    return apiMutator<HogFlowTemplateApi>(getHogFlowTemplatesUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowTemplateApi),
+    })
+}
+
+export const getHogFlowTemplatesPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/${id}/`
+}
+
+export const hogFlowTemplatesPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedHogFlowTemplateApi: NonReadonly<PatchedHogFlowTemplateApi>,
+    options?: RequestInit
+): Promise<HogFlowTemplateApi> => {
+    return apiMutator<HogFlowTemplateApi>(getHogFlowTemplatesPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedHogFlowTemplateApi),
+    })
+}
+
+export const getHogFlowTemplatesDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/${id}/`
+}
+
+export const hogFlowTemplatesDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getHogFlowTemplatesDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getHogFlowTemplatesLogsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flow_templates/${id}/logs/`
+}
+
+export const hogFlowTemplatesLogsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getHogFlowTemplatesLogsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsListUrl = (projectId: string, params?: HogFlowsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/hog_flows/?${stringifiedParams}`
+        : `/api/projects/${projectId}/hog_flows/`
+}
+
+export const hogFlowsList = async (
+    projectId: string,
+    params?: HogFlowsListParams,
+    options?: RequestInit
+): Promise<PaginatedHogFlowMinimalListApi> => {
+    return apiMutator<PaginatedHogFlowMinimalListApi>(getHogFlowsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/hog_flows/`
+}
+
+export const hogFlowsCreate = async (
+    projectId: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+export const getHogFlowsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/`
+}
+
+export const hogFlowsRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/`
+}
+
+export const hogFlowsUpdate = async (
+    projectId: string,
+    id: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+export const getHogFlowsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/`
+}
+
+export const hogFlowsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedHogFlowApi: NonReadonly<PatchedHogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedHogFlowApi),
+    })
+}
+
+export const getHogFlowsDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/`
+}
+
+export const hogFlowsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getHogFlowsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getHogFlowsBatchJobsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/batch_jobs/`
+}
+
+export const hogFlowsBatchJobsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsBatchJobsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsBatchJobsCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/batch_jobs/`
+}
+
+export const hogFlowsBatchJobsCreate = async (
+    projectId: string,
+    id: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsBatchJobsCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+export const getHogFlowsInvocationsCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/invocations/`
+}
+
+export const hogFlowsInvocationsCreate = async (
+    projectId: string,
+    id: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsInvocationsCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+export const getHogFlowsLogsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/logs/`
+}
+
+export const hogFlowsLogsRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getHogFlowsLogsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsMetricsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/metrics/`
+}
+
+export const hogFlowsMetricsRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getHogFlowsMetricsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsMetricsTotalsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/metrics/totals/`
+}
+
+export const hogFlowsMetricsTotalsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getHogFlowsMetricsTotalsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFlowsBulkDeleteCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/hog_flows/bulk_delete/`
+}
+
+export const hogFlowsBulkDeleteCreate = async (
+    projectId: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsBulkDeleteCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+export const getHogFlowsUserBlastRadiusCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/hog_flows/user_blast_radius/`
+}
+
+export const hogFlowsUserBlastRadiusCreate = async (
+    projectId: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsUserBlastRadiusCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
     })
 }

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -68,7 +68,10 @@ tools:
             List all workflows in the project. Returns workflows with their name, description, status
             (draft/active/archived), version, trigger configuration, and timestamps.
         mcp_version: 1
-        ui_resource_uri: 'ui://posthog/workflow-list.html'
+        ui_resource_uri: ui://posthog/workflow-list.html
+    hog-flows-create:
+        operation: hog_flows_create
+        enabled: false
     workflows-get:
         operation: hog_flows_retrieve
         enabled: true
@@ -78,16 +81,13 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: 'hog-{id}'
+        enrich_url: hog-{id}
         title: Get workflow
         description: >
             Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit
             condition, and variables.
         mcp_version: 1
-        ui_resource_uri: 'ui://posthog/workflow.html'
-    hog-flows-create:
-        operation: hog_flows_create
-        enabled: false
+        ui_resource_uri: ui://posthog/workflow.html
     hog-flows-update:
         operation: hog_flows_update
         enabled: false

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -5,9 +5,54 @@
 # To enable a tool, set enabled: true and add required scopes + annotations.
 # All other fields (title, description, enrich_url, etc.) are yours to configure.
 category: Workflows
-feature: hog_flows
+feature: workflows
 url_prefix: /pipeline/destinations
 tools:
+    messaging-categories-list:
+        operation: messaging_categories_list
+        enabled: false
+    messaging-categories-create:
+        operation: messaging_categories_create
+        enabled: false
+    messaging-categories-import-from-customerio-create:
+        operation: messaging_categories_import_from_customerio_create
+        enabled: false
+    messaging-categories-import-preferences-csv-create:
+        operation: messaging_categories_import_preferences_csv_create
+        enabled: false
+    messaging-preferences-generate-link-create:
+        operation: messaging_preferences_generate_link_create
+        enabled: false
+    messaging-preferences-opt-outs-retrieve:
+        operation: messaging_preferences_opt_outs_retrieve
+        enabled: false
+    messaging-templates-list:
+        operation: messaging_templates_list
+        enabled: false
+    messaging-templates-create:
+        operation: messaging_templates_create
+        enabled: false
+    hog-flow-templates-list:
+        operation: hog_flow_templates_list
+        enabled: false
+    hog-flow-templates-create:
+        operation: hog_flow_templates_create
+        enabled: false
+    hog-flow-templates-retrieve:
+        operation: hog_flow_templates_retrieve
+        enabled: false
+    hog-flow-templates-update:
+        operation: hog_flow_templates_update
+        enabled: false
+    hog-flow-templates-partial-update:
+        operation: hog_flow_templates_partial_update
+        enabled: false
+    hog-flow-templates-destroy:
+        operation: hog_flow_templates_destroy
+        enabled: false
+    hog-flow-templates-logs-retrieve:
+        operation: hog_flow_templates_logs_retrieve
+        enabled: false
     workflows-list:
         operation: hog_flows_list
         enabled: true
@@ -20,9 +65,8 @@ tools:
         list: true
         title: List workflows
         description: >
-            List all workflows in the project. Returns workflows with their name,
-            description, status (draft/active/archived), version, trigger configuration,
-            and timestamps.
+            List all workflows in the project. Returns workflows with their name, description, status
+            (draft/active/archived), version, trigger configuration, and timestamps.
         mcp_version: 1
         ui_resource_uri: 'ui://posthog/workflow-list.html'
     workflows-get:
@@ -37,7 +81,43 @@ tools:
         enrich_url: 'hog-{id}'
         title: Get workflow
         description: >
-            Get a specific workflow by ID. Returns the full workflow definition
-            including trigger, edges, actions, exit condition, and variables.
+            Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit
+            condition, and variables.
         mcp_version: 1
         ui_resource_uri: 'ui://posthog/workflow.html'
+    hog-flows-create:
+        operation: hog_flows_create
+        enabled: false
+    hog-flows-update:
+        operation: hog_flows_update
+        enabled: false
+    hog-flows-partial-update:
+        operation: hog_flows_partial_update
+        enabled: false
+    hog-flows-destroy:
+        operation: hog_flows_destroy
+        enabled: false
+    hog-flows-batch-jobs-retrieve:
+        operation: hog_flows_batch_jobs_retrieve
+        enabled: false
+    hog-flows-batch-jobs-create:
+        operation: hog_flows_batch_jobs_create
+        enabled: false
+    hog-flows-invocations-create:
+        operation: hog_flows_invocations_create
+        enabled: false
+    hog-flows-logs-retrieve:
+        operation: hog_flows_logs_retrieve
+        enabled: false
+    hog-flows-metrics-retrieve:
+        operation: hog_flows_metrics_retrieve
+        enabled: false
+    hog-flows-metrics-totals-retrieve:
+        operation: hog_flows_metrics_totals_retrieve
+        enabled: false
+    hog-flows-bulk-delete-create:
+        operation: hog_flows_bulk_delete_create
+        enabled: false
+    hog-flows-user-blast-radius-create:
+        operation: hog_flows_user_blast_radius_create
+        enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -272,7 +272,7 @@
     "workflows-list": {
         "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",
-        "feature": "hog_flows",
+        "feature": "workflows",
         "summary": "List workflows",
         "title": "List workflows",
         "required_scopes": ["hog_flow:read"],
@@ -287,7 +287,7 @@
     "workflows-get": {
         "description": "Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
         "category": "Workflows",
-        "feature": "hog_flows",
+        "feature": "workflows",
         "summary": "Get workflow",
         "title": "Get workflow",
         "required_scopes": ["hog_flow:read"],

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1185,7 +1185,7 @@
     "workflows-list": {
         "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",
-        "feature": "hog_flows",
+        "feature": "workflows",
         "summary": "List workflows",
         "title": "List workflows",
         "required_scopes": ["hog_flow:read"],
@@ -1200,7 +1200,7 @@
     "workflows-get": {
         "description": "Get a specific workflow by ID. Returns the full workflow definition including trigger, edges, actions, exit condition, and variables.",
         "category": "Workflows",
-        "feature": "hog_flows",
+        "feature": "workflows",
         "summary": "Get workflow",
         "title": "Get workflow",
         "required_scopes": ["hog_flow:read"],

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -2,8 +2,8 @@
 /**
  * Scaffolds YAML tool definitions from the OpenAPI schema.
  *
- * Discovers operations by matching URL paths containing /{product}/,
- * same approach as frontend/bin/generate-openapi-types.mjs.
+ * Discovers operations using x-explicit-tags (priority 1) and URL path
+ * substring matching (fallback), same approach as generate-openapi-types.mjs.
  *
  * Idempotent: re-running on an existing file only adds newly discovered
  * operations and removes stale ones. All hand-authored config is preserved.
@@ -427,8 +427,8 @@ function main(): void {
         console.error('       scaffold-yaml --path <prefix> [--output <file>]')
         console.error('       scaffold-yaml --sync-all')
         console.error('')
-        console.error('--product is a substring match: selects endpoints whose path contains /<name>/')
-        console.error('(hyphens normalized to underscores). Can be a product name or any path segment.')
+        console.error('--product discovers endpoints by x-explicit-tags first, then URL path fallback.')
+        console.error('Uses the product folder name (underscores), e.g. error_tracking, workflows.')
         process.exit(1)
     }
 

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -36,6 +36,8 @@ interface OpenApiOperation {
     parameters?: Array<{ in: string; name: string }>
     summary?: string
     description?: string
+    deprecated?: boolean
+    'x-explicit-tags'?: string[]
 }
 
 interface OpenApiSpec {
@@ -88,10 +90,41 @@ function operationIdToToolName(operationId: string): string {
 }
 
 /**
- * Find operations whose URL path contains /{product}/ — same approach
- * as frontend/bin/generate-openapi-types.mjs matchUrlToProduct().
+ * Find operations by x-explicit-tags — same priority-1 approach as
+ * frontend/bin/generate-openapi-types.mjs resolveTagToProduct().
+ * Tags are set via @extend_schema(tags=[...]) or auto-derived from
+ * the ViewSet module path (products/<name>/backend/ → tag "<name>").
  */
-function findOperationsByProduct(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
+function findOperationsByTag(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
+    const ops: DiscoveredOperation[] = []
+    const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete'])
+
+    for (const [urlPath, methods] of Object.entries(spec.paths)) {
+        for (const [method, op] of Object.entries(methods)) {
+            if (!httpMethods.has(method) || !op?.operationId || op.deprecated) {
+                continue
+            }
+            const tags = op['x-explicit-tags'] ?? []
+            if (tags.includes(product)) {
+                ops.push({
+                    operationId: op.operationId,
+                    method: method.toUpperCase(),
+                    path: urlPath,
+                    description: op.summary || op.description,
+                })
+            }
+        }
+    }
+
+    return ops
+}
+
+/**
+ * Find operations whose URL path contains /{product}/ — fallback when
+ * x-explicit-tags doesn't match, same as generate-openapi-types.mjs
+ * matchUrlToProduct().
+ */
+function findOperationsByUrl(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
     const ops: DiscoveredOperation[] = []
     const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete'])
     const needle = `/${product}/`
@@ -102,7 +135,7 @@ function findOperationsByProduct(spec: OpenApiSpec, product: string): Discovered
         }
 
         for (const [method, op] of Object.entries(methods)) {
-            if (!httpMethods.has(method) || !op?.operationId) {
+            if (!httpMethods.has(method) || !op?.operationId || op.deprecated) {
                 continue
             }
 
@@ -118,6 +151,30 @@ function findOperationsByProduct(spec: OpenApiSpec, product: string): Discovered
     return ops
 }
 
+/**
+ * Find operations for a product. Uses the same priority as
+ * frontend/bin/generate-openapi-types.mjs:
+ * 1. x-explicit-tags match (covers ViewSets with @extend_schema(tags=[...])
+ *    and ViewSets in products/<name>/backend/)
+ * 2. URL path substring match (fallback for legacy endpoints)
+ */
+function findOperationsByProduct(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
+    const byTag = findOperationsByTag(spec, product)
+    const byUrl = findOperationsByUrl(spec, product)
+
+    // Merge, preferring tag-matched ops and deduping by operationId
+    const seen = new Set(byTag.map((op) => op.operationId))
+    const merged = [...byTag]
+    for (const op of byUrl) {
+        if (!seen.has(op.operationId)) {
+            merged.push(op)
+            seen.add(op.operationId)
+        }
+    }
+
+    return merged
+}
+
 function findOperationsByPath(spec: OpenApiSpec, pathPrefix: string): DiscoveredOperation[] {
     const ops: DiscoveredOperation[] = []
     const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete'])
@@ -128,7 +185,7 @@ function findOperationsByPath(spec: OpenApiSpec, pathPrefix: string): Discovered
         }
 
         for (const [method, op] of Object.entries(methods)) {
-            if (!httpMethods.has(method) || !op?.operationId) {
+            if (!httpMethods.has(method) || !op?.operationId || op.deprecated) {
                 continue
             }
 

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -3,22 +3,10 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 13 ops
+ * PostHog API - MCP 12 ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
-
-/**
- * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
- * @deprecated
- */
-export const EnvironmentsPersonsCohortsRetrieveParams = zod.object({
-    environment_id: zod.string().describe('Deprecated. Use /api/projects/{project_id}/ instead.'),
-})
-
-export const EnvironmentsPersonsCohortsRetrieveQueryParams = zod.object({
-    format: zod.enum(['csv', 'json']).optional(),
-})
 
 export const CohortsListParams = zod.object({
     project_id: zod

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -3,10 +3,1133 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 2 ops
+ * PostHog API - MCP 29 ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+export const MessagingCategoriesListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const MessagingCategoriesListQueryParams = zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const messagingCategoriesListResponseResultsItemKeyMax = 64
+
+export const messagingCategoriesListResponseResultsItemNameMax = 128
+
+export const MessagingCategoriesListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod.object({
+            id: zod.string(),
+            key: zod.string().max(messagingCategoriesListResponseResultsItemKeyMax),
+            name: zod.string().max(messagingCategoriesListResponseResultsItemNameMax),
+            description: zod.string().optional(),
+            public_description: zod.string().optional(),
+            category_type: zod
+                .enum(['marketing', 'transactional'])
+                .optional()
+                .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+            created_at: zod.string().datetime({}),
+            updated_at: zod.string().datetime({}),
+            created_by: zod.number().nullable(),
+            deleted: zod.boolean().optional(),
+        })
+    ),
+})
+
+export const MessagingCategoriesCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const messagingCategoriesCreateBodyKeyMax = 64
+
+export const messagingCategoriesCreateBodyNameMax = 128
+
+export const MessagingCategoriesCreateBody = zod.object({
+    key: zod.string().max(messagingCategoriesCreateBodyKeyMax),
+    name: zod.string().max(messagingCategoriesCreateBodyNameMax),
+    description: zod.string().optional(),
+    public_description: zod.string().optional(),
+    category_type: zod
+        .enum(['marketing', 'transactional'])
+        .optional()
+        .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+    deleted: zod.boolean().optional(),
+})
+
+/**
+ * Import subscription topics and globally unsubscribed users from Customer.io API
+ */
+export const MessagingCategoriesImportFromCustomerioCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const messagingCategoriesImportFromCustomerioCreateBodyKeyMax = 64
+
+export const messagingCategoriesImportFromCustomerioCreateBodyNameMax = 128
+
+export const MessagingCategoriesImportFromCustomerioCreateBody = zod.object({
+    key: zod.string().max(messagingCategoriesImportFromCustomerioCreateBodyKeyMax),
+    name: zod.string().max(messagingCategoriesImportFromCustomerioCreateBodyNameMax),
+    description: zod.string().optional(),
+    public_description: zod.string().optional(),
+    category_type: zod
+        .enum(['marketing', 'transactional'])
+        .optional()
+        .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+    deleted: zod.boolean().optional(),
+})
+
+export const messagingCategoriesImportFromCustomerioCreateResponseKeyMax = 64
+
+export const messagingCategoriesImportFromCustomerioCreateResponseNameMax = 128
+
+export const MessagingCategoriesImportFromCustomerioCreateResponse = zod.object({
+    id: zod.string(),
+    key: zod.string().max(messagingCategoriesImportFromCustomerioCreateResponseKeyMax),
+    name: zod.string().max(messagingCategoriesImportFromCustomerioCreateResponseNameMax),
+    description: zod.string().optional(),
+    public_description: zod.string().optional(),
+    category_type: zod
+        .enum(['marketing', 'transactional'])
+        .optional()
+        .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+    created_at: zod.string().datetime({}),
+    updated_at: zod.string().datetime({}),
+    created_by: zod.number().nullable(),
+    deleted: zod.boolean().optional(),
+})
+
+/**
+ * Import customer preferences from CSV file
+Expected CSV columns: id, email, cio_subscription_preferences
+ */
+export const MessagingCategoriesImportPreferencesCsvCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const messagingCategoriesImportPreferencesCsvCreateBodyKeyMax = 64
+
+export const messagingCategoriesImportPreferencesCsvCreateBodyNameMax = 128
+
+export const MessagingCategoriesImportPreferencesCsvCreateBody = zod.object({
+    key: zod.string().max(messagingCategoriesImportPreferencesCsvCreateBodyKeyMax),
+    name: zod.string().max(messagingCategoriesImportPreferencesCsvCreateBodyNameMax),
+    description: zod.string().optional(),
+    public_description: zod.string().optional(),
+    category_type: zod
+        .enum(['marketing', 'transactional'])
+        .optional()
+        .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+    deleted: zod.boolean().optional(),
+})
+
+export const messagingCategoriesImportPreferencesCsvCreateResponseKeyMax = 64
+
+export const messagingCategoriesImportPreferencesCsvCreateResponseNameMax = 128
+
+export const MessagingCategoriesImportPreferencesCsvCreateResponse = zod.object({
+    id: zod.string(),
+    key: zod.string().max(messagingCategoriesImportPreferencesCsvCreateResponseKeyMax),
+    name: zod.string().max(messagingCategoriesImportPreferencesCsvCreateResponseNameMax),
+    description: zod.string().optional(),
+    public_description: zod.string().optional(),
+    category_type: zod
+        .enum(['marketing', 'transactional'])
+        .optional()
+        .describe('* `marketing` - Marketing\n* `transactional` - Transactional'),
+    created_at: zod.string().datetime({}),
+    updated_at: zod.string().datetime({}),
+    created_by: zod.number().nullable(),
+    deleted: zod.boolean().optional(),
+})
+
+/**
+ * Generate an unsubscribe link for the current user's email address
+ */
+export const MessagingPreferencesGenerateLinkCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Get opt-outs filtered by category or overall opt-outs if no category specified
+ */
+export const MessagingPreferencesOptOutsRetrieveParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const MessagingTemplatesListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const MessagingTemplatesListQueryParams = zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const messagingTemplatesListResponseResultsItemNameMax = 400
+
+export const messagingTemplatesListResponseResultsItemCreatedByOneDistinctIdMax = 200
+
+export const messagingTemplatesListResponseResultsItemCreatedByOneFirstNameMax = 150
+
+export const messagingTemplatesListResponseResultsItemCreatedByOneLastNameMax = 150
+
+export const messagingTemplatesListResponseResultsItemCreatedByOneEmailMax = 254
+
+export const messagingTemplatesListResponseResultsItemTypeMax = 24
+
+export const MessagingTemplatesListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(messagingTemplatesListResponseResultsItemNameMax),
+            description: zod.string().optional(),
+            created_at: zod.string().datetime({}),
+            updated_at: zod.string().datetime({}),
+            content: zod
+                .object({
+                    templating: zod.enum(['hog', 'liquid']).optional().describe('* `hog` - hog\n* `liquid` - liquid'),
+                    email: zod
+                        .object({
+                            subject: zod.string().optional(),
+                            text: zod.string().optional(),
+                            html: zod.string().optional(),
+                            design: zod.unknown().optional(),
+                        })
+                        .nullish(),
+                })
+                .optional(),
+            created_by: zod.object({
+                id: zod.number(),
+                uuid: zod.string(),
+                distinct_id: zod
+                    .string()
+                    .max(messagingTemplatesListResponseResultsItemCreatedByOneDistinctIdMax)
+                    .nullish(),
+                first_name: zod
+                    .string()
+                    .max(messagingTemplatesListResponseResultsItemCreatedByOneFirstNameMax)
+                    .optional(),
+                last_name: zod
+                    .string()
+                    .max(messagingTemplatesListResponseResultsItemCreatedByOneLastNameMax)
+                    .optional(),
+                email: zod.string().email().max(messagingTemplatesListResponseResultsItemCreatedByOneEmailMax),
+                is_email_verified: zod.boolean().nullish(),
+                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+                role_at_organization: zod
+                    .union([
+                        zod
+                            .enum([
+                                'engineering',
+                                'data',
+                                'product',
+                                'founder',
+                                'leadership',
+                                'marketing',
+                                'sales',
+                                'other',
+                            ])
+                            .describe(
+                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                            ),
+                        zod.enum(['']),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+            }),
+            type: zod.string().max(messagingTemplatesListResponseResultsItemTypeMax).optional(),
+            message_category: zod.string().nullish(),
+            deleted: zod.boolean().optional(),
+        })
+    ),
+})
+
+export const MessagingTemplatesCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const messagingTemplatesCreateBodyNameMax = 400
+
+export const messagingTemplatesCreateBodyTypeMax = 24
+
+export const MessagingTemplatesCreateBody = zod.object({
+    name: zod.string().max(messagingTemplatesCreateBodyNameMax),
+    description: zod.string().optional(),
+    content: zod
+        .object({
+            templating: zod.enum(['hog', 'liquid']).optional().describe('* `hog` - hog\n* `liquid` - liquid'),
+            email: zod
+                .object({
+                    subject: zod.string().optional(),
+                    text: zod.string().optional(),
+                    html: zod.string().optional(),
+                    design: zod.unknown().optional(),
+                })
+                .nullish(),
+        })
+        .optional(),
+    type: zod.string().max(messagingTemplatesCreateBodyTypeMax).optional(),
+    message_category: zod.string().nullish(),
+    deleted: zod.boolean().optional(),
+})
+
+/**
+ * Override list to include global templates from files alongside team templates from DB.
+ */
+export const HogFlowTemplatesListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowTemplatesListQueryParams = zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const hogFlowTemplatesListResponseResultsItemNameMax = 400
+
+export const hogFlowTemplatesListResponseResultsItemImageUrlMax = 8201
+
+export const hogFlowTemplatesListResponseResultsItemTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesListResponseResultsItemTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesListResponseResultsItemActionsItemNameMax = 400
+
+export const hogFlowTemplatesListResponseResultsItemActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesListResponseResultsItemActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesListResponseResultsItemActionsItemTypeMax = 100
+
+export const hogFlowTemplatesListResponseResultsItemAbortActionMax = 400
+
+export const HogFlowTemplatesListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod
+            .object({
+                id: zod.string(),
+                name: zod.string().max(hogFlowTemplatesListResponseResultsItemNameMax),
+                description: zod.string().optional(),
+                image_url: zod.string().max(hogFlowTemplatesListResponseResultsItemImageUrlMax).nullish(),
+                tags: zod.array(zod.string()).optional(),
+                scope: zod
+                    .enum(['team', 'organization', 'global'])
+                    .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+                created_at: zod.string().datetime({}),
+                created_by: zod.string(),
+                updated_at: zod.string().datetime({}),
+                trigger: zod.unknown().optional(),
+                trigger_masking: zod
+                    .object({
+                        ttl: zod
+                            .number()
+                            .min(hogFlowTemplatesListResponseResultsItemTriggerMaskingOneTtlMin)
+                            .max(hogFlowTemplatesListResponseResultsItemTriggerMaskingOneTtlMax)
+                            .nullish(),
+                        threshold: zod.number().nullish(),
+                        hash: zod.string(),
+                        bytecode: zod.unknown().nullish(),
+                    })
+                    .nullish(),
+                conversion: zod.unknown().nullish(),
+                exit_condition: zod
+                    .enum([
+                        'exit_on_conversion',
+                        'exit_on_trigger_not_matched',
+                        'exit_on_trigger_not_matched_or_conversion',
+                        'exit_only_at_end',
+                    ])
+                    .optional()
+                    .describe(
+                        '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+                    ),
+                edges: zod.unknown().optional(),
+                actions: zod.array(
+                    zod
+                        .object({
+                            id: zod.string(),
+                            name: zod.string().max(hogFlowTemplatesListResponseResultsItemActionsItemNameMax),
+                            description: zod
+                                .string()
+                                .default(hogFlowTemplatesListResponseResultsItemActionsItemDescriptionDefault),
+                            on_error: zod
+                                .union([
+                                    zod
+                                        .enum(['continue', 'abort', 'complete', 'branch'])
+                                        .describe(
+                                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                        ),
+                                    zod.literal(null),
+                                ])
+                                .nullish(),
+                            created_at: zod.number().optional(),
+                            updated_at: zod.number().optional(),
+                            filters: zod
+                                .object({
+                                    source: zod
+                                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                        .describe(
+                                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                        )
+                                        .default(
+                                            hogFlowTemplatesListResponseResultsItemActionsItemFiltersOneSourceDefault
+                                        ),
+                                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    bytecode: zod.unknown().nullish(),
+                                    transpiled: zod.unknown().optional(),
+                                    filter_test_accounts: zod.boolean().optional(),
+                                    bytecode_error: zod.string().optional(),
+                                })
+                                .nullish(),
+                            type: zod.string().max(hogFlowTemplatesListResponseResultsItemActionsItemTypeMax),
+                            config: zod.unknown(),
+                            output_variable: zod.unknown().nullish(),
+                        })
+                        .describe(
+                            'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                        )
+                ),
+                abort_action: zod.string().max(hogFlowTemplatesListResponseResultsItemAbortActionMax).nullish(),
+                variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+            })
+            .describe(
+                'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+            )
+    ),
+})
+
+export const HogFlowTemplatesCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowTemplatesCreateBodyNameMax = 400
+
+export const hogFlowTemplatesCreateBodyImageUrlMax = 8201
+
+export const hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesCreateBodyActionsItemNameMax = 400
+
+export const hogFlowTemplatesCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesCreateBodyActionsItemTypeMax = 100
+
+export const hogFlowTemplatesCreateBodyAbortActionMax = 400
+
+export const HogFlowTemplatesCreateBody = zod
+    .object({
+        name: zod.string().max(hogFlowTemplatesCreateBodyNameMax),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesCreateBodyImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesCreateBodyTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod.array(
+            zod
+                .object({
+                    id: zod.string(),
+                    name: zod.string().max(hogFlowTemplatesCreateBodyActionsItemNameMax),
+                    description: zod.string().default(hogFlowTemplatesCreateBodyActionsItemDescriptionDefault),
+                    on_error: zod
+                        .union([
+                            zod
+                                .enum(['continue', 'abort', 'complete', 'branch'])
+                                .describe(
+                                    '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                ),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                    created_at: zod.number().optional(),
+                    updated_at: zod.number().optional(),
+                    filters: zod
+                        .object({
+                            source: zod
+                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                .describe(
+                                    '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                )
+                                .default(hogFlowTemplatesCreateBodyActionsItemFiltersOneSourceDefault),
+                            actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            bytecode: zod.unknown().nullish(),
+                            transpiled: zod.unknown().optional(),
+                            filter_test_accounts: zod.boolean().optional(),
+                            bytecode_error: zod.string().optional(),
+                        })
+                        .nullish(),
+                    type: zod.string().max(hogFlowTemplatesCreateBodyActionsItemTypeMax),
+                    config: zod.unknown(),
+                    output_variable: zod.unknown().nullish(),
+                })
+                .describe(
+                    'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                )
+        ),
+        abort_action: zod.string().max(hogFlowTemplatesCreateBodyAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+/**
+ * Check file-based global templates first, then DB team templates.
+The queryset excludes all global templates from DB, so this only returns team templates from DB.
+ */
+export const HogFlowTemplatesRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowTemplatesRetrieveResponseNameMax = 400
+
+export const hogFlowTemplatesRetrieveResponseImageUrlMax = 8201
+
+export const hogFlowTemplatesRetrieveResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesRetrieveResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesRetrieveResponseActionsItemNameMax = 400
+
+export const hogFlowTemplatesRetrieveResponseActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesRetrieveResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesRetrieveResponseActionsItemTypeMax = 100
+
+export const hogFlowTemplatesRetrieveResponseAbortActionMax = 400
+
+export const HogFlowTemplatesRetrieveResponse = zod
+    .object({
+        id: zod.string(),
+        name: zod.string().max(hogFlowTemplatesRetrieveResponseNameMax),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesRetrieveResponseImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        created_at: zod.string().datetime({}),
+        created_by: zod.string(),
+        updated_at: zod.string().datetime({}),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesRetrieveResponseTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesRetrieveResponseTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod.array(
+            zod
+                .object({
+                    id: zod.string(),
+                    name: zod.string().max(hogFlowTemplatesRetrieveResponseActionsItemNameMax),
+                    description: zod.string().default(hogFlowTemplatesRetrieveResponseActionsItemDescriptionDefault),
+                    on_error: zod
+                        .union([
+                            zod
+                                .enum(['continue', 'abort', 'complete', 'branch'])
+                                .describe(
+                                    '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                ),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                    created_at: zod.number().optional(),
+                    updated_at: zod.number().optional(),
+                    filters: zod
+                        .object({
+                            source: zod
+                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                .describe(
+                                    '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                )
+                                .default(hogFlowTemplatesRetrieveResponseActionsItemFiltersOneSourceDefault),
+                            actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            bytecode: zod.unknown().nullish(),
+                            transpiled: zod.unknown().optional(),
+                            filter_test_accounts: zod.boolean().optional(),
+                            bytecode_error: zod.string().optional(),
+                        })
+                        .nullish(),
+                    type: zod.string().max(hogFlowTemplatesRetrieveResponseActionsItemTypeMax),
+                    config: zod.unknown(),
+                    output_variable: zod.unknown().nullish(),
+                })
+                .describe(
+                    'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                )
+        ),
+        abort_action: zod.string().max(hogFlowTemplatesRetrieveResponseAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+export const HogFlowTemplatesUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowTemplatesUpdateBodyNameMax = 400
+
+export const hogFlowTemplatesUpdateBodyImageUrlMax = 8201
+
+export const hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesUpdateBodyActionsItemNameMax = 400
+
+export const hogFlowTemplatesUpdateBodyActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesUpdateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesUpdateBodyActionsItemTypeMax = 100
+
+export const hogFlowTemplatesUpdateBodyAbortActionMax = 400
+
+export const HogFlowTemplatesUpdateBody = zod
+    .object({
+        name: zod.string().max(hogFlowTemplatesUpdateBodyNameMax),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesUpdateBodyImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesUpdateBodyTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod.array(
+            zod
+                .object({
+                    id: zod.string(),
+                    name: zod.string().max(hogFlowTemplatesUpdateBodyActionsItemNameMax),
+                    description: zod.string().default(hogFlowTemplatesUpdateBodyActionsItemDescriptionDefault),
+                    on_error: zod
+                        .union([
+                            zod
+                                .enum(['continue', 'abort', 'complete', 'branch'])
+                                .describe(
+                                    '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                ),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                    created_at: zod.number().optional(),
+                    updated_at: zod.number().optional(),
+                    filters: zod
+                        .object({
+                            source: zod
+                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                .describe(
+                                    '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                )
+                                .default(hogFlowTemplatesUpdateBodyActionsItemFiltersOneSourceDefault),
+                            actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            bytecode: zod.unknown().nullish(),
+                            transpiled: zod.unknown().optional(),
+                            filter_test_accounts: zod.boolean().optional(),
+                            bytecode_error: zod.string().optional(),
+                        })
+                        .nullish(),
+                    type: zod.string().max(hogFlowTemplatesUpdateBodyActionsItemTypeMax),
+                    config: zod.unknown(),
+                    output_variable: zod.unknown().nullish(),
+                })
+                .describe(
+                    'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                )
+        ),
+        abort_action: zod.string().max(hogFlowTemplatesUpdateBodyAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+export const hogFlowTemplatesUpdateResponseNameMax = 400
+
+export const hogFlowTemplatesUpdateResponseImageUrlMax = 8201
+
+export const hogFlowTemplatesUpdateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesUpdateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesUpdateResponseActionsItemNameMax = 400
+
+export const hogFlowTemplatesUpdateResponseActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesUpdateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesUpdateResponseActionsItemTypeMax = 100
+
+export const hogFlowTemplatesUpdateResponseAbortActionMax = 400
+
+export const HogFlowTemplatesUpdateResponse = zod
+    .object({
+        id: zod.string(),
+        name: zod.string().max(hogFlowTemplatesUpdateResponseNameMax),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesUpdateResponseImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        created_at: zod.string().datetime({}),
+        created_by: zod.string(),
+        updated_at: zod.string().datetime({}),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesUpdateResponseTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesUpdateResponseTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod.array(
+            zod
+                .object({
+                    id: zod.string(),
+                    name: zod.string().max(hogFlowTemplatesUpdateResponseActionsItemNameMax),
+                    description: zod.string().default(hogFlowTemplatesUpdateResponseActionsItemDescriptionDefault),
+                    on_error: zod
+                        .union([
+                            zod
+                                .enum(['continue', 'abort', 'complete', 'branch'])
+                                .describe(
+                                    '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                ),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                    created_at: zod.number().optional(),
+                    updated_at: zod.number().optional(),
+                    filters: zod
+                        .object({
+                            source: zod
+                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                .describe(
+                                    '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                )
+                                .default(hogFlowTemplatesUpdateResponseActionsItemFiltersOneSourceDefault),
+                            actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            bytecode: zod.unknown().nullish(),
+                            transpiled: zod.unknown().optional(),
+                            filter_test_accounts: zod.boolean().optional(),
+                            bytecode_error: zod.string().optional(),
+                        })
+                        .nullish(),
+                    type: zod.string().max(hogFlowTemplatesUpdateResponseActionsItemTypeMax),
+                    config: zod.unknown(),
+                    output_variable: zod.unknown().nullish(),
+                })
+                .describe(
+                    'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                )
+        ),
+        abort_action: zod.string().max(hogFlowTemplatesUpdateResponseAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+export const HogFlowTemplatesPartialUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowTemplatesPartialUpdateBodyNameMax = 400
+
+export const hogFlowTemplatesPartialUpdateBodyImageUrlMax = 8201
+
+export const hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesPartialUpdateBodyActionsItemNameMax = 400
+
+export const hogFlowTemplatesPartialUpdateBodyActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesPartialUpdateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesPartialUpdateBodyActionsItemTypeMax = 100
+
+export const hogFlowTemplatesPartialUpdateBodyAbortActionMax = 400
+
+export const HogFlowTemplatesPartialUpdateBody = zod
+    .object({
+        name: zod.string().max(hogFlowTemplatesPartialUpdateBodyNameMax).optional(),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesPartialUpdateBodyImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .optional()
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesPartialUpdateBodyTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod
+            .array(
+                zod
+                    .object({
+                        id: zod.string(),
+                        name: zod.string().max(hogFlowTemplatesPartialUpdateBodyActionsItemNameMax),
+                        description: zod
+                            .string()
+                            .default(hogFlowTemplatesPartialUpdateBodyActionsItemDescriptionDefault),
+                        on_error: zod
+                            .union([
+                                zod
+                                    .enum(['continue', 'abort', 'complete', 'branch'])
+                                    .describe(
+                                        '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                    ),
+                                zod.literal(null),
+                            ])
+                            .nullish(),
+                        created_at: zod.number().optional(),
+                        updated_at: zod.number().optional(),
+                        filters: zod
+                            .object({
+                                source: zod
+                                    .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                    .describe(
+                                        '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                    )
+                                    .default(hogFlowTemplatesPartialUpdateBodyActionsItemFiltersOneSourceDefault),
+                                actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                bytecode: zod.unknown().nullish(),
+                                transpiled: zod.unknown().optional(),
+                                filter_test_accounts: zod.boolean().optional(),
+                                bytecode_error: zod.string().optional(),
+                            })
+                            .nullish(),
+                        type: zod.string().max(hogFlowTemplatesPartialUpdateBodyActionsItemTypeMax),
+                        config: zod.unknown(),
+                        output_variable: zod.unknown().nullish(),
+                    })
+                    .describe(
+                        'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                    )
+            )
+            .optional(),
+        abort_action: zod.string().max(hogFlowTemplatesPartialUpdateBodyAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+export const hogFlowTemplatesPartialUpdateResponseNameMax = 400
+
+export const hogFlowTemplatesPartialUpdateResponseImageUrlMax = 8201
+
+export const hogFlowTemplatesPartialUpdateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowTemplatesPartialUpdateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowTemplatesPartialUpdateResponseActionsItemNameMax = 400
+
+export const hogFlowTemplatesPartialUpdateResponseActionsItemDescriptionDefault = ``
+export const hogFlowTemplatesPartialUpdateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowTemplatesPartialUpdateResponseActionsItemTypeMax = 100
+
+export const hogFlowTemplatesPartialUpdateResponseAbortActionMax = 400
+
+export const HogFlowTemplatesPartialUpdateResponse = zod
+    .object({
+        id: zod.string(),
+        name: zod.string().max(hogFlowTemplatesPartialUpdateResponseNameMax),
+        description: zod.string().optional(),
+        image_url: zod.string().max(hogFlowTemplatesPartialUpdateResponseImageUrlMax).nullish(),
+        tags: zod.array(zod.string()).optional(),
+        scope: zod
+            .enum(['team', 'organization', 'global'])
+            .describe('* `team` - Only team\n* `organization` - Organization\n* `global` - Global'),
+        created_at: zod.string().datetime({}),
+        created_by: zod.string(),
+        updated_at: zod.string().datetime({}),
+        trigger: zod.unknown().optional(),
+        trigger_masking: zod
+            .object({
+                ttl: zod
+                    .number()
+                    .min(hogFlowTemplatesPartialUpdateResponseTriggerMaskingOneTtlMin)
+                    .max(hogFlowTemplatesPartialUpdateResponseTriggerMaskingOneTtlMax)
+                    .nullish(),
+                threshold: zod.number().nullish(),
+                hash: zod.string(),
+                bytecode: zod.unknown().nullish(),
+            })
+            .nullish(),
+        conversion: zod.unknown().nullish(),
+        exit_condition: zod
+            .enum([
+                'exit_on_conversion',
+                'exit_on_trigger_not_matched',
+                'exit_on_trigger_not_matched_or_conversion',
+                'exit_only_at_end',
+            ])
+            .optional()
+            .describe(
+                '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+            ),
+        edges: zod.unknown().optional(),
+        actions: zod.array(
+            zod
+                .object({
+                    id: zod.string(),
+                    name: zod.string().max(hogFlowTemplatesPartialUpdateResponseActionsItemNameMax),
+                    description: zod
+                        .string()
+                        .default(hogFlowTemplatesPartialUpdateResponseActionsItemDescriptionDefault),
+                    on_error: zod
+                        .union([
+                            zod
+                                .enum(['continue', 'abort', 'complete', 'branch'])
+                                .describe(
+                                    '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                                ),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                    created_at: zod.number().optional(),
+                    updated_at: zod.number().optional(),
+                    filters: zod
+                        .object({
+                            source: zod
+                                .enum(['events', 'person-updates', 'data-warehouse-table'])
+                                .describe(
+                                    '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                                )
+                                .default(hogFlowTemplatesPartialUpdateResponseActionsItemFiltersOneSourceDefault),
+                            actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                            bytecode: zod.unknown().nullish(),
+                            transpiled: zod.unknown().optional(),
+                            filter_test_accounts: zod.boolean().optional(),
+                            bytecode_error: zod.string().optional(),
+                        })
+                        .nullish(),
+                    type: zod.string().max(hogFlowTemplatesPartialUpdateResponseActionsItemTypeMax),
+                    config: zod.unknown(),
+                    output_variable: zod.unknown().nullish(),
+                })
+                .describe(
+                    'Custom action serializer for templates that skips input validation\n(since templates should have default/empty values).'
+                )
+        ),
+        abort_action: zod.string().max(hogFlowTemplatesPartialUpdateResponseAbortActionMax).nullish(),
+        variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    })
+    .describe(
+        'Serializer for creating hog flow templates.\nValidates and sanitizes the workflow before creating it as a template.'
+    )
+
+export const HogFlowTemplatesDestroyParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowTemplatesLogsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 export const HogFlowsListParams = zod.object({
     project_id: zod
@@ -98,6 +1221,101 @@ export const HogFlowsListResponse = zod.object({
             billable_action_types: zod.unknown().nullable(),
         })
     ),
+})
+
+export const HogFlowsCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsCreateBodyNameMax = 400
+
+export const hogFlowsCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsCreateBody = zod.object({
+    name: zod.string().max(hogFlowsCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
 })
 
 export const HogFlowsRetrieveParams = zod.object({
@@ -222,6 +1440,1481 @@ export const HogFlowsRetrieveResponse = zod.object({
                 })
                 .nullish(),
             type: zod.string().max(hogFlowsRetrieveResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsUpdateBodyNameMax = 400
+
+export const hogFlowsUpdateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsUpdateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsUpdateBodyActionsItemNameMax = 400
+
+export const hogFlowsUpdateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsUpdateBodyActionsItemTypeMax = 100
+
+export const HogFlowsUpdateBody = zod.object({
+    name: zod.string().max(hogFlowsUpdateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsUpdateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsUpdateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsUpdateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsUpdateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsUpdateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsUpdateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsUpdateResponseNameMax = 400
+
+export const hogFlowsUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsUpdateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsUpdateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsUpdateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsUpdateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsUpdateResponseActionsItemNameMax = 400
+
+export const hogFlowsUpdateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsUpdateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsUpdateResponseActionsItemTypeMax = 100
+
+export const HogFlowsUpdateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsUpdateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsUpdateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsUpdateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsUpdateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsUpdateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsUpdateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsUpdateResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsPartialUpdateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsPartialUpdateBodyNameMax = 400
+
+export const hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsPartialUpdateBodyActionsItemNameMax = 400
+
+export const hogFlowsPartialUpdateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsPartialUpdateBodyActionsItemTypeMax = 100
+
+export const HogFlowsPartialUpdateBody = zod.object({
+    name: zod.string().max(hogFlowsPartialUpdateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsPartialUpdateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod
+        .array(
+            zod.object({
+                id: zod.string(),
+                name: zod.string().max(hogFlowsPartialUpdateBodyActionsItemNameMax),
+                description: zod.string().default(hogFlowsPartialUpdateBodyActionsItemDescriptionDefault),
+                on_error: zod
+                    .union([
+                        zod
+                            .enum(['continue', 'abort', 'complete', 'branch'])
+                            .describe(
+                                '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                            ),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+                created_at: zod.number().optional(),
+                updated_at: zod.number().optional(),
+                filters: zod
+                    .object({
+                        source: zod
+                            .enum(['events', 'person-updates', 'data-warehouse-table'])
+                            .describe(
+                                '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                            )
+                            .default(hogFlowsPartialUpdateBodyActionsItemFiltersOneSourceDefault),
+                        actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        bytecode: zod.unknown().nullish(),
+                        transpiled: zod.unknown().optional(),
+                        filter_test_accounts: zod.boolean().optional(),
+                        bytecode_error: zod.string().optional(),
+                    })
+                    .nullish(),
+                type: zod.string().max(hogFlowsPartialUpdateBodyActionsItemTypeMax),
+                config: zod.unknown(),
+                output_variable: zod.unknown().nullish(),
+            })
+        )
+        .optional(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsPartialUpdateResponseNameMax = 400
+
+export const hogFlowsPartialUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsPartialUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsPartialUpdateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsPartialUpdateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsPartialUpdateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsPartialUpdateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsPartialUpdateResponseActionsItemNameMax = 400
+
+export const hogFlowsPartialUpdateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsPartialUpdateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsPartialUpdateResponseActionsItemTypeMax = 100
+
+export const HogFlowsPartialUpdateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsPartialUpdateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsPartialUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsPartialUpdateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsPartialUpdateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsPartialUpdateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsPartialUpdateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsPartialUpdateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsPartialUpdateResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsDestroyParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsBatchJobsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsBatchJobsRetrieveResponseNameMax = 400
+
+export const hogFlowsBatchJobsRetrieveResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsBatchJobsRetrieveResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsBatchJobsRetrieveResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsBatchJobsRetrieveResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsBatchJobsRetrieveResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsBatchJobsRetrieveResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsBatchJobsRetrieveResponseActionsItemNameMax = 400
+
+export const hogFlowsBatchJobsRetrieveResponseActionsItemDescriptionDefault = ``
+export const hogFlowsBatchJobsRetrieveResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsBatchJobsRetrieveResponseActionsItemTypeMax = 100
+
+export const HogFlowsBatchJobsRetrieveResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsBatchJobsRetrieveResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsBatchJobsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsBatchJobsRetrieveResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsBatchJobsRetrieveResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsBatchJobsRetrieveResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsBatchJobsRetrieveResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsBatchJobsRetrieveResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsBatchJobsRetrieveResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsBatchJobsRetrieveResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsBatchJobsRetrieveResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsBatchJobsRetrieveResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsBatchJobsCreateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsBatchJobsCreateBodyNameMax = 400
+
+export const hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsBatchJobsCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsBatchJobsCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsBatchJobsCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsBatchJobsCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsBatchJobsCreateBody = zod.object({
+    name: zod.string().max(hogFlowsBatchJobsCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsBatchJobsCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsBatchJobsCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsBatchJobsCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsBatchJobsCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsBatchJobsCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsBatchJobsCreateResponseNameMax = 400
+
+export const hogFlowsBatchJobsCreateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsBatchJobsCreateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsBatchJobsCreateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsBatchJobsCreateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsBatchJobsCreateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsBatchJobsCreateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsBatchJobsCreateResponseActionsItemNameMax = 400
+
+export const hogFlowsBatchJobsCreateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsBatchJobsCreateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsBatchJobsCreateResponseActionsItemTypeMax = 100
+
+export const HogFlowsBatchJobsCreateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsBatchJobsCreateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsBatchJobsCreateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsBatchJobsCreateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsBatchJobsCreateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsBatchJobsCreateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsBatchJobsCreateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsBatchJobsCreateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsBatchJobsCreateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsBatchJobsCreateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsBatchJobsCreateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsBatchJobsCreateResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsInvocationsCreateParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsInvocationsCreateBodyNameMax = 400
+
+export const hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsInvocationsCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsInvocationsCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsInvocationsCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsInvocationsCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsInvocationsCreateBody = zod.object({
+    name: zod.string().max(hogFlowsInvocationsCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsInvocationsCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsInvocationsCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsInvocationsCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsInvocationsCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsInvocationsCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsInvocationsCreateResponseNameMax = 400
+
+export const hogFlowsInvocationsCreateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsInvocationsCreateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsInvocationsCreateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsInvocationsCreateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsInvocationsCreateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsInvocationsCreateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsInvocationsCreateResponseActionsItemNameMax = 400
+
+export const hogFlowsInvocationsCreateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsInvocationsCreateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsInvocationsCreateResponseActionsItemTypeMax = 100
+
+export const HogFlowsInvocationsCreateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsInvocationsCreateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsInvocationsCreateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsInvocationsCreateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsInvocationsCreateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsInvocationsCreateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsInvocationsCreateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsInvocationsCreateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsInvocationsCreateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsInvocationsCreateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsInvocationsCreateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsInvocationsCreateResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsLogsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsMetricsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsMetricsTotalsRetrieveParams = zod.object({
+    id: zod.string().describe('A UUID string identifying this hog flow.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const HogFlowsBulkDeleteCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsBulkDeleteCreateBodyNameMax = 400
+
+export const hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsBulkDeleteCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsBulkDeleteCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsBulkDeleteCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsBulkDeleteCreateBody = zod.object({
+    name: zod.string().max(hogFlowsBulkDeleteCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsBulkDeleteCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsBulkDeleteCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsBulkDeleteCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsBulkDeleteCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsBulkDeleteCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsBulkDeleteCreateResponseNameMax = 400
+
+export const hogFlowsBulkDeleteCreateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsBulkDeleteCreateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsBulkDeleteCreateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsBulkDeleteCreateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsBulkDeleteCreateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsBulkDeleteCreateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsBulkDeleteCreateResponseActionsItemNameMax = 400
+
+export const hogFlowsBulkDeleteCreateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsBulkDeleteCreateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsBulkDeleteCreateResponseActionsItemTypeMax = 100
+
+export const HogFlowsBulkDeleteCreateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsBulkDeleteCreateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsBulkDeleteCreateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsBulkDeleteCreateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsBulkDeleteCreateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsBulkDeleteCreateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsBulkDeleteCreateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsBulkDeleteCreateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsBulkDeleteCreateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsBulkDeleteCreateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsBulkDeleteCreateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsBulkDeleteCreateResponseActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    abort_action: zod.string().nullable(),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+    billable_action_types: zod.unknown().nullable(),
+})
+
+export const HogFlowsUserBlastRadiusCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const hogFlowsUserBlastRadiusCreateBodyNameMax = 400
+
+export const hogFlowsUserBlastRadiusCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsUserBlastRadiusCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsUserBlastRadiusCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsUserBlastRadiusCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsUserBlastRadiusCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsUserBlastRadiusCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsUserBlastRadiusCreateBody = zod.object({
+    name: zod.string().max(hogFlowsUserBlastRadiusCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsUserBlastRadiusCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsUserBlastRadiusCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsUserBlastRadiusCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsUserBlastRadiusCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsUserBlastRadiusCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsUserBlastRadiusCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+export const hogFlowsUserBlastRadiusCreateResponseNameMax = 400
+
+export const hogFlowsUserBlastRadiusCreateResponseCreatedByOneDistinctIdMax = 200
+
+export const hogFlowsUserBlastRadiusCreateResponseCreatedByOneFirstNameMax = 150
+
+export const hogFlowsUserBlastRadiusCreateResponseCreatedByOneLastNameMax = 150
+
+export const hogFlowsUserBlastRadiusCreateResponseCreatedByOneEmailMax = 254
+
+export const hogFlowsUserBlastRadiusCreateResponseTriggerMaskingOneTtlMin = 60
+export const hogFlowsUserBlastRadiusCreateResponseTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsUserBlastRadiusCreateResponseActionsItemNameMax = 400
+
+export const hogFlowsUserBlastRadiusCreateResponseActionsItemDescriptionDefault = ``
+export const hogFlowsUserBlastRadiusCreateResponseActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsUserBlastRadiusCreateResponseActionsItemTypeMax = 100
+
+export const HogFlowsUserBlastRadiusCreateResponse = zod.object({
+    id: zod.string(),
+    name: zod.string().max(hogFlowsUserBlastRadiusCreateResponseNameMax).nullish(),
+    description: zod.string().optional(),
+    version: zod.number(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    created_at: zod.string().datetime({}),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(hogFlowsUserBlastRadiusCreateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(hogFlowsUserBlastRadiusCreateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(hogFlowsUserBlastRadiusCreateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(hogFlowsUserBlastRadiusCreateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    updated_at: zod.string().datetime({}),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsUserBlastRadiusCreateResponseTriggerMaskingOneTtlMin)
+                .max(hogFlowsUserBlastRadiusCreateResponseTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsUserBlastRadiusCreateResponseActionsItemNameMax),
+            description: zod.string().default(hogFlowsUserBlastRadiusCreateResponseActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsUserBlastRadiusCreateResponseActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsUserBlastRadiusCreateResponseActionsItemTypeMax),
             config: zod.unknown(),
             output_variable: zod.unknown().nullish(),
         })


### PR DESCRIPTION
**Problem**
The MCP scaffold script discovers operations by matching the product folder name as a URL substring (e.g. searching for `/workflows/` in API paths). This breaks for products whose API routes use a different slug — `workflows` owns `/hog_flows/` routes, so `scaffold-yaml --sync-all` silently skipped it with "no operations found."

The hand-authored YAML for workflows survived only because the skip path doesn't touch the file.

**Fix**
Use `x-explicit-tags` from the OpenAPI spec as priority 1 for operation discovery, same approach as the frontend type generator (`generate-openapi-types.mjs`). Falls back to URL matching for endpoints that don't have tags yet.

ViewSets in `products/<name>/backend/` are auto-tagged via module path. ViewSets living elsewhere (like `posthog/api/hog_flow.py`) need an explicit `@extend_schema(tags=["workflows"])` decorator — added here for both `HogFlowViewSet` and `HogFlowTemplateViewSet`.

Also skips deprecated endpoints now, so `/api/environments/` duplicates no longer leak into YAML files (was causing noise in cohorts and error_tracking).

**`feature` field**
Changed `feature: hog_flows` → `feature: workflows` to align with the product folder name. This field is used for runtime tool filtering via `?features=` query param. Open to discussion on whether `feature` should always equal the product dir name or if there are cases where it shouldn't — would appreciate input from folks who use the features param.

**Docs**
Updated the implementing-mcp-tools guide and improving-drf-endpoints skill with the tagging requirement for ViewSets outside `products/`.