### PR TITLE
feat(dagster): add concurrent run protection to sdk versions job

### DIFF
--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -82,12 +82,12 @@ def check_for_concurrent_runs(
     return None
 
 
-def skip_iteration_if_already_running(**schedule_kwargs) -> Callable:
+def skip_if_already_running(**schedule_kwargs) -> Callable:
     """
     Decorator that combines @dagster.schedule with concurrent run protection.
 
     Usage:
-        @skip_iteration_if_already_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
+        @skip_if_already_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
         def my_schedule(context: dagster.ScheduleEvaluationContext):
             return dagster.RunRequest()
     """

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -82,12 +82,12 @@ def check_for_concurrent_runs(
     return None
 
 
-def skip_if_running(**schedule_kwargs) -> Callable:
+def skip_iteration_if_already_running(**schedule_kwargs) -> Callable:
     """
     Decorator that combines @dagster.schedule with concurrent run protection.
 
     Usage:
-        @skip_if_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
+        @skip_iteration_if_already_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
         def my_schedule(context: dagster.ScheduleEvaluationContext):
             return dagster.RunRequest()
     """

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -82,24 +82,22 @@ def check_for_concurrent_runs(
     return None
 
 
-def skip_if_already_running(**schedule_kwargs) -> Callable:
+def skip_if_already_running(fn: Callable) -> Callable:
     """
-    Decorator that combines @dagster.schedule with concurrent run protection.
+    Decorator that skips schedule execution if a previous run is still active.
 
     Usage:
-        @skip_if_already_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
+        @dagster.schedule(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
+        @skip_if_already_running
         def my_schedule(context: dagster.ScheduleEvaluationContext):
             return dagster.RunRequest()
     """
 
-    def decorator(fn: Callable) -> dagster.ScheduleDefinition:
-        @wraps(fn)
-        def wrapper(context: dagster.ScheduleEvaluationContext):
-            skip_reason = check_for_concurrent_runs(context, tags={})
-            if skip_reason:
-                return skip_reason
-            return fn(context)
+    @wraps(fn)
+    def wrapper(context: dagster.ScheduleEvaluationContext):
+        skip_reason = check_for_concurrent_runs(context, tags={})
+        if skip_reason:
+            return skip_reason
+        return fn(context)
 
-        return dagster.schedule(**schedule_kwargs)(wrapper)
-
-    return decorator
+    return wrapper

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -1,4 +1,6 @@
+from collections.abc import Callable
 from contextlib import suppress
+from functools import wraps
 from typing import Optional
 
 import dagster
@@ -78,3 +80,26 @@ def check_for_concurrent_runs(
         return dagster.SkipReason(f"Skipping {job_name} run because another run of the same job is already active")
 
     return None
+
+
+def skip_if_running(**schedule_kwargs) -> Callable:
+    """
+    Decorator that combines @dagster.schedule with concurrent run protection.
+
+    Usage:
+        @skip_if_running(cron_schedule="0 0 * * *", job=my_job, execution_timezone="UTC")
+        def my_schedule(context: dagster.ScheduleEvaluationContext):
+            return dagster.RunRequest()
+    """
+
+    def decorator(fn: Callable) -> dagster.ScheduleDefinition:
+        @wraps(fn)
+        def wrapper(context: dagster.ScheduleEvaluationContext):
+            skip_reason = check_for_concurrent_runs(context, tags={})
+            if skip_reason:
+                return skip_reason
+            return fn(context)
+
+        return dagster.schedule(**schedule_kwargs)(wrapper)
+
+    return decorator

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -13,7 +13,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.dags.common import JobOwners, skip_if_running
+from posthog.dags.common import JobOwners, skip_iteration_if_already_running
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.dags.common.resources import redis
 from posthog.exceptions_capture import capture_exception
@@ -221,7 +221,7 @@ def cache_all_team_sdk_versions_job():
     aggregate_results_op(results.collect())
 
 
-@skip_if_running(
+@skip_iteration_if_already_running(
     cron_schedule="0 0 * * *",  # Every day at midnight
     job=cache_all_team_sdk_versions_job,
     execution_timezone="UTC",

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -13,7 +13,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.dags.common import JobOwners
+from posthog.dags.common import JobOwners, check_for_concurrent_runs
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.dags.common.resources import redis
 from posthog.exceptions_capture import capture_exception
@@ -221,9 +221,13 @@ def cache_all_team_sdk_versions_job():
     aggregate_results_op(results.collect())
 
 
-cache_all_team_sdk_versions_schedule = dagster.ScheduleDefinition(
-    job=cache_all_team_sdk_versions_job,
+@dagster.schedule(
     cron_schedule="0 0 * * *",  # Every day at midnight
+    job=cache_all_team_sdk_versions_job,
     execution_timezone="UTC",
-    name="cache_all_team_sdk_versions_schedule",
 )
+def cache_all_team_sdk_versions_schedule(context: dagster.ScheduleEvaluationContext):
+    skip_reason = check_for_concurrent_runs(context, tags={})
+    if skip_reason:
+        return skip_reason
+    return dagster.RunRequest()

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -13,7 +13,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.dags.common import JobOwners, check_for_concurrent_runs
+from posthog.dags.common import JobOwners, skip_if_running
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.dags.common.resources import redis
 from posthog.exceptions_capture import capture_exception
@@ -221,13 +221,10 @@ def cache_all_team_sdk_versions_job():
     aggregate_results_op(results.collect())
 
 
-@dagster.schedule(
+@skip_if_running(
     cron_schedule="0 0 * * *",  # Every day at midnight
     job=cache_all_team_sdk_versions_job,
     execution_timezone="UTC",
 )
 def cache_all_team_sdk_versions_schedule(context: dagster.ScheduleEvaluationContext):
-    skip_reason = check_for_concurrent_runs(context, tags={})
-    if skip_reason:
-        return skip_reason
     return dagster.RunRequest()

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -13,7 +13,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.dags.common import JobOwners, skip_iteration_if_already_running
+from posthog.dags.common import JobOwners, skip_if_already_running
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.dags.common.resources import redis
 from posthog.exceptions_capture import capture_exception
@@ -221,7 +221,7 @@ def cache_all_team_sdk_versions_job():
     aggregate_results_op(results.collect())
 
 
-@skip_iteration_if_already_running(
+@skip_if_already_running(
     cron_schedule="0 0 * * *",  # Every day at midnight
     job=cache_all_team_sdk_versions_job,
     execution_timezone="UTC",

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -221,10 +221,11 @@ def cache_all_team_sdk_versions_job():
     aggregate_results_op(results.collect())
 
 
-@skip_if_already_running(
+@dagster.schedule(
     cron_schedule="0 0 * * *",  # Every day at midnight
     job=cache_all_team_sdk_versions_job,
     execution_timezone="UTC",
 )
+@skip_if_already_running
 def cache_all_team_sdk_versions_schedule(context: dagster.ScheduleEvaluationContext):
     return dagster.RunRequest()


### PR DESCRIPTION
## Summary

- Add `skip_if_already_running` decorator to skip scheduled runs when a previous run is still active
- Apply it to `cache_all_team_sdk_versions_job` to prevent resource issues from concurrent instances