### PR TITLE
fix: reduce resize hitbox for top handle

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -95,13 +95,12 @@
         cursor: ns-resize;
     }
 
-    // TODO: move these over to tailwind after
     & > .react-resizable-handle.react-resizable-handle-n {
         top: -0.5rem;
-        right: 2rem;
-        left: 0;
+        right: 3rem;
+        left: 3rem;
         width: auto;
-        height: 2rem;
+        height: 1rem;
         cursor: ns-resize;
     }
 


### PR DESCRIPTION
## Problem
Now that we introduced top handles for resizing, its conflicting with the hitbox for moving around since the top of the cards are usually what is grab allowable

## Changes
Shrinks top hitbox for the purpose of resizing.

## How did you test this code?

Locally
## Publish to changelog?
No.