### PR TITLE
fix(funnels): make link in breakdown attribution tooltip clickable

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -325,6 +325,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                                   <span>Breakdown attribution</span>
                                   <Tooltip
                                       closeDelayMs={200}
+                                      interactive
                                       title={
                                           <div className="deprecated-space-y-2">
                                               <div>


### PR DESCRIPTION
## Problem

Wasn't possible to click this link.

![Screenshot 2026-03-11 at 15.12.36.png](https://app.graphite.com/user-attachments/assets/099de99d-5591-4d5f-b39b-34c720493cda.png)

## Changes

Now it is.

## How did you test this code?

🖱️ 