### PR TITLE
fix(llma): rename default clustering jobs to avoid double brackets in UI

### DIFF
--- a/products/llm_analytics/backend/api/clustering_job.py
+++ b/products/llm_analytics/backend/api/clustering_job.py
@@ -77,7 +77,7 @@ class ClusteringJobViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ClusteringJob.objects.filter(
                 team_id=self.team_id,
                 analysis_level=instance.analysis_level,
-                name__startswith="Default (",
+                name__startswith="Default - ",
                 enabled=True,
             )
             .exclude(id=instance.id)

--- a/products/llm_analytics/backend/api/test/test_clustering_job.py
+++ b/products/llm_analytics/backend/api/test/test_clustering_job.py
@@ -149,8 +149,8 @@ class TestClusteringJobViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_disables_default_job_at_same_level(self):
-        default_trace = self._create_job(name="Default (traces)", analysis_level="trace", enabled=True)
-        default_gen = self._create_job(name="Default (generations)", analysis_level="generation", enabled=True)
+        default_trace = self._create_job(name="Default - traces", analysis_level="trace", enabled=True)
+        default_gen = self._create_job(name="Default - generations", analysis_level="generation", enabled=True)
 
         response = self.client.post(
             self._url(),

--- a/products/llm_analytics/backend/migrations/0018_migrate_clustering_configs_to_jobs.py
+++ b/products/llm_analytics/backend/migrations/0018_migrate_clustering_configs_to_jobs.py
@@ -10,7 +10,7 @@ def migrate_clustering_configs_to_jobs(apps, schema_editor):
         for level, suffix in [("trace", "traces"), ("generation", "generations")]:
             ClusteringJob.objects.create(
                 team_id=config.team_id,
-                name=f"Default ({suffix})",
+                name=f"Default - {suffix}",
                 analysis_level=level,
                 event_filters=config.event_filters,
                 enabled=True,

--- a/products/llm_analytics/backend/migrations/0019_rename_default_clustering_jobs.py
+++ b/products/llm_analytics/backend/migrations/0019_rename_default_clustering_jobs.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def rename_default_clustering_jobs(apps, schema_editor):
+    """Rename 'Default (traces)' -> 'Default - traces', etc."""
+    ClusteringJob = apps.get_model("llm_analytics", "ClusteringJob")
+    for old_suffix, new_name in [
+        ("traces)", "Default - traces"),
+        ("generations)", "Default - generations"),
+    ]:
+        ClusteringJob.objects.filter(name=f"Default ({old_suffix}").update(name=new_name)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_analytics", "0018_migrate_clustering_configs_to_jobs"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_default_clustering_jobs,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/products/llm_analytics/backend/migrations/0019_rename_default_clustering_jobs.py
+++ b/products/llm_analytics/backend/migrations/0019_rename_default_clustering_jobs.py
@@ -4,11 +4,11 @@ from django.db import migrations
 def rename_default_clustering_jobs(apps, schema_editor):
     """Rename 'Default (traces)' -> 'Default - traces', etc."""
     ClusteringJob = apps.get_model("llm_analytics", "ClusteringJob")
-    for old_suffix, new_name in [
-        ("traces)", "Default - traces"),
-        ("generations)", "Default - generations"),
+    for old_name, new_name in [
+        ("Default (traces)", "Default - traces"),
+        ("Default (generations)", "Default - generations"),
     ]:
-        ClusteringJob.objects.filter(name=f"Default ({old_suffix}").update(name=new_name)
+        ClusteringJob.objects.filter(name=old_name).update(name=new_name)
 
 
 class Migration(migrations.Migration):

--- a/products/llm_analytics/backend/migrations/max_migration.txt
+++ b/products/llm_analytics/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0018_migrate_clustering_configs_to_jobs
+0019_rename_default_clustering_jobs


### PR DESCRIPTION
## Summary

- Default clustering job names changed from `Default (traces)` / `Default (generations)` to `Default - traces` / `Default - generations`
- The runs dropdown was displaying these as `<timestamp> (Default (traces))` which had awkward nested brackets — now renders as `<timestamp> (Default - traces)`
- Includes a data migration to rename existing default jobs
- Updated the `name__startswith` check that auto-disables defaults when a custom job is created

## Test plan

- [x] Existing clustering job tests pass (22/22)
- [ ] Verify the runs dropdown renders cleanly with the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)