### PR TITLE
feat(deduplicator): expose RocksDB config for per-deployment tuning

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4726,7 +4726,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "object_store",
- "once_cell",
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.22.1",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -27,7 +27,6 @@ itertools = "0.14"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 object_store = { version = "0.13.0", features = ["aws"] }
-once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -530,6 +530,7 @@ impl Drop for CheckpointManager {
 mod tests {
     use super::*;
     use crate::checkpoint::{CheckpointPlan, CheckpointUploader};
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::{
         DeduplicationStore, DeduplicationStoreConfig, TimestampKey, TimestampMetadata,
     };
@@ -598,6 +599,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: TempDir::new().unwrap().path().to_path_buf(),
             max_capacity: 1_000_000,
+            rocksdb: RocksDbConfig::default(),
         };
         Arc::new(StoreManager::new(config, create_test_tracker()))
     }
@@ -606,6 +608,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: TempDir::new().unwrap().path().to_path_buf(),
             max_capacity: 1_000_000,
+            rocksdb: RocksDbConfig::default(),
         };
         DeduplicationStore::new(config.clone(), topic.to_string(), partition).unwrap()
     }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -267,12 +267,12 @@ pub struct Config {
     // Limits memory usage by bounding the number of in-flight HTTP connections
     // Critical during rebalance when many partitions are assigned simultaneously
     // Higher values speed up rebalance; streaming bounds memory per download to ~8KB
-    #[envconfig(default = "1000")]
+    #[envconfig(default = "200")]
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export
     // Less critical than downloads since uploads are bounded by max_concurrent_checkpoints
-    #[envconfig(default = "1000")]
+    #[envconfig(default = "200")]
     pub max_concurrent_checkpoint_file_uploads: usize,
 
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -5,6 +5,8 @@ use bytesize::ByteSize;
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 
+use crate::rocksdb::store::RocksDbConfig;
+
 /// Pipeline type for the deduplicator service.
 ///
 /// Each pipeline type handles a different event format:
@@ -97,6 +99,18 @@ pub struct Config {
     // RocksDB storage configuration
     #[envconfig(default = "/tmp/deduplication-store")]
     pub store_path: String,
+
+    // RocksDB tuning (optional — omit to use compiled-in defaults from RocksDbConfig)
+    pub rocksdb_shared_cache_size_bytes: Option<usize>,
+    pub rocksdb_total_write_buffer_size_bytes: Option<usize>,
+    pub rocksdb_max_background_jobs: Option<i32>,
+    pub rocksdb_write_buffer_size_bytes: Option<usize>,
+    pub rocksdb_target_file_size_base_bytes: Option<u64>,
+    pub rocksdb_max_open_files: Option<i32>,
+    pub rocksdb_l0_compaction_trigger: Option<i32>,
+    pub rocksdb_l0_slowdown_writes_trigger: Option<i32>,
+    pub rocksdb_l0_stop_writes_trigger: Option<i32>,
+    pub rocksdb_write_buffer_manager_allow_stall: Option<bool>,
 
     #[envconfig(default = "1073741824")]
     // 1GB default, supports: raw bytes, scientific notation (9.663676416e+09), or units (9Gi, 1GB)
@@ -440,6 +454,54 @@ impl Config {
         // Try as raw integer
         s.parse::<u64>()
             .with_context(|| format!("Failed to parse storage capacity: '{s}'. Expected format: raw bytes, scientific notation, or units (1Gi, 1GB)"))
+    }
+
+    /// Build a RocksDbConfig from env-configured overrides, falling back to defaults.
+    /// Validates max_background_jobs >= 1, clamping with a warning if invalid.
+    pub fn build_rocksdb_config(&self) -> RocksDbConfig {
+        let defaults = RocksDbConfig::default();
+        let max_background_jobs = match self.rocksdb_max_background_jobs {
+            Some(v) if v >= 1 => v,
+            Some(v) => {
+                tracing::warn!(
+                    value = v,
+                    default = defaults.max_background_jobs,
+                    "ROCKSDB_MAX_BACKGROUND_JOBS must be >= 1, using default"
+                );
+                defaults.max_background_jobs
+            }
+            None => defaults.max_background_jobs,
+        };
+        RocksDbConfig {
+            shared_cache_size_bytes: self
+                .rocksdb_shared_cache_size_bytes
+                .unwrap_or(defaults.shared_cache_size_bytes),
+            total_write_buffer_size_bytes: self
+                .rocksdb_total_write_buffer_size_bytes
+                .unwrap_or(defaults.total_write_buffer_size_bytes),
+            max_background_jobs,
+            write_buffer_size_bytes: self
+                .rocksdb_write_buffer_size_bytes
+                .unwrap_or(defaults.write_buffer_size_bytes),
+            target_file_size_base_bytes: self
+                .rocksdb_target_file_size_base_bytes
+                .unwrap_or(defaults.target_file_size_base_bytes),
+            max_open_files: self
+                .rocksdb_max_open_files
+                .unwrap_or(defaults.max_open_files),
+            l0_compaction_trigger: self
+                .rocksdb_l0_compaction_trigger
+                .unwrap_or(defaults.l0_compaction_trigger),
+            l0_slowdown_writes_trigger: self
+                .rocksdb_l0_slowdown_writes_trigger
+                .unwrap_or(defaults.l0_slowdown_writes_trigger),
+            l0_stop_writes_trigger: self
+                .rocksdb_l0_stop_writes_trigger
+                .unwrap_or(defaults.l0_stop_writes_trigger),
+            write_buffer_manager_allow_stall: self
+                .rocksdb_write_buffer_manager_allow_stall
+                .unwrap_or(defaults.write_buffer_manager_allow_stall),
+        }
     }
 
     // Check multiple conditions for safe checkpoint export enablement

--- a/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
@@ -159,6 +159,7 @@ impl ClickHouseEventsBatchProcessor {
 mod tests {
     use super::*;
     use crate::pipelines::{DeduplicationResult, DuplicateReason};
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::test_utils::create_test_tracker;
     use common_types::PersonMode;
     use tempfile::TempDir;
@@ -169,6 +170,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let config = ClickHouseEventsConfig {

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
@@ -589,6 +589,7 @@ impl IngestionEventsBatchProcessor {
 mod tests {
     use super::*;
     use crate::pipelines::DuplicateReason;
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::DeduplicationStoreConfig;
     use crate::test_utils::create_test_tracker;
     use serde_json::json;
@@ -601,6 +602,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let mut producer_config = rdkafka::ClientConfig::new();

--- a/rust/kafka-deduplicator/src/pipelines/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/processor.rs
@@ -253,6 +253,7 @@ pub fn batch_write_timestamp_records(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::DeduplicationStoreConfig;
     use crate::test_utils::create_test_tracker;
     use std::sync::Arc;
@@ -263,6 +264,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
         (manager, temp_dir)
@@ -326,6 +328,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let store = DeduplicationStore::new(config, "test-topic".to_string(), 0).unwrap();
 

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -791,6 +791,7 @@ mod tests {
     use crate::kafka::batch_message::KafkaMessage;
     use crate::kafka::offset_tracker::OffsetTracker;
     use crate::kafka::partition_router::PartitionRouterConfig;
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::DeduplicationStoreConfig;
     use crate::test_utils::create_test_tracker;
     use rdkafka::Offset;
@@ -811,6 +812,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -851,6 +853,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -913,6 +916,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -982,6 +986,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator));
@@ -1018,6 +1023,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1083,6 +1089,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator));
@@ -1120,6 +1127,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1166,6 +1174,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1228,6 +1237,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1317,6 +1327,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1431,6 +1442,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1477,6 +1489,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1519,6 +1532,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1596,6 +1610,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -1706,6 +1721,7 @@ mod tests {
         let store_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
         let coordinator = create_test_tracker();
         let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -1,10 +1,9 @@
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use anyhow::{Context, Result};
-use once_cell::sync::Lazy;
 use rocksdb::{
     checkpoint::Checkpoint, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
     DBWithThreadMode, MultiThreaded, Options, SliceTransform, WriteBatch, WriteBufferManager,
@@ -16,6 +15,84 @@ use tracing::error;
 use crate::metrics::MetricsHelper;
 use crate::rocksdb::metrics_consts::*;
 
+// ── RocksDbConfig defaults (env-overridable via Config) ─────────────────────
+
+const DEFAULT_SHARED_CACHE_SIZE_BYTES: usize = 2048 * 1024 * 1024; // 2 GB
+const DEFAULT_TOTAL_WRITE_BUFFER_SIZE_BYTES: usize = 2048 * 1024 * 1024; // 2 GB across ALL stores
+const DEFAULT_MAX_BACKGROUND_JOBS_CAP: i32 = 2;
+const DEFAULT_PARALLELISM_FALLBACK: usize = 2;
+const DEFAULT_WRITE_BUFFER_SIZE_BYTES: usize = 64 * 1024 * 1024; // 64 MB per memtable
+const DEFAULT_TARGET_FILE_SIZE_BASE_BYTES: u64 = 256 * 1024 * 1024; // 256 MB SST files
+const DEFAULT_MAX_OPEN_FILES: i32 = 1024;
+// L0 compaction thresholds — higher values batch more L0 files before compaction,
+// reducing compaction frequency at the cost of higher read amplification.
+const DEFAULT_L0_COMPACTION_TRIGGER: i32 = 8; // RocksDB default: 4
+const DEFAULT_L0_SLOWDOWN_WRITES_TRIGGER: i32 = 20;
+const DEFAULT_L0_STOP_WRITES_TRIGGER: i32 = 36;
+
+// ── rocksdb_options() fixed settings (not env-overridable) ──────────────────
+
+/// Bloom filter bits per key — 10 bits ≈ 1% false-positive rate.
+const BLOOM_FILTER_BITS_PER_KEY: f64 = 10.0;
+/// Timestamp key prefix length for SliceTransform (8-byte epoch seconds).
+const TIMESTAMP_PREFIX_LEN: usize = 8;
+/// 2 write buffers: one active for writes, one flushing to disk.
+const MAX_WRITE_BUFFER_NUMBER: i32 = 2;
+/// Merge every buffer immediately — avoids batching delay before flush.
+const MIN_WRITE_BUFFER_NUMBER_TO_MERGE: i32 = 1;
+/// Periodic fsync interval for SST and WAL data.
+const BYTES_PER_SYNC: u64 = 1024 * 1024; // 1 MB
+/// Readahead buffer for compaction I/O.
+const COMPACTION_READAHEAD_SIZE: usize = 2 * 1024 * 1024; // 2 MB
+
+// Universal compaction tuning — we don't call optimize_universal_style_compaction()
+// because it forces Snappy compression. Instead, manual config with relaxed triggers
+// to reduce compaction frequency on slow PVC storage.
+const UNIVERSAL_SIZE_RATIO: i32 = 10; // Allow 10% size difference before compacting (default: 1)
+const UNIVERSAL_MIN_MERGE_WIDTH: i32 = 2;
+const UNIVERSAL_MAX_MERGE_WIDTH: i32 = 16;
+const UNIVERSAL_MAX_SIZE_AMPLIFICATION_PERCENT: i32 = 200; // Allow 2x space amplification
+const UNIVERSAL_COMPRESSION_SIZE_PERCENT: i32 = -1; // Compress all levels
+
+/// RocksDB tuning knobs exposed as env vars for per-deploy overrides.
+/// Concrete types — all values fully resolved at construction time.
+/// Tests use `RocksDbConfig::default()` which mirrors the constants above.
+#[derive(Debug, Clone)]
+pub struct RocksDbConfig {
+    pub shared_cache_size_bytes: usize,
+    pub total_write_buffer_size_bytes: usize,
+    pub max_background_jobs: i32,
+    pub write_buffer_size_bytes: usize,
+    pub target_file_size_base_bytes: u64,
+    pub max_open_files: i32,
+    pub l0_compaction_trigger: i32,
+    pub l0_slowdown_writes_trigger: i32,
+    pub l0_stop_writes_trigger: i32,
+    /// Whether the write buffer manager should stall writes when memory is full.
+    /// false = backpressure handled at Kafka level instead.
+    pub write_buffer_manager_allow_stall: bool,
+}
+
+impl Default for RocksDbConfig {
+    fn default() -> Self {
+        let num_threads = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(DEFAULT_PARALLELISM_FALLBACK);
+        Self {
+            shared_cache_size_bytes: DEFAULT_SHARED_CACHE_SIZE_BYTES,
+            total_write_buffer_size_bytes: DEFAULT_TOTAL_WRITE_BUFFER_SIZE_BYTES,
+            max_background_jobs: std::cmp::min(num_threads as i32, DEFAULT_MAX_BACKGROUND_JOBS_CAP),
+            write_buffer_size_bytes: DEFAULT_WRITE_BUFFER_SIZE_BYTES,
+            target_file_size_base_bytes: DEFAULT_TARGET_FILE_SIZE_BASE_BYTES,
+            max_open_files: DEFAULT_MAX_OPEN_FILES,
+            l0_compaction_trigger: DEFAULT_L0_COMPACTION_TRIGGER,
+            l0_slowdown_writes_trigger: DEFAULT_L0_SLOWDOWN_WRITES_TRIGGER,
+            l0_stop_writes_trigger: DEFAULT_L0_STOP_WRITES_TRIGGER,
+            write_buffer_manager_allow_stall: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RocksDbStore {
     pub(crate) db: Arc<DBWithThreadMode<MultiThreaded>>,
@@ -23,41 +100,31 @@ pub struct RocksDbStore {
     metrics: MetricsHelper,
 }
 
-// Shared block cache for all RocksDB instances (1GB default)
-static SHARED_BLOCK_CACHE: Lazy<Arc<Cache>> = Lazy::new(|| {
-    let cache_size = std::env::var("ROCKSDB_SHARED_CACHE_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(2048 * 1024 * 1024); // 2GB default
-
-    Arc::new(Cache::new_lru_cache(cache_size))
-});
+// Shared block cache for all RocksDB instances — initialized via init_shared_resources()
+static SHARED_BLOCK_CACHE: OnceLock<Arc<Cache>> = OnceLock::new();
 
 // Shared write buffer manager to limit total memory used for write buffers
-static SHARED_WRITE_BUFFER_MANAGER: Lazy<Arc<WriteBufferManager>> = Lazy::new(|| {
-    let total_write_buffer_size = std::env::var("ROCKSDB_TOTAL_WRITE_BUFFER_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(2048 * 1024 * 1024); // 2GB total for ALL stores
+static SHARED_WRITE_BUFFER_MANAGER: OnceLock<Arc<WriteBufferManager>> = OnceLock::new();
 
-    // false = don't allow stall (we'll handle backpressure at Kafka level)
-    Arc::new(WriteBufferManager::new_write_buffer_manager(
-        total_write_buffer_size,
-        false,
-    ))
-});
+/// Initialize shared RocksDB resources (block cache, write buffer manager).
+/// Idempotent — safe to call multiple times; first call wins.
+/// Called explicitly in Service::new() and as a fallback in rocksdb_options().
+pub fn init_shared_resources(config: &RocksDbConfig) {
+    SHARED_BLOCK_CACHE
+        .get_or_init(|| Arc::new(Cache::new_lru_cache(config.shared_cache_size_bytes)));
 
-const WRITE_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64MB
-const TARGET_FILE_SIZE_BASE: u64 = 256 * 1024 * 1024; // 256MB
+    SHARED_WRITE_BUFFER_MANAGER.get_or_init(|| {
+        Arc::new(WriteBufferManager::new_write_buffer_manager(
+            config.total_write_buffer_size_bytes,
+            config.write_buffer_manager_allow_stall,
+        ))
+    });
+}
 
 pub fn block_based_table_factory() -> BlockBasedOptions {
-    // Optimize for point lookups (dedup check)
     let mut block_opts = BlockBasedOptions::default();
-    // Set bloom filter to 10 bits per key, not approximate
-    // Bloom filter is a probabilistic data structure that allows for fast lookups
-    // but with a small probability of false positives, we will use this
-    // to avoid full lookups
-    block_opts.set_bloom_filter(10.0, false);
+    // Bloom filter reduces full-key lookups during dedup checks
+    block_opts.set_bloom_filter(BLOOM_FILTER_BITS_PER_KEY, false);
     block_opts.set_cache_index_and_filter_blocks(true);
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_whole_key_filtering(true);
@@ -66,92 +133,77 @@ pub fn block_based_table_factory() -> BlockBasedOptions {
     block_opts
 }
 
-fn rocksdb_options() -> Options {
-    // Use std::thread::available_parallelism() which is cgroup-aware (respects container CPU limits)
-    let num_threads = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(2);
+fn rocksdb_options(config: &RocksDbConfig) -> Options {
+    // Ensure shared resources are initialized (idempotent fallback for tests)
+    init_shared_resources(config);
 
     let mut opts = Options::default();
     opts.create_if_missing(true);
-    // Enable atomic flush to ensure consistency between column families
     opts.set_atomic_flush(true);
     opts.create_missing_column_families(true);
 
-    // Universal compaction reduces write amplification for write-heavy workloads
-    // Trade-off: higher space amplification, but better for batch writes on slow storage
+    // Universal compaction: lower write amplification for write-heavy workloads
+    // at the cost of higher space amplification — good for batch writes on slow PVC storage
     opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-
-    // NOTE: We don't call optimize_universal_style_compaction() because it sets Snappy compression.
-    // Instead, we manually configure universal compaction for reduced CPU usage:
-    // - Higher size_ratio (10% vs 1% default) means less aggressive compaction
-    // - This reduces compaction frequency at the cost of slightly higher space amplification
     let mut universal_opts = rocksdb::UniversalCompactOptions::default();
-    universal_opts.set_size_ratio(10); // Allow 10% size difference before compacting (default: 1)
-    universal_opts.set_min_merge_width(2); // Minimum files to merge (default: 2)
-    universal_opts.set_max_merge_width(16); // Maximum files to merge at once (default: UINT_MAX)
-    universal_opts.set_max_size_amplification_percent(200); // Allow 2x space amp (default: 200)
-    universal_opts.set_compression_size_percent(-1); // Compress all levels (default: -1)
+    universal_opts.set_size_ratio(UNIVERSAL_SIZE_RATIO);
+    universal_opts.set_min_merge_width(UNIVERSAL_MIN_MERGE_WIDTH);
+    universal_opts.set_max_merge_width(UNIVERSAL_MAX_MERGE_WIDTH);
+    universal_opts.set_max_size_amplification_percent(UNIVERSAL_MAX_SIZE_AMPLIFICATION_PERCENT);
+    universal_opts.set_compression_size_percent(UNIVERSAL_COMPRESSION_SIZE_PERCENT);
     opts.set_universal_compaction_options(&universal_opts);
 
     let mut block_opts = block_based_table_factory();
-    // Timestamp CF
+
+    // Timestamp column family uses prefix extractor for 8-byte epoch-second keys
     let mut ts_cf = Options::default();
     ts_cf.set_block_based_table_factory(&block_opts);
-    ts_cf.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
+    ts_cf.set_prefix_extractor(SliceTransform::create_fixed_prefix(TIMESTAMP_PREFIX_LEN));
 
     // CRITICAL: Use shared block cache across all stores
-    block_opts.set_block_cache(&SHARED_BLOCK_CACHE);
-
+    block_opts.set_block_cache(
+        SHARED_BLOCK_CACHE
+            .get()
+            .expect("shared block cache not initialized"),
+    );
     opts.set_block_based_table_factory(&block_opts);
 
     // CRITICAL: Use shared write buffer manager to limit total memory
-    opts.set_write_buffer_manager(&SHARED_WRITE_BUFFER_MANAGER);
+    opts.set_write_buffer_manager(
+        SHARED_WRITE_BUFFER_MANAGER
+            .get()
+            .expect("shared write buffer manager not initialized"),
+    );
 
-    // Write buffer tuning for batch workloads:
-    // - Larger buffers = fewer flushes = less I/O pressure on PVC storage
-    // - With 64 partitions and shared write buffer manager (2GB), each partition
-    //   can use up to 64MB per memtable, but the shared manager limits total usage
-    opts.set_write_buffer_size(WRITE_BUFFER_SIZE); // 64MB per memtable (up from 32MB)
-    opts.set_max_write_buffer_number(2); // 2 buffers to allow writes during flush
-    opts.set_min_write_buffer_number_to_merge(1); // Merge 1 buffer before flush (faster)
+    // Write buffer tuning — larger buffers = fewer flushes = less I/O on PVC storage.
+    // The shared write buffer manager caps total memory across all partition stores.
+    opts.set_write_buffer_size(config.write_buffer_size_bytes);
+    opts.set_max_write_buffer_number(MAX_WRITE_BUFFER_NUMBER);
+    opts.set_min_write_buffer_number_to_merge(MIN_WRITE_BUFFER_NUMBER_TO_MERGE);
 
-    // SST file size should be proportional to write buffer for efficient compaction
-    opts.set_target_file_size_base(TARGET_FILE_SIZE_BASE); // 256MB SST files
+    opts.set_target_file_size_base(config.target_file_size_base_bytes);
 
-    // L0 tuning to reduce write stalls:
-    // - Higher trigger = batch more L0 files before compaction
-    // - Reduces compaction frequency on slow storage
-    opts.set_level_zero_file_num_compaction_trigger(8); // Default is 4
-    opts.set_level_zero_slowdown_writes_trigger(20); // Slow down at 20 L0 files
-    opts.set_level_zero_stop_writes_trigger(36); // Stop at 36 L0 files
+    opts.set_level_zero_file_num_compaction_trigger(config.l0_compaction_trigger);
+    opts.set_level_zero_slowdown_writes_trigger(config.l0_slowdown_writes_trigger);
+    opts.set_level_zero_stop_writes_trigger(config.l0_stop_writes_trigger);
 
-    // Compression: LZ4 is fast and reduces I/O significantly
     opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
 
-    // Parallelism - limit background jobs to reduce I/O contention
-    // With many partitions, too many background jobs can overwhelm disk
-    let max_bg_jobs = std::env::var("ROCKSDB_MAX_BACKGROUND_JOBS")
-        .ok()
-        .and_then(|s| s.parse::<i32>().ok())
-        .unwrap_or(std::cmp::min(num_threads as i32, 2));
-    opts.increase_parallelism(max_bg_jobs);
-    opts.set_max_background_jobs(max_bg_jobs);
+    // Limit background jobs to reduce I/O contention when many partitions share a disk
+    opts.increase_parallelism(config.max_background_jobs);
+    opts.set_max_background_jobs(config.max_background_jobs);
 
-    // IO & safety
     opts.set_paranoid_checks(true);
-    opts.set_bytes_per_sync(1024 * 1024);
-    opts.set_wal_bytes_per_sync(1024 * 1024);
+    opts.set_bytes_per_sync(BYTES_PER_SYNC);
+    opts.set_wal_bytes_per_sync(BYTES_PER_SYNC);
 
-    // Disable direct I/O to allow OS page cache buffering
-    // Critical for PVC storage where the OS cache helps batch writes
+    // Let OS page cache buffer writes — critical for PVC storage
     opts.set_use_direct_reads(false);
     opts.set_use_direct_io_for_flush_and_compaction(false);
-    opts.set_compaction_readahead_size(2 * 1024 * 1024);
+    opts.set_compaction_readahead_size(COMPACTION_READAHEAD_SIZE);
 
-    // Compaction settings
     opts.set_disable_auto_compactions(false);
-    opts.set_max_open_files(1024);
+    opts.set_max_open_files(config.max_open_files);
 
     // CRITICAL: Disable mmap with many partitions to avoid virtual memory explosion
     opts.set_allow_mmap_reads(false);
@@ -165,9 +217,10 @@ impl RocksDbStore {
         path: P,
         cf_descriptors: Vec<ColumnFamilyDescriptor>,
         metrics: MetricsHelper,
+        rocksdb_config: &RocksDbConfig,
     ) -> Result<Self> {
         let path_ref = path.as_ref();
-        let opts = rocksdb_options();
+        let opts = rocksdb_options(rocksdb_config);
 
         let db =
             DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(&opts, path_ref, cf_descriptors)
@@ -550,7 +603,13 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let cf_descriptor = ColumnFamilyDescriptor::new(TEST_CF, Options::default());
         let metrics = MetricsHelper::new().with_label("test", "true");
-        let store = RocksDbStore::new(temp_dir.path(), vec![cf_descriptor], metrics).unwrap();
+        let store = RocksDbStore::new(
+            temp_dir.path(),
+            vec![cf_descriptor],
+            metrics,
+            &RocksDbConfig::default(),
+        )
+        .unwrap();
         (store, temp_dir)
     }
 
@@ -714,9 +773,13 @@ mod tests {
         // Create original store and add data
         {
             let cf_descriptor = ColumnFamilyDescriptor::new(TEST_CF, Options::default());
-            let original_store =
-                RocksDbStore::new(&original_path, vec![cf_descriptor], MetricsHelper::new())
-                    .unwrap();
+            let original_store = RocksDbStore::new(
+                &original_path,
+                vec![cf_descriptor],
+                MetricsHelper::new(),
+                &RocksDbConfig::default(),
+            )
+            .unwrap();
 
             original_store.put(TEST_CF, b"key1", b"value1").unwrap();
             original_store.put(TEST_CF, b"key2", b"value2").unwrap();
@@ -727,8 +790,13 @@ mod tests {
 
         // Open new store from checkpoint
         let cf_descriptor = ColumnFamilyDescriptor::new(TEST_CF, Options::default());
-        let recovered_store =
-            RocksDbStore::new(&checkpoint_path, vec![cf_descriptor], MetricsHelper::new()).unwrap();
+        let recovered_store = RocksDbStore::new(
+            &checkpoint_path,
+            vec![cf_descriptor],
+            MetricsHelper::new(),
+            &RocksDbConfig::default(),
+        )
+        .unwrap();
 
         // Verify data is recovered
         let keys = vec![b"key1".as_slice(), b"key2".as_slice()];
@@ -799,7 +867,13 @@ mod tests {
         let checkpoint2_path = temp_dir.path().join("checkpoint2");
 
         let cf_descriptor = ColumnFamilyDescriptor::new(TEST_CF, Options::default());
-        let store = RocksDbStore::new(&db_path, vec![cf_descriptor], MetricsHelper::new()).unwrap();
+        let store = RocksDbStore::new(
+            &db_path,
+            vec![cf_descriptor],
+            MetricsHelper::new(),
+            &RocksDbConfig::default(),
+        )
+        .unwrap();
 
         // Phase 1: Add initial data
         store.put(TEST_CF, b"key1", b"value1").unwrap();

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -131,7 +131,10 @@ fn rocksdb_options() -> Options {
 
     // Parallelism - limit background jobs to reduce I/O contention
     // With many partitions, too many background jobs can overwhelm disk
-    let max_bg_jobs = std::cmp::min(num_threads as i32, 2);
+    let max_bg_jobs = std::env::var("ROCKSDB_MAX_BACKGROUND_JOBS")
+        .ok()
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(std::cmp::min(num_threads as i32, 2));
     opts.increase_parallelism(max_bg_jobs);
     opts.set_max_background_jobs(max_bg_jobs);
 

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -23,6 +23,7 @@ use crate::{
     config::Config,
     kafka::{PartitionRouterConfig, PartitionWorkerConfig},
     rebalance_tracker::RebalanceTracker,
+    rocksdb::store::init_shared_resources,
     store::DeduplicationStoreConfig,
     store_manager::{CleanupTaskHandle, StoreManager},
 };
@@ -89,12 +90,17 @@ impl KafkaDeduplicatorService {
         // Validate configuration
         config.validate().with_context(|| format!("Configuration validation failed for service with consumer topic '{}' and group '{}'", config.kafka_consumer_topic, config.kafka_consumer_group))?;
 
+        // Build RocksDB config from env overrides and initialize shared resources
+        let rocksdb_config = config.build_rocksdb_config();
+        init_shared_resources(&rocksdb_config);
+
         // Create store configuration
         let store_config = DeduplicationStoreConfig {
             path: config.store_path_buf(),
             max_capacity: config
                 .parse_storage_capacity()
                 .context("Failed to parse max_store_capacity")?,
+            rocksdb: rocksdb_config,
         };
 
         // Create rebalance coordinator first (other components depend on it)

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -7,7 +7,7 @@ use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform};
 use tracing::info;
 
 use crate::metrics::MetricsHelper;
-use crate::rocksdb::store::{block_based_table_factory, RocksDbStore};
+use crate::rocksdb::store::{block_based_table_factory, RocksDbConfig, RocksDbStore};
 
 use super::keys::TimestampKey;
 use crate::pipelines::ingestion_events::TimestampMetadata;
@@ -18,6 +18,8 @@ pub struct DeduplicationStoreConfig {
     pub path: PathBuf,
     // Maximum capacity in bytes
     pub max_capacity: u64,
+    // RocksDB tuning knobs
+    pub rocksdb: RocksDbConfig,
 }
 
 /// Entry for batch writing timestamp records
@@ -42,7 +44,7 @@ impl DeduplicationStore {
         let metrics = MetricsHelper::with_partition(&topic, partition);
 
         let cf_descriptors = Self::get_cf_descriptors();
-        let store = RocksDbStore::new(&config.path, cf_descriptors, metrics)?;
+        let store = RocksDbStore::new(&config.path, cf_descriptors, metrics, &config.rocksdb)?;
 
         Ok(Self {
             store: Arc::new(store),
@@ -383,6 +385,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1_000_000,
+            rocksdb: RocksDbConfig::default(),
         };
         let store = DeduplicationStore::new(config, "test_topic".to_string(), 0).unwrap();
         (store, temp_dir)

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -362,6 +362,7 @@ impl StoreManager {
         let store_config = DeduplicationStoreConfig {
             path: path.to_path_buf(),
             max_capacity: self.store_config.max_capacity,
+            rocksdb: self.store_config.rocksdb.clone(),
         };
         let restored = DeduplicationStore::new(store_config, topic.to_string(), partition)
             .with_context(|| {
@@ -1316,6 +1317,7 @@ impl CleanupTaskHandle {
 
 #[cfg(test)]
 mod tests {
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::{TimestampKey, TimestampMetadata};
     use crate::test_utils::create_test_tracker;
 
@@ -1330,6 +1332,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 100, // Very small capacity to test the logic
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1369,6 +1372,7 @@ mod tests {
         let zero_config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 0,
+            rocksdb: RocksDbConfig::default(),
         };
         let zero_manager = Arc::new(StoreManager::new(zero_config, create_test_tracker()));
         assert!(
@@ -1383,6 +1387,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 5_000, // Small capacity
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1431,6 +1436,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1_000_000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1459,6 +1465,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 0, // Unlimited capacity
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1477,6 +1484,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024, // 1GB
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -1518,6 +1526,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1574,6 +1583,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -1611,6 +1621,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -1655,6 +1666,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -1716,6 +1728,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -1756,6 +1769,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1813,6 +1827,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1880,6 +1895,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 100, // Very small to trigger cleanup
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1924,6 +1940,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1956,6 +1973,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -1989,6 +2007,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -2033,6 +2052,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -2056,6 +2076,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -2082,6 +2103,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1000,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = StoreManager::new(config, create_test_tracker());
@@ -2121,6 +2143,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -2188,6 +2211,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -2232,6 +2256,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -2288,6 +2313,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
@@ -2367,6 +2393,7 @@ mod tests {
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
             max_capacity: 1024 * 1024 * 1024,
+            rocksdb: RocksDbConfig::default(),
         };
 
         let manager = Arc::new(StoreManager::new(config, create_test_tracker()));

--- a/rust/kafka-deduplicator/src/test_utils.rs
+++ b/rust/kafka-deduplicator/src/test_utils.rs
@@ -23,6 +23,7 @@ pub mod test_helpers {
     use serde_json::{json, Value};
     use uuid::Uuid;
 
+    use crate::rocksdb::store::RocksDbConfig;
     use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
 
     /// Creates a simple test RawEvent with reasonable defaults.
@@ -124,6 +125,7 @@ pub mod test_helpers {
         let config = DeduplicationStoreConfig {
             path: path.to_path_buf(),
             max_capacity: 1_000_000,
+            rocksdb: RocksDbConfig::default(),
         };
         DeduplicationStore::new(config, topic.to_string(), partition).unwrap()
     }

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -11,6 +11,7 @@ use kafka_deduplicator::checkpoint::{
     METADATA_FILENAME,
 };
 use kafka_deduplicator::kafka::types::Partition;
+use kafka_deduplicator::rocksdb::store::RocksDbConfig;
 use kafka_deduplicator::store::{
     DeduplicationStore, DeduplicationStoreConfig, TimestampKey, TimestampMetadata,
 };
@@ -361,6 +362,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
         // Checkpoint files are imported directly to the store directory
         path: import_result.clone(),
         max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
     };
     let restored_store = DeduplicationStore::new(
         restored_store_config,

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -43,6 +43,7 @@ use kafka_deduplicator::kafka::{
     rebalance_handler::RebalanceHandler, routing_processor::RoutingProcessor, types::Partition,
 };
 use kafka_deduplicator::processor_rebalance_handler::ProcessorRebalanceHandler;
+use kafka_deduplicator::rocksdb::store::RocksDbConfig;
 use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig};
 use kafka_deduplicator::store_manager::StoreManager;
 use kafka_deduplicator::test_utils::create_test_tracker;
@@ -227,6 +228,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
     let store_config = DeduplicationStoreConfig {
         path: tmp_store_dir.path().to_path_buf(),
         max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
     };
     let store = DeduplicationStore::new(store_config, test_topic.clone(), test_partition)?;
 
@@ -298,6 +300,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
     let consumer_store_config = DeduplicationStoreConfig {
         path: tmp_consumer_store_dir.path().to_path_buf(),
         max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
     };
     let coordinator = create_test_tracker();
     let store_manager = Arc::new(StoreManager::new(
@@ -446,6 +449,7 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
     let store_config = DeduplicationStoreConfig {
         path: tmp_store_dir.path().to_path_buf(),
         max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
     };
     let coordinator = create_test_tracker();
     let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));
@@ -534,6 +538,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
     let store_config = DeduplicationStoreConfig {
         path: tmp_store_dir.path().to_path_buf(),
         max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
     };
     let coordinator = create_test_tracker();
     let store_manager = Arc::new(StoreManager::new(store_config, coordinator.clone()));


### PR DESCRIPTION
## Problem
Two of the chief performance tuning issues we're addressing in the deduplicator involve spikes in memory and CPU utilization during RocksDB checkpoint creation.

Let's go ahead and refactor to expose a `RocksDbConfig` we can parameterize more cleanly with env vars in our deployments 🚀 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement `RocksDbConfig` and injection path for stores
* Add constants to replace magic numbers in values we don't want to parameterize yet
* Expose new configs we do want to adjust on the fly in app config
* Update several base cfg values
* Related updates to tests, defaults, comments, docs etc.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
