### PR TITLE
fix(perf): reduce UI seeming slow to load when CH is down

### DIFF
--- a/frontend/src/scenes/appLogic.tsx
+++ b/frontend/src/scenes/appLogic.tsx
@@ -47,7 +47,7 @@ export const appLogic = kea<appLogicType>([
     events(({ actions, cache }) => ({
         afterMount: () => {
             cache.disposables.add(() => {
-                const timerId = window.setTimeout(() => actions.enableDelayedSpinner(), 1000)
+                const timerId = window.setTimeout(() => actions.enableDelayedSpinner(), 350)
                 return () => clearTimeout(timerId)
             }, 'spinnerTimeout')
             cache.disposables.add(() => {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -370,6 +370,16 @@ def get_js_url(request: HttpRequest) -> str:
     return settings.JS_URL
 
 
+def _safe_preflight_check(request: HttpRequest) -> dict:
+    """Run preflight_check with a fallback so it never blocks page rendering."""
+    from posthog.views import preflight_check
+
+    try:
+        return json.loads(preflight_check(request).getvalue())
+    except Exception:
+        return {"django": True, "cloud": is_cloud()}
+
+
 def get_context_for_template(
     template_name: str,
     request: HttpRequest,
@@ -444,13 +454,12 @@ def get_context_for_template(
         from posthog.models.file_system.user_product_list import UserProductList
         from posthog.rbac.user_access_control import ACCESS_CONTROL_RESOURCES, UserAccessControl
         from posthog.user_permissions import UserPermissions
-        from posthog.views import preflight_check
 
         posthog_app_context = {
             "current_user": None,
             "current_project": None,
             "current_team": None,
-            "preflight": json.loads(preflight_check(request).getvalue()),
+            "preflight": _safe_preflight_check(request),
             "default_event_name": "$pageview",
             "custom_products": [],
             "switched_team": getattr(request, "switched_team", None),
@@ -619,8 +628,22 @@ async def initialize_self_capture_api_token():
         posthoganalytics.host = settings.SITE_URL
 
 
+DEFAULT_EVENT_INFO_CACHE_TTL = 300  # 5 minutes — rarely changes
+
+
 def get_default_event_info(team: "Team") -> dict:
+    from django.core.cache import cache
+
     from posthog.models import EventDefinition
+
+    cache_key = f"default_event_info_{team.pk}"
+    try:
+        cached = cache.get(cache_key)
+    except Exception:
+        cached = None
+
+    if cached is not None:
+        return cached
 
     existing_names = set(
         EventDefinition.objects.filter(team=team, name__in=["$pageview", "$screen"]).values_list("name", flat=True)
@@ -637,11 +660,18 @@ def get_default_event_info(team: "Team") -> dict:
     else:
         default_event_name = "$pageview"
 
-    return {
+    result = {
         "default_event_name": default_event_name,
         "has_pageview": has_pageview,
         "has_screen": has_screen,
     }
+
+    try:
+        cache.set(cache_key, result, DEFAULT_EVENT_INFO_CACHE_TTL)
+    except Exception:
+        pass
+
+    return result
 
 
 def get_default_event_name(team: "Team") -> str | None:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -371,7 +371,12 @@ def get_js_url(request: HttpRequest) -> str:
 
 
 def _safe_preflight_check(request: HttpRequest) -> dict:
-    """Run preflight_check with a fallback so it never blocks page rendering."""
+    """Embed preflight data in the initial page context to avoid an extra API round-trip.
+
+    On failure, returns a minimal fallback dict so the page still renders.
+    The frontend (preflightLogic) checks for this embedded data on mount and
+    falls back to fetching /_preflight/ via API if it's missing or incomplete.
+    """
     from posthog.views import preflight_check
 
     try:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -633,7 +633,19 @@ async def initialize_self_capture_api_token():
         posthoganalytics.host = settings.SITE_URL
 
 
-DEFAULT_EVENT_INFO_CACHE_TTL = 300  # 5 minutes — rarely changes
+# Cache TTL is team-age-aware: new teams are actively onboarding and ingesting
+# their first events, so stale cache causes confusing UI (e.g. showing "no events"
+# right after the first $pageview lands). After the first day event definitions
+# rarely change, so we can cache aggressively.
+_EVENT_INFO_CACHE_TTL_NEW_TEAM = 0  # no cache — team < 1 day old
+_EVENT_INFO_CACHE_TTL_ESTABLISHED_TEAM = 900  # 15 minutes — team >= 1 day old
+
+
+def _event_info_cache_ttl(team: "Team") -> int:
+    team_age = timezone.now() - team.created_at
+    if team_age < dt.timedelta(days=1):
+        return _EVENT_INFO_CACHE_TTL_NEW_TEAM
+    return _EVENT_INFO_CACHE_TTL_ESTABLISHED_TEAM
 
 
 def get_default_event_info(team: "Team") -> dict:
@@ -641,14 +653,17 @@ def get_default_event_info(team: "Team") -> dict:
 
     from posthog.models import EventDefinition
 
+    ttl = _event_info_cache_ttl(team)
     cache_key = f"default_event_info_{team.pk}"
-    try:
-        cached = cache.get(cache_key)
-    except Exception:
-        cached = None
 
-    if cached is not None:
-        return cached
+    if ttl > 0:
+        try:
+            cached = cache.get(cache_key)
+        except Exception:
+            cached = None
+
+        if cached is not None:
+            return cached
 
     existing_names = set(
         EventDefinition.objects.filter(team=team, name__in=["$pageview", "$screen"]).values_list("name", flat=True)
@@ -671,10 +686,11 @@ def get_default_event_info(team: "Team") -> dict:
         "has_screen": has_screen,
     }
 
-    try:
-        cache.set(cache_key, result, DEFAULT_EVENT_INFO_CACHE_TTL)
-    except Exception:
-        pass
+    if ttl > 0:
+        try:
+            cache.set(cache_key, result, ttl)
+        except Exception:
+            pass
 
     return result
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -166,56 +166,6 @@ def render_query(request: HttpRequest) -> HttpResponse:
     return render_template("render_query.html", request, context={"render_query_payload": payload})
 
 
-PREFLIGHT_HEALTH_CACHE_KEY = "preflight_health_status"
-PREFLIGHT_HEALTH_CACHE_TTL = 30  # seconds
-
-
-def _get_cached_health_status() -> dict[str, bool]:
-    """Return cached infrastructure health checks, refreshing if stale.
-
-    On Cloud, all checks short-circuit to True so caching is unnecessary.
-    For self-hosted, each health check (ClickHouse, Redis, Kafka, etc.) can
-    block for seconds on timeout. Caching prevents every page load from
-    paying that cost, especially during outages.
-    """
-    from django.core.cache import cache
-
-    if is_cloud():
-        return {
-            "redis": True,
-            "plugins": True,
-            "celery": True,
-            "clickhouse": True,
-            "kafka": True,
-            "db": True,
-        }
-
-    cached = None
-    try:
-        cached = cache.get(PREFLIGHT_HEALTH_CACHE_KEY)
-    except Exception:
-        pass
-
-    if cached is not None:
-        return cached
-
-    health = {
-        "redis": is_redis_alive() or settings.TEST,
-        "plugins": is_plugin_server_alive() or settings.TEST,
-        "celery": is_celery_alive() or settings.TEST,
-        "clickhouse": is_clickhouse_connected() or settings.TEST,
-        "kafka": is_kafka_connected() or settings.TEST,
-        "db": is_postgres_alive(),
-    }
-
-    try:
-        cache.set(PREFLIGHT_HEALTH_CACHE_KEY, health, PREFLIGHT_HEALTH_CACHE_TTL)
-    except Exception:
-        pass
-
-    return health
-
-
 @never_cache
 def preflight_check(request: HttpRequest) -> JsonResponse:
     slack_client_id = SlackIntegration.slack_config().get("SLACK_APP_CLIENT_ID")
@@ -225,11 +175,14 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
     hubspot_client_id = settings.HUBSPOT_APP_CLIENT_ID
     salesforce_client_id = settings.SALESFORCE_CONSUMER_KEY
 
-    health = _get_cached_health_status()
-
     response = {
         "django": True,
-        **health,
+        "redis": is_cloud() or is_redis_alive() or settings.TEST,
+        "plugins": is_cloud() or is_plugin_server_alive() or settings.TEST,
+        "celery": is_cloud() or is_celery_alive() or settings.TEST,
+        "clickhouse": is_cloud() or is_clickhouse_connected() or settings.TEST,
+        "kafka": is_cloud() or is_kafka_connected() or settings.TEST,
+        "db": is_cloud() or is_postgres_alive(),
         "initiated": is_cloud() or Organization.objects.exists(),
         "cloud": is_cloud(),
         "demo": settings.DEMO,

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -166,6 +166,56 @@ def render_query(request: HttpRequest) -> HttpResponse:
     return render_template("render_query.html", request, context={"render_query_payload": payload})
 
 
+PREFLIGHT_HEALTH_CACHE_KEY = "preflight_health_status"
+PREFLIGHT_HEALTH_CACHE_TTL = 30  # seconds
+
+
+def _get_cached_health_status() -> dict[str, bool]:
+    """Return cached infrastructure health checks, refreshing if stale.
+
+    On Cloud, all checks short-circuit to True so caching is unnecessary.
+    For self-hosted, each health check (ClickHouse, Redis, Kafka, etc.) can
+    block for seconds on timeout. Caching prevents every page load from
+    paying that cost, especially during outages.
+    """
+    from django.core.cache import cache
+
+    if is_cloud():
+        return {
+            "redis": True,
+            "plugins": True,
+            "celery": True,
+            "clickhouse": True,
+            "kafka": True,
+            "db": True,
+        }
+
+    cached = None
+    try:
+        cached = cache.get(PREFLIGHT_HEALTH_CACHE_KEY)
+    except Exception:
+        pass
+
+    if cached is not None:
+        return cached
+
+    health = {
+        "redis": is_redis_alive() or settings.TEST,
+        "plugins": is_plugin_server_alive() or settings.TEST,
+        "celery": is_celery_alive() or settings.TEST,
+        "clickhouse": is_clickhouse_connected() or settings.TEST,
+        "kafka": is_kafka_connected() or settings.TEST,
+        "db": is_postgres_alive(),
+    }
+
+    try:
+        cache.set(PREFLIGHT_HEALTH_CACHE_KEY, health, PREFLIGHT_HEALTH_CACHE_TTL)
+    except Exception:
+        pass
+
+    return health
+
+
 @never_cache
 def preflight_check(request: HttpRequest) -> JsonResponse:
     slack_client_id = SlackIntegration.slack_config().get("SLACK_APP_CLIENT_ID")
@@ -175,14 +225,11 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
     hubspot_client_id = settings.HUBSPOT_APP_CLIENT_ID
     salesforce_client_id = settings.SALESFORCE_CONSUMER_KEY
 
+    health = _get_cached_health_status()
+
     response = {
         "django": True,
-        "redis": is_cloud() or is_redis_alive() or settings.TEST,
-        "plugins": is_cloud() or is_plugin_server_alive() or settings.TEST,
-        "celery": is_cloud() or is_celery_alive() or settings.TEST,
-        "clickhouse": is_cloud() or is_clickhouse_connected() or settings.TEST,
-        "kafka": is_cloud() or is_kafka_connected() or settings.TEST,
-        "db": is_cloud() or is_postgres_alive(),
+        **health,
         "initiated": is_cloud() or Organization.objects.exists(),
         "cloud": is_cloud(),
         "demo": settings.DEMO,


### PR DESCRIPTION
## Problem

during a clickhouse incident the UI seemed very slow to load to me

largely because of vite hotloading drowning out everything else this is super difficult to test locally

## Changes

- **Reduced spinner delay**: Changed delayed spinner timeout from 1000ms to 350ms for more responsive loading feedback
- **Added safe preflight check**: Implemented `_safe_preflight_check()` function that embeds preflight data in initial page context to avoid extra API round-trips, with graceful fallback on failure
- **Implemented team-age-aware caching**: Added intelligent caching for event definitions that disables cache for teams less than 1 day old (when actively onboarding) and uses 15-minute cache for established teams

## How did you test this code?

Checked locally I could still load the site

## Publish to changelog?

No