### PR TITLE
fix(ai): add exception tracking to agent executor failure paths

### DIFF
--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from django.conf import settings
 
 import structlog
+import posthoganalytics
 from prometheus_client import Histogram
 from temporalio.client import WorkflowExecutionStatus, WorkflowHandle
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
@@ -98,6 +99,7 @@ class AgentExecutor:
                 raise Exception(f"Workflow failed to start within timeout: {self._workflow_id}")
 
         except Exception as e:
+            posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
             logger.exception("Error starting workflow", error=e)
             yield self._failure_message()
             return
@@ -201,6 +203,7 @@ class AgentExecutor:
                 if message:
                     yield message
         except Exception as e:
+            posthoganalytics.capture_exception(e, properties={"tag": "max_ai"})
             logger.exception("Error streaming conversation", error=e)
             yield self._failure_message()
 


### PR DESCRIPTION
## Problem

The customer reported an issue where the problem appears to be in `executor.py`, but the logs don't show anything. 

## Summary
- Adds `posthoganalytics.capture_exception` with `tag="max_ai"` to the agent executor's failure paths (workflow start and stream errors)
- These paths previously only logged but didn't report to exception tracking

## Test plan
- [ ] Verify exception tracking fires when workflow start fails
- [ ] Verify exception tracking fires when streaming fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)