### PR TITLE
chore(mcp): improve scaffold-yaml subset file handling and warnings

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -90,6 +90,7 @@ class LLMPromptFeatureFlagPermission(BasePermission):
         )
 
 
+@extend_schema(tags=["llm_analytics"])
 class LLMPromptViewSet(
     TeamAndOrgViewSetMixin,
     AccessControlViewSetMixin,

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -648,6 +648,73 @@ export interface TextReprResponseApi {
     metadata: TextReprMetadataApi
 }
 
+export interface LLMPromptApi {
+    readonly id: string
+    /**
+     * Unique prompt name using letters, numbers, hyphens, and underscores only.
+     * @maxLength 255
+     */
+    name: string
+    /** Prompt payload as JSON or string data. */
+    prompt: unknown
+    readonly version: number
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+    readonly deleted: boolean
+    readonly is_latest: boolean
+    readonly latest_version: number
+    readonly version_count: number
+    readonly first_version_created_at: string
+}
+
+export interface PaginatedLLMPromptListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: LLMPromptApi[]
+}
+
+export interface LLMPromptPublicApi {
+    id: string
+    name: string
+    prompt: unknown
+    version: number
+    created_at: string
+    updated_at: string
+    deleted: boolean
+    is_latest: boolean
+    latest_version: number
+    version_count: number
+    first_version_created_at: string
+}
+
+export interface PatchedLLMPromptPublishApi {
+    /** Prompt payload to publish as a new version. */
+    prompt?: unknown
+    /**
+     * Latest version you are editing from. Used for optimistic concurrency checks.
+     * @minimum 1
+     */
+    base_version?: number
+}
+
+export interface LLMPromptVersionSummaryApi {
+    readonly id: string
+    readonly version: number
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly is_latest: boolean
+}
+
+export interface LLMPromptResolveResponseApi {
+    prompt: LLMPromptApi
+    versions: LLMPromptVersionSummaryApi[]
+    has_more: boolean
+}
+
 export interface DatasetItemApi {
     readonly id: string
     dataset: string
@@ -835,6 +902,57 @@ export type LlmAnalyticsTextReprCreate400 = { [key: string]: unknown }
 export type LlmAnalyticsTextReprCreate500 = { [key: string]: unknown }
 
 export type LlmAnalyticsTextReprCreate503 = { [key: string]: unknown }
+
+export type LlmPromptsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * Optional substring filter applied to prompt names and prompt content.
+     */
+    search?: string
+}
+
+export type LlmPromptsNameRetrieveParams = {
+    /**
+     * Specific prompt version to fetch. If omitted, the latest version is returned.
+     * @minimum 1
+     */
+    version?: number
+}
+
+export type LlmPromptsResolveNameRetrieveParams = {
+    /**
+     * Return versions older than this version number. Mutually exclusive with offset.
+     * @minimum 1
+     */
+    before_version?: number
+    /**
+     * Maximum number of versions to return per page (1-100).
+     * @minimum 1
+     * @maximum 100
+     */
+    limit?: number
+    /**
+     * Zero-based offset into version history for pagination. Mutually exclusive with before_version.
+     * @minimum 0
+     */
+    offset?: number
+    /**
+     * Specific prompt version to fetch. If omitted, the latest version is returned.
+     * @minimum 1
+     */
+    version?: number
+    /**
+     * Exact prompt version UUID to resolve. Can be used together with version for extra safety.
+     */
+    version_id?: string
+}
 
 export type DatasetItemsListParams = {
     /**

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -21,17 +21,25 @@ import type {
     EvaluationSummaryRequestApi,
     EvaluationSummaryResponseApi,
     EvaluationsListParams,
+    LLMPromptApi,
+    LLMPromptPublicApi,
+    LLMPromptResolveResponseApi,
     LLMProviderKeyApi,
     LlmAnalyticsClusteringJobsListParams,
     LlmAnalyticsProviderKeysListParams,
+    LlmPromptsListParams,
+    LlmPromptsNameRetrieveParams,
+    LlmPromptsResolveNameRetrieveParams,
     PaginatedClusteringJobListApi,
     PaginatedDatasetItemListApi,
     PaginatedDatasetListApi,
     PaginatedEvaluationListApi,
+    PaginatedLLMPromptListApi,
     PaginatedLLMProviderKeyListApi,
     PatchedClusteringJobApi,
     PatchedDatasetApi,
     PatchedDatasetItemApi,
+    PatchedLLMPromptPublishApi,
     PatchedLLMProviderKeyApi,
     SentimentBatchResponseApi,
     SentimentRequestApi,
@@ -715,6 +723,150 @@ export const llmAnalyticsTranslateCreate = async (projectId: string, options?: R
     return apiMutator<void>(getLlmAnalyticsTranslateCreateUrl(projectId), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getLlmPromptsListUrl = (projectId: string, params?: LlmPromptsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/llm_prompts/?${stringifiedParams}`
+        : `/api/environments/${projectId}/llm_prompts/`
+}
+
+export const llmPromptsList = async (
+    projectId: string,
+    params?: LlmPromptsListParams,
+    options?: RequestInit
+): Promise<PaginatedLLMPromptListApi> => {
+    return apiMutator<PaginatedLLMPromptListApi>(getLlmPromptsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getLlmPromptsCreateUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/llm_prompts/`
+}
+
+export const llmPromptsCreate = async (
+    projectId: string,
+    lLMPromptApi: NonReadonly<LLMPromptApi>,
+    options?: RequestInit
+): Promise<LLMPromptApi> => {
+    return apiMutator<LLMPromptApi>(getLlmPromptsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(lLMPromptApi),
+    })
+}
+
+export const getLlmPromptsNameRetrieveUrl = (
+    projectId: string,
+    promptName: string,
+    params?: LlmPromptsNameRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/llm_prompts/name/${promptName}/?${stringifiedParams}`
+        : `/api/environments/${projectId}/llm_prompts/name/${promptName}/`
+}
+
+export const llmPromptsNameRetrieve = async (
+    projectId: string,
+    promptName: string,
+    params?: LlmPromptsNameRetrieveParams,
+    options?: RequestInit
+): Promise<LLMPromptPublicApi> => {
+    return apiMutator<LLMPromptPublicApi>(getLlmPromptsNameRetrieveUrl(projectId, promptName, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getLlmPromptsNamePartialUpdateUrl = (projectId: string, promptName: string) => {
+    return `/api/environments/${projectId}/llm_prompts/name/${promptName}/`
+}
+
+export const llmPromptsNamePartialUpdate = async (
+    projectId: string,
+    promptName: string,
+    patchedLLMPromptPublishApi: PatchedLLMPromptPublishApi,
+    options?: RequestInit
+): Promise<LLMPromptApi> => {
+    return apiMutator<LLMPromptApi>(getLlmPromptsNamePartialUpdateUrl(projectId, promptName), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedLLMPromptPublishApi),
+    })
+}
+
+export const getLlmPromptsNameArchiveCreateUrl = (projectId: string, promptName: string) => {
+    return `/api/environments/${projectId}/llm_prompts/name/${promptName}/archive/`
+}
+
+export const llmPromptsNameArchiveCreate = async (
+    projectId: string,
+    promptName: string,
+    lLMPromptApi: NonReadonly<LLMPromptApi>,
+    options?: RequestInit
+): Promise<LLMPromptApi> => {
+    return apiMutator<LLMPromptApi>(getLlmPromptsNameArchiveCreateUrl(projectId, promptName), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(lLMPromptApi),
+    })
+}
+
+export const getLlmPromptsResolveNameRetrieveUrl = (
+    projectId: string,
+    promptName: string,
+    params?: LlmPromptsResolveNameRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/llm_prompts/resolve/name/${promptName}/?${stringifiedParams}`
+        : `/api/environments/${projectId}/llm_prompts/resolve/name/${promptName}/`
+}
+
+export const llmPromptsResolveNameRetrieve = async (
+    projectId: string,
+    promptName: string,
+    params?: LlmPromptsResolveNameRetrieveParams,
+    options?: RequestInit
+): Promise<LLMPromptResolveResponseApi> => {
+    return apiMutator<LLMPromptResolveResponseApi>(getLlmPromptsResolveNameRetrieveUrl(projectId, promptName, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -260,8 +260,9 @@ function mergeWithExisting(
     existingPath: string,
     ops: DiscoveredOperation[],
     tag: string,
-    validOperationIds: Set<string>
-): { content: string; added: number; removed: number } {
+    validOperationIds: Set<string>,
+    subset = false
+): { content: string; added: number; removed: number; matched: number; unmatchedTools: string[] } {
     const parsed = parseYaml(fs.readFileSync(existingPath, 'utf-8'))
     const result = CategoryConfigSchema.safeParse(parsed)
     if (!result.success) {
@@ -278,6 +279,8 @@ function mergeWithExisting(
     const mergedTools: Record<string, unknown> = {}
     let added = 0
     let removed = 0
+    let matched = 0
+    const unmatchedTools: string[] = []
 
     // Preserve existing tool order and hand-authored operation values
     for (const [name, config] of Object.entries(existingTools)) {
@@ -290,21 +293,29 @@ function mergeWithExisting(
             // operationId when their variant was renumbered or removed.
             const operation = validOperationIds.has(config.operation) ? config.operation : op.operationId
             mergedTools[name] = { ...config, operation }
+            matched++
+        } else if (subset) {
+            // Subset files: keep unmatched tools (they may reference ops from a
+            // different tag/URL space) but warn so missing tags get noticed
+            mergedTools[name] = { ...config }
+            unmatchedTools.push(`${name} (${config.operation})`)
         } else {
             removed++
         }
     }
 
-    // Append new operations (not yet in YAML) at the end
-    const existingBaseIds = new Set(Object.values(existingTools).map((c) => c.operation.replace(/_\d+$/, '')))
-    for (const op of ops) {
-        const base = op.operationId.replace(/_\d+$/, '')
-        if (!existingBaseIds.has(base)) {
-            mergedTools[operationIdToToolName(op.operationId)] = {
-                operation: op.operationId,
-                enabled: false,
+    // Append new operations (not yet in YAML) at the end — skip for subset files
+    if (!subset) {
+        const existingBaseIds = new Set(Object.values(existingTools).map((c) => c.operation.replace(/_\d+$/, '')))
+        for (const op of ops) {
+            const base = op.operationId.replace(/_\d+$/, '')
+            if (!existingBaseIds.has(base)) {
+                mergedTools[operationIdToToolName(op.operationId)] = {
+                    operation: op.operationId,
+                    enabled: false,
+                }
+                added++
             }
-            added++
         }
     }
 
@@ -315,7 +326,13 @@ function mergeWithExisting(
         tools: mergedTools,
     }
 
-    return { content: YAML_HEADER + stringifyYaml(merged, { indent: 4, lineWidth: 120 }), added, removed }
+    return {
+        content: YAML_HEADER + stringifyYaml(merged, { indent: 4, lineWidth: 120 }),
+        added,
+        removed,
+        matched,
+        unmatchedTools,
+    }
 }
 
 // ------------------------------------------------------------------
@@ -333,6 +350,8 @@ function syncAll(spec: OpenApiSpec): void {
     interface SyncTarget {
         product: string
         filePath: string
+        /** Subset files (filename != tools.yaml) only validate — no adds/removes */
+        subset: boolean
     }
 
     const targets: SyncTarget[] = []
@@ -346,11 +365,14 @@ function syncAll(spec: OpenApiSpec): void {
             targets.push({
                 product: file.replace(/\.ya?ml$/, ''),
                 filePath: path.join(DEFINITIONS_DIR, file),
+                subset: false,
             })
         }
     }
 
-    // Product definitions — product derived from directory name
+    // Product definitions — product always from directory name.
+    // Non-tools.yaml files are subset files that own a curated slice of the
+    // product's operations (e.g. prompts.yaml inside llm_analytics/mcp/).
     if (fs.existsSync(PRODUCTS_DIR)) {
         for (const entry of fs.readdirSync(PRODUCTS_DIR, { withFileTypes: true })) {
             if (!entry.isDirectory() || entry.name.startsWith('_')) {
@@ -364,9 +386,8 @@ function syncAll(spec: OpenApiSpec): void {
                 if (!file.endsWith('.yaml') && !file.endsWith('.yml')) {
                     continue
                 }
-                const product =
-                    file === 'tools.yaml' || file === 'tools.yml' ? entry.name : file.replace(/\.ya?ml$/, '')
-                targets.push({ product, filePath: path.join(mcpDir, file) })
+                const subset = file !== 'tools.yaml' && file !== 'tools.yml'
+                targets.push({ product: entry.name, filePath: path.join(mcpDir, file), subset })
             }
         }
     }
@@ -378,28 +399,47 @@ function syncAll(spec: OpenApiSpec): void {
 
     const writtenFiles: string[] = []
 
-    for (const { product, filePath } of targets) {
+    for (const { product, filePath, subset } of targets) {
         const rawOps = findOperationsByProduct(spec, product)
         const ops = deduplicateOperations(rawOps)
         if (ops.length === 0) {
             process.stdout.write(`${product}: no operations found in OpenAPI, skipping\n`)
             continue
         }
+        const label = path.relative(REPO_ROOT, filePath)
         const validIds = new Set(rawOps.map((op) => op.operationId))
-        const { content, added, removed } = mergeWithExisting(filePath, ops, product, validIds)
-        fs.writeFileSync(filePath, content)
-        writtenFiles.push(filePath)
-        const parts = [`${ops.length} operation(s)`]
+        const { content, added, removed, matched, unmatchedTools } = mergeWithExisting(
+            filePath,
+            ops,
+            product,
+            validIds,
+            subset
+        )
+        // Only write when there are actual changes (avoids formatting-only rewrites)
+        if (added > 0 || removed > 0) {
+            fs.writeFileSync(filePath, content)
+            writtenFiles.push(filePath)
+        }
+        const total = matched + unmatchedTools.length
+        const parts = [subset ? `${matched}/${total} tool(s) matched` : `${ops.length} operation(s)`]
         if (added > 0) {
             parts.push(`${added} new`)
         }
         if (removed > 0) {
             parts.push(`${removed} removed`)
         }
-        if (added === 0 && removed === 0) {
+        if (added === 0 && removed === 0 && unmatchedTools.length === 0) {
             parts.push('no changes')
         }
-        process.stdout.write(`${product}: ${parts.join(', ')}\n`)
+        process.stdout.write(`${label}: ${parts.join(', ')}\n`)
+        if (unmatchedTools.length > 0) {
+            process.stderr.write(
+                `  ⚠ ${unmatchedTools.length} tool(s) not found in OpenAPI — add @extend_schema(tags=["${product}"]) to the ViewSet\n`
+            )
+            for (const tool of unmatchedTools) {
+                process.stderr.write(`    - ${tool}\n`)
+            }
+        }
     }
 
     formatWithPrettier(writtenFiles)

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -262,7 +262,7 @@ function mergeWithExisting(
     tag: string,
     validOperationIds: Set<string>,
     subset = false
-): { content: string; added: number; removed: number; matched: number; unmatchedTools: string[] } {
+): { content: string; added: number; removed: number; updated: number; matched: number; unmatchedTools: string[] } {
     const parsed = parseYaml(fs.readFileSync(existingPath, 'utf-8'))
     const result = CategoryConfigSchema.safeParse(parsed)
     if (!result.success) {
@@ -279,6 +279,7 @@ function mergeWithExisting(
     const mergedTools: Record<string, unknown> = {}
     let added = 0
     let removed = 0
+    let updated = 0
     let matched = 0
     const unmatchedTools: string[] = []
 
@@ -293,6 +294,9 @@ function mergeWithExisting(
             // operationId when their variant was renumbered or removed.
             const operation = validOperationIds.has(config.operation) ? config.operation : op.operationId
             mergedTools[name] = { ...config, operation }
+            if (operation !== config.operation) {
+                updated++
+            }
             matched++
         } else if (subset) {
             // Subset files: keep unmatched tools (they may reference ops from a
@@ -300,6 +304,7 @@ function mergeWithExisting(
             mergedTools[name] = { ...config }
             unmatchedTools.push(`${name} (${config.operation})`)
         } else {
+            unmatchedTools.push(`${name} (${config.operation})`)
             removed++
         }
     }
@@ -330,6 +335,7 @@ function mergeWithExisting(
         content: YAML_HEADER + stringifyYaml(merged, { indent: 4, lineWidth: 120 }),
         added,
         removed,
+        updated,
         matched,
         unmatchedTools,
     }
@@ -408,27 +414,32 @@ function syncAll(spec: OpenApiSpec): void {
         }
         const label = path.relative(REPO_ROOT, filePath)
         const validIds = new Set(rawOps.map((op) => op.operationId))
-        const { content, added, removed, matched, unmatchedTools } = mergeWithExisting(
+        const { content, added, removed, updated, matched, unmatchedTools } = mergeWithExisting(
             filePath,
             ops,
             product,
             validIds,
             subset
         )
-        // Only write when there are actual changes (avoids formatting-only rewrites)
-        if (added > 0 || removed > 0) {
+        // Only write when there are semantic changes (avoids formatting-only rewrites)
+        if (added > 0 || removed > 0 || updated > 0) {
             fs.writeFileSync(filePath, content)
             writtenFiles.push(filePath)
         }
         const total = matched + unmatchedTools.length
-        const parts = [subset ? `${matched}/${total} tool(s) matched` : `${ops.length} operation(s)`]
+        const parts = [
+            subset ? (total === 0 ? '0 tool(s)' : `${matched}/${total} tool(s) matched`) : `${ops.length} operation(s)`,
+        ]
         if (added > 0) {
             parts.push(`${added} new`)
         }
         if (removed > 0) {
             parts.push(`${removed} removed`)
         }
-        if (added === 0 && removed === 0 && unmatchedTools.length === 0) {
+        if (updated > 0) {
+            parts.push(`${updated} operation ID(s) updated`)
+        }
+        if (added === 0 && removed === 0 && updated === 0 && unmatchedTools.length === 0) {
             parts.push('no changes')
         }
         process.stdout.write(`${label}: ${parts.join(', ')}\n`)


### PR DESCRIPTION
Stacked on #50661.

**Subset files** (e.g. `prompts.yaml` inside `llm_analytics/mcp/`) now derive the product name from the directory instead of the filename. Files named something other than `tools.yaml` are treated as subsets — existing tools are validated but no new operations are added from the broader product.

**Warnings** — when tools in a YAML file can't be matched to OpenAPI operations, scaffold now warns on stderr with the specific tools and a hint to add `@extend_schema(tags=["..."])` to the ViewSet.

**Tag fix** — adds `@extend_schema(tags=["llm_analytics"])` to `LLMPromptViewSet` so the 4 prompt tools are discoverable under the llm_analytics product. Without this the viewset lives in `posthog/api/` (not `products/llm_analytics/backend/`) and has no auto-derived tag.

Also skips file writes when there are no semantic changes to avoid formatting-only rewrites.