### PR TITLE
fix: correct default access control level calculation

### DIFF
--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -324,6 +324,72 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
 
         assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
 
+    def test_team_effective_membership_level_default_access_level_admin(self):
+        """Test that org members get admin level when the project default access level is set to admin"""
+        from ee.models.rbac.access_control import AccessControl
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        # Set the project's default access level to admin (no specific member or role)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="admin",
+        )
+
+        assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_default_access_level_member(self):
+        """Test that org members get member level when the project default access level is set to member"""
+        from ee.models.rbac.access_control import AccessControl
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        # Set the project's default access level to member
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="member",
+        )
+
+        assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.MEMBER
+
+    def test_team_effective_membership_level_direct_access_overrides_default(self):
+        """Test that direct user access overrides the project default access level"""
+        from ee.models.rbac.access_control import AccessControl
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        # Set the project's default access level to member
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="member",
+        )
+
+        # Give the user direct admin access, which should override the default
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=self.organization_membership,
+            access_level="admin",
+        )
+
+        assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
     def test_role_admin_access_overrides_direct_member_access(self):
         """
         BUG TEST: When a user has both:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -248,21 +248,30 @@ class UserTeamPermissions:
         if user_has_member_access:
             return OrganizationMembership.Level.MEMBER
 
-        # Check if the team is private
-        team_is_private = any(
-            ac["resource_id"] == str(self.team.id)
-            and ac["organization_member_id"] is None
-            and ac["role_id"] is None
-            and ac["access_level"] == "none"
-            for ac in access_controls
+        # Check for a default access level for this team (applies to all org members)
+        default_access_level = next(
+            (
+                ac["access_level"]
+                for ac in access_controls
+                if ac["resource_id"] == str(self.team.id)
+                and ac["organization_member_id"] is None
+                and ac["role_id"] is None
+            ),
+            None,
         )
 
-        # If team is not private, all organization members have access
-        if not team_is_private:
-            return cast("OrganizationMembership.Level", organization_membership.level)
+        if default_access_level == "none":
+            # Team is private and user has no specific access
+            return None
 
-        # No access found
-        return None
+        if default_access_level == "admin":
+            return OrganizationMembership.Level.ADMIN
+
+        if default_access_level == "member":
+            return OrganizationMembership.Level.MEMBER
+
+        # No default access control set, all organization members have implicit access
+        return cast("OrganizationMembership.Level", organization_membership.level)
 
 
 class UserDashboardPermissions:


### PR DESCRIPTION
## Problem

When we calculate the effective team membership level for access control, we use the organization default if the default for the team is private. In this case we should actually be using the project default.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add logic to use the proejct's access control defaults when the team is not private.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests + manually

Manually: set org-default to "member" and project default to "admin". Try to change the session replay toggle.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
