### PR TITLE
fix(ph-ai): stop button now cancels queued convs workflows

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -506,7 +506,10 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
     def cancel(self, request: Request, *args, **kwargs):
         conversation = self.get_object()
 
-        if conversation.status in [Conversation.Status.CANCELING, Conversation.Status.IDLE]:
+        # IDLE is intentionally not short-circuited: during the handoff between the main
+        # workflow completing and a queued workflow starting, the status is briefly IDLE
+        # even though a queued Temporal workflow may be running.
+        if conversation.status == Conversation.Status.CANCELING:
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         async def cancel_workflow():

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -408,8 +408,11 @@ class TestConversation(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-    def test_cancel_idle_conversation_noop(self):
-        """Test that canceling an idle conversation is a no-op."""
+    @patch("ee.hogai.core.executor.AgentExecutor.cancel_workflow")
+    def test_cancel_idle_conversation_still_cleans_up(self, mock_cancel):
+        """Test that canceling an idle conversation still attempts cleanup,
+        because queued workflows may be running even when status is IDLE
+        (during the transition between main and queued workflows)."""
         conversation = Conversation.objects.create(
             user=self.user,
             team=self.team,
@@ -423,9 +426,7 @@ class TestConversation(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        conversation.refresh_from_db()
-        # Status should remain idle
-        self.assertEqual(conversation.status, Conversation.Status.IDLE)
+        mock_cancel.assert_called_once()
 
     def test_cancel_nonexistent_conversation(self):
         """Test canceling a conversation that doesn't exist."""

--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -17,6 +17,7 @@ from posthog.schema import AssistantEventType, FailureMessage
 from posthog.temporal.ai.base import AgentBaseWorkflow
 from posthog.temporal.common.client import async_connect
 
+from ee.hogai.queue import ConversationQueueStore
 from ee.hogai.stream.redis_stream import (
     CONVERSATION_STREAM_MAX_LENGTH,
     CONVERSATION_STREAM_TIMEOUT,
@@ -240,29 +241,46 @@ class AgentExecutor:
     async def cancel_workflow(self) -> None:
         """Cancel the current conversation and clean up resources.
 
-        This cancels both the main conversation workflow and any running subagent workflows.
+        This cancels the main conversation workflow, any running subagent workflows,
+        any queued message workflows, and clears the cache queue.
 
-        Raises:
-            Exception: If cancellation fails
+        The main workflow cancel is non-fatal because the main workflow may have already
+        completed after spawning a queued workflow. In that case, we still need to cancel
+        the queued workflows and clear the cache queue.
         """
         self._conversation.status = Conversation.Status.CANCELING
         await self._conversation.asave(update_fields=["status", "updated_at"])
 
-        client = await async_connect()
+        try:
+            client = await async_connect()
 
-        # Cancel the main conversation workflow
-        handle = client.get_workflow_handle(workflow_id=self._workflow_id)
-        await handle.cancel()
+            # Cancel the main conversation workflow.
+            # This may fail if the workflow already completed (e.g. after spawning a queued workflow),
+            # but we must continue to cancel queued workflows and clean up.
+            try:
+                handle = client.get_workflow_handle(workflow_id=self._workflow_id)
+                await handle.cancel()
+            except Exception as e:
+                logger.warning(
+                    "Failed to cancel main workflow (may have already completed)",
+                    workflow_id=self._workflow_id,
+                    conversation_id=str(self._conversation.id),
+                    error=str(e),
+                )
 
-        # Cancel any running subagent workflows for this conversation
-        await self._cancel_subagent_workflows(client)
-        # Cancel any queued message workflows for this conversation
-        await self._cancel_queue_workflows(client)
+            # Cancel any running subagent workflows for this conversation
+            await self._cancel_subagent_workflows(client)
+            # Cancel any running queued message workflows for this conversation
+            await self._cancel_queue_workflows(client)
 
-        await self._redis_stream.delete_stream()
+            # Clear the cache queue so no new queued workflows are spawned
+            queue_store = ConversationQueueStore(str(self._conversation.id))
+            await queue_store.clear_async()
 
-        self._conversation.status = Conversation.Status.IDLE
-        await self._conversation.asave(update_fields=["status", "updated_at"])
+            await self._redis_stream.delete_stream()
+        finally:
+            self._conversation.status = Conversation.Status.IDLE
+            await self._conversation.asave(update_fields=["status", "updated_at"])
 
     async def _cancel_subagent_workflows(self, client) -> None:
         """Cancel all running subagent workflows for this conversation.

--- a/ee/hogai/core/test/test_agent_executor.py
+++ b/ee/hogai/core/test/test_agent_executor.py
@@ -280,6 +280,7 @@ class TestAgentExecutor(BaseTest):
             patch("ee.hogai.core.executor.async_connect") as mock_connect,
             patch.object(self.manager._redis_stream, "delete_stream") as mock_delete,
             patch.object(self.conversation, "asave") as mock_save,
+            patch("ee.hogai.core.executor.ConversationQueueStore") as mock_queue_store_cls,
         ):
             # Setup client and handle mocks
             mock_client = Mock()
@@ -294,6 +295,11 @@ class TestAgentExecutor(BaseTest):
             mock_handle.cancel = cancel_mock
             mock_delete.return_value = True
 
+            # Setup queue store mock
+            mock_queue_store = Mock()
+            mock_queue_store.clear_async = AsyncMock(return_value=[])
+            mock_queue_store_cls.return_value = mock_queue_store
+
             # Call the method - should not raise exception
             await self.manager.cancel_workflow()
 
@@ -302,6 +308,9 @@ class TestAgentExecutor(BaseTest):
 
             # Verify Redis stream cleanup
             mock_delete.assert_called_once()
+
+            # Verify cache queue was cleared
+            mock_queue_store.clear_async.assert_called_once()
 
             # Verify conversation status update
             self.assertEqual(self.conversation.status, Conversation.Status.IDLE)
@@ -317,30 +326,60 @@ class TestAgentExecutor(BaseTest):
         with self.assertRaises(Exception):
             await self.manager.cancel_workflow()
 
-    async def test_cancel_conversation_workflow_cancel_error(self):
-        """Test conversation cancellation when workflow cancel fails."""
-        with patch("ee.hogai.core.executor.async_connect") as mock_connect:
-            # Setup mocks
+    async def test_cancel_continues_when_main_workflow_already_completed(self):
+        """Test that cancellation proceeds even if the main workflow cancel fails
+        (e.g. when the main workflow already completed after spawning a queued workflow).
+        Verifies subagent and queue workflow cancellation are still attempted."""
+        with (
+            patch("ee.hogai.core.executor.async_connect") as mock_connect,
+            patch.object(self.manager._redis_stream, "delete_stream") as mock_delete,
+            patch.object(self.conversation, "asave") as mock_save,
+            patch.object(self.manager, "_cancel_subagent_workflows") as mock_cancel_subagents,
+            patch.object(self.manager, "_cancel_queue_workflows") as mock_cancel_queue,
+            patch("ee.hogai.core.executor.ConversationQueueStore") as mock_queue_store_cls,
+        ):
             mock_client = Mock()
             mock_handle = Mock()
             mock_connect.return_value = mock_client
             mock_client.get_workflow_handle.return_value = mock_handle
 
-            # Create an async function that raises exception
+            # Main workflow cancel fails (already completed)
             async def cancel_error():
                 raise Exception("Workflow cancel failed")
 
             mock_handle.cancel = cancel_error
+            mock_delete.return_value = True
+            mock_cancel_subagents.return_value = None
+            mock_cancel_queue.return_value = None
 
-            # Call the method - should raise exception
-            with self.assertRaises(Exception):
-                await self.manager.cancel_workflow()
+            mock_queue_store = Mock()
+            mock_queue_store.clear_async = AsyncMock(return_value=[])
+            mock_queue_store_cls.return_value = mock_queue_store
+
+            # Should NOT raise — cancellation continues despite main workflow failure
+            await self.manager.cancel_workflow()
+
+            # Verify subagent and queue workflow cancellation were still attempted
+            mock_cancel_subagents.assert_called_once_with(mock_client)
+            mock_cancel_queue.assert_called_once_with(mock_client)
+
+            # Verify cache queue was still cleared
+            mock_queue_store.clear_async.assert_called_once()
+
+            # Verify Redis stream was still cleaned up
+            mock_delete.assert_called_once()
+
+            # Verify conversation status was reset to IDLE
+            self.assertEqual(self.conversation.status, Conversation.Status.IDLE)
+            mock_save.assert_called()
 
     async def test_cancel_conversation_redis_cleanup_error(self):
-        """Test conversation cancellation when Redis cleanup fails."""
+        """Test conversation cancellation when Redis cleanup fails.
+        Status should still be reset to IDLE via the finally block."""
         with (
             patch("ee.hogai.core.executor.async_connect") as mock_connect,
             patch.object(self.manager._redis_stream, "delete_stream") as mock_delete,
+            patch("ee.hogai.core.executor.ConversationQueueStore") as mock_queue_store_cls,
         ):
             # Setup mocks
             mock_client = Mock()
@@ -354,9 +393,16 @@ class TestAgentExecutor(BaseTest):
             mock_handle.cancel = cancel_mock
             mock_delete.side_effect = Exception("Redis cleanup failed")
 
-            # Call the method - should raise exception
+            mock_queue_store = Mock()
+            mock_queue_store.clear_async = AsyncMock(return_value=[])
+            mock_queue_store_cls.return_value = mock_queue_store
+
+            # Should raise exception from delete_stream
             with self.assertRaises(Exception):
                 await self.manager.cancel_workflow()
+
+            # Status should still be reset to IDLE via finally
+            self.assertEqual(self.conversation.status, Conversation.Status.IDLE)
 
     async def test_cancel_conversation_save_error(self):
         """Test conversation cancellation when conversation save fails."""
@@ -559,6 +605,7 @@ class TestAgentExecutor(BaseTest):
             patch.object(self.manager._redis_stream, "delete_stream") as mock_delete,
             patch.object(self.conversation, "asave"),
             patch.object(self.manager, "_cancel_subagent_workflows") as mock_cancel_subagents,
+            patch("ee.hogai.core.executor.ConversationQueueStore") as mock_queue_store_cls,
         ):
             mock_client = Mock()
             mock_handle = Mock()
@@ -571,6 +618,10 @@ class TestAgentExecutor(BaseTest):
             mock_handle.cancel = cancel_mock
             mock_delete.return_value = True
             mock_cancel_subagents.return_value = None
+
+            mock_queue_store = Mock()
+            mock_queue_store.clear_async = AsyncMock(return_value=[])
+            mock_queue_store_cls.return_value = mock_queue_store
 
             await self.manager.cancel_workflow()
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -978,6 +978,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             try {
                 await api.conversations.cancel(values.conversation.id)
                 cache.generationController?.abort()
+                actions.clearQueuedMessages()
                 actions.resetThread()
             } catch (e: any) {
                 lemonToast.error(e?.data?.detail || 'Failed to cancel the generation.')


### PR DESCRIPTION
## Problem

The stop button in PostHog AI did not actually cancel conversations when queued messages were being processed.

Bonus: added E2E test so this is a bit more stable