### PR TITLE
feat(llma): add expand user only display option

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -6,7 +6,11 @@ import { Provider } from 'kea'
 import { initKeaTests } from '~/test/init'
 
 import { CompatMessage } from '../types'
-import { ConversationMessagesDisplay, LLMMessageDisplay } from './ConversationMessagesDisplay'
+import {
+    ConversationDisplayOption,
+    ConversationMessagesDisplay,
+    LLMMessageDisplay,
+} from './ConversationMessagesDisplay'
 
 describe('LLMMessageDisplay', () => {
     beforeEach(() => {
@@ -53,16 +57,51 @@ describe('LLMMessageDisplay', () => {
         )
         expect(container.textContent).toContain(expectedSubstring)
     })
+})
 
-    it('expands only user messages with expand_user_only display option', () => {
-        const inputNormalized: CompatMessage[] = [
-            { role: 'system', content: 'system input content' },
-            { role: 'user', content: 'first user input content' },
-            { role: 'assistant', content: 'assistant input content' },
-            { role: 'user', content: 'second user input content' },
-        ]
-        const outputNormalized: CompatMessage[] = [{ role: 'assistant', content: 'assistant output content' }]
+describe('ConversationMessagesDisplay', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
 
+    afterEach(() => {
+        cleanup()
+    })
+
+    const inputNormalized: CompatMessage[] = [
+        { role: 'system', content: 'system input content' },
+        { role: 'user', content: 'first user input content' },
+        { role: 'assistant', content: 'assistant input content' },
+        { role: 'user', content: 'second user input content' },
+    ]
+    const outputNormalized: CompatMessage[] = [{ role: 'assistant', content: 'assistant output content' }]
+
+    it.each<[string, string, string[], string[]]>([
+        [
+            'expand_all',
+            'expand_all',
+            [
+                'system input content',
+                'first user input content',
+                'assistant input content',
+                'second user input content',
+                'assistant output content',
+            ],
+            [],
+        ],
+        [
+            'expand_user_only',
+            'expand_user_only',
+            ['first user input content', 'second user input content'],
+            ['system input content', 'assistant input content', 'assistant output content'],
+        ],
+        [
+            'collapse_except_output_and_last_input',
+            'collapse_except_output_and_last_input',
+            ['second user input content', 'assistant output content'],
+            ['system input content', 'first user input content', 'assistant input content'],
+        ],
+    ])('display option %s shows/hides correct messages', (_label, displayOption, visible, hidden) => {
         render(
             <Provider>
                 <ConversationMessagesDisplay
@@ -70,15 +109,16 @@ describe('LLMMessageDisplay', () => {
                     outputNormalized={outputNormalized}
                     errorData={null}
                     raisedError={false}
-                    displayOption="expand_user_only"
+                    displayOption={displayOption as ConversationDisplayOption}
                 />
             </Provider>
         )
 
-        expect(screen.getByText('first user input content')).toBeInTheDocument()
-        expect(screen.getByText('second user input content')).toBeInTheDocument()
-        expect(screen.queryByText('system input content')).not.toBeInTheDocument()
-        expect(screen.queryByText('assistant input content')).not.toBeInTheDocument()
-        expect(screen.queryByText('assistant output content')).not.toBeInTheDocument()
+        for (const text of visible) {
+            expect(screen.getByText(text)).toBeInTheDocument()
+        }
+        for (const text of hidden) {
+            expect(screen.queryByText(text)).not.toBeInTheDocument()
+        }
     })
 })

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -1,12 +1,12 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { Provider } from 'kea'
 
 import { initKeaTests } from '~/test/init'
 
 import { CompatMessage } from '../types'
-import { LLMMessageDisplay } from './ConversationMessagesDisplay'
+import { ConversationMessagesDisplay, LLMMessageDisplay } from './ConversationMessagesDisplay'
 
 describe('LLMMessageDisplay', () => {
     beforeEach(() => {
@@ -52,5 +52,33 @@ describe('LLMMessageDisplay', () => {
             </Provider>
         )
         expect(container.textContent).toContain(expectedSubstring)
+    })
+
+    it('expands only user messages with expand_user_only display option', () => {
+        const inputNormalized: CompatMessage[] = [
+            { role: 'system', content: 'system input content' },
+            { role: 'user', content: 'first user input content' },
+            { role: 'assistant', content: 'assistant input content' },
+            { role: 'user', content: 'second user input content' },
+        ]
+        const outputNormalized: CompatMessage[] = [{ role: 'assistant', content: 'assistant output content' }]
+
+        render(
+            <Provider>
+                <ConversationMessagesDisplay
+                    inputNormalized={inputNormalized}
+                    outputNormalized={outputNormalized}
+                    errorData={null}
+                    raisedError={false}
+                    displayOption="expand_user_only"
+                />
+            </Provider>
+        )
+
+        expect(screen.getByText('first user input content')).toBeInTheDocument()
+        expect(screen.getByText('second user input content')).toBeInTheDocument()
+        expect(screen.queryByText('system input content')).not.toBeInTheDocument()
+        expect(screen.queryByText('assistant input content')).not.toBeInTheDocument()
+        expect(screen.queryByText('assistant output content')).not.toBeInTheDocument()
     })
 })

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -35,21 +35,33 @@ import { HighlightedXMLViewer } from './HighlightedXMLViewer'
 import { MessageActionsMenu } from './MessageActionsMenu'
 import { XMLViewer } from './XMLViewer'
 
-export type ConversationDisplayOption = 'expand_all' | 'collapse_except_output_and_last_input' | 'text_view'
+export type ConversationDisplayOption =
+    | 'expand_all'
+    | 'expand_user_only'
+    | 'collapse_except_output_and_last_input'
+    | 'text_view'
 type MessageType = 'input' | 'output'
 
 function getInitialMessageShowStates(
-    inputCount: number,
-    outputCount: number,
+    inputMessages: CompatMessage[],
+    outputMessages: CompatMessage[],
     displayOption: ConversationDisplayOption = 'collapse_except_output_and_last_input'
 ): { input: boolean[]; output: boolean[] } {
-    const inputStates = new Array(inputCount).fill(false).map((_, i) => {
+    const inputStates = inputMessages.map((message, i) => {
         if (displayOption === 'expand_all') {
             return true
         }
-        return i === inputCount - 1
+        if (displayOption === 'expand_user_only') {
+            return message.role === 'user'
+        }
+        return i === inputMessages.length - 1
     })
-    const outputStates = new Array(outputCount).fill(true)
+    const outputStates = outputMessages.map((message) => {
+        if (displayOption === 'expand_user_only') {
+            return message.role === 'user'
+        }
+        return true
+    })
     return { input: inputStates, output: outputStates }
 }
 
@@ -80,11 +92,13 @@ export function ConversationMessagesDisplay({
     generationEventId?: string
 }): JSX.Element {
     const [messageShowStates, setMessageShowStates] = React.useState(() =>
-        getInitialMessageShowStates(inputNormalized.length, outputNormalized.length, displayOption)
+        getInitialMessageShowStates(inputNormalized, outputNormalized, displayOption)
     )
     const [isRenderingMarkdown, setIsRenderingMarkdown] = React.useState(true)
     const [isRenderingXml, setIsRenderingXml] = React.useState(false)
     const previousSearchQueryRef = React.useRef('')
+    const inputRolesSignature = inputNormalized.map((message) => message.role).join('|')
+    const outputRolesSignature = outputNormalized.map((message) => message.role).join('|')
     const inputMessageShowStates = messageShowStates.input
     const outputMessageShowStates = messageShowStates.output
     const { getGenerationSentiment } = useValues(llmGenerationSentimentLazyLoaderLogic)
@@ -126,10 +140,8 @@ export function ConversationMessagesDisplay({
 
     // Initialize message states when message counts or display option changes.
     React.useEffect(() => {
-        setMessageShowStates(
-            getInitialMessageShowStates(inputNormalized.length, outputNormalized.length, displayOption)
-        )
-    }, [inputNormalized.length, outputNormalized.length, displayOption])
+        setMessageShowStates(getInitialMessageShowStates(inputNormalized, outputNormalized, displayOption))
+    }, [inputNormalized.length, outputNormalized.length, inputRolesSignature, outputRolesSignature, displayOption])
 
     // Expand only messages matching the current search query.
     React.useEffect(() => {
@@ -145,9 +157,7 @@ export function ConversationMessagesDisplay({
             })
             setMessageShowStates({ input: inputMatches, output: outputMatches })
         } else if (previousSearchQueryRef.current) {
-            setMessageShowStates(
-                getInitialMessageShowStates(inputNormalized.length, outputNormalized.length, displayOption)
-            )
+            setMessageShowStates(getInitialMessageShowStates(inputNormalized, outputNormalized, displayOption))
         }
         previousSearchQueryRef.current = trimmedSearchQuery
     }, [searchQuery, inputNormalized, outputNormalized, inputNormalized.length, outputNormalized.length, displayOption])

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -1298,6 +1298,12 @@ function DisplayOptionsSelect(): JSX.Element {
             'data-attr': 'llma-trace-display-expand-all',
         },
         {
+            value: DisplayOption.ExpandUserOnly,
+            label: 'Expand user only',
+            tooltip: 'Show only user messages in expanded view',
+            'data-attr': 'llma-trace-display-expand-user-only',
+        },
+        {
             value: DisplayOption.CollapseExceptOutputAndLastInput,
             label: 'Collapse except output and last input',
             tooltip: 'Focus on the most recent input and final output',

--- a/products/llm_analytics/frontend/components/EventContentWithAsyncData.tsx
+++ b/products/llm_analytics/frontend/components/EventContentWithAsyncData.tsx
@@ -3,7 +3,10 @@ import React from 'react'
 import { HighlightedJSONViewer } from 'lib/components/HighlightedJSONViewer'
 import { isObject } from 'lib/utils'
 
-import { ConversationMessagesDisplay } from '../ConversationDisplay/ConversationMessagesDisplay'
+import {
+    ConversationDisplayOption,
+    ConversationMessagesDisplay,
+} from '../ConversationDisplay/ConversationMessagesDisplay'
 import { useAIData } from '../hooks/useAIData'
 import { normalizeMessage, normalizeMessages } from '../utils'
 import { AIDataLoading } from './AIDataLoading'
@@ -18,7 +21,7 @@ interface EventContentGenerationProps {
     httpStatus: unknown
     raisedError: boolean
     searchQuery?: string
-    displayOption?: 'expand_all' | 'collapse_except_output_and_last_input' | 'text_view'
+    displayOption?: ConversationDisplayOption
 }
 
 export function EventContentGeneration({

--- a/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
@@ -34,6 +34,7 @@ const persistConfig = { persist: true, prefix: `${teamId}__` }
 
 export enum DisplayOption {
     ExpandAll = 'expand_all',
+    ExpandUserOnly = 'expand_user_only',
     CollapseExceptOutputAndLastInput = 'collapse_except_output_and_last_input',
     TextView = 'text_view',
 }


### PR DESCRIPTION
## Problem

When reviewing conversation traces, we sometimes want to quickly scan just the user side of the conversation.
Current display options do not provide a direct way to expand only user rows.

## Changes

- Added a new display option in the trace dropdown: `Expand user only`.
- Added a new display mode value: `expand_user_only`.
- Updated initial message expansion behavior so this mode expands only rows where `role === 'user'`.
- Wired typing updates so generation content and conversation display share the same display-option type.
- Added a focused test that verifies only user messages are expanded in this mode.

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx products/llm_analytics/frontend/llmAnalyticsTraceLogic.test.ts`

## Publish to changelog?

no
