### PR TITLE
fix(mcp): build ui-apps before wrangler deploy

### DIFF
--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -7,7 +7,7 @@
     "name": "mcp1",
     "main": "src/index.ts",
     "build": {
-        "command": "npx tsx scripts/copy-instructions.ts",
+        "command": "pnpm run build:ui-apps && npx tsx scripts/copy-instructions.ts",
         "watch_dir": "src",
     },
     "compatibility_date": "2025-03-10",


### PR DESCRIPTION
## Problem

The wrangler build command in `wrangler.jsonc` only ran `copy-instructions.ts` but did not build the UI apps first. Since `ui-apps-dist/` is gitignored and generated by `build:ui-apps`, the wrangler deploy would fail with ENOENT errors when any new UI app was added (e.g., survey, workflow, llm-costs) because the built HTML files didn't exist.

## Changes

Chain `pnpm run build:ui-apps` before `copy-instructions.ts` in the wrangler build command so that all UI app HTML files are generated before wrangler bundles the worker.

## How did you test this code?

Ran `npx wrangler deploy --dry-run` — all 21 UI apps built successfully and the dry-run completed without errors.

## Publish to changelog?

no