### PR TITLE
fix: Scope first-party tokens by organization instead of team

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -177,6 +177,34 @@ class TestOAuthAPI(APIBaseTest):
         response = self.client.get(self.base_authorization_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_first_party_app_auto_approves_with_org_scoped_grant(self):
+        first_party_app = OAuthApplication.objects.create(
+            name="First Party App",
+            client_id="first_party_client_id",
+            client_secret="first_party_client_secret",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            user=self.user,
+            hash_client_secret=True,
+            algorithm="RS256",
+            is_first_party=True,
+        )
+
+        url = self.replace_param_in_url(self.base_authorization_url, "client_id", first_party_app.client_id)
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        location = response["Location"]
+        self.assertIn("code=", location)
+
+        code = parse_qs(urlparse(location).query)["code"][0]
+        grant = OAuthGrant.objects.get(code=code)
+
+        self.assertEqual(grant.scoped_teams, [])
+        self.assertIn(str(self.organization.id), grant.scoped_organizations)
+
     def test_authorize_missing_client_id(self):
         url = self.base_authorization_url
 

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -202,7 +202,7 @@ class TestOAuthAPI(APIBaseTest):
         code = parse_qs(urlparse(location).query)["code"][0]
         grant = OAuthGrant.objects.get(code=code)
 
-        self.assertEqual(grant.scoped_teams, [])
+        self.assertIn(self.team.pk, grant.scoped_teams)
         self.assertIn(str(self.organization.id), grant.scoped_organizations)
 
     def test_authorize_missing_client_id(self):

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -310,13 +310,14 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         if application.is_first_party:
             try:
                 # Auto-approve with all user's accessible organizations.
-                # Scope by org (not team) so the token works on both org-level
-                # endpoints (e.g. /api/organizations/{id}/projects/) and
-                # project-level endpoints. Team-level access is derived from
-                # org membership via queryset filtering.
                 org_ids = request.user.organizations.values_list("id", flat=True)
-                credentials["scoped_teams"] = []
                 credentials["scoped_organizations"] = [str(org_id) for org_id in org_ids]
+
+                # TODO(charlesvien): Populate scoped_teams for backwards compat with old
+                # Code clients that throw "No team found in OAuth scopes" when
+                # scoped_teams is empty. Remove once Code reads scoped_organizations.
+                team_ids = Team.objects.filter(organization__members=request.user).values_list("pk", flat=True)
+                credentials["scoped_teams"] = list(team_ids)
 
                 uri, headers, body, status_code = self.create_authorization_response(
                     request=request, scopes=" ".join(scopes), credentials=credentials, allow=True

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -309,10 +309,14 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         # First-party apps skip consent screen entirely
         if application.is_first_party:
             try:
-                # Auto-approve with all user's accessible teams
-                teams = Team.objects.filter(organization__members=request.user).values_list("pk", flat=True)
-                credentials["scoped_teams"] = list(teams)
-                credentials["scoped_organizations"] = []
+                # Auto-approve with all user's accessible organizations.
+                # Scope by org (not team) so the token works on both org-level
+                # endpoints (e.g. /api/organizations/{id}/projects/) and
+                # project-level endpoints. Team-level access is derived from
+                # org membership via queryset filtering.
+                org_ids = request.user.organizations.values_list("id", flat=True)
+                credentials["scoped_teams"] = []
+                credentials["scoped_organizations"] = [str(org_id) for org_id in org_ids]
 
                 uri, headers, body, status_code = self.create_authorization_response(
                     request=request, scopes=" ".join(scopes), credentials=credentials, allow=True


### PR DESCRIPTION
## Problem

The first-party OAuth auto-approve flow (used by Code, MCP, etc.) was scoping tokens to all teams with `scoped_teams = [every team ID]` and `scoped_organizations = []`. The APIScopePermission.check_team_and_org_permissions check sees non-empty scoped_teams and tries to resolve view.team, but org-level endpoints like `/api/organizations/{id}/projects/` don't have a team, so it falls into the exception handler and raises a **403: "API keys with scoped projects are only supported on project-based endpoints."**

This meant scoped OAuth tokens could only hit project-level endpoints, never org-level ones. In practice, there was no way to list all projects across orgs without either:
  - Calling `/api/projects/{id}/` individually for every project (N+1 — 70+ requests for the PostHog org)
  - Using switch organization to patch the active org on `/@me`, which mutates shared state across us.posthog.com and code

The fix scopes first-party tokens by organizations instead of teams. `scoped_teams = []` (falsy) skips the team permission check entirely, and `scoped_organizations = [all user org IDs]` passes the org-level check. Project-level access is still enforced via queryset filtering by org membership.

Ref: https://github.com/PostHog/code/issues/1101

## Changes

The change is semantically equivalent in access scope, first-party tokens previously had `scoped_teams = [all teams]` (derived from org membership) and now have `scoped_organizations  = [all orgs]` (from which team access is derived).

  1. Change first-party OAuth auto-approve to set scoped_organizations (all user orgs) instead of scoped_teams (all teams)
  2. Fix 403 on org-level endpoints (e.g. /api/organizations/{id}/projects/) caused by APIScopePermission rejecting non-project-scoped views when scoped_teams is set
  3. Unblock MCP/Code from listing projects across multiple organizations (enables a proper org/project switcher instead of N+1 web requests bottlenecking the users network)

## How did you test this code?

Manually testing + automated tests