### PR TITLE
feat: Add mcpcat observability tracking to MCP service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2909,6 +2909,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      mcpcat:
+        specifier: ^0.1.13
+        version: 0.1.13(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.0)
       posthog-js-lite:
         specifier: 4.2.2
         version: 4.2.2
@@ -16752,6 +16755,14 @@ packages:
   maxmind@4.3.11:
     resolution: {integrity: sha512-tJDrKbUzN6PSA88tWgg0L2R4Ln00XwecYQJPFI+RvlF2k1sx6VQYtuQ1SVxm8+bw5tF7GWV4xyb+3/KyzEpPUw==}
     engines: {node: '>=12', npm: '>=6'}
+
+  mcpcat-api@0.1.7:
+    resolution: {integrity: sha512-c8kJ5rQ68xYFT8O3bbsu68WzGEzGbmmYVcD87YuvlNRof8iy+2vM8uRuZ4kO3OEUTeDA/FA4kgI+DCjOAeO7sw==}
+
+  mcpcat@0.1.13:
+    resolution: {integrity: sha512-nqtcLxyEJUnLMBcZ0Ea3qudQXl69jiDNv8gIB1sr+50o2T2DMc5nLQ1S3itEiYtqrxcuhcPffsrHNwZHZFlncg==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.26.0
 
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
@@ -40396,6 +40407,16 @@ snapshots:
     dependencies:
       mmdb-lib: 2.0.2
       tiny-lru: 11.0.1
+
+  mcpcat-api@0.1.7: {}
+
+  mcpcat@0.1.13(@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.0):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      mcpcat-api: 0.1.7
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
 
   md5.js@1.3.5:
     dependencies:

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -39,6 +39,7 @@
         "agents": "^0.3.6",
         "ai": "^6.0.0",
         "fflate": "^0.8.2",
+        "mcpcat": "^0.1.13",
         "posthog-js-lite": "4.2.2",
         "posthog-node": "^5.25.0",
         "uuid": "^11.1.0",

--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -9,17 +9,6 @@ const DEV_POSTHOG_HOST = env.POSTHOG_ANALYTICS_HOST ?? POSTHOG_HOST
 
 let _client: PostHog | undefined
 
-export enum AnalyticsEvent {
-    MCP_TOOL_CALL = 'mcp tool call',
-    MCP_TOOL_RESPONSE = 'mcp tool response',
-    AI_TRACE = '$ai_trace',
-    AI_SPAN = '$ai_span',
-}
-
-export function generateId(): string {
-    return crypto.randomUUID()
-}
-
 export const getPostHogClient = (devMode?: boolean): PostHog => {
     if (!_client) {
         const apiKey = devMode ? DEV_POSTHOG_API_KEY : POSTHOG_API_KEY

--- a/services/mcp/src/lib/mcpcat.ts
+++ b/services/mcp/src/lib/mcpcat.ts
@@ -1,0 +1,67 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { track } from 'mcpcat'
+
+const POSTHOG_API_KEY = 'sTMFPsFhdP1Ssg'
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+
+/** Provider interface for resolving user/session identity. */
+export type McpCatIdentityProvider = {
+    getDistinctId: () => Promise<string>
+    getSessionUuid: () => Promise<string | undefined>
+    getMcpClientName: () => string | undefined
+    getMcpClientVersion: () => string | undefined
+    getMcpProtocolVersion: () => string | undefined
+    getRegion: () => string | undefined
+    getOrganizationId: () => string | undefined
+    getProjectId: () => string | undefined
+    getClientUserAgent: () => string | undefined
+    getVersion: () => number | undefined
+}
+
+export function initMcpCatObservability(server: McpServer, identity: McpCatIdentityProvider): void {
+    try {
+        track(server, null, {
+            enableReportMissing: false,
+            enableToolCallContext: false,
+            enableTracing: true,
+            identify: async () => {
+                try {
+                    const distinctId = await identity.getDistinctId()
+                    const sessionUuid = await identity.getSessionUuid()
+
+                    return {
+                        userId: distinctId,
+                        userData: {
+                            ...(sessionUuid ? { $session_id: sessionUuid } : {}),
+                            ...(identity.getMcpClientName() ? { mcp_client_name: identity.getMcpClientName() } : {}),
+                            ...(identity.getMcpClientVersion()
+                                ? { mcp_client_version: identity.getMcpClientVersion() }
+                                : {}),
+                            ...(identity.getMcpProtocolVersion()
+                                ? { mcp_protocol_version: identity.getMcpProtocolVersion() }
+                                : {}),
+                            ...(identity.getRegion() ? { region: identity.getRegion() } : {}),
+                            ...(identity.getOrganizationId() ? { organization_id: identity.getOrganizationId() } : {}),
+                            ...(identity.getProjectId() ? { project_id: identity.getProjectId() } : {}),
+                            ...(identity.getClientUserAgent()
+                                ? { client_user_agent: identity.getClientUserAgent() }
+                                : {}),
+                            ...(identity.getVersion() != null ? { mcp_version: identity.getVersion() } : {}),
+                        },
+                    }
+                } catch {
+                    return null
+                }
+            },
+            exporters: {
+                posthog: {
+                    type: 'posthog',
+                    apiKey: POSTHOG_API_KEY,
+                    host: POSTHOG_HOST,
+                },
+            },
+        })
+    } catch {
+        // MCPCat initialization must never block MCP server startup
+    }
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -5,7 +5,6 @@ import { McpAgent } from 'agents/mcp'
 import type { z } from 'zod'
 
 import { ApiClient } from '@/api/client'
-import { AnalyticsEvent, generateId, getPostHogClient } from '@/lib/analytics'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import {
     CUSTOM_API_BASE_URL,
@@ -15,6 +14,7 @@ import {
     toCloudRegion,
 } from '@/lib/constants'
 import { handleToolError } from '@/lib/errors'
+import { initMcpCatObservability } from '@/lib/mcpcat'
 import { formatResponse } from '@/lib/response'
 import { SessionManager } from '@/lib/SessionManager'
 import { StateManager } from '@/lib/StateManager'
@@ -201,73 +201,15 @@ export class MCP extends McpAgent<Env> {
         return _distinctId
     }
 
-    async trackEvent(event: AnalyticsEvent, properties: Record<string, any> = {}): Promise<void> {
-        try {
-            const distinctId = await this.getDistinctId()
-
-            const client = getPostHogClient(!!CUSTOM_API_BASE_URL)
-
-            await this.resolveClientInfo()
-
-            client.capture({
-                distinctId,
-                event,
-                properties: {
-                    ...(this.requestProperties.sessionId
-                        ? {
-                              $session_id: await this.sessionManager.getSessionUuid(this.requestProperties.sessionId),
-                          }
-                        : {}),
-                    ...(this._mcpClientName ? { mcp_client_name: this._mcpClientName } : {}),
-                    ...(this._mcpClientVersion ? { mcp_client_version: this._mcpClientVersion } : {}),
-                    ...(this._mcpProtocolVersion ? { mcp_protocol_version: this._mcpProtocolVersion } : {}),
-                    ...properties,
-                },
-            })
-        } catch {
-            // skip
-        }
-    }
-
     registerTool<TSchema extends z.ZodObject>(
         tool: Tool<TSchema>,
         handler: (params: z.infer<TSchema>) => Promise<any>
     ): void {
         const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
-            const traceId = generateId()
-            const spanId = generateId()
-            const spanName = `mcp/${tool.name}`
-            const startTime = performance.now()
-            const inputState = params
             const validation = tool.schema.safeParse(params)
 
             if (!validation.success) {
-                await this.trackEvent(AnalyticsEvent.MCP_TOOL_CALL, {
-                    tool: tool.name,
-                    valid_input: false,
-                    input: params,
-                })
-                const latency = (performance.now() - startTime) / 1000
                 const errorOutput = `Invalid input: ${validation.error.message}`
-                const outputState = { error: errorOutput }
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
-                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
-                    $ai_trace_id: traceId,
-                    $ai_span_id: spanId,
-                    $ai_parent_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_input_state: inputState,
-                    $ai_output_state: outputState,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
                 return [
                     {
                         type: 'text',
@@ -276,35 +218,8 @@ export class MCP extends McpAgent<Env> {
                 ]
             }
 
-            await this.trackEvent(AnalyticsEvent.MCP_TOOL_CALL, {
-                tool: tool.name,
-                valid_input: true,
-            })
-
             try {
                 const result = await handler(params)
-                const latency = (performance.now() - startTime) / 1000
-                const outputState = result
-
-                await this.trackEvent(AnalyticsEvent.MCP_TOOL_RESPONSE, {
-                    tool: tool.name,
-                })
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    ai_product: 'mcp',
-                })
-                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
-                    $ai_trace_id: traceId,
-                    $ai_span_id: spanId,
-                    $ai_parent_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_input_state: inputState,
-                    $ai_output_state: outputState,
-                    $ai_latency: latency,
-                    ai_product: 'mcp',
-                })
 
                 // For tools with UI resources, include structuredContent for better UI rendering
                 // structuredContent is not added to model context, only used by UI apps
@@ -336,27 +251,6 @@ export class MCP extends McpAgent<Env> {
                     ...(hasUiResource ? { structuredContent } : {}),
                 }
             } catch (error: any) {
-                const latency = (performance.now() - startTime) / 1000
-                const errorMessage = error instanceof Error ? error.message : String(error)
-                const outputState = { error: errorMessage }
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
-                await this.trackEvent(AnalyticsEvent.AI_SPAN, {
-                    $ai_trace_id: traceId,
-                    $ai_span_id: spanId,
-                    $ai_parent_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_input_state: inputState,
-                    $ai_output_state: outputState,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
                 const distinctId = await this.getDistinctId()
                 return handleToolError(
                     error,
@@ -444,5 +338,21 @@ export class MCP extends McpAgent<Env> {
             const typedTool = tool as Tool<z.ZodObject>
             this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
         }
+
+        initMcpCatObservability(this.server, {
+            getDistinctId: () => this.getDistinctId(),
+            getSessionUuid: async () =>
+                this.requestProperties.sessionId
+                    ? this.sessionManager.getSessionUuid(this.requestProperties.sessionId)
+                    : undefined,
+            getMcpClientName: () => this._mcpClientName,
+            getMcpClientVersion: () => this._mcpClientVersion,
+            getMcpProtocolVersion: () => this._mcpProtocolVersion,
+            getRegion: () => this.requestProperties.region,
+            getOrganizationId: () => this.requestProperties.organizationId,
+            getProjectId: () => this.requestProperties.projectId,
+            getClientUserAgent: () => this.requestProperties.clientUserAgent,
+            getVersion: () => this.requestProperties.version,
+        })
     }
 }

--- a/services/mcp/tests/setup.ts
+++ b/services/mcp/tests/setup.ts
@@ -5,6 +5,11 @@ import { vi } from 'vitest'
 // Load .env.test file
 config({ path: resolve(process.cwd(), '.env.test') })
 
+// Mock mcpcat module to not do anything in tests
+vi.mock('mcpcat', () => ({
+    track: vi.fn(),
+}))
+
 // Mock cloudflare:workers module for Node.js test environment
 vi.mock('cloudflare:workers', () => ({
     env: {

--- a/services/mcp/tests/unit/mcpcat.test.ts
+++ b/services/mcp/tests/unit/mcpcat.test.ts
@@ -1,0 +1,130 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { track } from 'mcpcat'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { initMcpCatObservability, type McpCatIdentityProvider } from '@/lib/mcpcat'
+
+describe('initMcpCatObservability', () => {
+    beforeEach(() => {
+        vi.mocked(track).mockClear()
+    })
+
+    function createMockIdentity(overrides: Partial<McpCatIdentityProvider> = {}): McpCatIdentityProvider {
+        return {
+            getDistinctId: vi.fn().mockResolvedValue('user-123'),
+            getSessionUuid: vi.fn().mockResolvedValue('session-uuid-456'),
+            getMcpClientName: vi.fn().mockReturnValue('claude-code'),
+            getMcpClientVersion: vi.fn().mockReturnValue('1.2.3'),
+            getMcpProtocolVersion: vi.fn().mockReturnValue('2024-11-05'),
+            getRegion: vi.fn().mockReturnValue('us'),
+            getOrganizationId: vi.fn().mockReturnValue('org-789'),
+            getProjectId: vi.fn().mockReturnValue('proj-101'),
+            getClientUserAgent: vi.fn().mockReturnValue('test-agent/1.0'),
+            getVersion: vi.fn().mockReturnValue(2),
+            ...overrides,
+        }
+    }
+
+    it('calls mcpcat.track with null projectId and correct options', () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        initMcpCatObservability(server, identity)
+
+        expect(track).toHaveBeenCalledWith(
+            server,
+            null,
+            expect.objectContaining({
+                enableReportMissing: false,
+                enableToolCallContext: false,
+                enableTracing: true,
+                identify: expect.any(Function),
+                exporters: {
+                    posthog: {
+                        type: 'posthog',
+                        apiKey: 'sTMFPsFhdP1Ssg',
+                        host: 'https://us.i.posthog.com',
+                    },
+                },
+            })
+        )
+    })
+
+    function getIdentifyCallback(): () => Promise<unknown> {
+        const call = vi.mocked(track).mock.calls[0]!
+        const options = call[2] as { identify: () => Promise<unknown> }
+        return options.identify
+    }
+
+    it('identify callback resolves identity from provider', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        initMcpCatObservability(server, identity)
+
+        const result = await getIdentifyCallback()()
+
+        expect(result).toEqual({
+            userId: 'user-123',
+            userData: {
+                $session_id: 'session-uuid-456',
+                mcp_client_name: 'claude-code',
+                mcp_client_version: '1.2.3',
+                mcp_protocol_version: '2024-11-05',
+                region: 'us',
+                organization_id: 'org-789',
+                project_id: 'proj-101',
+                client_user_agent: 'test-agent/1.0',
+                mcp_version: 2,
+            },
+        })
+    })
+
+    it('identify callback skips undefined properties in userData', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity({
+            getSessionUuid: vi.fn().mockResolvedValue(undefined),
+            getMcpClientName: vi.fn().mockReturnValue(undefined),
+            getMcpClientVersion: vi.fn().mockReturnValue(undefined),
+            getMcpProtocolVersion: vi.fn().mockReturnValue(undefined),
+            getRegion: vi.fn().mockReturnValue(undefined),
+            getOrganizationId: vi.fn().mockReturnValue(undefined),
+            getProjectId: vi.fn().mockReturnValue(undefined),
+            getClientUserAgent: vi.fn().mockReturnValue(undefined),
+            getVersion: vi.fn().mockReturnValue(undefined),
+        })
+
+        initMcpCatObservability(server, identity)
+
+        const result = await getIdentifyCallback()()
+
+        expect(result).toEqual({
+            userId: 'user-123',
+            userData: {},
+        })
+    })
+
+    it('identify callback returns null when provider throws', async () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity({
+            getDistinctId: vi.fn().mockRejectedValue(new Error('auth failed')),
+        })
+
+        initMcpCatObservability(server, identity)
+
+        const result = await getIdentifyCallback()()
+
+        expect(result).toBeNull()
+    })
+
+    it('swallows errors if mcpcat.track throws', () => {
+        const server = new McpServer({ name: 'test', version: '1.0.0' })
+        const identity = createMockIdentity()
+
+        vi.mocked(track).mockImplementationOnce(() => {
+            throw new Error('mcpcat init failed')
+        })
+
+        expect(() => initMcpCatObservability(server, identity)).not.toThrow()
+    })
+})


### PR DESCRIPTION
## Problem

The MCP service needs better observability and analytics tracking for tool calls and server operations. The current custom analytics implementation is tightly coupled to the tool registration logic and lacks comprehensive tracing capabilities.

## Changes

- Added `mcpcat` dependency (^0.1.13) for standardized MCP observability
- Replaced custom analytics tracking with mcpcat's built-in observability features
- Removed manual event tracking code from tool registration handlers
- Created new `mcpcat.ts` module with identity provider interface and initialization logic
- Simplified tool registration by removing embedded analytics calls
- Added comprehensive test coverage for the new mcpcat integration
- Configured mcpcat with PostHog exporter and proper identity resolution

The new implementation provides automatic tracing and analytics without cluttering the core tool execution logic, while maintaining all the same tracking capabilities through the mcpcat library.

## How did you test this code?

Added unit tests for the mcpcat integration covering:
- Proper initialization with correct configuration
- Identity resolution with all user/session properties
- Graceful handling of undefined properties
- Error handling when identity providers fail
- Resilient initialization that doesn't break server startup

The tests verify that mcpcat is called with the expected parameters and that the identity callback correctly maps all available properties while handling edge cases.

## Publish to changelog?

No