### PR TITLE
fix(experiments): Reset active tab when navigating between experiments

### DIFF
--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -50,6 +50,7 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             'metrics' as string,
             {
                 setActiveTabKey: (_, { activeTabKey }) => activeTabKey,
+                setSceneState: () => 'metrics',
             },
         ],
         experimentId: [


### PR DESCRIPTION
## Problem
Navigating between experiments preserved the previously selected tab instead of defaulting to Metrics.

## Changes
Reset `activeTabKey` to `'metrics'` on `setSceneState`.

## How did you test this code?
Manually tested