### PR TITLE
fix: render markdown in shared dashboard descriptions

### DIFF
--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -9,6 +9,7 @@ import { Logo } from 'lib/brand/Logo'
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { useThemedHtml } from 'lib/hooks/useThemedHtml'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { Link } from 'lib/lemon-ui/Link'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
@@ -99,7 +100,7 @@ export function Exporter(props: ExportedData): JSX.Element {
                                 <h1 className="mb-2" data-attr="dashboard-item-title">
                                     {dashboard.name}
                                 </h1>
-                                <span>{dashboard.description}</span>
+                                <LemonMarkdown lowKeyHeadings>{dashboard.description || ''}</LemonMarkdown>
                             </div>
                             <span className="SharedDashboard-header-team">{currentTeam?.name}</span>
                         </div>
@@ -113,7 +114,7 @@ export function Exporter(props: ExportedData): JSX.Element {
                     ) : type === ExportType.Image ? (
                         <>
                             <h1 className="mb-2">{dashboard.name}</h1>
-                            <p>{dashboard.description}</p>
+                            <LemonMarkdown lowKeyHeadings>{dashboard.description || ''}</LemonMarkdown>
                         </>
                     ) : null
                 ) : null}


### PR DESCRIPTION
## Problem

Dashboard descriptions support markdown — the editor shows a "Markdown supported" tooltip, and descriptions render through `<LemonMarkdown>` on the regular dashboard view. However, on shared/public dashboards and image exports, the description is rendered as plain text (`<span>` / `<p>`), so any markdown formatting (e.g. `_italic_`, `**bold**`) appears as raw syntax.

## Changes

Replace plain text rendering of `dashboard.description` in `Exporter.tsx` with `<LemonMarkdown lowKeyHeadings>` for both the shared dashboard view and image export path, matching the behaviour of the regular dashboard.

## How did you test this code?

To test:
1. Create a dashboard with markdown in the description (e.g. `_example text_` or `**bold**`)
2. Share the dashboard via a public link
3. Confirm the description renders with markdown formatting (italic, bold, etc.) instead of raw syntax
4. Also verify the image export path renders markdown correctly

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code.