### PR TITLE
chore(batch_exports): add query observability to backfill estimation

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -282,10 +282,10 @@ async def _get_backfill_info_for_events(
     extra_query_parameters: dict[str, typing.Any],
     log_comment: str = "{}",
 ) -> tuple[dt.datetime | None, int | None]:
-    """Get adjusted start time and estimated record count for events model.
+    """Get earliest timestamp and estimated record count for events model.
 
     Returns:
-        A tuple of (adjusted_start_at, estimated_records_count).
+        A tuple of (min_timestamp, estimated_records_count).
         If no data exists, returns (None, 0).
     """
     team_id = batch_export.team_id
@@ -347,10 +347,7 @@ async def _get_backfill_info_for_events(
     if min_timestamp.year == 1970:
         return None, 0
 
-    # Align to interval boundary considering the batch export's offset and timezone
-    earliest_start = _align_timestamp_to_interval(min_timestamp, batch_export)
-
-    return earliest_start, record_count
+    return min_timestamp, record_count
 
 
 async def _get_backfill_info_for_persons(
@@ -359,15 +356,15 @@ async def _get_backfill_info_for_persons(
     end_at: dt.datetime | None,
     log_comment: str = "{}",
 ) -> tuple[dt.datetime | None, int | None]:
-    """Get adjusted start time and estimated record count for persons model.
+    """Get earliest timestamp and estimated record count for persons model.
 
     Queries both `person` and `person_distinct_id2` tables. The count uses
     `uniq()` for an approximate count to reduce memory usage on large teams.
 
     Returns:
-        A tuple of (adjusted_start_at, estimated_records_count).
+        A tuple of (min_timestamp, estimated_records_count).
         If no data exists, returns (None, 0).
-        For limited export teams, returns (adjusted_start_at, None) since
+        For limited export teams, returns (min_timestamp, None) since
         the count would not reflect the actual export behavior.
     """
     team_id = batch_export.team_id
@@ -440,10 +437,8 @@ async def _get_backfill_info_for_persons(
     if earliest_timestamp is None:
         return None, 0
 
-    earliest_start = _align_timestamp_to_interval(earliest_timestamp, batch_export)
-
     if is_limited_export:
-        return earliest_start, None
+        return earliest_timestamp, None
 
     count_query = f"""
         WITH new_persons AS (
@@ -496,7 +491,7 @@ async def _get_backfill_info_for_persons(
 
     record_count = int(count_results[0]["record_count"])
 
-    return earliest_start, record_count
+    return earliest_timestamp, record_count
 
 
 async def _get_backfill_info_for_sessions(
@@ -505,13 +500,13 @@ async def _get_backfill_info_for_sessions(
     end_at: dt.datetime | None,
     log_comment: str | None = None,
 ) -> tuple[dt.datetime | None, int | None]:
-    """Get adjusted start time and estimated record count for sessions model.
+    """Get earliest timestamp and estimated record count for sessions model.
 
     Queries the sessions table via HogQL, filtering by $end_timestamp
     (this logic is the same as the actual export query, which aliases `$end_timestamp` as `_inserted_at`).
 
     Returns:
-        A tuple of (adjusted_start_at, estimated_records_count).
+        A tuple of (min_timestamp, estimated_records_count).
         If no data exists, returns (None, 0).
     """
 
@@ -521,8 +516,7 @@ async def _get_backfill_info_for_sessions(
     if min_timestamp is None:
         return None, 0
 
-    earliest_start = _align_timestamp_to_interval(min_timestamp, batch_export)
-    return earliest_start, record_count
+    return min_timestamp, record_count
 
 
 @temporalio.activity.defn
@@ -574,7 +568,7 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
     interval_seconds = batch_export.interval_time_delta.total_seconds()
 
     if model == "events":
-        adjusted_start_at, record_count = await _get_backfill_info_for_events(
+        min_timestamp, record_count = await _get_backfill_info_for_events(
             batch_export=batch_export,
             start_at=start_at,
             end_at=end_at,
@@ -585,14 +579,14 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             log_comment=log_comment,
         )
     elif model == "persons":
-        adjusted_start_at, record_count = await _get_backfill_info_for_persons(
+        min_timestamp, record_count = await _get_backfill_info_for_persons(
             batch_export=batch_export,
             start_at=start_at,
             end_at=end_at,
             log_comment=log_comment,
         )
     elif model == "sessions":
-        adjusted_start_at, record_count = await _get_backfill_info_for_sessions(
+        min_timestamp, record_count = await _get_backfill_info_for_sessions(
             batch_export=batch_export,
             start_at=start_at,
             end_at=end_at,
@@ -609,7 +603,7 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             interval_seconds=interval_seconds,
         )
 
-    if adjusted_start_at is None:
+    if min_timestamp is None:
         logger.info(
             "No data exists for backfill",
             team_id=inputs.team_id,
@@ -621,6 +615,8 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             total_records_count=0,
             interval_seconds=interval_seconds,
         )
+
+    adjusted_start_at = _align_timestamp_to_interval(min_timestamp, batch_export)
 
     adjusted_start_at_str = inputs.start_at
     if start_at is not None and adjusted_start_at != start_at:

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -1,5 +1,4 @@
 import json
-import time
 import uuid
 import typing
 import asyncio
@@ -20,6 +19,8 @@ from asgiref.sync import sync_to_async
 from structlog.contextvars import bind_contextvars
 
 from posthog.batch_exports.models import BatchExport, BatchExportBackfill, BatchExportRun
+from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import Product
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
@@ -34,6 +35,7 @@ from products.batch_exports.backend.service import (
     unpause_batch_export,
     update_batch_export_backfill,
 )
+from products.batch_exports.backend.temporal.metrics import log_query_duration
 from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
 from products.batch_exports.backend.temporal.spmc import compose_filters_clause
 
@@ -323,14 +325,13 @@ async def _get_backfill_info_for_events(
     }
 
     query_id = str(uuid.uuid4())
-    logger.info("Executing backfill info query for events", query_id=query_id)
-    start_time = time.monotonic()
-
-    async with get_client(team_id=team_id) as client:
-        result = await client.read_query_as_jsonl(query, query_parameters=query_parameters, query_id=query_id)
-
-    execution_time = time.monotonic() - start_time
-    logger.info("Backfill info query for events completed", query_id=query_id, query_duration_seconds=execution_time)
+    async with log_query_duration(
+        logger=logger,
+        query_id=query_id,
+        query_type="backfill_info:events",
+    ):
+        async with get_client(team_id=team_id) as client:
+            result = await client.read_query_as_jsonl(query, query_parameters=query_parameters, query_id=query_id)
 
     min_timestamp_str = result[0]["min_timestamp"]
     record_count = int(result[0]["record_count"])
@@ -401,21 +402,16 @@ async def _get_backfill_info_for_persons(
         SETTINGS log_comment=%(log_comment)s
     """
 
-    query_id = str(uuid.uuid4())
-    logger.info("Executing backfill info min_timestamp query for persons", query_id=query_id)
-    start_time = time.monotonic()
-
-    async with get_client(team_id=team_id) as client:
-        min_timestamp_results = await client.read_query_as_jsonl(
-            min_timestamp_query, query_parameters=query_parameters, query_id=query_id
-        )
-
-    execution_time = time.monotonic() - start_time
-    logger.info(
-        "Backfill info min_timestamp query for persons completed",
-        query_id=query_id,
-        query_duration_seconds=execution_time,
-    )
+    min_timestamp_query_id = str(uuid.uuid4())
+    async with log_query_duration(
+        logger=logger,
+        query_id=min_timestamp_query_id,
+        query_type="backfill_info:persons_min_timestamp",
+    ):
+        async with get_client(team_id=team_id) as client:
+            min_timestamp_results = await client.read_query_as_jsonl(
+                min_timestamp_query, query_parameters=query_parameters, query_id=min_timestamp_query_id
+            )
 
     # Find the earliest valid timestamp across both tables
     earliest_timestamp: dt.datetime | None = None
@@ -473,20 +469,15 @@ async def _get_backfill_info_for_persons(
     """
 
     count_query_id = str(uuid.uuid4())
-    logger.info("Executing backfill info count query for persons", query_id=count_query_id)
-    count_start_time = time.monotonic()
-
-    async with get_client(team_id=team_id) as client:
-        count_results = await client.read_query_as_jsonl(
-            count_query, query_parameters=query_parameters, query_id=count_query_id
-        )
-
-    count_execution_time = time.monotonic() - count_start_time
-    logger.info(
-        "Backfill info count query for persons completed",
+    async with log_query_duration(
+        logger=logger,
         query_id=count_query_id,
-        query_duration_seconds=count_execution_time,
-    )
+        query_type="backfill_info:persons_count",
+    ):
+        async with get_client(team_id=team_id) as client:
+            count_results = await client.read_query_as_jsonl(
+                count_query, query_parameters=query_parameters, query_id=count_query_id
+            )
 
     record_count = int(count_results[0]["record_count"])
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -6,6 +6,7 @@ import asyncio
 import datetime as dt
 import dataclasses
 import collections.abc
+from contextlib import suppress
 
 from django.conf import settings
 from django.db.models import Sum
@@ -279,6 +280,7 @@ async def _get_backfill_info_for_events(
     exclude_events: list[str],
     filters_str: str,
     extra_query_parameters: dict[str, typing.Any],
+    log_comment: str = "{}",
 ) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for events model.
 
@@ -310,12 +312,14 @@ async def _get_backfill_info_for_events(
         {filters_str}
         {date_conditions}
         FORMAT JSONEachRow
+        SETTINGS log_comment=%(log_comment)s
     """
 
     query_parameters = {
         "team_id": team_id,
         "include_events": include_events,
         "exclude_events": exclude_events,
+        "log_comment": log_comment,
         **extra_query_parameters,
     }
 
@@ -353,6 +357,7 @@ async def _get_backfill_info_for_persons(
     batch_export: BatchExport,
     start_at: dt.datetime | None,
     end_at: dt.datetime | None,
+    log_comment: str = "{}",
 ) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for persons model.
 
@@ -371,7 +376,7 @@ async def _get_backfill_info_for_persons(
 
     date_conditions = ""
     having_date_conditions = ""
-    query_parameters: dict[str, typing.Any] = {"team_id": team_id}
+    query_parameters: dict[str, typing.Any] = {"team_id": team_id, "log_comment": log_comment}
 
     if start_at is not None:
         date_conditions += "AND _timestamp >= %(start_at)s "
@@ -397,6 +402,7 @@ async def _get_backfill_info_for_persons(
         AND _timestamp > '2000-01-01'
         {date_conditions}
         FORMAT JSONEachRow
+        SETTINGS log_comment=%(log_comment)s
     """
 
     query_id = str(uuid.uuid4())
@@ -469,7 +475,7 @@ async def _get_backfill_info_for_persons(
         SELECT uniq(distinct_id) AS record_count
         FROM distinct_ids
         FORMAT JSONEachRow
-        SETTINGS optimize_uniq_to_count = 0
+        SETTINGS optimize_uniq_to_count = 0, log_comment=%(log_comment)s
     """
 
     count_query_id = str(uuid.uuid4())
@@ -497,6 +503,7 @@ async def _get_backfill_info_for_sessions(
     batch_export: BatchExport,
     start_at: dt.datetime | None,
     end_at: dt.datetime | None,
+    log_comment: str | None = None,
 ) -> tuple[dt.datetime | None, int | None]:
     """Get adjusted start time and estimated record count for sessions model.
 
@@ -509,7 +516,7 @@ async def _get_backfill_info_for_sessions(
     """
 
     model = SessionsRecordBatchModel(team_id=batch_export.team_id, batch_export_id=str(batch_export.id))
-    min_timestamp, record_count = await model.get_backfill_info(start_at, end_at)
+    min_timestamp, record_count = await model.get_backfill_info(start_at, end_at, log_comment=log_comment)
 
     if min_timestamp is None:
         return None, 0
@@ -534,6 +541,14 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
     logger = LOGGER.bind()
 
     logger.info("Getting backfill info")
+
+    tags = query_tagging.get_query_tags()
+    tags.team_id = inputs.team_id
+    with suppress(Exception):
+        tags.batch_export_id = uuid.UUID(inputs.batch_export_id)
+    tags.product = Product.BATCH_EXPORT
+    tags.query_type = "backfill_estimate"
+    log_comment = tags.to_json()
 
     batch_export = await BatchExport.objects.select_related("destination").aget(id=inputs.batch_export_id)
 
@@ -567,18 +582,21 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
             exclude_events=exclude_events,
             filters_str=filters_str,
             extra_query_parameters=extra_query_parameters,
+            log_comment=log_comment,
         )
     elif model == "persons":
         adjusted_start_at, record_count = await _get_backfill_info_for_persons(
             batch_export=batch_export,
             start_at=start_at,
             end_at=end_at,
+            log_comment=log_comment,
         )
     elif model == "sessions":
         adjusted_start_at, record_count = await _get_backfill_info_for_sessions(
             batch_export=batch_export,
             start_at=start_at,
             end_at=end_at,
+            log_comment=log_comment,
         )
     else:
         logger.info(

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -325,7 +325,7 @@ async def _get_backfill_info_for_events(
     }
 
     query_id = str(uuid.uuid4())
-    async with log_query_duration(
+    with log_query_duration(
         logger=logger,
         query_id=query_id,
         query_type="backfill_info:events",
@@ -403,7 +403,7 @@ async def _get_backfill_info_for_persons(
     """
 
     min_timestamp_query_id = str(uuid.uuid4())
-    async with log_query_duration(
+    with log_query_duration(
         logger=logger,
         query_id=min_timestamp_query_id,
         query_type="backfill_info:persons_min_timestamp",
@@ -469,7 +469,7 @@ async def _get_backfill_info_for_persons(
     """
 
     count_query_id = str(uuid.uuid4())
-    async with log_query_duration(
+    with log_query_duration(
         logger=logger,
         query_id=count_query_id,
         query_type="backfill_info:persons_count",

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -1,4 +1,5 @@
 import json
+import time
 import uuid
 import typing
 import asyncio
@@ -286,6 +287,7 @@ async def _get_backfill_info_for_events(
         If no data exists, returns (None, 0).
     """
     team_id = batch_export.team_id
+    logger = LOGGER.bind()
 
     date_conditions = ""
     if start_at is not None:
@@ -317,8 +319,15 @@ async def _get_backfill_info_for_events(
         **extra_query_parameters,
     }
 
+    query_id = str(uuid.uuid4())
+    logger.info("Executing backfill info query for events", query_id=query_id)
+    start_time = time.monotonic()
+
     async with get_client(team_id=team_id) as client:
-        result = await client.read_query_as_jsonl(query, query_parameters=query_parameters)
+        result = await client.read_query_as_jsonl(query, query_parameters=query_parameters, query_id=query_id)
+
+    execution_time = time.monotonic() - start_time
+    logger.info("Backfill info query for events completed", query_id=query_id, query_duration_seconds=execution_time)
 
     min_timestamp_str = result[0]["min_timestamp"]
     record_count = int(result[0]["record_count"])
@@ -357,6 +366,7 @@ async def _get_backfill_info_for_persons(
         the count would not reflect the actual export behavior.
     """
     team_id = batch_export.team_id
+    logger = LOGGER.bind()
     is_limited_export = str(team_id) in settings.BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS
 
     date_conditions = ""
@@ -389,8 +399,21 @@ async def _get_backfill_info_for_persons(
         FORMAT JSONEachRow
     """
 
+    query_id = str(uuid.uuid4())
+    logger.info("Executing backfill info min_timestamp query for persons", query_id=query_id)
+    start_time = time.monotonic()
+
     async with get_client(team_id=team_id) as client:
-        min_timestamp_results = await client.read_query_as_jsonl(min_timestamp_query, query_parameters=query_parameters)
+        min_timestamp_results = await client.read_query_as_jsonl(
+            min_timestamp_query, query_parameters=query_parameters, query_id=query_id
+        )
+
+    execution_time = time.monotonic() - start_time
+    logger.info(
+        "Backfill info min_timestamp query for persons completed",
+        query_id=query_id,
+        query_duration_seconds=execution_time,
+    )
 
     # Find the earliest valid timestamp across both tables
     earliest_timestamp: dt.datetime | None = None
@@ -449,8 +472,21 @@ async def _get_backfill_info_for_persons(
         SETTINGS optimize_uniq_to_count = 0
     """
 
+    count_query_id = str(uuid.uuid4())
+    logger.info("Executing backfill info count query for persons", query_id=count_query_id)
+    count_start_time = time.monotonic()
+
     async with get_client(team_id=team_id) as client:
-        count_results = await client.read_query_as_jsonl(count_query, query_parameters=query_parameters)
+        count_results = await client.read_query_as_jsonl(
+            count_query, query_parameters=query_parameters, query_id=count_query_id
+        )
+
+    count_execution_time = time.monotonic() - count_start_time
+    logger.info(
+        "Backfill info count query for persons completed",
+        query_id=count_query_id,
+        query_duration_seconds=count_execution_time,
+    )
 
     record_count = int(count_results[0]["record_count"])
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -6,7 +6,6 @@ import asyncio
 import datetime as dt
 import dataclasses
 import collections.abc
-from contextlib import suppress
 
 from django.conf import settings
 from django.db.models import Sum
@@ -280,7 +279,7 @@ async def _get_backfill_info_for_events(
     exclude_events: list[str],
     filters_str: str,
     extra_query_parameters: dict[str, typing.Any],
-    log_comment: str = "{}",
+    log_comment: str,
 ) -> tuple[dt.datetime | None, int | None]:
     """Get earliest timestamp and estimated record count for events model.
 
@@ -354,7 +353,7 @@ async def _get_backfill_info_for_persons(
     batch_export: BatchExport,
     start_at: dt.datetime | None,
     end_at: dt.datetime | None,
-    log_comment: str = "{}",
+    log_comment: str,
 ) -> tuple[dt.datetime | None, int | None]:
     """Get earliest timestamp and estimated record count for persons model.
 
@@ -498,7 +497,7 @@ async def _get_backfill_info_for_sessions(
     batch_export: BatchExport,
     start_at: dt.datetime | None,
     end_at: dt.datetime | None,
-    log_comment: str | None = None,
+    log_comment: str,
 ) -> tuple[dt.datetime | None, int | None]:
     """Get earliest timestamp and estimated record count for sessions model.
 
@@ -538,8 +537,7 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
 
     tags = query_tagging.get_query_tags()
     tags.team_id = inputs.team_id
-    with suppress(Exception):
-        tags.batch_export_id = uuid.UUID(inputs.batch_export_id)
+    tags.batch_export_id = uuid.UUID(inputs.batch_export_id)
     tags.product = Product.BATCH_EXPORT
     tags.query_type = "backfill_estimate"
     log_comment = tags.to_json()

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -2,6 +2,7 @@ import time
 import typing
 import asyncio
 import datetime as dt
+from contextlib import asynccontextmanager
 
 from django.conf import settings
 
@@ -340,6 +341,28 @@ def log_execution_time(
             "Failed to log execution time with attributes '%s' and configuration '%s'",
             arguments,
             structlog.get_config(),
+        )
+
+
+@asynccontextmanager
+async def log_query_duration(
+    logger: structlog.stdlib.BoundLogger,
+    query_id: str,
+    query_type: str,
+) -> typing.AsyncIterator[None]:
+    """Async context manager to log query duration."""
+    logger.info(f"Executing query: {query_type}", query_id=query_id, query_type=query_type)
+    start_time = time.monotonic()
+
+    try:
+        yield
+    finally:
+        execution_time = time.monotonic() - start_time
+        logger.info(
+            f"Query completed: {query_type}",
+            query_id=query_id,
+            query_duration_seconds=execution_time,
+            query_type=query_type,
         )
 
 

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -2,7 +2,7 @@ import time
 import typing
 import asyncio
 import datetime as dt
-from contextlib import asynccontextmanager
+from contextlib import contextmanager
 
 from django.conf import settings
 
@@ -344,13 +344,13 @@ def log_execution_time(
         )
 
 
-@asynccontextmanager
-async def log_query_duration(
+@contextmanager
+def log_query_duration(
     logger: structlog.stdlib.BoundLogger,
     query_id: str,
     query_type: str,
-) -> typing.AsyncIterator[None]:
-    """Async context manager to log query duration."""
+) -> typing.Iterator[None]:
+    """Context manager to log query duration."""
     logger.info(f"Executing query: {query_type}", query_id=query_id, query_type=query_type)
     start_time = time.monotonic()
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -1,5 +1,4 @@
 import sys
-import time
 import uuid
 import socket
 import typing
@@ -45,6 +44,7 @@ from products.batch_exports.backend.service import (
     BatchExportSchema,
 )
 from products.batch_exports.backend.temporal.batch_exports import default_fields
+from products.batch_exports.backend.temporal.metrics import log_query_duration
 from products.batch_exports.backend.temporal.record_batch_model import resolve_batch_exports_model
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchModel,
@@ -550,21 +550,17 @@ async def _execute_query(client: ClickHouseClient, query: str, query_parameters:
     and process list.
     If the query fails, we will raise an error.
     """
-    query_id = uuid.uuid4()
-    logger = LOGGER.bind(query_id=str(query_id))
-    start_time = time.monotonic()
-    logger.info("Executing insert into internal stage query")
-    try:
-        await client.execute_query(query, query_parameters=query_parameters, query_id=str(query_id), timeout=300)
-    except ClickHouseClientTimeoutError:
-        logger.warning(
-            "Timed-out waiting for insert into S3. Will attempt to check query status and wait for completion",
-            timeout=300,
-        )
-        await _wait_for_query_completion(client, str(query_id))
-
-    execution_time = time.monotonic() - start_time
-    logger.info("Query completed successfully", query_duration_seconds=execution_time)
+    query_id = str(uuid.uuid4())
+    logger = LOGGER.bind(query_id=query_id)
+    async with log_query_duration(logger=logger, query_id=query_id, query_type="insert_into_internal_stage"):
+        try:
+            await client.execute_query(query, query_parameters=query_parameters, query_id=query_id, timeout=300)
+        except ClickHouseClientTimeoutError:
+            logger.warning(
+                "Timed-out waiting for insert into S3. Will attempt to check query status and wait for completion",
+                timeout=300,
+            )
+            await _wait_for_query_completion(client, query_id)
 
 
 async def _wait_for_query_completion(client: ClickHouseClient, query_id: str) -> None:

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -552,7 +552,7 @@ async def _execute_query(client: ClickHouseClient, query: str, query_parameters:
     """
     query_id = str(uuid.uuid4())
     logger = LOGGER.bind(query_id=query_id)
-    async with log_query_duration(logger=logger, query_id=query_id, query_type="insert_into_internal_stage"):
+    with log_query_duration(logger=logger, query_id=query_id, query_type="insert_into_internal_stage"):
         try:
             await client.execute_query(query, query_parameters=query_parameters, query_id=query_id, timeout=300)
         except ClickHouseClientTimeoutError:

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -243,7 +243,7 @@ INSERT INTO FUNCTION {s3_function}
         )
 
     async def get_backfill_info(
-        self, start_at: dt.datetime | None, end_at: dt.datetime | None
+        self, start_at: dt.datetime | None, end_at: dt.datetime | None, log_comment: str | None = None
     ) -> tuple[dt.datetime | None, int | None]:
         """Estimate record count and earliest timestamp for a backfill.
 
@@ -253,6 +253,9 @@ INSERT INTO FUNCTION {s3_function}
         """
         hogql_query = self.get_backfill_info_hogql_query(start_at, end_at)
         context = await self.get_hogql_context()
+
+        if log_comment is not None:
+            context.values["log_comment"] = log_comment
 
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]
@@ -265,6 +268,11 @@ INSERT INTO FUNCTION {s3_function}
             dialect="clickhouse",
             stack=[],
         )
+
+        if "settings" not in printed.lower():
+            printed += " SETTINGS log_comment={log_comment}"
+        else:
+            printed += ", log_comment={log_comment}"
 
         query_id = str(uuid.uuid4())
         logger = LOGGER.bind(query_id=query_id)

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -243,7 +243,7 @@ INSERT INTO FUNCTION {s3_function}
         )
 
     async def get_backfill_info(
-        self, start_at: dt.datetime | None, end_at: dt.datetime | None, log_comment: str | None = None
+        self, start_at: dt.datetime | None, end_at: dt.datetime | None, log_comment: str
     ) -> tuple[dt.datetime | None, int | None]:
         """Estimate record count and earliest timestamp for a backfill.
 
@@ -254,8 +254,7 @@ INSERT INTO FUNCTION {s3_function}
         hogql_query = self.get_backfill_info_hogql_query(start_at, end_at)
         context = await self.get_hogql_context()
 
-        if log_comment is not None:
-            context.values["log_comment"] = log_comment
+        context.values["log_comment"] = log_comment
 
         prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
             hogql_query, context=context, dialect="clickhouse", stack=[]

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -1,5 +1,4 @@
 import abc
-import time
 import uuid
 import typing
 import datetime as dt
@@ -20,6 +19,7 @@ from posthog.temporal.common.logger import get_write_only_logger
 
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
 from products.batch_exports.backend.temporal import sql
+from products.batch_exports.backend.temporal.metrics import log_query_duration
 
 LOGGER = get_write_only_logger()
 
@@ -275,14 +275,14 @@ INSERT INTO FUNCTION {s3_function}
 
         query_id = str(uuid.uuid4())
         logger = LOGGER.bind(query_id=query_id)
-        logger.info("Executing backfill info query for sessions")
-        start_time = time.monotonic()
 
-        async with get_client(team_id=self.team_id) as client:
-            result = await client.read_query_as_jsonl(printed, query_parameters=context.values, query_id=query_id)
-
-        execution_time = time.monotonic() - start_time
-        logger.info("Backfill info query for sessions completed", query_duration_seconds=execution_time)
+        async with log_query_duration(
+            logger=logger,
+            query_id=query_id,
+            query_type="backfill_info:sessions",
+        ):
+            async with get_client(team_id=self.team_id) as client:
+                result = await client.read_query_as_jsonl(printed, query_parameters=context.values, query_id=query_id)
 
         min_timestamp_str = result[0]["min_timestamp"]
         record_count = int(result[0]["record_count"])

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -1,4 +1,5 @@
 import abc
+import time
 import uuid
 import typing
 import datetime as dt
@@ -15,9 +16,12 @@ from posthog.clickhouse.query_tagging import Product
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.logger import get_write_only_logger
 
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
 from products.batch_exports.backend.temporal import sql
+
+LOGGER = get_write_only_logger()
 
 Query = str
 QueryParameters = dict[str, typing.Any]
@@ -262,8 +266,16 @@ INSERT INTO FUNCTION {s3_function}
             stack=[],
         )
 
+        query_id = str(uuid.uuid4())
+        logger = LOGGER.bind(query_id=query_id)
+        logger.info("Executing backfill info query for sessions")
+        start_time = time.monotonic()
+
         async with get_client(team_id=self.team_id) as client:
-            result = await client.read_query_as_jsonl(printed, query_parameters=context.values)
+            result = await client.read_query_as_jsonl(printed, query_parameters=context.values, query_id=query_id)
+
+        execution_time = time.monotonic() - start_time
+        logger.info("Backfill info query for sessions completed", query_duration_seconds=execution_time)
 
         min_timestamp_str = result[0]["min_timestamp"]
         record_count = int(result[0]["record_count"])

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -276,7 +276,7 @@ INSERT INTO FUNCTION {s3_function}
         query_id = str(uuid.uuid4())
         logger = LOGGER.bind(query_id=query_id)
 
-        async with log_query_duration(
+        with log_query_duration(
             logger=logger,
             query_id=query_id,
             query_type="backfill_info:sessions",

--- a/products/batch_exports/backend/tests/temporal/backfills/test_align_timestamp_to_interval.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_align_timestamp_to_interval.py
@@ -1,0 +1,73 @@
+import datetime as dt
+
+import pytest
+
+from posthog.batch_exports.models import BatchExport
+
+from products.batch_exports.backend.temporal.backfill_batch_export import _align_timestamp_to_interval
+
+
+@pytest.mark.parametrize(
+    "timestamp,interval,interval_offset,timezone,expected",
+    [
+        # Hourly interval — 10:37 aligns to 10:00
+        (
+            dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC),
+            "hour",
+            None,
+            "UTC",
+            dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC),
+        ),
+        # 5-minute interval — 10:37 aligns to 10:35
+        (
+            dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC),
+            "every 5 minutes",
+            None,
+            "UTC",
+            dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC),
+        ),
+        # Daily with offset_hour=5 — 10:30 aligns to 5am same day
+        (
+            dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC),
+            "day",
+            5 * 3600,
+            "UTC",
+            dt.datetime(2021, 1, 15, 5, 0, 0, tzinfo=dt.UTC),
+        ),
+        # Daily with offset_hour=5 — 4:30am aligns to 5am previous day
+        (
+            dt.datetime(2021, 1, 15, 4, 30, 0, tzinfo=dt.UTC),
+            "day",
+            5 * 3600,
+            "UTC",
+            dt.datetime(2021, 1, 14, 5, 0, 0, tzinfo=dt.UTC),
+        ),
+        # Weekly starting Monday at 5am — Thursday 10am aligns to Monday 5am
+        (
+            dt.datetime(2021, 1, 14, 10, 0, 0, tzinfo=dt.UTC),
+            "week",
+            1 * 86400 + 5 * 3600,
+            "UTC",
+            dt.datetime(2021, 1, 11, 5, 0, 0, tzinfo=dt.UTC),
+        ),
+        # Daily at 1am US/Pacific — 10:00 UTC (2am PST) aligns to 9:00 UTC (1am PST)
+        (
+            dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC),
+            "day",
+            1 * 3600,
+            "US/Pacific",
+            dt.datetime(2021, 1, 15, 9, 0, 0, tzinfo=dt.UTC),
+        ),
+        # Daily at 1am US/Pacific — 8:30 UTC (0:30am PST) aligns to previous day's 1am PST
+        (
+            dt.datetime(2021, 1, 15, 8, 30, 0, tzinfo=dt.UTC),
+            "day",
+            1 * 3600,
+            "US/Pacific",
+            dt.datetime(2021, 1, 14, 9, 0, 0, tzinfo=dt.UTC),
+        ),
+    ],
+)
+def test_align_timestamp_to_interval(timestamp, interval, interval_offset, timezone, expected):
+    batch_export = BatchExport(interval=interval, interval_offset=interval_offset, timezone=timezone)
+    assert _align_timestamp_to_interval(timestamp, batch_export) == expected

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -10,13 +10,7 @@ from posthog.batch_exports.models import BatchExport, BatchExportDestination
 from posthog.models.utils import uuid7
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, insert_sessions_in_clickhouse
 
-from products.batch_exports.backend.temporal.backfill_batch_export import (
-    GetBackfillInfoInputs,
-    _get_backfill_info_for_events,
-    _get_backfill_info_for_persons,
-    _get_backfill_info_for_sessions,
-    get_backfill_info,
-)
+from products.batch_exports.backend.temporal.backfill_batch_export import GetBackfillInfoInputs, get_backfill_info
 from products.batch_exports.backend.tests.temporal.utils.clickhouse import (
     truncate_events,
     truncate_persons,
@@ -31,25 +25,70 @@ from products.batch_exports.backend.tests.temporal.utils.persons import (
 )
 
 
-class TestGetBackfillInfoForEvents:
-    """Tests for the _get_backfill_info_for_events function."""
+@pytest.fixture
+def activity_environment():
+    return ActivityEnvironment()
 
+
+@pytest.fixture
+def run_get_backfill_info(activity_environment):
+    async def _run(batch_export, start_at=None, end_at=None):
+        inputs = GetBackfillInfoInputs(
+            team_id=batch_export.team_id,
+            batch_export_id=str(batch_export.id),
+            start_at=start_at.isoformat() if start_at else None,
+            end_at=end_at.isoformat() if end_at else None,
+        )
+        return await activity_environment.run(get_backfill_info, inputs)
+
+    return _run
+
+
+@pytest.fixture
+def mock_clickhouse_client():
+    mock_client = MockClickHouseClient(
+        read_query_as_jsonl_responses=[[{"min_timestamp": "1970-01-01 00:00:00", "record_count": "0"}]],
+    )
+    with (
+        patch(
+            "products.batch_exports.backend.temporal.backfill_batch_export.get_client",
+            return_value=mock_client.mock_client_cm,
+        ),
+        patch(
+            "products.batch_exports.backend.temporal.record_batch_model.get_client",
+            return_value=mock_client.mock_client_cm,
+        ),
+    ):
+        yield mock_client
+
+
+class TestGetBackfillInfoForEvents:
     @pytest.fixture(autouse=True)
     async def truncate_events_table(self, clickhouse_client):
-        """Fixture to truncate events table before each test."""
         await truncate_events(clickhouse_client)
 
     @pytest.fixture
-    def make_batch_export(self, ateam):
-        """Factory fixture to create BatchExport objects (not saved to DB)."""
-
-        def _make(
+    def create_batch_export(self, ateam):
+        async def _create(
             interval: str = "hour",
             interval_offset: int | None = None,
             timezone: str = "UTC",
+            include_events: list[str] | None = None,
+            exclude_events: list[str] | None = None,
         ) -> BatchExport:
-            destination = BatchExportDestination(type="S3", config={})
-            return BatchExport(
+            config = {
+                "bucket_name": "test",
+                "region": "us-east-1",
+                "prefix": "/",
+                "aws_access_key_id": "key",
+                "aws_secret_access_key": "secret",
+            }
+            if include_events:
+                config["include_events"] = include_events
+            if exclude_events:
+                config["exclude_events"] = exclude_events
+            destination = await BatchExportDestination.objects.acreate(type="S3", config=config)
+            return await BatchExport.objects.acreate(
                 team_id=ateam.pk,
                 name="Test Batch Export",
                 destination=destination,
@@ -58,93 +97,78 @@ class TestGetBackfillInfoForEvents:
                 timezone=timezone,
             )
 
-        return _make
+        return _create
 
-    async def test_returns_earliest_start_and_count_when_data_exists(self, ateam, generate_events, make_batch_export):
-        """Test basic case: returns earliest_start and record_count when events exist."""
+    async def test_returns_earliest_start_and_count_when_data_exists(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
         event_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
         await generate_events(start_time=event_time, count=25, count_other_team=10)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
 
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 25
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 25
 
-    async def test_returns_none_and_zero_when_no_data_exists(self, ateam, make_batch_export):
-        """Test that (None, 0) is returned when no events exist for the team."""
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
+    async def test_returns_count_with_no_adjusted_start_when_start_at_is_none(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
+        event_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        await generate_events(start_time=event_time, count=25, count_other_team=10)
 
-        assert earliest_start is None
-        assert record_count == 0
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
 
-    async def test_counts_only_events_after_start_at(self, ateam, generate_events, make_batch_export):
-        """Test that count respects start_at filter."""
+        assert result.adjusted_start_at is None
+        assert result.total_records_count == 25
+
+    async def test_returns_zero_when_no_data_exists(self, ateam, create_batch_export, run_get_backfill_info):
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
+
+        assert result.total_records_count == 0
+
+    async def test_counts_only_events_after_start_at(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
 
         await generate_events(start_time=early_time, count=10, count_other_team=10)
         await generate_events(start_time=late_time, count=15, count_other_team=10)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
         )
 
-        # earliest_start should be the earliest event within the date range
-        assert earliest_start == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
-        # count should only include events after start_at
-        assert record_count == 15
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 15
 
-    async def test_counts_only_events_before_end_at(self, ateam, generate_events, make_batch_export):
-        """Test that count respects end_at filter."""
+    async def test_counts_only_events_before_end_at(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
 
         await generate_events(start_time=early_time, count=10, count_other_team=10)
         await generate_events(start_time=late_time, count=15, count_other_team=10)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
         )
 
-        # earliest_start should be the earliest event within the date range
-        assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
-        # count should only include events before end_at
-        assert record_count == 10
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 10
 
-    async def test_counts_only_events_in_range(self, ateam, generate_events, make_batch_export):
-        """Test that count respects both start_at and end_at filters."""
+    async def test_counts_only_events_in_range(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
         times = [
             dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
             dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
@@ -155,258 +179,87 @@ class TestGetBackfillInfoForEvents:
         for event_time, count in zip(times, counts):
             await generate_events(start_time=event_time, count=count, count_other_team=10)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC),
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
         )
 
-        # earliest_start should be the earliest event within the date range
-        assert earliest_start == dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
-        # count should only include the middle batch (10 events)
-        assert record_count == 10
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 10
 
-    async def test_respects_include_events_filter(self, ateam, generate_events, make_batch_export):
-        """Test that include_events filter is respected."""
-        event_time = dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=20, count_other_team=10, event_name="pageview")
-        await generate_events(start_time=event_time, count=30, count_other_team=10, event_name="click")
-
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=["pageview"],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-
-        assert earliest_start is not None
-        assert record_count == 20
-
-    async def test_respects_exclude_events_filter(self, ateam, generate_events, make_batch_export):
-        """Test that exclude_events filter is respected."""
-        event_time = dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=20, count_other_team=10, event_name="pageview")
-        await generate_events(start_time=event_time, count=30, count_other_team=10, event_name="click")
-
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=["click"],
-            filters_str="",
-            extra_query_parameters={},
-        )
-
-        assert earliest_start is not None
-        assert record_count == 20
-
-    async def test_earliest_start_aligned_to_interval(self, ateam, generate_events, make_batch_export):
-        """Test that earliest_start is aligned to the interval boundary."""
-        event_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
-        await generate_events(
-            start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1), count_other_team=10
-        )
-
-        # Hourly interval - should align to 10:00
-        batch_export = make_batch_export(interval="hour")
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-
-        # 5-minute interval - should align to 10:35
-        batch_export = make_batch_export(interval="every 5 minutes")
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)
-
-    async def test_custom_filters_str_is_applied(self, ateam, generate_events, make_batch_export):
-        """Test that custom filters_str is included in the query."""
-        event_time = dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=50, count_other_team=10)
-
-        # Apply a filter that excludes all events
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="AND 1 = 0",
-            extra_query_parameters={},
-        )
-
-        assert earliest_start is None
-        assert record_count == 0
-
-    async def test_earliest_start_respects_interval_offset_daily(self, ateam, generate_events, make_batch_export):
-        """Test that earliest_start respects interval_offset for daily exports.
-
-        For a daily export with offset_hour=5 (interval_offset=18000):
-        - 10:30am aligns to 5am same day
-        - 4:30am aligns to 5am previous day
-        """
-        # Event at 10:30am on Jan 15 should align to 5am Jan 15
-        event_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1))
-
-        # Daily interval with offset_hour=5 (18000s offset)
-        batch_export = make_batch_export(interval="day", interval_offset=5 * 3600)
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 5, 0, 0, tzinfo=dt.UTC)
-
-    async def test_earliest_start_respects_interval_offset_daily_before_offset(
-        self, ateam, generate_events, make_batch_export
+    async def test_respects_include_events_filter(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
     ):
-        """Test that earliest_start correctly aligns when event is before offset hour.
+        event_time = dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
+        await generate_events(start_time=event_time, count=20, count_other_team=10, event_name="pageview")
+        await generate_events(start_time=event_time, count=30, count_other_team=10, event_name="click")
 
-        For a daily export with offset_hour=5:
-        - Event at 4:30am should align to 5am the PREVIOUS day
+        batch_export = await create_batch_export(include_events=["pageview"])
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
+
+        assert result.adjusted_start_at is not None
+        assert result.total_records_count == 20
+
+    async def test_respects_exclude_events_filter(
+        self, ateam, generate_events, create_batch_export, run_get_backfill_info
+    ):
+        event_time = dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
+        await generate_events(start_time=event_time, count=20, count_other_team=10, event_name="pageview")
+        await generate_events(start_time=event_time, count=30, count_other_team=10, event_name="click")
+
+        batch_export = await create_batch_export(exclude_events=["click"])
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
+
+        assert result.adjusted_start_at is not None
+        assert result.total_records_count == 20
+
+    async def test_query_metadata(self, mock_clickhouse_client, run_get_backfill_info, create_batch_export, ateam):
+        """Test that the query is executed as expected. This test uses a mocked ClickHouse client to
+        verify the query metadata.
         """
-        # Event at 4:30am on Jan 15 should align to 5am Jan 14
-        event_time = dt.datetime(2021, 1, 15, 4, 30, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1))
 
-        # Daily interval with offset_hour=5 (18000s offset)
-        batch_export = make_batch_export(interval="day", interval_offset=5 * 3600)
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
+        batch_export = await create_batch_export()
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
         )
-        # Event is before 5am, so it falls in the previous day's interval starting at 5am
-        assert earliest_start == dt.datetime(2021, 1, 14, 5, 0, 0, tzinfo=dt.UTC)
 
-    async def test_earliest_start_respects_interval_offset_weekly(self, ateam, generate_events, make_batch_export):
-        """Test that earliest_start respects interval_offset for weekly exports.
-
-        For a weekly export starting Monday at 5am (offset_day=1, offset_hour=5):
-        - An event on Thursday at 10am should align to Monday 5am of that week
-        """
-        # Thursday Jan 14, 2021 at 10am (Monday was Jan 11)
-        event_time = dt.datetime(2021, 1, 14, 10, 0, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1))
-
-        # Weekly interval with offset_day=1 (Monday) and offset_hour=5
-        # offset = 1 * 86400 + 5 * 3600 = 86400 + 18000 = 104400
-        batch_export = make_batch_export(interval="week", interval_offset=1 * 86400 + 5 * 3600)
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
+        mock_clickhouse_client.expect_query_count(1)
+        mock_clickhouse_client.expect_all_calls_have_query_id()
+        mock_clickhouse_client.expect_properties_in_log_comment(
+            {
+                "team_id": ateam.pk,
+                "batch_export_id": str(batch_export.id),
+                "product": "batch_export",
+                "query_type": "backfill_estimate",
+            }
         )
-        # Monday Jan 11, 2021 at 5am UTC
-        assert earliest_start == dt.datetime(2021, 1, 11, 5, 0, 0, tzinfo=dt.UTC)
-
-    async def test_earliest_start_respects_timezone_us_pacific(self, ateam, generate_events, make_batch_export):
-        """Test that earliest_start respects timezone for daily exports.
-
-        For a daily export at 1am US/Pacific:
-        - In January (PST = UTC-8), 1am Pacific = 9am UTC
-        - An event at 10:00 UTC (2:00am PST) should align to 9:00 UTC (1:00am PST)
-        - An event at 08:30 UTC (0:30am PST) should align to previous day's 9:00 UTC
-        """
-        # Event at 10:00 UTC on Jan 15 (which is 2:00am PST on Jan 15)
-        event_time = dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1))
-
-        # Daily interval at 1am US/Pacific (offset_hour=1)
-        batch_export = make_batch_export(interval="day", interval_offset=1 * 3600, timezone="US/Pacific")
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-        # 1am PST on Jan 15 = 9am UTC on Jan 15
-        assert earliest_start == dt.datetime(2021, 1, 15, 9, 0, 0, tzinfo=dt.UTC)
-
-    async def test_earliest_start_respects_timezone_before_offset_hour(self, ateam, generate_events, make_batch_export):
-        """Test that earliest_start aligns to previous day when event is before offset hour in local time.
-
-        For a daily export at 1am US/Pacific:
-        - An event at 08:30 UTC (0:30am PST) should align to previous day's 1am PST = 9am UTC
-        """
-        # Event at 08:30 UTC on Jan 15 (which is 0:30am PST on Jan 15, before 1am)
-        event_time = dt.datetime(2021, 1, 15, 8, 30, 0, tzinfo=dt.UTC)
-        await generate_events(start_time=event_time, count=5, end_time=event_time + dt.timedelta(minutes=1))
-
-        # Daily interval at 1am US/Pacific (offset_hour=1)
-        batch_export = make_batch_export(interval="day", interval_offset=1 * 3600, timezone="US/Pacific")
-        earliest_start, _ = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-            include_events=[],
-            exclude_events=[],
-            filters_str="",
-            extra_query_parameters={},
-        )
-        # Event is before 1am PST, so it falls in previous day's interval
-        # 1am PST on Jan 14 = 9am UTC on Jan 14
-        assert earliest_start == dt.datetime(2021, 1, 14, 9, 0, 0, tzinfo=dt.UTC)
 
 
 class TestGetBackfillInfoForPersons:
-    """Tests for the _get_backfill_info_for_persons function."""
-
     @pytest.fixture(autouse=True)
     async def truncate_persons_tables(self, clickhouse_client):
         await truncate_persons(clickhouse_client)
 
     @pytest.fixture
-    def make_batch_export(self, ateam):
-        def _make(
+    def create_batch_export(self, ateam):
+        async def _create(
             interval: str = "hour",
             interval_offset: int | None = None,
             timezone: str = "UTC",
         ) -> BatchExport:
-            destination = BatchExportDestination(type="S3", config={})
-            return BatchExport(
+            config = {
+                "bucket_name": "test",
+                "region": "us-east-1",
+                "prefix": "/",
+                "aws_access_key_id": "key",
+                "aws_secret_access_key": "secret",
+            }
+            destination = await BatchExportDestination.objects.acreate(type="S3", config=config)
+            return await BatchExport.objects.acreate(
                 team_id=ateam.pk,
                 name="Test Batch Export",
                 destination=destination,
@@ -416,7 +269,7 @@ class TestGetBackfillInfoForPersons:
                 model="persons",
             )
 
-        return _make
+        return _create
 
     @pytest.fixture
     def generate_persons(self, clickhouse_client, ateam):
@@ -462,36 +315,41 @@ class TestGetBackfillInfoForPersons:
         return _generate
 
     async def test_returns_earliest_start_and_count_when_data_exists(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         person_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
         persons = await generate_persons(start_time=person_time, count=5, count_other_team=3)
         person_ids = [p["id"] for p in persons]
         await generate_person_distinct_ids(timestamp=person_time, count=5, person_ids=person_ids)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
 
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 5
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 5
 
-    async def test_returns_none_and_zero_when_no_data_exists(self, ateam, make_batch_export):
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
+    async def test_returns_count_with_no_adjusted_start_when_start_at_is_none(
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
+    ):
+        person_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        persons = await generate_persons(start_time=person_time, count=5, count_other_team=3)
+        person_ids = [p["id"] for p in persons]
+        await generate_person_distinct_ids(timestamp=person_time, count=5, person_ids=person_ids)
 
-        assert earliest_start is None
-        assert record_count == 0
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
+
+        assert result.adjusted_start_at is None
+        assert result.total_records_count == 5
+
+    async def test_returns_zero_when_no_data_exists(self, ateam, create_batch_export, run_get_backfill_info):
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
+
+        assert result.total_records_count == 0
 
     async def test_takes_minimum_timestamp_across_both_tables(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         earlier_time = dt.datetime(2021, 1, 10, 5, 0, 0, tzinfo=dt.UTC)
         later_time = dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
@@ -501,21 +359,16 @@ class TestGetBackfillInfoForPersons:
         person_ids = [p["id"] for p in persons]
         await generate_person_distinct_ids(timestamp=earlier_time, count=3, person_ids=person_ids)
 
-        batch_export = make_batch_export()
-        earliest_start, _ = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
 
         # Should use the earlier timestamp from person_distinct_id2
-        assert earliest_start == dt.datetime(2021, 1, 10, 5, 0, 0, tzinfo=dt.UTC)
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 10, 5, 0, 0, tzinfo=dt.UTC).isoformat()
 
     async def test_count_includes_distinct_ids_from_changed_persons(
-        self, ateam, clickhouse_client, generate_person_distinct_ids, make_batch_export
+        self, ateam, clickhouse_client, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         """When a person changes, all their existing distinct_ids should be counted."""
-        # Create a person with 3 distinct_ids at an old timestamp
         old_time = dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
         new_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
 
@@ -551,20 +404,21 @@ class TestGetBackfillInfoForPersons:
         # Create 3 distinct_ids for this person at old time (not in the query range)
         await generate_person_distinct_ids(timestamp=old_time, count=3, person_ids=[str(person_id)] * 3)
 
-        batch_export = make_batch_export()
+        batch_export = await create_batch_export()
         # Query range only covers new_time — person changed but distinct_ids didn't
-        _, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 16, 0, 0, 0, tzinfo=dt.UTC),
         )
 
         # All 3 distinct_ids should be counted via the UNION DISTINCT branch
-        assert record_count == 3
+        assert result.total_records_count == 3
 
-    async def test_count_deduplicates_by_latest_version(self, ateam, clickhouse_client, make_batch_export):
+    async def test_count_deduplicates_by_latest_version(
+        self, ateam, clickhouse_client, create_batch_export, run_get_backfill_info
+    ):
         """Only count distinct_ids/persons whose latest version is in range."""
-
         old_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         new_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
 
@@ -572,7 +426,6 @@ class TestGetBackfillInfoForPersons:
         person_id = uuid.uuid4()
 
         # Insert person with v1 in range and v2 outside range
-        # argMax(_timestamp, version) will return new_time (v2), which is outside the query range
         await insert_person_values_in_clickhouse(
             client=clickhouse_client,
             persons=[
@@ -622,20 +475,20 @@ class TestGetBackfillInfoForPersons:
             ],
         )
 
-        batch_export = make_batch_export()
+        batch_export = await create_batch_export()
 
         # Query range covers only old_time — but latest versions are at new_time for both
-        _, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
         )
 
         # Neither person nor distinct_id has latest version in range, so count should be 0
-        assert record_count == 0
+        assert result.total_records_count == 0
 
     async def test_counts_only_records_after_start_at(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
@@ -646,18 +499,17 @@ class TestGetBackfillInfoForPersons:
         late_persons = await generate_persons(start_time=late_time, count=8)
         await generate_person_distinct_ids(timestamp=late_time, count=8, person_ids=[p["id"] for p in late_persons])
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
-            end_at=None,
         )
 
-        assert earliest_start == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 8
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 8
 
     async def test_counts_only_records_before_end_at(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
@@ -668,18 +520,18 @@ class TestGetBackfillInfoForPersons:
         late_persons = await generate_persons(start_time=late_time, count=8)
         await generate_person_distinct_ids(timestamp=late_time, count=8, person_ids=[p["id"] for p in late_persons])
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
         )
 
-        assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 5
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 5
 
     async def test_counts_only_records_in_range(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, generate_person_distinct_ids, create_batch_export, run_get_backfill_info
     ):
         times = [
             dt.datetime(2021, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
@@ -692,78 +544,94 @@ class TestGetBackfillInfoForPersons:
             persons = await generate_persons(start_time=t, count=c)
             await generate_person_distinct_ids(timestamp=t, count=c, person_ids=[p["id"] for p in persons])
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC),
         )
 
-        assert earliest_start == dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 7
-
-    async def test_earliest_start_aligned_to_interval(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
-    ):
-        person_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
-        persons = await generate_persons(
-            start_time=person_time, count=3, end_time=person_time + dt.timedelta(minutes=1)
-        )
-        await generate_person_distinct_ids(timestamp=person_time, count=3, person_ids=[p["id"] for p in persons])
-
-        # Hourly interval — should align to 10:00
-        batch_export = make_batch_export(interval="hour")
-        earliest_start, _ = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-
-        # 5-minute interval — should align to 10:35
-        batch_export = make_batch_export(interval="every 5 minutes")
-        earliest_start, _ = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 7
 
     async def test_ignores_data_from_other_teams(
-        self, ateam, generate_persons, generate_person_distinct_ids, make_batch_export
+        self, ateam, generate_persons, create_batch_export, run_get_backfill_info
     ):
         person_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
         # Generate persons for this team AND other team — only other team data
         await generate_persons(start_time=person_time, count=0, count_other_team=10)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
+
+        assert result.total_records_count == 0
+
+    async def test_query_metadata_when_no_data(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export, ateam
+    ):
+        """Persons model runs min_timestamp query first; if no data, skips the count query."""
+        batch_export = await create_batch_export()
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
         )
 
-        assert earliest_start is None
-        assert record_count == 0
+        mock_clickhouse_client.expect_query_count(1)
+        mock_clickhouse_client.expect_all_calls_have_query_id()
+        mock_clickhouse_client.expect_properties_in_log_comment(
+            {
+                "team_id": ateam.pk,
+                "batch_export_id": str(batch_export.id),
+                "product": "batch_export",
+                "query_type": "backfill_estimate",
+            }
+        )
+
+    async def test_executes_two_queries_when_data_exists(
+        self, mock_clickhouse_client, run_get_backfill_info, create_batch_export, ateam
+    ):
+        """Persons model runs both min_timestamp and count queries when data exists."""
+        batch_export = await create_batch_export()
+
+        mock_clickhouse_client.read_query_as_jsonl_responses = [
+            [{"min_timestamp": "2021-01-15 10:30:00"}, {"min_timestamp": "2021-01-15 10:30:00"}],
+            [{"record_count": "42"}],
+        ]
+
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
+        )
+
+        mock_clickhouse_client.expect_query_count(2)
+        mock_clickhouse_client.expect_unique_query_ids()
+        mock_clickhouse_client.expect_properties_in_log_comment({"query_type": "backfill_estimate"})
 
 
 class TestGetBackfillInfoForSessions:
-    """Tests for the _get_backfill_info_for_sessions function."""
-
     @pytest.fixture(autouse=True)
     async def truncate_tables(self, clickhouse_client):
         await truncate_events(clickhouse_client)
         await truncate_sessions(clickhouse_client)
 
     @pytest.fixture
-    def make_batch_export(self, ateam):
-        def _make(
+    def create_batch_export(self, ateam):
+        async def _create(
             interval: str = "hour",
             interval_offset: int | None = None,
             timezone: str = "UTC",
         ) -> BatchExport:
-            destination = BatchExportDestination(type="S3", config={})
-            return BatchExport(
+            config = {
+                "bucket_name": "test",
+                "region": "us-east-1",
+                "prefix": "/",
+                "aws_access_key_id": "key",
+                "aws_secret_access_key": "secret",
+            }
+            destination = await BatchExportDestination.objects.acreate(type="S3", config=config)
+            return await BatchExport.objects.acreate(
                 team_id=ateam.pk,
                 name="Test Batch Export",
                 destination=destination,
@@ -773,7 +641,7 @@ class TestGetBackfillInfoForSessions:
                 model="sessions",
             )
 
-        return _make
+        return _create
 
     @pytest.fixture
     def generate_sessions(self, clickhouse_client, ateam):
@@ -825,250 +693,89 @@ class TestGetBackfillInfoForSessions:
 
         return _generate
 
-    async def test_returns_earliest_start_and_count_when_data_exists(self, generate_sessions, make_batch_export):
+    async def test_returns_earliest_start_and_count_when_data_exists(
+        self, generate_sessions, create_batch_export, run_get_backfill_info
+    ):
         session_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
         await generate_sessions(start_time=session_time, count=5, count_other_team=3)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export, start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC))
 
-        assert earliest_start == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 5
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 5
 
-    async def test_returns_none_and_zero_when_no_data_exists(self, make_batch_export):
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
+    async def test_returns_count_with_no_adjusted_start_when_start_at_is_none(
+        self, generate_sessions, create_batch_export, run_get_backfill_info
+    ):
+        session_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        await generate_sessions(start_time=session_time, count=5, count_other_team=3)
 
-        assert earliest_start is None
-        assert record_count == 0
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
 
-    async def test_counts_only_sessions_after_start_at(self, generate_sessions, make_batch_export):
+        assert result.adjusted_start_at is None
+        assert result.total_records_count == 5
+
+    async def test_returns_zero_when_no_data_exists(self, create_batch_export, run_get_backfill_info):
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(batch_export)
+
+        assert result.total_records_count == 0
+
+    async def test_counts_only_sessions_after_start_at(
+        self, generate_sessions, create_batch_export, run_get_backfill_info
+    ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
 
         await generate_sessions(start_time=early_time, count=5)
         await generate_sessions(start_time=late_time, count=8)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
             start_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
-            end_at=None,
         )
 
-        assert earliest_start == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 8
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 8
 
-    async def test_counts_only_sessions_before_end_at(self, ateam, generate_sessions, make_batch_export):
+    async def test_counts_only_sessions_before_end_at(
+        self, generate_sessions, create_batch_export, run_get_backfill_info
+    ):
         early_time = dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
         late_time = dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC)
 
         await generate_sessions(start_time=early_time, count=5)
         await generate_sessions(start_time=late_time, count=8)
 
-        batch_export = make_batch_export()
-        earliest_start, record_count = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=None,
+        batch_export = await create_batch_export()
+        result = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2000, 1, 1, tzinfo=dt.UTC),
             end_at=dt.datetime(2021, 1, 15, 0, 0, 0, tzinfo=dt.UTC),
         )
 
-        assert earliest_start == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC)
-        assert record_count == 5
+        assert result.adjusted_start_at == dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result.total_records_count == 5
 
-    @pytest.mark.parametrize(
-        "interval,expected_start",
-        [
-            ("hour", dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC)),
-            ("every 5 minutes", dt.datetime(2021, 1, 15, 10, 35, 0, tzinfo=dt.UTC)),
-        ],
-    )
-    async def test_earliest_start_aligned_to_interval(
-        self, interval, expected_start, generate_sessions, make_batch_export
-    ):
-        session_time = dt.datetime(2021, 1, 15, 10, 37, 45, tzinfo=dt.UTC)
-        await generate_sessions(start_time=session_time, count=3)
-
-        batch_export = make_batch_export(interval=interval)
-        earliest_start, _ = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=None,
-            end_at=None,
-        )
-        assert earliest_start == expected_start
-
-
-class TestGetBackfillInfoQueryMetadata:
-    """Tests for query metadata (query_id, query tags) set by the get_backfill_info activity."""
-
-    @pytest.fixture
-    def mock_clickhouse_client(self):
-        mock_client = MockClickHouseClient(
-            read_query_as_jsonl_responses=[[{"min_timestamp": "1970-01-01 00:00:00", "record_count": "0"}]],
-        )
-        with (
-            patch(
-                "products.batch_exports.backend.temporal.backfill_batch_export.get_client",
-                return_value=mock_client.mock_client_cm,
-            ),
-            patch(
-                "products.batch_exports.backend.temporal.record_batch_model.get_client",
-                return_value=mock_client.mock_client_cm,
-            ),
-        ):
-            yield mock_client
-
-    @pytest.fixture
-    def activity_environment(self):
-        return ActivityEnvironment()
-
-    @pytest.fixture
-    def batch_export_id(self):
-        return str(uuid.uuid4())
-
-    @pytest.fixture
-    def create_batch_export(self, ateam, batch_export_id):
-        async def _create(model: str = "events") -> BatchExport:
-            destination = await BatchExportDestination.objects.acreate(
-                type="S3",
-                config={
-                    "bucket_name": "test",
-                    "region": "us-east-1",
-                    "prefix": "/",
-                    "aws_access_key_id": "key",
-                    "aws_secret_access_key": "secret",
-                },
-            )
-            return await BatchExport.objects.acreate(
-                id=batch_export_id,
-                team_id=ateam.pk,
-                name="Test",
-                destination=destination,
-                interval="hour",
-                model=model,
-            )
-
-        return _create
-
-    @pytest.mark.parametrize("model", ["events", "persons", "sessions"])
-    async def test_sets_query_tags(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export, model
-    ):
-        await create_batch_export(model=model)
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+    async def test_query_metadata(self, mock_clickhouse_client, run_get_backfill_info, create_batch_export, ateam):
+        """Test that the query is executed as expected. This test uses a mocked ClickHouse client to verify the query metadata."""
+        batch_export = await create_batch_export()
+        await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC),
         )
 
-        await activity_environment.run(get_backfill_info, inputs)
-
-        assert len(mock_clickhouse_client.calls) >= 1
+        mock_clickhouse_client.expect_query_count(1)
+        mock_clickhouse_client.expect_all_calls_have_query_id()
         mock_clickhouse_client.expect_properties_in_log_comment(
             {
                 "team_id": ateam.pk,
-                "batch_export_id": batch_export_id,
+                "batch_export_id": str(batch_export.id),
                 "product": "batch_export",
                 "query_type": "backfill_estimate",
             }
         )
-
-    @pytest.mark.parametrize("model", ["events", "persons", "sessions"])
-    async def test_passes_query_id(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export, model
-    ):
-        await create_batch_export(model=model)
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
-        )
-
-        await activity_environment.run(get_backfill_info, inputs)
-
-        mock_clickhouse_client.expect_all_calls_have_query_id()
-
-    async def test_events_executes_single_query(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
-    ):
-        await create_batch_export(model="events")
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
-        )
-
-        await activity_environment.run(get_backfill_info, inputs)
-
-        mock_clickhouse_client.expect_query_count(1)
-
-    async def test_persons_executes_single_query_when_no_data(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
-    ):
-        """Persons model runs min_timestamp query first; if no data, skips the count query."""
-        await create_batch_export(model="persons")
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
-        )
-
-        await activity_environment.run(get_backfill_info, inputs)
-
-        mock_clickhouse_client.expect_query_count(1)
-
-    async def test_persons_executes_two_queries_when_data_exists(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
-    ):
-        """Persons model runs both min_timestamp and count queries when data exists."""
-        await create_batch_export(model="persons")
-
-        mock_clickhouse_client.read_query_as_jsonl_responses = [
-            [{"min_timestamp": "2021-01-15 10:30:00"}, {"min_timestamp": "2021-01-15 10:30:00"}],
-            [{"record_count": "42"}],
-        ]
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
-        )
-
-        await activity_environment.run(get_backfill_info, inputs)
-
-        mock_clickhouse_client.expect_query_count(2)
-        mock_clickhouse_client.expect_unique_query_ids()
-        mock_clickhouse_client.expect_properties_in_log_comment({"query_type": "backfill_estimate"})
-
-    async def test_sessions_executes_single_query(
-        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
-    ):
-        await create_batch_export(model="sessions")
-
-        inputs = GetBackfillInfoInputs(
-            team_id=ateam.pk,
-            batch_export_id=batch_export_id,
-            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
-            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
-        )
-
-        await activity_environment.run(get_backfill_info, inputs)
-
-        mock_clickhouse_client.expect_query_count(1)

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -2,21 +2,27 @@ import uuid
 import datetime as dt
 
 import pytest
+from unittest.mock import patch
+
+from temporalio.testing import ActivityEnvironment
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination
 from posthog.models.utils import uuid7
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, insert_sessions_in_clickhouse
 
 from products.batch_exports.backend.temporal.backfill_batch_export import (
+    GetBackfillInfoInputs,
     _get_backfill_info_for_events,
     _get_backfill_info_for_persons,
     _get_backfill_info_for_sessions,
+    get_backfill_info,
 )
 from products.batch_exports.backend.tests.temporal.utils.clickhouse import (
     truncate_events,
     truncate_persons,
     truncate_sessions,
 )
+from products.batch_exports.backend.tests.temporal.utils.mock_clickhouse import MockClickHouseClient
 from products.batch_exports.backend.tests.temporal.utils.persons import (
     generate_test_person_distinct_id2,
     generate_test_persons_in_clickhouse,
@@ -898,3 +904,171 @@ class TestGetBackfillInfoForSessions:
             end_at=None,
         )
         assert earliest_start == expected_start
+
+
+class TestGetBackfillInfoQueryMetadata:
+    """Tests for query metadata (query_id, query tags) set by the get_backfill_info activity."""
+
+    @pytest.fixture
+    def mock_clickhouse_client(self):
+        mock_client = MockClickHouseClient(
+            read_query_as_jsonl_responses=[[{"min_timestamp": "1970-01-01 00:00:00", "record_count": "0"}]],
+        )
+        with (
+            patch(
+                "products.batch_exports.backend.temporal.backfill_batch_export.get_client",
+                return_value=mock_client.mock_client_cm,
+            ),
+            patch(
+                "products.batch_exports.backend.temporal.record_batch_model.get_client",
+                return_value=mock_client.mock_client_cm,
+            ),
+        ):
+            yield mock_client
+
+    @pytest.fixture
+    def activity_environment(self):
+        return ActivityEnvironment()
+
+    @pytest.fixture
+    def batch_export_id(self):
+        return str(uuid.uuid4())
+
+    @pytest.fixture
+    def create_batch_export(self, ateam, batch_export_id):
+        async def _create(model: str = "events") -> BatchExport:
+            destination = await BatchExportDestination.objects.acreate(
+                type="S3",
+                config={
+                    "bucket_name": "test",
+                    "region": "us-east-1",
+                    "prefix": "/",
+                    "aws_access_key_id": "key",
+                    "aws_secret_access_key": "secret",
+                },
+            )
+            return await BatchExport.objects.acreate(
+                id=batch_export_id,
+                team_id=ateam.pk,
+                name="Test",
+                destination=destination,
+                interval="hour",
+                model=model,
+            )
+
+        return _create
+
+    @pytest.mark.parametrize("model", ["events", "persons", "sessions"])
+    async def test_sets_query_tags(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export, model
+    ):
+        await create_batch_export(model=model)
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        assert len(mock_clickhouse_client.calls) >= 1
+        mock_clickhouse_client.expect_properties_in_log_comment(
+            {
+                "team_id": ateam.pk,
+                "batch_export_id": batch_export_id,
+                "product": "batch_export",
+                "query_type": "backfill_estimate",
+            }
+        )
+
+    @pytest.mark.parametrize("model", ["events", "persons", "sessions"])
+    async def test_passes_query_id(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export, model
+    ):
+        await create_batch_export(model=model)
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        mock_clickhouse_client.expect_all_calls_have_query_id()
+
+    async def test_events_executes_single_query(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
+    ):
+        await create_batch_export(model="events")
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        mock_clickhouse_client.expect_query_count(1)
+
+    async def test_persons_executes_single_query_when_no_data(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
+    ):
+        """Persons model runs min_timestamp query first; if no data, skips the count query."""
+        await create_batch_export(model="persons")
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        mock_clickhouse_client.expect_query_count(1)
+
+    async def test_persons_executes_two_queries_when_data_exists(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
+    ):
+        """Persons model runs both min_timestamp and count queries when data exists."""
+        await create_batch_export(model="persons")
+
+        mock_clickhouse_client.read_query_as_jsonl_responses = [
+            [{"min_timestamp": "2021-01-15 10:30:00"}, {"min_timestamp": "2021-01-15 10:30:00"}],
+            [{"record_count": "42"}],
+        ]
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        mock_clickhouse_client.expect_query_count(2)
+        mock_clickhouse_client.expect_unique_query_ids()
+        mock_clickhouse_client.expect_properties_in_log_comment({"query_type": "backfill_estimate"})
+
+    async def test_sessions_executes_single_query(
+        self, mock_clickhouse_client, activity_environment, ateam, batch_export_id, create_batch_export
+    ):
+        await create_batch_export(model="sessions")
+
+        inputs = GetBackfillInfoInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            start_at=dt.datetime(2021, 1, 1, tzinfo=dt.UTC).isoformat(),
+            end_at=dt.datetime(2021, 1, 2, tzinfo=dt.UTC).isoformat(),
+        )
+
+        await activity_environment.run(get_backfill_info, inputs)
+
+        mock_clickhouse_client.expect_query_count(1)

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -1,4 +1,5 @@
 import uuid
+import typing as t
 import datetime as dt
 
 import pytest
@@ -76,7 +77,7 @@ class TestGetBackfillInfoForEvents:
             include_events: list[str] | None = None,
             exclude_events: list[str] | None = None,
         ) -> BatchExport:
-            config = {
+            config: dict[str, t.Any] = {
                 "bucket_name": "test",
                 "region": "us-east-1",
                 "prefix": "/",
@@ -540,9 +541,9 @@ class TestGetBackfillInfoForPersons:
         ]
         counts = [3, 7, 4]
 
-        for t, c in zip(times, counts):
-            persons = await generate_persons(start_time=t, count=c)
-            await generate_person_distinct_ids(timestamp=t, count=c, person_ids=[p["id"] for p in persons])
+        for time, count in zip(times, counts):
+            persons = await generate_persons(start_time=time, count=count)
+            await generate_person_distinct_ids(timestamp=time, count=count, person_ids=[p["id"] for p in persons])
 
         batch_export = await create_batch_export()
         result = await run_get_backfill_info(

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -1,4 +1,3 @@
-import re
 import json
 import uuid
 import typing as t
@@ -7,7 +6,6 @@ import datetime as dt
 from collections.abc import AsyncGenerator
 
 import pytest
-from unittest import mock
 from unittest.mock import patch
 
 from django.conf import settings
@@ -26,6 +24,7 @@ from products.batch_exports.backend.temporal.pipeline.internal_stage import (
 )
 from products.batch_exports.backend.temporal.pipeline.producer import Producer
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
+from products.batch_exports.backend.tests.temporal.utils.mock_clickhouse import MockClickHouseClient
 from products.batch_exports.backend.tests.temporal.utils.persons import (
     generate_test_person_distinct_id2_in_clickhouse,
     generate_test_persons_in_clickhouse,
@@ -39,49 +38,6 @@ from products.batch_exports.backend.tests.temporal.utils.s3 import (
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
 TEST_DATA_INTERVAL_END = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-
-
-class MockClickHouseClient:
-    """Helper class to mock ClickHouse client."""
-
-    def __init__(self):
-        self.mock_client = mock.AsyncMock(spec=ClickHouseClient)
-        self.mock_client_cm = mock.AsyncMock()
-        self.mock_client_cm.__aenter__.return_value = self.mock_client
-        self.mock_client_cm.__aexit__.return_value = None
-
-    def expect_select_from_table(self, table_name: str) -> None:
-        """Assert that the executed query selects from the expected table.
-
-        Args:
-            table_name: The name of the table to check for in the FROM clause.
-
-        The method handles different formatting of the FROM clause, including newlines
-        and varying amounts of whitespace.
-        """
-        assert self.mock_client.execute_query.call_count == 1
-        call_args = self.mock_client.execute_query.call_args
-        query = call_args[0][0]  # First positional argument of the first call
-
-        # Create a pattern that matches "FROM" followed by optional whitespace/newlines and then the table name
-        pattern = rf"FROM\s+{re.escape(table_name)}"
-        assert re.search(pattern, query, re.IGNORECASE), f"Query does not select FROM {table_name}"
-
-    def expect_properties_in_log_comment(self, properties: dict[str, t.Any]) -> None:
-        """Assert that the executed query has the expected properties in the log comment."""
-        assert self.mock_client.execute_query.call_count == 1
-        call_args = self.mock_client.execute_query.call_args
-        # assert that log_comment is in the query
-        query = call_args[0][0]
-        assert "log_comment" in query, "log_comment is not in the query"
-        # check that the log_comment is passed in as a query parameter
-        query_parameters = call_args[1].get("query_parameters", {})
-        log_comment = query_parameters.get("log_comment")
-        assert log_comment is not None
-        assert isinstance(log_comment, str)
-        log_comment_dict = json.loads(log_comment)
-        for key, value in properties.items():
-            assert log_comment_dict[key] == value
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/utils/mock_clickhouse.py
+++ b/products/batch_exports/backend/tests/temporal/utils/mock_clickhouse.py
@@ -1,0 +1,107 @@
+import re
+import json
+import typing
+import dataclasses
+
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from posthog.temporal.common.clickhouse import ClickHouseClient
+
+type JsonResponseSequence = list[list[dict[str, typing.Any]]]
+
+
+@dataclasses.dataclass
+class CapturedCall:
+    query: str
+    query_parameters: dict[str, typing.Any] | None
+    query_id: str | None
+
+
+class MockClickHouseClient:
+    """Mock ClickHouse client that captures query calls and their metadata.
+
+    Supports both write queries (via `execute_query`) and read queries
+    (via `read_query_as_jsonl`).  Each call is recorded in `self.calls`.
+
+    Set `read_query_as_jsonl_responses` to a list of responses (one per
+    call).  The last response is reused for any additional calls beyond
+    the list length.  An empty list returns `[]` for every call.
+    """
+
+    def __init__(
+        self,
+        read_query_as_jsonl_responses: JsonResponseSequence | None = None,
+    ):
+        self.calls: list[CapturedCall] = []
+        self.mock_client = AsyncMock(spec=ClickHouseClient)
+        self.mock_client.read_query_as_jsonl = self._capture_read_query_as_jsonl
+        self.mock_client.execute_query = self._capture_execute_query
+        self.mock_client_cm = mock.AsyncMock()
+        self.mock_client_cm.__aenter__.return_value = self.mock_client
+        self.mock_client_cm.__aexit__.return_value = None
+
+        # Return values for read_query_as_jsonl.
+        # Each call pops from the front; the last value is reused for any extra calls.
+        self.read_query_as_jsonl_responses: JsonResponseSequence = read_query_as_jsonl_responses or []
+
+    # -- recording helpers ---------------------------------------------------
+
+    def _snapshot_call(self, query: str, query_parameters: dict | None, query_id: str | None) -> None:
+        self.calls.append(
+            CapturedCall(
+                query=query,
+                query_parameters=query_parameters,
+                query_id=query_id,
+            )
+        )
+
+    async def _capture_read_query_as_jsonl(self, query, query_parameters=None, query_id=None):
+        self._snapshot_call(query, query_parameters, query_id)
+        if not self.read_query_as_jsonl_responses:
+            return []
+        if len(self.read_query_as_jsonl_responses) == 1:
+            return self.read_query_as_jsonl_responses[0]
+        return self.read_query_as_jsonl_responses.pop(0)
+
+    async def _capture_execute_query(self, query, *data, query_parameters=None, query_id=None, **kwargs):
+        self._snapshot_call(query, query_parameters, query_id)
+
+    # -- assertion helpers ---------------------------------------------------
+
+    def expect_query_count(self, expected: int) -> None:
+        """Assert that exactly `expected` queries were captured."""
+        assert len(self.calls) == expected, f"Expected {expected} queries, got {len(self.calls)}"
+
+    def expect_select_from_table(self, table_name: str, call_index: int = 0) -> None:
+        """Assert that a captured query selects from `table_name`."""
+        query = self.calls[call_index].query
+        pattern = rf"FROM\s+{re.escape(table_name)}"
+        assert re.search(pattern, query, re.IGNORECASE), f"Query does not select FROM {table_name}"
+
+    def expect_properties_in_log_comment(
+        self, properties: dict[str, typing.Any], call_index: int | None = None
+    ) -> None:
+        """Assert that the `log_comment` query parameter contains `properties`.
+
+        If `call_index` is `None` (default), checks all captured calls.
+        """
+        indices = range(len(self.calls)) if call_index is None else [call_index]
+        for i in indices:
+            query_parameters = self.calls[i].query_parameters or {}
+            raw = query_parameters.get("log_comment")
+            assert raw is not None, f"Call {i}: log_comment not found in query_parameters"
+            log_comment = json.loads(raw) if isinstance(raw, str) else raw
+            for key, value in properties.items():
+                actual = log_comment.get(key)
+                assert actual == value, f"Call {i}: expected log_comment[{key}]={value!r}, got {actual!r}"
+
+    def expect_all_calls_have_query_id(self) -> None:
+        """Assert that every captured call has a non-None query_id."""
+        for i, call in enumerate(self.calls):
+            assert call.query_id is not None, f"Call {i} has no query_id"
+
+    def expect_unique_query_ids(self) -> None:
+        """Assert that all captured query_ids are unique."""
+        query_ids = [call.query_id for call in self.calls]
+        assert len(query_ids) == len(set(query_ids)), f"Duplicate query_ids found: {query_ids}"


### PR DESCRIPTION
## Problem

Backfill estimation queries for batch exports had no observability — no query IDs, no log comments, and no structured logging — making it hard to debug slow or problematic queries in ClickHouse.

## Changes

### Main changes

- Add `log_comment` with structured JSON to all backfill estimation queries to match what we do in the actual export queries
- Add unique `query_id` to every ClickHouse query call
- Add structured logging with query duration for all queries

### Other changes

- Refactor: move `_align_timestamp_to_interval` call from the three model-specific helpers into the parent `get_backfill_info` function

### Test improvements

- Add tests to ensure `log_comment` and `query_id` are generated as expected (using `MockClickHouseClient`)
- Refactor all tests to call the full `get_backfill_info` Temporal activity via `ActivityEnvironment` instead of internal helper functions
- Add dedicated tests for `_align_timestamp_to_interval`

## How did you test this code?

All tests pass:

- `pytest products/batch_exports/backend/tests/temporal/backfills/test_align_timestamp_to_interval.py -v` — 7 passed
- `pytest products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py -v` — 27 passed

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code across multiple sessions. Changes were iteratively developed and tested.