### PR TITLE
fix(hogli): fix zsh completion breaking on apostrophes

### DIFF
--- a/common/hogli/core/completion.py
+++ b/common/hogli/core/completion.py
@@ -50,7 +50,7 @@ def generate_zsh_completion(cli_name: str = "hogli") -> str:
             desc = cmd_config.get("description", "")
             # Escape special characters for zsh
             desc = desc.replace("[", "\\[").replace("]", "\\]")
-            desc = desc.replace("'", "\\'")
+            desc = desc.replace("'", "'\"'\"'")
 
         # Escape colons in command name for zsh completion format
         escaped_cmd = cmd.replace(":", "\\:")


### PR DESCRIPTION
Zsh single-quoted strings don't support backslash escapes — `\'` just ends the string early, causing `_hogli:150: unmatched '` on tab complete.

Two manifest commands have apostrophes in their descriptions (`dev:api-key` and `posthog:hobby-installer-linux`). Switched to the POSIX `'"'"'` idiom.