### PR TITLE
feat(surveys): add copy response key button to question viz

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -1,8 +1,10 @@
 import { useValues } from 'kea'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
+import { IconCopy } from '@posthog/icons'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { humanFriendlyNumber, pluralize } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { AnalyzeResponsesButton } from 'scenes/surveys/components/AnalyzeResponsesButton'
 import { MultipleChoiceQuestionViz } from 'scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz'
@@ -12,7 +14,7 @@ import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
-import { QuestionProcessedResponses, SurveyQuestion, SurveyQuestionType } from '~/types'
+import { QuestionProcessedResponses, SurveyEventProperties, SurveyQuestion, SurveyQuestionType } from '~/types'
 
 import { SCALE_LABELS } from '../../constants'
 import { isThumbQuestion } from '../../utils'
@@ -75,6 +77,24 @@ function QuestionTitle({
                         <span className={part.className}>{part.text}</span>
                     </span>
                 ))}
+                {question.id && (
+                    <>
+                        <span className="text-border-dark">•</span>
+                        <LemonButton
+                            size="xxsmall"
+                            type="tertiary"
+                            icon={<IconCopy />}
+                            onClick={() =>
+                                void copyToClipboard(
+                                    `${SurveyEventProperties.SURVEY_RESPONSE}_${question.id}`,
+                                    'survey response key'
+                                )
+                            }
+                        >
+                            Copy response key
+                        </LemonButton>
+                    </>
+                )}
             </div>
             <div className="flex flex-row justify-between items-center gap-3">
                 <h3 className="text-xl font-semibold mb-0 leading-tight">


### PR DESCRIPTION
## Problem

it's quite hard to find the response key for a given survey question, which means it's hard to build notifications and custom queries

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a small "copy response key" button to the question viz cards

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## ![Screenshot 2026-03-11 at 10.06.17 AM.png](https://app.graphite.com/user-attachments/assets/aac8b60d-a841-4367-b34d-1ecff39af7f9.png)



## How did you test this code?

manually

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->