### PR TITLE
feat(dashboard): add dashboard grid when in edit mode

### DIFF
--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -56,3 +56,8 @@ declare module '*.sql?raw' {
 declare module '@tiptap/react/menus' {
     export * from '@tiptap/react/dist/menus/index.d.ts'
 }
+
+// This fixes a TS error where react-grid-layout/extras cannot be found because of our moduleResolution
+declare module 'react-grid-layout/extras' {
+    export * from 'react-grid-layout/dist/extras'
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -198,6 +198,7 @@ export const FEATURE_FLAGS = {
     /* The below flag is used to activate unmounting charts outside the viewport, as we're currently investigating frontend performance
     issues related to this and want to know the impact of having it on vs. off. */
     EXPERIMENTAL_DASHBOARD_ITEM_RENDERING: 'experimental-dashboard-item-rendering', // owner: @thmsobrmlr #team-product-analytics
+    DASHBOARD_GRID: 'dashboard-grid', // owner: @mattp, #team-analytics-platform, controls dashboard grid background in edit mode
     IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: #team-web-analytics
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: #team-data-stack
     MEMBERS_CAN_USE_PERSONAL_API_KEYS: 'members-can-use-personal-api-keys', // owner: @yasen-posthog #team-platform-features

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -5,9 +5,11 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useRef, useState } from 'react'
 import { Layout, Responsive as ReactGridLayout } from 'react-grid-layout'
+import { GridBackground } from 'react-grid-layout/extras'
 
 import { InsightCard } from 'lib/components/Cards/InsightCard'
 import { TextCard } from 'lib/components/Cards/TextCard/TextCard'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
@@ -102,6 +104,8 @@ export function DashboardItems(): JSX.Element {
     const canEnterEditModeFromEdge =
         !!dashboard && canEditDashboard && dashboardMode !== DashboardMode.Edit && !isMobileView && isEditablePlacement
 
+    const showDashboardGrid = useFeatureFlag('DASHBOARD_GRID')
+
     return (
         <div className="dashboard-items-wrapper" ref={gridWrapperRef}>
             {dashboardMode === DashboardMode.Edit && isMobileView && (
@@ -111,288 +115,306 @@ export function DashboardItems(): JSX.Element {
                 </LemonBanner>
             )}
             {gridWrapperWidth && (
-                <ReactGridLayout
-                    width={gridWrapperWidth}
-                    className={className}
-                    dragConfig={{
-                        enabled: dashboardMode === DashboardMode.Edit && !isMobileView,
-                        handle: '.CardMeta,.TextCard__body',
-                        cancel: 'a,table,button,input,.Popover',
-                    }}
-                    resizeConfig={{
-                        enabled: dashboardMode === DashboardMode.Edit && !isMobileView,
-                        handles: ['s', 'e', 'se', 'n', 'w', 'nw', 'ne', 'sw'],
-                    }}
-                    layouts={layouts as Partial<Record<DashboardLayoutSize, Layout>>}
-                    rowHeight={80}
-                    margin={[16, 16]}
-                    containerPadding={[0, 0]}
-                    onLayoutChange={(_, newLayouts) => {
-                        if (dashboardMode === DashboardMode.Edit) {
-                            updateLayouts(newLayouts)
-                        }
-                    }}
-                    onWidthChange={(containerWidth, _, newCols) => {
-                        updateContainerWidth(containerWidth, newCols)
-                    }}
-                    breakpoints={BREAKPOINTS}
-                    cols={BREAKPOINT_COLUMN_COUNTS}
-                    onResize={(_layout: any, _oldItem: any, newItem: any) => {
-                        if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
-                            setResizingItem(newItem)
-                        }
-                    }}
-                    onResizeStop={() => {
-                        setResizingItem(null)
-                        if (dashboard?.id) {
-                            reportDashboardTileRepositioned(dashboard.id, 'resized')
-                        }
-                    }}
-                    onDragStart={() => {
-                        scrollContainerRef.current = document.getElementById('main-content')
-                        scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
-                    }}
-                    onDrag={(_layout, _oldItem, _newItem, _placeholder, e) => {
-                        isDragging.current = true
-                        if (dragEndTimeout.current) {
-                            window.clearTimeout(dragEndTimeout.current)
-                        }
-                        if (scrollAnimationRef.current) {
-                            cancelAnimationFrame(scrollAnimationRef.current)
-                            scrollAnimationRef.current = null
-                        }
+                <div className="relative">
+                    {dashboardMode === DashboardMode.Edit && !isMobileView && showDashboardGrid && (
+                        <GridBackground
+                            width={gridWrapperWidth}
+                            cols={BREAKPOINT_COLUMN_COUNTS.sm}
+                            rowHeight={80}
+                            margin={[16, 16]}
+                            containerPadding={[0, 0]}
+                            rows="auto"
+                            height={gridWrapperWidth} // rough heuristic; RGL will grow as needed
+                            color="var(--color-bg-surface-secondary)"
+                        />
+                    )}
 
-                        const scrollContainer = scrollContainerRef.current
-                        const containerRect = scrollContainerRectRef.current
-                        if (!scrollContainer || !containerRect) {
-                            return
-                        }
+                    <ReactGridLayout
+                        width={gridWrapperWidth}
+                        className={className}
+                        dragConfig={{
+                            enabled: dashboardMode === DashboardMode.Edit && !isMobileView,
+                            handle: '.CardMeta,.TextCard__body',
+                            cancel: 'a,table,button,input,.Popover',
+                        }}
+                        resizeConfig={{
+                            enabled: dashboardMode === DashboardMode.Edit && !isMobileView,
+                            handles: ['s', 'e', 'se', 'n', 'w', 'nw', 'ne', 'sw'],
+                        }}
+                        layouts={layouts as Partial<Record<DashboardLayoutSize, Layout>>}
+                        rowHeight={80}
+                        margin={[16, 16]}
+                        containerPadding={[0, 0]}
+                        onLayoutChange={(_, newLayouts) => {
+                            if (dashboardMode === DashboardMode.Edit) {
+                                updateLayouts(newLayouts)
+                            }
+                        }}
+                        onWidthChange={(containerWidth, _, newCols) => {
+                            updateContainerWidth(containerWidth, newCols)
+                        }}
+                        breakpoints={BREAKPOINTS}
+                        cols={BREAKPOINT_COLUMN_COUNTS}
+                        onResize={(_layout: any, _oldItem: any, newItem: any) => {
+                            if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
+                                setResizingItem(newItem)
+                            }
+                        }}
+                        onResizeStop={() => {
+                            setResizingItem(null)
+                            if (dashboard?.id) {
+                                reportDashboardTileRepositioned(dashboard.id, 'resized')
+                            }
+                        }}
+                        onDragStart={() => {
+                            scrollContainerRef.current = document.getElementById('main-content')
+                            scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
+                        }}
+                        onDrag={(_layout, _oldItem, _newItem, _placeholder, e) => {
+                            isDragging.current = true
+                            if (dragEndTimeout.current) {
+                                window.clearTimeout(dragEndTimeout.current)
+                            }
+                            if (scrollAnimationRef.current) {
+                                cancelAnimationFrame(scrollAnimationRef.current)
+                                scrollAnimationRef.current = null
+                            }
 
-                        const mouseY = (e as MouseEvent).clientY
+                            const scrollContainer = scrollContainerRef.current
+                            const containerRect = scrollContainerRectRef.current
+                            if (!scrollContainer || !containerRect) {
+                                return
+                            }
 
-                        let scrollSpeed = 0
-                        if (mouseY < containerRect.top + DRAG_AUTO_SCROLL_THRESHOLD) {
-                            scrollSpeed = -DRAG_AUTO_SCROLL_SPEED
-                        } else if (mouseY > containerRect.bottom - DRAG_AUTO_SCROLL_THRESHOLD) {
-                            scrollSpeed = DRAG_AUTO_SCROLL_SPEED
-                        }
+                            const mouseY = (e as MouseEvent).clientY
 
-                        if (scrollSpeed !== 0) {
-                            const scroll = (): void => {
-                                const atTop = scrollSpeed < 0 && scrollContainer.scrollTop === 0
-                                const atBottom =
-                                    scrollSpeed > 0 &&
-                                    scrollContainer.scrollTop + scrollContainer.clientHeight >=
-                                        scrollContainer.scrollHeight
-                                if (atTop || atBottom) {
-                                    return
+                            let scrollSpeed = 0
+                            if (mouseY < containerRect.top + DRAG_AUTO_SCROLL_THRESHOLD) {
+                                scrollSpeed = -DRAG_AUTO_SCROLL_SPEED
+                            } else if (mouseY > containerRect.bottom - DRAG_AUTO_SCROLL_THRESHOLD) {
+                                scrollSpeed = DRAG_AUTO_SCROLL_SPEED
+                            }
+
+                            if (scrollSpeed !== 0) {
+                                const scroll = (): void => {
+                                    const atTop = scrollSpeed < 0 && scrollContainer.scrollTop === 0
+                                    const atBottom =
+                                        scrollSpeed > 0 &&
+                                        scrollContainer.scrollTop + scrollContainer.clientHeight >=
+                                            scrollContainer.scrollHeight
+                                    if (atTop || atBottom) {
+                                        return
+                                    }
+                                    scrollContainer.scrollBy(0, scrollSpeed)
+                                    scrollAnimationRef.current = requestAnimationFrame(scroll)
                                 }
-                                scrollContainer.scrollBy(0, scrollSpeed)
                                 scrollAnimationRef.current = requestAnimationFrame(scroll)
                             }
-                            scrollAnimationRef.current = requestAnimationFrame(scroll)
-                        }
-                    }}
-                    onDragStop={() => {
-                        if (scrollAnimationRef.current) {
-                            cancelAnimationFrame(scrollAnimationRef.current)
-                            scrollAnimationRef.current = null
-                        }
-                        scrollContainerRef.current = null
-                        scrollContainerRectRef.current = null
-                        if (dragEndTimeout.current) {
-                            window.clearTimeout(dragEndTimeout.current)
-                        }
-                        dragEndTimeout.current = window.setTimeout(() => {
-                            isDragging.current = false
-                        }, 250)
-                        if (dashboard?.id) {
-                            reportDashboardTileRepositioned(dashboard.id, 'moved')
-                        }
-                    }}
-                >
-                    {tiles?.map((tile) => {
-                        const { insight, text } = tile
-                        const smLayout = layouts['sm']?.find((l) => {
-                            return l.i == tile.id.toString()
-                        })
+                        }}
+                        onDragStop={() => {
+                            if (scrollAnimationRef.current) {
+                                cancelAnimationFrame(scrollAnimationRef.current)
+                                scrollAnimationRef.current = null
+                            }
+                            scrollContainerRef.current = null
+                            scrollContainerRectRef.current = null
+                            if (dragEndTimeout.current) {
+                                window.clearTimeout(dragEndTimeout.current)
+                            }
+                            dragEndTimeout.current = window.setTimeout(() => {
+                                isDragging.current = false
+                            }, 250)
+                            if (dashboard?.id) {
+                                reportDashboardTileRepositioned(dashboard.id, 'moved')
+                            }
+                        }}
+                    >
+                        {tiles?.map((tile) => {
+                            const { insight, text } = tile
+                            const smLayout = layouts['sm']?.find((l) => {
+                                return l.i == tile.id.toString()
+                            })
 
-                        const commonTileProps = {
-                            dashboardId: dashboard?.id,
-                            showResizeHandles:
-                                dashboardMode === DashboardMode.Edit && !isMobileView && isEditablePlacement,
-                            canEnterEditModeFromEdge,
-                            onEnterEditModeFromEdge: canEnterEditModeFromEdge
-                                ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardEdgeHover)
-                                : undefined,
-                            onDragHandleMouseDown: canEnterEditModeFromEdge
-                                ? (e: React.MouseEvent) => {
-                                      const target = e.target as Element | null
-                                      if (!target) {
-                                          return
+                            const commonTileProps = {
+                                dashboardId: dashboard?.id,
+                                showResizeHandles:
+                                    dashboardMode === DashboardMode.Edit && !isMobileView && isEditablePlacement,
+                                canEnterEditModeFromEdge,
+                                onEnterEditModeFromEdge: canEnterEditModeFromEdge
+                                    ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardEdgeHover)
+                                    : undefined,
+                                onDragHandleMouseDown: canEnterEditModeFromEdge
+                                    ? (e: React.MouseEvent) => {
+                                          const target = e.target as Element | null
+                                          if (!target) {
+                                              return
+                                          }
+
+                                          const gridItem = target.closest('.react-grid-item')
+                                          if (!gridItem) {
+                                              return
+                                          }
+
+                                          // Don't trigger when clicking obvious interactive controls
+                                          if (
+                                              target.closest(
+                                                  'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"]'
+                                              )
+                                          ) {
+                                              return
+                                          }
+                                          e.preventDefault()
+                                          e.stopPropagation()
+                                          setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardDragHandle)
                                       }
-
-                                      const gridItem = target.closest('.react-grid-item')
-                                      if (!gridItem) {
-                                          return
-                                      }
-
-                                      // Don't trigger when clicking obvious interactive controls
-                                      if (
-                                          target.closest(
-                                              'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"]'
-                                          )
-                                      ) {
-                                          return
-                                      }
-                                      e.preventDefault()
-                                      e.stopPropagation()
-                                      setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardDragHandle)
-                                  }
-                                : undefined,
-                            showEditingControls: isEditablePlacement,
-                            moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
-                                if (!dashboard) {
-                                    throw new Error('must be on a dashboard to move this tile')
-                                }
-                                moveToDashboard(tile, dashboard.id, id, name)
-                            },
-                            removeFromDashboard: () => removeTile(tile),
-                        }
-
-                        if (insight) {
-                            // Check if this insight has an error from the server
-                            const isErrorTile = !!tile.error
-                            const apiErrored = isErrorTile || refreshStatus[insight.short_id]?.errored || false
-                            const apiError = isErrorTile
-                                ? ({ status: 400, detail: `${tile.error!.type}: ${tile.error!.message}` } as any)
-                                : refreshStatus[insight.short_id]?.error
-                            const loadingQueued = isErrorTile ? false : isRefreshingQueued(insight.short_id)
-                            const loading = isErrorTile ? false : isRefreshing(insight.short_id)
-
-                            return (
-                                <InsightCard
-                                    key={tile.id}
-                                    tile={tile}
-                                    insight={insight}
-                                    loadingQueued={loadingQueued}
-                                    loading={loading}
-                                    apiErrored={apiErrored}
-                                    apiError={apiError}
-                                    highlighted={highlightedInsightId && insight.short_id === highlightedInsightId}
-                                    updateColor={(color) => updateTileColor(tile.id, color)}
-                                    toggleShowDescription={() => toggleTileDescription(tile.id)}
-                                    ribbonColor={tile.color}
-                                    refresh={() => refreshDashboardItem({ tile })}
-                                    refreshEnabled={!itemsLoading}
-                                    rename={() => renameInsight(insight)}
-                                    duplicate={() => duplicateTile(tile)}
-                                    setOverride={() => setTileOverride(tile)}
-                                    showDetailsControls={
-                                        placement != DashboardPlacement.Export &&
-                                        placement != DashboardPlacement.Public &&
-                                        !getCurrentExporterData()?.hideExtraDetails
+                                    : undefined,
+                                showEditingControls: isEditablePlacement,
+                                moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
+                                    if (!dashboard) {
+                                        throw new Error('must be on a dashboard to move this tile')
                                     }
-                                    placement={placement}
-                                    loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
-                                    filtersOverride={effectiveEditBarFilters}
-                                    variablesOverride={effectiveDashboardVariableOverrides}
-                                    // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
-                                    breakdownColorOverride={temporaryBreakdownColors}
-                                    dataColorThemeId={dataColorThemeId}
-                                    surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
-                                    {...commonTileProps}
-                                    // NOTE: ReactGridLayout additionally injects its resize handles as `children`!
-                                />
-                            )
-                        }
+                                    moveToDashboard(tile, dashboard.id, id, name)
+                                },
+                                removeFromDashboard: () => removeTile(tile),
+                            }
 
-                        if (text) {
-                            return (
-                                <TextCard
-                                    key={tile.id}
-                                    textTile={tile}
-                                    placement={placement}
-                                    moreButtonOverlay={
-                                        <>
-                                            <LemonButton
-                                                fullWidth
-                                                onClick={() =>
-                                                    dashboard?.id &&
-                                                    push(urls.dashboardTextTile(dashboard?.id, tile.id))
-                                                }
-                                                data-attr="edit-text"
-                                            >
-                                                Edit text
-                                            </LemonButton>
+                            if (insight) {
+                                // Check if this insight has an error from the server
+                                const isErrorTile = !!tile.error
+                                const apiErrored = isErrorTile || refreshStatus[insight.short_id]?.errored || false
+                                const apiError = isErrorTile
+                                    ? ({ status: 400, detail: `${tile.error!.type}: ${tile.error!.message}` } as any)
+                                    : refreshStatus[insight.short_id]?.error
+                                const loadingQueued = isErrorTile ? false : isRefreshingQueued(insight.short_id)
+                                const loading = isErrorTile ? false : isRefreshing(insight.short_id)
 
-                                            {commonTileProps.moveToDashboard && (
-                                                <LemonButtonWithDropdown
-                                                    disabledReason={
-                                                        otherDashboards.length > 0 ? undefined : 'No other dashboards'
-                                                    }
-                                                    dropdown={{
-                                                        overlay: otherDashboards.map((otherDashboard) => (
-                                                            <LemonButton
-                                                                key={otherDashboard.id}
-                                                                onClick={() => {
-                                                                    commonTileProps.moveToDashboard(otherDashboard)
-                                                                }}
-                                                                fullWidth
-                                                            >
-                                                                {otherDashboard.name || <i>Untitled</i>}
-                                                            </LemonButton>
-                                                        )),
-                                                        placement: 'right-start',
-                                                        fallbackPlacements: ['left-start'],
-                                                        actionable: true,
-                                                        closeParentPopoverOnClickInside: true,
-                                                    }}
-                                                    fullWidth
-                                                >
-                                                    Move to
-                                                </LemonButtonWithDropdown>
-                                            )}
-                                            <LemonButton
-                                                onClick={() => duplicateTile(tile)}
-                                                fullWidth
-                                                data-attr="duplicate-text-from-dashboard"
-                                            >
-                                                Duplicate
-                                            </LemonButton>
-                                            <LemonDivider />
-                                            {commonTileProps.removeFromDashboard && (
+                                return (
+                                    <InsightCard
+                                        key={tile.id}
+                                        tile={tile}
+                                        insight={insight}
+                                        loadingQueued={loadingQueued}
+                                        loading={loading}
+                                        apiErrored={apiErrored}
+                                        apiError={apiError}
+                                        highlighted={highlightedInsightId && insight.short_id === highlightedInsightId}
+                                        updateColor={(color) => updateTileColor(tile.id, color)}
+                                        toggleShowDescription={() => toggleTileDescription(tile.id)}
+                                        ribbonColor={tile.color}
+                                        refresh={() => refreshDashboardItem({ tile })}
+                                        refreshEnabled={!itemsLoading}
+                                        rename={() => renameInsight(insight)}
+                                        duplicate={() => duplicateTile(tile)}
+                                        setOverride={() => setTileOverride(tile)}
+                                        showDetailsControls={
+                                            placement != DashboardPlacement.Export &&
+                                            placement != DashboardPlacement.Public &&
+                                            !getCurrentExporterData()?.hideExtraDetails
+                                        }
+                                        placement={placement}
+                                        loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
+                                        filtersOverride={effectiveEditBarFilters}
+                                        variablesOverride={effectiveDashboardVariableOverrides}
+                                        // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
+                                        breakdownColorOverride={temporaryBreakdownColors}
+                                        dataColorThemeId={dataColorThemeId}
+                                        surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
+                                        {...commonTileProps}
+                                        // NOTE: ReactGridLayout additionally injects its resize handles as `children`!
+                                    />
+                                )
+                            }
+
+                            if (text) {
+                                return (
+                                    <TextCard
+                                        key={tile.id}
+                                        textTile={tile}
+                                        placement={placement}
+                                        moreButtonOverlay={
+                                            <>
                                                 <LemonButton
-                                                    status="danger"
-                                                    onClick={() =>
-                                                        LemonDialog.open({
-                                                            title: 'Remove text from dashboard',
-                                                            description:
-                                                                'Are you sure you want to remove this text card from the dashboard?',
-                                                            primaryButton: {
-                                                                children: 'Remove from dashboard',
-                                                                status: 'danger',
-                                                                onClick: () => commonTileProps.removeFromDashboard?.(),
-                                                            },
-                                                            secondaryButton: {
-                                                                children: 'Cancel',
-                                                            },
-                                                        })
-                                                    }
                                                     fullWidth
-                                                    data-attr="remove-text-tile-from-dashboard"
+                                                    onClick={() =>
+                                                        dashboard?.id &&
+                                                        push(urls.dashboardTextTile(dashboard?.id, tile.id))
+                                                    }
+                                                    data-attr="edit-text"
                                                 >
-                                                    Delete
+                                                    Edit text
                                                 </LemonButton>
-                                            )}
-                                        </>
-                                    }
-                                    {...commonTileProps}
-                                />
-                            )
-                        }
-                    })}
-                </ReactGridLayout>
+
+                                                {commonTileProps.moveToDashboard && (
+                                                    <LemonButtonWithDropdown
+                                                        disabledReason={
+                                                            otherDashboards.length > 0
+                                                                ? undefined
+                                                                : 'No other dashboards'
+                                                        }
+                                                        dropdown={{
+                                                            overlay: otherDashboards.map((otherDashboard) => (
+                                                                <LemonButton
+                                                                    key={otherDashboard.id}
+                                                                    onClick={() => {
+                                                                        commonTileProps.moveToDashboard(otherDashboard)
+                                                                    }}
+                                                                    fullWidth
+                                                                >
+                                                                    {otherDashboard.name || <i>Untitled</i>}
+                                                                </LemonButton>
+                                                            )),
+                                                            placement: 'right-start',
+                                                            fallbackPlacements: ['left-start'],
+                                                            actionable: true,
+                                                            closeParentPopoverOnClickInside: true,
+                                                        }}
+                                                        fullWidth
+                                                    >
+                                                        Move to
+                                                    </LemonButtonWithDropdown>
+                                                )}
+                                                <LemonButton
+                                                    onClick={() => duplicateTile(tile)}
+                                                    fullWidth
+                                                    data-attr="duplicate-text-from-dashboard"
+                                                >
+                                                    Duplicate
+                                                </LemonButton>
+                                                <LemonDivider />
+                                                {commonTileProps.removeFromDashboard && (
+                                                    <LemonButton
+                                                        status="danger"
+                                                        onClick={() =>
+                                                            LemonDialog.open({
+                                                                title: 'Remove text from dashboard',
+                                                                description:
+                                                                    'Are you sure you want to remove this text card from the dashboard?',
+                                                                primaryButton: {
+                                                                    children: 'Remove from dashboard',
+                                                                    status: 'danger',
+                                                                    onClick: () =>
+                                                                        commonTileProps.removeFromDashboard?.(),
+                                                                },
+                                                                secondaryButton: {
+                                                                    children: 'Cancel',
+                                                                },
+                                                            })
+                                                        }
+                                                        fullWidth
+                                                        data-attr="remove-text-tile-from-dashboard"
+                                                    >
+                                                        Delete
+                                                    </LemonButton>
+                                                )}
+                                            </>
+                                        }
+                                        {...commonTileProps}
+                                    />
+                                )
+                            }
+                        })}
+                    </ReactGridLayout>
+                </div>
             )}
             {dashboardStreaming && (
                 <div className="mt-4 flex items-center justify-center">


### PR DESCRIPTION
## Problem

When we're activating the edit layout mode for dashboards, sometimes the tiles jump around because there are in fact specific grid locations that tiles must be assigned to, but its not visually clear to the user.


Note: use hide whitespace when looking at the PR otherwise its gonna make it look like i did more than i did


## Changes

Shows the grid, places it behind a new feature flag called dashboard-grid.

<img width="1140" height="490" alt="image" src="https://github.com/user-attachments/assets/f79dc80c-2410-40c0-9bdb-526855514196" />

<img width="1162" height="489" alt="image" src="https://github.com/user-attachments/assets/a0a50ba4-9fb3-4d63-b464-10c3e05ebcd3" />

<img width="1162" height="561" alt="image" src="https://github.com/user-attachments/assets/d569a8b8-c0e6-42ab-b7cc-c9629605cbc2" />




## How did you test this code?
Locally.

