### PR TITLE
fix: auto-set POSTHOG_PERSONAL_API_KEY for local development

### DIFF
--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -308,7 +308,9 @@ If you'd like to have ALL feature flags that exist in PostHog at your disposal r
 
 This command automatically turns any feature flag ending in `_EXPERIMENT` as a multivariate flag with `control` and `test` variants.
 
-Backend side flags are only evaluated locally, which requires the `POSTHOG_PERSONAL_API_KEY` env var to be set. Generate the key in [your user settings](http://localhost:8010/settings/user#personal-api-keys).
+Backend side flags are automatically configured in DEBUG mode using the
+dev API key created by `manage.py setup_local_api_key`.
+If you need to override the key, set the `POSTHOG_PERSONAL_API_KEY` env var.
 
 ## Extra: Debugging with VS Code
 

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -22,6 +22,8 @@ class PostHogConfig(AppConfig):
     def ready(self):
         self._setup_lazy_admin()
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
+        # Fall back to DEV_API_KEY in debug so feature flags work locally without manual env setup.
+        # DEV_API_KEY lives in ee/settings.py — getattr returns None in OSS mode.
         posthoganalytics.personal_api_key = os.environ.get(
             "POSTHOG_PERSONAL_API_KEY",
             getattr(settings, "DEV_API_KEY", None) if settings.DEBUG else None,

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -22,7 +22,10 @@ class PostHogConfig(AppConfig):
     def ready(self):
         self._setup_lazy_admin()
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
-        posthoganalytics.personal_api_key = os.environ.get("POSTHOG_PERSONAL_API_KEY")
+        posthoganalytics.personal_api_key = os.environ.get(
+            "POSTHOG_PERSONAL_API_KEY",
+            getattr(settings, "DEV_API_KEY", None) if settings.DEBUG else None,
+        )
         posthoganalytics.poll_interval = 90
         posthoganalytics.enable_exception_autocapture = True
         posthoganalytics.log_captured_exceptions = True


### PR DESCRIPTION
## Problem

Feature flags evaluated via `posthoganalytics` don't work locally out of the box because `POSTHOG_PERSONAL_API_KEY` is never automatically set, requiring manual `export POSTHOG_PERSONAL_API_KEY=...`.

## Changes

- Default `personal_api_key` to `settings.DEV_API_KEY` in DEBUG mode (the key already exists in `ee/settings.py` and is created by `manage.py setup_local_api_key`)
- Env var `POSTHOG_PERSONAL_API_KEY` still takes precedence if explicitly set
- Updated local development docs to reflect auto-configuration

## Testing

1. Start dev server without `POSTHOG_PERSONAL_API_KEY` set
2. Confirm feature flags are working out of the box
3. Confirm setting `POSTHOG_PERSONAL_API_KEY` explicitly still overrides the default