### PR TITLE
feat: add stripe deep link login endpoint

### DIFF
--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -1,42 +1,14 @@
-import time
-from urllib.parse import urlencode
-
 from django.core.cache import cache
 from django.test import override_settings
 
-from ee.api.agentic_provisioning.signature import compute_signature
+from parameterized import parameterized
+
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
-from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX, DEEP_LINK_CACHE_PREFIX
+from ee.api.agentic_provisioning.views import DEEP_LINK_CACHE_PREFIX
 
 
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
 class TestDeepLinks(StripeProvisioningTestBase):
-    def _get_bearer_token(self) -> str:
-        code = "dl_test_code"
-        cache.set(
-            f"{AUTH_CODE_CACHE_PREFIX}{code}",
-            {
-                "user_id": self.user.id,
-                "org_id": str(self.organization.id),
-                "team_id": self.team.id,
-                "stripe_account_id": "acct_123",
-                "scopes": ["query:read"],
-                "region": "US",
-            },
-            timeout=300,
-        )
-        body = urlencode({"grant_type": "authorization_code", "code": code}).encode()
-        ts = int(time.time())
-        sig = compute_signature(HMAC_SECRET, ts, body)
-        res = self.client.post(
-            "/api/agentic/oauth/token",
-            data=body,
-            content_type="application/x-www-form-urlencoded",
-            HTTP_STRIPE_SIGNATURE=f"t={ts},v1={sig}",
-            HTTP_API_VERSION="0.1d",
-        )
-        return res.json()["access_token"]
-
     def test_deep_link_returns_url(self):
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
@@ -81,7 +53,7 @@ class TestStripeLogin(StripeProvisioningTestBase):
         token = self._create_deep_link_token()
         res = self.client.get(f"/login/stripe?token={token}")
         assert res.status_code == 302
-        assert f"/project/{self.team.id}" in res.url
+        assert res["Location"] == f"/project/{self.team.id}"
 
     def test_valid_token_creates_session(self):
         token = self._create_deep_link_token()
@@ -94,20 +66,22 @@ class TestStripeLogin(StripeProvisioningTestBase):
         token = self._create_deep_link_token()
         res1 = self.client.get(f"/login/stripe?token={token}")
         assert res1.status_code == 302
-        assert "/project/" in res1.url
+        assert "/project/" in res1["Location"]
         res2 = self.client.get(f"/login/stripe?token={token}")
         assert res2.status_code == 302
-        assert "expired_or_invalid_token" in res2.url
+        assert "expired_or_invalid_token" in res2["Location"]
 
-    def test_missing_token_redirects_with_error(self):
-        res = self.client.get("/login/stripe")
+    @parameterized.expand(
+        [
+            ("missing_token", "", "missing_token"),
+            ("invalid_token", "bogus", "expired_or_invalid_token"),
+        ]
+    )
+    def test_error_redirect(self, _name: str, token_value: str, expected_error: str):
+        url = "/login/stripe" if not token_value else f"/login/stripe?token={token_value}"
+        res = self.client.get(url)
         assert res.status_code == 302
-        assert "missing_token" in res.url
-
-    def test_invalid_token_redirects_with_error(self):
-        res = self.client.get("/login/stripe?token=bogus")
-        assert res.status_code == 302
-        assert "expired_or_invalid_token" in res.url
+        assert expected_error in res["Location"]
 
     def test_without_team_id_redirects_to_root(self):
         token = "test_no_team_token"
@@ -118,4 +92,32 @@ class TestStripeLogin(StripeProvisioningTestBase):
         )
         res = self.client.get(f"/login/stripe?token={token}")
         assert res.status_code == 302
-        assert res.url == "/"
+        assert res["Location"] == "/"
+
+    def test_expired_token_redirects_with_error(self):
+        token = "test_expired_token"
+        cache.set(
+            f"{DEEP_LINK_CACHE_PREFIX}{token}",
+            {"user_id": self.user.id, "team_id": self.team.id},
+            timeout=0,
+        )
+        res = self.client.get(f"/login/stripe?token={token}")
+        assert res.status_code == 302
+        assert res["Location"] == "/?error=expired_or_invalid_token"
+
+    def test_deleted_user_redirects_with_error(self):
+        token = "test_deleted_user_token"
+        cache.set(
+            f"{DEEP_LINK_CACHE_PREFIX}{token}",
+            {"user_id": 999999, "team_id": self.team.id},
+            timeout=600,
+        )
+        res = self.client.get(f"/login/stripe?token={token}")
+        assert res.status_code == 302
+        assert res["Location"] == "/?error=user_not_found"
+
+    def test_redirects_are_relative(self):
+        token = self._create_deep_link_token()
+        res = self.client.get(f"/login/stripe?token={token}")
+        assert res.status_code == 302
+        assert not res["Location"].startswith("http")

--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -39,7 +39,7 @@ class TestDeepLinks(StripeProvisioningTestBase):
 
 
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
-class TestStripeLogin(StripeProvisioningTestBase):
+class TestAgenticLogin(StripeProvisioningTestBase):
     def _create_deep_link_token(self) -> str:
         token = "test_deep_link_token"
         cache.set(
@@ -51,23 +51,23 @@ class TestStripeLogin(StripeProvisioningTestBase):
 
     def test_valid_token_logs_in_and_redirects_to_project(self):
         token = self._create_deep_link_token()
-        res = self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get(f"/agentic/login?token={token}")
         assert res.status_code == 302
         assert res["Location"] == f"/project/{self.team.id}"
 
     def test_valid_token_creates_session(self):
         token = self._create_deep_link_token()
-        self.client.get(f"/login/stripe?token={token}")
+        self.client.get(f"/agentic/login?token={token}")
         res = self.client.get("/api/users/@me/")
         assert res.status_code == 200
         assert res.json()["email"] == self.user.email
 
     def test_token_is_single_use(self):
         token = self._create_deep_link_token()
-        res1 = self.client.get(f"/login/stripe?token={token}")
+        res1 = self.client.get(f"/agentic/login?token={token}")
         assert res1.status_code == 302
         assert "/project/" in res1["Location"]
-        res2 = self.client.get(f"/login/stripe?token={token}")
+        res2 = self.client.get(f"/agentic/login?token={token}")
         assert res2.status_code == 302
         assert "expired_or_invalid_token" in res2["Location"]
 
@@ -78,7 +78,7 @@ class TestStripeLogin(StripeProvisioningTestBase):
         ]
     )
     def test_error_redirect(self, _name: str, token_value: str, expected_error: str):
-        url = "/login/stripe" if not token_value else f"/login/stripe?token={token_value}"
+        url = "/agentic/login" if not token_value else f"/agentic/login?token={token_value}"
         res = self.client.get(url)
         assert res.status_code == 302
         assert expected_error in res["Location"]
@@ -90,7 +90,7 @@ class TestStripeLogin(StripeProvisioningTestBase):
             {"user_id": self.user.id, "team_id": None},
             timeout=600,
         )
-        res = self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get(f"/agentic/login?token={token}")
         assert res.status_code == 302
         assert res["Location"] == "/"
 
@@ -101,7 +101,7 @@ class TestStripeLogin(StripeProvisioningTestBase):
             {"user_id": self.user.id, "team_id": self.team.id},
             timeout=0,
         )
-        res = self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get(f"/agentic/login?token={token}")
         assert res.status_code == 302
         assert res["Location"] == "/?error=expired_or_invalid_token"
 
@@ -112,12 +112,12 @@ class TestStripeLogin(StripeProvisioningTestBase):
             {"user_id": 999999, "team_id": self.team.id},
             timeout=600,
         )
-        res = self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get(f"/agentic/login?token={token}")
         assert res.status_code == 302
         assert res["Location"] == "/?error=user_not_found"
 
     def test_redirects_are_relative(self):
         token = self._create_deep_link_token()
-        res = self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get(f"/agentic/login?token={token}")
         assert res.status_code == 302
         assert not res["Location"].startswith("http")

--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -1,12 +1,12 @@
 import time
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from django.core.cache import cache
 from django.test import override_settings
 
 from ee.api.agentic_provisioning.signature import compute_signature
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
-from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX
+from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX, DEEP_LINK_CACHE_PREFIX
 
 
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
@@ -64,3 +64,59 @@ class TestDeepLinks(StripeProvisioningTestBase):
     def test_deep_link_missing_bearer_returns_401(self):
         res = self._post_signed("/api/agentic/provisioning/deep_links", data={"purpose": "dashboard"})
         assert res.status_code == 401
+
+
+@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+class TestStripeLogin(StripeProvisioningTestBase):
+    def _create_deep_link_token(self) -> str:
+        token = "test_deep_link_token"
+        cache.set(
+            f"{DEEP_LINK_CACHE_PREFIX}{token}",
+            {"user_id": self.user.id, "team_id": self.team.id},
+            timeout=600,
+        )
+        return token
+
+    def test_valid_token_logs_in_and_redirects_to_project(self):
+        token = self._create_deep_link_token()
+        res = self.client.get(f"/login/stripe?token={token}")
+        assert res.status_code == 302
+        assert f"/project/{self.team.id}" in res.url
+
+    def test_valid_token_creates_session(self):
+        token = self._create_deep_link_token()
+        self.client.get(f"/login/stripe?token={token}")
+        res = self.client.get("/api/users/@me/")
+        assert res.status_code == 200
+        assert res.json()["email"] == self.user.email
+
+    def test_token_is_single_use(self):
+        token = self._create_deep_link_token()
+        res1 = self.client.get(f"/login/stripe?token={token}")
+        assert res1.status_code == 302
+        assert "/project/" in res1.url
+        res2 = self.client.get(f"/login/stripe?token={token}")
+        assert res2.status_code == 302
+        assert "expired_or_invalid_token" in res2.url
+
+    def test_missing_token_redirects_with_error(self):
+        res = self.client.get("/login/stripe")
+        assert res.status_code == 302
+        assert "missing_token" in res.url
+
+    def test_invalid_token_redirects_with_error(self):
+        res = self.client.get("/login/stripe?token=bogus")
+        assert res.status_code == 302
+        assert "expired_or_invalid_token" in res.url
+
+    def test_without_team_id_redirects_to_root(self):
+        token = "test_no_team_token"
+        cache.set(
+            f"{DEEP_LINK_CACHE_PREFIX}{token}",
+            {"user_id": self.user.id, "team_id": None},
+            timeout=600,
+        )
+        res = self.client.get(f"/login/stripe?token={token}")
+        assert res.status_code == 302
+        parsed = urlparse(res.url)
+        assert parsed.path == "/" or parsed.path == ""

--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -1,5 +1,5 @@
 import time
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 from django.core.cache import cache
 from django.test import override_settings
@@ -118,5 +118,4 @@ class TestStripeLogin(StripeProvisioningTestBase):
         )
         res = self.client.get(f"/login/stripe?token={token}")
         assert res.status_code == 302
-        parsed = urlparse(res.url)
-        assert parsed.path == "/" or parsed.path == ""
+        assert res.url == "/"

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -1,6 +1,6 @@
 import time
 from datetime import timedelta
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.test import override_settings
 from django.utils import timezone
@@ -98,15 +98,30 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
         rotated_api_key = res.json()["complete"]["access_configuration"]["api_key"]
         assert rotated_api_key != original_api_key
 
-        # 8. Deep link
+        # 8. Deep link — create and use it to login
         res = self._post_signed_with_bearer(
             "/api/agentic/provisioning/deep_links",
             data={"purpose": "dashboard"},
             token=access_token,
         )
         assert res.status_code == 200
-        assert "url" in res.json()
+        deep_link_url = res.json()["url"]
         assert "expires_at" in res.json()
+
+        parsed = urlparse(deep_link_url)
+        deep_link_token = parse_qs(parsed.query)["token"][0]
+
+        login_res = self.client.get(f"/login/stripe?token={deep_link_token}")
+        assert login_res.status_code == 302
+        assert "/project/" in login_res["Location"]
+
+        me_res = self.client.get("/api/users/@me/")
+        assert me_res.status_code == 200
+        assert me_res.json()["email"] == "e2e-test@example.com"
+
+        reuse_res = self.client.get(f"/login/stripe?token={deep_link_token}")
+        assert reuse_res.status_code == 302
+        assert "expired_or_invalid_token" in reuse_res["Location"]
 
         # 9. Refresh the token
         refresh_body = urlencode({"grant_type": "refresh_token", "refresh_token": refresh_token}).encode()

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -111,7 +111,7 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
         parsed = urlparse(deep_link_url)
         deep_link_token = parse_qs(parsed.query)["token"][0]
 
-        login_res = self.client.get(f"/login/stripe?token={deep_link_token}")
+        login_res = self.client.get(f"/agentic/login?token={deep_link_token}")
         assert login_res.status_code == 302
         assert "/project/" in login_res["Location"]
 
@@ -119,7 +119,7 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
         assert me_res.status_code == 200
         assert me_res.json()["email"] == "e2e-test@example.com"
 
-        reuse_res = self.client.get(f"/login/stripe?token={deep_link_token}")
+        reuse_res = self.client.get(f"/agentic/login?token={deep_link_token}")
         assert reuse_res.status_code == 302
         assert "expired_or_invalid_token" in reuse_res["Location"]
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -883,14 +883,9 @@ def agentic_login(request: Any) -> HttpResponseBase:
         logger.warning("agentic_login.invalid_token_data")
         return HttpResponseRedirect("/?error=invalid_token_data")
 
-    user_id = link_data.get("user_id")
+    user_id = link_data["user_id"]
     team_id = link_data.get("team_id")
     purpose = link_data.get("purpose", "dashboard")
-
-    if not user_id:
-        _capture_deep_link_event("invalid_token_data")
-        logger.warning("agentic_login.missing_user_id")
-        return HttpResponseRedirect("/?error=invalid_token_data")
 
     try:
         user = User.objects.get(id=user_id)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from django.conf import settings
+from django.contrib.auth import login as auth_login
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.db import IntegrityError
@@ -828,3 +829,35 @@ def _region_to_host(region: str) -> str:
     elif region_lower in ("us", "dev"):
         return "https://us.posthog.com"
     return settings.SITE_URL
+
+
+# ---------------------------------------------------------------------------
+# GET /login/stripe — deep link login for Stripe APP users
+# ---------------------------------------------------------------------------
+
+
+def stripe_login(request: Any) -> HttpResponseBase:
+    token = request.GET.get("token", "")
+    if not token:
+        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=missing_token")
+
+    cache_key = f"{DEEP_LINK_CACHE_PREFIX}{token}"
+    link_data = cache.get(cache_key)
+    if link_data is None:
+        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=expired_or_invalid_token")
+
+    cache.delete(cache_key)
+
+    user_id = link_data.get("user_id")
+    team_id = link_data.get("team_id")
+
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=user_not_found")
+
+    auth_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+
+    if team_id:
+        return HttpResponseRedirect(f"{settings.SITE_URL}/project/{team_id}")
+    return HttpResponseRedirect(settings.SITE_URL)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -44,7 +44,7 @@ PENDING_AUTH_TTL_SECONDS = 600
 DEEP_LINK_TTL_SECONDS = 600
 DEEP_LINK_CACHE_PREFIX = "stripe_app_deep_link:"
 SUPPORTED_DEEP_LINK_PURPOSES = {"dashboard"}
-DEEP_LINK_RATE_LIMIT_PREFIX = "stripe_login_rate:"
+DEEP_LINK_RATE_LIMIT_PREFIX = "agentic_login_rate:"
 DEEP_LINK_RATE_LIMIT_MAX_ATTEMPTS = 10
 DEEP_LINK_RATE_LIMIT_WINDOW_SECONDS = 300
 
@@ -777,7 +777,7 @@ def deep_links(request: Request) -> Response:
 
     expires_at = timezone.now() + timedelta(seconds=DEEP_LINK_TTL_SECONDS)
 
-    url = f"{host}/login/stripe?token={token}"
+    url = f"{host}/agentic/login?token={token}"
     if team_id:
         url += f"&team_id={team_id}"
 
@@ -848,15 +848,15 @@ def _region_to_host(region: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# GET /login/stripe — deep link login for Stripe APP users
+# GET /agentic/login — deep link login for agentic provisioning users
 # ---------------------------------------------------------------------------
 
 
-def stripe_login(request: Any) -> HttpResponseBase:
+def agentic_login(request: Any) -> HttpResponseBase:
     token = request.GET.get("token", "")
     if not token:
         _capture_deep_link_event("missing_token")
-        logger.warning("stripe_login.missing_token")
+        logger.warning("agentic_login.missing_token")
         return HttpResponseRedirect("/?error=missing_token")
 
     cache_key = f"{DEEP_LINK_CACHE_PREFIX}{token}"
@@ -869,18 +869,18 @@ def stripe_login(request: Any) -> HttpResponseBase:
 
     if link_data is None:
         _capture_deep_link_event("expired_or_invalid_token")
-        logger.warning("stripe_login.expired_or_invalid_token")
+        logger.warning("agentic_login.expired_or_invalid_token")
         return HttpResponseRedirect("/?error=expired_or_invalid_token")
 
     # Atomic delete — if another request already consumed this token, reject
     if not cache.delete(cache_key):
         _capture_deep_link_event("expired_or_invalid_token")
-        logger.warning("stripe_login.token_already_consumed")
+        logger.warning("agentic_login.token_already_consumed")
         return HttpResponseRedirect("/?error=expired_or_invalid_token")
 
     if not isinstance(link_data, dict):
         _capture_deep_link_event("invalid_token_data")
-        logger.warning("stripe_login.invalid_token_data")
+        logger.warning("agentic_login.invalid_token_data")
         return HttpResponseRedirect("/?error=invalid_token_data")
 
     user_id = link_data.get("user_id")
@@ -889,7 +889,7 @@ def stripe_login(request: Any) -> HttpResponseBase:
 
     if not user_id:
         _capture_deep_link_event("invalid_token_data")
-        logger.warning("stripe_login.missing_user_id")
+        logger.warning("agentic_login.missing_user_id")
         return HttpResponseRedirect("/?error=invalid_token_data")
 
     try:
@@ -904,13 +904,13 @@ def stripe_login(request: Any) -> HttpResponseBase:
 
     if not user.is_active:
         _capture_deep_link_event("user_inactive", user_id=user_id)
-        logger.warning("stripe_login.user_inactive", user_id=user_id)
+        logger.warning("agentic_login.user_inactive", user_id=user_id)
         return HttpResponseRedirect("/?error=user_inactive")
 
     auth_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
 
     _capture_deep_link_event("success", user_id=user_id, team_id=team_id, purpose=purpose)
-    logger.info("stripe_login.success", user_id=user_id, team_id=team_id, purpose=purpose)
+    logger.info("agentic_login.success", user_id=user_id, team_id=team_id, purpose=purpose)
 
     redirect_path = _deep_link_redirect_path(purpose, team_id)
     return HttpResponseRedirect(redirect_path)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -16,6 +16,7 @@ from django.http.response import HttpResponseBase
 from django.utils import timezone
 
 import structlog
+import posthoganalytics
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
@@ -42,6 +43,10 @@ AUTH_CODE_TTL_SECONDS = 300
 PENDING_AUTH_TTL_SECONDS = 600
 DEEP_LINK_TTL_SECONDS = 600
 DEEP_LINK_CACHE_PREFIX = "stripe_app_deep_link:"
+SUPPORTED_DEEP_LINK_PURPOSES = {"dashboard"}
+DEEP_LINK_RATE_LIMIT_PREFIX = "stripe_login_rate:"
+DEEP_LINK_RATE_LIMIT_MAX_ATTEMPTS = 10
+DEEP_LINK_RATE_LIMIT_WINDOW_SECONDS = 300
 
 STRIPE_APP_NAME = "PostHog Stripe App"
 
@@ -741,6 +746,16 @@ def deep_links(request: Request) -> Response:
         return error
 
     purpose = request.data.get("purpose", "dashboard")
+    if purpose not in SUPPORTED_DEEP_LINK_PURPOSES:
+        return Response(
+            {
+                "error": {
+                    "code": "unsupported_purpose",
+                    "message": f"Unsupported purpose: {purpose}. Supported: {', '.join(sorted(SUPPORTED_DEEP_LINK_PURPOSES))}",
+                }
+            },
+            status=400,
+        )
 
     scoped_teams = access_token.scoped_teams or []
     team_id = scoped_teams[0] if scoped_teams else None
@@ -755,6 +770,7 @@ def deep_links(request: Request) -> Response:
         {
             "user_id": access_token.user_id,
             "team_id": team_id,
+            "purpose": purpose,
         },
         timeout=DEEP_LINK_TTL_SECONDS,
     )
@@ -839,25 +855,76 @@ def _region_to_host(region: str) -> str:
 def stripe_login(request: Any) -> HttpResponseBase:
     token = request.GET.get("token", "")
     if not token:
+        _capture_deep_link_event("missing_token")
+        logger.warning("stripe_login.missing_token")
         return HttpResponseRedirect("/?error=missing_token")
 
     cache_key = f"{DEEP_LINK_CACHE_PREFIX}{token}"
-    link_data = cache.get(cache_key)
+
+    try:
+        link_data = cache.get(cache_key)
+    except Exception:
+        capture_exception(additional_properties={"cache_key": cache_key})
+        return HttpResponseRedirect("/?error=service_unavailable")
+
     if link_data is None:
+        _capture_deep_link_event("expired_or_invalid_token")
+        logger.warning("stripe_login.expired_or_invalid_token")
         return HttpResponseRedirect("/?error=expired_or_invalid_token")
 
-    cache.delete(cache_key)
+    # Atomic delete — if another request already consumed this token, reject
+    if not cache.delete(cache_key):
+        _capture_deep_link_event("expired_or_invalid_token")
+        logger.warning("stripe_login.token_already_consumed")
+        return HttpResponseRedirect("/?error=expired_or_invalid_token")
+
+    if not isinstance(link_data, dict):
+        _capture_deep_link_event("invalid_token_data")
+        logger.warning("stripe_login.invalid_token_data")
+        return HttpResponseRedirect("/?error=invalid_token_data")
 
     user_id = link_data.get("user_id")
     team_id = link_data.get("team_id")
+    purpose = link_data.get("purpose", "dashboard")
+
+    if not user_id:
+        _capture_deep_link_event("invalid_token_data")
+        logger.warning("stripe_login.missing_user_id")
+        return HttpResponseRedirect("/?error=invalid_token_data")
 
     try:
         user = User.objects.get(id=user_id)
     except User.DoesNotExist:
+        _capture_deep_link_event("user_not_found", user_id=user_id)
+        capture_exception(
+            Exception("Deep link login user not found"),
+            {"user_id": user_id, "team_id": team_id},
+        )
         return HttpResponseRedirect("/?error=user_not_found")
+
+    if not user.is_active:
+        _capture_deep_link_event("user_inactive", user_id=user_id)
+        logger.warning("stripe_login.user_inactive", user_id=user_id)
+        return HttpResponseRedirect("/?error=user_inactive")
 
     auth_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
 
-    if team_id:
-        return HttpResponseRedirect(f"/project/{team_id}")
-    return HttpResponseRedirect("/")
+    _capture_deep_link_event("success", user_id=user_id, team_id=team_id, purpose=purpose)
+    logger.info("stripe_login.success", user_id=user_id, team_id=team_id, purpose=purpose)
+
+    redirect_path = _deep_link_redirect_path(purpose, team_id)
+    return HttpResponseRedirect(redirect_path)
+
+
+def _deep_link_redirect_path(purpose: str, team_id: int | None) -> str:
+    if team_id and Team.objects.filter(id=team_id).exists():
+        return f"/project/{team_id}"
+    return "/"
+
+
+def _capture_deep_link_event(outcome: str, **extra: object) -> None:
+    posthoganalytics.capture(
+        "agentic_provisioning deep link login",
+        distinct_id="agentic_provisioning_system",
+        properties={"outcome": outcome, **extra},
+    )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -883,9 +883,14 @@ def agentic_login(request: Any) -> HttpResponseBase:
         logger.warning("agentic_login.invalid_token_data")
         return HttpResponseRedirect("/?error=invalid_token_data")
 
-    user_id = link_data["user_id"]
+    user_id = link_data.get("user_id")
     team_id = link_data.get("team_id")
     purpose = link_data.get("purpose", "dashboard")
+
+    if not user_id:
+        _capture_deep_link_event("invalid_token_data")
+        logger.warning("agentic_login.missing_user_id")
+        return HttpResponseRedirect("/?error=invalid_token_data")
 
     try:
         user = User.objects.get(id=user_id)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -839,12 +839,12 @@ def _region_to_host(region: str) -> str:
 def stripe_login(request: Any) -> HttpResponseBase:
     token = request.GET.get("token", "")
     if not token:
-        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=missing_token")
+        return HttpResponseRedirect("/?error=missing_token")
 
     cache_key = f"{DEEP_LINK_CACHE_PREFIX}{token}"
     link_data = cache.get(cache_key)
     if link_data is None:
-        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=expired_or_invalid_token")
+        return HttpResponseRedirect("/?error=expired_or_invalid_token")
 
     cache.delete(cache_key)
 
@@ -854,10 +854,10 @@ def stripe_login(request: Any) -> HttpResponseBase:
     try:
         user = User.objects.get(id=user_id)
     except User.DoesNotExist:
-        return HttpResponseRedirect(f"{settings.SITE_URL}/?error=user_not_found")
+        return HttpResponseRedirect("/?error=user_not_found")
 
     auth_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
 
     if team_id:
-        return HttpResponseRedirect(f"{settings.SITE_URL}/project/{team_id}")
-    return HttpResponseRedirect(settings.SITE_URL)
+        return HttpResponseRedirect(f"/project/{team_id}")
+    return HttpResponseRedirect("/")

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -300,9 +300,9 @@ urlpatterns: list[Any] = [
         name="agentic_provisioning_deep_links",
     ),
     path(
-        "login/stripe",
-        agentic_provisioning_views.stripe_login,
-        name="stripe_login",
+        "agentic/login",
+        agentic_provisioning_views.agentic_login,
+        name="agentic_login",
     ),
     *admin_urlpatterns,
 ]

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -299,5 +299,10 @@ urlpatterns: list[Any] = [
         csrf_exempt(agentic_provisioning_views.deep_links),
         name="agentic_provisioning_deep_links",
     ),
+    path(
+        "login/stripe",
+        agentic_provisioning_views.stripe_login,
+        name="stripe_login",
+    ),
     *admin_urlpatterns,
 ]


### PR DESCRIPTION
## Problem

The `POST /api/agentic/provisioning/deep_links` endpoint generates URLs pointing to `/login/stripe?token=...` but no view existed to handle them — visiting the URL returned a 404. This blocks the Stripe APP deep link flow.

## Changes

- Added `stripe_login` view (`GET /login/stripe`) that:
  1. Validates the deep link token from cache
  2. Logs the user in via Django's `auth_login()`
  3. Redirects to `/project/{team_id}` (or `/` if no team)
  4. Token is single-use (deleted from cache after first use, with atomic delete to prevent TOCTOU races)
- Registered the route in `ee/urls.py`
- Added observability: PostHog analytics events, structured logging, `capture_exception` for error paths
- Added purpose validation in `deep_links` endpoint
- Added tests covering: valid login + session, single-use enforcement, missing/invalid/expired tokens, deleted user, no-team fallback, relative redirects

## How did you test this code

- All 13 deep link + e2e tests pass locally (`pytest ee/api/agentic_provisioning/test/test_deep_links.py ee/api/agentic_provisioning/test/test_e2e_flow.py`)
- End-to-end smoke test against prod confirms deep link URL is generated correctly
- Opened a generated deep link in an incognito browser window — it logged me in and redirected to the project dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)