### PR TITLE
chore(web-analytics): Move live map behind a feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -417,6 +417,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_CONVERSION_GOAL_PREAGG: 'web-analytics-conversion-goal-preagg', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_LIVE_MAP: 'web-analytics-live-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_METRICS: 'web-analytics-live-metrics', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics
     WEB_ANALYTICS_OPEN_URL: 'web-analytics-open-url', // owner: @lricoy #team-web-analytics

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -2,7 +2,9 @@ import { useActions, useValues } from 'kea'
 import { useEffect, useMemo } from 'react'
 
 import { liveUserCountLogic } from 'lib/components/LiveUserCount/liveUserCountLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { BreakdownLiveCard } from './BreakdownLiveCard'
 import { getBrowserLogo } from './browserLogos'
@@ -43,6 +45,7 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
         liveUserCountLogic({ pollIntervalMs: STATS_POLL_INTERVAL_MS })
     )
 
+    const { featureFlags } = useValues(featureFlagLogic)
     const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
@@ -103,12 +106,14 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                 />
             </div>
 
-            <LiveChartCard title="Countries" isLoading={isLoading} contentClassName="">
-                <LiveWorldMap
-                    data={countryBreakdown}
-                    totalEvents={countryBreakdown.reduce((sum, c) => sum + c.count, 0)}
-                />
-            </LiveChartCard>
+            {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_MAP] && (
+                <LiveChartCard title="Countries" isLoading={isLoading} contentClassName="">
+                    <LiveWorldMap
+                        data={countryBreakdown}
+                        totalEvents={countryBreakdown.reduce((sum, c) => sum + c.count, 0)}
+                    />
+                </LiveChartCard>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem
The live map is causing significant lag, move it behind a feature flag for now.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds new feature flag, moves live map behind it

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally tested
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
