### PR TITLE
fix: onboarding initial state

### DIFF
--- a/frontend/src/scenes/onboarding/productSelection/SimplifiedProductSelection.scss
+++ b/frontend/src/scenes/onboarding/productSelection/SimplifiedProductSelection.scss
@@ -1,5 +1,5 @@
 .SimplifiedProductSelection {
-    &__SimplifiedProductSelection__buzz {
+    &__buzz {
         animation: SimplifiedProductSelection__buzz 0.12s infinite linear;
     }
 

--- a/frontend/src/scenes/onboarding/productSelection/SimplifiedProductSelection.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/SimplifiedProductSelection.tsx
@@ -69,7 +69,8 @@ const DIRECTION_CHANGE_BOOST = 12
 // ─── Carousel hook ──────────────────────────────────────────────────────────
 function useCarousel(
     itemCount: number,
-    onSettle: (index: number) => void
+    onSettle: (index: number) => void,
+    initialIndex: number = 0
 ): {
     position: number
     isDragging: boolean
@@ -81,17 +82,17 @@ function useCarousel(
     stepTo: (direction: number) => void
     goToIndex: (index: number) => void
 } {
-    const [position, setPosition] = useState(0)
+    const [position, setPosition] = useState(initialIndex)
     const [isDragging, setIsDragging] = useState(false)
     const [isNauseous, setIsNauseous] = useState(false)
     const [isAnimating, setIsAnimating] = useState(false)
 
-    const posRef = useRef(0)
+    const posRef = useRef(initialIndex)
     const velRef = useRef(0)
     const targetRef = useRef<number | null>(null)
     const draggingRef = useRef(false)
     const rafRef = useRef(0)
-    const settledRef = useRef<number | null>(0)
+    const settledRef = useRef<number | null>(initialIndex)
     const animatingRef = useRef(false)
     const agitationRef = useRef(0)
     const lastVelSignRef = useRef(0)
@@ -344,7 +345,7 @@ export function SimplifiedProductSelection(): JSX.Element {
     )
 
     const { position, isDragging, isNauseous, activeIndex, hadDragMovement, handlePointerDown, stepTo, goToIndex } =
-        useCarousel(allProducts.length, handleSettle)
+        useCarousel(allProducts.length, handleSettle, initialIndex)
 
     // Track when the user triggers the nauseous hedgehog (spin for fun)
     useEffect(() => {


### PR DESCRIPTION
## Problem

The onboarding product selection carousel always starts at the first item (index 0), but there are cases where it should start at a different position based on user context or previous selections.

## Changes

- Added `initialIndex` parameter to the `useCarousel` hook with a default value of 0
- Updated all carousel state initialization to use the `initialIndex` instead of hardcoded 0
- Passed `initialIndex` to the `useCarousel` hook in `SimplifiedProductSelection` component
- Simplified CSS class name from `&__SimplifiedProductSelection__buzz` to `&__buzz` to remove redundant naming

## How did you test this code?

As an AI agent, I have not manually tested this code. The changes maintain backward compatibility with the default parameter and should be tested by:
- Verifying the carousel still starts at index 0 when no initial index is provided
- Testing that the carousel correctly starts at a specified initial index when provided
- Ensuring the buzz animation still works correctly with the simplified CSS class name

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No