### PR TITLE
fix: correct stripe app manifest provisioning base_url

### DIFF
--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -77,7 +77,7 @@
         "stripe_api_access_type": "oauth"
     },
     "provisioning": {
-        "base_url": "https://us.posthog.com/api/agentic/provisioning/",
+        "base_url": "https://us.posthog.com/api/agentic/",
         "oauth_token_endpoint": "https://us.posthog.com/api/agentic/oauth/token",
         "oauth_client_id": "3pFZtlNOg7UEBtr8t0rBAEbI8E4GBf1YqIC2L4jJ",
         "oauth_client_secret_secret_store_key": "posthog_access_token",

--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,7 +2,7 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "icon": "./assets/logomark.png",
     "declarations": {
         "distribution_type": "public",


### PR DESCRIPTION
## Problem

The Stripe APP spec appends `/provisioning/services`, `/provisioning/health`, etc. to the `provisioning.base_url` in the manifest. Our `base_url` was set to `https://us.posthog.com/api/agentic/provisioning/`, which caused Stripe to call URLs like `https://us.posthog.com/api/agentic/provisioning/provisioning/services` (double `/provisioning/`), resulting in 404s.

## Changes

Changed `provisioning.base_url` in `services/stripe-app/stripe-app.json` from `https://us.posthog.com/api/agentic/provisioning/` to `https://us.posthog.com/api/agentic/` so Stripe correctly calls `https://us.posthog.com/api/agentic/provisioning/services`.

The dev manifest (`stripe-app.dev.json`) does not override `provisioning.base_url` so no change needed there.

## How did you test this code?

This is a config-only change. Verified by reading the [Stripe APP provisioning spec](https://docs.stripe.com/stripe-apps/build-provisioning-api) which confirms Stripe appends `/provisioning/*` paths to the base_url.

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Opus 4.6.