### PR TITLE
feat: Add email notification for reverse proxy provisioning

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -115,6 +115,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "approval_expired": "59",
     "approval_applied": "61",
     "conversation_restore": "63",
+    "proxy_provisioned": "64",
 }
 
 

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,0 +1,25 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
+{% block heading %}Your reverse proxy is ready{% endblock %}
+{% block section %}
+<!-- prettier-ignore -->
+<p>
+    Hey{% if user_name %} {{ user_name }}{% endif %},
+</p>
+<p>
+    Great news! Your reverse proxy for <strong>{{ domain }}</strong> has been successfully provisioned and is ready to use.
+</p>
+<p>
+    You can now update your PostHog SDK configuration to send events through <strong>{{ domain }}</strong> instead of
+    directly to PostHog. This helps improve data collection reliability by routing traffic through your own domain.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ settings_url }}">View proxy settings</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ settings_url }}">{{ settings_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/posthog/temporal/proxy_service/__init__.py
+++ b/posthog/temporal/proxy_service/__init__.py
@@ -1,6 +1,10 @@
 # ruff: noqa: F401 intentionally not using these
 
-from posthog.temporal.proxy_service.common import activity_capture_event, activity_update_proxy_record
+from posthog.temporal.proxy_service.common import (
+    activity_capture_event,
+    activity_send_proxy_created_email,
+    activity_update_proxy_record,
+)
 from posthog.temporal.proxy_service.create import (
     CreateManagedProxyInputs,
     CreateManagedProxyWorkflow,
@@ -40,6 +44,7 @@ ACTIVITIES = [
     check_dns,
     check_proxy_is_live,
     activity_capture_event,
+    activity_send_proxy_created_email,
     schedule_monitor_job,
     cleanup_monitor_job,
     # Cloudflare for SaaS activities

--- a/posthog/temporal/proxy_service/common.py
+++ b/posthog/temporal/proxy_service/common.py
@@ -185,3 +185,55 @@ def activity_capture_event(inputs: CaptureEventInputs):
         },
         groups=groups(org),
     )
+
+
+@dataclass
+class SendProxyCreatedEmailInputs:
+    organization_id: uuid.UUID
+    proxy_record_id: uuid.UUID
+    domain: str
+
+    @property
+    def properties_to_log(self) -> dict[str, t.Any]:
+        return {
+            "organization_id": self.organization_id,
+            "proxy_record_id": self.proxy_record_id,
+            "domain": self.domain,
+        }
+
+
+@activity.defn
+def activity_send_proxy_created_email(inputs: SendProxyCreatedEmailInputs):
+    """Send an email notification when a reverse proxy has been successfully provisioned."""
+    from posthog.email import EmailMessage, is_email_available
+
+    try:
+        connection.connect()
+
+        if not is_email_available():
+            return
+
+        record = ProxyRecord.objects.select_related("created_by").filter(id=inputs.proxy_record_id).first()
+        if record is None or record.created_by is None or not record.created_by.email:
+            return
+
+        user = record.created_by
+        message = EmailMessage(
+            campaign_key=f"proxy_provisioned_{inputs.proxy_record_id}",
+            subject="Your PostHog reverse proxy is ready",
+            template_name="proxy_provisioned",
+            template_context={
+                "user_name": user.first_name,
+                "domain": inputs.domain,
+                "settings_url": f"{settings.SITE_URL}/settings/organization-proxy",
+            },
+            use_http=True,
+        )
+        message.add_user_recipient(user)
+        message.send(send_async=True)
+    except Exception:
+        LOGGER.warning(
+            "Failed to send proxy provisioned email for proxy %s",
+            inputs.proxy_record_id,
+            exc_info=True,
+        )

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -39,7 +39,9 @@ from posthog.temporal.proxy_service.cloudflare import (
 from posthog.temporal.proxy_service.common import (
     NonRetriableException,
     RecordDeletedException,
+    SendProxyCreatedEmailInputs,
     UpdateProxyRecordInputs,
+    activity_send_proxy_created_email,
     activity_update_proxy_record,
     get_grpc_client,
     record_exists,
@@ -579,6 +581,27 @@ class CreateManagedProxyWorkflow(PostHogWorkflow):
                     non_retryable_error_types=["NonRetriableException", "RecordDeletedException"],
                 ),
             )
+
+            # Send email notification — failure should not block the workflow
+            try:
+                await temporalio.workflow.execute_activity(
+                    activity_send_proxy_created_email,
+                    SendProxyCreatedEmailInputs(
+                        organization_id=inputs.organization_id,
+                        proxy_record_id=inputs.proxy_record_id,
+                        domain=inputs.domain,
+                    ),
+                    start_to_close_timeout=dt.timedelta(seconds=30),
+                    retry_policy=temporalio.common.RetryPolicy(
+                        maximum_attempts=2,
+                        non_retryable_error_types=["NonRetriableException", "RecordDeletedException"],
+                    ),
+                )
+            except ActivityError:
+                logger.warning(
+                    "Failed to send proxy provisioned email for domain %s, continuing",
+                    inputs.domain,
+                )
 
             schedule_inputs = ScheduleMonitorJobInputs(
                 organization_id=inputs.organization_id,

--- a/posthog/temporal/proxy_service/test/test_create_workflow.py
+++ b/posthog/temporal/proxy_service/test/test_create_workflow.py
@@ -10,7 +10,7 @@ from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from posthog.temporal.proxy_service.common import UpdateProxyRecordInputs
+from posthog.temporal.proxy_service.common import SendProxyCreatedEmailInputs, UpdateProxyRecordInputs
 from posthog.temporal.proxy_service.create import (
     CreateCloudflareProxyInputs,
     CreateManagedProxyInputs,
@@ -53,6 +53,10 @@ def _make_mock_activities(failing_activity: str | None = None, error_type: str =
     async def mock_wait_cert(inputs: CreateCloudflareProxyInputs):
         _maybe_raise("wait_for_cloudflare_certificate")
 
+    @activity.defn(name="activity_send_proxy_created_email")
+    async def mock_send_email(inputs: SendProxyCreatedEmailInputs):
+        _maybe_raise("activity_send_proxy_created_email")
+
     @activity.defn(name="schedule_monitor_job")
     async def mock_schedule_monitor(inputs: ScheduleMonitorJobInputs):
         pass
@@ -62,6 +66,7 @@ def _make_mock_activities(failing_activity: str | None = None, error_type: str =
         mock_update_record,
         mock_create_hostname,
         mock_wait_cert,
+        mock_send_email,
         mock_schedule_monitor,
     ]
 
@@ -135,6 +140,28 @@ class TestCreateManagedProxyWorkflowErrorHandling:
 
     async def test_happy_path_sets_valid_status(self, _mock_cloudflare):
         activities, status_updates = _make_mock_activities()
+        task_queue = str(uuid.uuid4())
+
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[CreateManagedProxyWorkflow],
+                activities=activities,
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    CreateManagedProxyWorkflow.run,
+                    _make_workflow_inputs(),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+        assert "valid" in status_updates
+        assert "erroring" not in status_updates
+
+    async def test_email_failure_does_not_fail_workflow(self, _mock_cloudflare):
+        activities, status_updates = _make_mock_activities(failing_activity="activity_send_proxy_created_email")
         task_queue = str(uuid.uuid4())
 
         async with await WorkflowEnvironment.start_time_skipping() as env:

--- a/posthog/temporal/proxy_service/test/test_send_proxy_email.py
+++ b/posthog/temporal/proxy_service/test/test_send_proxy_email.py
@@ -1,0 +1,105 @@
+import uuid
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.models import ProxyRecord
+from posthog.models.organization import Organization
+from posthog.models.user import User
+from posthog.temporal.proxy_service.common import SendProxyCreatedEmailInputs, activity_send_proxy_created_email
+
+
+def _make_inputs(**overrides):
+    defaults = {
+        "organization_id": uuid.uuid4(),
+        "proxy_record_id": uuid.uuid4(),
+        "domain": "proxy.example.com",
+    }
+    defaults.update(overrides)
+    return SendProxyCreatedEmailInputs(**defaults)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSendProxyCreatedEmail:
+    def test_sends_email_when_record_and_user_exist(self):
+        org = Organization.objects.create(name="Test Org")
+        user = User.objects.create_and_join(org, "admin@example.com", "password", first_name="Alice")
+        proxy = ProxyRecord.objects.create(
+            organization=org,
+            domain="proxy.example.com",
+            target_cname="target.example.com",
+            created_by=user,
+        )
+
+        inputs = _make_inputs(organization_id=org.id, proxy_record_id=proxy.id)
+
+        with (
+            patch("posthog.email.is_email_available", return_value=True),
+            patch("posthog.email.EmailMessage") as MockEmailMessage,
+        ):
+            mock_instance = MagicMock()
+            MockEmailMessage.return_value = mock_instance
+
+            activity_send_proxy_created_email(inputs)
+
+            MockEmailMessage.assert_called_once()
+            call_kwargs = MockEmailMessage.call_args[1]
+            assert call_kwargs["template_name"] == "proxy_provisioned"
+            assert call_kwargs["use_http"] is True
+            assert call_kwargs["campaign_key"] == f"proxy_provisioned_{proxy.id}"
+            assert call_kwargs["template_context"]["domain"] == "proxy.example.com"
+            assert call_kwargs["template_context"]["user_name"] == "Alice"
+            mock_instance.add_user_recipient.assert_called_once_with(user)
+            mock_instance.send.assert_called_once_with(send_async=True)
+
+    def test_does_not_send_when_record_missing(self):
+        inputs = _make_inputs(proxy_record_id=uuid.uuid4())
+
+        with (
+            patch("posthog.email.is_email_available", return_value=True),
+            patch("posthog.email.EmailMessage") as MockEmailMessage,
+        ):
+            activity_send_proxy_created_email(inputs)
+            MockEmailMessage.assert_not_called()
+
+    def test_does_not_send_when_created_by_is_null(self):
+        org = Organization.objects.create(name="Test Org")
+        proxy = ProxyRecord.objects.create(
+            organization=org,
+            domain="proxy.example.com",
+            target_cname="target.example.com",
+            created_by=None,
+        )
+
+        inputs = _make_inputs(organization_id=org.id, proxy_record_id=proxy.id)
+
+        with (
+            patch("posthog.email.is_email_available", return_value=True),
+            patch("posthog.email.EmailMessage") as MockEmailMessage,
+        ):
+            activity_send_proxy_created_email(inputs)
+            MockEmailMessage.assert_not_called()
+
+    def test_does_not_send_when_email_unavailable(self):
+        org = Organization.objects.create(name="Test Org")
+        user = User.objects.create_and_join(org, "admin@example.com", "password", first_name="Alice")
+        proxy = ProxyRecord.objects.create(
+            organization=org,
+            domain="proxy.example.com",
+            target_cname="target.example.com",
+            created_by=user,
+        )
+
+        inputs = _make_inputs(organization_id=org.id, proxy_record_id=proxy.id)
+
+        with patch("posthog.email.is_email_available", return_value=False):
+            with patch("posthog.email.EmailMessage") as MockEmailMessage:
+                activity_send_proxy_created_email(inputs)
+                MockEmailMessage.assert_not_called()
+
+    def test_swallows_exceptions_without_raising(self):
+        inputs = _make_inputs()
+
+        with patch("posthog.email.is_email_available", side_effect=Exception("boom")):
+            # Should not raise
+            activity_send_proxy_created_email(inputs)

--- a/posthog/temporal/proxy_service/test/test_send_proxy_email.py
+++ b/posthog/temporal/proxy_service/test/test_send_proxy_email.py
@@ -16,7 +16,7 @@ def _make_inputs(**overrides):
         "domain": "proxy.example.com",
     }
     defaults.update(overrides)
-    return SendProxyCreatedEmailInputs(**defaults)
+    return SendProxyCreatedEmailInputs(**defaults)  # type: ignore
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

When users set up a reverse proxy for PostHog, they need to know when the provisioning process is complete so they can update their SDK configuration. Currently, there's no notification system to inform users that their proxy is ready to use.

## Changes

- Added email notification functionality for when reverse proxies are successfully provisioned
- Created new email template `proxy_provisioned.html` that informs users their proxy is ready and provides a link to proxy settings. This email is not used by default, we usually use customer.io email instead (see below)
- Added Customer.io template mapping for the new email type
- Integrated email sending into the proxy creation workflow as a non-blocking operation
- Email failures do not prevent the proxy provisioning workflow from completing successfully

![CleanShot 2026-03-11 at 17.25.16.png](https://app.graphite.com/user-attachments/assets/6421e083-1a23-4152-bec7-332568daddaf.png)

## Publish to changelog?

No - this is an internal improvement to the proxy provisioning system that enhances user experience but doesn't introduce new user-facing features.