### PR TITLE
chore: Let AI preserve existing comments when refactoring or moving code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - Error handling: Prefer explicit error handling with typed errors
 - Naming: Use descriptive names, camelCase for JS/TS, snake_case for Python
 - Comments: explain _why_, not _what_ — if the reason isn't important, skip the comment
+- Comments: when refactoring or moving code, preserve existing comments unless they are explicitly made obsolete by the change
 - Python tests: do not add doc comments
 - jest tests: when writing jest tests, prefer a single top-level describe block in a file
 - Tests: prefer parameterized tests (use the `parameterized` library in Python) — if you're writing multiple assertions for variations of the same logic, it should be parameterized


### PR DESCRIPTION
## Problem

Agents frequently removed pre-existing comments while moving code around

## Changes

Add instruction to AGENTS.md

## How did you test this code?

Manually

## Publish to changelog?

No