### PR TITLE
feat(data-warehouse): make Klaviyo source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -147,19 +147,19 @@ def get_rows(
         if not items:
             break
 
-        for item in items:
-            batcher.batch(_flatten_item(item))
-
-        # Get next page URL before yielding
+        # Get next page URL before iterating items
         links = data.get("links", {})
         next_url = links.get("next")
 
-        if batcher.should_yield():
-            py_table = batcher.get_table()
-            yield py_table
+        for item in items:
+            batcher.batch(_flatten_item(item))
 
-            if next_url:
-                resumable_source_manager.save_state(KlaviyoResumeConfig(next_url=next_url))
+            if batcher.should_yield():
+                py_table = batcher.get_table()
+                yield py_table
+
+                if next_url:
+                    resumable_source_manager.save_state(KlaviyoResumeConfig(next_url=next_url))
 
         if not next_url:
             break

--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -1,14 +1,22 @@
+import dataclasses
+from collections.abc import Iterator
 from datetime import date, datetime
 from typing import Any, Optional
 
-from dlt.sources.helpers.requests import Request, Response
-from dlt.sources.helpers.rest_client.paginators import BasePaginator
+from structlog.types import FilteringBoundLogger
 
 from posthog.security.outbound_proxy import external_requests
+from posthog.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resources
-from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS, KlaviyoEndpointConfig
+
+KLAVIYO_BASE_URL = "https://a.klaviyo.com/api"
+
+
+@dataclasses.dataclass
+class KlaviyoResumeConfig:
+    next_url: str
 
 
 def _format_incremental_value(value: Any) -> str:
@@ -37,86 +45,31 @@ def _build_filter(
         return incremental_filter
 
 
-def get_resource(
-    name: str,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> EndpointResource:
-    config = KLAVIYO_ENDPOINTS[name]
+def _build_url(base_url: str, params: dict[str, Any]) -> str:
+    """Build a URL with query params without percent-encoding.
 
-    formatted_last_value = (
-        _format_incremental_value(db_incremental_field_last_value)
-        if should_use_incremental_field and db_incremental_field_last_value
-        else None
-    )
+    Klaviyo's API expects literal brackets, parentheses, and quotes in query params
+    (e.g. page[size]=100, filter=equals(messages.channel,'email')).
+    All param keys and values are constructed internally, so no encoding is needed.
+    """
+    if not params:
+        return base_url
+    parts = [f"{key}={value}" for key, value in params.items()]
+    return f"{base_url}?{'&'.join(parts)}"
 
-    filter_value = _build_filter(config, incremental_field, formatted_last_value)
 
-    params: dict[str, Any] = {}
-    if config.page_size is not None and config.page_size > 0:
-        params["page[size]"] = config.page_size
-    if filter_value:
-        params["filter"] = filter_value
-    if config.sort:
-        params["sort"] = config.sort
-
+def _get_headers(api_key: str) -> dict[str, str]:
     return {
-        "name": config.name,
-        "table_name": config.name,
-        "primary_key": "id",
-        "write_disposition": {
-            "disposition": "merge",
-            "strategy": "upsert",
-        }
-        if should_use_incremental_field
-        else "replace",
-        "endpoint": {
-            "data_selector": "data",
-            "path": config.path,
-            "params": params if params else {},
-        },
-        "table_format": "delta",
-    }
-
-
-class KlaviyoPaginator(BasePaginator):
-    def update_state(self, response: Response, data: list[Any] | None = None) -> None:
-        res = response.json()
-
-        self._next_offset = None
-
-        if not res:
-            self._has_next_page = False
-            return
-
-        links = res.get("links", {})
-        next_url = links.get("next")
-
-        if next_url:
-            self._next_offset = next_url
-            self._has_next_page = True
-        else:
-            self._has_next_page = False
-
-    def update_request(self, request: Request) -> None:
-        if self._next_offset:
-            # Use the full next URL from the response
-            # Clear params since the next URL already contains all query parameters
-            request.url = self._next_offset
-            request.params = {}
-
-
-def validate_credentials(api_key: str) -> bool:
-    url = "https://a.klaviyo.com/api/accounts"
-    headers = {
         "Authorization": f"Klaviyo-API-Key {api_key}",
         "revision": "2024-10-15",
         "Accept": "application/json",
     }
 
+
+def validate_credentials(api_key: str) -> bool:
+    url = f"{KLAVIYO_BASE_URL}/accounts"
     try:
-        response = external_requests.get(url, headers=headers, timeout=10)
+        response = external_requests.get(url, headers=_get_headers(api_key), timeout=10)
         return response.status_code == 200
     except Exception:
         return False
@@ -130,58 +83,116 @@ def _flatten_item(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
+def _build_initial_params(
+    config: KlaviyoEndpointConfig,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: str | None,
+) -> dict[str, Any]:
+    """Build query params for the initial Klaviyo API request."""
+    params: dict[str, Any] = {}
+
+    if config.page_size is not None and config.page_size > 0:
+        params["page[size]"] = config.page_size
+
+    formatted_last_value = (
+        _format_incremental_value(db_incremental_field_last_value)
+        if should_use_incremental_field and db_incremental_field_last_value
+        else None
+    )
+    filter_value = _build_filter(config, incremental_field, formatted_last_value)
+    if filter_value:
+        params["filter"] = filter_value
+
+    if config.sort:
+        params["sort"] = config.sort
+
+    return params
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[KlaviyoResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+    incremental_field: str | None = None,
+) -> Iterator[Any]:
+    config = KLAVIYO_ENDPOINTS[endpoint]
+    headers = _get_headers(api_key)
+    batcher = Batcher(logger=logger)
+
+    params = _build_initial_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    # Check for resume state
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if resume_config is not None:
+        url = resume_config.next_url
+        logger.debug(f"Klaviyo: resuming from URL: {url}")
+    else:
+        url = _build_url(f"{KLAVIYO_BASE_URL}{config.path}", params)
+
+    while True:
+        response = external_requests.get(url, headers=headers, timeout=60)
+        if not response.ok:
+            logger.error(f"Klaviyo API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+        data = response.json()
+
+        items = data.get("data", [])
+        if not items:
+            break
+
+        for item in items:
+            batcher.batch(_flatten_item(item))
+
+        # Get next page URL before yielding
+        links = data.get("links", {})
+        next_url = links.get("next")
+
+        if batcher.should_yield():
+            py_table = batcher.get_table()
+            yield py_table
+
+            if next_url:
+                resumable_source_manager.save_state(KlaviyoResumeConfig(next_url=next_url))
+
+        if not next_url:
+            break
+
+        url = next_url
+
+    if batcher.should_yield(include_incomplete_chunk=True):
+        py_table = batcher.get_table()
+        yield py_table
+
+
 def klaviyo_source(
     api_key: str,
     endpoint: str,
-    team_id: int,
-    job_id: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[KlaviyoResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
 ) -> SourceResponse:
     endpoint_config = KLAVIYO_ENDPOINTS[endpoint]
 
-    config: RESTAPIConfig = {
-        "client": {
-            "base_url": "https://a.klaviyo.com/api",
-            "auth": {
-                "type": "api_key",
-                "api_key": f"Klaviyo-API-Key {api_key}",
-                "name": "Authorization",
-                "location": "header",
-            },
-            "headers": {
-                "revision": "2024-10-15",
-                "Accept": "application/json",
-            },
-            "paginator": KlaviyoPaginator(),
-        },
-        "resource_defaults": {
-            "primary_key": "id",
-            "write_disposition": "replace",
-            "endpoint": {
-                "params": {
-                    "page[size]": 100,
-                },
-            },
-        },
-        "resources": [
-            get_resource(
-                endpoint,
-                should_use_incremental_field,
-                db_incremental_field_last_value,
-                incremental_field,
-            )
-        ],
-    }
-
-    resources = rest_api_resources(config, team_id, job_id, None)
-    assert len(resources) == 1
-    resource = resources[0].add_map(_flatten_item)
-
     return SourceResponse(
         name=endpoint,
-        items=lambda: resource,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field=incremental_field,
+        ),
         primary_keys=["id"],
         partition_count=1,
         partition_size=1,

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -8,11 +8,13 @@ from posthog.schema import (
 )
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import KlaviyoSourceConfig
 from posthog.temporal.data_imports.sources.klaviyo.klaviyo import (
+    KlaviyoResumeConfig,
     klaviyo_source,
     validate_credentials as validate_klaviyo_credentials,
 )
@@ -22,7 +24,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class KlaviyoSource(SimpleSource[KlaviyoSourceConfig]):
+class KlaviyoSource(ResumableSource[KlaviyoSourceConfig, KlaviyoResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.KLAVIYO
@@ -86,12 +88,20 @@ Make sure to grant the following read permissions:
 
         return False, "Invalid Klaviyo API key"
 
-    def source_for_pipeline(self, config: KlaviyoSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[KlaviyoResumeConfig]:
+        return ResumableSourceManager[KlaviyoResumeConfig](inputs, KlaviyoResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: KlaviyoSourceConfig,
+        resumable_source_manager: ResumableSourceManager[KlaviyoResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         return klaviyo_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            team_id=inputs.team_id,
-            job_id=inputs.job_id,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field


### PR DESCRIPTION
## Problem

Klaviyo data warehouse source implement the resumable source pattern

## Changes

  - Changed KlaviyoSource base class from SimpleSource to ResumableSource[KlaviyoSourceConfig, KlaviyoResumeConfig]
  - Added KlaviyoResumeConfig dataclass storing the Klaviyo cursor URL for resuming pagination
  - Added get_resumable_source_manager() to create a ResumableSourceManager that persists state in Redis
  - Replaced DLT rest_api_resources / KlaviyoPaginator with manual HTTP pagination via get_rows() generator
  - get_rows() uses Batcher to yield PyArrow tables and saves the next page URL after each batch
  - Removed KlaviyoPaginator, get_resource(), and all DLT REST client dependencies from klaviyo.py

## How did you test this code?

Locally and tests

## Publish to changelog?

No


