### PR TITLE
fix(mcp): build ui-apps before wrangler deploy

### DIFF
--- a/services/mcp/scripts/build-ui-apps.ts
+++ b/services/mcp/scripts/build-ui-apps.ts
@@ -96,23 +96,31 @@ function buildAppSync(appName: string): void {
     })
 }
 
-async function buildAllAppsParallel(apps: string[], concurrency = 4): Promise<void> {
-    console.info(`\n📦 Building ${apps.length} apps (concurrency: ${concurrency})...`)
-    const remaining = [...apps]
-    const results: Promise<void>[] = []
+async function buildAllAppsParallel(apps: string[]): Promise<void> {
+    // CI environments have limited memory — limit concurrency to avoid OOM kills
+    const concurrency = process.env.CI ? 4 : apps.length
 
-    async function next(): Promise<void> {
-        while (remaining.length > 0) {
-            const app = remaining.shift()!
-            await buildAppAsync(app)
+    if (concurrency < apps.length) {
+        console.info(`\n📦 Building ${apps.length} apps (concurrency: ${concurrency})...`)
+        const remaining = [...apps]
+        const workers: Promise<void>[] = []
+
+        async function next(): Promise<void> {
+            while (remaining.length > 0) {
+                const app = remaining.shift()!
+                await buildAppAsync(app)
+            }
         }
-    }
 
-    for (let i = 0; i < Math.min(concurrency, apps.length); i++) {
-        results.push(next())
-    }
+        for (let i = 0; i < concurrency; i++) {
+            workers.push(next())
+        }
 
-    await Promise.all(results)
+        await Promise.all(workers)
+    } else {
+        console.info(`\n📦 Building ${apps.length} apps in parallel...`)
+        await Promise.all(apps.map((app) => buildAppAsync(app)))
+    }
 }
 
 function watchApps(apps: string[]): void {

--- a/services/mcp/scripts/build-ui-apps.ts
+++ b/services/mcp/scripts/build-ui-apps.ts
@@ -96,9 +96,23 @@ function buildAppSync(appName: string): void {
     })
 }
 
-async function buildAllAppsParallel(apps: string[]): Promise<void> {
-    console.info(`\n📦 Building ${apps.length} apps in parallel...`)
-    await Promise.all(apps.map((app) => buildAppAsync(app)))
+async function buildAllAppsParallel(apps: string[], concurrency = 4): Promise<void> {
+    console.info(`\n📦 Building ${apps.length} apps (concurrency: ${concurrency})...`)
+    const remaining = [...apps]
+    const results: Promise<void>[] = []
+
+    async function next(): Promise<void> {
+        while (remaining.length > 0) {
+            const app = remaining.shift()!
+            await buildAppAsync(app)
+        }
+    }
+
+    for (let i = 0; i < Math.min(concurrency, apps.length); i++) {
+        results.push(next())
+    }
+
+    await Promise.all(results)
 }
 
 function watchApps(apps: string[]): void {

--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -7,7 +7,7 @@
     "name": "mcp1",
     "main": "src/index.ts",
     "build": {
-        "command": "pnpm run build:ui-apps && npx tsx scripts/copy-instructions.ts",
+        "command": "npx tsx scripts/copy-instructions.ts",
         "watch_dir": "src",
     },
     "compatibility_date": "2025-03-10",


### PR DESCRIPTION
## Problem

The wrangler build command only ran `copy-instructions.ts` but never built the UI apps. Since `ui-apps-dist/` is gitignored, wrangler deploy would fail with ENOENT errors whenever new UI apps were added (survey, workflow, llm-costs, etc.) because the built HTML files didn't exist.

Additionally, building all 21 Vite+React apps in parallel caused OOM kills (exit code 137) in CI.

## Changes

- Chain `pnpm run build:ui-apps` before `copy-instructions.ts` in the wrangler build command so UI app HTML files are always generated before bundling
- Limit build concurrency to 4 parallel Vite processes to avoid OOM in CI

## How did you test this code?

Ran `npx wrangler deploy --dry-run` — all 21 UI apps built successfully and the dry-run completed without errors.

## Publish to changelog?

no