### PR TITLE
fix: use dedicated STRIPE_APP_SIGNING_SECRET for HMAC signature verification

### DIFF
--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -33,7 +33,7 @@ def verify_stripe_signature(request: Request) -> Response | None:
             status=400,
         )
 
-    secret = settings.STRIPE_APP_SECRET_KEY
+    secret = settings.STRIPE_APP_SIGNING_SECRET
     if not secret:
         return Response({"error": {"code": "server_error", "message": "Signing secret not configured"}}, status=500)
 

--- a/ee/api/agentic_provisioning/test/base.py
+++ b/ee/api/agentic_provisioning/test/base.py
@@ -16,7 +16,7 @@ HMAC_SECRET = "test_hmac_secret"
 TEST_STRIPE_OAUTH_CLIENT_ID = "test_stripe_oauth_client_id"
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET, STRIPE_POSTHOG_OAUTH_CLIENT_ID=TEST_STRIPE_OAUTH_CLIENT_ID)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET, STRIPE_POSTHOG_OAUTH_CLIENT_ID=TEST_STRIPE_OAUTH_CLIENT_ID)
 class StripeProvisioningTestBase(APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -15,7 +15,7 @@ from ee.api.agentic_provisioning import PENDING_AUTH_CACHE_PREFIX
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestAccountRequests(StripeProvisioningTestBase):
     def _account_request_payload(self, **overrides):
         payload = {

--- a/ee/api/agentic_provisioning/test/test_authorize.py
+++ b/ee/api/agentic_provisioning/test/test_authorize.py
@@ -73,7 +73,7 @@ class TestAgenticAuthorize(APIBaseTest):
         assert code_data["team_id"] == self.team.id
         assert code_data["scopes"] == ["query:read", "project:read"]
 
-    @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET, STRIPE_ORCHESTRATOR_CALLBACK_URL=DUMMY_CALLBACK)
+    @override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET, STRIPE_ORCHESTRATOR_CALLBACK_URL=DUMMY_CALLBACK)
     def test_full_a1_flow_with_token_exchange(self):
         self._set_pending_auth("state_e2e", self.user.email)
 

--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -9,7 +9,7 @@ from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisionin
 from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestDeepLinks(StripeProvisioningTestBase):
     def _get_bearer_token(self) -> str:
         code = "dl_test_code"

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -9,7 +9,7 @@ from ee.api.agentic_provisioning.signature import compute_signature
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestE2EProvisioningFlow(StripeProvisioningTestBase):
     """Walk through the full APP 0.1d provisioning flow end-to-end."""
 

--- a/ee/api/agentic_provisioning/test/test_health.py
+++ b/ee/api/agentic_provisioning/test/test_health.py
@@ -6,7 +6,7 @@ from ee.api.agentic_provisioning.signature import compute_signature
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestProvisioningHealth(StripeProvisioningTestBase):
     def test_valid_request(self):
         res = self._get_signed("/api/agentic/provisioning/health")

--- a/ee/api/agentic_provisioning/test/test_oauth_token.py
+++ b/ee/api/agentic_provisioning/test/test_oauth_token.py
@@ -9,7 +9,7 @@ from ee.api.agentic_provisioning.signature import compute_signature
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestOAuthTokenExchange(StripeProvisioningTestBase):
     def _store_auth_code(self, code: str = "test_code", **overrides):
         data = {

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestProvisioningResources(StripeProvisioningTestBase):
     def test_create_resource_returns_complete(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -8,7 +8,7 @@ from posthog.models.team.team import Team
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
     def test_rotate_returns_new_access_configuration(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -103,7 +103,7 @@ def _mock_cache_empty():
     return mock
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestProvisioningServices(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.external_requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -24,7 +24,7 @@ class TestParseSignatureHeader(TestCase):
         assert _parse_signature_header(header) == expected
 
 
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)
 class TestComputeSignature(TestCase):
     @parameterized.expand(
         [

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -63,12 +63,14 @@ ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
 # We also support their agentic provisioning protocol which requires us to check even more stuff
 # - STRIPE_APP_CLIENT_ID: The app's public client ID, used in the OAuth authorize redirect URL
 # - STRIPE_APP_OVERRIDE_AUTHORIZE_URL: Optional override for testing (e.g., with a channel link URL)
-# - STRIPE_APP_SECRET_KEY: API secret key used for HTTP Basic auth during token exchange/refresh
+# - STRIPE_APP_SECRET_KEY: Stripe API secret key (sk_live_*) used for HTTP Basic auth during token exchange/refresh
+# - STRIPE_APP_SIGNING_SECRET: App Signing Secret (absec_*) from the Stripe dashboard, used to verify Stripe-Signature HMAC headers on inbound agentic provisioning requests
 # - STRIPE_POSTHOG_OAUTH_CLIENT_ID: Client ID of the PostHog OAuthApplication for Stripe to authenticate with PostHog APIs
 # - STRIPE_SIGNING_SECRET: Used to verify the authenticity of incoming webhook/agentic provisioning requests from Stripe
 STRIPE_APP_CLIENT_ID = get_from_env("STRIPE_APP_CLIENT_ID", "")
 STRIPE_APP_OVERRIDE_AUTHORIZE_URL = get_from_env("STRIPE_APP_OVERRIDE_AUTHORIZE_URL", "")
 STRIPE_APP_SECRET_KEY = get_from_env("STRIPE_APP_SECRET_KEY", "")
+STRIPE_APP_SIGNING_SECRET = get_from_env("STRIPE_APP_SIGNING_SECRET", "")
 STRIPE_POSTHOG_OAUTH_CLIENT_ID = get_from_env("STRIPE_POSTHOG_OAUTH_CLIENT_ID", "")
 STRIPE_SIGNING_SECRET = get_from_env("STRIPE_SIGNING_SECRET", "")
 STRIPE_ORCHESTRATOR_CALLBACK_URL = get_from_env("STRIPE_ORCHESTRATOR_CALLBACK_URL", "")

--- a/services/stripe-app/README.md
+++ b/services/stripe-app/README.md
@@ -40,7 +40,7 @@ Key files:
 - `posthog/models/integration.py` — `StripeIntegration` class: writes and clears secrets in Stripe
 - `posthog/api/integration.py` — triggers `write_posthog_secrets()` after Stripe OAuth callback
 - `posthog/settings/integrations.py` — env vars (`STRIPE_APP_CLIENT_ID`, `STRIPE_APP_SECRET_KEY`,
-  `STRIPE_POSTHOG_OAUTH_CLIENT_ID`, `STRIPE_APP_OVERRIDE_AUTHORIZE_URL`)
+  `STRIPE_APP_SIGNING_SECRET`, `STRIPE_POSTHOG_OAUTH_CLIENT_ID`, `STRIPE_APP_OVERRIDE_AUTHORIZE_URL`)
 
 ### Stripe App (this directory)
 
@@ -168,9 +168,10 @@ This creates a `package-lock.json` (required by Stripe) and uploads the app.
 
 ## Environment variables
 
-| Variable                            | Description                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------- |
-| `STRIPE_APP_CLIENT_ID`              | Stripe App OAuth client ID (from Stripe Apps dashboard)                   |
-| `STRIPE_APP_SECRET_KEY`             | Stripe API secret key for token exchange                                  |
-| `STRIPE_POSTHOG_OAUTH_CLIENT_ID`    | Client ID of the PostHog OAuthApplication used by the Stripe App          |
-| `STRIPE_APP_OVERRIDE_AUTHORIZE_URL` | Channel link authorize URL (required for non-published app installations) |
+| Variable                            | Description                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `STRIPE_APP_CLIENT_ID`              | Stripe App OAuth client ID (from Stripe Apps dashboard)                                                |
+| `STRIPE_APP_SECRET_KEY`             | Stripe API secret key (`sk_live_*` / `sk_test_*`) used for HTTP Basic auth during OAuth token exchange |
+| `STRIPE_APP_SIGNING_SECRET`         | App Signing Secret (`absec_*`) from the Stripe dashboard, used to verify Stripe-Signature HMAC headers |
+| `STRIPE_POSTHOG_OAUTH_CLIENT_ID`    | Client ID of the PostHog OAuthApplication used by the Stripe App                                       |
+| `STRIPE_APP_OVERRIDE_AUTHORIZE_URL` | Channel link authorize URL (required for non-published app installations)                              |


### PR DESCRIPTION
## Problem

`STRIPE_APP_SECRET_KEY` is the Stripe API secret key (`sk_live_*`) used for OAuth token exchange via HTTP Basic auth. However, `ee/api/agentic_provisioning/signature.py` was using it as the HMAC signing secret for verifying inbound `Stripe-Signature` headers. The actual HMAC signing secret is a different key — the App Signing Secret from the Stripe dashboard, which starts with `absec_`.

Using the wrong key means signature verification would fail in production whenever the API secret key and signing secret differ (which they always do).

## Changes

- Added a new Django setting `STRIPE_APP_SIGNING_SECRET` in `posthog/settings/integrations.py` (reads from env var `STRIPE_APP_SIGNING_SECRET`, defaults to empty string)
- Updated `ee/api/agentic_provisioning/signature.py` to use `settings.STRIPE_APP_SIGNING_SECRET` instead of `settings.STRIPE_APP_SECRET_KEY`
- Updated all 11 test files that used `@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)` to use `@override_settings(STRIPE_APP_SIGNING_SECRET=HMAC_SECRET)`
- Updated `services/stripe-app/README.md` to document the new setting and clarify the distinction between the two keys

## How did you test this code?

- All 101 tests in `ee/api/agentic_provisioning/test/` pass: `python -m pytest ee/api/agentic_provisioning/test/ -v --timeout=30`
- Ran `ruff check` and `ruff format` on all changed files with no issues
- I am an agent and have not tested this manually. The `STRIPE_APP_SIGNING_SECRET` env var will need to be set in deployed environments with the `absec_*` value from the Stripe Apps dashboard.

## Publish to changelog?

No

## 🤖 LLM context

This PR was authored by Claude Code (Claude Opus 4.6).