### PR TITLE
fix(llma): optimize sentiment ClickHouse queries for high-volume teams

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/constants.py
+++ b/posthog/temporal/llm_analytics/sentiment/constants.py
@@ -19,7 +19,7 @@ MAX_CLASSIFICATIONS_PER_TRACE = 200
 MAX_GENERATIONS_PER_TRACE = 10  # per-trace cap enforced by window function in ClickHouse
 MAX_INPUT_CHARS = 300_000  # skip $ai_input longer than this (covers p99; extraction truncates before inference)
 MAX_INPUT_CHARS_GENERATION = 1_000_000  # higher limit for generation-level — user asked for specific UUIDs
-QUERY_LOOKBACK_DAYS = 30  # timestamp filter to enable partition pruning
+QUERY_LOOKBACK_DAYS = 7  # fallback timestamp filter when caller omits date range
 
 # Temporal workflow/activity config
 WORKFLOW_NAME = "llma-sentiment-classify"
@@ -65,8 +65,9 @@ GENERATIONS_QUERY = """
 """
 
 # Fetch specific generation events by UUID — no window function needed.
-# Uses a higher size limit than the trace query since the user asked for
-# these specific generations (extraction + truncation caps inference cost).
+# No length() filter here: it translates to JSONExtractRaw on every scanned
+# row which is expensive on high-volume teams (benchmarked 2.4x slower).
+# The size check is applied post-fetch in Python instead.
 GENERATIONS_BY_UUID_QUERY = """
     SELECT
         uuid,
@@ -76,5 +77,4 @@ GENERATIONS_BY_UUID_QUERY = """
       AND timestamp >= toDateTime({date_from}, 'UTC')
       AND timestamp <= toDateTime({date_to}, 'UTC')
       AND uuid IN {uuids}
-      AND length(properties.$ai_input) <= {max_input_chars}
 """

--- a/posthog/temporal/llm_analytics/sentiment/data.py
+++ b/posthog/temporal/llm_analytics/sentiment/data.py
@@ -101,17 +101,22 @@ def fetch_generations_by_uuid(
             "date_from": ast.Constant(value=date_from),
             "date_to": ast.Constant(value=date_to),
             "uuids": ast.Tuple(exprs=[ast.Constant(value=uid) for uid in generation_ids]),
-            "max_input_chars": ast.Constant(value=MAX_INPUT_CHARS_GENERATION),
         },
         team=team,
         limit_context=LimitContext.QUERY_ASYNC,
     )
 
+    # Size guard applied post-fetch instead of in SQL — the SQL length()
+    # filter forced JSONExtractRaw on every scanned row, 2.4x slower on
+    # high-volume teams. Here we just skip before json.loads to avoid
+    # wasting time parsing huge payloads we'll mostly discard anyway.
     rows: list[tuple[str, object]] = []
     total_input_bytes = 0
     for row in result.results or []:
         raw_ai_input = row[1]
         if isinstance(raw_ai_input, str):
+            if len(raw_ai_input) > MAX_INPUT_CHARS_GENERATION:
+                continue
             total_input_bytes += len(raw_ai_input.encode("utf-8"))
             try:
                 ai_input = json.loads(raw_ai_input)

--- a/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsSessionScene.tsx
@@ -8,6 +8,7 @@ import { LemonButton, LemonTag, Spinner, SpinnerOverlay, Tooltip } from '@postho
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -25,6 +26,7 @@ import { SentimentBar } from './components/SentimentTag'
 import { TraceSummary, llmAnalyticsSessionDataLogic } from './llmAnalyticsSessionDataLogic'
 import { llmAnalyticsSessionLogic } from './llmAnalyticsSessionLogic'
 import { llmSentimentLazyLoaderLogic } from './llmSentimentLazyLoaderLogic'
+import { SENTIMENT_DATE_WINDOW_DAYS } from './sentimentUtils'
 import { formatLLMCost, getTraceTimestamp, sanitizeTraceUrlSearchParams } from './utils'
 
 const LLMASessionFeedbackDisplay = lazy(() =>
@@ -52,7 +54,7 @@ export function LLMAnalyticsSessionScene({ tabId }: { tabId?: string }): JSX.Ele
     )
 }
 
-function SessionTraceSentimentBar({ traceId }: { traceId: string }): JSX.Element | null {
+function SessionTraceSentimentBar({ traceId, createdAt }: { traceId: string; createdAt?: string }): JSX.Element | null {
     const { sentimentByTraceId, isTraceLoading } = useValues(llmSentimentLazyLoaderLogic)
     const { ensureSentimentLoaded } = useActions(llmSentimentLazyLoaderLogic)
 
@@ -60,7 +62,12 @@ function SessionTraceSentimentBar({ traceId }: { traceId: string }): JSX.Element
     const loading = isTraceLoading(traceId)
 
     if (cached === undefined && !loading) {
-        ensureSentimentLoaded(traceId)
+        ensureSentimentLoaded(
+            traceId,
+            createdAt
+                ? { dateFrom: createdAt, dateTo: dayjs(createdAt).add(SENTIMENT_DATE_WINDOW_DAYS, 'day').toISOString() }
+                : undefined
+        )
     }
 
     if (cached === null) {
@@ -246,7 +253,12 @@ function SessionSceneWrapper(): JSX.Element {
                                                             {formatLLMCost(trace.totalCost)}
                                                         </LemonTag>
                                                     )}
-                                                    {showSentiment && <SessionTraceSentimentBar traceId={trace.id} />}
+                                                    {showSentiment && (
+                                                        <SessionTraceSentimentBar
+                                                            traceId={trace.id}
+                                                            createdAt={trace.createdAt}
+                                                        />
+                                                    )}
                                                     <Link
                                                         to={
                                                             combineUrl(urls.llmAnalyticsTrace(trace.id), {

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -36,6 +36,7 @@ import { JSONViewer } from 'lib/components/JSONViewer'
 import { NotFound } from 'lib/components/NotFound'
 import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
@@ -76,6 +77,7 @@ import { llmPersonsLazyLoaderLogic } from './llmPersonsLazyLoaderLogic'
 import { llmSentimentLazyLoaderLogic } from './llmSentimentLazyLoaderLogic'
 import { llmPlaygroundPromptsLogic } from './playground/llmPlaygroundPromptsLogic'
 import { SearchHighlight } from './SearchHighlight'
+import { SENTIMENT_DATE_WINDOW_DAYS } from './sentimentUtils'
 import { SummaryViewDisplay } from './summary-view/SummaryViewDisplay'
 import { TextViewDisplay } from './text-view/TextViewDisplay'
 import { exportTraceToClipboard } from './traceExportUtils'
@@ -344,7 +346,10 @@ function TraceMetadata({
     const sentimentResult = showSentiment ? getTraceSentiment(trace.id) : undefined
     const sentimentLoading = showSentiment ? isTraceLoading(trace.id) : false
     if (showSentiment && sentimentResult === undefined && !sentimentLoading) {
-        ensureSentimentLoaded(trace.id)
+        ensureSentimentLoaded(trace.id, {
+            dateFrom: trace.createdAt,
+            dateTo: dayjs(trace.createdAt).add(SENTIMENT_DATE_WINDOW_DAYS, 'day').toISOString(),
+        })
     }
 
     const cached = personsCache[trace.distinctId]
@@ -613,7 +618,10 @@ const TreeNode = React.memo(function TraceNode({
     const isGeneration = isLLMEvent(item) && (item as LLMTraceEvent).event === '$ai_generation'
     const genSentiment = showSentiment && isGeneration ? getGenerationSentiment(item.id) : undefined
     if (showSentiment && isGeneration && genSentiment === undefined && !isGenerationLoading(item.id)) {
-        ensureGenerationSentimentLoaded(item.id)
+        ensureGenerationSentimentLoaded(item.id, {
+            dateFrom: topLevelTrace.createdAt,
+            dateTo: dayjs(topLevelTrace.createdAt).add(SENTIMENT_DATE_WINDOW_DAYS, 'day').toISOString(),
+        })
     }
 
     const children = [

--- a/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
@@ -31,6 +31,7 @@ import {
     findSidebarOccurrences,
     findTraceOccurrences,
 } from './searchUtils'
+import { SENTIMENT_DATE_WINDOW_DAYS } from './sentimentUtils'
 import { formatLLMUsage, getEventType, isLLMEvent, normalizeMessages } from './utils'
 
 export interface TraceDataLogicProps {
@@ -432,6 +433,7 @@ export const llmAnalyticsTraceDataLogic = kea<llmAnalyticsTraceDataLogicType>([
             if (trace?.id && values.featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SENTIMENT]) {
                 llmSentimentLazyLoaderLogic.actions.ensureSentimentLoaded(trace.id, {
                     dateFrom: trace.createdAt,
+                    dateTo: dayjs(trace.createdAt).add(SENTIMENT_DATE_WINDOW_DAYS, 'day').toISOString(),
                 })
             }
 

--- a/products/llm_analytics/frontend/sentimentUtils.ts
+++ b/products/llm_analytics/frontend/sentimentUtils.ts
@@ -1,3 +1,6 @@
+/** Tight date window around trace creation for sentiment ClickHouse queries. */
+export const SENTIMENT_DATE_WINDOW_DAYS = 2
+
 export type SentimentLabel = 'positive' | 'neutral' | 'negative'
 
 interface MessageScore {


### PR DESCRIPTION
## Problem

Sentiment classification workflows are timing out for high-volume teams. A team with 1.4B `$ai_generation` events per week was hitting 80s+ ClickHouse query times on UUID-based lookups that should return only 5 rows.

Root cause: the `GENERATIONS_BY_UUID_QUERY` included a `length(properties.$ai_input) <= N` filter which translates to `JSONExtractRaw` on every scanned row in the date range. Combined with a 30-day default lookback and several frontend callers not passing date ranges at all, this created massive full-scan queries.

## Changes

**Backend:**
- Remove `length(properties.$ai_input)` filter from `GENERATIONS_BY_UUID_QUERY` -- it forced ClickHouse to decompress + parse JSON for every row in the scan (benchmarked 2.4x slower: 40s with vs 17s without on a 7-day window)
- Apply the size guard post-fetch in Python instead (before `json.loads`), where it only runs on the ~5 returned rows
- Reduce `QUERY_LOOKBACK_DAYS` from 30 to 7 as a safer fallback when callers omit date ranges

**Frontend:**
- Pass tight date windows (`createdAt` to `createdAt + 2 days`) from trace detail and session scene callers that were previously omitting date ranges entirely
- Extract `SENTIMENT_DATE_WINDOW_DAYS` constant to `sentimentUtils.ts` for consistency across callers
- The list view column renderers already passed the global date filter and are unchanged

## How did you test this code?

Benchmarked directly on production ClickHouse via the sentiment worker pod against the affected team:

| Query variant | Time |
|--------------|------|
| WITH `length()`, 7d window | 40,532ms |
| WITHOUT `length()`, 7d window | 17,134ms |
| WITHOUT `length()`, 1d window | 14,524ms |

The downstream extraction pipeline already has semantic caps (max 50 messages, 2000 chars each, 200 classifications total) so the SQL-level length filter was redundant protection.

## Publish to changelog?

No