### PR TITLE
fix(data-warehouse): filter postgres schema queries by table name

### DIFF
--- a/posthog/temporal/data_imports/sources/ashby/source.py
+++ b/posthog/temporal/data_imports/sources/ashby/source.py
@@ -42,7 +42,9 @@ class AshbySource(SimpleSource[AshbySourceConfig]):
         # and if not, returns an error message to return to the user
         raise NotImplementedError()
 
-    def get_schemas(self, config: AshbySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: AshbySourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         raise NotImplementedError()
 
     def source_for_pipeline(self, config: AshbySourceConfig, inputs: SourceInputs) -> SourceResponse:

--- a/posthog/temporal/data_imports/sources/attio/source.py
+++ b/posthog/temporal/data_imports/sources/attio/source.py
@@ -67,7 +67,9 @@ You can generate an API key in your Attio workspace settings. Check out [this gu
             featureFlag="dwh_attio",
         )
 
-    def get_schemas(self, config: AttioSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: AttioSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         # Attio API doesn't support updatedAt filtering, so only full refresh is supported
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -44,7 +44,13 @@ class BigQuerySource(SimpleSource[BigQuerySourceConfig]):
             "NotFound: 404": "BigQuery dataset or table not found. Please verify your project, dataset, and table names.",
         }
 
-    def get_schemas(self, config: BigQuerySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: BigQuerySourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         bq_schemas = get_bigquery_schemas(
             config,
             logger=None,

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -70,7 +70,13 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate Bing Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: BingAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: BingAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         bing_ads_schemas = get_schemas()
         ads_incremental_fields = get_incremental_fields()
 

--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -35,7 +35,11 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
         }
 
     def get_schemas(
-        self, config: BuildBetterSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: BuildBetterSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -35,7 +35,13 @@ class ChargebeeSource(SimpleSource[ChargebeeSourceConfig]):
             "Unauthorized for url": "Chargebee authentication failed. Please check your API key and site name.",
         }
 
-    def get_schemas(self, config: ChargebeeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: ChargebeeSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -54,7 +54,9 @@ The secret key starts with `sk_live_`.
             ),
         )
 
-    def get_schemas(self, config: ClerkSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: ClerkSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         # Clerk only supports full refresh - the API doesn't support filtering by updated_at
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -67,7 +67,9 @@ class _BaseSource(ABC, Generic[ConfigType]):
 
         return {}
 
-    def get_schemas(self, config: ConfigType, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: ConfigType, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         raise NotImplementedError()
 
     @property

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -43,7 +43,11 @@ class CustomerIOSource(SimpleSource[CustomerIOSourceConfig]):
         raise NotImplementedError()
 
     def get_schemas(
-        self, config: CustomerIOSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: CustomerIOSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         raise NotImplementedError()
 

--- a/posthog/temporal/data_imports/sources/doit/source.py
+++ b/posthog/temporal/data_imports/sources/doit/source.py
@@ -23,7 +23,9 @@ class DoItSource(SimpleSource[DoItSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DOIT
 
-    def get_schemas(self, config: DoItSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: DoItSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         reports = doit_list_reports(config)
 
         return [

--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -121,7 +121,9 @@ class GithubSource(SimpleSource[GithubSourceConfig], OAuthMixin):
             raise ValueError("GitHub access token not found")
         return integration.access_token
 
-    def get_schemas(self, config: GithubSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: GithubSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -55,6 +55,7 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
         config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig,
         team_id: int,
         with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         google_ads_schemas = get_google_ads_schemas(
             config,

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -39,7 +39,11 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         }
 
     def get_schemas(
-        self, config: GoogleSheetsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: GoogleSheetsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         sheets = get_google_sheets_schemas(config)
 

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -65,7 +65,11 @@ class HubspotSource(SimpleSource[HubspotSourceConfig | HubspotSourceOldConfig], 
         return HubspotSourceOldConfig.from_dict(job_inputs)
 
     def get_schemas(
-        self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int, with_counts: bool = False
+        self,
+        config: HubspotSourceConfig | HubspotSourceOldConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -63,7 +63,13 @@ Make sure to grant the following read permissions:
             featureFlag="dwh_klaviyo",
         )
 
-    def get_schemas(self, config: KlaviyoSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: KlaviyoSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         # Events are immutable - append-only is the only sync mode
         append_only_endpoints = {"events"}
 

--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -66,7 +66,9 @@ class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
             raise ValueError("Linear access token not found")
         return integration.access_token
 
-    def get_schemas(self, config: LinearSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: LinearSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -82,7 +82,11 @@ class LinkedInAdsSource(SimpleSource[LinkedinAdsSourceConfig]):
             return False, f"Failed to validate LinkedIn Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: LinkedinAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: LinkedinAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         linkedin_ads_schemas = get_linkedin_ads_schemas()
         ads_incremental_fields = get_linkedin_ads_incremental_fields()

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -62,7 +62,13 @@ The API key format is: `key-dc` (e.g., `abc123def456-us6`), where `dc` is the da
             "Invalid Mailchimp API key format": "Invalid API key format. Expected format: key-dc (e.g., abc123-us6)",
         }
 
-    def get_schemas(self, config: MailchimpSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: MailchimpSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -32,7 +32,13 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
             "cannot be loaded due to missing permissions": None,
         }
 
-    def get_schemas(self, config: MetaAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: MetaAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -35,7 +35,13 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {"The DNS query name does not exist": None, "authentication failed": None, "SSL handshake failed": None}
 
-    def get_schemas(self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: MongoDBSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         mongo_schemas = get_mongo_schemas(config, team_id=team_id)
 
         connection_params = _parse_connection_string(config.connection_string)

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -99,7 +99,9 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
             ),
         )
 
-    def get_schemas(self, config: MSSQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: MSSQLSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -111,7 +111,9 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
             "Bad handshake": None,
         }
 
-    def get_schemas(self, config: MySQLSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: MySQLSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -80,7 +80,11 @@ class PinterestAdsSource(SimpleSource[PinterestAdsSourceConfig], OAuthMixin):
             return False, f"Failed to validate Pinterest Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: PinterestAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: PinterestAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -140,7 +140,14 @@ def get_postgres_row_count(
 
 
 def get_schemas(
-    host: str, database: str, user: str, password: str, schema: str, port: int, require_ssl: bool = False
+    host: str,
+    database: str,
+    user: str,
+    password: str,
+    schema: str,
+    port: int,
+    require_ssl: bool = False,
+    table_names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Get all tables from PostgreSQL source schemas to sync."""
 
@@ -166,12 +173,19 @@ def get_schemas(
             ) from e
         raise
 
+    table_filter = ""
+    params: dict[str, Any] = {"schema": schema}
+    if table_names is not None:
+        table_filter = " AND table_name = ANY(%(table_names)s)"
+        params["table_names"] = table_names
+
     with connection.cursor() as cursor:
+        cursor.execute(sql.SQL("SET LOCAL statement_timeout = {timeout}").format(timeout=sql.Literal(1000 * 30)))
         cursor.execute(
-            """
+            f"""
             SELECT * FROM (
                 SELECT table_name, column_name, data_type, is_nullable FROM information_schema.columns
-                WHERE table_schema = %(schema)s
+                WHERE table_schema = %(schema)s{table_filter}
                 UNION ALL
                 SELECT
                     c.relname AS table_name,
@@ -181,13 +195,14 @@ def get_schemas(
                 FROM pg_class c
                 JOIN pg_namespace n ON c.relnamespace = n.oid
                 JOIN pg_attribute a ON a.attrelid = c.oid
-                WHERE c.relkind = 'm'  -- materialized view
+                WHERE c.relkind = 'm'
                 AND n.nspname = %(schema)s
                 AND a.attnum > 0
                 AND NOT a.attisdropped
+                {"AND c.relname = ANY(%(table_names)s)" if table_names is not None else ""}
             ) t
             ORDER BY table_name ASC""",
-            {"schema": schema},
+            params,
         )
         result = cursor.fetchall()
 
@@ -201,7 +216,14 @@ def get_schemas(
 
 
 def get_foreign_keys(
-    host: str, database: str, user: str, password: str, schema: str, port: int, require_ssl: bool = False
+    host: str,
+    database: str,
+    user: str,
+    password: str,
+    schema: str,
+    port: int,
+    require_ssl: bool = False,
+    table_names: list[str] | None = None,
 ) -> dict[str, list[tuple[str, str, str]]]:
     """Get foreign keys for tables in the selected PostgreSQL schema."""
 
@@ -227,9 +249,16 @@ def get_foreign_keys(
             ) from e
         raise
 
+    table_filter = ""
+    params: dict[str, Any] = {"schema": schema}
+    if table_names is not None:
+        table_filter = " AND tc.table_name = ANY(%(table_names)s)"
+        params["table_names"] = table_names
+
     with connection.cursor() as cursor:
+        cursor.execute(sql.SQL("SET LOCAL statement_timeout = {timeout}").format(timeout=sql.Literal(1000 * 30)))
         cursor.execute(
-            """
+            f"""
             SELECT
                 tc.table_name AS table_name,
                 kcu.column_name AS column_name,
@@ -244,10 +273,10 @@ def get_foreign_keys(
                 AND ccu.table_schema = tc.table_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_schema = %(schema)s
-              AND ccu.table_schema = %(schema)s
+              AND ccu.table_schema = %(schema)s{table_filter}
             ORDER BY tc.table_name, kcu.ordinal_position
             """,
-            {"schema": schema},
+            params,
         )
         result = cursor.fetchall()
 

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -146,7 +146,13 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
             "No space left on device": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
         }
 
-    def get_schemas(self, config: PostgresSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: PostgresSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):
@@ -157,6 +163,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                table_names=table_names,
             )
             db_foreign_keys = get_postgres_foreign_keys(
                 host=host,
@@ -165,6 +172,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
                 password=config.password,
                 database=config.database,
                 schema=config.schema,
+                table_names=table_names,
             )
 
             if with_counts:

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -72,7 +72,13 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate Reddit Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: RedditAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: RedditAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -135,7 +135,13 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
             "Connection refused": None,
         }
 
-    def get_schemas(self, config: RedshiftSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: RedshiftSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         schemas = []
 
         with self.with_ssh_tunnel(config) as (host, port):

--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -35,7 +35,11 @@ class SalesforceSource(SimpleSource[SalesforceSourceConfig], OAuthMixin):
         }
 
     def get_schemas(
-        self, config: SalesforceSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: SalesforceSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -81,7 +81,13 @@ class ShopifySource(SimpleSource[ShopifySourceConfig]):
         except Exception as e:
             return False, str(e)
 
-    def get_schemas(self, config: ShopifySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: ShopifySourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         schemas = []
         for obj in SHOPIFY_GRAPHQL_OBJECTS.values():
             endpoint_config = ENDPOINT_CONFIGS.get(obj.name)

--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -72,7 +72,11 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             return False, f"Failed to validate Snapchat Ads credentials: {str(e)}"
 
     def get_schemas(
-        self, config: SnapchatAdsSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: SnapchatAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -162,7 +162,13 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",
         }
 
-    def get_schemas(self, config: SnowflakeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: SnowflakeSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         schemas = []
 
         db_schemas = get_snowflake_schemas(config)

--- a/posthog/temporal/data_imports/sources/source.template
+++ b/posthog/temporal/data_imports/sources/source.template
@@ -73,7 +73,7 @@ class TemplateSource(SimpleSource[Config]):  # rename this class and replace `Co
         )  # implement logic to validate the credentials of your source, e.g. check the validity of API keys. return a tuple of whether the credentials are valid, and if not, return an error message to return to the user
 
     def get_schemas(
-        self, config: Config, team_id: int, with_counts: bool = False
+        self, config: Config, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
     ) -> list[SourceSchema]:  # replace `Config` with the generated class
         return []  # implement your source logic
 

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -143,7 +143,9 @@ These permissions are automatically pre-filled in the API key creation form if y
             "PermissionError": "Your API key does not have permissions to access endpoint. Please check your API key configuration and permissions in Stripe, then try again.",
         }
 
-    def get_schemas(self, config: StripeSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self, config: StripeSourceConfig, team_id: int, with_counts: bool = False, table_names: list[str] | None = None
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -31,7 +31,11 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
         return ExternalDataSourceType.TEMPORALIO
 
     def get_schemas(
-        self, config: TemporalIOSourceConfig, team_id: int, with_counts: bool = False
+        self,
+        config: TemporalIOSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
     ) -> list[SourceSchema]:
         return [
             SourceSchema(

--- a/posthog/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/source.py
@@ -69,7 +69,13 @@ class TikTokAdsSource(SimpleSource[TikTokAdsSourceConfig], OAuthMixin):
             capture_exception(e)
             return False, f"Failed to validate TikTok Ads credentials: {str(e)}"
 
-    def get_schemas(self, config: TikTokAdsSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: TikTokAdsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=str(endpoint_config.resource["name"]),

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -33,7 +33,13 @@ class VitallySource(SimpleSource[VitallySourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.VITALLY
 
-    def get_schemas(self, config: VitallySourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: VitallySourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -38,7 +38,13 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             "401 Client Error": "Zendesk authentication failed. Please check your API token and subdomain.",
         }
 
-    def get_schemas(self, config: ZendeskSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
+    def get_schemas(
+        self,
+        config: ZendeskSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        table_names: list[str] | None = None,
+    ) -> list[SourceSchema]:
         return [
             SourceSchema(
                 name=endpoint,

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -17,7 +17,6 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, changes_between, log_activity
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.temporal.data_imports.sources import SourceRegistry
-from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 
 from products.data_warehouse.backend.data_load.service import (
     cancel_external_data_workflow,
@@ -367,12 +366,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": str(e)},
             )
 
-        schema: SourceSchema | None = None
-
-        for s in schemas:
-            if s.name == instance.name:
-                schema = s
-                break
+        schema = next((s for s in schemas if s.name == instance.name), None)
 
         if schema is None:
             return Response(

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -359,7 +359,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         try:
-            schemas = new_source.get_schemas(config, self.team_id)
+            schemas = new_source.get_schemas(config, self.team_id, table_names=[instance.name])
         except Exception as e:
             capture_exception(e)
             return Response(


### PR DESCRIPTION
## Problem

When re-syncing a single schema via the `incremental_fields` endpoint, we were querying **all tables** from the remote Postgres `information_schema` and foreign key metadata .

## Changes

  * Added `table_names: list[str] | None` parameter to `_BaseSource.get_schemas` and all source subclass overrides
  * Added `table_names` filtering to `get_schemas()` and `get_foreign_keys()` in `postgres.py` —> filters both `information_schema.columns` and materialized view queries via `ANY(%(table_names)s)`
  * Added 30-second `SET LOCAL statement_timeout` to Postgres schema and foreign key queries to prevent long-running queries on source databases
  * Updated `ExternalDataSchemaViewset.resync_schema` to pass `table_names=[instance.name]` so only the relevant table is queried
  * Updated `source.template` for new source scaffolding

## How did you test this code?

Local run of postgres pipeline and googleads (to try another source type)
Test pass

## Publish to changelog?

NO
