### PR TITLE
fix(llma): add query tagging to all llm analytics temporal workflows

### DIFF
--- a/posthog/temporal/llm_analytics/sentiment/data.py
+++ b/posthog/temporal/llm_analytics/sentiment/data.py
@@ -7,6 +7,7 @@ results by trace_id for downstream processing.
 import json
 from dataclasses import dataclass, field
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.temporal.llm_analytics.sentiment.constants import (
     GENERATIONS_BY_UUID_QUERY,
     GENERATIONS_QUERY,
@@ -43,19 +44,20 @@ def fetch_generations(
 
     team = Team.objects.get(id=team_id)
     query = parse_select(GENERATIONS_QUERY)
-    result = execute_hogql_query(
-        query_type="SentimentOnDemand",
-        query=query,
-        placeholders={
-            "date_from": ast.Constant(value=date_from),
-            "date_to": ast.Constant(value=date_to),
-            "trace_ids": ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids]),
-            "max_input_chars": ast.Constant(value=MAX_INPUT_CHARS),
-            "max_gens_per_trace": ast.Constant(value=MAX_GENERATIONS_PER_TRACE),
-        },
-        team=team,
-        limit_context=LimitContext.QUERY_ASYNC,
-    )
+    with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+        result = execute_hogql_query(
+            query_type="SentimentOnDemand",
+            query=query,
+            placeholders={
+                "date_from": ast.Constant(value=date_from),
+                "date_to": ast.Constant(value=date_to),
+                "trace_ids": ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids]),
+                "max_input_chars": ast.Constant(value=MAX_INPUT_CHARS),
+                "max_gens_per_trace": ast.Constant(value=MAX_GENERATIONS_PER_TRACE),
+            },
+            team=team,
+            limit_context=LimitContext.QUERY_ASYNC,
+        )
 
     fetch = FetchResult()
     for row in result.results or []:
@@ -94,17 +96,18 @@ def fetch_generations_by_uuid(
 
     team = Team.objects.get(id=team_id)
     query = parse_select(GENERATIONS_BY_UUID_QUERY)
-    result = execute_hogql_query(
-        query_type="SentimentOnDemandGeneration",
-        query=query,
-        placeholders={
-            "date_from": ast.Constant(value=date_from),
-            "date_to": ast.Constant(value=date_to),
-            "uuids": ast.Tuple(exprs=[ast.Constant(value=uid) for uid in generation_ids]),
-        },
-        team=team,
-        limit_context=LimitContext.QUERY_ASYNC,
-    )
+    with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+        result = execute_hogql_query(
+            query_type="SentimentOnDemandGeneration",
+            query=query,
+            placeholders={
+                "date_from": ast.Constant(value=date_from),
+                "date_to": ast.Constant(value=date_to),
+                "uuids": ast.Tuple(exprs=[ast.Constant(value=uid) for uid in generation_ids]),
+            },
+            team=team,
+            limit_context=LimitContext.QUERY_ASYNC,
+        )
 
     # Size guard applied post-fetch instead of in SQL — the SQL length()
     # filter forced JSONExtractRaw on every scanned row, 2.4x slower on

--- a/posthog/temporal/llm_analytics/trace_summarization/fetch_and_format.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/fetch_and_format.py
@@ -9,6 +9,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models.team import Team
 from posthog.redis import get_async_client
 from posthog.sync import database_sync_to_async
@@ -108,16 +109,17 @@ def _fetch_and_format_generation(
         """
     )
 
-    result = execute_hogql_query(
-        query_type="GenerationForSummarization",
-        query=query,
-        placeholders={
-            "start_dt": ast.Constant(value=start_dt_str),
-            "end_dt": ast.Constant(value=end_dt_str),
-            "generation_id": ast.Constant(value=generation_id),
-        },
-        team=team,
-    )
+    with tags_context(product=Product.LLM_ANALYTICS, team_id=team.id):
+        result = execute_hogql_query(
+            query_type="GenerationForSummarization",
+            query=query,
+            placeholders={
+                "start_dt": ast.Constant(value=start_dt_str),
+                "end_dt": ast.Constant(value=end_dt_str),
+                "generation_id": ast.Constant(value=generation_id),
+            },
+            team=team,
+        )
 
     if not result.results:
         return None

--- a/posthog/temporal/llm_analytics/trace_summarization/queries.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/queries.py
@@ -16,6 +16,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models.team import Team
 from posthog.temporal.llm_analytics.trace_summarization.constants import AI_EVENT_TYPES, TRACE_CAPTURE_RANGE
 
@@ -41,18 +42,19 @@ def fetch_trace(team: Team, trace_id: str, window_start: str, window_end: str) -
     end_dt = datetime.fromisoformat(window_end).astimezone(UTC) + TRACE_CAPTURE_RANGE
 
     query = parse_select(_TRACE_EVENTS_QUERY)
-    result = execute_hogql_query(
-        query_type="SummarizationTraceFetch",
-        query=query,
-        placeholders={
-            "event_types": ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES]),
-            "start_ts": ast.Constant(value=start_dt.strftime("%Y-%m-%d %H:%M:%S")),
-            "end_ts": ast.Constant(value=end_dt.strftime("%Y-%m-%d %H:%M:%S")),
-            "trace_id": ast.Constant(value=trace_id),
-        },
-        team=team,
-        limit_context=LimitContext.QUERY_ASYNC,
-    )
+    with tags_context(product=Product.LLM_ANALYTICS, team_id=team.id):
+        result = execute_hogql_query(
+            query_type="SummarizationTraceFetch",
+            query=query,
+            placeholders={
+                "event_types": ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES]),
+                "start_ts": ast.Constant(value=start_dt.strftime("%Y-%m-%d %H:%M:%S")),
+                "end_ts": ast.Constant(value=end_dt.strftime("%Y-%m-%d %H:%M:%S")),
+                "trace_id": ast.Constant(value=trace_id),
+            },
+            team=team,
+            limit_context=LimitContext.QUERY_ASYNC,
+        )
 
     if not result.results:
         return None

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -16,6 +16,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -100,20 +101,21 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 """
             )
 
-            result = execute_hogql_query(
-                query_type="GenerationsForSampling",
-                query=generations_query,
-                placeholders={
-                    "start_ts": ast.Constant(value=start_dt_str),
-                    "end_ts": ast.Constant(value=end_dt_str),
-                    "limit": ast.Constant(value=max_items),
-                    "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
-                    "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
-                    "trace_filter": trace_filter_expr or ast.Constant(value=True),
-                },
-                team=team,
-                limit_context=LimitContext.QUERY_ASYNC,
-            )
+            with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+                result = execute_hogql_query(
+                    query_type="GenerationsForSampling",
+                    query=generations_query,
+                    placeholders={
+                        "start_ts": ast.Constant(value=start_dt_str),
+                        "end_ts": ast.Constant(value=end_dt_str),
+                        "limit": ast.Constant(value=max_items),
+                        "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
+                        "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
+                        "trace_filter": trace_filter_expr or ast.Constant(value=True),
+                    },
+                    team=team,
+                    limit_context=LimitContext.QUERY_ASYNC,
+                )
 
             logger.debug(
                 "generation_sampling_result",
@@ -166,20 +168,21 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 """
             )
 
-            result = execute_hogql_query(
-                query_type="TracesForSampling",
-                query=traces_query,
-                placeholders={
-                    "start_ts": ast.Constant(value=start_dt_str),
-                    "end_ts": ast.Constant(value=end_dt_str),
-                    "limit": ast.Constant(value=max_items),
-                    "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
-                    "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
-                    "trace_filter": trace_filter_expr or ast.Constant(value=True),
-                },
-                team=team,
-                limit_context=LimitContext.QUERY_ASYNC,
-            )
+            with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+                result = execute_hogql_query(
+                    query_type="TracesForSampling",
+                    query=traces_query,
+                    placeholders={
+                        "start_ts": ast.Constant(value=start_dt_str),
+                        "end_ts": ast.Constant(value=end_dt_str),
+                        "limit": ast.Constant(value=max_items),
+                        "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
+                        "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
+                        "trace_filter": trace_filter_expr or ast.Constant(value=True),
+                    },
+                    team=team,
+                    limit_context=LimitContext.QUERY_ASYNC,
+                )
 
             logger.debug(
                 "trace_sampling_result",


### PR DESCRIPTION
## Problem

ClickHouse queries from LLM analytics temporal workflows (sentiment, trace summarization) are missing `product` and `team_id` tags in `system.query_log.log_comment`. This makes it hard for the infra team to attribute load to the LLM analytics product.

The sibling `trace_clustering` module already tags correctly via `tags_context`, but sentiment and trace summarization were missed.

## Changes

Added `tags_context(product=Product.LLM_ANALYTICS, team_id=...)` to all 6 untagged `execute_hogql_query` calls across 4 files:

- `sentiment/data.py` - `SentimentOnDemand`, `SentimentOnDemandGeneration`
- `trace_summarization/queries.py` - `SummarizationTraceFetch`
- `trace_summarization/sampling.py` - `GenerationsForSampling`, `TracesForSampling`
- `trace_summarization/fetch_and_format.py` - `GenerationForSummarization`

Uses the scoped `tags_context` context manager pattern, consistent with `trace_clustering/data.py`.

## How did you test this code?

Ran the full test suite for all three llm_analytics sub-modules (113 tests pass). Query tagging is transparent to query results so existing tests cover correctness.