### PR TITLE
feat(batch-exports): implement backfill estimation for sessions model

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -464,8 +464,8 @@ async def _get_backfill_info_for_sessions(
 ) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for sessions model.
 
-    Uses HogQL to query the sessions table, matching the same filtering
-    logic as the actual export query in SessionsRecordBatchModel.
+    Queries the sessions table via HogQL, filtering by $end_timestamp
+    (this logic is the same as the actual export query, which aliases `$end_timestamp` as `_inserted_at`).
 
     Returns:
         A tuple of (adjusted_start_at, estimated_records_count).

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -33,6 +33,7 @@ from posthog.temporal.common.client import connect
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
 
+from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import compose_filters_clause
 
 LOGGER = get_write_only_logger(__name__)
@@ -456,12 +457,34 @@ async def _get_backfill_info_for_persons(
     return earliest_start, record_count
 
 
+async def _get_backfill_info_for_sessions(
+    batch_export: BatchExport,
+    start_at: dt.datetime | None,
+    end_at: dt.datetime | None,
+) -> tuple[dt.datetime | None, int | None]:
+    """Get adjusted start time and estimated record count for sessions model.
+
+    Uses HogQL to query the sessions table, matching the same filtering
+    logic as the actual export query in SessionsRecordBatchModel.
+
+    Returns:
+        A tuple of (adjusted_start_at, estimated_records_count).
+        If no data exists, returns (None, 0).
+    """
+
+    model = SessionsRecordBatchModel(team_id=batch_export.team_id, batch_export_id=str(batch_export.id))
+    min_timestamp, record_count = await model.get_backfill_info(start_at, end_at)
+
+    if min_timestamp is None:
+        return None, 0
+
+    earliest_start = _align_timestamp_to_interval(min_timestamp, batch_export)
+    return earliest_start, record_count
+
+
 @temporalio.activity.defn
 async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOutputs:
     """Validate backfill parameters and estimate record count.
-
-    For events model: runs combined query for earliest date + count.
-    For persons/sessions: runs earliest date only (count returns None for now).
 
     If no data exists or range contains no data, returns estimated_records_count=0
     (workflow should complete early rather than raising an error).
@@ -515,8 +538,13 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             start_at=start_at,
             end_at=end_at,
         )
+    elif model == "sessions":
+        adjusted_start_at, record_count = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=start_at,
+            end_at=end_at,
+        )
     else:
-        # For sessions and other models, proceed without estimation
         logger.info(
             "Backfill info not yet implemented for model, skipping estimation",
             model=model,

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -6,6 +6,7 @@ import datetime as dt
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import ast
+from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.visitor import clone_expr
 
@@ -14,6 +15,7 @@ from posthog.clickhouse import query_tagging
 from posthog.clickhouse.query_tagging import Product
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
+from posthog.temporal.common.clickhouse import get_client
 
 from products.batch_exports.backend.temporal import sql
 
@@ -187,6 +189,93 @@ INSERT INTO FUNCTION {s3_function}
 """
 
         return insert_query, context.values
+
+    def get_backfill_info_hogql_query(
+        self, start_at: dt.datetime | None, end_at: dt.datetime | None
+    ) -> ast.SelectQuery:
+        """Return a HogQL query to estimate record count and earliest timestamp for a backfill."""
+        where_and = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["sessions", "team_id"]),
+                    right=ast.Constant(value=self.team_id),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Gt,
+                    left=ast.Field(chain=["$end_timestamp"]),
+                    right=ast.Constant(value=dt.datetime(2000, 1, 1, tzinfo=dt.UTC)),
+                ),
+            ]
+        )
+
+        if end_at is not None:
+            where_and.exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["$end_timestamp"]),
+                    right=ast.Constant(value=end_at),
+                ),
+            )
+
+        if start_at is not None:
+            where_and.exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["$end_timestamp"]),
+                    right=ast.Constant(value=start_at),
+                ),
+            )
+
+        return ast.SelectQuery(
+            select=[
+                parse_expr("min($end_timestamp) as min_timestamp"),
+                parse_expr("count() as record_count"),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["sessions"])),
+            where=where_and,
+        )
+
+    async def get_backfill_info(
+        self, start_at: dt.datetime | None, end_at: dt.datetime | None
+    ) -> tuple[dt.datetime | None, int | None]:
+        """Estimate record count and earliest timestamp for a backfill.
+
+        Returns:
+            A tuple of (min_timestamp, estimated_records_count).
+            If no data exists, returns (None, 0).
+        """
+        hogql_query = self.get_backfill_info_hogql_query(start_at, end_at)
+        context = await self.get_hogql_context()
+
+        prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+            hogql_query, context=context, dialect="clickhouse", stack=[]
+        )
+        assert prepared_hogql_query is not None
+        context.output_format = "JSONEachRow"
+        printed = print_prepared_ast(
+            prepared_hogql_query,
+            context=context,
+            dialect="clickhouse",
+            stack=[],
+        )
+
+        async with get_client(team_id=self.team_id) as client:
+            result = await client.read_query_as_jsonl(printed, query_parameters=context.values)
+
+        min_timestamp_str = result[0]["min_timestamp"]
+        record_count = int(result[0]["record_count"])
+
+        min_timestamp = dt.datetime.fromisoformat(min_timestamp_str)
+        if min_timestamp.tzinfo is None:
+            min_timestamp = min_timestamp.replace(tzinfo=dt.UTC)
+        else:
+            min_timestamp = min_timestamp.astimezone(dt.UTC)
+
+        if min_timestamp.year == 1970:
+            return None, 0
+
+        return min_timestamp, record_count
 
 
 def resolve_batch_exports_model(

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -235,6 +235,7 @@ INSERT INTO FUNCTION {s3_function}
             ],
             select_from=ast.JoinExpr(table=ast.Field(chain=["sessions"])),
             where=where_and,
+            settings=sql.HogQLQueryBatchExportSettings(),
         )
 
     async def get_backfill_info(

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -201,6 +201,7 @@ INSERT INTO FUNCTION {s3_function}
                     left=ast.Field(chain=["sessions", "team_id"]),
                     right=ast.Constant(value=self.team_id),
                 ),
+                # filter out sessions before 2000-01-01 in case we have any incorrect timestamps
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Gt,
                     left=ast.Field(chain=["$end_timestamp"]),

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
@@ -201,6 +201,7 @@ async def events_batch_export(temporal_client, ateam, clickhouse_client, bucket_
     "interval,timezone,offset_day,offset_hour",
     [
         ("every 5 minutes", "UTC", None, None),  # only supports UTC and no offset
+        ("every 15 minutes", "UTC", None, None),  # only supports UTC and no offset
         ("hour", "UTC", None, None),  # only supports UTC and no offset
         ("day", "UTC", None, None),
         ("week", "UTC", None, None),

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -4,12 +4,19 @@ import datetime as dt
 import pytest
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination
+from posthog.models.utils import uuid7
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, insert_sessions_in_clickhouse
 
 from products.batch_exports.backend.temporal.backfill_batch_export import (
     _get_backfill_info_for_events,
     _get_backfill_info_for_persons,
+    _get_backfill_info_for_sessions,
 )
-from products.batch_exports.backend.tests.temporal.utils.clickhouse import truncate_events, truncate_persons
+from products.batch_exports.backend.tests.temporal.utils.clickhouse import (
+    truncate_events,
+    truncate_persons,
+    truncate_sessions,
+)
 from products.batch_exports.backend.tests.temporal.utils.persons import (
     generate_test_person_distinct_id2,
     generate_test_persons_in_clickhouse,
@@ -732,3 +739,163 @@ class TestGetBackfillInfoForPersons:
 
         assert earliest_start is None
         assert record_count == 0
+
+
+class TestGetBackfillInfoForSessions:
+    """Tests for the _get_backfill_info_for_sessions function."""
+
+    @pytest.fixture(autouse=True)
+    async def truncate_tables(self, clickhouse_client):
+        await truncate_events(clickhouse_client)
+        await truncate_sessions(clickhouse_client)
+
+    @pytest.fixture
+    def make_batch_export(self, ateam):
+        def _make(
+            interval: str = "hour",
+            interval_offset: int | None = None,
+            timezone: str = "UTC",
+        ) -> BatchExport:
+            destination = BatchExportDestination(type="S3", config={})
+            return BatchExport(
+                team_id=ateam.pk,
+                name="Test Batch Export",
+                destination=destination,
+                interval=interval,
+                interval_offset=interval_offset,
+                timezone=timezone,
+                model="sessions",
+            )
+
+        return _make
+
+    @pytest.fixture
+    def generate_sessions(self, clickhouse_client, ateam):
+        async def _generate(
+            start_time: dt.datetime,
+            end_time: dt.datetime | None = None,
+            count: int = 10,
+            count_other_team: int = 0,
+        ):
+            """Generate events with unique session IDs and derive sessions from them.
+
+            Each event gets a unique $session_id, so the number of sessions equals count.
+            """
+            for i in range(count):
+                event_time = start_time + dt.timedelta(seconds=i)
+                session_id = str(uuid7(unix_ms_time=int(event_time.timestamp() * 1000)))
+                await generate_test_events_in_clickhouse(
+                    client=clickhouse_client,
+                    team_id=ateam.pk,
+                    start_time=event_time,
+                    end_time=(end_time or event_time + dt.timedelta(minutes=2)),
+                    count=1,
+                    inserted_at=event_time,
+                    table="sharded_events",
+                    event_name="test-event",
+                    count_outside_range=0,
+                    count_other_team=0,
+                    properties={"$session_id": session_id},
+                )
+
+            for i in range(count_other_team):
+                event_time = start_time + dt.timedelta(seconds=i)
+                session_id = str(uuid7(unix_ms_time=int(event_time.timestamp() * 1000)))
+                await generate_test_events_in_clickhouse(
+                    client=clickhouse_client,
+                    team_id=ateam.pk + 1,
+                    start_time=event_time,
+                    end_time=(end_time or event_time + dt.timedelta(minutes=2)),
+                    count=1,
+                    inserted_at=event_time,
+                    table="sharded_events",
+                    event_name="test-event",
+                    count_outside_range=0,
+                    count_other_team=0,
+                    properties={"$session_id": session_id},
+                )
+
+            await insert_sessions_in_clickhouse(client=clickhouse_client, table="sharded_events")
+
+        return _generate
+
+    async def test_returns_earliest_start_and_count_when_data_exists(self, generate_sessions, make_batch_export):
+        session_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        await generate_sessions(start_time=session_time, count=5, count_other_team=3)
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 5
+
+    async def test_returns_none_and_zero_when_no_data_exists(self, make_batch_export):
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+
+        assert earliest_start is None
+        assert record_count == 0
+
+    async def test_counts_only_sessions_after_start_at(self, generate_sessions, make_batch_export):
+        early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+
+        await generate_sessions(start_time=early_time, count=5)
+        await generate_sessions(start_time=late_time, count=8)
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=None,
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 8
+
+    async def test_counts_only_sessions_before_end_at(self, ateam, generate_sessions, make_batch_export):
+        early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
+
+        await generate_sessions(start_time=early_time, count=5)
+        await generate_sessions(start_time=late_time, count=8)
+
+        batch_export = make_batch_export()
+        earliest_start, record_count = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
+        assert record_count == 5
+
+    async def test_earliest_start_aligned_to_interval(self, ateam, generate_sessions, make_batch_export):
+        session_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
+        await generate_sessions(start_time=session_time, count=3)
+
+        # Hourly interval — should align to 10:00
+        batch_export = make_batch_export(interval="hour")
+        earliest_start, _ = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
+
+        # 5-minute interval — should align to 10:35
+        batch_export = make_batch_export(interval="every 5 minutes")
+        earliest_start, _ = await _get_backfill_info_for_sessions(
+            batch_export=batch_export,
+            start_at=None,
+            end_at=None,
+        )
+        assert earliest_start == dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -878,24 +878,23 @@ class TestGetBackfillInfoForSessions:
         assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         assert record_count == 5
 
-    async def test_earliest_start_aligned_to_interval(self, ateam, generate_sessions, make_batch_export):
+    @pytest.mark.parametrize(
+        "interval,expected_start",
+        [
+            ("hour", dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)),
+            ("every 5 minutes", dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)),
+        ],
+    )
+    async def test_earliest_start_aligned_to_interval(
+        self, interval, expected_start, generate_sessions, make_batch_export
+    ):
         session_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
         await generate_sessions(start_time=session_time, count=3)
 
-        # Hourly interval — should align to 10:00
-        batch_export = make_batch_export(interval="hour")
+        batch_export = make_batch_export(interval=interval)
         earliest_start, _ = await _get_backfill_info_for_sessions(
             batch_export=batch_export,
             start_at=None,
             end_at=None,
         )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-
-        # 5-minute interval — should align to 10:35
-        batch_export = make_batch_export(interval="every 5 minutes")
-        earliest_start, _ = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)
+        assert earliest_start == expected_start

--- a/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
+++ b/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
@@ -82,6 +82,7 @@ async def truncate_persons(clickhouse_client):
 
 
 async def truncate_sessions(clickhouse_client):
+    await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS sharded_raw_sessions")
     await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS raw_sessions")
 
 


### PR DESCRIPTION
## Problem

When creating a backfill for a sessions batch export, we don't currently estimate the record count or determine the earliest data timestamp.

## Changes

- Added `_get_backfill_info_for_sessions` in `backfill_batch_export.py` that delegates to the `SessionsRecordBatchModel` to query the sessions table via HogQL
- Added `get_backfill_info` and `get_backfill_info_hogql_query` methods to `SessionsRecordBatchModel` in `record_batch_model.py`

## How did you test this code?

- [x] Added unit tests for `_get_backfill_info_for_sessions` covering all key scenarios
- [x] Tested with the UI locally
- [x] Test performance of queries in production

## Publish to changelog?

No