### PR TITLE
fix(ai): tag untagged ClickHouse queries with MAX_AI product

### DIFF
--- a/ee/hogai/tools/manage_memories.py
+++ b/ee/hogai/tools/manage_memories.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.sync import database_sync_to_async
 
 from products.posthog_ai.backend.models import AgentMemory
@@ -180,19 +181,20 @@ class ManageMemoriesTool(MaxTool):
 
         @database_sync_to_async(thread_sensitive=False)
         def run_query():
-            return execute_hogql_query(
-                query_type="ManageMemoriesTool",
-                query=query,
-                team=self._team,
-                placeholders={
-                    "query_text": ast.Constant(value=query_text),
-                    "model_name": ast.Constant(value=EMBEDDING_MODEL),
-                    "user_id": ast.Constant(value=user_id),
-                    "skip_user_filter": ast.Constant(value=skip_user_filter),
-                    "limit": ast.Constant(value=limit),
-                    **metadata_placeholders,
-                },
-            )
+            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+                return execute_hogql_query(
+                    query_type="ManageMemoriesTool",
+                    query=query,
+                    team=self._team,
+                    placeholders={
+                        "query_text": ast.Constant(value=query_text),
+                        "model_name": ast.Constant(value=EMBEDDING_MODEL),
+                        "user_id": ast.Constant(value=user_id),
+                        "skip_user_filter": ast.Constant(value=skip_user_filter),
+                        "limit": ast.Constant(value=limit),
+                        **metadata_placeholders,
+                    },
+                )
 
         result = await run_query()
 

--- a/ee/hogai/tools/replay/filter_session_recordings.py
+++ b/ee/hogai/tools/replay/filter_session_recordings.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import MaxRecordingUniversalFilters, RecordingsQuery
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.session_recordings.playlist_counters import convert_filters_to_recordings_query
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.session_recordings.queries.utils import SessionRecordingQueryResult
@@ -187,10 +188,11 @@ class FilterSessionRecordingsTool(MaxTool):
 
     def _get_recordings_with_filters(self, recordings_query: RecordingsQuery) -> SessionRecordingQueryResult:
         """Get recordings from DB with filters"""
-        query_runner = SessionRecordingListFromQuery(
-            team=self._team, query=recordings_query, hogql_query_modifiers=None
-        )
-        return query_runner.run()
+        with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+            query_runner = SessionRecordingListFromQuery(
+                team=self._team, query=recordings_query, hogql_query_modifiers=None
+            )
+            return query_runner.run()
 
     def _format_recording_metadata(self, recording: dict[str, Any]) -> str:
         """Format recording metadata for display."""

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from posthog.schema import MaxRecordingUniversalFilters, RecordingsQuery
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.session_recordings.playlist_counters import convert_filters_to_recordings_query
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
@@ -286,10 +287,11 @@ class SummarizeSessionsTool(MaxTool):
 
         # Execute the query to get session IDs
         try:
-            query_runner = SessionRecordingListFromQuery(
-                team=self._team, query=replay_filters, hogql_query_modifiers=None
-            )
-            results = query_runner.run()
+            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+                query_runner = SessionRecordingListFromQuery(
+                    team=self._team, query=replay_filters, hogql_query_modifiers=None
+                )
+                results = query_runner.run()
         except Exception as e:
             logger.exception(
                 f"Error getting session ids for session summarization with filters query "

--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -27,6 +27,7 @@ from posthog.schema import (
 )
 
 from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.experiments.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
@@ -207,12 +208,15 @@ class ExperimentSummaryDataService:
                     experiment_id=experiment_id,
                     metric=metric_obj,
                 )
-                query_runner = ExperimentQueryRunner(
-                    query=experiment_query,
-                    team=experiment.team,
-                    workload=Workload.ONLINE,
-                )
-                result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
+                with tags_context(
+                    product=Product.MAX_AI, team_id=experiment.team.pk, org_id=experiment.team.organization_id
+                ):
+                    query_runner = ExperimentQueryRunner(
+                        query=experiment_query,
+                        team=experiment.team,
+                        workload=Workload.ONLINE,
+                    )
+                    result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
                 refresh_time = getattr(result, "last_refresh", None)
 
                 if is_incomplete_response(result):
@@ -253,13 +257,16 @@ class ExperimentSummaryDataService:
                         exposure_criteria=experiment.exposure_criteria,
                         holdout=experiment.holdout,
                     )
-                    exposure_runner = ExperimentExposuresQueryRunner(
-                        query=exposure_query,
-                        team=experiment.team,
-                    )
-                    exposure_result = exposure_runner.run(
-                        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
-                    )
+                    with tags_context(
+                        product=Product.MAX_AI, team_id=experiment.team.pk, org_id=experiment.team.organization_id
+                    ):
+                        exposure_runner = ExperimentExposuresQueryRunner(
+                            query=exposure_query,
+                            team=experiment.team,
+                        )
+                        exposure_result = exposure_runner.run(
+                            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
+                        )
 
                     if is_incomplete_response(exposure_result):
                         return ExposureQueryResult(exposures=None, refresh_time=None, pending=True)

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import MaxExperimentMetricResult
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models import Experiment, FeatureFlag
@@ -481,9 +482,12 @@ class SessionReplaySummaryTool(MaxTool):
 
                     @database_sync_to_async
                     def count_recordings(q):
-                        recordings, has_more, _, _ = list_recordings_from_query(query=q, user=None, team=self._team)
-                        # If has_more, there are 100+ recordings
-                        return len(recordings) if not has_more else 100
+                        with tags_context(
+                            product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id
+                        ):
+                            recordings, has_more, _, _ = list_recordings_from_query(query=q, user=None, team=self._team)
+                            # If has_more, there are 100+ recordings
+                            return len(recordings) if not has_more else 100
 
                     count = await count_recordings(query)
                     recording_counts[variant_key] = count


### PR DESCRIPTION
## Problem

Several ClickHouse queries executed by Max AI tools were missing `tags_context(product=Product.MAX_AI)` tagging, making them invisible in query monitoring and cost attribution dashboards.

## Changes

Added `tags_context(product=Product.MAX_AI, team_id=..., org_id=...)` wrapping to:

- `ee/hogai/tools/replay/filter_session_recordings.py` — `SessionRecordingListFromQuery.run()`
- `ee/hogai/tools/replay/summarize_sessions.py` — `SessionRecordingListFromQuery.run()`
- `ee/hogai/tools/manage_memories.py` — `execute_hogql_query()` for memory search
- `products/experiments/backend/experiment_summary_data_service.py` — `ExperimentQueryRunner.run()` and `ExperimentExposuresQueryRunner.run()`
- `products/experiments/backend/max_tools.py` — `list_recordings_from_query()` for experiment session replay counts

## How did you test this code?

Verified import sorting with `ruff check`. The pattern matches existing tagged queries in `ee/hogai/context/insight/query_executor.py` and `ee/hogai/chat_agent/`.

## Publish to changelog?

no