### PR TITLE
fix(cdp): fix retrying destination invocations bug

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/hogFunctionLogsLogic.ts
+++ b/frontend/src/scenes/hog-functions/logs/hogFunctionLogsLogic.ts
@@ -190,7 +190,7 @@ export const hogFunctionLogsLogic = kea<hogFunctionLogsLogicType>([
                     )
 
                     if (!entryContainingEventId) {
-                        return undefined
+                        continue
                     }
 
                     for (const matcher of eventIdMatchers) {

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -240,7 +240,7 @@ describe('Hogflow Executor', () => {
                 finished: true,
                 logs: [
                     {
-                        level: 'debug',
+                        level: 'info',
                         message:
                             'Starting workflow execution at trigger for [Person:person_id|John Doe] on [Event:uuid|test|2026-01-30T20:20:20.200Z]',
                         timestamp: expect.any(DateTime),

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -172,7 +172,7 @@ export class HogFlowExecutorService {
 
             if (result.finished) {
                 if (result.error) {
-                    this.log(result, 'error', this.logExecutionErrorInfo(result, new Error(result.error)))
+                    this.log(result, 'error', this.logExecutionErrorInfo(result, result.error))
                 } else {
                     this.log(result, 'info', `Workflow completed`)
                 }

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -172,7 +172,7 @@ export class HogFlowExecutorService {
 
             if (result.finished) {
                 if (result.error) {
-                    this.log(result, 'error', `Workflow encountered an error: ${result.error}`)
+                    this.log(result, 'error', this.logExecutionErrorInfo(result, new Error(result.error)))
                 } else {
                     this.log(result, 'info', `Workflow completed`)
                 }
@@ -625,9 +625,25 @@ export class HogFlowExecutorService {
             : ''
 
         return {
-            level: 'debug',
+            level: 'info',
             message: `${hasCurrentAction ? 'Resuming' : 'Starting'} ${isBatchWorkflow ? 'batch ' : ''}workflow execution at ${currentAction}${triggeredForActor}${triggeredByEvent}`,
             timestamp: DateTime.now(),
         }
+    }
+
+    private logExecutionErrorInfo(
+        result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow>,
+        error: Error
+    ): string {
+        const invocation = result.invocation
+        const currentActionId = invocation.state.currentAction?.id
+        const currentAction = currentActionId ? invocation.hogFlow.actions.find((a) => a.id === currentActionId) : null
+
+        const hasAssociatedEvent = Boolean(invocation.state.event)
+        const triggeredByEvent = hasAssociatedEvent
+            ? `. This workflow was triggered by [Event:${invocation.state.event?.uuid}|${invocation.state.event?.event?.replaceAll('|', '')}|${invocation.state.event?.timestamp}]`
+            : ''
+
+        return `Workflow encountered an error: ${error.message} at ${currentAction ? actionIdForLogging(currentAction) : 'unknown action'}${triggeredByEvent}`
     }
 }


### PR DESCRIPTION
## Problem

There's a bug where if any invocation log group in a page doesn't have the event ID logs in it, we return `undefined` for `eventIdByInvocationId` instead of just skipping the one entry.

Also, we don't show the event ID in workflow failure logs, which would be helpful in the future when filtering just to error-ing invocations

## Changes

- Fix the aforementioned bug
- Emit workflow starting log as `info` level instead of `debug` - it's just really useful and we don't want people to miss it
- add event link to final error log on workflows

## How did you test this code?
<img width="487" height="252" alt="image" src="https://github.com/user-attachments/assets/3defa3b2-00c4-481f-9fca-98711b3b290d" />

<img width="1217" height="72" alt="image" src="https://github.com/user-attachments/assets/3f5bf3f7-3c52-438e-a495-8fc2dbfabae4" />



## Publish to changelog?

No