### PR TITLE
fix: Raise non-retryable exception on missing version key

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -815,8 +815,8 @@ class SnowflakeClient:
                     "Missing one or more fields from the table's primary key, "
                     f"which are required for mutable models: {', '.join(f"'{name}'" for name in missing_primary_key_fields)}. "
                     "Please review your batch export configuration: "
-                    "- Has the model been updated without updating the target table?"
-                    "- Have you configured the correct table for this model?"
+                    "\n\t- Has the model been updated without updating the target table?"
+                    "\n\t- Have you configured the correct table for this model?"
                 )
 
             missing_version_key_fields = set(table.version_key) - existing
@@ -825,8 +825,8 @@ class SnowflakeClient:
                     "Missing one or more fields from the table's version key, "
                     f"which are required for mutable models: {', '.join(f"'{name}'" for name in missing_version_key_fields)}. "
                     "Please review your batch export configuration: "
-                    "- Has the model been updated without updating the target table?"
-                    "- Have you configured the correct table for this model?"
+                    "\n\t- Has the model been updated without updating the target table?"
+                    "\n\t- Have you configured the correct table for this model?"
                 )
 
         record_batch_field_names = {field.name.lower() for field in table.fields}

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -808,15 +808,25 @@ class SnowflakeClient:
                 raise
 
         if table.is_mutable():
-            missing_primary_key_fields = set(table.primary_key) - {
-                field_metadata.name.lower() for field_metadata in metadata
-            }
+            existing = {field_metadata.name.lower() for field_metadata in metadata}
+            missing_primary_key_fields = set(table.primary_key) - existing
             if missing_primary_key_fields:
                 raise SnowflakeIncompatibleSchemaError(
                     "Missing one or more fields from the table's primary key, "
                     f"which are required for mutable models: {', '.join(f"'{name}'" for name in missing_primary_key_fields)}. "
-                    "Please review your table's schema and model configuration. "
-                    "Has the model been updated without updating the target table?"
+                    "Please review your batch export configuration: "
+                    "- Has the model been updated without updating the target table?"
+                    "- Have you configured the correct table for this model?"
+                )
+
+            missing_version_key_fields = set(table.version_key) - existing
+            if missing_version_key_fields:
+                raise SnowflakeIncompatibleSchemaError(
+                    "Missing one or more fields from the table's version key, "
+                    f"which are required for mutable models: {', '.join(f"'{name}'" for name in missing_version_key_fields)}. "
+                    "Please review your batch export configuration: "
+                    "- Has the model been updated without updating the target table?"
+                    "- Have you configured the correct table for this model?"
                 )
 
         record_batch_field_names = {field.name.lower() for field in table.fields}

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -213,10 +213,34 @@ async def test_get_table_raises_incompatible_schema_on_missing_primary_key_field
         ),
         parents=test_table.parents,
         primary_key=("missing_key_one", "missing_key_two"),
-        version_key=("id"),
+        version_key=("id",),
     )
 
     with pytest.raises(SnowflakeIncompatibleSchemaError) as excinfo:
         await snowflake_client.get_table(table)
 
-    assert "'missing_key_one', 'missing_key_two'" in str(excinfo.value)
+    assert "'missing_key_one'" in str(excinfo.value)
+    assert "'missing_key_two'" in str(excinfo.value)
+
+
+async def test_get_table_raises_incompatible_schema_on_missing_version_key_fields(
+    snowflake_client, database, schema, test_table
+):
+    """Test attempting to get a table with missing version_key fields fails"""
+    table = SnowflakeTable(
+        name=test_table.name,
+        fields=(
+            *test_table.fields,
+            SnowflakeField("missing_key_one", SnowflakeType("INTEGER", False), pa.int64(), True),
+            SnowflakeField("missing_key_two", SnowflakeType("INTEGER", False), pa.int64(), True),
+        ),
+        parents=test_table.parents,
+        primary_key=("id",),
+        version_key=("missing_key_one", "missing_key_two"),
+    )
+
+    with pytest.raises(SnowflakeIncompatibleSchemaError) as excinfo:
+        await snowflake_client.get_table(table)
+
+    assert "'missing_key_one'" in str(excinfo.value)
+    assert "'missing_key_two'" in str(excinfo.value)


### PR DESCRIPTION
## Problem

In Snowflake batch exports, sometimes the destination table can be missing required fields. These are the table's primary key and version key for mutable models. We already check if the primary key is missing, and raise an error if it is, but we don't do the same for the version key.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Raise non-retryable error if version key is missing from destination table.
Also, update the exception message a bit.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a new unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
