### PR TITLE
feat(replay): track 'session recording not found' events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
@@ -127,7 +127,7 @@ export const sessionRecordingMetaLogic = kea<sessionRecordingMetaLogicType>([
         },
 
         loadRecordingMetaFailure: () => {
-            posthog.capture('recording not found', {
+            posthog.capture('session recording not found', {
                 recording_id: props.sessionRecordingId,
                 current_url: window.location.href,
             })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, defaults, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
@@ -101,7 +102,7 @@ export const sessionRecordingMetaLogic = kea<sessionRecordingMetaLogicType>([
             },
         },
     })),
-    listeners(({ values, actions }) => ({
+    listeners(({ values, actions, props }) => ({
         loadRecordingFromFile: ({ recording }: { recording: ExportedSessionRecordingFileV2['data'] }) => {
             const { id, snapshots, person } = recording
             actions.setSnapshots(snapshots)
@@ -123,6 +124,13 @@ export const sessionRecordingMetaLogic = kea<sessionRecordingMetaLogicType>([
             if (!values.sessionPlayerMetaDataLoading) {
                 actions.loadRecordingMeta()
             }
+        },
+
+        loadRecordingMetaFailure: () => {
+            posthog.capture('recording not found', {
+                recording_id: props.sessionRecordingId,
+                current_url: window.location.href,
+            })
         },
     })),
 ])


### PR DESCRIPTION
## Summary
- Captures a `session recording not found` posthog event when `loadRecordingMeta` fails in the session recording player
- Includes `recording_id` and `current_url` as properties, so we can see where users are hitting missing recordings (e.g. from LLM analytics trace pages)
- Currently there's only a `recording loaded` success event — this adds the failure counterpart

## Test plan
- [ ] Open a trace in LLM analytics that has a linked session recording that no longer exists
- [ ] Click "View recording" — modal should show "Recording not found"
- [ ] Verify a `session recording not found` event appears in the project's live events with `recording_id` and `current_url` properties