### PR TITLE
fix(proxy): handle Cloudflare CNAME flattening in DNS validation

### DIFF
--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -12,6 +12,7 @@ from django.conf import settings
 
 import grpc.aio
 import dns.resolver
+import dns.asyncresolver
 import temporalio.common
 from structlog import get_logger
 from temporalio import activity, workflow
@@ -119,7 +120,7 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
         raise RecordDeletedException("proxy record was deleted while waiting for DNS records")
 
     try:
-        cnames = dns.resolver.query(inputs.domain, "CNAME")
+        cnames = await dns.asyncresolver.resolve(inputs.domain, "CNAME")
         value = cnames[0].target.canonicalize().to_text()
 
         if cnames[0].target == dns.name.from_text(inputs.target_cname):
@@ -137,7 +138,7 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
         # It means there is a record set, but it's not a CNAME record
         # A likely reason for this is that they have set Cloudflare proxying on.
         # Check for this explicitly to create a nice message for the user.
-        arecords = dns.resolver.query(inputs.domain, "A")
+        arecords = await dns.asyncresolver.resolve(inputs.domain, "A")
         if len(arecords) == 0:
             raise
         ip = arecords[0].to_text()
@@ -152,7 +153,7 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
             # off (grey cloud). If the IPs match our target, the setup is
             # correct — the CNAME is just being flattened.
             try:
-                target_arecords = dns.resolver.query(inputs.target_cname, "A")
+                target_arecords = await dns.asyncresolver.resolve(inputs.target_cname, "A")
                 target_ips = {r.to_text() for r in target_arecords}
                 customer_ips = {r.to_text() for r in arecords}
                 if customer_ips == target_ips:
@@ -162,8 +163,12 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
                         inputs.target_cname,
                     )
                     return
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "Failed to resolve A records for target CNAME %s: %s",
+                    inputs.target_cname,
+                    exc,
+                )
             # IPs don't match our target — customer likely has Cloudflare
             # proxying enabled on their own zone
             await update_record(

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -146,7 +146,26 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
         cloudflare_ips = external_requests.get("https://www.cloudflare.com/ips-v4").text.split("\n")
         is_cloudflare = any(ipaddress.ip_address(ip) in ipaddress.ip_network(cidr) for cidr in cloudflare_ips)
         if is_cloudflare:
-            # the customer has set cloudflare proxying on
+            # Before blaming the customer, check if the IPs match our target
+            # CNAME. Cloudflare CNAME flattening (for domains using Cloudflare
+            # nameservers) replaces the CNAME with A records even when proxy is
+            # off (grey cloud). If the IPs match our target, the setup is
+            # correct — the CNAME is just being flattened.
+            try:
+                target_arecords = dns.resolver.query(inputs.target_cname, "A")
+                target_ips = {r.to_text() for r in target_arecords}
+                customer_ips = {r.to_text() for r in arecords}
+                if customer_ips == target_ips:
+                    logger.info(
+                        "DNS for %s returned flattened A records matching target %s - treating as valid",
+                        inputs.domain,
+                        inputs.target_cname,
+                    )
+                    return
+            except Exception:
+                pass
+            # IPs don't match our target — customer likely has Cloudflare
+            # proxying enabled on their own zone
             await update_record(
                 proxy_record_id=inputs.proxy_record_id,
                 message="The DNS record appears to have Cloudflare proxying enabled - please disable this. For more information see [the docs](https://posthog.com/docs/advanced/proxy/managed-reverse-proxy)",


### PR DESCRIPTION
## Problem\

Customers whose domains use Cloudflare nameservers get a false positive "Cloudflare proxying enabled" error during managed proxy setup, even when their CNAME record has proxy disabled (grey cloud/DNS 
This is because Cloudflare automatically flattens CNAME records into A records at the authoritative DNS level, so the `wait_for_dns_records` activity sees Cloudflare IPs without a visible CNAME and
incorrectly blames the customer.
## Changes

In the `wait_for_dns_records` activity's `NoAnswer` handler, before showing the Cloudflare proxying error, we now resolve the target CNAME to its A records and compare them with the customer's A records. 
the IPs match, the setup is valid — the CNAME is just being flattened — and we treat it as a successful validation. If the IPs differ, the customer genuinely has proxy enabled on their zone and we show the
existing error message.
## How did you test this code?

Validated with real DNS lookups against domains in both states:
- Domain with Cloudflare nameservers + DNS only: A records match target CNAME's A records → correctly treated as valid
- Domain with proxy enabled: A records differ from target → correctly shows error
- Domain with non-Cloudflare nameservers: CNAME visible → works as before (no change in behavior)

