### PR TITLE
test(visual-review): trigger isolated backend tests

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -983,8 +983,9 @@ def get_run_snapshots(run_id: UUID, team_id: int | None = None) -> list[RunSnaps
     return list(
         run.snapshots.select_related("current_artifact", "baseline_artifact", "diff_artifact").order_by(
             db_models.Case(
-                db_models.When(result=SnapshotResult.UNCHANGED, then=1),
-                default=0,
+                db_models.When(result=SnapshotResult.UNCHANGED, then=2),
+                db_models.When(result=SnapshotResult.NEW, then=0),
+                default=1,
             ),
             "identifier",
         )


### PR DESCRIPTION
Temp PR to verify visual_review isolated tests run in CI. Tweak snapshot sort order in logic.py to bust turbo cache.