### PR TITLE
feat(signals): support session problem signals in inbox UI

### DIFF
--- a/frontend/src/scenes/inbox/SignalCard.tsx
+++ b/frontend/src/scenes/inbox/SignalCard.tsx
@@ -17,16 +17,31 @@ import type {
     ErrorTrackingSignalExtra,
     GithubIssueSignalExtra,
     LlmEvalSignalExtra,
+    SessionProblemSignalExtra,
     SessionSegmentClusterSignalExtra,
     ZendeskTicketSignalExtra,
 } from '~/queries/schema/schema-signals'
 
+const PROBLEM_TYPE_LABELS: Record<
+    SessionProblemSignalExtra['problem_type'],
+    { label: string; type: 'danger' | 'warning' }
+> = {
+    blocking_exception: { label: 'Blocking exception', type: 'danger' },
+    non_blocking_exception: { label: 'Non-blocking exception', type: 'warning' },
+    abandonment: { label: 'Abandonment', type: 'danger' },
+    confusion: { label: 'Confusion', type: 'warning' },
+    failure: { label: 'Failure', type: 'danger' },
+}
+
 export function SignalCard({ signal }: { signal: SignalNode }): JSX.Element {
+    if (isSessionProblemExtra(signal.extra)) {
+        return <SessionProblemSignalCard signal={signal} extra={signal.extra} />
+    }
     if (signal.source_product === 'error_tracking' && isErrorTrackingExtra(signal.extra)) {
         return <ErrorTrackingSignalCard signal={signal} extra={signal.extra} />
     }
     if (isSessionReplayExtra(signal.extra)) {
-        return <SessionReplaySignalCard signal={signal} extra={signal.extra} />
+        return <SessionSegmentClusterSignalCard signal={signal} extra={signal.extra} />
     }
     if (isGithubIssueExtra(signal.extra)) {
         return <GithubIssueSignalCard signal={signal} extra={signal.extra} />
@@ -40,7 +55,7 @@ export function SignalCard({ signal }: { signal: SignalNode }): JSX.Element {
     return <GenericSignalCard signal={signal} />
 }
 
-function SessionReplaySignalCard({
+function SessionSegmentClusterSignalCard({
     signal,
     extra,
 }: {
@@ -119,6 +134,55 @@ function SessionReplaySignalCard({
                     )}
                 </>
             )}
+        </div>
+    )
+}
+
+function SessionProblemSignalCard({
+    signal,
+    extra,
+}: {
+    signal: SignalNode
+    extra: SessionProblemSignalExtra
+}): JSX.Element {
+    const problemInfo = PROBLEM_TYPE_LABELS[extra.problem_type] ?? {
+        label: extra.problem_type,
+        type: 'warning' as const,
+    }
+
+    return (
+        <div className="border rounded p-3 bg-surface-primary">
+            <SignalCardHeader signal={signal} label={extra.segment_title} />
+
+            {signal.content && <LemonMarkdown className="text-sm text-secondary mb-2">{signal.content}</LemonMarkdown>}
+
+            <div className="flex items-center gap-2 text-xs text-tertiary mb-2">
+                <LemonTag size="small" type={problemInfo.type}>
+                    {problemInfo.label}
+                </LemonTag>
+            </div>
+
+            <div className="border rounded p-2 bg-surface-secondary">
+                <div className="flex items-start gap-2">
+                    <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 text-xs text-tertiary">
+                            <span className="font-mono">{extra.distinct_id.slice(0, 10)}...</span>
+                            <span>·</span>
+                            <span>
+                                {extra.start_time} – {extra.end_time}
+                            </span>
+                        </div>
+                    </div>
+                    <ViewRecordingButton
+                        sessionId={extra.session_id}
+                        timestamp={extra.session_start_time}
+                        openPlayerIn={RecordingPlayerType.Modal}
+                        size="xsmall"
+                        type="secondary"
+                        label="Play"
+                    />
+                </div>
+            </div>
         </div>
     )
 }
@@ -285,6 +349,12 @@ function SignalCardHeader({ signal, label }: { signal: SignalNode; label?: strin
             </LemonTag>
         </div>
     )
+}
+
+function isSessionProblemExtra(
+    extra: Record<string, unknown>
+): extra is Record<string, unknown> & SessionProblemSignalExtra {
+    return 'session_id' in extra && 'problem_type' in extra && 'segment_title' in extra
 }
 
 function isSessionReplayExtra(

--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -126,12 +126,12 @@ function isNonEmptyFilters(obj: unknown): boolean {
     return obj != null && typeof obj === 'object' && Object.keys(obj as Record<string, unknown>).length > 0
 }
 
-function ClusteringStatusIndicator({ status }: { status: SignalSourceConfigStatus | null }): JSX.Element | null {
+function AnalysisStatusIndicator({ status }: { status: SignalSourceConfigStatus | null }): JSX.Element | null {
     if (status === SignalSourceConfigStatus.RUNNING) {
         return (
             <div className="mt-2 flex items-center gap-2 rounded bg-accent-light text-xs text-accent">
                 <Spinner className="size-3.5" />
-                <span>Session analysis run in progress now… (est. 30 min)</span>
+                <span>Session analysis in progress…</span>
             </div>
         )
     }
@@ -171,7 +171,7 @@ export function SourcesList(): JSX.Element {
                     </div>
                 }
                 title="PostHog Session Replay"
-                description="Session recordings + event data → Signals"
+                description="Issues detected in session recordings → Signals"
                 variant="available"
                 checked={!!sessionAnalysisConfig?.enabled}
                 loading={isSessionAnalysisToggling}
@@ -188,7 +188,7 @@ export function SourcesList(): JSX.Element {
                     ),
                 }}
                 onClearClick={hasNonEmptyFilters ? clearSessionAnalysisFilters : undefined}
-                statusSection={<ClusteringStatusIndicator status={sessionAnalysisConfig?.status ?? null} />}
+                statusSection={<AnalysisStatusIndicator status={sessionAnalysisConfig?.status ?? null} />}
             />
 
             <Source

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -26,13 +26,13 @@ const REPORTS_PAGE_SIZE = 200
 
 export type DetailTab = 'overview' | 'signals'
 
-const CLUSTERING_POLL_INTERVAL_MS = 5000
+const ANALYSIS_POLL_INTERVAL_MS = 5000
 
 export const inboxSceneLogic = kea<inboxSceneLogicType>([
     path(['scenes', 'inbox', 'inboxSceneLogic']),
 
     connect({
-        values: [signalSourcesLogic, ['hasNoSources', 'isClusteringRunning']],
+        values: [signalSourcesLogic, ['hasNoSources', 'isAnalysisRunning']],
         actions: [signalSourcesLogic, ['loadSourceConfigs']],
     }),
 
@@ -258,12 +258,12 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             }
         },
         loadSourceConfigsSuccess: () => {
-            clearInterval(cache.clusteringPollInterval)
-            if (values.isClusteringRunning) {
-                cache.clusteringPollInterval = setInterval(() => {
+            clearInterval(cache.analysisPollInterval)
+            if (values.isAnalysisRunning) {
+                cache.analysisPollInterval = setInterval(() => {
                     actions.loadSourceConfigs()
                     actions.loadReports()
-                }, CLUSTERING_POLL_INTERVAL_MS)
+                }, ANALYSIS_POLL_INTERVAL_MS)
             }
         },
         runSessionAnalysis: async () => {
@@ -287,7 +287,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             actions.loadReports()
         },
         beforeUnmount: () => {
-            clearInterval(cache.clusteringPollInterval)
+            clearInterval(cache.analysisPollInterval)
         },
     })),
 

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -277,7 +277,7 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 })
             },
         ],
-        isClusteringRunning: [
+        isAnalysisRunning: [
             (s) => [s.sessionAnalysisConfig],
             (config: SignalSourceConfig | null): boolean => config?.status === SignalSourceConfigStatus.RUNNING,
         ],


### PR DESCRIPTION
## Problem

Edit: Closing this PR as the Cloud UI is not a priority, the Code one is.

Session problem signals emitted by the new per-session pipeline (PR #50596) need a dedicated card in the inbox UI.
The existing `SessionSegmentClusterSignalCard` renders cluster-based signals with segment lists, but session problem signals have a different shape — they represent a single problem-indicating segment with a problem type classification.

## Changes

- Add `SessionProblemSignalCard` with color-coded problem type badges (danger for blocking exceptions/abandonment/failure, warning for non-blocking exceptions/confusion) and a session replay play button
- Keep legacy `SessionSegmentClusterSignalCard` for rendering old cluster-based signals
- Rename clustering-related UI references to "analysis" (`AnalysisStatusIndicator`, `isAnalysisRunning`) since the workflow now does more than just clustering

## How did you test this code?

Agent-authored. No manual testing performed — reviewers should verify:

- New session problem signals render with correct problem type badges and play button
- Old cluster-based signals still render with the legacy card
- Analysis status indicator shows correctly in the sources list

## Publish to changelog?

no

## Docs update

n/a

## 🤖 LLM context

Restacked onto master which refactored the `Source` component props (config object pattern) and added error tracking source support. Conflict resolution kept master's prop format while applying the branch's AnalysisStatusIndicator rename.