### PR TITLE
fix(insights): breakdown column item guarded against invalid breakdowns

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -256,7 +256,7 @@ export function InsightsTable({
                 },
             })
         }
-    } else if (breakdownFilter?.breakdowns && !isSingleSeriesWithBreakdown) {
+    } else if (isValidBreakdown(breakdownFilter) && breakdownFilter?.breakdowns && !isSingleSeriesWithBreakdown) {
         breakdownFilter.breakdowns.forEach((breakdown, index) => {
             const formatItemBreakdownLabel = (item: IndexedTrendResult): string =>
                 formatBreakdownLabel(

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -215,7 +215,7 @@ export function InsightsTable({
         },
     })
 
-    if (isValidBreakdown(breakdownFilter)) {
+    if (isValidBreakdown(breakdownFilter) && breakdownFilter.breakdown) {
         if (!isSingleSeriesWithBreakdown) {
             columns.push({
                 title: (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -215,7 +215,7 @@ export function InsightsTable({
         },
     })
 
-    if (isValidBreakdown(breakdownFilter) && breakdownFilter.breakdown) {
+    if (breakdownFilter?.breakdown && isValidBreakdown(breakdownFilter)) {
         if (!isSingleSeriesWithBreakdown) {
             columns.push({
                 title: (
@@ -256,7 +256,7 @@ export function InsightsTable({
                 },
             })
         }
-    } else if (isValidBreakdown(breakdownFilter) && breakdownFilter?.breakdowns && !isSingleSeriesWithBreakdown) {
+    } else if (breakdownFilter?.breakdowns && isValidBreakdown(breakdownFilter) && !isSingleSeriesWithBreakdown) {
         breakdownFilter.breakdowns.forEach((breakdown, index) => {
             const formatItemBreakdownLabel = (item: IndexedTrendResult): string =>
                 formatBreakdownLabel(

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -215,7 +215,7 @@ export function InsightsTable({
         },
     })
 
-    if (breakdownFilter?.breakdown) {
+    if (isValidBreakdown(breakdownFilter)) {
         if (!isSingleSeriesWithBreakdown) {
             columns.push({
                 title: (


### PR DESCRIPTION
## Problem

User reported an issue where they were experiencing a `TypeError` when viewing an insight (https://posthoghelp.zendesk.com/agent/tickets/52622 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54584)), looks like we've got a case where we're trying to use `<BreakdownColumnItem.. />` but with an `undefined` `formatItemBreakdownLabel`, resulting in this issue.

Also affects another customer: https://posthoghelp.zendesk.com/agent/tickets/53163 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54980)

## Changes

Adds guards to ensure the breakdown is valid before proceeding, specifically the presence of a `breakdown_type`.

## How did you test this code?

No testing added yet at this stage

## Publish to changelog?

no