### PR TITLE
fix: server-side state validation for GitHub integration setup

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -149,7 +149,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
 
                     await api.integrations.create({
                         kind: 'github',
-                        config: { installation_id },
+                        config: { installation_id, state: stateToken },
                     })
 
                     actions.loadIntegrations()

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -278,6 +278,8 @@ class IntegrationViewSet(
             response = redirect(installation_url)
             # nosemgrep: python.django.security.audit.secure-cookies.django-secure-set-cookie (OAuth state, short-lived, needed for cross-site redirect)
             response.set_cookie("ph_github_state", token, max_age=60 * 5)
+            # Store server-side so the backend can enforce that the same user who
+            # initiated the flow is the one completing it (not just cookie-validated).
             cache.set(f"github_state:{request.user.id}", token, timeout=60 * 5)
 
             return response

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -124,9 +124,19 @@ class IntegrationSerializer(serializers.ModelSerializer):
         elif validated_data["kind"] == "github":
             config = validated_data.get("config", {})
             installation_id = config.get("installation_id")
+            state = config.get("state")
 
             if not installation_id:
                 raise ValidationError("An installation_id must be provided")
+
+            if not state:
+                raise ValidationError("A state token must be provided")
+
+            cache_key = f"github_state:{request.user.id}"
+            expected_state = cache.get(cache_key)
+            if not expected_state or expected_state != state:
+                raise ValidationError("Invalid or expired state token")
+            cache.delete(cache_key)
 
             instance = GitHubIntegration.integration_from_installation_id(installation_id, team_id, request.user)
             return instance
@@ -268,6 +278,7 @@ class IntegrationViewSet(
             response = redirect(installation_url)
             # nosemgrep: python.django.security.audit.secure-cookies.django-secure-set-cookie (OAuth state, short-lived, needed for cross-site redirect)
             response.set_cookie("ph_github_state", token, max_age=60 * 5)
+            cache.set(f"github_state:{request.user.id}", token, timeout=60 * 5)
 
             return response
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.core.cache import cache
 from django.test.client import Client as HttpClient
 
 from rest_framework import status
@@ -689,3 +690,128 @@ class TestIntegrationAPIKeyAccess:
         kinds = [integration["kind"] for integration in results]
         assert "github" in kinds
         assert "twilio" in kinds
+
+
+class TestGitHubIntegrationStateValidation:
+    @pytest.fixture(autouse=True)
+    def setup_environment(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(self.organization, "test@posthog.com", "test")
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_without_state_rejected(self, mock_from_install, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "state token must be provided" in response.json()["detail"]
+        mock_from_install.assert_not_called()
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_with_invalid_state_rejected(self, mock_from_install, client: HttpClient):
+        client.force_login(self.user)
+        cache.set(f"github_state:{self.user.id}", "correct-token", timeout=300)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": "wrong-token"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid or expired state token" in response.json()["detail"]
+        mock_from_install.assert_not_called()
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_with_expired_state_rejected(self, mock_from_install, client: HttpClient):
+        client.force_login(self.user)
+        # No token in cache = expired
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": "some-token"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid or expired state token" in response.json()["detail"]
+        mock_from_install.assert_not_called()
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_with_valid_state_succeeds(self, mock_from_install, client: HttpClient):
+        client.force_login(self.user)
+        state_token = "valid-token-abc123"
+        cache.set(f"github_state:{self.user.id}", state_token, timeout=300)
+
+        mock_integration = Integration(
+            id=1,
+            team=self.team,
+            kind="github",
+            config={"installation_id": "12345"},
+        )
+        mock_from_install.return_value = mock_integration
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": state_token}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_from_install.assert_called_once_with("12345", self.team.pk, self.user)
+        # Token consumed — cannot be reused
+        assert cache.get(f"github_state:{self.user.id}") is None
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_state_token_single_use(self, mock_from_install, client: HttpClient):
+        client.force_login(self.user)
+        state_token = "single-use-token"
+        cache.set(f"github_state:{self.user.id}", state_token, timeout=300)
+
+        mock_integration = Integration(
+            id=1,
+            team=self.team,
+            kind="github",
+            config={"installation_id": "12345"},
+        )
+        mock_from_install.return_value = mock_integration
+
+        # First request succeeds
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": state_token}},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Second request with same token fails
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": state_token}},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid or expired state token" in response.json()["detail"]
+
+    @patch("posthog.models.integration.GitHubIntegration.integration_from_installation_id")
+    def test_create_github_integration_cross_user_state_rejected(self, mock_from_install, client: HttpClient):
+        other_user = User.objects.create_and_join(self.organization, "attacker@posthog.com", "test")
+        client.force_login(other_user)
+        # Token belongs to self.user, not other_user
+        cache.set(f"github_state:{self.user.id}", "victim-token", timeout=300)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations/",
+            {"kind": "github", "config": {"installation_id": "12345", "state": "victim-token"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid or expired state token" in response.json()["detail"]
+        mock_from_install.assert_not_called()


### PR DESCRIPTION
This moves the state check from client-only (cookie) to backend-enforced via cache, ensuring the user who initiated the flow is the one completing it.
